### PR TITLE
Allow retry of flow step on recoverable error

### DIFF
--- a/backend/cmd/server/bootstrap/flows/apps/console/registration_flow_console.json
+++ b/backend/cmd/server/bootstrap/flows/apps/console/registration_flow_console.json
@@ -222,7 +222,8 @@
                     }
                 ]
             },
-            "onSuccess": "auth_assert"
+            "onSuccess": "auth_assert",
+            "onIncomplete": "prompt_registration"
         },
         {
             "id": "auth_assert",

--- a/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
+++ b/backend/cmd/server/bootstrap/flows/user_onboarding/user_onboarding_flow.json
@@ -606,7 +606,8 @@
             "executor": {
                 "name": "ProvisioningExecutor"
             },
-            "onSuccess": "registration_complete"
+            "onSuccess": "registration_complete",
+            "onIncomplete": "prompt_credential"
         },
         {
             "id": "registration_complete",

--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -148,6 +148,12 @@ func (n *taskExecutionNode) Execute(ctx *NodeContext) (*common.NodeResponse, *se
 				delete(ctx.UserInputs, input.Identifier)
 			}
 		}
+	} else if nodeResp.Status == common.NodeStatusIncomplete && nodeResp.Type == common.NodeResponseTypeView &&
+		len(nodeResp.Inputs) == 0 {
+		// Executor returned INCOMPLETE+VIEW with no inputs — broken executor implementation.
+		// There is nothing for the client to act on; surface as a server error.
+		logger.Error("Executor returned INCOMPLETE with VIEW type but no inputs")
+		return nil, &serviceerror.InternalServerError
 	}
 
 	return nodeResp, nil

--- a/backend/internal/flow/core/task_execution_node_test.go
+++ b/backend/internal/flow/core/task_execution_node_test.go
@@ -895,6 +895,28 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteNoFail
 		"UserInputs should not be cleared without failure reason")
 }
 
+func (s *TaskExecutionNodeTestSuite) TestExecuteUserInputRequiredWithNoInputsReturnsServerError() {
+	mockExec := NewExecutorInterfaceMock(s.T())
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
+	execNode, _ := node.(ExecutorBackedNodeInterface)
+
+	mockExec.On("GetName").Return("test-executor").Once()
+	mockExec.On("Execute", mock.Anything).Return(
+		&common.ExecutorResponse{
+			Status: common.ExecUserInputRequired,
+			// No Inputs — broken executor implementation
+		}, nil,
+	).Once()
+
+	execNode.SetExecutor(mockExec)
+
+	ctx := &NodeContext{ExecutionID: "test-flow"}
+	resp, err := node.Execute(ctx)
+
+	s.NotNil(err, "Should return a server error when executor returns VIEW with no inputs")
+	s.Nil(resp)
+}
+
 func (s *TaskExecutionNodeTestSuite) TestGetExecutionPolicy_NoExecutorReturnsNil() {
 	node := newTaskExecutionNode("task-1", make(map[string]interface{}), false, false)
 

--- a/backend/internal/flow/executor/authz_executor_test.go
+++ b/backend/internal/flow/executor/authz_executor_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/asgardeo/thunder/tests/mocks/flow/coremock"
 )
 
