### PR TITLE
Fix helm chart

### DIFF
--- a/install/helm/templates/service-account.yaml
+++ b/install/helm/templates/service-account.yaml
@@ -21,8 +21,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "thunder.labels" . | nindent 4 }}
-  {{- if .Values.setup.enabled }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-10"
-  {{- end }}

--- a/install/helm/templates/thunder-deployment.yaml
+++ b/install/helm/templates/thunder-deployment.yaml
@@ -83,6 +83,9 @@ spec:
           image: {{ .Values.deployment.image.registry }}/{{ .Values.deployment.image.repository }}:{{ default "latest" .Values.deployment.image.tag }}
           {{- end }}
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          env:
+            - name: THUNDER_SKIP_SECURITY
+              value: {{ .Values.deployment.skipSecurity | quote }}
           startupProbe:
             exec:
               command:

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -61,6 +61,9 @@ deployment:
     requests:
       cpu: 1
       memory: 256Mi
+  # Controls the THUNDER_SKIP_SECURITY environment variable. Set this to true only
+  # in non-production environments for testing purposes to bypass REST API security checks.
+  skipSecurity: false
 
 hpa:
   enabled: true


### PR DESCRIPTION
### Purpose

This pull request introduces a new configuration option to control a security-related environment variable in the Thunder deployment and makes a minor change to the Helm service account template. The most important changes are summarized below:

### Approach

**Deployment configuration and security:**

* Added a new `skipSecurity` value in `values.yaml` under the `deployment` section, defaulting to `false`. This value is now injected as the `THUNDER_SKIP_SECURITY` environment variable in the Thunder deployment, allowing security checks to be optionally skipped via configuration. [[1]](diffhunk://#diff-dbfbfa7b39e8bcf96bc8cb5cce6dca2faa2ca85481e5e3b62aa3e4a3d4ffcf7eR64) [[2]](diffhunk://#diff-9eee6422f971f25bdbc27ecf6052ee4b8a96cce102a4fad67da84c3066fa43a1R86-R88)

**Helm template simplification:**

* Removed a conditional block in the service account Helm template, so that annotations for Helm hooks are always included, regardless of the `setup.enabled` value.

### Related Issues
- https://github.com/asgardeo/thunder/issues/1067

### Related PRs
- https://github.com/asgardeo/thunder-performance/pull/29

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
