### PR TITLE
Add react releases page to display Thunder release information and download options

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -212,9 +212,8 @@ const config: Config = {
           className: 'navbar__link--dropdown',
           items: [
             {
-              type: 'doc',
-              docId: 'releases',
               label: 'Releases',
+              href: '/docs/next/releases',
               className: 'navbar-resources__releases',
             },
             {

--- a/docs/docusaurus.product.config.ts
+++ b/docs/docusaurus.product.config.ts
@@ -70,7 +70,7 @@ const DocusaurusProductConfig = {
         url: 'https://github.com/thunder-id/thunderid',
         discussionsUrl: 'https://github.com/thunder-id/thunderid/discussions',
         issuesUrl: 'https://github.com/thunder-id/thunderid/issues',
-        releasesUrl: 'https://github.com/thunder-id/thunderid/releases',
+        releasesUrl: '/docs/next/releases',
         editUrls: {
           blog: 'https://github.com/thunder-id/thunderid/tree/main/blog/',
           content: 'https://github.com/thunder-id/thunderid/tree/main/docs/',

--- a/docs/scripts/generate-changelog.mjs
+++ b/docs/scripts/generate-changelog.mjs
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {writeFileSync, readFileSync} from 'fs';
+import {existsSync, mkdirSync, writeFileSync} from 'fs';
 import {join, dirname} from 'path';
 import {fileURLToPath} from 'url';
 import {createLogger} from '@thunderid/logger';
@@ -24,45 +24,92 @@ import {createLogger} from '@thunderid/logger';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const PRODUCT_CONFIG_PATH = join(__dirname, '..', 'docusaurus.product.config.ts');
-
-function readProductConfig(configPath) {
-  const content = readFileSync(configPath, 'utf8');
-  const nameMatch = content.match(/project\s*:\s*\{[^}]*?name\s*:\s*['"]([^'"]+)['"]/s);
-  const projectName = nameMatch ? nameMatch[1] : 'Unknown Project';
-  const fullNameMatch = content.match(/fullName\s*:\s*['"]([^'"]+)['"]/);
-  const githubFullName = fullNameMatch ? fullNameMatch[1] : '';
-  const [githubOwner = '', githubRepoName = projectName.toLowerCase()] = githubFullName.split('/');
-  return {projectName, githubFullName, githubOwner, githubRepoName};
-}
-
-const {projectName, githubFullName, githubOwner, githubRepoName} = readProductConfig(PRODUCT_CONFIG_PATH);
-
-const OUTPUT_FILE = join(__dirname, '..', 'content', 'releases.md');
-const GITHUB_REPO = githubFullName;
-const GITHUB_API_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases`;
+const OUTPUT_FILE = join(__dirname, '..', 'static', 'data', 'releases.json');
+const GITHUB_REPO = 'asgardeo/thunder';
+const GITHUB_REPO_API_URL = `https://api.github.com/repos/${GITHUB_REPO}`;
+const GITHUB_RELEASES_API_URL = `${GITHUB_REPO_API_URL}/releases`;
 
 const logger = createLogger('generate-changelog');
 
 // Cache for user avatars to avoid repeated API calls.
 const userAvatarCache = {};
+const ignoredContributorUsernames = [
+  '123',
+  'asgardeo',
+  'copilot',
+  'dependabot',
+  'example',
+  'renovate',
+  'thunder',
+  'wso2',
+  '7',
+].map((u) => u.toLowerCase());
+
+function getGitHubHeaders() {
+  return {
+    'User-Agent': 'Thunder-Docs-Changelog-Generator',
+    ...(process.env.GITHUB_TOKEN ? {Authorization: `token ${process.env.GITHUB_TOKEN}`} : {}),
+  };
+}
+
+async function fetchJson(url) {
+  const {body} = await fetchJsonWithHeaders(url);
+
+  return body;
+}
+
+async function fetchJsonWithHeaders(url) {
+  const response = await fetch(url, {
+    headers: getGitHubHeaders(),
+  });
+
+  if (!response.ok) {
+    const error = new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+
+    error.status = response.status;
+    throw error;
+  }
+
+  return {
+    body: await response.json(),
+    headers: response.headers,
+  };
+}
+
+async function fetchRepository() {
+  logger.info(`Fetching repository metadata from ${GITHUB_REPO_API_URL}...`);
+
+  try {
+    return await fetchJson(GITHUB_REPO_API_URL);
+  } catch (error) {
+    logger.error('Error fetching repository metadata:', error);
+
+    return null;
+  }
+}
 
 async function fetchReleases() {
-  logger.info(`Fetching releases from ${GITHUB_API_URL}...`);
-  try {
-    const response = await fetch(GITHUB_API_URL, {
-      headers: {
-        'User-Agent': `${projectName}-Docs-Changelog-Generator`,
-        // Add Authorization header if GITHUB_TOKEN is present to avoid rate limits.
-        ...(process.env.GITHUB_TOKEN ? {Authorization: `token ${process.env.GITHUB_TOKEN}`} : {}),
-      },
-    });
+  logger.info(`Fetching releases from ${GITHUB_RELEASES_API_URL}...`);
 
-    if (!response.ok) {
-      throw new Error(`Failed to fetch releases: ${response.status} ${response.statusText}`);
+  try {
+    const releases = [];
+    let nextUrl = `${GITHUB_RELEASES_API_URL}?per_page=100`;
+
+    while (nextUrl) {
+      const {body, headers} = await fetchJsonWithHeaders(nextUrl);
+
+      if (!Array.isArray(body)) {
+        throw new Error(`Failed to fetch ${nextUrl}: unexpected response format`);
+      }
+
+      releases.push(...body);
+
+      const linkHeader = headers.get('link') || '';
+      const nextLinkMatch = linkHeader.match(/<([^>]+)>\s*;\s*rel="next"/i);
+
+      nextUrl = nextLinkMatch ? nextLinkMatch[1] : null;
     }
 
-    const releases = await response.json();
     return releases;
   } catch (error) {
     logger.error('Error fetching releases:', error);
@@ -70,37 +117,30 @@ async function fetchReleases() {
   }
 }
 
-function sanitizeReleaseBody(body, releaseTag) {
-  // Convert HTML img tags to Markdown img syntax and remove p tags.
-  // This prevents MDX compilation errors with mixed HTML and Markdown.
+function sanitizeReleaseBody(body = '', releaseTag) {
   let sanitized = body
     .replace(/<p\s+align="left">\s*<img\s+src="([^"]+)"\s+alt="([^"]*)"\s+width="([^"]+)">\s*<\/p>/g, '![$2]($1)')
     .replace(/<p\s+align="left">/g, '')
     .replace(/<\/p>/g, '')
     .replace(/<img\s+src="([^"]+)"\s+alt="([^"]*)"\s+width="([^"]+)">/g, '![$2]($1)');
 
-  // Convert relative image paths to absolute GitHub URLs.
-  // Matches markdown image syntax: ![alt](path).
   sanitized = sanitized.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt, src) => {
-    // If the path is relative (doesn't start with http), convert to GitHub raw content URL.
     if (!src.startsWith('http')) {
-      // Use the tag_name from the release to construct the correct GitHub URL.
-      const githubRawUrl = `https://raw.githubusercontent.com/${githubFullName}/${releaseTag}/${src}`;
+      const githubRawUrl = `https://raw.githubusercontent.com/asgardeo/thunder/${releaseTag}/${src}`;
+
       return `![${alt}](${githubRawUrl})`;
     }
+
     return match;
   });
 
-  // Escape angle brackets that look like template variables (e.g., <os>, <arch>, <version>).
-  // to prevent MDX parser from treating them as JSX tags.
-  // This regex matches <word> patterns that are not part of valid HTML tags.
   sanitized = sanitized.replace(/<([a-zA-Z_-]+)>/g, (match, word) => {
-    // List of actual HTML tags to preserve
     const htmlTags = ['div', 'img', 'p', 'span', 'a', 'strong', 'em', 'br', 'hr'];
+
     if (!htmlTags.includes(word.toLowerCase())) {
-      // Replace with HTML entities to prevent MDX parser issues.
       return `&lt;${word}&gt;`;
     }
+
     return match;
   });
 
@@ -122,94 +162,65 @@ function sanitizeReleaseBody(body, releaseTag) {
 }
 
 async function fetchUserAvatar(username) {
-  // Return cached avatar if available.
-  if (userAvatarCache[username]) {
+  if (Object.prototype.hasOwnProperty.call(userAvatarCache, username)) {
     return userAvatarCache[username];
   }
 
   try {
-    const response = await fetch(`https://api.github.com/users/${username}`, {
-      headers: {
-        'User-Agent': `${projectName}-Docs-Changelog-Generator`,
-        ...(process.env.GITHUB_TOKEN ? {Authorization: `token ${process.env.GITHUB_TOKEN}`} : {}),
-      },
-    });
+    const data = await fetchJson(`https://api.github.com/users/${username}`);
 
-    if (response.ok) {
-      const data = await response.json();
-      userAvatarCache[username] = {
-        avatar: data.avatar_url,
-        url: data.html_url,
-      };
-      return userAvatarCache[username];
-    }
+    userAvatarCache[username] = {
+      avatarUrl: data.avatar_url,
+      profileUrl: data.html_url,
+      username,
+    };
+
+    return userAvatarCache[username];
   } catch (error) {
-    logger.warn(`Failed to fetch avatar for ${username}: ${error.message}`);
-  }
+    userAvatarCache[username] = null;
 
-  return null;
+    if (error.status !== 404) {
+      logger.warn(`Failed to fetch avatar for ${username}: ${error.message}`);
+    }
+
+    return null;
+  }
 }
 
 function extractContributorsFromBody(body) {
-  // Extract unique usernames mentioned with @ symbol.
   const mentions = body.match(/@([a-zA-Z0-9-]+)/g) || [];
-  const uniqueContributors = [...new Set(mentions.map((m) => m.substring(1)))];
+  const uniqueContributors = [...new Set(mentions.map((mention) => mention.substring(1)))];
 
-  // Filter out common non-user mentions and known non-user references.
-  return uniqueContributors.filter(
-    (username) =>
-      ![
-        'dependabot',
-        'renovate',
-        'example',
-        'wso2',
-        '123',
-        githubOwner.toLowerCase(),
-        githubRepoName.toLowerCase(),
-      ].includes(username.toLowerCase()),
-  );
+  return uniqueContributors.filter((username) => !ignoredContributorUsernames.includes(username.toLowerCase()));
 }
 
 function cleanChangeText(text) {
-  // Remove "by @username in PR_LINK" pattern.
-  // Pattern: " by @<username> in https://github.com/...".
   return text.replace(/\s+by\s+@[\w-]+\s+in\s+https:\/\/github\.com\/\S+/, '').trim();
 }
 
+function isNewContributorLine(text) {
+  return /made their first contribution/i.test(text);
+}
+
 function extractNewContributorUsernames(body) {
-  // Extract usernames from "New Contributors" section.
-  // Pattern: "* @username made their first contribution...".
   const newContributorsMatch = body.match(/New Contributors[\s\S]*?(?=###|$)/);
+
   if (!newContributorsMatch) {
     return [];
   }
 
   const mentions = (newContributorsMatch[0] || '').match(/@([a-zA-Z0-9-]+)/g) || [];
-  const usernames = [...new Set(mentions.map((m) => m.substring(1)))];
+  const usernames = [...new Set(mentions.map((mention) => mention.substring(1)))];
 
-  // Filter out common non-user mentions and known non-user references.
-  return usernames.filter(
-    (username) =>
-      ![
-        'dependabot',
-        'renovate',
-        'example',
-        'wso2',
-        '123',
-        githubOwner.toLowerCase(),
-        githubRepoName.toLowerCase(),
-      ].includes(username.toLowerCase()),
-  );
+  return usernames.filter((username) => !ignoredContributorUsernames.includes(username.toLowerCase()));
 }
 
 function extractChanges(body) {
-  // Extract and categorize changes from the release body.
   const categories = {
     breaking: [],
+    bugs: [],
     features: [],
     improvements: [],
-    bugs: [],
-    contributors: [],
   };
 
   const lines = body.split('\n');
@@ -226,17 +237,14 @@ function extractChanges(body) {
       currentCategory = 'improvements';
     } else if (trimmed.includes('Bug Fixes') || trimmed.includes('🐛')) {
       currentCategory = 'bugs';
-    } else if (trimmed.includes('New Contributors') || trimmed.includes('Contributors')) {
-      currentCategory = 'contributors';
     } else if (trimmed.startsWith('*') && currentCategory) {
       const cleanedText = cleanChangeText(trimmed.substring(1).trim());
-
-      // Filter out unwanted lines.
       const isFullChangelog = cleanedText.toLowerCase().includes('full changelog');
       const isNoteAboutSampleApp = cleanedText.toLowerCase().includes('note the id of the sample app');
       const isEmptyOrLink = !cleanedText || cleanedText.startsWith('http');
+      const isNewContributor = isNewContributorLine(cleanedText);
 
-      if (cleanedText && !isFullChangelog && !isNoteAboutSampleApp && !isEmptyOrLink) {
+      if (cleanedText && !isFullChangelog && !isNoteAboutSampleApp && !isEmptyOrLink && !isNewContributor) {
         categories[currentCategory].push(cleanedText);
       }
     }
@@ -245,101 +253,130 @@ function extractChanges(body) {
   return categories;
 }
 
-async function formatChangelog(releases) {
-  let content = '# Releases\n\n';
-  content += `Explore the latest updates, features, and improvements to **${projectName}**.\n\n`;
-  content += '---\n\n';
-
-  if (releases.length === 0) {
-    content += 'No release notes found.\n';
-    return content;
+function formatBytes(bytes) {
+  if (!bytes) {
+    return '0 B';
   }
 
-  for (const release of releases) {
-    if (release.draft) continue;
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const unitIndex = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** unitIndex;
 
-    const date = new Date(release.published_at).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
+  return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function pickPrimaryAsset(assets) {
+  if (assets.length === 0) {
+    return null;
+  }
+
+  return (
+    assets.find((asset) => /thunder-.*\.(zip|tgz|tar\.gz)$/i.test(asset.name)) ||
+    assets.find((asset) => /\.(zip|tgz|tar\.gz)$/i.test(asset.name)) ||
+    assets[0]
+  );
+}
+
+async function buildContributorProfiles(usernames) {
+  const profiles = await Promise.all(
+    usernames.map(async (username) => {
+      const profile = await fetchUserAvatar(username);
+
+      return (
+        profile || {
+          avatarUrl: null,
+          profileUrl: `https://github.com/${username}`,
+          username,
+        }
+      );
+    }),
+  );
+
+  return profiles.filter(Boolean);
+}
+
+async function buildReleaseEntry(release) {
+  const sanitizedBody = sanitizeReleaseBody(release.body, release.tag_name);
+  const contributors = await buildContributorProfiles(extractContributorsFromBody(sanitizedBody));
+  const newContributors = await buildContributorProfiles(extractNewContributorUsernames(sanitizedBody));
+  const changes = extractChanges(sanitizedBody);
+  const assets = (release.assets || []).map((asset) => ({
+    contentType: asset.content_type,
+    downloadCount: asset.download_count,
+    downloadUrl: asset.browser_download_url,
+    id: asset.id,
+    name: asset.name,
+    sizeBytes: asset.size,
+    sizeLabel: formatBytes(asset.size),
+    updatedAt: asset.updated_at,
+  }));
+  const primaryAsset = pickPrimaryAsset(assets);
+
+  return {
+    assets,
+    body: sanitizedBody,
+    changes,
+    contributors,
+    htmlUrl: release.html_url,
+    id: release.id,
+    isDraft: release.draft,
+    isLatest: false,
+    isPrerelease: release.prerelease,
+    name: release.name || release.tag_name,
+    newContributors,
+    primaryDownloadUrl: primaryAsset?.downloadUrl || release.html_url,
+    publishedAt: release.published_at,
+    publishedDateLabel: new Date(release.published_at).toLocaleDateString('en-US', {
       day: 'numeric',
-    });
-    const versionName = release.tag_name; // Use tag_name for shorter TOC entries.
+      month: 'long',
+      year: 'numeric',
+    }),
+    tagName: release.tag_name,
+  };
+}
 
-    // Visual Header for the Release.
-    content += `## ${versionName} {#${release.tag_name.toLowerCase().replace(/\./g, '-')}}\n`;
-    content += `<p style={{ fontSize: '0.9rem', color: '#666', marginTop: '-10px', marginBottom: '20px' }}>\n`;
-    content += `  <span>📅 Published on <strong>${date}</strong></span> • \n`;
-    content += `  <a href="${release.html_url}" target="_blank" style={{ textDecoration: 'none' }}>View on GitHub ↗</a>\n`;
-    content += `</p>\n\n`;
+async function buildChangelogData(repository, releases) {
+  const publishedReleases = releases.filter((release) => !release.draft);
+  const releaseEntries = await Promise.all(publishedReleases.map(buildReleaseEntry));
 
-    const sanitizedBody = sanitizeReleaseBody(release.body, release.tag_name);
-    const changes = extractChanges(sanitizedBody);
-
-    // Render Contributors with a better layout.
-    const contributors = extractContributorsFromBody(sanitizedBody);
-    if (contributors.length > 0) {
-      content += `<div style={{ padding: '15px', marginBottom: '10px',}}>\n`;
-      content += `<span style={{ fontSize: '0.85rem', fontWeight: 'bold', display: 'block', marginBottom: '10px', color: '#555', textTransform: 'uppercase' }}>Contributors</span>\n`;
-      content += `<div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>\n`;
-
-      for (const username of contributors) {
-        const userInfo = await fetchUserAvatar(username);
-        if (userInfo) {
-          content += `  <a href="${userInfo.url}" title="${username}" target="_blank" style={{ transition: 'transform 0.2s' }}>\n`;
-          content += `    <img src="${userInfo.avatar}" width="55" height="55" style={{ borderRadius: '50%', border: '2px solid #ff8c00', boxShadow: '0 2px 4px rgba(0,0,0,0.1)' }} alt="${username}" />\n`;
-          content += `  </a>\n`;
-        }
-      }
-      content += `</div></div>\n\n`;
-    }
-
-    // Render New Contributors section.
-    const newContributors = extractNewContributorUsernames(sanitizedBody);
-    if (newContributors.length > 0) {
-      content += `<div style={{ padding: '15px', marginBottom: '40px',}}>\n`;
-      content += `<span style={{ fontSize: '0.85rem', fontWeight: 'bold', display: 'block', marginBottom: '10px', color: '#555', textTransform: 'uppercase' }}>New Contributors</span>\n`;
-      content += `<div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>\n`;
-
-      for (const username of newContributors) {
-        const userInfo = await fetchUserAvatar(username);
-        if (userInfo) {
-          content += `  <a href="${userInfo.url}" title="${username}" target="_blank" style={{ transition: 'transform 0.2s' }}>\n`;
-          content += `    <img src="${userInfo.avatar}" width="55" height="55" style={{ borderRadius: '50%', border: '2px solid #ff8c00', boxShadow: '0 2px 4px rgba(0,0,0,0.1)' }} alt="${username}" />\n`;
-          content += `  </a>\n`;
-        }
-      }
-      content += `</div></div>\n\n`;
-    }
-
-    // Categorized Changes with cleaner list styling.
-    const renderCategory = (title, items, icon) => {
-      if (items.length === 0) return '';
-      let section = `#### ${icon} ${title}\n\n`;
-      section += `<div style={{ borderLeft: '3px solid #ff8c00', paddingLeft: '5px', marginLeft: '8px', marginBottom: '24px' }}>\n`;
-      items.forEach((item) => {
-        section += `- ${item}\n`;
-      });
-      section += `</div>\n\n`;
-      return section;
-    };
-
-    content += renderCategory('Breaking Changes', changes.breaking, '⚠️');
-    content += renderCategory('Features', changes.features, '🚀');
-    content += renderCategory('Improvements', changes.improvements, '✨');
-    content += renderCategory('Bug Fixes', changes.bugs, '🐛');
-
-    content += `\n<hr style={{ border: 'none', borderTop: '1px solid #eaeaea', margin: '40px 0' }} />\n\n`;
+  const latestEntry = releaseEntries.find((entry) => !entry.isPrerelease) ?? releaseEntries[0];
+  if (latestEntry) {
+    latestEntry.isLatest = true;
   }
 
-  return content;
+  return {
+    generatedAt: new Date().toISOString(),
+    latestRelease: latestEntry || null,
+    releases: releaseEntries,
+    repository: {
+      description: repository?.description || 'Thunder release notes and downloads.',
+      forks: repository?.forks_count || 0,
+      fullName: repository?.full_name || GITHUB_REPO,
+      stars: repository?.stargazers_count || 0,
+      subscribers: repository?.subscribers_count || 0,
+      url: repository?.html_url || `https://github.com/${GITHUB_REPO}`,
+      releasesUrl: `${repository?.html_url || `https://github.com/${GITHUB_REPO}`}/releases`,
+    },
+  };
 }
 
 async function generate() {
   try {
-    const releases = await fetchReleases();
-    const markdown = await formatChangelog(releases);
-    writeFileSync(OUTPUT_FILE, markdown, 'utf8');
-    logger.info(`✅ Changelog generated at ${OUTPUT_FILE}`);
+    const [repository, releases] = await Promise.all([fetchRepository(), fetchReleases()]);
+
+    if (!repository && releases.length === 0) {
+      if (existsSync(OUTPUT_FILE)) {
+        logger.warn(`Skipping changelog data update because GitHub data is unavailable. Preserving ${OUTPUT_FILE}.`);
+
+        return;
+      }
+    }
+
+    const changelogData = await buildChangelogData(repository, releases);
+
+    mkdirSync(dirname(OUTPUT_FILE), {recursive: true});
+    writeFileSync(OUTPUT_FILE, `${JSON.stringify(changelogData, null, 2)}\n`, 'utf8');
+    logger.info(`Changelog data generated at ${OUTPUT_FILE}`);
   } catch (error) {
     logger.error('❌ Failed to generate changelog — keeping existing file:', error);
   }

--- a/docs/src/components/icons/LinuxLogo.tsx
+++ b/docs/src/components/icons/LinuxLogo.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+
+export default function LinuxLogo({size = 18}: {size?: number}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M12 2.2c1.8 0 3.2 1.4 3.2 3.2v2.1c0 .9-.4 1.8-1 2.4.8.8 1.4 1.9 1.4 3.2v1.7c0 1.8-1.5 3.3-3.3 3.3h-.6c-1.8 0-3.3-1.5-3.3-3.3v-1.7c0-1.3.5-2.4 1.4-3.2-.7-.6-1-1.5-1-2.4V5.4c0-1.8 1.4-3.2 3.2-3.2Z"
+        fill="currentColor"
+      />
+      <circle cx="10.5" cy="6.4" r=".8" fill="#fff" />
+      <circle cx="13.5" cy="6.4" r=".8" fill="#fff" />
+      <path d="M6.7 17.2c1.1 0 2 .9 2 2v.9c0 1-.9 1.9-2 1.9s-2-.9-2-1.9v-.9c0-1.1.9-2 2-2Z" fill="currentColor" />
+      <path d="M17.3 17.2c1.1 0 2 .9 2 2v.9c0 1-.9 1.9-2 1.9s-2-.9-2-1.9v-.9c0-1.1.9-2 2-2Z" fill="currentColor" />
+      <path d="M10.2 9.8c.5.3 1.1.5 1.8.5s1.3-.2 1.8-.5" stroke="#fff" strokeWidth=".9" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/docs/src/components/icons/WindowsLogo.tsx
+++ b/docs/src/components/icons/WindowsLogo.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+
+export default function WindowsLogo({size = 18}: {size?: number}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M2 3.2 11 2v9H2V3.2Zm10 7.8h10V0.8L12 1.9V11Zm0 1v9.1l10 1.1V12H12ZM2 12v7.8l9 1.1V12H2Z" />
+    </svg>
+  );
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -514,15 +514,438 @@ html[data-page='home'][data-theme='dark'] .dropdown>.navbar__link:after {
   text-transform: capitalize;
 }
 
-/* ------------------------------ Releases Page TOC Spacing ---------------------- */
+/* ------------------------------ Releases Page ---------------------- */
 
-/* Increase space between main content and right sidebar TOC */
-.theme-doc-toc-desktop {
-  padding-left: 2rem;
+.releases-page main {
+  background-attachment: var(--site-background-attachment);
+  background-image: var(--site-background);
+  background-blend-mode: var(--site-background-blend-mode);
+  min-width: 0;
+  overflow-x: hidden;
 }
 
-.table-of-contents {
-  padding: 1.5rem 1rem;
+.releases-shell {
+  width: 100%;
+  max-width: 1200px;
+  min-width: 0;
+  margin: 0 auto;
+  padding: 4rem 1.5rem 5rem;
+}
+
+.releases-hero {
+  display: grid;
+  gap: 1.5rem;
+  margin-bottom: 4rem;
+}
+
+.releases-hero h1 {
+  margin: 0;
+  font-size: clamp(3rem, 7vw, 5.3rem);
+  line-height: 0.95;
+}
+
+.releases-hero p,
+.releases-status,
+.releases-release-header p,
+.releases-footer-note p {
+  color: rgba(17, 24, 39, 0.7);
+}
+
+.releases-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.releases-status {
+  margin: 0 0 2rem;
+}
+
+.releases-latest {
+  margin-bottom: 3rem;
+}
+
+.releases-release-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.releases-version-picker {
+  display: grid;
+  gap: 0.45rem;
+  min-width: min(100%, 260px);
+}
+
+.releases-version-picker span {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(17, 24, 39, 0.62);
+}
+
+.releases-version-picker select {
+  width: 100%;
+  min-height: 2.9rem;
+  padding: 0.75rem 0.95rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 0.95rem;
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--ifm-font-color-base);
+  font: inherit;
+}
+
+.releases-release-card {
+  width: 100%;
+  min-width: 0;
+  padding: 2rem;
+  border-radius: 1.8rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.08);
+}
+
+.releases-release-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.releases-release-title-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.releases-release-header h2 {
+  margin: 0;
+  font-size: 2.2rem;
+  line-height: 1.1;
+}
+
+.releases-release-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.28rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 153, 0, 0.12);
+  color: #b76500;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.releases-section-block {
+  margin-top: 2rem;
+}
+
+.releases-download-feature {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1.25rem;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding: 1.35rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 107, 0, 0.14);
+  background:
+    radial-gradient(circle at top right, rgba(255, 140, 0, 0.14), transparent 35%),
+    linear-gradient(180deg, rgba(255, 250, 245, 0.98) 0%, rgba(255, 255, 255, 0.92) 100%);
+}
+
+.releases-download-feature-copy {
+  display: grid;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.releases-download-feature-kicker {
+  color: #FF6B00;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.releases-download-feature h3 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.releases-download-feature-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 1rem;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: rgba(17, 24, 39, 0.58);
+  font-size: 0.9rem;
+}
+
+.releases-download-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: 2.9rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #FF6B00 0%, #FF8C00 100%);
+  color: #fff !important;
+  font-size: 0.92rem;
+  font-weight: 700;
+  text-decoration: none !important;
+}
+
+.releases-download-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(255, 107, 0, 0.24);
+}
+
+.releases-download-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 999px;
+  background: rgba(255, 107, 0, 0.08);
+  color: #FF6B00;
+}
+
+.releases-other-downloads-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.releases-other-downloads-card {
+  padding: 0.95rem 1rem;
+  border-radius: 1.15rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.76);
+}
+
+.releases-other-downloads-header {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 0.75rem;
+}
+
+.releases-other-downloads-header h4 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: rgba(17, 24, 39, 0.8);
+}
+
+.releases-other-downloads-os-icon {
+  display: inline-flex;
+  width: 1.3rem;
+  height: 1.3rem;
+  color: rgba(17, 24, 39, 0.72);
+}
+
+.releases-other-downloads-architectures {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.releases-other-downloads-architecture {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.25rem 0.5rem;
+  align-items: center;
+  min-height: 3.7rem;
+  padding: 0.65rem 0.8rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  background: rgba(255, 255, 255, 0.62);
+  color: inherit !important;
+  text-decoration: none !important;
+}
+
+.releases-other-downloads-architecture-title {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: rgba(17, 24, 39, 0.78);
+  font-size: 0.98rem;
+  font-weight: 600;
+}
+
+.releases-other-downloads-architecture-meta,
+.releases-other-downloads-architecture em {
+  color: rgba(17, 24, 39, 0.52);
+  font-size: 0.82rem;
+}
+
+.releases-other-downloads-architecture em {
+  grid-column: 2 / 3;
+  grid-row: 1 / 3;
+  font-style: normal;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.releases-change-grid {
+  display: grid;
+  gap: 1.4rem;
+  margin-top: 2rem;
+}
+
+.releases-change-group h3 {
+  margin: 0 0 0.7rem;
+  font-size: 1.2rem;
+}
+
+.releases-change-group ul {
+  margin: 0;
+  border-left: 2px solid rgba(255, 107, 0, 0.75);
+  padding-left: 1.35rem;
+}
+
+.releases-change-group li + li {
+  margin-top: 0.55rem;
+}
+
+.releases-change-group li {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.releases-contributors-avatar-group {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.releases-contributors-avatar-group .MuiAvatar-root {
+  width: 2.75rem;
+  height: 2.75rem;
+  font-size: 1rem;
+  border: 2px solid #fff;
+  background: #FF6B00;
+}
+
+.releases-contributor-avatar-link {
+  display: inline-flex;
+  border-radius: 999px;
+  line-height: 0;
+}
+
+.releases-contributor-avatar-link:hover {
+  transform: translateY(-2px);
+}
+
+.releases-footer-note {
+  padding-top: 1rem;
+}
+
+.releases-page .button--primary {
+  background-color: #FF6B00;
+}
+
+.releases-page .button--primary:hover {
+  background-color: #E55A00;
+}
+
+[data-theme='dark'] .releases-hero p,
+[data-theme='dark'] .releases-status,
+[data-theme='dark'] .releases-release-header p,
+[data-theme='dark'] .releases-version-picker span,
+[data-theme='dark'] .releases-footer-note p,
+[data-theme='dark'] .releases-download-feature-meta {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+[data-theme='dark'] .releases-release-card,
+[data-theme='dark'] .releases-other-downloads-card {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme='dark'] .releases-other-downloads-architecture {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+[data-theme='dark'] .releases-other-downloads-header h4,
+[data-theme='dark'] .releases-other-downloads-os-icon,
+[data-theme='dark'] .releases-other-downloads-architecture-title {
+  color: rgba(255, 255, 255, 0.76);
+}
+
+[data-theme='dark'] .releases-other-downloads-architecture-meta,
+[data-theme='dark'] .releases-other-downloads-architecture em {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+[data-theme='dark'] .releases-contributors-avatar-group .MuiAvatar-root {
+  border-color: rgba(15, 23, 42, 0.78);
+}
+
+[data-theme='dark'] .releases-version-picker select {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(15, 23, 42, 0.78);
+}
+
+[data-theme='dark'] .releases-download-feature {
+  border-color: rgba(255, 140, 0, 0.18);
+  background:
+    radial-gradient(circle at top right, rgba(255, 140, 0, 0.16), transparent 35%),
+    linear-gradient(180deg, rgba(33, 41, 54, 0.96) 0%, rgba(15, 23, 42, 0.88) 100%);
+}
+
+[data-theme='dark'] .releases-release-badge {
+  background: rgba(255, 190, 92, 0.12);
+  color: #ffc170;
+}
+
+[data-theme='dark'] .releases-download-icon {
+  background: rgba(255, 107, 0, 0.14);
+  color: #FF8C00;
+}
+
+@media (max-width: 996px) {
+  .releases-shell {
+    padding: 3rem 1rem 4rem;
+  }
+
+  .releases-change-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .releases-download-feature {
+    grid-template-columns: 1fr;
+  }
+
+  .releases-release-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .releases-download-primary {
+    width: 100%;
+  }
+
+  .releases-release-header {
+    flex-direction: column;
+  }
+
+  .releases-release-header h2 {
+    font-size: 1.8rem;
+  }
 }
 
 /*

--- a/docs/src/pages/docs/next/releases.tsx
+++ b/docs/src/pages/docs/next/releases.tsx
@@ -1,0 +1,638 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, {useEffect, useMemo, useState} from 'react';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {Avatar, AvatarGroup, Tooltip} from '@wso2/oxygen-ui';
+import GithubIcon from '@site/src/components/icons/GithubIcon';
+import IOSLogo from '@site/src/components/icons/IOSLogo';
+import LinuxLogo from '@site/src/components/icons/LinuxLogo';
+import WindowsLogo from '@site/src/components/icons/WindowsLogo';
+
+const OS_LABELS: Record<DistributionAsset['os'], string> = {
+  linux: 'Linux',
+  macos: 'Mac OS',
+  win: 'Windows',
+};
+
+const OS_ICONS: Record<DistributionAsset['os'], React.ReactNode> = {
+  linux: <LinuxLogo size={18} />,
+  macos: <IOSLogo size={18} />,
+  win: <WindowsLogo size={18} />,
+};
+
+interface ReleaseAsset {
+  contentType: string;
+  downloadCount: number;
+  downloadUrl: string;
+  id: number;
+  name: string;
+  sizeBytes: number;
+  sizeLabel: string;
+  updatedAt: string;
+}
+
+interface DistributionAsset extends ReleaseAsset {
+  architecture: 'arm64' | 'x64';
+  architectureLabel: string;
+  os: 'linux' | 'macos' | 'win';
+  osLabel: string;
+}
+
+interface DetectedPlatform {
+  architecture: DistributionAsset['architecture'] | null;
+  os: DistributionAsset['os'] | null;
+}
+
+interface NavigatorWithUserAgentData extends Navigator {
+  userAgentData?: {
+    getHighEntropyValues?: (
+      hints: ('architecture' | 'bitness' | 'platform')[],
+    ) => Promise<{architecture?: string; bitness?: string; platform?: string}>;
+  };
+}
+
+interface Contributor {
+  avatarUrl: string | null;
+  profileUrl: string;
+  username: string;
+}
+
+interface ReleaseChanges {
+  breaking: string[];
+  bugs: string[];
+  features: string[];
+  improvements: string[];
+}
+
+interface ReleaseEntry {
+  assets: ReleaseAsset[];
+  body: string;
+  changes: ReleaseChanges;
+  contributors: Contributor[];
+  htmlUrl: string;
+  id: number;
+  isDraft: boolean;
+  isLatest: boolean;
+  isPrerelease: boolean;
+  name: string;
+  newContributors: Contributor[];
+  primaryDownloadUrl: string;
+  publishedAt: string;
+  publishedDateLabel: string;
+  tagName: string;
+}
+
+interface ReleasesData {
+  generatedAt: string;
+  latestRelease: ReleaseEntry | null;
+  releases: ReleaseEntry[];
+  repository: {
+    description: string;
+    forks: number;
+    fullName: string;
+    releasesUrl: string;
+    stars: number;
+    subscribers: number;
+    url: string;
+  };
+}
+
+const RELEASES_UNAVAILABLE_MESSAGE = 'Release information is currently unavailable. Please check back soon.';
+
+function getDistributionAsset(asset: ReleaseAsset): DistributionAsset | null {
+  const match = /^thunder-[0-9A-Za-z.+-]+-(macos|linux|win)-(arm64|x64)\.zip$/i.exec(asset.name);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, os, architecture] = match;
+
+  const architectureLabelMap: Record<string, string> = {
+    arm64: os === 'macos' ? 'ARM64 (Apple Silicon)' : 'ARM64',
+    x64: os === 'macos' ? 'x64 (Intel)' : 'x64',
+  };
+
+  return {
+    ...asset,
+    architecture: architecture as DistributionAsset['architecture'],
+    architectureLabel: architectureLabelMap[architecture],
+    os: os as DistributionAsset['os'],
+    osLabel: OS_LABELS[os as DistributionAsset['os']],
+  };
+}
+
+function detectOperatingSystem(userAgent: string, platform: string): DetectedPlatform['os'] {
+  const normalizedPlatform = platform.toLowerCase();
+  const normalizedUserAgent = userAgent.toLowerCase();
+
+  if (normalizedPlatform.includes('mac') || /(mac os x|macintosh)/.test(normalizedUserAgent)) {
+    return 'macos';
+  }
+
+  if (normalizedPlatform.includes('win') || normalizedUserAgent.includes('windows')) {
+    return 'win';
+  }
+
+  if (normalizedPlatform.includes('linux') || normalizedUserAgent.includes('linux')) {
+    return 'linux';
+  }
+
+  return null;
+}
+
+function detectArchitecture(
+  userAgent: string,
+  operatingSystem: DetectedPlatform['os'],
+): DetectedPlatform['architecture'] {
+  const normalizedUserAgent = userAgent.toLowerCase();
+  const hasArmToken = /(arm64|aarch64|armv8|apple silicon|silicon)/.test(normalizedUserAgent);
+  const hasX64Token = /\b(wow64|win64|x64|x86_64|amd64|intel)\b/.test(normalizedUserAgent);
+
+  if (hasArmToken) {
+    return 'arm64';
+  }
+
+  if (hasX64Token) {
+    // Safari on Apple Silicon often exposes Intel-style tokens in the UA string.
+    // Avoid recommending x64 on macOS unless we have explicit ARM evidence.
+    if (operatingSystem === 'macos') {
+      return null;
+    }
+
+    return 'x64';
+  }
+
+  return null;
+}
+
+async function detectPlatform(): Promise<DetectedPlatform> {
+  if (typeof navigator === 'undefined') {
+    return {architecture: null, os: null};
+  }
+
+  const {platform, userAgent} = navigator;
+  const {userAgentData} = navigator as NavigatorWithUserAgentData;
+  const fallbackOs = detectOperatingSystem(userAgent, platform);
+
+  const fallback = {
+    architecture: detectArchitecture(userAgent, fallbackOs),
+    os: fallbackOs,
+  };
+
+  if (!userAgentData?.getHighEntropyValues) {
+    return fallback;
+  }
+
+  try {
+    const values = await userAgentData.getHighEntropyValues(['architecture', 'bitness', 'platform']);
+    const {architecture: detectedArchitectureValue, bitness: detectedBitness, platform: detectedPlatformValue} = values;
+    const detectedPlatform = detectedPlatformValue?.toLowerCase() ?? '';
+    const architecture = detectedArchitectureValue?.toLowerCase() ?? '';
+    const bitness = detectedBitness?.toLowerCase() ?? '';
+    const {architecture: fallbackArchitecture, os: fallbackOs} = fallback;
+    let os = fallbackOs;
+    let resolvedArchitecture = fallbackArchitecture;
+
+    if (detectedPlatform === 'macos') {
+      os = 'macos';
+    } else if (detectedPlatform === 'windows') {
+      os = 'win';
+    } else if (detectedPlatform === 'linux') {
+      os = 'linux';
+    }
+
+    if (architecture === 'arm') {
+      resolvedArchitecture = 'arm64';
+    } else if (architecture === 'x86' && bitness === '64') {
+      resolvedArchitecture = 'x64';
+    }
+
+    return {architecture: resolvedArchitecture, os};
+  } catch {
+    return fallback;
+  }
+}
+
+function ContributorsAvatarGroup({contributors}: {contributors: Contributor[]}) {
+  return (
+    <AvatarGroup className="releases-contributors-avatar-group" max={5} total={contributors.length}>
+      {contributors.map((contributor) => (
+        <Tooltip key={contributor.username} title={`@${contributor.username}`} arrow>
+          <a
+            className="releases-contributor-avatar-link"
+            href={contributor.profileUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`View @${contributor.username} on GitHub`}
+          >
+            <Avatar alt={contributor.username} src={contributor.avatarUrl ?? undefined}>
+              {contributor.username.charAt(0).toUpperCase()}
+            </Avatar>
+          </a>
+        </Tooltip>
+      ))}
+    </AvatarGroup>
+  );
+}
+
+function normalizeReleaseChangeItem(item: string): string {
+  const trimmed = item.trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  // Drop malformed markdown-only headings like "*Linux/macOS:**" that appear in older release notes.
+  if (/^\*[^*]+:\*\*\s*$/i.test(trimmed)) {
+    return '';
+  }
+
+  return trimmed
+    .replace(/^\*\s*/, '')
+    .replace(/^\*([^*]+):\*\*\s*/i, '$1: ')
+    .replace(/\*\*/g, '')
+    .trim();
+}
+
+function ChangeGroup({title, items}: {items: string[]; title: string}) {
+  const filteredItems = items
+    .map(normalizeReleaseChangeItem)
+    .filter((item) => item && !/made their first contribution/i.test(item));
+
+  if (filteredItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="releases-change-group">
+      <h3>{title}</h3>
+      <ul>
+        {filteredItems.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ReleaseCard({release}: {release: ReleaseEntry}) {
+  const distributionAssets = useMemo(
+    () => release.assets.map(getDistributionAsset).filter((asset): asset is DistributionAsset => asset !== null),
+    [release.assets],
+  );
+  const [detectedPlatform, setDetectedPlatform] = useState<DetectedPlatform | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    detectPlatform()
+      .then((platform) => {
+        if (!isMounted) {
+          return;
+        }
+
+        setDetectedPlatform(platform);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      isMounted = false;
+    };
+  }, [release.id]);
+
+  const detectedAsset = useMemo(
+    () =>
+      distributionAssets.find(
+        (asset) => asset.os === detectedPlatform?.os && asset.architecture === detectedPlatform?.architecture,
+      ) ??
+      distributionAssets.find((asset) => asset.os === detectedPlatform?.os) ??
+      null,
+    [detectedPlatform, distributionAssets],
+  );
+  const selectedAsset = useMemo(
+    () => detectedAsset ?? distributionAssets[0] ?? null,
+    [detectedAsset, distributionAssets],
+  );
+  const hasRenderedChanges = useMemo(() => {
+    const changeItemsByCategory: string[][] = [
+      release.changes.breaking,
+      release.changes.features,
+      release.changes.improvements,
+      release.changes.bugs,
+    ];
+
+    return changeItemsByCategory.some((items: string[]) =>
+      items.some((item: string) => {
+        const normalized = normalizeReleaseChangeItem(item);
+
+        if (!normalized || /made their first contribution/i.test(normalized)) {
+          return false;
+        }
+
+        return normalized.length > 0;
+      }),
+    );
+  }, [release.changes]);
+  const matchingAssetId = detectedAsset?.id;
+  const groupedAssetsByOs = useMemo(() => {
+    const osOrder: DistributionAsset['os'][] = ['linux', 'win', 'macos'];
+    const recommendedOs = detectedAsset?.os;
+
+    const prioritizedOsOrder = recommendedOs
+      ? [recommendedOs, ...osOrder.filter((os) => os !== recommendedOs)]
+      : osOrder;
+
+    return prioritizedOsOrder
+      .map((os) => ({
+        assets: distributionAssets.filter((asset) => asset.os === os),
+        os,
+      }))
+      .filter((group) => group.assets.length > 0);
+  }, [distributionAssets, detectedAsset?.os]);
+
+  return (
+    <article className="releases-release-card">
+      <div className="releases-release-header">
+        <div>
+          <div className="releases-release-title-row">
+            <h2>{release.tagName}</h2>
+            {release.isLatest ? <span className="releases-release-badge">Latest release</span> : null}
+            {release.isPrerelease ? <span className="releases-release-badge">Pre-release</span> : null}
+          </div>
+          <p>Released on {release.publishedDateLabel}</p>
+        </div>
+      </div>
+
+      {distributionAssets.length > 0 ? (
+        <section className="releases-section-block">
+          <h2>Downloads</h2>
+          {selectedAsset ? (
+            <div className="releases-download-feature">
+              <div className="releases-download-feature-copy">
+                <span className="releases-download-feature-kicker">
+                  {matchingAssetId === selectedAsset.id ? 'Recommended for this device' : 'Selected download'}
+                </span>
+                <h3>
+                  {selectedAsset.osLabel} · {selectedAsset.architectureLabel}
+                </h3>
+                <div className="releases-download-feature-meta">
+                  <span>{selectedAsset.sizeLabel}</span>
+                  <span>{selectedAsset.downloadCount.toLocaleString('en-US')} downloads</span>
+                  <span>{selectedAsset.name}</span>
+                </div>
+              </div>
+              <a
+                className="releases-download-primary"
+                href={selectedAsset.downloadUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <span>Download for {selectedAsset.osLabel}</span>
+                <span
+                  className="releases-download-icon"
+                  aria-hidden="true"
+                  style={{display: 'inline-flex', alignItems: 'center'}}
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    style={{width: '20px', height: '20px'}}
+                  >
+                    <path d="M12 3v12" />
+                    <path d="m7 10 5 5 5-5" />
+                    <path d="M5 21h14" />
+                  </svg>
+                </span>
+              </a>
+            </div>
+          ) : null}
+          <div className="releases-other-downloads-grid">
+            {groupedAssetsByOs.map(({assets, os}) => (
+              <section key={os} className="releases-other-downloads-card">
+                <header className="releases-other-downloads-header">
+                  <span aria-hidden="true" className="releases-other-downloads-os-icon">
+                    {OS_ICONS[os]}
+                  </span>
+                  <h4>{OS_LABELS[os]}</h4>
+                </header>
+                <div className="releases-other-downloads-architectures">
+                  {assets.map((asset) => {
+                    const isRecommended = matchingAssetId === asset.id;
+
+                    return (
+                      <a
+                        key={asset.id}
+                        className="releases-other-downloads-architecture"
+                        href={asset.downloadUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        <span className="releases-other-downloads-architecture-title">
+                          {asset.osLabel} {asset.architectureLabel} ({asset.name.slice(asset.name.lastIndexOf('.'))})
+                        </span>
+                        <span className="releases-other-downloads-architecture-meta">{asset.sizeLabel}</span>
+                        {isRecommended ? <em>Recommended</em> : null}
+                      </a>
+                    );
+                  })}
+                </div>
+              </section>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {release.contributors.length > 0 ? (
+        <section className="releases-section-block">
+          <h2>Contributors ({release.contributors.length})</h2>
+          <ContributorsAvatarGroup contributors={release.contributors} />
+        </section>
+      ) : null}
+
+      {release.newContributors.length > 0 ? (
+        <section className="releases-section-block">
+          <h3>New Contributors ({release.newContributors.length})</h3>
+          <ContributorsAvatarGroup contributors={release.newContributors} />
+        </section>
+      ) : null}
+
+      {hasRenderedChanges ? (
+        <section className="releases-section-block">
+          <h2>What's Changed</h2>
+          <div className="releases-change-grid">
+            <ChangeGroup title="⚠️ Breaking Changes" items={release.changes.breaking} />
+            <ChangeGroup title="🚀 Features" items={release.changes.features} />
+            <ChangeGroup title="✨ Improvements" items={release.changes.improvements} />
+            <ChangeGroup title="🐛 Bug Fixes" items={release.changes.bugs} />
+          </div>
+        </section>
+      ) : null}
+    </article>
+  );
+}
+
+export default function ReleasesPage() {
+  const {siteConfig} = useDocusaurusContext();
+  const {withBaseUrl} = useBaseUrlUtils();
+  const [data, setData] = useState<ReleasesData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedReleaseId, setSelectedReleaseId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadReleases() {
+      try {
+        const response = await fetch(withBaseUrl('/data/releases.json'), {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(RELEASES_UNAVAILABLE_MESSAGE);
+        }
+
+        const payloadText = await response.text();
+        let payload: ReleasesData;
+
+        try {
+          payload = JSON.parse(payloadText) as ReleasesData;
+        } catch {
+          throw new Error(RELEASES_UNAVAILABLE_MESSAGE);
+        }
+
+        if (!payload || typeof payload !== 'object' || !Array.isArray(payload.releases)) {
+          throw new Error(RELEASES_UNAVAILABLE_MESSAGE);
+        }
+
+        setError(null);
+        setData(payload);
+        setSelectedReleaseId(payload.latestRelease?.id ?? payload.releases[0]?.id ?? null);
+      } catch {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setError(RELEASES_UNAVAILABLE_MESSAGE);
+      }
+    }
+
+    loadReleases().catch(() => undefined);
+
+    return () => controller.abort();
+  }, [withBaseUrl]);
+  const repository = data?.repository;
+  const releases = data?.releases ?? [];
+  const selectedRelease =
+    releases.find((release: ReleaseEntry) => release.id === selectedReleaseId) ?? data?.latestRelease ?? null;
+
+  return (
+    <Layout
+      title="Releases"
+      description="Explore ThunderID releases, changelogs, and downloads."
+      wrapperClassName="releases-page"
+    >
+      <main className="releases-shell">
+        <section className="releases-hero">
+          <h1>
+            ThunderID{' '}
+            <span
+              style={{
+                background: 'linear-gradient(90deg, #FF6B00 0%, #FF8C00 100%)',
+                WebkitBackgroundClip: 'text',
+                WebkitTextFillColor: 'transparent',
+                backgroundClip: 'text',
+              }}
+            >
+              Releases
+            </span>
+          </h1>
+          <p>Explore every release with detailed changelogs, download options, and the people building ThunderID.</p>
+
+          <div className="releases-hero-actions">
+            <a
+              className="button button--primary"
+              href={repository?.releasesUrl ?? 'https://github.com/asgardeo/thunder/releases'}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <span style={{display: 'inline-flex', alignItems: 'center', gap: '0.5rem'}}>
+                <span aria-hidden="true" style={{display: 'inline-flex'}}>
+                  <GithubIcon size={16} />
+                </span>
+                <span>View on GitHub</span>
+                <svg width="12" height="12" aria-label="(opens in new tab)" className="iconExternalLink_lApV">
+                  <use href="#theme-svg-external-link"></use>
+                </svg>
+              </span>
+            </a>
+          </div>
+        </section>
+
+        {error ? <p className="releases-status">{error}</p> : null}
+        {!data && !error ? <p className="releases-status">Loading releases...</p> : null}
+        {data && !selectedRelease ? (
+          <p className="releases-status">No releases are available right now. Please check back soon.</p>
+        ) : null}
+
+        {selectedRelease ? (
+          <section className="releases-latest">
+            <div className="releases-release-toolbar">
+              <label className="releases-version-picker" htmlFor="releases-version-select">
+                <span>Version</span>
+                <select
+                  id="releases-version-select"
+                  value={selectedRelease.id}
+                  onChange={(event) => {
+                    setSelectedReleaseId(Number(event.target.value));
+                  }}
+                >
+                  {releases.map((release) => (
+                    <option key={release.id} value={release.id}>
+                      {release.tagName}
+                      {release.isPrerelease ? ' · Pre-release' : ''}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <ReleaseCard release={selectedRelease} />
+          </section>
+        ) : null}
+
+        <section className="releases-footer-note">
+          <p>
+            Source:{' '}
+            <Link to={repository?.url ?? 'https://github.com/asgardeo/thunder'}>
+              {repository?.fullName ?? siteConfig.title}
+            </Link>
+            {data?.generatedAt ? ` · Updated ${new Date(data.generatedAt).toLocaleString('en-US')}` : ''}
+          </p>
+        </section>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
- Introduce a dedicated Docs Releases experience (/docs/next/releases) so users can browse Thunder versions, changelogs,
    contributors, and platform-specific downloads in one place instead of relying on the GitHub releases page alone.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
- Add a new releases page UI at docs/src/pages/docs/next/releases.tsx that:
  - Loads release data from /data/releases.json
  - Detects OS/arch and highlights a recommended binary
  - Shows categorized changes, contributors, and version selector

- Rework changelog generation in docs/scripts/generate-changelog.mjs:
  - Switch output from markdown to structured JSON (docs/static/data/releases.json)
  - Fetch both repo metadata and releases from GitHub API
  - Normalize assets/contributors/changes for the UI
  
<img width="1440" height="779" alt="Screenshot 2026-04-23 at 16 47 03" src="https://github.com/user-attachments/assets/5829ccbd-66ba-4e03-b401-e566f9e64a64" /> <br>
  
<img width="1440" height="779" alt="Screenshot 2026-04-23 at 16 47 57" src="https://github.com/user-attachments/assets/d514097c-8759-474d-856f-79b377306afc" />

### Related Issues
- https://github.com/asgardeo/thunder/issues/2338

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated Releases page with version selector, platform-aware download recommendation, per-release download groups, contributor lists, and categorized change summaries.
  * Added Linux and Windows SVG icons for platform displays.

* **Navigation**
  * "Releases" entry now points to the internal Releases documentation page (navbar and footer).

* **Style**
  * New responsive releases styling, improved hero/toolbar/CTA layouts, dark-mode tweaks, and better mobile behavior.

* **Chores**
  * Release generation updated to produce a structured, resilient releases feed (JSON) with normalized entries and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->