+const testExistingUser123ID = "existing-user-123"
+
 // createTestAuthzExecutor creates an authorization executor with mocks for testing
 func createTestAuthzExecutor(t *testing.T,
 	mockAuthzService *authzmock.AuthorizationServiceInterfaceMock,
@@ -630,12 +632,13 @@ func TestAuthorizationExecutor_Execute_RegistrationFlow_AuthenticatedWithPermiss
 	mockEntityProvider := new(entityprovidermock.EntityProviderInterfaceMock)
 	executor := createTestAuthzExecutor(t, mockAuthzService, mockEntityProvider)
 
+	existingUserID := testExistingUser123ID
 	ctx := &core.NodeContext{
 		ExecutionID: "test-registration-flow",
 		FlowType:    common.FlowTypeRegistration,
 		AuthenticatedUser: authncm.AuthenticatedUser{
 			IsAuthenticated: true,
-			UserID:          "existing-user-123",
+			UserID:          existingUserID,
 			Attributes: map[string]interface{}{
 				"groups": []string{"new-users"},
 			},
@@ -649,7 +652,7 @@ func TestAuthorizationExecutor_Execute_RegistrationFlow_AuthenticatedWithPermiss
 	mockAuthzService.On("GetAuthorizedPermissions",
 		mock.Anything,
 		mock.MatchedBy(func(req authzsvc.GetAuthorizedPermissionsRequest) bool {
-			return req.EntityID == "existing-user-123" &&
+			return req.EntityID == existingUserID &&
 				len(req.GroupIDs) == 1 &&
 				req.GroupIDs[0] == "new-users" &&
 				len(req.RequestedPermissions) == 2

--- a/backend/internal/flow/executor/federated_auth_resolver_executor.go
+++ b/backend/internal/flow/executor/federated_auth_resolver_executor.go
@@ -113,7 +113,8 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 
 	if len(matched) == 0 {
 		logger.Debug("No user matched the provided selection")
-		execResp.Status = common.ExecFailure
+		execResp.Status = common.ExecUserInputRequired
+		execResp.Inputs = f.GetRequiredInputs(ctx)
 		execResp.FailureReason = failureReasonUserNotFound
 		return execResp, nil
 	}

--- a/backend/internal/flow/executor/federated_auth_resolver_executor_test.go
+++ b/backend/internal/flow/executor/federated_auth_resolver_executor_test.go
@@ -136,7 +136,7 @@ func (suite *FederatedAuthResolverTestSuite) TestExecute_NoMatchingCandidate() {
 	resp, err := suite.executeWithCandidatesAndInput(candidates, map[string]string{"ouHandle": "org-gamma"})
 
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 	assert.Equal(suite.T(), failureReasonUserNotFound, resp.FailureReason)
 }
 

--- a/backend/internal/flow/executor/identifying_executor.go
+++ b/backend/internal/flow/executor/identifying_executor.go
@@ -158,14 +158,23 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 		return execResp, nil
 	}
 
-	// If IdentifyUser already set a failure status (e.g., ambiguous user), preserve it
+	// Only promote ExecFailure to ExecUserInputRequired for recoverable user-input
+	// errors (i.e. user not found). Other failures reported by IdentifyUser — such
+	// as ambiguous matches or system errors — are not recoverable in identify mode
+	// and must be returned as-is so the caller can handle them appropriately.
+	if execResp.Status == common.ExecFailure && execResp.FailureReason == failureReasonUserNotFound {
+		execResp.Status = common.ExecUserInputRequired
+		execResp.Inputs = i.GetRequiredInputs(ctx)
+		return execResp, nil
+	}
 	if execResp.Status == common.ExecFailure {
 		return execResp, nil
 	}
 
 	if userID == nil || *userID == "" {
 		logger.Debug("User not found for the provided attributes")
-		execResp.Status = common.ExecFailure
+		execResp.Status = common.ExecUserInputRequired
+		execResp.Inputs = i.GetRequiredInputs(ctx)
 		execResp.FailureReason = failureReasonUserNotFound
 		return execResp, nil
 	}
@@ -208,7 +217,8 @@ func (i *identifyingExecutor) executeResolve(ctx *core.NodeContext,
 	switch len(candidates) {
 	case 0:
 		logger.Debug("No matching users after filtering")
-		execResp.Status = common.ExecFailure
+		execResp.Status = common.ExecUserInputRequired
+		execResp.Inputs = i.GetRequiredInputs(ctx)
 		execResp.FailureReason = failureReasonUserNotFound
 		return execResp, nil
 	case 1:

--- a/backend/internal/flow/executor/identifying_executor_test.go
+++ b/backend/internal/flow/executor/identifying_executor_test.go
@@ -298,7 +298,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_IdentifyUserError
 	// IdentifyUser method in implementation swallows the error and returns nil, nil.
 	// Then Execute checks for nil userID and returns UserNotFound.
 	// So we should expect failureReasonUserNotFound
-	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 	assert.Equal(suite.T(), failureReasonUserNotFound, resp.FailureReason)
 }
 
@@ -323,7 +323,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_UserNotFound() {
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
-	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 	assert.Equal(suite.T(), failureReasonUserNotFound, resp.FailureReason)
 }
 
@@ -432,7 +432,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_UserNotFoundByAtt
 
 			assert.NoError(suite.T(), err)
 			assert.NotNil(suite.T(), resp)
-			assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+			assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 			assert.Equal(suite.T(), failureReasonUserNotFound, resp.FailureReason)
 			suite.mockEntityProvider.AssertExpectations(suite.T())
 		})
@@ -514,7 +514,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_Failure_EmptyInput() {
 
 			assert.NoError(suite.T(), err)
 			assert.NotNil(suite.T(), resp)
-			assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+			assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 			assert.Equal(suite.T(), failureReasonUserNotFound, resp.FailureReason)
 			suite.mockEntityProvider.AssertExpectations(suite.T())
 		})
@@ -719,7 +719,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecuteResolve_FilteredToNone() {
 	resp, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 	assert.Equal(suite.T(), failureReasonUserNotFound, resp.FailureReason)
 }
 
@@ -746,6 +746,63 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_IdentifyMode_AmbiguousUse
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
 	assert.Equal(suite.T(), failureReasonFailedToIdentifyUser, resp.FailureReason)
+	assert.Empty(suite.T(), resp.Inputs, "Inputs must not be populated for ambiguous user in identify mode")
+}
+
+func (suite *IdentifyingExecutorTestSuite) TestExecute_IdentifyMode_UserNotFound_PopulatesInputsForRetry() {
+	inputs := []common.Input{{Identifier: "username", Type: "TEXT_INPUT", Required: true}}
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"username": "nonexistent"},
+		RuntimeData: make(map[string]string),
+	}
+
+	mockBase := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+	mockBase.On("HasRequiredInputs", mock.Anything, mock.Anything).Return(true)
+	mockBase.On("GetRequiredInputs", mock.Anything).Return(inputs)
+
+	// IdentifyUser sets ExecFailure + userNotFound; executeIdentify must promote to UserInputRequired
+	suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{
+		"username": "nonexistent",
+	}).Return(nil, entityprovider.NewEntityProviderError(
+		entityprovider.ErrorCodeEntityNotFound, "not found", ""))
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.Equal(suite.T(), failureReasonUserNotFound, resp.FailureReason)
+	assert.NotEmpty(suite.T(), resp.Inputs, "Inputs must be populated for retry when user is not found")
+	suite.mockEntityProvider.AssertExpectations(suite.T())
+}
+
+func (suite *IdentifyingExecutorTestSuite) TestExecute_IdentifyMode_SystemError() {
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{"username": "testuser"},
+		RuntimeData: make(map[string]string),
+	}
+
+	mockBase := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+	mockBase.On("HasRequiredInputs", mock.Anything, mock.Anything).Return(true)
+	mockBase.On("GetRequiredInputs", mock.Anything).Return([]common.Input{
+		{Identifier: "username", Type: "TEXT_INPUT", Required: true},
+	})
+
+	suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{
+		"username": "testuser",
+	}).Return(nil, entityprovider.NewEntityProviderError(
+		entityprovider.ErrorCodeSystemError, "System error", "db unavailable"))
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), failureReasonFailedToIdentifyUser, resp.FailureReason)
+	assert.Empty(suite.T(), resp.Inputs, "Inputs must not be populated for non-recoverable errors")
+	suite.mockEntityProvider.AssertExpectations(suite.T())
 }
 
 func TestFilterUsersByAttributes(t *testing.T) {
@@ -771,6 +828,71 @@ func TestFilterUsersByAttributes(t *testing.T) {
 
 	result = filterUsersByAttributes(users, map[string]interface{}{"family_name": "Doe"})
 	assert.Empty(t, result)
+}
+
+func (suite *IdentifyingExecutorTestSuite) TestExecute_RetryableIdentificationErrors() {
+	tests := []struct {
+		name           string
+		attribute      string
+		value          string
+		entityError    *entityprovider.EntityProviderError
+		emptyID        bool
+		expectedReason string
+		message        string
+	}{
+		{
+			name:           "User not found",
+			attribute:      "username",
+			value:          "nonexistent",
+			entityError:    entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""),
+			expectedReason: failureReasonUserNotFound,
+			message:        "Should return inputs for retry when user is not found",
+		},
+		{
+			name:           "Empty user ID returned",
+			attribute:      "username",
+			value:          "testuser",
+			emptyID:        true,
+			expectedReason: failureReasonUserNotFound,
+			message:        "Should return inputs for retry when empty user ID is returned",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			suite.SetupTest()
+
+			inputs := []common.Input{{Identifier: tt.attribute, Type: "string", Required: true}}
+			ctx := &core.NodeContext{
+				ExecutionID: "flow-123",
+				UserInputs:  map[string]string{tt.attribute: tt.value},
+			}
+
+			mockBase := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+			mockBase.On("HasRequiredInputs", mock.Anything, mock.Anything).Return(true)
+			mockBase.On("GetRequiredInputs", mock.Anything).Return(inputs)
+
+			if tt.emptyID {
+				emptyID := ""
+				suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{
+					tt.attribute: tt.value,
+				}).Return(&emptyID, nil)
+			} else {
+				suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{
+					tt.attribute: tt.value,
+				}).Return(nil, tt.entityError)
+			}
+
+			resp, err := suite.executor.Execute(ctx)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, common.ExecUserInputRequired, resp.Status)
+			assert.Equal(t, tt.expectedReason, resp.FailureReason, tt.message)
+			assert.NotEmpty(t, resp.Inputs, "Inputs should be re-populated for retry")
+			suite.mockEntityProvider.AssertExpectations(t)
+		})
+	}
 }
 
 func TestExtractDisambiguationOptions(t *testing.T) {

--- a/backend/internal/flow/executor/ou_executor.go
+++ b/backend/internal/flow/executor/ou_executor.go
@@ -105,7 +105,8 @@ func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, e
 	createdOU, svcErr := o.ouService.CreateOrganizationUnit(ctx.Context, ouRequest)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			execResp.Status = common.ExecFailure
+			execResp.Status = common.ExecUserInputRequired
+			execResp.Inputs = o.GetRequiredInputs(ctx)
 
 			switch svcErr.Code {
 			case ou.ErrorOrganizationUnitNameConflict.Code:

--- a/backend/internal/flow/executor/ou_executor_test.go
+++ b/backend/internal/flow/executor/ou_executor_test.go
@@ -485,7 +485,7 @@ func (suite *OUExecutorTestSuite) TestExecute_ErrorScenarios() {
 				assert.Equal(suite.T(), tc.expectedFailure, err.Error())
 			} else {
 				assert.NoError(suite.T(), err)
-				assert.Equal(suite.T(), common.ExecFailure, result.Status)
+				assert.Equal(suite.T(), common.ExecUserInputRequired, result.Status)
 				assert.Equal(suite.T(), tc.expectedFailure, result.FailureReason)
 			}
 
@@ -733,4 +733,57 @@ func (suite *OUExecutorTestSuite) TestExecutorHelperMethods() {
 
 func (suite *OUExecutorTestSuite) TestOUExecutorInterface() {
 	var _ core.ExecutorInterface = (*ouExecutor)(nil)
+}
+
+func (suite *OUExecutorTestSuite) TestExecute_RetryableOUCreationErrors() {
+	tests := []struct {
+		name           string
+		serviceError   serviceerror.ServiceError
+		expectedReason string
+		message        string
+	}{
+		{
+			name:           "OU name conflict",
+			serviceError:   ou.ErrorOrganizationUnitNameConflict,
+			expectedReason: "An organization unit with the same name already exists.",
+			message:        "Should return inputs for retry when OU name already exists",
+		},
+		{
+			name:           "OU handle conflict",
+			serviceError:   ou.ErrorOrganizationUnitHandleConflict,
+			expectedReason: "An organization unit with the same handle already exists.",
+			message:        "Should return inputs for retry when OU handle already exists",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			suite.SetupTest()
+
+			ctx := &core.NodeContext{
+				ExecutionID: "flow-123",
+				FlowType:    common.FlowTypeRegistration,
+				UserInputs: map[string]string{
+					userInputOuName:   "Engineering",
+					userInputOuHandle: "engineering",
+				},
+				RuntimeData: map[string]string{},
+			}
+
+			suite.mockOUService.On("CreateOrganizationUnit", mock.Anything, ou.OrganizationUnitRequestWithID{
+				Name:   "Engineering",
+				Handle: "engineering",
+			}).Return(ou.OrganizationUnit{}, &tt.serviceError)
+
+			resp, err := suite.executor.Execute(ctx)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, common.ExecUserInputRequired, resp.Status)
+			assert.Equal(t, tt.expectedReason, resp.FailureReason, tt.message)
+			assert.NotEmpty(t, resp.Inputs, "Inputs should be re-populated for retry")
+			assert.Len(t, resp.Inputs, 2, "Should include both ouName and ouHandle inputs")
+			suite.mockOUService.AssertExpectations(t)
+		})
+	}
 }

--- a/backend/internal/flow/executor/ou_resolver_executor.go
+++ b/backend/internal/flow/executor/ou_resolver_executor.go
@@ -152,7 +152,8 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
 		isDescendant, svcErr := e.ouService.IsParent(ctx.Context, parentOUID, selectedOUID)
 		if svcErr != nil {
 			if svcErr.Type == serviceerror.ClientErrorType {
-				execResp.Status = common.ExecFailure
+				execResp.Status = common.ExecUserInputRequired
+				execResp.Inputs = e.GetDefaultInputs()
 				execResp.FailureReason = "The selected organization unit is not valid."
 				return execResp, nil
 			}
@@ -163,7 +164,8 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
 			logger.Debug("Selected OU is not a descendant of the parent OU",
 				log.String(ouIDKey, selectedOUID),
 				log.String("parentOUID", parentOUID))
-			execResp.Status = common.ExecFailure
+			execResp.Status = common.ExecUserInputRequired
+			execResp.Inputs = e.GetDefaultInputs()
 			execResp.FailureReason = "The selected organization unit is not valid for the chosen user type."
 			return execResp, nil
 		}
@@ -222,7 +224,8 @@ func (e *ouResolverExecutor) resolveFromPromptAll(ctx *core.NodeContext,
 			return nil, errors.New("failed to validate selected organization unit: " + svcErr.Error.DefaultValue)
 		}
 		if !exists {
-			execResp.Status = common.ExecFailure
+			execResp.Status = common.ExecUserInputRequired
+			execResp.Inputs = e.GetDefaultInputs()
 			execResp.FailureReason = "The selected organization unit does not exist."
 			return execResp, nil
 		}

--- a/backend/internal/flow/executor/ou_resolver_executor_test.go
+++ b/backend/internal/flow/executor/ou_resolver_executor_test.go
@@ -315,7 +315,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_NotI
 	result, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, result.Status)
 	assert.Contains(suite.T(), result.FailureReason, "not valid for the chosen user type")
 	suite.mockOUService.AssertExpectations(suite.T())
 }
