### PR TITLE
Add stepID parameter to flow engine and node contexts

### DIFF
--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -32,6 +32,7 @@ type NodeContext struct {
 
 	FlowID        string
 	FlowType      common.FlowType
+	StepID        string
 	AppID         string
 	Verbose       bool
 	CurrentAction string

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -62,7 +62,7 @@ func newPromptNode(id string, properties map[string]interface{},
 
 // Execute executes the prompt node logic based on the current context.
 func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceerror.ServiceError) {
-	logger := n.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := n.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing prompt node")
 
 	nodeResp := &common.NodeResponse{
@@ -166,7 +166,7 @@ func (n *promptNode) resolvePromptInputs(ctx *NodeContext, nodeResp *common.Node
 // hasRequiredInputs checks if all required inputs are available in the context. Adds missing
 // inputs to the node response. Returns true if all required inputs are available, otherwise false.
 func (n *promptNode) hasRequiredInputs(ctx *NodeContext, nodeResp *common.NodeResponse) bool {
-	logger := n.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := n.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	if nodeResp.Inputs == nil {
 		nodeResp.Inputs = make([]common.Input, 0)
@@ -194,7 +194,8 @@ func (n *promptNode) hasRequiredInputs(ctx *NodeContext, nodeResp *common.NodeRe
 // Returns true if any required data is found missing, otherwise false.
 func (n *promptNode) appendMissingInputs(ctx *NodeContext, nodeResp *common.NodeResponse,
 	requiredInputs []common.Input) bool {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := log.GetLogger().With(log.String(log.LoggerKeyFlowID, ctx.FlowID),
+		log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	requireInputs := false
 	for _, input := range requiredInputs {
@@ -227,7 +228,8 @@ func (n *promptNode) enrichInputsFromForwardedData(ctx *NodeContext, nodeResp *c
 	// Type assert to []common.Input
 	forwardedInputs, ok := forwardedInputsData.([]common.Input)
 	if !ok {
-		n.logger.Debug("ForwardedData contains 'inputs' key but value is not []common.Input, skipping enrichment")
+		n.logger.With(log.String(log.LoggerKeyStepID, ctx.StepID)).
+			Debug("ForwardedData contains 'inputs' key but value is not []common.Input, skipping enrichment")
 		return
 	}
 
@@ -243,9 +245,10 @@ func (n *promptNode) enrichInputsFromForwardedData(ctx *NodeContext, nodeResp *c
 			// Only enrich Options - do not overwrite other fields like Ref, Type, Required
 			if len(fwdInput.Options) > 0 {
 				nodeResp.Inputs[i].Options = fwdInput.Options
-				n.logger.Debug("Enriched input with options from ForwardedData",
-					log.String("identifier", nodeResp.Inputs[i].Identifier),
-					log.Int("optionsCount", len(fwdInput.Options)))
+				n.logger.With(log.String(log.LoggerKeyStepID, ctx.StepID)).
+					Debug("Enriched input with options from ForwardedData",
+						log.String("identifier", nodeResp.Inputs[i].Identifier),
+						log.Int("optionsCount", len(fwdInput.Options)))
 			}
 		}
 	}
@@ -288,7 +291,7 @@ func (n *promptNode) tryAutoSelectSingleAction(ctx *NodeContext) bool {
 	if len(actions) == 1 && ctx.CurrentAction == "" && len(allInputs) > 0 {
 		ctx.CurrentAction = actions[0].Ref
 		n.logger.Debug("Auto-selected single action", log.String(log.LoggerKeyFlowID, ctx.FlowID),
-			log.String("actionRef", actions[0].Ref))
+			log.String(log.LoggerKeyStepID, ctx.StepID), log.String("actionRef", actions[0].Ref))
 		return true
 	}
 	return false

--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -83,7 +83,8 @@ func newTaskExecutionNode(id string, properties map[string]interface{}, isStartN
 
 // Execute executes the node's executor.
 func (n *taskExecutionNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceerror.ServiceError) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := log.GetLogger().With(log.String(log.LoggerKeyFlowID, ctx.FlowID),
+		log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing task execution node")
 
 	if n.executor == nil {

--- a/backend/internal/flow/executor/attribute_collector.go
+++ b/backend/internal/flow/executor/attribute_collector.go
@@ -72,7 +72,7 @@ func newAttributeCollector(
 
 // Execute executes the attribute collection logic.
 func (a *attributeCollector) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing attribute collect executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/attribute_uniqueness_validator.go
+++ b/backend/internal/flow/executor/attribute_uniqueness_validator.go
@@ -69,7 +69,7 @@ func newAttributeUniquenessValidator(
 // Returns ExecUserInputRequired (triggering onIncomplete routing) with the specific attribute
 // named in FailureReason when a conflict is detected, or ExecComplete when all values are free.
 func (e *attributeUniquenessValidator) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing uniqueness checker executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -95,7 +95,7 @@ func newAuthAssertExecutor(
 
 // Execute executes the authentication assertion logic.
 func (a *authAssertExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing authentication assertion executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/authz_executor.go
+++ b/backend/internal/flow/executor/authz_executor.go
@@ -70,7 +70,7 @@ func newAuthorizationExecutor(
 // Execute executes the authorization logic by determining required permissions based on context,
 // calling the authorization service, and storing authorized permissions in runtime data.
 func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := a.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing authorization executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/basic_auth_executor.go
+++ b/backend/internal/flow/executor/basic_auth_executor.go
@@ -88,7 +88,7 @@ func newBasicAuthExecutor(
 
 // Execute executes the basic authentication logic.
 func (b *basicAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := b.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := b.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing basic authentication executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -89,7 +89,7 @@ func newConsentExecutor(
 
 // Execute runs the consent enforcement logic.
 func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing consent executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/credential_setter.go
+++ b/backend/internal/flow/executor/credential_setter.go
@@ -67,7 +67,7 @@ func newCredentialSetter(
 
 // Execute sets the password for the user identified by userID in RuntimeData.
 func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing credential set")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/email_executor.go
+++ b/backend/internal/flow/executor/email_executor.go
@@ -72,7 +72,7 @@ func (e *emailExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 // executeSend resolves the email template, constructs the email, and sends it.
 // If the email client is not configured, it completes without sending (no-op).
 func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing email executor in send mode")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/http_request_executor.go
+++ b/backend/internal/flow/executor/http_request_executor.go
@@ -98,7 +98,7 @@ func newHTTPRequestExecutor(
 
 // Execute executes the HTTP request logic.
 func (h *httpRequestExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := h.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := h.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing HTTP request executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/identifying_executor.go
+++ b/backend/internal/flow/executor/identifying_executor.go
@@ -110,7 +110,7 @@ func (i *identifyingExecutor) IdentifyUser(filters map[string]interface{},
 
 // Execute executes the identifying executor logic.
 func (i *identifyingExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := i.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := i.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing identifying executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -72,7 +72,7 @@ func (e *inviteExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespons
 
 // executeGenerate generates the invite token and link.
 func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing invite executor in generate mode")
 
 	execResp := &common.ExecutorResponse{
@@ -102,7 +102,7 @@ func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.Executo
 
 // executeVerify validates the user-provided invite token against the stored token.
 func (e *inviteExecutor) executeVerify(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing invite executor in verify mode")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -118,7 +118,7 @@ func newOAuthExecutor(
 
 // Execute executes the OAuth authentication flow.
 func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing OAuth authentication executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -88,7 +88,7 @@ func newOIDCAuthExecutor(
 
 // Execute executes the OIDC authentication logic.
 func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing OIDC authentication executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/ou_executor.go
+++ b/backend/internal/flow/executor/ou_executor.go
@@ -74,7 +74,7 @@ func newOUExecutor(
 
 // Execute executes the ou creation logic.
 func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := o.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing OU creation executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/ou_resolver_executor.go
+++ b/backend/internal/flow/executor/ou_resolver_executor.go
@@ -82,7 +82,7 @@ func newOUResolverExecutor(
 //   - "prompt": checks for child OUs and prompts the user to select one if applicable.
 //   - "promptAll": shows the full OU tree from root, independent of UserTypeResolver.
 func (e *ouResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	execResp := &common.ExecutorResponse{
 		Status:      common.ExecComplete,

--- a/backend/internal/flow/executor/passkey_executor.go
+++ b/backend/internal/flow/executor/passkey_executor.go
@@ -143,7 +143,7 @@ func newPasskeyAuthExecutor(
 
 // Execute executes the passkey authentication logic.
 func (p *passkeyAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing passkey authentication executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/permission_validator.go
+++ b/backend/internal/flow/executor/permission_validator.go
@@ -55,7 +55,7 @@ func newPermissionValidator(flowFactory core.FlowFactoryInterface) *permissionVa
 
 // Execute validates that the request has the required permission/scope to access the next node.
 func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := e.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -74,7 +74,7 @@ func newProvisioningExecutor(
 
 // Execute executes the user provisioning logic based on the inputs provided.
 func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := p.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing user provisioning executor")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -94,7 +94,7 @@ func newSMSOTPAuthExecutor(
 
 // Execute executes the SMS OTP authentication logic.
 func (s *smsOTPAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing SMS OTP authentication executor")
 
 	execResp := &common.ExecutorResponse{
@@ -121,7 +121,7 @@ func (s *smsOTPAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 // executeSend executes the OTP sending step.
 func (s *smsOTPAuthExecutor) executeSend(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	err := s.InitiateOTP(ctx, execResp)
 	if err != nil {
@@ -136,7 +136,7 @@ func (s *smsOTPAuthExecutor) executeSend(ctx *core.NodeContext,
 // executeVerify executes the OTP verification step.
 func (s *smsOTPAuthExecutor) executeVerify(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	if !s.HasRequiredInputs(ctx, execResp) {
 		logger.Debug("Required inputs for SMS OTP verification are not provided")
@@ -159,7 +159,7 @@ func (s *smsOTPAuthExecutor) executeVerify(ctx *core.NodeContext,
 // InitiateOTP initiates the OTP sending process to the user's mobile number.
 func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Sending SMS OTP to user")
 
 	mobileNumber, err := s.getUserMobileFromContext(ctx)
@@ -229,7 +229,7 @@ func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 // ProcessAuthFlowResponse processes the authentication flow response for SMS OTP.
 func (s *smsOTPAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Processing authentication flow response for SMS OTP")
 
 	err := s.validateOTP(ctx, execResp, logger)
@@ -261,7 +261,7 @@ func (s *smsOTPAuthExecutor) ValidatePrerequisites(ctx *core.NodeContext,
 		return true
 	}
 
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	if ctx.FlowType == common.FlowTypeRegistration {
 		logger.Debug("Prerequisites not met for registration flow, prompting for mobile number")
@@ -305,7 +305,7 @@ func (s *smsOTPAuthExecutor) getUserMobileFromContext(ctx *core.NodeContext) (st
 // satisfyPrerequisites tries to satisfy the prerequisites for the SMSOTPAuthExecutor.
 func (s *smsOTPAuthExecutor) satisfyPrerequisites(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	execResp.Status = ""
 	execResp.FailureReason = ""
@@ -353,7 +353,7 @@ func (s *smsOTPAuthExecutor) satisfyPrerequisites(ctx *core.NodeContext,
 // resolveUserID resolves the user ID from the context based on various attributes.
 // TODO: Move to a separate resolver when the support is added.
 func (s *smsOTPAuthExecutor) resolveUserID(ctx *core.NodeContext) (bool, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	// First, check if the user ID is already available in the context.
 	userID := s.GetUserIDFromContext(ctx)
@@ -431,7 +431,9 @@ func (s *smsOTPAuthExecutor) resolveUserIDFromAttribute(ctx *core.NodeContext,
 // getUserMobileNumber retrieves the mobile number for the given user ID.
 func (s *smsOTPAuthExecutor) getUserMobileNumber(userID string, ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (string, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String("userID", userID))
+	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID),
+		log.String(log.LoggerKeyStepID, ctx.StepID),
+		log.String("userID", userID))
 	logger.Debug("Retrieving user mobile number")
 
 	// Try to get mobile number from context
@@ -602,7 +604,7 @@ func (s *smsOTPAuthExecutor) validateOTP(ctx *core.NodeContext, execResp *common
 // getAuthenticatedUser returns the authenticated user details for the given user ID.
 func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*authncm.AuthenticatedUser, error) {
-	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := s.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	mobileNumber, err := s.getUserMobileFromContext(ctx)
 	if err != nil {

--- a/backend/internal/flow/executor/user_type_resolver.go
+++ b/backend/internal/flow/executor/user_type_resolver.go
@@ -82,7 +82,7 @@ func newUserTypeResolver(
 
 // Execute resolves the user type from inputs or prompts the user to select one.
 func (u *userTypeResolver) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
-	logger := u.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID))
+	logger := u.logger.With(log.String(log.LoggerKeyFlowID, ctx.FlowID), log.String(log.LoggerKeyStepID, ctx.StepID))
 	logger.Debug("Executing user type resolver")
 
 	execResp := &common.ExecutorResponse{

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -59,8 +59,18 @@ func newFlowEngine(
 func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine"))
 
+	// Generate step ID for the current execution step if not already set
+	if ctx.StepID == "" {
+		stepID, errUUID := sysutils.GenerateUUIDv7()
+		if errUUID != nil {
+			logger.Error("Failed to generate UUID")
+			return FlowStep{}, &serviceerror.InternalServerError
+		}
+		ctx.StepID = stepID
+	}
 	flowStep := FlowStep{
 		FlowID: ctx.FlowID,
+		StepID: ctx.StepID,
 	}
 
 	// Track flow execution start time
@@ -81,13 +91,15 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 	// Execute the graph nodes until a terminal condition is met or currentNode is nil
 	for currentNode != nil {
 		logger.Debug("Executing node", log.String("nodeID", currentNode.GetID()),
-			log.String("nodeType", string(currentNode.GetType())))
+			log.String("nodeType", string(currentNode.GetType())),
+			log.String(log.LoggerKeyStepID, ctx.StepID))
 
 		nodeCtx := &core.NodeContext{
 			Context:           ctx.Context,
 			FlowID:            ctx.FlowID,
 			FlowType:          ctx.FlowType,
 			AppID:             ctx.AppID,
+			StepID:            ctx.StepID,
 			CurrentAction:     ctx.CurrentAction,
 			Verbose:           ctx.Verbose,
 			NodeInputs:        getNodeInputs(ctx.CurrentNode),
@@ -118,7 +130,8 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 
 		// Check if the node should be executed based on its condition
 		if !currentNode.ShouldExecute(nodeCtx) {
-			logger.Debug("Skipping node due to unmet condition", log.String("nodeID", currentNode.GetID()))
+			logger.Debug("Skipping node due to unmet condition", log.String("nodeID", currentNode.GetID()),
+				log.String(log.LoggerKeyStepID, ctx.StepID))
 			nextNode, svcErr := fe.skipToNextNode(ctx, currentNode, logger)
 			if svcErr != nil {
 				return flowStep, svcErr
@@ -194,17 +207,20 @@ func (fe *flowEngine) setCurrentExecutionNode(ctx *EngineContext, logger *log.Lo
 	core.NodeInterface, *serviceerror.ServiceError) {
 	graph := ctx.Graph
 	if graph == nil {
-		logger.Error("Flow graph is not initialized in the context")
+		logger.Error("Flow graph is not initialized in the context", log.String(log.LoggerKeyStepID, ctx.StepID))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	currentNode := ctx.CurrentNode
 	if currentNode == nil {
-		logger.Debug("Current node is nil. Setting start node as the current node.")
+		logger.Debug("Current node is nil. Setting start node as the current node.",
+			log.String(log.LoggerKeyStepID, ctx.StepID))
 		var err error
 		currentNode, err = graph.GetStartNode()
 		if err != nil {
-			logger.Error("Start node not found in the flow graph", log.Error(err))
+			logger.Error("Start node not found in the flow graph",
+				log.Error(err),
+				log.String(log.LoggerKeyStepID, ctx.StepID))
 			return nil, &serviceerror.InternalServerError
 		}
 		ctx.CurrentNode = currentNode
@@ -440,7 +456,7 @@ func (fe *flowEngine) processNodeResponse(ctx *EngineContext, nodeResp *common.N
 	flowStep *FlowStep, logger *log.Logger) (
 	core.NodeInterface, bool, *serviceerror.ServiceError) {
 	if nodeResp.Status == "" {
-		logger.Error("Node response status not found in the flow graph")
+		logger.Error("Node response status not found in the flow graph", log.String(log.LoggerKeyStepID, ctx.StepID))
 		return nil, false, &serviceerror.InternalServerError
 	}
 
@@ -469,7 +485,7 @@ func (fe *flowEngine) processNodeResponse(ctx *EngineContext, nodeResp *common.N
 		return nil, false, nil
 	default:
 		logger.Error("Unsupported response status returned from the node",
-			log.String("status", string(nodeResp.Status)))
+			log.String("status", string(nodeResp.Status)), log.String(log.LoggerKeyStepID, ctx.StepID))
 		return nil, false, &serviceerror.InternalServerError
 	}
 }
@@ -480,7 +496,7 @@ func (fe *flowEngine) handleCompletedResponse(ctx *EngineContext,
 	core.NodeInterface, *serviceerror.ServiceError) {
 	nextNode, err := fe.resolveToNextNode(ctx.Graph, nodeResp)
 	if err != nil {
-		logger.Error("Error moving to the next node", log.Error(err))
+		logger.Error("Error moving to the next node", log.Error(err), log.String(log.LoggerKeyStepID, ctx.StepID))
 		return nil, &serviceerror.InternalServerError
 	}
 	ctx.CurrentNode = nextNode
@@ -496,20 +512,24 @@ func (fe *flowEngine) handleIncompleteResponse(ctx *EngineContext, nodeResp *com
 	case common.NodeResponseTypeRedirection:
 		err := fe.resolveStepForRedirection(ctx, nodeResp, flowStep)
 		if err != nil {
-			logger.Error("Error while resolving step for redirection", log.Error(err))
+			logger.Error("Error while resolving step for redirection",
+				log.Error(err),
+				log.String(log.LoggerKeyStepID, ctx.StepID))
 			return &serviceerror.InternalServerError
 		}
 		return nil
 	case common.NodeResponseTypeView:
 		err := fe.resolveStepDetailsForPrompt(ctx, nodeResp, flowStep)
 		if err != nil {
-			logger.Error("Error while resolving step details for prompt", log.Error(err))
+			logger.Error("Error while resolving step details for prompt",
+				log.Error(err),
+				log.String(log.LoggerKeyStepID, ctx.StepID))
 			return &serviceerror.InternalServerError
 		}
 		return nil
 	default:
 		logger.Error("Unsupported response type returned from the node",
-			log.String("responseType", string(nodeResp.Type)))
+			log.String("responseType", string(nodeResp.Type)), log.String(log.LoggerKeyStepID, ctx.StepID))
 		return &serviceerror.InternalServerError
 	}
 	// TODO: Handle retry scenarios with nodeResp.Type == common.NodeResponseTypeRetry
@@ -521,11 +541,12 @@ func (fe *flowEngine) handleForwardResponse(ctx *EngineContext,
 	core.NodeInterface, *serviceerror.ServiceError) {
 	logger.Debug("Forwarding to next node",
 		log.String("nextNodeID", nodeResp.NextNodeID),
-		log.String("failureReason", nodeResp.FailureReason))
+		log.String("failureReason", nodeResp.FailureReason),
+		log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	nextNode, err := fe.resolveToNextNode(ctx.Graph, nodeResp)
 	if err != nil {
-		logger.Error("Error resolving to next node", log.Error(err))
+		logger.Error("Error resolving to next node", log.Error(err), log.String(log.LoggerKeyStepID, ctx.StepID))
 		return nil, &serviceerror.InternalServerError
 	}
 	ctx.CurrentNode = nextNode
@@ -541,19 +562,22 @@ func (fe *flowEngine) skipToNextNode(ctx *EngineContext, currentNode core.NodeIn
 	// Condition must specify where to skip to
 	if condition == nil || condition.OnSkip == "" {
 		logger.Error("Node has condition but onSkip is not specified",
-			log.String("nodeID", currentNode.GetID()))
+			log.String("nodeID", currentNode.GetID()), log.String(log.LoggerKeyStepID, ctx.StepID))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	logger.Debug("Using condition's onSkip for skipped node",
-		log.String("nodeID", currentNode.GetID()), log.String("onSkip", condition.OnSkip))
+		log.String("nodeID", currentNode.GetID()), log.String("onSkip", condition.OnSkip),
+		log.String(log.LoggerKeyStepID, ctx.StepID))
 
 	nodeResp := &common.NodeResponse{NextNodeID: condition.OnSkip}
 
 	// Resolve to the next node
 	nextNode, err := fe.resolveToNextNode(ctx.Graph, nodeResp)
 	if err != nil {
-		logger.Error("Error moving to the next node after skipping", log.Error(err))
+		logger.Error("Error moving to the next node after skipping",
+			log.Error(err),
+			log.String(log.LoggerKeyStepID, ctx.StepID))
 		return nil, &serviceerror.InternalServerError
 	}
 	ctx.CurrentNode = nextNode

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -38,6 +38,7 @@ type EngineContext struct {
 
 	FlowID         string
 	FlowType       common.FlowType
+	StepID         string
 	AppID          string
 	Verbose        bool
 	UserInputs     map[string]string

--- a/backend/internal/system/log/constants.go
+++ b/backend/internal/system/log/constants.go
@@ -27,6 +27,8 @@ const (
 	LoggerKeyFlowID = "flowId"
 	// LoggerKeyNodeID is the key used to identify the node ID in the logger.
 	LoggerKeyNodeID = "nodeId"
+	// LoggerKeyStepID is the key used to identify the step ID in the logger.
+	LoggerKeyStepID = "stepID"
 	// LoggerKeyTraceID is the key used to identify the trace ID (correlation ID) in the logger.
 	LoggerKeyTraceID = "trace_id"
 )


### PR DESCRIPTION
### Purpose
The step ID defined in the flow execution layer is currently neither used nor returned in the API, making step-level execution difficult to track. 


### Approach
To improve traceability, this change introduces a UUID generated by the flow engine. The UUID is stored in the flowEngineContext and used in logging. During each new execute call, a UUID is generated and added to the flowEngineContext if a step ID is not already present.

Example response:

```
{
    "flowId": "019d6168-ab7f-78cd-ac51-9368bd682e88",
    "stepId": "019d6168-ab80-77fc-8cbb-158c88443ab2",
    "flowStatus": "INCOMPLETE",
    "type": "VIEW",
    "data": {
        "inputs": [
            {
                "ref": "input_001",
                "identifier": "username",
                "type": "TEXT_INPUT",
                "required": true
            },
            {
                "ref": "input_002",
                "identifier": "password",
                "type": "PASSWORD_INPUT",
                "required": true
            }
        ],
        "actions": [
            {
                "ref": "action_001",
                "nextNode": "basic_auth"
            }
        ],
        "meta": {
                       .....
            }
}
```

#### Note: As the stepID is used for tracing the flow during the flow execution process for a given call, it will not be persisted to the DB.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2062

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced logging and trace context across the flow execution system to include per-step identifiers for improved observability, correlation, and debugging of individual steps.
  * Engine now initializes and propagates step IDs into execution context and logs, and a standardized step-ID logging key was added to support step-scoped telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->