### PR TITLE
fix: remove OIDC fields from OAuth authorization server metadata

### DIFF
--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -113,7 +113,10 @@ func (suite *DiscoveryTestSuite) TestOAuth2AuthorizationServerMetadata() {
 	assert.NotEmpty(suite.T(), metadata.JWKSUri)
 	assert.NotEmpty(suite.T(), metadata.RegistrationEndpoint)
 	assert.NotEmpty(suite.T(), metadata.IntrospectionEndpoint)
-	assert.NotEmpty(suite.T(), metadata.UserInfoEndpoint)
+
+	// Verify OIDC-specific fields are absent from OAuth2 authorization server metadata
+	assert.Empty(suite.T(), metadata.UserInfoEndpoint, "userinfo_endpoint should not be present in OAuth2 authorization server metadata")
+	assert.NotContains(suite.T(), metadata.ScopesSupported, "openid", "openid scope should not be present in OAuth2 authorization server metadata")
 
 	// Verify only implemented endpoints are present
 	assert.Empty(suite.T(), metadata.RevocationEndpoint) // Not implemented
@@ -155,6 +158,10 @@ func (suite *DiscoveryTestSuite) TestOIDCDiscovery() {
 
 	// Verify claims parameter support
 	assert.True(suite.T(), metadata.ClaimsParameterSupported, "claims_parameter_supported should be true")
+
+	// Verify OIDC-specific fields are present in OIDC metadata
+	assert.NotEmpty(suite.T(), metadata.UserInfoEndpoint, "userinfo_endpoint should be present in OIDC metadata")
+	assert.Contains(suite.T(), metadata.ScopesSupported, "openid", "openid scope should be present in OIDC metadata")
 }
 
 // TestGrantTypeIsValid tests the GrantType.IsValid() method

--- a/backend/internal/oauth/oauth2/discovery/model.go
+++ b/backend/internal/oauth/oauth2/discovery/model.go
@@ -23,7 +23,6 @@ type OAuth2AuthorizationServerMetadata struct {
 	Issuer                            string   `json:"issuer"`
 	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
 	TokenEndpoint                     string   `json:"token_endpoint"`
-	UserInfoEndpoint                  string   `json:"userinfo_endpoint,omitempty"`
 	JWKSUri                           string   `json:"jwks_uri"`
 	RegistrationEndpoint              string   `json:"registration_endpoint,omitempty"`
 	RevocationEndpoint                string   `json:"revocation_endpoint,omitempty"`
@@ -38,6 +37,7 @@ type OAuth2AuthorizationServerMetadata struct {
 // OIDCProviderMetadata represents OpenID Connect Provider Metadata (OIDC Discovery 1.0)
 type OIDCProviderMetadata struct {
 	OAuth2AuthorizationServerMetadata
+	UserInfoEndpoint                 string   `json:"userinfo_endpoint,omitempty"`
 	SubjectTypesSupported            []string `json:"subject_types_supported"`
 	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
 	ClaimsSupported                  []string `json:"claims_supported"`

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -55,7 +55,6 @@ func (ds *discoveryService) GetOAuth2AuthorizationServerMetadata(
 		Issuer:                            ds.getIssuer(),
 		AuthorizationEndpoint:             ds.getAuthorizationEndpoint(),
 		TokenEndpoint:                     ds.getTokenEndpoint(),
-		UserInfoEndpoint:                  ds.getUserInfoEndpoint(),
 		JWKSUri:                           ds.getJWKSUri(),
 		RegistrationEndpoint:              ds.getRegistrationEndpoint(),
 		IntrospectionEndpoint:             ds.getIntrospectionEndpoint(),
@@ -71,13 +70,15 @@ func (ds *discoveryService) GetOAuth2AuthorizationServerMetadata(
 func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) *OIDCProviderMetadata {
 	oauth2Meta := ds.GetOAuth2AuthorizationServerMetadata(ctx)
 
-	return &OIDCProviderMetadata{
+	oidcMetadata := &OIDCProviderMetadata{
 		OAuth2AuthorizationServerMetadata: *oauth2Meta,
 		SubjectTypesSupported:             ds.getSupportedSubjectTypes(),
 		IDTokenSigningAlgValuesSupported:  ds.pkiService.GetSupportedSigningAlgorithms(),
 		ClaimsSupported:                   ds.getSupportedClaims(),
 		ClaimsParameterSupported:          true,
 	}
+	oidcMetadata.UserInfoEndpoint = ds.getUserInfoEndpoint()
+	return oidcMetadata
 }
 
 func (ds *discoveryService) getIssuer() string {
@@ -111,6 +112,9 @@ func (ds *discoveryService) getRegistrationEndpoint() string {
 func (ds *discoveryService) getSupportedScopes() []string {
 	scopes := make([]string, 0, len(constants.StandardOIDCScopes))
 	for scope := range constants.StandardOIDCScopes {
+		if scope == constants.ScopeOpenID {
+			continue
+		}
 		scopes = append(scopes, scope)
 	}
 	return scopes

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -78,6 +78,7 @@ func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) *OIDCProviderMe
 		ClaimsParameterSupported:          true,
 	}
 	oidcMetadata.UserInfoEndpoint = ds.getUserInfoEndpoint()
+	oidcMetadata.ScopesSupported = ds.getOIDCSupportedScopes()
 	return oidcMetadata
 }
 
@@ -107,6 +108,14 @@ func (ds *discoveryService) getUserInfoEndpoint() string {
 
 func (ds *discoveryService) getRegistrationEndpoint() string {
 	return ds.baseURL + constants.OAuth2DCREndpoint
+}
+
+func (ds *discoveryService) getOIDCSupportedScopes() []string {
+	scopes := make([]string, 0, len(constants.StandardOIDCScopes))
+	for scope := range constants.StandardOIDCScopes {
+		scopes = append(scopes, scope)
+	}
+	return scopes
 }
 
 func (ds *discoveryService) getSupportedScopes() []string {


### PR DESCRIPTION
## Description                                                                                                                                                                                  
The `/.well-known/oauth-authorization-server` endpoint was incorrectly
including OIDC-specific fields (`userinfo_endpoint` and `openid` scope)
even though a separate OIDC discovery endpoint already exists.                                                                                                                                  
                                                                
## Changes                                                                                                                                                                                      
- Removed `userinfo_endpoint` from `OAuth2AuthorizationServerMetadata` struct
- Moved `userinfo_endpoint` to `OIDCProviderMetadata` struct                 
- Excluded `openid` scope from OAuth AS metadata `scopes_supported`                                                                                                                             
- Assigned `userinfo_endpoint` inside `GetOIDCMetadata()`          
- Updated tests to assert correct field presence/absence on both endpoints                                                                                                                      
                                                                            
  Closes #2189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified OAuth 2.0 vs OIDC discovery: the userinfo endpoint is now exposed only for OIDC, and scopes are separated so OAuth 2.0 metadata no longer lists the openid scope while OIDC metadata does. This ensures discovery responses match protocol expectations.
* **Tests**
  * Updated discovery tests to validate the presence/absence of the userinfo endpoint and the correct scopes for OAuth 2.0 and OIDC metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->