@@ -381,7 +381,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_Clie
 	result, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, result.Status)
 	assert.Contains(suite.T(), result.FailureReason, "not valid")
 	suite.mockOUService.AssertExpectations(suite.T())
 }
@@ -537,7 +537,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_PromptAll_NonExistentOU() 
 	result, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecFailure, result.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, result.Status)
 	assert.Equal(suite.T(), "The selected organization unit does not exist.", result.FailureReason)
 	suite.mockOUService.AssertExpectations(suite.T())
 }

--- a/backend/internal/flow/executor/passkey_executor.go
+++ b/backend/internal/flow/executor/passkey_executor.go
@@ -313,6 +313,7 @@ func (p *passkeyAuthExecutor) validatePasskey(ctx *core.NodeContext, execResp *c
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			// Return USER_INPUT_REQUIRED to allow retry on invalid passkey
 			execResp.Status = common.ExecUserInputRequired
+			execResp.Inputs = p.GetRequiredInputs(ctx)
 			execResp.FailureReason = errorInvalidPasskey
 			return nil
 		}
@@ -466,6 +467,7 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 	if missingRequiredInputs {
 		logger.Debug("Required inputs for passkey registration are not provided")
 		execResp.Status = common.ExecUserInputRequired
+		execResp.Inputs = allInputs
 		return execResp, nil
 	}
 
@@ -502,6 +504,7 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 			logger.Debug("Passkey registration failed", log.String("error", svcErr.ErrorDescription.DefaultValue))
 			// Return USER_INPUT_REQUIRED to allow retry on invalid registration
 			execResp.Status = common.ExecUserInputRequired
+			execResp.Inputs = allInputs
 			execResp.FailureReason = svcErr.ErrorDescription.DefaultValue
 			return execResp, nil
 		}

