### PR TITLE
fix: add missing onFailure field to BASIC_FEDERATED template executors

### DIFF
--- a/frontend/apps/thunder-develop/src/features/login-flow/data/templates.json
+++ b/frontend/apps/thunder-develop/src/features/login-flow/data/templates.json
@@ -448,7 +448,8 @@
                 "executor": {
                   "name": "BasicAuthExecutor"
                 },
-                "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}"
+                "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+                "onFailure": ""
               }
             }
           },
@@ -469,7 +470,8 @@
                 "executor": {
                   "name": "GoogleOIDCAuthExecutor"
                 },
-                "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}"
+                "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+                "onFailure": ""
               },
               "properties": {
                 "idpId": "{{IDP_ID}}"


### PR DESCRIPTION
Fixes #1475

## Summary

The `BasicAuthExecutor` and `GoogleOIDCAuthExecutor` nodes in the `BASIC_FEDERATED` template were missing the `onFailure` field. This caused the flow builder to not render failure-path handles for these nodes.

## Changes

- Added `"onFailure": ""` to `BasicAuthExecutor` in `BASIC_FEDERATED` template
- Added `"onFailure": ""` to `GoogleOIDCAuthExecutor` in `BASIC_FEDERATED` template

This matches the pattern used in all other templates (`BASIC`, `BASIC_SMS_OTP_MFA`, `SMS_OTP`, `PASSKEY_LOGIN`).