### PR TITLE
Fix references to build outputs in release workflow

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -353,7 +353,7 @@ jobs:
 
       - name: 🏷️ Update Product Version
         run: |
-          VERSION="${{ needs.build-product.outputs.version }}"
+          VERSION="${{ needs.build.outputs.version }}"
           echo "$VERSION" > version.txt
 
       - name: ⚙️ Set up Go Environment
@@ -403,7 +403,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-          TAG_VERSION="${{ needs.build-product.outputs.version }}"
+          TAG_VERSION="${{ needs.build.outputs.version }}"
           if [[ ! $TAG_VERSION == v* ]]; then
             TAG_VERSION="v$TAG_VERSION"
           fi
@@ -442,7 +442,7 @@ jobs:
           IMAGE_NAME="ghcr.io/${REPO_NAME}"
           
           # Get version without 'v' prefix for Docker tags
-          DOCKER_VERSION="${{ needs.build-product.outputs.version }}"
+          DOCKER_VERSION="${{ needs.build.outputs.version }}"
           if [[ $DOCKER_VERSION == v* ]]; then
             DOCKER_VERSION="${DOCKER_VERSION#v}"
           fi
@@ -467,7 +467,7 @@ jobs:
       - name: 🏷️ Update Helm Values Image Tag
         run: |
           # Get version without 'v' prefix
-          CHART_VERSION="${{ needs.build-product.outputs.version }}"
+          CHART_VERSION="${{ needs.build.outputs.version }}"
           if [[ $CHART_VERSION == v* ]]; then
             CHART_VERSION="${CHART_VERSION#v}"
           fi
@@ -513,7 +513,7 @@ jobs:
           HELM_REGISTRY="ghcr.io/${OWNER_NAME}"
           
           # Get version without 'v' prefix for Helm chart version
-          CHART_VERSION="${{ needs.build-product.outputs.version }}"
+          CHART_VERSION="${{ needs.build.outputs.version }}"
           if [[ $CHART_VERSION == v* ]]; then
             CHART_VERSION="${CHART_VERSION#v}"
           fi
@@ -546,7 +546,7 @@ jobs:
           OWNER_NAME=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           HELM_REGISTRY="ghcr.io/${OWNER_NAME}/helm-charts"
 
-          CHART_VERSION="${{ needs.build-product.outputs.version }}"
+          CHART_VERSION="${{ needs.build.outputs.version }}"
           if [[ $CHART_VERSION == v* ]]; then
             CHART_VERSION="${CHART_VERSION#v}"
           fi
@@ -568,7 +568,7 @@ jobs:
         id: next_version
         run: |
           # Get the current release version and remove 'v' prefix
-          RELEASE_VERSION="${{ needs.build-product.outputs.version }}"
+          RELEASE_VERSION="${{ needs.build.outputs.version }}"
           if [[ $RELEASE_VERSION == v* ]]; then
             RELEASE_VERSION="${RELEASE_VERSION#v}"
           fi
@@ -660,7 +660,7 @@ jobs:
       - name: 📝 Update Sample Apps Version
         uses: ./.github/actions/update-sample-versions
         with:
-          version: ${{ needs.build-product.outputs.version }}
+          version: ${{ needs.build.outputs.version }}
 
       - name: 📦 Build and Package Linux Samples
         run: |
@@ -694,7 +694,7 @@ jobs:
       - name: 📝 Update Sample Apps Version
         uses: ./.github/actions/update-sample-versions
         with:
-          version: ${{ needs.build-product.outputs.version }}
+          version: ${{ needs.build.outputs.version }}
 
       - name: 📦 Build and Package macOS Samples
         run: |
@@ -763,7 +763,7 @@ jobs:
       - name: 📝 Read Version
         id: version
         run: |
-          VERSION="${{ needs.build-product.outputs.version }}"
+          VERSION="${{ needs.build.outputs.version }}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: 📝 Generate Automatic Release Notes
@@ -771,7 +771,7 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const currentTag = '${{ needs.build-product.outputs.version }}';
+            const currentTag = '${{ needs.build.outputs.version }}';
             
             try {
               // Get only the 2 most recent releases (current + previous)
@@ -850,7 +850,7 @@ jobs:
         id: readme_extract
         run: |
           # Get the release version without v prefix for replacement
-          RELEASE_VERSION="${{ needs.build-product.outputs.version }}"
+          RELEASE_VERSION="${{ needs.build.outputs.version }}"
           if [[ $RELEASE_VERSION == v* ]]; then
             RELEASE_VERSION="${RELEASE_VERSION#v}"
           fi
@@ -989,7 +989,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.version }}
           name: ${{ env.PRODUCT_NAME }} ${{ steps.version.outputs.version }}
           draft: false
-          prerelease: ${{ needs.build-product.outputs.prerelease }}
+          prerelease: ${{ needs.build.outputs.prerelease }}
           files: target/dist/*.zip
           body: ${{ env.RELEASE_BODY }}
           generate_release_notes: false
@@ -1015,7 +1015,7 @@ jobs:
     name: 🧪 Trigger Performance Test
     runs-on: ubuntu-latest
     needs: [build, release]
-    if: ${{ needs.build-product.outputs.run_performance_test == 'true' }}
+    if: ${{ needs.build.outputs.run_performance_test == 'true' }}
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request updates the `.github/workflows/release-builder.yml` workflow to consistently reference outputs from the `build` job instead of the deprecated `build-product` job. This change ensures that all version, prerelease, and performance test information is sourced from the correct job, improving maintainability and reducing the risk of errors due to outdated references.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->


**Workflow job output reference updates:**

* Updated all occurrences of `needs.build-product.outputs.version` to `needs.build.outputs.version` for versioning in steps such as updating product version, Docker and Helm chart tagging, and sample app version updates. [[1]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L356-R356) [[2]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L445-R445) [[3]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L470-R470) [[4]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L516-R516) [[5]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L549-R549) [[6]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L571-R571) [[7]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L663-R663) [[8]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L697-R697) [[9]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L766-R774) [[10]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L853-R853)
* Changed references from `needs.build-product.outputs.prerelease` to `needs.build.outputs.prerelease` for release publishing.
* Updated the performance test trigger condition to use `needs.build.outputs.run_performance_test` instead of the old job output.
* Updated tag and version variables in shell scripts and GitHub Actions steps to use the correct job output. [[1]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L406-R406) [[2]](diffhunk://#diff-1cdf1af77befe417f910761e837fb1c584918a76429a22096a777d44a97d7234L766-R774)


### Related Issues
- https://github.com/asgardeo/thunder/issues/2465

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release build workflow to use standardized dependency output references, affecting version propagation for Git tags, Docker images, Helm charts, and release documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->