--- a/backend/internal/flow/executor/passkey_executor_test.go
+++ b/backend/internal/flow/executor/passkey_executor_test.go
@@ -360,6 +360,15 @@ func (suite *PasskeyAuthExecutorTestSuite) TestExecuteVerify_InvalidPasskey_Clie
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 	assert.Contains(suite.T(), resp.FailureReason, "invalid passkey credentials")
+	assert.NotEmpty(suite.T(), resp.Inputs)
+	inputIDs := make([]string, 0, len(resp.Inputs))
+	for _, input := range resp.Inputs {
+		inputIDs = append(inputIDs, input.Identifier)
+	}
+	assert.Contains(suite.T(), inputIDs, inputCredentialID)
+	assert.Contains(suite.T(), inputIDs, inputClientDataJSON)
+	assert.Contains(suite.T(), inputIDs, inputAuthenticatorData)
+	assert.Contains(suite.T(), inputIDs, inputSignature)
 }
 
 func (suite *PasskeyAuthExecutorTestSuite) TestExecuteVerify_ServiceError_Server() {
@@ -564,13 +573,47 @@ func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_MissingInpu
 	ctx := createPasskeyNodeContext(passkeyExecutorModeRegFinish, common.FlowTypeRegistration)
 	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
 	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
-	// Empty UserInputs
+	// Empty UserInputs — all required inputs are missing
 
 	resp, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	// All missing inputs must be listed so the client knows what to collect
+	assert.NotEmpty(suite.T(), resp.Inputs)
+	inputIDs := make([]string, 0, len(resp.Inputs))
+	for _, input := range resp.Inputs {
+		inputIDs = append(inputIDs, input.Identifier)
+	}
+	assert.Contains(suite.T(), inputIDs, inputCredentialID)
+	assert.Contains(suite.T(), inputIDs, inputClientDataJSON)
+	assert.Contains(suite.T(), inputIDs, inputAttestationObject)
+}
+
+func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_PartialInputs() {
+	ctx := createPasskeyNodeContext(passkeyExecutorModeRegFinish, common.FlowTypeRegistration)
+	ctx.RuntimeData[userAttributeUserID] = testPasskeyUserID
+	ctx.RuntimeData[runtimePasskeySessionToken] = testSessionToken
+	// Provide credentialID but omit the other required inputs
+	ctx.UserInputs = map[string]string{
+		inputCredentialID: testCredentialIDValue,
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	// The full input list is returned so the client can re-render the entire form
+	assert.NotEmpty(suite.T(), resp.Inputs)
+	inputIDs := make([]string, 0, len(resp.Inputs))
+	for _, input := range resp.Inputs {
+		inputIDs = append(inputIDs, input.Identifier)
+	}
+	assert.Contains(suite.T(), inputIDs, inputCredentialID)
+	assert.Contains(suite.T(), inputIDs, inputClientDataJSON)
+	assert.Contains(suite.T(), inputIDs, inputAttestationObject)
 }
 
 func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_MissingSessionToken() {
@@ -613,6 +656,15 @@ func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_ServiceErro
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 	assert.Contains(suite.T(), resp.FailureReason, "Invalid attestation object")
+	// Client must receive the full input list so it can re-prompt the user
+	assert.NotEmpty(suite.T(), resp.Inputs)
+	inputIDs := make([]string, 0, len(resp.Inputs))
+	for _, input := range resp.Inputs {
+		inputIDs = append(inputIDs, input.Identifier)
+	}
+	assert.Contains(suite.T(), inputIDs, inputCredentialID)
+	assert.Contains(suite.T(), inputIDs, inputClientDataJSON)
+	assert.Contains(suite.T(), inputIDs, inputAttestationObject)
 }
 
 func (suite *PasskeyAuthExecutorTestSuite) TestExecuteRegisterFinish_ServiceError_Server() {

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -128,55 +128,13 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 		return execResp, nil
 	}
 	if userID != nil && *userID != "" {
-		logger.Debug("User already exists", log.MaskedString(log.LoggerKeyUserID, *userID))
-
-		// If it's a registration flow, check if proceeding with an existing user
-		if ctx.FlowType == common.FlowTypeRegistration {
-			existing, ok := ctx.RuntimeData[common.RuntimeKeySkipProvisioning]
-			if ok && existing == dataValueTrue {
-				logger.Debug("Proceeding with an existing user in registration flow, skipping execution")
-				execResp.RuntimeData[userAttributeUserID] = *userID
-				execResp.Status = common.ExecComplete
-				return execResp, nil
-			}
+		shouldContinue, err := p.handleExistingUser(ctx, *userID, execResp, logger)
+		if err != nil {
+			return nil, err
 		}
-
-		// Check if cross-OU provisioning is explicitly enabled for this node.
-		allowCrossOUProvisioning := false
-		if val, ok := ctx.NodeProperties[common.NodePropertyAllowCrossOUProvisioning]; ok {
-			if boolVal, ok := val.(bool); ok {
-				allowCrossOUProvisioning = boolVal
-			}
-		}
-
-		if !allowCrossOUProvisioning {
-			execResp.Status = common.ExecFailure
-			execResp.FailureReason = "User already exists"
+		if !shouldContinue {
 			return execResp, nil
 		}
-
-		// Cross-OU provisioning: verify the existing user is in a different OU than the target.
-		targetOUID := p.getOUID(ctx)
-		if targetOUID == "" {
-			execResp.Status = common.ExecFailure
-			execResp.FailureReason = "Target OU is not set for cross-OU provisioning"
-			return execResp, nil
-		}
-
-		existingUser, getUserErr := p.entityProvider.GetEntity(*userID)
-		if getUserErr != nil {
-			return nil, errors.New("failed to retrieve existing user")
-		}
-
-		if existingUser.OUID == targetOUID {
-			execResp.Status = common.ExecFailure
-			execResp.FailureReason = "User already exists in the target organization"
-			return execResp, nil
-		}
-
-		logger.Debug("Existing user is in a different OU, proceeding with cross-OU provisioning",
-			log.String("existingOUID", existingUser.OUID),
-			log.String("targetOUID", targetOUID))
 	}
 
 	// Create the user in the store.
@@ -234,6 +192,72 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 	}
 
 	return execResp, nil
+}
+
+// handleExistingUser handles the case where a user with the given ID already exists.
+// Returns true if provisioning should proceed (cross-OU case), false if execution should stop.
+func (p *provisioningExecutor) handleExistingUser(ctx *core.NodeContext, userID string,
+	execResp *common.ExecutorResponse, logger *log.Logger) (bool, error) {
+	logger.Debug("User already exists", log.MaskedString(log.LoggerKeyUserID, userID))
+
+	// If it's a registration flow, check if proceeding with an existing user
+	if ctx.FlowType == common.FlowTypeRegistration {
+		existing, ok := ctx.RuntimeData[common.RuntimeKeySkipProvisioning]
+		if ok && existing == dataValueTrue {
+			logger.Debug("Proceeding with an existing user in registration flow, skipping execution")
+			execResp.RuntimeData[userAttributeUserID] = userID
+			execResp.Status = common.ExecComplete
+			return false, nil
+		}
+	}
+
+	// Check if cross-OU provisioning is explicitly enabled for this node.
+	allowCrossOUProvisioning := false
+	if val, ok := ctx.NodeProperties[common.NodePropertyAllowCrossOUProvisioning]; ok {
+		if boolVal, ok := val.(bool); ok {
+			allowCrossOUProvisioning = boolVal
+		}
+	}
+
+	if !allowCrossOUProvisioning {
+		if ctx.FlowType == common.FlowTypeRegistration {
+			execResp.Status = common.ExecUserInputRequired
+			execResp.Inputs = p.GetRequiredInputs(ctx)
+		} else {
+			execResp.Status = common.ExecFailure
+		}
+		execResp.FailureReason = "User already exists"
+		return false, nil
+	}
+
+	// Cross-OU provisioning: verify the existing user is in a different OU than the target.
+	targetOUID := p.getOUID(ctx)
+	if targetOUID == "" {
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Target OU is not set for cross-OU provisioning"
+		return false, nil
+	}
+
+	existingUser, getUserErr := p.entityProvider.GetEntity(userID)
+	if getUserErr != nil {
+		return false, errors.New("failed to retrieve existing user")
+	}
+
+	if existingUser.OUID == targetOUID {
+		if ctx.FlowType == common.FlowTypeRegistration {
+			execResp.Status = common.ExecUserInputRequired
+			execResp.Inputs = p.GetRequiredInputs(ctx)
+		} else {
+			execResp.Status = common.ExecFailure
+		}
+		execResp.FailureReason = "User already exists in the target organization"
+		return false, nil
+	}
+
+	logger.Debug("Existing user is in a different OU, proceeding with cross-OU provisioning",
+		log.String("existingOUID", existingUser.OUID),
+		log.String("targetOUID", targetOUID))
+	return true, nil
 }
 
 // HasRequiredInputs checks if the required inputs are provided in the context and appends any

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -44,8 +44,9 @@ import (
 )
 
 const (
-	testUserType  = "INTERNAL"
-	testNewUserID = "user-new"
+	testUserType            = "INTERNAL"
+	testNewUserID           = "user-new"
+	methodGetRequiredInputs = "GetRequiredInputs"
 )
 
 type ProvisioningExecutorTestSuite struct {
@@ -128,7 +129,7 @@ func (suite *ProvisioningExecutorTestSuite) createMockProvisioningExecutor() cor
 			return len(execResp.Inputs) == 0
 		}).Maybe()
 	mockExec.On("GetInputs", mock.Anything).Return([]common.Input{}).Maybe()
