### PR TITLE
Fix: Docker build failures on Windows by enforcing LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Force LF line endings for shell scripts (required for Docker/Linux builds)
+*.sh text eol=lf
+
+# Other common files that should use LF
+Makefile text eol=lf
+Dockerfile text eol=lf


### PR DESCRIPTION

---


## Summary

Fix Docker build failures on Windows by enforcing LF (Unix) line endings for shell-related files.

## Problem

When building the Docker image on Windows environments, the build failed with errors such as:



/bin/sh: ./build.sh: not found



Even though the file existed in the image.

This was caused by CRLF (`\r\n`) line endings being introduced by Windows Git configurations.  
Linux-based Docker environments expect LF (`\n`) line endings for shell scripts and related files.  
CRLF line endings can cause interpreter resolution failures inside containers.

## Root Cause

By default, Git on Windows may convert line endings to CRLF depending on `core.autocrlf` settings.  
This affects:

- `*.sh` scripts
- `Dockerfile`
- `Makefile`

When these files contain CRLF endings, Docker builds may fail inside Linux containers.

## Solution

Added a `.gitattributes` file to enforce LF line endings for:

```gitattributes
*.sh text eol=lf
Makefile text eol=lf
Dockerfile text eol=lf
````

This ensures:

* Consistent LF line endings across platforms
* Reliable Docker builds on Windows, macOS, and Linux
* Prevention of future cross-platform build inconsistencies

## Impact

* No functional changes to application logic
* Improves cross-platform developer experience
* Prevents subtle Docker build failures for Windows contributors
* Aligns with standard cross-platform Git best practices

## Testing

* Verified Docker build failure occurs with CRLF line endings
* Confirmed successful build after enforcing LF via `.gitattributes`
* Tested using fresh clone to ensure consistent behavior

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development build configuration for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->