### PR TITLE
Add llms.txt support to documentation site

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -20,6 +20,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 import type {Config} from '@docusaurus/types';
 import {themes as prismThemes} from 'prism-react-renderer';
 import thunderConfig from './docusaurus.thunder.config';
+import llmsOriginRelativePlugin from './plugins/llmsOriginRelativePlugin';
 import personaPlugin from './plugins/personaPlugin';
 import webpackPlugin from './plugins/webpackPlugin';
 
@@ -83,6 +84,7 @@ const config: Config = {
         description: thunderConfig.project.description,
       },
     ],
+    llmsOriginRelativePlugin,
   ],
 
   presets: [

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -19,8 +19,8 @@
 import type * as Preset from '@docusaurus/preset-classic';
 import type {Config} from '@docusaurus/types';
 import {themes as prismThemes} from 'prism-react-renderer';
-import personaPlugin from './plugins/personaPlugin';
 import thunderConfig from './docusaurus.thunder.config';
+import personaPlugin from './plugins/personaPlugin';
 import webpackPlugin from './plugins/webpackPlugin';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
@@ -67,7 +67,23 @@ const config: Config = {
     },
   },
 
-  plugins: [webpackPlugin, personaPlugin],
+  plugins: [
+    webpackPlugin,
+    personaPlugin,
+    [
+      'docusaurus-plugin-llms',
+      {
+        docsDir: 'content',
+        excludeImports: true,
+        generateLLMsFullTxt: true,
+        generateLLMsTxt: true,
+        generateMarkdownFiles: true,
+        removeDuplicateHeadings: true,
+        title: `${thunderConfig.project.name} Documentation`,
+        description: thunderConfig.project.description,
+      },
+    ],
+  ],
 
   presets: [
     [

--- a/docs/package.json
+++ b/docs/package.json
@@ -60,6 +60,7 @@
     "@docusaurus/module-type-aliases": "3.9.2",
     "@docusaurus/tsconfig": "3.9.2",
     "@docusaurus/types": "3.9.2",
+    "docusaurus-plugin-llms": "0.4.0",
     "openapi-to-postmanv2": "4.23.0",
     "typescript": "catalog:",
     "yaml": "2.8.2"

--- a/docs/plugins/llmsOriginRelativePlugin.ts
+++ b/docs/plugins/llmsOriginRelativePlugin.ts
@@ -16,14 +16,11 @@
  * under the License.
  */
 
-import {access, readFile, writeFile} from 'fs/promises';
+import {readFile, writeFile} from 'fs/promises';
 import {join} from 'path';
-import {setTimeout as sleep} from 'timers/promises';
 import type {Plugin} from '@docusaurus/types';
 
 const llmsFiles = ['llms.txt', 'llms-full.txt'];
-const llmsGenerationTimeoutMs = 30000;
-const llmsGenerationPollIntervalMs = 100;
 
 const isMissingFileError = (error: unknown): boolean => {
   if (typeof error !== 'object' || error === null || !('code' in error)) {
@@ -43,26 +40,6 @@ const normalizeBaseUrl = (baseUrl: string | undefined): string => {
   return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`;
 };
 
-const waitForFile = async (filePath: string): Promise<boolean> => {
-  const deadline = Date.now() + llmsGenerationTimeoutMs;
-
-  while (Date.now() < deadline) {
-    try {
-      await access(filePath);
-
-      return true;
-    } catch (error) {
-      if (!isMissingFileError(error)) {
-        throw error;
-      }
-
-      await sleep(llmsGenerationPollIntervalMs);
-    }
-  }
-
-  return false;
-};
-
 // TODO: Remove this plugin once both of the following are resolved:
 // 1. docusaurus-plugin-llms adds native support for origin-relative URL generation
 //    (tracked at https://github.com/rachfop/docusaurus-plugin-llms/issues/42).
@@ -77,11 +54,6 @@ export default function llmsOriginRelativePlugin(): Plugin {
     async postBuild({siteConfig, outDir}) {
       const baseUrl = normalizeBaseUrl(siteConfig.baseUrl);
       const absoluteBaseUrl = `${siteConfig.url.replace(/\/$/, '')}${baseUrl}`;
-      const llmsTxtPath = join(outDir, 'llms.txt');
-
-      if (!(await waitForFile(llmsTxtPath))) {
-        return;
-      }
 
       for (const file of llmsFiles) {
         const filePath = join(outDir, file);

--- a/docs/plugins/llmsOriginRelativePlugin.ts
+++ b/docs/plugins/llmsOriginRelativePlugin.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {access, readFile, writeFile} from 'fs/promises';
+import {join} from 'path';
+import {setTimeout as sleep} from 'timers/promises';
+import type {Plugin} from '@docusaurus/types';
+
+const llmsFiles = ['llms.txt', 'llms-full.txt'];
+const llmsGenerationTimeoutMs = 30000;
+const llmsGenerationPollIntervalMs = 100;
+
+const isMissingFileError = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return false;
+  }
+
+  return (error as {code?: unknown}).code === 'ENOENT';
+};
+
+const normalizeBaseUrl = (baseUrl: string | undefined): string => {
+  if (!baseUrl || baseUrl === '/') {
+    return '/';
+  }
+
+  const withLeadingSlash = baseUrl.startsWith('/') ? baseUrl : `/${baseUrl}`;
+
+  return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`;
+};
+
+const waitForFile = async (filePath: string): Promise<boolean> => {
+  const deadline = Date.now() + llmsGenerationTimeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      await access(filePath);
+
+      return true;
+    } catch (error) {
+      if (!isMissingFileError(error)) {
+        throw error;
+      }
+
+      await sleep(llmsGenerationPollIntervalMs);
+    }
+  }
+
+  return false;
+};
+
+// TODO: Remove this plugin once both of the following are resolved:
+// 1. docusaurus-plugin-llms adds native support for origin-relative URL generation
+//    (tracked at https://github.com/rachfop/docusaurus-plugin-llms/issues/42).
+// 2. Docusaurus supports subpaths in the `url` config field, allowing the real
+//    deployment URL (GitHub Pages) to be set instead of the current placeholder.
+//    Until then, absolute URLs baked into llms.txt by the plugin would point to the
+//    wrong host, so this plugin rewrites them to origin-relative paths at build time.
+export default function llmsOriginRelativePlugin(): Plugin {
+  return {
+    name: 'thunder-llms-origin-relative-plugin',
+
+    async postBuild({siteConfig, outDir}) {
+      const baseUrl = normalizeBaseUrl(siteConfig.baseUrl);
+      const absoluteBaseUrl = `${siteConfig.url.replace(/\/$/, '')}${baseUrl}`;
+      const llmsTxtPath = join(outDir, 'llms.txt');
+
+      if (!(await waitForFile(llmsTxtPath))) {
+        return;
+      }
+
+      for (const file of llmsFiles) {
+        const filePath = join(outDir, file);
+
+        try {
+          const content = await readFile(filePath, 'utf8');
+          const nextContent = content.replaceAll(absoluteBaseUrl, baseUrl);
+
+          if (nextContent !== content) {
+            await writeFile(filePath, nextContent);
+          }
+        } catch (error) {
+          if (isMissingFileError(error)) {
+            continue;
+          }
+
+          throw error;
+        }
+      }
+    },
+  };
+}

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -26,7 +26,8 @@ import thunderConfig from './docusaurus.thunder.config';
 
 // TODO: Use `@wso2/oxygen-ui-icons` in the sidebar. Currently, there's only a React wrapper available, so we need to create custom SVG icons for the sidebar until we have a web component version of the icons.
 
-const llmsTxtHref = `pathname:///${thunderConfig.documentation.deployment.production.baseUrl}/llms.txt`;
+const productionBaseUrl = thunderConfig.documentation.deployment.production.baseUrl.replace(/^\/+|\/+$/g, '');
+const llmsTxtHref = `pathname:///${productionBaseUrl}/llms.txt`;
 
 /**
  * Creating a sidebar enables you to:

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -20,10 +20,13 @@
 
 import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 import reactSdkSidebar from './content/sdks/react/sidebar';
+import thunderConfig from './docusaurus.thunder.config';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 // TODO: Use `@wso2/oxygen-ui-icons` in the sidebar. Currently, there's only a React wrapper available, so we need to create custom SVG icons for the sidebar until we have a web component version of the icons.
+
+const llmsTxtHref = `pathname:///${thunderConfig.documentation.deployment.production.baseUrl}/llms.txt`;
 
 /**
  * Creating a sidebar enables you to:
@@ -87,6 +90,11 @@ const sidebars: SidebarsConfig = {
           type: 'doc',
           id: 'guides/working-with-ai/mcp-server',
           label: 'MCP Server',
+        },
+        {
+          type: 'link',
+          href: llmsTxtHref,
+          label: 'llms.txt',
         },
       ],
     },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       '@docusaurus/types':
         specifier: 3.9.2
         version: 3.9.2(@swc/core@1.15.21(@swc/helpers@0.5.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      docusaurus-plugin-llms:
+        specifier: 0.4.0
+        version: 0.4.0(@docusaurus/core@3.9.2(@mdx-js/react@3.0.0(@types/react@19.2.7)(react@19.2.3))(@swc/core@1.15.21(@swc/helpers@0.5.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
       openapi-to-postmanv2:
         specifier: 4.23.0
         version: 4.23.0
@@ -5719,6 +5722,9 @@ packages:
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -6490,6 +6496,12 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  docusaurus-plugin-llms@0.4.0:
+    resolution: {integrity: sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -8615,6 +8627,10 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -17918,6 +17934,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.2
@@ -18714,6 +18734,13 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  docusaurus-plugin-llms@0.4.0(@docusaurus/core@3.9.2(@mdx-js/react@3.0.0(@types/react@19.2.7)(react@19.2.3))(@swc/core@1.15.21(@swc/helpers@0.5.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)):
+    dependencies:
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.0.0(@types/react@19.2.7)(react@19.2.3))(@swc/core@1.15.21(@swc/helpers@0.5.18))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      gray-matter: 4.0.3
+      minimatch: 9.0.9
+      yaml: 2.8.3
 
   dom-accessibility-api@0.5.16: {}
 
@@ -21424,6 +21451,10 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.13
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
### Purpose

Adds `llms.txt` (and `llms-full.txt`) to the Thunder documentation site, making the docs machine-readable for LLMs. The file will be hosted at `https://asgardeo.github.io/thunder/llms.txt` once deployed.

A sidebar link under the **Working with AI** section lets users discover the file directly from the docs.

#### Note on the domain configuration

Docusaurus requires a fully-qualified `url` in its config to construct absolute links. Thunder's config currently uses `https://thunder.dev` as a placeholder because the real GitHub Pages deployment URL (`https://asgardeo.github.io/thunder`) hasn't been set yet.

`docusaurus-plugin-llms` inherits this limitation: it bakes the absolute `url + baseUrl` prefix into every link inside `llms.txt`, resulting in `https://thunder.dev/thunder/...` URLs that would not resolve on the actual deployment host.

To work around this, a small post-build plugin (`llmsOriginRelativePlugin`) rewrites those absolute URLs to origin-relative paths (`/thunder/...`) after the build, so links in `llms.txt` resolve correctly regardless of which host serves the docs.

One upstream issue tracks the long-term fix for this workaround:
- `docusaurus-plugin-llms` native origin-relative URL support: https://github.com/rachfop/docusaurus-plugin-llms/issues/42

### Approach

- Adds `docusaurus-plugin-llms@0.4.0` to generate `llms.txt` and `llms-full.txt` at build time
- Adds `llmsOriginRelativePlugin` as a post-build step to rewrite absolute URLs to origin-relative paths
- Adds a sidebar link to `llms.txt` under the AI/MCP section

### References

- [llmstxt.org](https://llmstxt.org/) — the `llms.txt` standard specification
- [docusaurus-plugin-llms](https://github.com/rachfop/docusaurus-plugin-llms) — the Docusaurus plugin used to generate `llms.txt`

### Related Issues

- Fixes #1565

### Related PRs

- N/A

### Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks

- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

### Attachments

https://github.com/user-attachments/assets/12fbb3b4-1bcf-4442-b51f-b5c55f54ac86