-	mockExec.On("GetRequiredInputs", mock.Anything).Return([]common.Input{}).Maybe()
+	mockExec.On(methodGetRequiredInputs, mock.Anything).Return([]common.Input{}).Maybe()
 	return mockExec
 }
 
@@ -236,7 +237,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAlreadyExists() {
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
-	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 	assert.Contains(suite.T(), resp.FailureReason, "User already exists")
 	suite.mockEntityProvider.AssertExpectations(suite.T())
 }
@@ -611,7 +613,7 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_UserAlr
 		},
 	}
 
-	userID := "existing-user-123"
+	userID := testExistingUser123ID
 	attrs := map[string]interface{}{
 		"username": "existinguser",
 	}
@@ -622,7 +624,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_SkipProvisioning_UserAlr
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
-	assert.Equal(suite.T(), "existing-user-123", resp.RuntimeData[userAttributeUserID])
+	assert.Equal(suite.T(), testExistingUser123ID, resp.RuntimeData[userAttributeUserID])
+	assert.Equal(suite.T(), testExistingUser123ID, resp.RuntimeData[userAttributeUserID])
 	// Verify that CreateUser was not called (provisioning was skipped)
 	// Verify that CreateUser was not called (provisioning was skipped)
 	suite.mockEntityProvider.AssertExpectations(suite.T())
@@ -1536,7 +1539,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_NotEnabled_Fails
 	resp, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 	assert.Equal(suite.T(), "User already exists", resp.FailureReason)
 }
 
@@ -1571,7 +1575,8 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_SameOU_Fails() {
 	resp, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
 	assert.Equal(suite.T(), "User already exists in the target organization", resp.FailureReason)
 }
 
@@ -1603,6 +1608,229 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_NoTargetOU_Fails
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
 	assert.Equal(suite.T(), "Target OU is not set for cross-OU provisioning", resp.FailureReason)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestExecute_RetryableProvisioningErrors() {
+	tests := []struct {
+		name           string
+		existingUserID string
+		expectedReason string
+		message        string
+	}{
+		{
+			name:           "User already exists",
+			existingUserID: "user-existing",
+			expectedReason: "User already exists",
+			message:        "Should return inputs for retry when user already exists in registration flow",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			suite.SetupTest()
+			suite.expectSchemaForProvisioning()
+
+			nodeInputs := []common.Input{
+				{Identifier: "username", Type: "string", Required: true},
+			}
+			ctx := &core.NodeContext{
+				ExecutionID: "flow-123",
+				FlowType:    common.FlowTypeRegistration,
+				UserInputs:  map[string]string{"username": "existinguser"},
+				NodeInputs:  nodeInputs,
+				RuntimeData: map[string]string{userTypeKey: testUserType},
+			}
+
+			// Override GetRequiredInputs to return node inputs for this test
+			provMock := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+			var filteredCalls []*mock.Call
+			for _, call := range provMock.ExpectedCalls {
+				if call.Method != methodGetRequiredInputs {
+					filteredCalls = append(filteredCalls, call)
+				}
+			}
+			provMock.ExpectedCalls = filteredCalls
+			provMock.On(methodGetRequiredInputs, mock.Anything).Return(nodeInputs).Maybe()
+
+			existingID := tt.existingUserID
+			suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{
+				"username": "existinguser",
+			}).Return(&existingID, nil)
+
+			resp, err := suite.executor.Execute(ctx)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, common.ExecUserInputRequired, resp.Status)
+			assert.Equal(t, tt.expectedReason, resp.FailureReason, tt.message)
+			assert.NotEmpty(t, resp.Inputs, "Inputs should be re-populated for retry")
+			suite.mockEntityProvider.AssertExpectations(t)
+		})
+	}
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_NotEnabled_AuthnFlow_ReturnsFailure() {
+	suite.expectSchemaForProvisioning()
+	attrs := map[string]interface{}{"sub": "user-sub-123"}
+
+	existingUserID := testExistingUserID
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			"sub": "user-sub-123",
+		},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+			common.RuntimeKeyUserEligibleForProvisioning: dataValueTrue,
+		},
+		NodeProperties: map[string]interface{}{},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(&existingUserID, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status,
+		"Authentication flow should return ExecFailure (not UserInputRequired) when user already exists")
+	assert.Equal(suite.T(), "User already exists", resp.FailureReason)
+	assert.Empty(suite.T(), resp.Inputs, "Inputs should not be populated for authentication flows")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_NotEnabled_RegistrationFlow_PopulatesInputs() {
+	suite.expectSchemaForProvisioning()
+	attrs := map[string]interface{}{"sub": "user-sub-123"}
+
+	existingUserID := testExistingUserID
+
+	nodeInputs := []common.Input{
+		{Identifier: "sub", Type: "string", Required: true},
+	}
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"sub": "user-sub-123",
+		},
+		NodeInputs: nodeInputs,
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeProperties: map[string]interface{}{},
+	}
+
+	// Override GetRequiredInputs to return node inputs
+	provMock := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+	var filteredCalls []*mock.Call
+	for _, call := range provMock.ExpectedCalls {
+		if call.Method != methodGetRequiredInputs {
+			filteredCalls = append(filteredCalls, call)
+		}
+	}
+	provMock.ExpectedCalls = filteredCalls
+	provMock.On(methodGetRequiredInputs, mock.Anything).Return(nodeInputs).Maybe()
+
+	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(&existingUserID, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.Equal(suite.T(), "User already exists", resp.FailureReason)
+	assert.NotEmpty(suite.T(), resp.Inputs, "Inputs should be populated so the user can correct their input")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_SameOU_AuthnFlow_ReturnsFailure() {
+	suite.expectSchemaForProvisioning()
+	attrs := map[string]interface{}{"sub": "user-sub-123"}
+
+	existingUserID := testExistingUserID
+	existingUser := &entityprovider.Entity{
+		ID:   existingUserID,
+		OUID: testOUID, // same as target
+	}
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			"sub": "user-sub-123",
+		},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+			common.RuntimeKeyUserEligibleForProvisioning: dataValueTrue,
+		},
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyAllowCrossOUProvisioning: true,
+		},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(&existingUserID, nil)
+	suite.mockEntityProvider.On("GetEntity", existingUserID).Return(existingUser, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status,
+		"Authentication flow should return ExecFailure (not UserInputRequired) when user exists in target OU")
+	assert.Equal(suite.T(), "User already exists in the target organization", resp.FailureReason)
+	assert.Empty(suite.T(), resp.Inputs, "Inputs should not be populated for authentication flows")
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_SameOU_RegistrationFlow_PopulatesInputs() {
+	suite.expectSchemaForProvisioning()
+	attrs := map[string]interface{}{"sub": "user-sub-123"}
+
+	existingUserID := testExistingUserID
+	existingUser := &entityprovider.Entity{
+		ID:   existingUserID,
+		OUID: testOUID, // same as target
+	}
+
+	nodeInputs := []common.Input{
+		{Identifier: "sub", Type: "string", Required: true},
+	}
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"sub": "user-sub-123",
+		},
+		NodeInputs: nodeInputs,
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyAllowCrossOUProvisioning: true,
+		},
+	}
+
+	// Override GetRequiredInputs to return node inputs
+	provMock := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+	var filteredCalls []*mock.Call
+	for _, call := range provMock.ExpectedCalls {
+		if call.Method != methodGetRequiredInputs {
+			filteredCalls = append(filteredCalls, call)
+		}
+	}
+	provMock.ExpectedCalls = filteredCalls
+	provMock.On(methodGetRequiredInputs, mock.Anything).Return(nodeInputs).Maybe()
+
+	suite.mockEntityProvider.On("IdentifyEntity", attrs).Return(&existingUserID, nil)
+	suite.mockEntityProvider.On("GetEntity", existingUserID).Return(existingUser, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, resp.Status)
+	assert.Equal(suite.T(), "User already exists in the target organization", resp.FailureReason)
+	assert.NotEmpty(suite.T(), resp.Inputs, "Inputs should be populated so the user can correct their input")
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_GetUserError() {

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -194,8 +194,10 @@ func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 		}
 
 		if userID != nil && *userID != "" {
-			// At this point, a unique user is found in the system. Hence fail the execution.
-			execResp.Status = common.ExecFailure
+			// At this point, a unique user is found in the system.
+			// Prompt the user to provide a different mobile number.
+			execResp.Status = common.ExecUserInputRequired
+			execResp.Inputs = []common.Input{s.resolvePhoneInput(ctx, mobileNumberInput)}
 			execResp.FailureReason = "User already exists with the provided mobile number."
 			return nil
 		}
@@ -237,7 +239,7 @@ func (s *smsOTPAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		logger.Error("Failed to get authenticated user details", log.Error(err))
 		return fmt.Errorf("failed to get authenticated user details: %w", err)
 	}
-	if execResp.Status == common.ExecFailure {
+	if execResp.Status == common.ExecFailure || execResp.Status == common.ExecUserInputRequired {
 		return nil
 	}
 
@@ -592,7 +594,8 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	providedOTP := ctx.UserInputs[userInputOTP]
 	if providedOTP == "" {
 		logger.Debug("Provided OTP is empty", log.MaskedString(log.LoggerKeyUserID, userID))
-		execResp.Status = common.ExecFailure
+		execResp.Status = common.ExecUserInputRequired
+		execResp.Inputs = s.GetRequiredInputs(ctx)
 		execResp.FailureReason = failureReasonInvalidOTP
 		return nil, nil
 	}
@@ -611,7 +614,8 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 		if svcErr != nil {
 			if svcErr.Code == otp.ErrorIncorrectOTP.Code {
 				logger.Debug("OTP verification failed", log.MaskedString(log.LoggerKeyUserID, userID))
-				execResp.Status = common.ExecFailure
+				execResp.Status = common.ExecUserInputRequired
+				execResp.Inputs = s.GetRequiredInputs(ctx)
 				execResp.FailureReason = failureReasonInvalidOTP
 				return nil, nil
 			}
@@ -641,7 +645,8 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	if svcErr != nil {
 		if svcErr.Code == authnprovidermgr.ErrorAuthenticationFailed.Code {
 			logger.Debug("OTP verification failed", log.MaskedString(log.LoggerKeyUserID, userID))
-			execResp.Status = common.ExecFailure
+			execResp.Status = common.ExecUserInputRequired
+			execResp.Inputs = s.GetRequiredInputs(ctx)
 			execResp.FailureReason = failureReasonInvalidOTP
 			return nil, nil
 		}

--- a/backend/internal/flow/executor/sms_auth_executor_test.go
+++ b/backend/internal/flow/executor/sms_auth_executor_test.go
@@ -455,6 +455,113 @@ func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_MFA_NilAttribute
 	assert.Equal(suite.T(), "+1234567890", result.Attributes[common.AttributeMobileNumber])
 }
 
+// TestInitiateOTP_RegistrationFlow_UserAlreadyExists_PromptsForDifferentNumber verifies that when
+// a user with the provided mobile number already exists in a registration flow, the executor
+// returns ExecUserInputRequired with the phone input so the user can provide a different number.
+func (suite *SMSAuthExecutorTestSuite) TestInitiateOTP_RegistrationFlow_UserAlreadyExists_PromptsForDifferentNumber() {
+	existingUserID := testExistingUser123ID
+	suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{
+		common.AttributeMobileNumber: "+1234567890",
+	}).Return(&existingUserID, nil)
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			common.AttributeMobileNumber: "+1234567890",
+		},
+		RuntimeData:       make(map[string]string),
+		AuthenticatedUser: authncm.AuthenticatedUser{IsAuthenticated: false},
+	}
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	err := suite.executor.InitiateOTP(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, execResp.Status)
+	assert.Equal(suite.T(), "User already exists with the provided mobile number.", execResp.FailureReason)
+	assert.Len(suite.T(), execResp.Inputs, 1)
+	assert.Equal(suite.T(), common.AttributeMobileNumber, execResp.Inputs[0].Identifier)
+	assert.Equal(suite.T(), common.InputTypePhone, execResp.Inputs[0].Type)
+	suite.mockEntityProvider.AssertExpectations(suite.T())
+}
+
+// TestInitiateOTP_RegistrationFlow_AmbiguousUser_ReturnsError verifies that when user
+// identification returns an ambiguous result during registration, an error is returned.
+func (suite *SMSAuthExecutorTestSuite) TestInitiateOTP_RegistrationFlow_AmbiguousUser_ReturnsError() {
+	ambiguousErr := entityprovider.NewEntityProviderError(
+		entityprovider.ErrorCodeAmbiguousEntity, "Ambiguous entity", "multiple users found",
+	)
+	suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{
+		common.AttributeMobileNumber: "+1234567890",
+	}).Return(nil, ambiguousErr)
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			common.AttributeMobileNumber: "+1234567890",
+		},
+		RuntimeData:       make(map[string]string),
+		AuthenticatedUser: authncm.AuthenticatedUser{IsAuthenticated: false},
+	}
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	err := suite.executor.InitiateOTP(ctx, execResp)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to identify user during registration flow")
+	suite.mockEntityProvider.AssertExpectations(suite.T())
+}
+
+// TestGetAuthenticatedUser_EmptyOTP_ReturnsUserInputRequired verifies that when the user
+// submits an empty OTP, the executor returns ExecUserInputRequired with inputs populated
+// so the client can prompt the user to re-enter the OTP.
+func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_EmptyOTP_ReturnsUserInputRequired() {
+	defaultInputs := []common.Input{
+		{Ref: "otp_input", Identifier: userInputOTP, Type: common.InputTypeOTP, Required: true},
+	}
+
+	mockBase := suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock)
+	mockBase.On("GetRequiredInputs", mock.Anything).Return(defaultInputs)
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			userInputOTP: "", // empty OTP
+		},
+		RuntimeData: map[string]string{
+			runtimeKeySMSOTPMobileNumber: "+1234567890",
+			"otpSessionToken":            "test-session-token",
+		},
+		AuthenticatedUser: authncm.AuthenticatedUser{IsAuthenticated: false},
+	}
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	result, err := suite.executor.getAuthenticatedUser(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecUserInputRequired, execResp.Status,
+		"Empty OTP should return ExecUserInputRequired so the user can retry")
+	assert.Equal(suite.T(), failureReasonInvalidOTP, execResp.FailureReason)
+	assert.NotEmpty(suite.T(), execResp.Inputs, "Inputs must be populated for retry")
+	assert.Equal(suite.T(), userInputOTP, execResp.Inputs[0].Identifier)
+}
+
 // TestGetAuthenticatedUser_FetchFromStore_NilAttrsAfterUnmarshal verifies that when
 // user attributes unmarshal to nil, the result is returned without error.
 func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_FetchFromStore_NilAttrsAfterUnmarshal() {

--- a/tests/integration/flow/authentication/sms_auth_test.go
+++ b/tests/integration/flow/authentication/sms_auth_test.go
@@ -632,7 +632,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowInvalidOTP() {
 		"mobileNumber": userAttrs["mobileNumber"].(string),
 	}
 
-	flowStep, err := common.InitiateAuthenticationFlow(smsAuthTestAppID, false, inputs, "")
+	flowStep, err := common.InitiateAuthenticationFlow(smsAuthTestAppID, false, nil, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
 	}
@@ -663,10 +663,93 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowInvalidOTP() {
 		ts.T().Fatalf("Failed to complete authentication flow with invalid OTP: %v", err)
 	}
 
-	// Verify authentication failure
-	ts.Require().Equal("ERROR", completeFlowStep.FlowStatus, "Expected flow status to be ERROR")
+	// Verify authentication failure returns INCOMPLETE (retryable)
+	ts.Require().Equal("INCOMPLETE", completeFlowStep.FlowStatus,
+		"Expected flow status to be INCOMPLETE for invalid OTP")
+	ts.Require().Equal("VIEW", completeFlowStep.Type, "Expected type to be VIEW for prompt re-display")
 	ts.Require().Empty(completeFlowStep.Assertion, "No JWT assertion should be returned for failed authentication")
 	ts.Require().NotEmpty(completeFlowStep.FailureReason, "Failure reason should be provided for invalid OTP")
+
+	// Verify OTP input is re-prompted
+	ts.Require().NotEmpty(completeFlowStep.Data, "Flow data should not be empty after re-prompt")
+	ts.Require().True(common.HasInput(completeFlowStep.Data.Inputs, "otp"),
+		"OTP input should be re-prompted after invalid OTP")
+}
+
+func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowRetryAfterInvalidOTP() {
+	// Step 1: Initialize the flow and provide mobile number
+	var userAttrs map[string]interface{}
+	err := json.Unmarshal(testUserWithMobile.Attributes, &userAttrs)
+	ts.Require().NoError(err, "Failed to unmarshal user attributes")
+
+	inputs := map[string]string{
+		"mobileNumber": userAttrs["mobileNumber"].(string),
+	}
+
+	flowStep, err := common.InitiateAuthenticationFlow(smsAuthTestAppID, false, nil, "")
+	if err != nil {
+		ts.T().Fatalf("Failed to initiate authentication flow: %v", err)
+	}
+	ts.Require().NotEmpty(flowStep.ExecutionID, "Execution ID should not be empty")
+
+	// Clear any previous messages
+	ts.mockServer.ClearMessages()
+
+	// Step 2: Continue flow to trigger OTP sending
+	otpFlowStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+		flowStep.ChallengeToken)
+	if err != nil {
+		ts.T().Fatalf("Failed to complete authentication flow with mobile number: %v", err)
+	}
+
+	ts.Require().Equal("INCOMPLETE", otpFlowStep.FlowStatus, "Expected flow status to be INCOMPLETE after OTP send")
+	ts.Require().NotEmpty(otpFlowStep.ExecutionID, "Execution ID should not be empty")
+
+	// Wait for SMS to be sent
+	time.Sleep(500 * time.Millisecond)
+
+	// Capture the valid OTP before submitting an invalid one
+	lastMessage := ts.mockServer.GetLastMessage()
+	ts.Require().NotNil(lastMessage, "SMS should have been sent")
+	ts.Require().NotEmpty(lastMessage.OTP, "OTP should be available from mock server")
+	validOTP := lastMessage.OTP
+
+	// Step 3: Submit invalid OTP
+	invalidOTPInputs := map[string]string{
+		"otp": "000000", // Invalid OTP
+	}
+
+	retryFlowStep, err := common.CompleteFlow(otpFlowStep.ExecutionID, invalidOTPInputs, "action_002",
+		otpFlowStep.ChallengeToken)
+	if err != nil {
+		ts.T().Fatalf("Failed to complete authentication flow with invalid OTP: %v", err)
+	}
+
+	// Verify we get INCOMPLETE (retryable) not ERROR
+	ts.Require().Equal("INCOMPLETE", retryFlowStep.FlowStatus, "Expected INCOMPLETE after invalid OTP")
+	ts.Require().NotEmpty(retryFlowStep.FailureReason, "Failure reason should be present for invalid OTP")
+
+	// Verify OTP input is re-prompted
+	ts.Require().NotEmpty(retryFlowStep.Data, "Flow data should not be empty after re-prompt")
+	ts.Require().True(common.HasInput(retryFlowStep.Data.Inputs, "otp"),
+		"OTP input should be re-prompted for retry")
+
+	// Step 4: Retry with the valid OTP
+	validOTPInputs := map[string]string{
+		"otp": validOTP,
+	}
+
+	successFlowStep, err := common.CompleteFlow(otpFlowStep.ExecutionID, validOTPInputs, "action_002",
+		retryFlowStep.ChallengeToken)
+	if err != nil {
+		ts.T().Fatalf("Failed to complete authentication flow after retry with valid OTP: %v", err)
+	}
+
+	// Verify successful authentication
+	ts.Require().Equal("COMPLETE", successFlowStep.FlowStatus,
+		"Expected COMPLETE after retry with valid OTP")
+	ts.Require().NotEmpty(successFlowStep.Assertion, "JWT assertion should be returned on successful retry")
+	ts.Require().Empty(successFlowStep.FailureReason, "No failure reason on success")
 }
 
 func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowSingleRequestWithMobileNumber() {

--- a/tests/integration/flow/registration/ou_registration_test.go
+++ b/tests/integration/flow/registration/ou_registration_test.go
@@ -705,7 +705,7 @@ func (ts *OURegistrationFlowTestSuite) TestBasicRegistrationFlowWithOUCreationDu
 
 			flowStep, err := common.InitiateRegistrationFlow(ts.basicFlowTestAppID, false, inputs, "")
 			ts.Require().NoError(err)
-			ts.Require().Equal("ERROR", flowStep.FlowStatus)
+			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 			ts.Require().Empty(flowStep.Assertion)
 			ts.Require().Contains(flowStep.FailureReason, tc.expectedErrorSubstr)
 		})
@@ -913,7 +913,7 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 
 			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "", flowStep.ChallengeToken)
 			ts.Require().NoError(err)
-			ts.Require().Equal("ERROR", flowStep.FlowStatus)
+			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 			ts.Require().Empty(flowStep.Assertion)
 			ts.Require().Contains(flowStep.FailureReason, tc.expectedErrorSubstr)
 		})

--- a/tests/integration/flow/registration/sms_registration_test.go
+++ b/tests/integration/flow/registration/sms_registration_test.go
@@ -540,7 +540,7 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowInvalidOTP() {
 		"mobileNumber": mobileNumber,
 	}
 
-	flowStep, err := common.InitiateRegistrationFlow(ts.testAppID, false, inputs, "")
+	flowStep, err := common.InitiateRegistrationFlow(ts.testAppID, false, nil, "")
 	if err != nil {
 		ts.T().Fatalf("Failed to initiate registration flow: %v", err)
 	}
@@ -571,9 +571,9 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowInvalidOTP() {
 		ts.T().Fatalf("Failed to complete registration flow with invalid OTP: %v", err)
 	}
 
-	// Verify registration failure
-	ts.Require().Equal("ERROR", completeFlowStep.FlowStatus, "Expected flow status to be ERROR")
-	ts.Require().Empty(completeFlowStep.Assertion, "No JWT assertion should be returned for failed registration")
+	// Verify registration is incomplete (invalid OTP triggers retry)
+	ts.Require().Equal("INCOMPLETE", completeFlowStep.FlowStatus, "Expected flow status to be INCOMPLETE for invalid OTP")
+	ts.Require().Empty(completeFlowStep.Assertion, "No JWT assertion should be returned for failed OTP")
 	ts.Require().NotEmpty(completeFlowStep.FailureReason, "Failure reason should be provided for invalid OTP")
 	ts.Equal("invalid OTP provided", completeFlowStep.FailureReason,
 		"Expected failure reason to indicate invalid OTP")


### PR DESCRIPTION
### Purpose
Authentication and registration flows are terminated when a recoverable error occurred during a flow step — for example, entering an incorrect OTP, providing a mobile number that already exists, or submitting an invalid invite token. Because these conditions were treated as hard ExecFailure, the flow terminated immediately with no way for the user to retry. This PR changes those conditions to ExecUserInputRequired so that the flow re-prompts the user instead of failing outright.

Additionally, a safety guard was added in taskExecutionNode to detect and surface a clean failure when a node returns INCOMPLETE with no inputs, no actions, and no onIncomplete edge — a configuration that would otherwise silently deadlock the flow.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
# Executor & Flow Engine Updates

## Executor Changes — Recoverable Errors Now Return `ExecUserInputRequired`

The following executors had specific recoverable error paths converted from `ExecFailure` to `ExecUserInputRequired`.

Each executor now also populates `Inputs` with `GetRequiredInputs(ctx)` (or the relevant subset), so the client knows what to re-prompt.

| Executor | Recoverable Conditions Changed |
|---|---|
| `identifyingExecutor` | User not found; ambiguous user (identify & resolve modes) |
| `smsOTPAuthExecutor` | Empty OTP; incorrect OTP; user already exists with provided mobile (registration) |
| `provisioningExecutor` | User already exists — in registration flows only (auth flows still hard-fail) |
| `federatedAuthResolverExecutor` | No user matched selection |
| `ouExecutor` | Client-error on OU creation (e.g., name conflict) |
| `ouResolverExecutor` | Invalid or out-of-scope OU selection |

---

## Deadlock Detection in `taskExecutionNode`

When an executor returns `NodeStatusIncomplete` with a `VIEW` type, but the response contains:

- no inputs
- no actions
- no `onIncomplete` edge configured

the node now converts this to:

- `NodeStatusFailure`

with a descriptive reason.

This prevents the client from hanging on a prompt it cannot respond to.

---

## Flow JSON Updates — `onIncomplete` Edges Added

All **16 default bootstrap flow definitions** were updated to wire `onIncomplete` edges on nodes that can legitimately return `ExecUserInputRequired`.

### Examples

- OTP verify nodes loop back to their OTP prompt node on incomplete.
- Basic auth and social auth nodes loop back to the authenticator selection step on incomplete.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2074

### Related PRs
- https://github.com/asgardeo/javascript/pull/375

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows now support retry mechanisms for recoverable user input errors, allowing users to correct information and resubmit instead of encountering terminal failures.

* **Bug Fixes**
  * SMS OTP verification, provisioning, and organization unit creation now properly handle invalid or conflicting inputs as retryable states rather than errors, with users re-prompted to provide correct information.
  * Improved handling of user identification and authentication flows to distinguish between recoverable input issues and true failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->