### PR TITLE
Add provisioning dynamic-input flow support to console

### DIFF
--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonStepPropertyFactory.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonStepPropertyFactory.tsx
@@ -45,7 +45,7 @@ export interface CommonStepPropertyFactoryPropsInterface {
    * @param newValue - The new value of the property.
    * @param resource - The resource associated with the property.
    */
-  onChange: (propertyKey: string, newValue: string | boolean, resource: Resource, debounce?: boolean) => void;
+  onChange: (propertyKey: string, newValue: string | boolean | number, resource: Resource, debounce?: boolean) => void;
   /**
    * Additional props.
    */
@@ -65,6 +65,9 @@ function CommonStepPropertyFactory({
   onChange,
   ...rest
 }: CommonStepPropertyFactoryPropsInterface): ReactElement | null {
+  const displayKey = propertyKey.replace(/^data\.properties\./, '');
+  const displayLabel = startCase(displayKey);
+
   if (propertyKey === 'text') {
     if (resource.type === ElementTypes.RichText) {
       return (
@@ -81,22 +84,47 @@ function CommonStepPropertyFactory({
     return (
       <FormControlLabel
         control={<Checkbox checked={propertyValue} />}
-        label={startCase(propertyKey)}
+        label={displayLabel}
         onChange={(_event: SyntheticEvent, checked: boolean) => onChange(propertyKey, checked, resource)}
         {...rest}
       />
     );
   }
 
+  if (typeof propertyValue === 'number') {
+    return (
+      <FormControl fullWidth sx={{mb: 3}}>
+        <FormLabel htmlFor={propertyKey}>{displayLabel} </FormLabel>
+        <TextField
+          fullWidth
+          id={propertyKey}
+          defaultValue={propertyValue}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => {
+            const val = e.target.value;
+            const num = Number(val);
+            if (val === '' || Number.isNaN(num)) {
+              return;
+            }
+            onChange(propertyKey, num, resource, true);
+          }}
+          placeholder={`Enter ${displayLabel}`}
+          type="number"
+          {...rest}
+        />
+      </FormControl>
+    );
+  }
+
   if (typeof propertyValue === 'string') {
     return (
       <FormControl fullWidth sx={{mb: 3}}>
-        <FormLabel htmlFor="name">{startCase(propertyKey)} </FormLabel>
+        <FormLabel htmlFor={propertyKey}>{displayLabel} </FormLabel>
         <TextField
           fullWidth
+          id={propertyKey}
           defaultValue={propertyValue}
           onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(propertyKey, e.target.value, resource, true)}
-          placeholder={`Enter ${startCase(propertyKey)}`}
+          placeholder={`Enter ${displayLabel}`}
           {...rest}
         />
       </FormControl>

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/ResourceProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/ResourceProperties.tsx
@@ -158,6 +158,20 @@ function ResourceProperties(): ReactElement {
       });
     }
 
+    const stepProperties = (
+      lastInteractedResource as Resource & {
+        data?: {
+          properties?: Record<string, unknown>;
+        };
+      }
+    ).data?.properties;
+
+    if (stepProperties) {
+      Object.entries(stepProperties).forEach(([key, value]) => {
+        (accumulated as Record<string, unknown>)[`data.properties.${key}`] = value;
+      });
+    }
+
     emitPropertyPanelOpen(lastInteractedResource, accumulated, lastInteractedStepId);
 
     return cloneDeep(accumulated);
@@ -229,13 +243,13 @@ function ResourceProperties(): ReactElement {
    * Handles plugin interception, ReactFlow node updates, and interaction state sync.
    */
   const applyPropertyChangeRef = useRef<
-    ((propertyKey: string, newValue: string | boolean | object, element: Element) => void) | null
+    ((propertyKey: string, newValue: string | boolean | number | object, element: Element) => void) | null
   >(null);
 
   useEffect(() => {
     applyPropertyChangeRef.current = (
       propertyKey: string,
-      newValue: string | boolean | object,
+      newValue: string | boolean | number | object,
       element: Element,
     ): void => {
       const currentStepId = lastInteractedStepIdRef.current;
@@ -319,13 +333,16 @@ function ResourceProperties(): ReactElement {
    * Batches rapid keystrokes with a 300ms delay before committing to ReactFlow state.
    */
   const handlePropertyChangeDebouncedRef = useRef<
-    ((propertyKey: string, newValue: string | boolean | object, element: Element) => void) | null
+    ((propertyKey: string, newValue: string | boolean | number | object, element: Element) => void) | null
   >(null);
 
   useEffect(() => {
-    const debouncedFn = debounce((propertyKey: string, newValue: string | boolean | object, element: Element): void => {
-      applyPropertyChangeRef.current?.(propertyKey, newValue, element);
-    }, 300);
+    const debouncedFn = debounce(
+      (propertyKey: string, newValue: string | boolean | number | object, element: Element): void => {
+        applyPropertyChangeRef.current?.(propertyKey, newValue, element);
+      },
+      300,
+    );
 
     handlePropertyChangeDebouncedRef.current = debouncedFn;
 
@@ -340,7 +357,7 @@ function ResourceProperties(): ReactElement {
    * - debounce=true: batches with 300ms delay for continuous inputs (text fields, number inputs).
    */
   const handlePropertyChange = useCallback(
-    (propertyKey: string, newValue: string | boolean | object, element: Element, shouldDebounce?: boolean) => {
+    (propertyKey: string, newValue: string | boolean | number | object, element: Element, shouldDebounce?: boolean) => {
       if (shouldDebounce) {
         void handlePropertyChangeDebouncedRef.current?.(propertyKey, newValue, element);
       } else {

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonStepPropertyFactory.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonStepPropertyFactory.test.tsx
@@ -287,6 +287,94 @@ describe('CommonStepPropertyFactory', () => {
     });
   });
 
+  describe('Number Properties', () => {
+    it('should render FormControl with number input for numeric value', () => {
+      const resource: Resource = {
+        id: 'resource-1',
+        type: 'VIEW',
+        config: {},
+      } as Resource;
+
+      render(
+        <CommonStepPropertyFactory
+          resource={resource}
+          propertyKey="maxPerPrompt"
+          propertyValue={5}
+          onChange={mockOnChange}
+        />,
+      );
+
+      const numberField = screen.getByRole('spinbutton');
+      expect(numberField).toBeInTheDocument();
+      expect(numberField).toHaveValue(5);
+      expect(screen.getByText('Max Per Prompt')).toBeInTheDocument();
+    });
+
+    it('should call onChange with numeric value when number input changes', () => {
+      const resource: Resource = {
+        id: 'resource-1',
+        type: 'VIEW',
+        config: {},
+      } as Resource;
+
+      render(
+        <CommonStepPropertyFactory
+          resource={resource}
+          propertyKey="maxPerPrompt"
+          propertyValue={5}
+          onChange={mockOnChange}
+        />,
+      );
+
+      const numberField = screen.getByRole('spinbutton');
+      fireEvent.change(numberField, {target: {value: '3'}});
+
+      expect(mockOnChange).toHaveBeenCalledWith('maxPerPrompt', 3, resource, true);
+    });
+
+    it('should ignore empty numeric input values', () => {
+      const resource: Resource = {
+        id: 'resource-1',
+        type: 'VIEW',
+        config: {},
+      } as Resource;
+
+      render(
+        <CommonStepPropertyFactory
+          resource={resource}
+          propertyKey="maxPerPrompt"
+          propertyValue={5}
+          onChange={mockOnChange}
+        />,
+      );
+
+      const numberField = screen.getByRole('spinbutton');
+      fireEvent.change(numberField, {target: {value: ''}});
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    it('should use cleaned labels for nested data property keys', () => {
+      const resource: Resource = {
+        id: 'resource-1',
+        type: 'VIEW',
+        config: {},
+      } as Resource;
+
+      render(
+        <CommonStepPropertyFactory
+          resource={resource}
+          propertyKey="data.properties.maxPerPrompt"
+          propertyValue={5}
+          onChange={mockOnChange}
+        />,
+      );
+
+      expect(screen.getByText('Max Per Prompt')).toBeInTheDocument();
+      expect(screen.queryByText('Data Properties Max Per Prompt')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Null Cases', () => {
     it('should return null for object property values', () => {
       const resource: Resource = {
@@ -300,25 +388,6 @@ describe('CommonStepPropertyFactory', () => {
           resource={resource}
           propertyKey="config"
           propertyValue={{nested: 'value'}}
-          onChange={mockOnChange}
-        />,
-      );
-
-      expect(container.firstChild).toBeNull();
-    });
-
-    it('should return null for number property values', () => {
-      const resource: Resource = {
-        id: 'resource-1',
-        type: 'VIEW',
-        config: {},
-      } as Resource;
-
-      const {container} = render(
-        <CommonStepPropertyFactory
-          resource={resource}
-          propertyKey="order"
-          propertyValue={123}
           onChange={mockOnChange}
         />,
       );

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
@@ -238,6 +238,39 @@ describe('ResourceProperties', () => {
       expect(properties.placeholder).toBe('Test Placeholder');
       expect(properties.required).toBe(true);
     });
+
+    it('should extract step data properties for task resources', () => {
+      const stepResourceWithProperties: Base = {
+        ...mockBaseResource,
+        resourceType: 'STEP',
+        type: 'TASK_EXECUTION',
+        data: {
+          properties: {
+            includeOptional: false,
+            maxPerPrompt: 5,
+          },
+        },
+      } as Base & {
+        data: {
+          properties: {
+            includeOptional: boolean;
+            maxPerPrompt: number;
+          };
+        };
+      };
+
+      const contextWithStepProperties = createContextValue({
+        lastInteractedResource: stepResourceWithProperties,
+      });
+
+      render(<ResourceProperties />, {wrapper: createWrapper(contextWithStepProperties)});
+
+      const propertiesDiv = screen.getByTestId('properties');
+      const properties = JSON.parse(propertiesDiv.textContent ?? '{}') as Record<string, unknown>;
+
+      expect(properties['data.properties.includeOptional']).toBe(false);
+      expect(properties['data.properties.maxPerPrompt']).toBe(5);
+    });
   });
 
   describe('Variant Change', () => {

--- a/frontend/apps/console/src/features/flows/components/resources/elements/CommonElementFactory.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/CommonElementFactory.tsx
@@ -24,6 +24,7 @@ import ChoiceAdapter from './adapters/ChoiceAdapter';
 import ConsentAdapter from './adapters/ConsentAdapter';
 import CustomAdapter from './adapters/CustomAdapter';
 import DividerAdapter from './adapters/DividerAdapter';
+import DynamicInputPlaceholderAdapter from './adapters/DynamicInputPlaceholderAdapter';
 import FormAdapter from './adapters/FormAdapter';
 import IconAdapter from './adapters/IconAdapter';
 import ImageAdapter from './adapters/ImageAdapter';
@@ -168,6 +169,9 @@ function CommonElementFactory({
   }
   if (resource.type === ElementTypes.Custom) {
     return <CustomAdapter resource={resource} />;
+  }
+  if (resource.type === ElementTypes.DynamicInputPlaceholder) {
+    return <DynamicInputPlaceholderAdapter resource={resource} />;
   }
 
   return null;

--- a/frontend/apps/console/src/features/flows/components/resources/elements/__tests__/CommonElementFactory.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/__tests__/CommonElementFactory.test.tsx
@@ -166,6 +166,14 @@ vi.mock('../adapters/CustomAdapter', () => ({
   ),
 }));
 
+vi.mock('../adapters/DynamicInputPlaceholderAdapter', () => ({
+  default: ({resource}: {resource: Element}) => (
+    <div data-testid="dynamic-input-placeholder-adapter" data-resource-id={resource.id}>
+      Dynamic Input Placeholder Adapter
+    </div>
+  ),
+}));
+
 describe('CommonElementFactory', () => {
   const createMockElement = (overrides: Partial<Element> = {}): Element =>
     ({
@@ -474,6 +482,19 @@ describe('CommonElementFactory', () => {
 
       expect(screen.getByTestId('custom-adapter')).toBeInTheDocument();
       expect(screen.getByTestId('custom-adapter')).toHaveAttribute('data-resource-id', 'element-1');
+    });
+  });
+
+  describe('Dynamic Input Placeholder Element', () => {
+    it('should render DynamicInputPlaceholderAdapter for DynamicInputPlaceholder type', () => {
+      const placeholderElement = createMockElement({
+        type: ElementTypes.DynamicInputPlaceholder,
+      });
+
+      render(<CommonElementFactory stepId="step-1" resource={placeholderElement} />);
+
+      expect(screen.getByTestId('dynamic-input-placeholder-adapter')).toBeInTheDocument();
+      expect(screen.getByTestId('dynamic-input-placeholder-adapter')).toHaveAttribute('data-resource-id', 'element-1');
     });
   });
 

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/DynamicInputPlaceholderAdapter.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/DynamicInputPlaceholderAdapter.tsx
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, Typography} from '@wso2/oxygen-ui';
+import {Layers} from '@wso2/oxygen-ui-icons-react';
+import {type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
+import type {Element as FlowElement} from '@/features/flows/models/elements';
+
+export interface DynamicInputPlaceholderAdapterPropsInterface {
+  resource: FlowElement;
+}
+
+function DynamicInputPlaceholderAdapter({resource}: DynamicInputPlaceholderAdapterPropsInterface): ReactElement {
+  const {t} = useTranslation();
+
+  const placeholder =
+    (resource as FlowElement & {placeholder?: string}).placeholder ??
+    t('flows:core.placeholders.dynamicInputPlaceholder.title', 'Dynamic Input');
+
+  const hint =
+    (resource as FlowElement & {hint?: string}).hint ??
+    t(
+      'flows:core.placeholders.dynamicInputPlaceholder.hint',
+      'Resolves input fields passed from runtime when the flow executes',
+    );
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      sx={{
+        width: '100%',
+        minHeight: 72,
+        borderRadius: 1,
+        border: '1px dashed',
+        borderColor: 'primary.light',
+        backgroundColor: (theme) =>
+          theme.palette.mode === 'dark' ? 'rgba(99, 102, 241, 0.08)' : 'rgba(99, 102, 241, 0.05)',
+        px: 1.5,
+        py: 1.5,
+        gap: 0.5,
+      }}
+    >
+      <Layers size={20} color="primary" />
+      <Typography variant="h5" color="primary" align="center">
+        {placeholder}
+      </Typography>
+      <Typography variant="subtitle2" color="textSecondary" align="center" sx={{fontSize: '0.7rem'}}>
+        {hint}
+      </Typography>
+    </Box>
+  );
+}
+
+export default DynamicInputPlaceholderAdapter;

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/__tests__/DynamicInputPlaceholderAdapter.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/__tests__/DynamicInputPlaceholderAdapter.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import type {Element} from '@/features/flows/models/elements';
+import {ElementCategories, ElementTypes} from '@/features/flows/models/elements';
+import DynamicInputPlaceholderAdapter from '../DynamicInputPlaceholderAdapter';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+describe('DynamicInputPlaceholderAdapter', () => {
+  const createResource = (overrides: Partial<Element> = {}): Element =>
+    ({
+      id: 'dynamic-input-placeholder',
+      type: ElementTypes.DynamicInputPlaceholder,
+      category: ElementCategories.Display,
+      config: {},
+      ...overrides,
+    }) as Element;
+
+  it('should render translated fallback copy when placeholder and hint are absent', () => {
+    render(<DynamicInputPlaceholderAdapter resource={createResource()} />);
+
+    expect(screen.getByText('Dynamic Input')).toBeInTheDocument();
+    expect(screen.getByText('Resolves input fields passed from runtime when the flow executes')).toBeInTheDocument();
+  });
+
+  it('should prefer resource placeholder and hint values when provided', () => {
+    render(
+      <DynamicInputPlaceholderAdapter
+        resource={createResource({
+          hint: 'Custom hint',
+          placeholder: 'Custom placeholder',
+        } as Partial<Element>)}
+      />,
+    );
+
+    expect(screen.getByText('Custom placeholder')).toBeInTheDocument();
+    expect(screen.getByText('Custom hint')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
@@ -71,9 +71,11 @@ import {type Step, type StepData} from '../../models/steps';
 import {type Template} from '../../models/templates';
 import type {Widget} from '../../models/widget';
 import applyAutoLayout from '../../utils/applyAutoLayout';
+import autoAssignConnections from '../../utils/autoAssignConnections';
 import computeExecutorConnections from '../../utils/computeExecutorConnections';
 import generateResourceId from '../../utils/generateResourceId';
 import {resolveCollisions} from '../../utils/resolveCollisions';
+import {widgetNeedsViewContainer} from '../../utils/widgetUtils';
 import Droppable from '../dnd/Droppable';
 import ResourcePanel from '../resource-panel/ResourcePanel';
 import ResourcePropertyPanel from '../resource-property-panel/ResourcePropertyPanel';
@@ -99,6 +101,7 @@ export interface DecoratedVisualFlowPropsInterface extends Omit<VisualFlowPropsI
     targetResource: Resource,
     currentNodes: Node[],
     edges: Edge[],
+    removeTargetViewWhenStandalone?: boolean,
   ) => [Node[], Edge[], Resource | null, string | null];
   onStepLoad: (step: Step) => Step;
   onResourceAdd: (resource: Resource) => void;
@@ -406,11 +409,36 @@ function DecoratedVisualFlow({
         return;
       }
 
-      // Widget dropped on canvas -> needs View
+      // Widget dropped on canvas
       if (isWidgetDrop && isCanvasTarget) {
+        const widget = sourceData.dragged as Widget;
+        const needsViewContainer = widgetNeedsViewContainer(widget);
+
         pendingDropRef.current = {event, sourceData, targetData};
         setDropScenario('widget-on-canvas');
-        setIsContainerDialogOpen(true);
+
+        if (needsViewContainer) {
+          setIsContainerDialogOpen(true);
+        } else {
+          const currentNodes = getNodes();
+          const currentEdges = getEdges();
+          const [newNodes, newEdges, defSelector, defStepId] = onWidgetLoad(
+            widget,
+            {} as Resource,
+            currentNodes,
+            currentEdges,
+          );
+
+          if (computedMetadata?.executorConnections) {
+            autoAssignConnections(newNodes, computedMetadata.executorConnections);
+          }
+
+          setNodes(() => newNodes);
+          setEdges(() => newEdges);
+          onResourceDropOnCanvas(defSelector ?? (widget as Resource), defStepId ?? '');
+          notifyElementAdded('widget');
+          pendingDropRef.current = null;
+        }
         return;
       }
 
@@ -532,6 +560,12 @@ function DecoratedVisualFlow({
       addToViewAtIndex,
       addToFormAtIndex,
       getNodes,
+      getEdges,
+      onWidgetLoad,
+      setNodes,
+      setEdges,
+      onResourceDropOnCanvas,
+      computedMetadata,
       notifyElementAdded,
     ],
   );

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
@@ -20,9 +20,9 @@
 
 import {render, screen, fireEvent, waitFor, cleanup} from '@thunderid/test-utils';
 import type {Node, Edge} from '@xyflow/react';
-import React from 'react';
+import React, {act} from 'react';
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import type {Resources} from '../../../models/resources';
+import type {Resource, Resources} from '../../../models/resources';
 import DecoratedVisualFlow from '../DecoratedVisualFlow';
 
 // Mock hooks
@@ -33,25 +33,36 @@ vi.mock('../../../hooks/useUIPanelState', () => ({
   }),
 }));
 
+const {flowConfigState, mockSetFlowNodes, mockOnResourceDropOnCanvas, mockNotifyElementAdded, mockTriggerAutoLayout} =
+  vi.hoisted(() => ({
+    flowConfigState: {
+      metadata: undefined as unknown,
+    },
+    mockSetFlowNodes: vi.fn(),
+    mockOnResourceDropOnCanvas: vi.fn(),
+    mockNotifyElementAdded: vi.fn(),
+    mockTriggerAutoLayout: vi.fn(),
+  }));
+
 vi.mock('../../../hooks/useFlowConfig', () => ({
   default: () => ({
     isFlowMetadataLoading: false,
-    metadata: undefined,
-    setFlowNodes: vi.fn(),
+    metadata: flowConfigState.metadata,
+    setFlowNodes: mockSetFlowNodes,
   }),
 }));
 
 vi.mock('../../../hooks/useInteractionState', () => ({
   default: () => ({
-    onResourceDropOnCanvas: vi.fn(),
+    onResourceDropOnCanvas: mockOnResourceDropOnCanvas,
   }),
 }));
 
 vi.mock('../../../hooks/useFlowEvents', () => ({
   default: () => ({
-    notifyElementAdded: vi.fn(),
+    notifyElementAdded: mockNotifyElementAdded,
     onElementAdded: vi.fn(() => vi.fn()),
-    triggerAutoLayout: vi.fn(),
+    triggerAutoLayout: mockTriggerAutoLayout,
     onAutoLayout: vi.fn(() => vi.fn()),
     restoreFromHistory: vi.fn(),
     onRestoreFromHistory: vi.fn(() => vi.fn()),
@@ -125,6 +136,14 @@ vi.mock('../../../utils/computeExecutorConnections', () => ({
   default: vi.fn(() => []),
 }));
 
+const {mockAutoAssignConnections} = vi.hoisted(() => ({
+  mockAutoAssignConnections: vi.fn(),
+}));
+
+vi.mock('../../../utils/autoAssignConnections', () => ({
+  default: mockAutoAssignConnections,
+}));
+
 vi.mock('@/features/integrations/api/useIdentityProviders', () => ({
   default: () => ({data: []}),
 }));
@@ -134,16 +153,23 @@ vi.mock('@/features/notification-senders/api/useNotificationSenders', () => ({
 }));
 
 // Use vi.hoisted for mocks that need to be referenced in vi.mock
-const {mockToObject, mockGetNodes, mockGetEdges, mockUpdateNodeData, mockFitView, mockUpdateNodeInternals} = vi.hoisted(
-  () => ({
-    mockToObject: vi.fn(() => ({viewport: {x: 0, y: 0, zoom: 1}})),
-    mockGetNodes: vi.fn((): Node[] => []),
-    mockGetEdges: vi.fn((): Edge[] => []),
-    mockUpdateNodeData: vi.fn(),
-    mockFitView: vi.fn().mockResolvedValue(undefined),
-    mockUpdateNodeInternals: vi.fn(),
-  }),
-);
+const {
+  mockToObject,
+  mockGetNodes,
+  mockGetEdges,
+  mockUpdateNodeData,
+  mockFitView,
+  mockUpdateNodeInternals,
+  mockScreenToFlowPosition,
+} = vi.hoisted(() => ({
+  mockToObject: vi.fn(() => ({viewport: {x: 0, y: 0, zoom: 1}})),
+  mockGetNodes: vi.fn((): Node[] => []),
+  mockGetEdges: vi.fn((): Edge[] => []),
+  mockUpdateNodeData: vi.fn(),
+  mockFitView: vi.fn().mockResolvedValue(undefined),
+  mockUpdateNodeInternals: vi.fn(),
+  mockScreenToFlowPosition: vi.fn(({x, y}: {x: number; y: number}) => ({x, y})),
+}));
 
 vi.mock('@xyflow/react', () => ({
   useReactFlow: () => ({
@@ -152,6 +178,7 @@ vi.mock('@xyflow/react', () => ({
     getEdges: mockGetEdges,
     updateNodeData: mockUpdateNodeData,
     fitView: mockFitView,
+    screenToFlowPosition: mockScreenToFlowPosition,
   }),
   useUpdateNodeInternals: () => mockUpdateNodeInternals,
 }));
@@ -163,6 +190,10 @@ type DragEndCallback = (event: {
     target: {id: string; data: Record<string, unknown>} | null;
   };
   canceled: boolean;
+  nativeEvent?: {
+    clientX: number;
+    clientY: number;
+  };
 }) => void;
 type DragOverCallback = (event: {
   operation: {
@@ -330,12 +361,14 @@ describe('DecoratedVisualFlow', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    flowConfigState.metadata = undefined;
     mockGetNodes.mockReturnValue([]);
     mockGetEdges.mockReturnValue([]);
     // Reset applyAutoLayout to return a resolved promise by default
     mockApplyAutoLayout.mockResolvedValue([]);
     // Reset fitView to return a resolved promise by default
     mockFitView.mockResolvedValue(undefined);
+    mockScreenToFlowPosition.mockImplementation(({x, y}: {x: number; y: number}) => ({x, y}));
   });
 
   afterEach(async () => {
@@ -787,22 +820,24 @@ describe('DecoratedVisualFlow', () => {
       renderComponent(<DecoratedVisualFlow {...defaultProps} />);
 
       // Simulate input drop on canvas
-      if (capturedOnDragEnd) {
-        capturedOnDragEnd({
-          operation: {
-            source: {
-              data: {
-                dragged: {category: 'FIELD'},
+      act(() => {
+        if (capturedOnDragEnd) {
+          capturedOnDragEnd({
+            operation: {
+              source: {
+                data: {
+                  dragged: {category: 'FIELD'},
+                },
+              },
+              target: {
+                id: 'flow-builder-canvas_test',
+                data: {},
               },
             },
-            target: {
-              id: 'flow-builder-canvas_test',
-              data: {},
-            },
-          },
-          canceled: false,
-        });
-      }
+            canceled: false,
+          });
+        }
+      });
 
       await waitFor(() => {
         const dialog = screen.getByTestId('form-requires-view-dialog');
@@ -814,22 +849,24 @@ describe('DecoratedVisualFlow', () => {
       renderComponent(<DecoratedVisualFlow {...defaultProps} />);
 
       // Simulate input drop on view
-      if (capturedOnDragEnd) {
-        capturedOnDragEnd({
-          operation: {
-            source: {
-              data: {
-                dragged: {category: 'FIELD'},
+      act(() => {
+        if (capturedOnDragEnd) {
+          capturedOnDragEnd({
+            operation: {
+              source: {
+                data: {
+                  dragged: {category: 'FIELD'},
+                },
+              },
+              target: {
+                id: 'flow-builder-view_test',
+                data: {},
               },
             },
-            target: {
-              id: 'flow-builder-view_test',
-              data: {},
-            },
-          },
-          canceled: false,
-        });
-      }
+            canceled: false,
+          });
+        }
+      });
 
       await waitFor(() => {
         const dialog = screen.getByTestId('form-requires-view-dialog');
@@ -841,27 +878,127 @@ describe('DecoratedVisualFlow', () => {
       renderComponent(<DecoratedVisualFlow {...defaultProps} />);
 
       // Simulate widget drop on canvas
-      if (capturedOnDragEnd) {
-        capturedOnDragEnd({
-          operation: {
-            source: {
-              data: {
-                dragged: {resourceType: 'WIDGET'},
+      act(() => {
+        if (capturedOnDragEnd) {
+          capturedOnDragEnd({
+            operation: {
+              source: {
+                data: {
+                  dragged: {resourceType: 'WIDGET'},
+                },
+              },
+              target: {
+                id: 'flow-builder-canvas_test',
+                data: {},
               },
             },
-            target: {
-              id: 'flow-builder-canvas_test',
-              data: {},
-            },
-          },
-          canceled: false,
-        });
-      }
+            canceled: false,
+          });
+        }
+      });
 
       await waitFor(() => {
         const dialog = screen.getByTestId('form-requires-view-dialog');
         expect(dialog).toHaveAttribute('data-scenario', 'widget-on-canvas');
       });
+    });
+
+    it('should open the container dialog for merge-at-drop-point widgets', async () => {
+      renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+
+      act(() => {
+        if (capturedOnDragEnd) {
+          capturedOnDragEnd({
+            operation: {
+              source: {
+                data: {
+                  dragged: {
+                    config: {
+                      data: {
+                        steps: [{__generationMeta__: {strategy: 'MERGE_WITH_DROP_POINT'}}],
+                      },
+                    },
+                    resourceType: 'WIDGET',
+                  },
+                },
+              },
+              target: {
+                id: 'flow-builder-canvas_test',
+                data: {},
+              },
+            },
+            canceled: false,
+          });
+        }
+      });
+
+      await waitFor(() => {
+        const dialog = screen.getByTestId('form-requires-view-dialog');
+        expect(dialog).toHaveAttribute('data-open', 'true');
+        expect(dialog).toHaveAttribute('data-scenario', 'widget-on-canvas');
+      });
+    });
+
+    it('should scaffold standalone widgets directly on the canvas', async () => {
+      const currentNodes: Node[] = [{id: 'existing-node', position: {x: 10, y: 20}, data: {}}];
+      const currentEdges: Edge[] = [{id: 'existing-edge', source: 'existing-node', target: 'target-node'}];
+      const widget = {
+        config: {
+          data: {
+            steps: [{__generationMeta__: {strategy: 'INLINE'}}],
+          },
+        },
+        id: 'widget-1',
+        resourceType: 'WIDGET',
+      };
+      const generatedNodes: Node[] = [{id: 'generated-node', position: {x: 150, y: 260}, data: {}}];
+      const generatedEdges: Edge[] = [{id: 'generated-edge', source: 'generated-node', target: 'view_test123'}];
+      const defaultSelector = {id: 'selector-1'} as Resource;
+      const onWidgetLoad = vi.fn(
+        () => [generatedNodes, generatedEdges, defaultSelector, 'generated-step'] as [Node[], Edge[], Resource, string],
+      );
+      const dragEvent = {
+        operation: {
+          source: {
+            data: {
+              dragged: widget,
+            },
+          },
+          target: {
+            id: 'flow-builder-canvas_test',
+            data: {},
+          },
+        },
+        canceled: false,
+        nativeEvent: {clientX: 150, clientY: 260},
+      } satisfies Parameters<NonNullable<typeof capturedOnDragEnd>>[0];
+      flowConfigState.metadata = {executorConnections: [{connections: ['social'], executorName: 'google'}]};
+      mockGetNodes.mockReturnValue(currentNodes);
+      mockGetEdges.mockReturnValue(currentEdges);
+
+      renderComponent(<DecoratedVisualFlow {...defaultProps} onWidgetLoad={onWidgetLoad} />);
+
+      act(() => {
+        capturedOnDragEnd?.(dragEvent);
+      });
+
+      await waitFor(() => {
+        expect(onWidgetLoad).toHaveBeenCalledWith(widget, {}, currentNodes, currentEdges);
+        expect(mockAutoAssignConnections).toHaveBeenCalledWith(generatedNodes, [
+          {connections: ['social'], executorName: 'google'},
+        ]);
+        expect(defaultProps.setNodes).toHaveBeenCalled();
+        expect(defaultProps.setEdges).toHaveBeenCalled();
+        expect(mockOnResourceDropOnCanvas).toHaveBeenCalledWith(defaultSelector, 'generated-step');
+        expect(mockNotifyElementAdded).toHaveBeenCalledWith('widget');
+      });
+
+      const setNodesUpdater = defaultProps.setNodes.mock.calls[0][0] as () => Node[];
+      const setEdgesUpdater = defaultProps.setEdges.mock.calls[0][0] as () => Edge[];
+
+      expect(setNodesUpdater()).toEqual(generatedNodes);
+      expect(setEdgesUpdater()).toEqual(generatedEdges);
+      expect(screen.getByTestId('form-requires-view-dialog')).toHaveAttribute('data-open', 'false');
     });
 
     it('should return early when event is canceled', () => {

--- a/frontend/apps/console/src/features/flows/constants/VisualFlowConstants.ts
+++ b/frontend/apps/console/src/features/flows/constants/VisualFlowConstants.ts
@@ -80,6 +80,7 @@ class VisualFlowConstants {
     WidgetTypes.GithubFederation,
     WidgetTypes.PasskeyAuthentication,
     WidgetTypes.SelfSignUpLink,
+    WidgetTypes.Provisioning,
     ElementTypes.Timer,
   ];
 
@@ -141,6 +142,7 @@ class VisualFlowConstants {
     ElementTypes.Image,
     ElementTypes.Timer,
     ElementTypes.Custom,
+    ElementTypes.DynamicInputPlaceholder,
   ];
 
   public static readonly FLOW_BUILDER_STACK_ALLOWED_RESOURCE_TYPES: string[] = [

--- a/frontend/apps/console/src/features/flows/context/FlowBuilderCoreProvider.tsx
+++ b/frontend/apps/console/src/features/flows/context/FlowBuilderCoreProvider.tsx
@@ -70,7 +70,12 @@ export interface ResourcePropertiesProps {
    * The event handler for the property change. Applies immediately by default.
    * Pass `true` as the 4th argument for text/number inputs to enable 300ms debouncing.
    */
-  onChange: (propertyKey: string, newValue: string | boolean | object, resource: Resource, debounce?: boolean) => void;
+  onChange: (
+    propertyKey: string,
+    newValue: string | boolean | number | object,
+    resource: Resource,
+    debounce?: boolean,
+  ) => void;
   /**
    * The event handler for the variant change.
    * @param variant - The variant of the element.

--- a/frontend/apps/console/src/features/flows/context/FlowConfigContext.tsx
+++ b/frontend/apps/console/src/features/flows/context/FlowConfigContext.tsx
@@ -40,7 +40,7 @@ export interface FlowConfigContextProps {
     resource: Resource;
     onChange: (
       propertyKey: string,
-      newValue: string | boolean | object,
+      newValue: string | number | boolean | object,
       resource: Resource,
       debounce?: boolean,
     ) => void;

--- a/frontend/apps/console/src/features/flows/data/elements.json
+++ b/frontend/apps/console/src/features/flows/data/elements.json
@@ -450,5 +450,17 @@
       "image": "Puzzle",
       "showOnResourcePanel": true
     }
+  },
+  {
+    "resourceType": "ELEMENT",
+    "category": "DISPLAY",
+    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+    "display": {
+      "label": "Dynamic Input",
+      "image": "Layers",
+      "showOnResourcePanel": true
+    },
+    "placeholder": "Dynamic Input",
+    "hint": "Resolves input fields passed from runtime when the flow executes"
   }
 ]

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -3278,10 +3278,24 @@
           "executor": {
             "name": "BasicAuthExecutor"
           },
-          "onSuccess": "prompt_user_info"
+          "onSuccess": "provisioning"
         },
         {
-          "id": "prompt_user_info",
+          "id": "provisioning",
+          "type": "TASK_EXECUTION",
+          "executor": {
+            "name": "ProvisioningExecutor"
+          },
+          "onSuccess": "auth_assert",
+          "properties": {
+            "includeOptional": false,
+            "includeOptionalCredentials": false,
+            "maxPerPrompt": 2
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
           "type": "PROMPT",
           "meta": {
             "components": [
@@ -3298,42 +3312,22 @@
               {
                 "align": "center",
                 "type": "TEXT",
-                "id": "heading_user_info",
+                "id": "heading_schema_attrs",
                 "label": "{{ t(signup:forms.user_info.title) }}",
                 "variant": "HEADING_1"
               },
               {
                 "type": "BLOCK",
-                "id": "block_user_info",
+                "id": "block_dynamic_user_inputs",
                 "components": [
                   {
-                    "type": "TEXT_INPUT",
-                    "id": "input_given_name",
-                    "ref": "given_name",
-                    "label": "{{ t(signup:forms.user_info.fields.first_name.label) }}",
-                    "placeholder": "{{ t(signup:forms.user_info.fields.first_name.placeholder) }}",
-                    "required": true
-                  },
-                  {
-                    "type": "TEXT_INPUT",
-                    "id": "input_family_name",
-                    "ref": "family_name",
-                    "label": "{{ t(signup:forms.user_info.fields.last_name.label) }}",
-                    "placeholder": "{{ t(signup:forms.user_info.fields.last_name.placeholder) }}",
-                    "required": true
-                  },
-                  {
-                    "type": "EMAIL_INPUT",
-                    "id": "input_email",
-                    "ref": "email",
-                    "label": "{{ t(signup:forms.user_info.fields.email_address.label) }}",
-                    "placeholder": "{{ t(signup:forms.user_info.fields.email_address.placeholder) }}",
-                    "required": true
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
                   },
                   {
                     "type": "ACTION",
-                    "id": "action_user_info",
-                    "label": "{{ t(signup:forms.user_info.actions.submit.label) }}",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
                     "variant": "PRIMARY",
                     "eventType": "SUBMIT"
                   }
@@ -3343,72 +3337,13 @@
           },
           "prompts": [
             {
-              "inputs": [
-                {
-                  "ref": "input_given_name",
-                  "identifier": "given_name",
-                  "type": "TEXT_INPUT",
-                  "required": true
-                },
-                {
-                  "ref": "input_family_name",
-                  "identifier": "family_name",
-                  "type": "TEXT_INPUT",
-                  "required": true
-                },
-                {
-                  "ref": "input_email",
-                  "identifier": "email",
-                  "type": "EMAIL_INPUT",
-                  "required": true
-                }
-              ],
+              "inputs": [],
               "action": {
-                "ref": "action_user_info",
+                "ref": "action_schema_attrs",
                 "nextNode": "provisioning"
               }
             }
           ]
-        },
-        {
-          "id": "provisioning",
-          "type": "TASK_EXECUTION",
-          "executor": {
-            "name": "ProvisioningExecutor",
-            "inputs": [
-              {
-                "ref": "input_001",
-                "identifier": "username",
-                "type": "TEXT_INPUT",
-                "required": true
-              },
-              {
-                "ref": "input_002",
-                "identifier": "password",
-                "type": "PASSWORD_INPUT",
-                "required": true
-              },
-              {
-                "ref": "input_003",
-                "identifier": "given_name",
-                "type": "TEXT_INPUT",
-                "required": true
-              },
-              {
-                "ref": "input_004",
-                "identifier": "family_name",
-                "type": "TEXT_INPUT",
-                "required": true
-              },
-              {
-                "ref": "input_005",
-                "identifier": "email",
-                "type": "EMAIL_INPUT",
-                "required": true
-              }
-            ]
-          },
-          "onSuccess": "auth_assert"
         },
         {
           "id": "auth_assert",
@@ -3804,7 +3739,74 @@
           "executor": {
             "name": "ProvisioningExecutor"
           },
-          "onSuccess": "auth_assert"
+          "onSuccess": "auth_assert",
+          "properties": {
+            "includeOptional": false,
+            "includeOptionalCredentials": false,
+            "maxPerPrompt": 2
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 430
+            },
+            "position": {
+              "x": 2157,
+              "y": -241
+            }
+          },
+          "meta": {
+            "components": [
+              {
+                "alt": "{{ t(signup:images.app_logo.alt) }}",
+                "category": "DISPLAY",
+                "height": "60",
+                "id": "image",
+                "resourceType": "ELEMENT",
+                "src": "{{ meta(application.logoUrl) }}",
+                "type": "IMAGE",
+                "width": ""
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signup:forms.user_info.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ]
         },
         {
           "id": "auth_assert",
@@ -3887,7 +3889,7 @@
           "executor": {
             "name": "UserTypeResolver"
           },
-          "onSuccess": "collect_user_info",
+          "onSuccess": "provisioning",
           "onIncomplete": "prompt_usertype"
         },
         {
@@ -3973,16 +3975,40 @@
           ]
         },
         {
-          "id": "collect_user_info",
+          "id": "provisioning",
+          "type": "TASK_EXECUTION",
+          "layout": {
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1164,
+              "y": 179
+            }
+          },
+          "executor": {
+            "name": "ProvisioningExecutor"
+          },
+          "onSuccess": "passkey_reg_start",
+          "properties": {
+            "includeOptional": false,
+            "includeOptionalCredentials": false,
+            "maxPerPrompt": 2
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
           "type": "PROMPT",
           "layout": {
             "size": {
               "width": 350,
-              "height": 683
+              "height": 430
             },
             "position": {
-              "x": 652,
-              "y": 264
+              "x": 1089,
+              "y": -421
             }
           },
           "meta": {
@@ -3999,96 +4025,39 @@
               },
               {
                 "align": "center",
-                "category": "DISPLAY",
-                "id": "text_001",
-                "label": "{{ t(signup:forms.collect_user_info.title) }}",
-                "resourceType": "ELEMENT",
                 "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signup:forms.user_info.title) }}",
                 "variant": "HEADING_1"
               },
               {
-                "category": "BLOCK",
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
                 "components": [
                   {
-                    "category": "FIELD",
-                    "hint": "",
-                    "id": "input_001",
-                    "inputType": "text",
-                    "label": "{{ t(signup:forms.collect_user_info.fields.username.label) }}",
-                    "placeholder": "{{ t(signup:forms.collect_user_info.fields.username.placeholder) }}",
-                    "ref": "username",
-                    "required": true,
-                    "resourceType": "ELEMENT",
-                    "type": "TEXT_INPUT"
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
                   },
                   {
-                    "category": "FIELD",
-                    "hint": "",
-                    "id": "input_002",
-                    "inputType": "text",
-                    "label": "{{ t(signup:forms.collect_user_info.fields.email.label) }}",
-                    "placeholder": "{{ t(signup:forms.collect_user_info.fields.email.placeholder) }}",
-                    "ref": "email",
-                    "required": true,
-                    "resourceType": "ELEMENT",
-                    "type": "TEXT_INPUT"
-                  },
-                  {
-                    "category": "ACTION",
-                    "eventType": "SUBMIT",
-                    "id": "action_001",
-                    "label": "{{ t(signup:forms.collect_user_info.actions.submit.label) }}",
-                    "resourceType": "ELEMENT",
                     "type": "ACTION",
-                    "variant": "PRIMARY"
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
                   }
-                ],
-                "id": "block_001",
-                "resourceType": "ELEMENT",
-                "type": "BLOCK"
+                ]
               }
             ]
           },
           "prompts": [
             {
-              "inputs": [
-                {
-                  "ref": "input_001",
-                  "type": "TEXT_INPUT",
-                  "identifier": "username",
-                  "required": true
-                },
-                {
-                  "ref": "input_002",
-                  "type": "TEXT_INPUT",
-                  "identifier": "email",
-                  "required": true
-                }
-              ],
+              "inputs": [],
               "action": {
-                "ref": "action_001",
+                "ref": "action_schema_attrs",
                 "nextNode": "provisioning"
               }
             }
           ]
-        },
-        {
-          "id": "provisioning",
-          "type": "TASK_EXECUTION",
-          "layout": {
-            "size": {
-              "width": 200,
-              "height": 113
-            },
-            "position": {
-              "x": 1164,
-              "y": 179
-            }
-          },
-          "executor": {
-            "name": "ProvisioningExecutor"
-          },
-          "onSuccess": "passkey_reg_start"
         },
         {
           "id": "passkey_reg_start",
@@ -4397,7 +4366,7 @@
             {
               "action": {
                 "ref": "action_passkey",
-                "nextNode": "collect_passkey_user_info"
+                "nextNode": "passkey_provisioning"
               }
             }
           ],
@@ -4418,7 +4387,7 @@
           "executor": {
             "name": "BasicAuthExecutor"
           },
-          "onSuccess": "prompt_basic_user_info",
+          "onSuccess": "provisioning",
           "layout": {
             "size": {
               "width": 217,
@@ -4427,114 +4396,6 @@
             "position": {
               "x": 1183,
               "y": 645
-            }
-          }
-        },
-        {
-          "id": "prompt_basic_user_info",
-          "type": "PROMPT",
-          "meta": {
-            "components": [
-              {
-                "alt": "{{ t(signup:images.app_logo.alt) }}",
-                "category": "DISPLAY",
-                "height": "60",
-                "id": "image",
-                "resourceType": "ELEMENT",
-                "src": "{{ meta(application.logoUrl) }}",
-                "type": "IMAGE",
-                "width": ""
-              },
-              {
-                "align": "center",
-                "type": "TEXT",
-                "id": "text_user_info_heading",
-                "label": "{{ t(signup:forms.basic_user_info.title) }}",
-                "variant": "HEADING_1"
-              },
-              {
-                "category": "DISPLAY",
-                "id": "text_user_info_description",
-                "label": "{{ t(signup:forms.basic_user_info.complete_profile) }}",
-                "resourceType": "ELEMENT",
-                "type": "TEXT",
-                "variant": "BODY"
-              },
-              {
-                "type": "BLOCK",
-                "id": "block_user_info",
-                "components": [
-                  {
-                    "type": "TEXT_INPUT",
-                    "id": "input_given_name",
-                    "ref": "given_name",
-                    "label": "{{ t(signup:forms.basic_user_info.fields.first_name.label) }}",
-                    "placeholder": "{{ t(signup:forms.basic_user_info.fields.first_name.placeholder) }}",
-                    "required": true
-                  },
-                  {
-                    "type": "TEXT_INPUT",
-                    "id": "input_family_name",
-                    "ref": "family_name",
-                    "label": "{{ t(signup:forms.basic_user_info.fields.last_name.label) }}",
-                    "placeholder": "{{ t(signup:forms.basic_user_info.fields.last_name.placeholder) }}",
-                    "required": true
-                  },
-                  {
-                    "type": "EMAIL_INPUT",
-                    "id": "input_email",
-                    "ref": "email",
-                    "label": "{{ t(signup:forms.basic_user_info.fields.email.label) }}",
-                    "placeholder": "{{ t(signup:forms.basic_user_info.fields.email.placeholder) }}",
-                    "required": true
-                  },
-                  {
-                    "type": "ACTION",
-                    "id": "action_user_info",
-                    "label": "{{ t(signup:forms.basic_user_info.actions.continue.label) }}",
-                    "variant": "PRIMARY",
-                    "eventType": "SUBMIT"
-                  }
-                ]
-              }
-            ]
-          },
-          "prompts": [
-            {
-              "inputs": [
-                {
-                  "ref": "input_given_name",
-                  "identifier": "given_name",
-                  "type": "TEXT_INPUT",
-                  "required": true
-                },
-                {
-                  "ref": "input_family_name",
-                  "identifier": "family_name",
-                  "type": "TEXT_INPUT",
-                  "required": true
-                },
-                {
-                  "ref": "input_email",
-                  "identifier": "email",
-                  "type": "EMAIL_INPUT",
-                  "required": true
-                }
-              ],
-              "action": {
-                "ref": "action_user_info",
-                "nextNode": "provisioning"
-              }
-            }
-          ],
-          "layout": {
-            "size": {
-              "width": 350,
-              "height": 835
-            },
-            "position": {
-              "x": 1501,
-              "y": 283
             }
           }
         },
@@ -4553,6 +4414,73 @@
             "position": {
               "x": 2017,
               "y": 911
+            }
+          },
+          "properties": {
+            "includeOptional": false,
+            "includeOptionalCredentials": false,
+            "maxPerPrompt": 2
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "alt": "{{ t(signup:images.app_logo.alt) }}",
+                "category": "DISPLAY",
+                "height": "60",
+                "id": "image",
+                "resourceType": "ELEMENT",
+                "src": "{{ meta(application.logoUrl) }}",
+                "type": "IMAGE",
+                "width": ""
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signup:forms.user_info.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ],
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 430
+            },
+            "position": {
+              "x": 1942,
+              "y": 311
             }
           }
         },
@@ -4681,100 +4609,6 @@
           }
         },
         {
-          "id": "collect_passkey_user_info",
-          "type": "PROMPT",
-          "meta": {
-            "components": [
-              {
-                "alt": "{{ t(signup:images.app_logo.alt) }}",
-                "category": "DISPLAY",
-                "height": "60",
-                "id": "image",
-                "resourceType": "ELEMENT",
-                "src": "{{ meta(application.logoUrl) }}",
-                "type": "IMAGE",
-                "width": ""
-              },
-              {
-                "align": "center",
-                "type": "TEXT",
-                "id": "text_passkey_info_heading",
-                "label": "{{ t(signup:forms.collect_passkey_user_info.title) }}",
-                "variant": "HEADING_1"
-              },
-              {
-                "category": "DISPLAY",
-                "id": "text_passkey_info_description",
-                "label": "{{ t(signup:forms.collect_passkey_user_info.description) }}",
-                "resourceType": "ELEMENT",
-                "type": "TEXT",
-                "variant": "BODY"
-              },
-              {
-                "type": "BLOCK",
-                "id": "block_passkey_info",
-                "components": [
-                  {
-                    "type": "TEXT_INPUT",
-                    "id": "input_passkey_username",
-                    "ref": "username",
-                    "label": "{{ t(signup:forms.collect_passkey_user_info.fields.username.label) }}",
-                    "placeholder": "{{ t(signup:forms.collect_passkey_user_info.fields.username.placeholder) }}",
-                    "required": true
-                  },
-                  {
-                    "type": "EMAIL_INPUT",
-                    "id": "input_passkey_email",
-                    "ref": "email",
-                    "label": "{{ t(signup:forms.collect_passkey_user_info.fields.email.label) }}",
-                    "placeholder": "{{ t(signup:forms.collect_passkey_user_info.fields.email.placeholder) }}",
-                    "required": true
-                  },
-                  {
-                    "type": "ACTION",
-                    "id": "action_passkey_continue",
-                    "label": "{{ t(signup:forms.collect_passkey_user_info.actions.continue.label) }}",
-                    "variant": "PRIMARY",
-                    "eventType": "SUBMIT"
-                  }
-                ]
-              }
-            ]
-          },
-          "prompts": [
-            {
-              "inputs": [
-                {
-                  "ref": "input_passkey_username",
-                  "identifier": "username",
-                  "type": "TEXT_INPUT",
-                  "required": true
-                },
-                {
-                  "ref": "input_passkey_email",
-                  "identifier": "email",
-                  "type": "EMAIL_INPUT",
-                  "required": true
-                }
-              ],
-              "action": {
-                "ref": "action_passkey_continue",
-                "nextNode": "passkey_provisioning"
-              }
-            }
-          ],
-          "layout": {
-            "size": {
-              "width": 350,
-              "height": 756
-            },
-            "position": {
-              "x": 1496,
-              "y": 1218
-            }
-          }
-        },
-        {
           "id": "passkey_provisioning",
           "type": "TASK_EXECUTION",
           "executor": {
@@ -4789,6 +4623,73 @@
             "position": {
               "x": 2027,
               "y": 1445
+            }
+          },
+          "properties": {
+            "includeOptional": false,
+            "includeOptionalCredentials": false,
+            "maxPerPrompt": 2
+          },
+          "onIncomplete": "prompt_schema_attrs_passkey"
+        },
+        {
+          "id": "prompt_schema_attrs_passkey",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "alt": "{{ t(signup:images.app_logo.alt) }}",
+                "category": "DISPLAY",
+                "height": "60",
+                "id": "image_passkey",
+                "resourceType": "ELEMENT",
+                "src": "{{ meta(application.logoUrl) }}",
+                "type": "IMAGE",
+                "width": ""
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs_passkey",
+                "label": "{{ t(signup:forms.user_info.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs_passkey",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs_passkey"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs_passkey",
+                    "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs_passkey",
+                "nextNode": "passkey_provisioning"
+              }
+            }
+          ],
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 430
+            },
+            "position": {
+              "x": 1952,
+              "y": 845
             }
           }
         },
@@ -5232,7 +5133,74 @@
               "x": 1388,
               "y": 1130
             }
-          }
+          },
+          "properties": {
+            "includeOptional": false,
+            "includeOptionalCredentials": false,
+            "maxPerPrompt": 2
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 430
+            },
+            "position": {
+              "x": 1313,
+              "y": 530
+            }
+          },
+          "meta": {
+            "components": [
+              {
+                "alt": "{{ t(signup:images.app_logo.alt) }}",
+                "category": "DISPLAY",
+                "height": "60",
+                "id": "image",
+                "resourceType": "ELEMENT",
+                "src": "{{ meta(application.logoUrl) }}",
+                "type": "IMAGE",
+                "width": ""
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signup:forms.user_info.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ]
         },
         {
           "id": "auth_assert",
@@ -5876,7 +5844,74 @@
           "executor": {
             "name": "ProvisioningExecutor"
           },
-          "onSuccess": "auth_assert"
+          "onSuccess": "auth_assert",
+          "properties": {
+            "includeOptional": false,
+            "includeOptionalCredentials": false,
+            "maxPerPrompt": 2
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 430
+            },
+            "position": {
+              "x": 2718,
+              "y": 148
+            }
+          },
+          "meta": {
+            "components": [
+              {
+                "alt": "{{ t(signup:images.app_logo.alt) }}",
+                "category": "DISPLAY",
+                "height": "60",
+                "id": "image",
+                "resourceType": "ELEMENT",
+                "src": "{{ meta(application.logoUrl) }}",
+                "type": "IMAGE",
+                "width": ""
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signup:forms.user_info.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ]
         },
         {
           "id": "auth_assert",
@@ -6185,39 +6220,7 @@
           "id": "provisioning",
           "type": "TASK_EXECUTION",
           "executor": {
-            "name": "ProvisioningExecutor",
-            "inputs": [
-              {
-                "ref": "input_001",
-                "identifier": "username",
-                "type": "TEXT_INPUT",
-                "required": true
-              },
-              {
-                "ref": "input_002",
-                "identifier": "password",
-                "type": "PASSWORD_INPUT",
-                "required": true
-              },
-              {
-                "ref": "input_003",
-                "identifier": "given_name",
-                "type": "TEXT_INPUT",
-                "required": true
-              },
-              {
-                "ref": "input_004",
-                "identifier": "family_name",
-                "type": "TEXT_INPUT",
-                "required": true
-              },
-              {
-                "ref": "input_005",
-                "identifier": "email",
-                "type": "EMAIL_INPUT",
-                "required": true
-              }
-            ]
+            "name": "ProvisioningExecutor"
           },
           "onSuccess": "auth_assert",
           "layout": {
@@ -6229,7 +6232,74 @@
               "x": 1383,
               "y": 933
             }
-          }
+          },
+          "properties": {
+            "includeOptional": false,
+            "includeOptionalCredentials": false,
+            "maxPerPrompt": 2
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 430
+            },
+            "position": {
+              "x": 1308,
+              "y": 333
+            }
+          },
+          "meta": {
+            "components": [
+              {
+                "alt": "{{ t(signup:images.app_logo.alt) }}",
+                "category": "DISPLAY",
+                "height": "60",
+                "id": "image",
+                "resourceType": "ELEMENT",
+                "src": "{{ meta(application.logoUrl) }}",
+                "type": "IMAGE",
+                "width": ""
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signup:forms.user_info.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ]
         },
         {
           "id": "auth_assert",
@@ -6508,7 +6578,7 @@
             "name": "EmailExecutor",
             "mode": "send"
           },
-          "onSuccess": "invite_verify",
+          "onSuccess": "registration_email_sent",
           "layout": {
             "size": {
               "width": 200,
@@ -6519,6 +6589,47 @@
               "y": 835
             }
           }
+        },
+        {
+          "id": "registration_email_sent",
+          "type": "PROMPT",
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 381
+            },
+            "position": {
+              "x": 2242,
+              "y": 617
+            }
+          },
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "registration_email_sent_icon",
+                "label": "✅",
+                "variant": "HEADING_1"
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "registration_email_sent_heading",
+                "label": "{{ t(signup:forms.email_sent.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "registration_email_sent_message",
+                "label": "{{ t(signup:forms.email_sent.message) }}",
+                "variant": "HEADING_6"
+              }
+            ]
+          },
+          "message": "Check your email for a verification link",
+          "next": "invite_verify"
         },
         {
           "id": "invite_verify",
@@ -6568,6 +6679,13 @@
                 "id": "text_header_details",
                 "label": "{{ t(signup:forms.user_details.title) }}",
                 "variant": "HEADING_1"
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "text_subtitle_user_details",
+                "label": "{{ t(signup:forms.credentials.complete_profile) }}",
+                "variant": "HEADING_6"
               },
               {
                 "type": "BLOCK",
@@ -6718,7 +6836,7 @@
           "executor": {
             "name": "ProvisioningExecutor"
           },
-          "onSuccess": "end",
+          "onSuccess": "registration_complete",
           "layout": {
             "size": {
               "width": 200,
@@ -6728,7 +6846,115 @@
               "x": 3480,
               "y": 832
             }
-          }
+          },
+          "properties": {
+            "includeOptional": false,
+            "includeOptionalCredentials": false,
+            "maxPerPrompt": 2
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "registration_complete",
+          "type": "PROMPT",
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 381
+            },
+            "position": {
+              "x": 3874,
+              "y": 698
+            }
+          },
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "registration_complete_icon",
+                "label": "✅",
+                "variant": "HEADING_1"
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "registration_complete_heading",
+                "label": "{{ t(invite:complete.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "registration_complete_message",
+                "label": "{{ t(invite:complete.description) }}",
+                "variant": "HEADING_6"
+              }
+            ]
+          },
+          "message": "Registration complete",
+          "next": "end"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 430
+            },
+            "position": {
+              "x": 3405,
+              "y": 232
+            }
+          },
+          "meta": {
+            "components": [
+              {
+                "alt": "{{ t(signup:images.app_logo.alt) }}",
+                "category": "DISPLAY",
+                "height": "60",
+                "id": "image",
+                "resourceType": "ELEMENT",
+                "src": "{{ meta(application.logoUrl) }}",
+                "type": "IMAGE",
+                "width": ""
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signup:forms.user_info.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ]
         },
         {
           "id": "end",
@@ -6739,7 +6965,7 @@
               "height": 34
             },
             "position": {
-              "x": 3814,
+              "x": 4272,
               "y": 870
             }
           }

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useContainerDialogConfirm.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useContainerDialogConfirm.test.tsx
@@ -467,6 +467,7 @@ describe('useContainerDialogConfirm', () => {
         expect.objectContaining({type: StepTypes.View}),
         expect.any(Array),
         expect.any(Array),
+        true,
       );
       expect(mockSetNodes).toHaveBeenCalled();
       expect(mockSetEdges).toHaveBeenCalled();

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useDeleteExecutionResource.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useDeleteExecutionResource.test.tsx
@@ -32,6 +32,7 @@ const {
   mockGetNodes,
   mockUpdateNodeData,
   mockSetNodes,
+  mockSetEdges,
   mockSetIsOpenResourcePropertiesPanel,
   registeredHandlers,
   mockUnsubscribes,
@@ -40,6 +41,7 @@ const {
   mockGetNodes: vi.fn().mockReturnValue([]),
   mockUpdateNodeData: vi.fn(),
   mockSetNodes: vi.fn(),
+  mockSetEdges: vi.fn(),
   mockSetIsOpenResourcePropertiesPanel: vi.fn(),
   registeredHandlers: {} as Record<string, ((...args: unknown[]) => Promise<boolean>)[]>,
   mockUnsubscribes: {} as Record<string, ReturnType<typeof vi.fn>[]>,
@@ -99,6 +101,7 @@ vi.mock('@xyflow/react', async () => {
       getNodes: mockGetNodes,
       updateNodeData: mockUpdateNodeData,
       setNodes: mockSetNodes,
+      setEdges: mockSetEdges,
     }),
   };
 });
@@ -346,7 +349,7 @@ describe('useDeleteExecutionResource', () => {
           id: 'edge-1',
           source: 'action-1',
           target: 'execution-1',
-          sourceHandle: 'button-1-next',
+          sourceHandle: 'button-1_NEXT',
         },
       ]);
 
@@ -483,7 +486,7 @@ describe('useDeleteExecutionResource', () => {
           id: 'edge-1',
           source: 'view-1',
           target: 'view-2',
-          sourceHandle: 'button-1-next',
+          sourceHandle: 'button-1_NEXT',
         },
       ];
 
@@ -522,7 +525,7 @@ describe('useDeleteExecutionResource', () => {
           id: 'edge-1',
           source: 'action-1',
           target: 'execution-1',
-          sourceHandle: 'button-1-next',
+          sourceHandle: 'button-1_NEXT',
         },
       ];
 
@@ -573,13 +576,13 @@ describe('useDeleteExecutionResource', () => {
           id: 'edge-1',
           source: 'action-1',
           target: 'execution-1',
-          sourceHandle: 'button-1-next',
+          sourceHandle: 'button-1_NEXT',
         },
         {
           id: 'edge-2',
           source: 'action-1',
           target: 'execution-2',
-          sourceHandle: 'button-2-next',
+          sourceHandle: 'button-2_NEXT',
         },
       ];
 
@@ -656,7 +659,7 @@ describe('useDeleteExecutionResource', () => {
           id: 'edge-1',
           source: 'action-1',
           target: 'execution-1',
-          sourceHandle: 'button-1-next',
+          sourceHandle: 'button-1_NEXT',
         },
       ];
 
@@ -667,6 +670,71 @@ describe('useDeleteExecutionResource', () => {
       const result = capturedCallback!(actionNode);
       expect(result.components).toHaveLength(1);
       expect(result.components[0]).toEqual({id: 'button-2', type: 'ACTION'});
+    });
+
+    it('should not delete execution node when it has other incoming edges (loop-back pattern)', async () => {
+      const executionNode: Node = {
+        id: 'execution-1',
+        type: 'TASK_EXECUTION',
+        position: {x: 100, y: 0},
+        data: {},
+      };
+
+      const promptView: Node = {
+        id: 'prompt-view',
+        type: 'VIEW',
+        position: {x: 0, y: 200},
+        data: {
+          components: [{id: 'submit-btn', type: 'ACTION'}],
+        },
+      };
+
+      mockGetNodes.mockReturnValue([promptView, executionNode]);
+
+      // execution-1 has a second incoming edge from a previous step (e.g. BasicAuthExecutor onSuccess).
+      // This simulates the provisioning loop-back pattern where the prompt VIEW loops back to
+      // ProvisioningExecutor which is also reached via another executor's onSuccess.
+      mockGetEdges.mockReturnValue([
+        {
+          id: 'other-incoming',
+          source: 'prev-executor',
+          target: 'execution-1',
+          sourceHandle: 'prev-executor_SUCCESS',
+        },
+        {
+          id: 'loop-back',
+          source: 'prompt-view',
+          target: 'execution-1',
+          sourceHandle: 'submit-btn_NEXT',
+        },
+      ]);
+
+      renderHook(() => useDeleteExecutionResource(), {
+        wrapper: createWrapper(),
+      });
+
+      const deleteEdgeHandler = registeredHandlers.onEdgeDelete?.[0];
+
+      // Delete the loop-back edge from the prompt VIEW to the execution node.
+      const deletedEdges = [
+        {
+          id: 'loop-back',
+          source: 'prompt-view',
+          target: 'execution-1',
+          sourceHandle: 'submit-btn_NEXT',
+        },
+      ];
+
+      const result = await deleteEdgeHandler(deletedEdges);
+      expect(result).toBe(true);
+
+      // The execution node must survive because it still has 'other-incoming'.
+      expect(mockSetNodes).not.toHaveBeenCalled();
+      // Edges are not modified since no node was cascade-deleted.
+      expect(mockSetEdges).not.toHaveBeenCalled();
+
+      // The action button component in the prompt VIEW is still cleaned up.
+      expect(mockUpdateNodeData).toHaveBeenCalledWith('prompt-view', expect.any(Function));
     });
   });
 

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useDragDropHandlers.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useDragDropHandlers.test.tsx
@@ -326,7 +326,13 @@ describe('useDragDropHandlers', () => {
         );
       });
 
-      expect(mockOnWidgetLoad).toHaveBeenCalledWith(widgetResource as Widget, expect.any(Object), mockNodes, mockEdges);
+      expect(mockOnWidgetLoad).toHaveBeenCalledWith(
+        widgetResource as Widget,
+        expect.any(Object),
+        mockNodes,
+        mockEdges,
+        false,
+      );
       expect(mockSetNodes).toHaveBeenCalled();
       expect(mockSetEdges).toHaveBeenCalled();
     });

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useResourceAdd.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useResourceAdd.test.tsx
@@ -493,9 +493,10 @@ describe('useResourceAdd', () => {
 
       expect(mockOnWidgetLoad).toHaveBeenCalledWith(
         expect.objectContaining({id: 'widget-1'}),
-        expect.objectContaining({id: 'view-1'}),
-        expect.any(Array),
-        expect.any(Array),
+        {},
+        [expect.objectContaining({id: 'view-1'})],
+        [],
+        false,
       );
       expect(mockSetNodes).toHaveBeenCalledWith(newNodes);
     });
@@ -518,13 +519,7 @@ describe('useResourceAdd', () => {
         result.current(widget);
       });
 
-      expect(mockScreenToFlowPosition).toHaveBeenCalled();
-      expect(mockOnWidgetLoad).toHaveBeenCalledWith(
-        expect.objectContaining({id: 'widget-1'}),
-        expect.objectContaining({type: StepTypes.View}),
-        expect.any(Array),
-        expect.any(Array),
-      );
+      expect(mockOnWidgetLoad).toHaveBeenCalledWith(expect.objectContaining({id: 'widget-1'}), {}, [], [], false);
     });
 
     it('should apply auto-assign connections for widgets when metadata exists', () => {

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
@@ -304,6 +304,39 @@ describe('useVisualFlowHandlers', () => {
 
       expect(mockSetEdges).toHaveBeenCalled();
     });
+
+    it('should reconnect nodes from the latest edges passed into the setter', () => {
+      const nodes = [{id: 'node-1'}, {id: 'node-2'}, {id: 'node-3'}] as Node[];
+      const latestEdges = [
+        {id: 'edge-1', source: 'node-1', target: 'node-2'},
+        {id: 'edge-2', source: 'node-2', target: 'node-3'},
+      ] as Edge[];
+
+      mockGetNodes.mockReturnValue(nodes);
+      mockGetEdges.mockReturnValue([]);
+
+      const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+        wrapper: createWrapper({edgeStyle: EdgeStyleTypes.Step}),
+      });
+
+      act(() => {
+        result.current.handleNodesDelete([{id: 'node-2'} as Node]);
+      });
+
+      const setterFn = mockSetEdges.mock.calls[0][0] as (edges: Edge[]) => Edge[];
+      const newEdges = setterFn(latestEdges);
+
+      expect(mockGetEdges).not.toHaveBeenCalled();
+      expect(newEdges).toEqual([
+        {
+          id: 'node-1-->node-3',
+          source: 'node-1',
+          target: 'node-3',
+          type: EdgeStyleTypes.Step,
+          markerEnd: {type: 'arrowclosed'},
+        },
+      ]);
+    });
   });
 
   describe('handleEdgesDelete', () => {

--- a/frontend/apps/console/src/features/flows/hooks/useContainerDialogConfirm.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useContainerDialogConfirm.ts
@@ -46,6 +46,7 @@ export interface UseContainerDialogConfirmProps {
     targetResource: Resource,
     currentNodes: Node[],
     edges: Edge[],
+    removeTargetViewWhenStandalone?: boolean,
   ) => [Node[], Edge[], Resource | null, string | null];
   metadata?: MetadataInterface;
   pendingDropRef: React.MutableRefObject<{
@@ -228,6 +229,7 @@ const useContainerDialogConfirm = (props: UseContainerDialogConfirmProps): (() =
         generatedViewStep,
         [...currentNodes, generatedViewStep],
         currentEdges,
+        true,
       );
 
       // Auto-assign connections for execution steps.

--- a/frontend/apps/console/src/features/flows/hooks/useDeleteExecutionResource.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useDeleteExecutionResource.ts
@@ -33,7 +33,7 @@ import {StepTypes} from '../models/steps';
  */
 const useDeleteExecutionResource = (): void => {
   const {setIsOpenResourcePropertiesPanel} = useUIPanelState();
-  const {getEdges, getNodes, updateNodeData, setNodes} = useReactFlow();
+  const {getEdges, getNodes, updateNodeData, setNodes, setEdges} = useReactFlow();
   const {onNodeDelete, onNodeElementDelete, onEdgeDelete} = useFlowPlugins();
 
   /**
@@ -124,27 +124,45 @@ const useDeleteExecutionResource = (): void => {
    */
   function deleteComponentAndNode(deleted: Edge[]): boolean {
     const nodes: Node[] = getNodes();
+    const allEdges: Edge[] = getEdges();
     const executionNodeIds: string[] = [];
     const actionNodeIds: string[] = [];
     const actionComponentIds: string[] = [];
 
+    const deletedEdgeIds = new Set(deleted.map((e: Edge) => e.id));
+    const remainingEdges = allEdges.filter((e: Edge) => !deletedEdgeIds.has(e.id));
+
     deleted.forEach((edge: Edge) => {
       nodes.forEach((node: Node) => {
-        if (node.type === StepTypes.Execution && edge.target === node.id && edge.sourceHandle) {
+        if (
+          node.type === StepTypes.Execution &&
+          edge.target === node.id &&
+          edge.sourceHandle?.includes(VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX)
+        ) {
           actionComponentIds.push(
             edge.sourceHandle.slice(0, -VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX.length),
           );
           actionNodeIds.push(edge.source);
-          executionNodeIds.push(edge.target);
+
+          // Cascade-delete the executor only if no other callers remain after this batch.
+          const hasOtherIncoming = remainingEdges.some((e: Edge) => e.target === node.id);
+
+          if (!hasOtherIncoming) {
+            executionNodeIds.push(edge.target);
+          }
         }
       });
     });
 
-    if (executionNodeIds.length === 0) {
+    if (actionComponentIds.length === 0) {
       return true;
     }
 
-    setNodes((nds: Node[]) => nds?.filter((node: Node) => !executionNodeIds.includes(node.id)));
+    if (executionNodeIds.length > 0) {
+      const deletedSet = new Set(executionNodeIds);
+      setNodes((nds: Node[]) => nds?.filter((node: Node) => !deletedSet.has(node.id)));
+      setEdges((eds: Edge[]) => eds?.filter((e: Edge) => !deletedSet.has(e.source) && !deletedSet.has(e.target)));
+    }
 
     actionNodeIds.forEach((actionNodeId: string) => {
       updateNodeData(actionNodeId, (node: Node) => {

--- a/frontend/apps/console/src/features/flows/hooks/useDragDropHandlers.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useDragDropHandlers.ts
@@ -45,6 +45,7 @@ export interface UseDragDropHandlersProps {
     targetResource: Resource,
     currentNodes: Node[],
     edges: Edge[],
+    removeTargetViewWhenStandalone?: boolean,
   ) => [Node[], Edge[], Resource | null, string | null];
   metadata?: MetadataInterface;
 }
@@ -178,6 +179,7 @@ const useDragDropHandlers = (props: UseDragDropHandlersProps): UseDragDropHandle
           targetResource,
           currentNodes,
           currentEdges,
+          false,
         );
 
         // Auto-assign connections for execution steps
@@ -287,6 +289,7 @@ const useDragDropHandlers = (props: UseDragDropHandlersProps): UseDragDropHandle
             targetNode as Resource,
             currentNodes,
             currentEdges,
+            false,
           );
 
           // Now we need to reorder the components to insert at the correct position

--- a/frontend/apps/console/src/features/flows/hooks/useResourceAdd.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useResourceAdd.ts
@@ -32,6 +32,7 @@ import {type Template} from '../models/templates';
 import type {Widget} from '../models/widget';
 import autoAssignConnections from '../utils/autoAssignConnections';
 import generateResourceId from '../utils/generateResourceId';
+import {widgetNeedsViewContainer} from '../utils/widgetUtils';
 
 /**
  * Props interface for useResourceAdd hook
@@ -43,6 +44,7 @@ export interface UseResourceAddProps {
     targetResource: Resource,
     currentNodes: Node[],
     edges: Edge[],
+    removeTargetViewWhenStandalone?: boolean,
   ) => [Node[], Edge[], Resource | null, string | null];
   onStepLoad: (step: Step) => Step;
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
@@ -158,7 +160,11 @@ const useResourceAdd = (props: UseResourceAddProps): ((resource: Resource) => vo
     if (resource.resourceType === ResourceTypes.Widget) {
       const currentNodes = getNodes();
       const currentEdges = getEdges();
-      const existingViewStep = currentNodes.find((node) => node.type === StepTypes.View);
+      const widget = clonedResource as Widget;
+      const needsViewContainer = widgetNeedsViewContainer(widget);
+      const existingViewStep = needsViewContainer
+        ? currentNodes.find((node) => node.type === StepTypes.View)
+        : undefined;
       let targetViewStep: Step;
       let nodesToPass: Node[];
 
@@ -166,7 +172,7 @@ const useResourceAdd = (props: UseResourceAddProps): ((resource: Resource) => vo
         const nodeData = existingViewStep.data as StepData | undefined;
         targetViewStep = {...existingViewStep, data: {...nodeData}} as Step;
         nodesToPass = currentNodes;
-      } else {
+      } else if (needsViewContainer) {
         const position: XYPosition = screenToFlowPosition({
           x: window.innerWidth / 2,
           y: window.innerHeight / 2,
@@ -181,9 +187,18 @@ const useResourceAdd = (props: UseResourceAddProps): ((resource: Resource) => vo
           type: StepTypes.View,
         } as Step;
         nodesToPass = [...currentNodes, targetViewStep];
+      } else {
+        targetViewStep = {} as Step;
+        nodesToPass = currentNodes;
       }
 
-      const [newNodes, newEdges] = onWidgetLoad(clonedResource as Widget, targetViewStep, nodesToPass, currentEdges);
+      const [newNodes, newEdges] = onWidgetLoad(
+        widget,
+        targetViewStep,
+        nodesToPass,
+        currentEdges,
+        needsViewContainer && !existingViewStep,
+      );
 
       if (metadata?.executorConnections) {
         autoAssignConnections(newNodes, metadata.executorConnections);

--- a/frontend/apps/console/src/features/flows/hooks/useVisualFlowHandlers.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useVisualFlowHandlers.ts
@@ -114,16 +114,15 @@ const useVisualFlowHandlers = (props: UseVisualFlowHandlersProps): UseVisualFlow
     handleNodesDelete: (deleted: Node[]): void => {
       const {props: currentProps, reactFlowInstance: rf, edgeStyle: currentEdgeStyle} = depsRef.current;
       const {setEdges} = currentProps;
-      const {getNodes, getEdges} = rf;
+      const {getNodes} = rf;
 
       const currentNodes = getNodes();
-      const currentEdges = getEdges();
 
-      setEdges(
+      setEdges((latestEdges: Edge[]) =>
         deleted.reduce((acc: Edge[], node: Node) => {
-          const incomers: Node[] = getIncomers(node, currentNodes, currentEdges);
-          const outgoers: Node[] = getOutgoers(node, currentNodes, currentEdges);
-          const connectedEdges: Edge[] = getConnectedEdges([node], currentEdges);
+          const incomers: Node[] = getIncomers(node, currentNodes, acc);
+          const outgoers: Node[] = getOutgoers(node, currentNodes, acc);
+          const connectedEdges: Edge[] = getConnectedEdges([node], acc);
 
           const remainingEdges: Edge[] = acc.filter((edge: Edge) => !connectedEdges.includes(edge));
 
@@ -138,7 +137,7 @@ const useVisualFlowHandlers = (props: UseVisualFlowHandlersProps): UseVisualFlow
           );
 
           return [...remainingEdges, ...createdEdges];
-        }, currentEdges),
+        }, latestEdges),
       );
     },
 

--- a/frontend/apps/console/src/features/flows/models/__tests__/elements.test.ts
+++ b/frontend/apps/console/src/features/flows/models/__tests__/elements.test.ts
@@ -86,8 +86,8 @@ describe('elements models', () => {
       expect(ElementTypes.Custom).toBe('CUSTOM');
     });
 
-    it('should have exactly 22 element types', () => {
-      expect(Object.keys(ElementTypes)).toHaveLength(22);
+    it('should have exactly 23 element types', () => {
+      expect(Object.keys(ElementTypes)).toHaveLength(23);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/models/elements.ts
+++ b/frontend/apps/console/src/features/flows/models/elements.ts
@@ -64,6 +64,7 @@ export const ElementTypes = {
   Timer: 'TIMER',
   Consent: 'CONSENT',
   Custom: 'CUSTOM',
+  DynamicInputPlaceholder: 'DYNAMIC_INPUT_PLACEHOLDER',
 } as const;
 
 export const BlockTypes = {

--- a/frontend/apps/console/src/features/flows/models/widget.ts
+++ b/frontend/apps/console/src/features/flows/models/widget.ts
@@ -46,6 +46,7 @@ export const WidgetTypes = {
   GithubFederation: 'GITHUB_FEDERATION',
   PasskeyAuthentication: 'PASSKEY_AUTHENTICATION',
   SelfSignUpLink: 'SELF_SIGN_UP_LINK',
+  Provisioning: 'PROVISIONING',
 } as const;
 
 export type WidgetTypes = (typeof WidgetTypes)[keyof typeof WidgetTypes];

--- a/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
@@ -985,6 +985,112 @@ describe('reactFlowTransformer', () => {
         expect(execNode?.executor?.name).toBe('TestExecutor');
         expect(execNode?.executor?.inputs).toBeUndefined();
       });
+
+      it('should not override ProvisioningExecutor inputs when preceding PROMPT has only dynamic placeholder content', () => {
+        const promptComponents: Element[] = [
+          {
+            id: 'block-1',
+            type: 'BLOCK',
+            category: ElementCategories.Block,
+            components: [
+              {
+                id: 'dynamic-inputs-1',
+                type: ElementTypes.DynamicInputPlaceholder,
+                category: ElementCategories.Display,
+              } as unknown as Element,
+              {
+                id: 'button-1',
+                type: ElementTypes.Action,
+                category: ElementCategories.Action,
+                action: {onSuccess: 'exec-1'},
+              } as Element,
+            ],
+          } as unknown as Element,
+        ];
+
+        const canvasData: ReactFlowCanvasData = {
+          nodes: [
+            createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components: promptComponents}),
+            createNode(
+              'exec-1',
+              StepTypes.Execution,
+              {x: 100, y: 0},
+              {
+                action: {
+                  executor: {
+                    name: 'ProvisioningExecutor',
+                  },
+                },
+              },
+            ),
+          ],
+          edges: [createEdge('edge-1', 'view-1', 'exec-1', 'button-1_NEXT')],
+        };
+
+        const result = transformReactFlow(canvasData);
+
+        const execNode = result.nodes.find((n) => n.id === 'exec-1');
+        expect(execNode?.executor?.name).toBe('ProvisioningExecutor');
+        expect(execNode?.executor?.inputs).toBeUndefined();
+      });
+
+      it('should preserve ProvisioningExecutor inputs when preceding PROMPT has only dynamic placeholder content', () => {
+        const promptComponents: Element[] = [
+          {
+            id: 'block-1',
+            type: 'BLOCK',
+            category: ElementCategories.Block,
+            components: [
+              {
+                id: 'dynamic-inputs-1',
+                type: ElementTypes.DynamicInputPlaceholder,
+                category: ElementCategories.Display,
+              } as unknown as Element,
+              {
+                id: 'button-1',
+                type: ElementTypes.Action,
+                category: ElementCategories.Action,
+                action: {onSuccess: 'exec-1'},
+              } as Element,
+            ],
+          } as unknown as Element,
+        ];
+
+        const existingInputs = [
+          {
+            ref: 'input_given_name',
+            type: 'TEXT_INPUT',
+            identifier: 'given_name',
+            required: true,
+          },
+        ];
+
+        const canvasData: ReactFlowCanvasData = {
+          nodes: [
+            createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components: promptComponents}),
+            createNode(
+              'exec-1',
+              StepTypes.Execution,
+              {x: 100, y: 0},
+              {
+                action: {
+                  executor: {
+                    name: 'ProvisioningExecutor',
+                    inputs: existingInputs,
+                  },
+                },
+              },
+            ),
+          ],
+          edges: [createEdge('edge-1', 'view-1', 'exec-1', 'button-1_NEXT')],
+        };
+
+        const result = transformReactFlow(canvasData);
+
+        const execNode = result.nodes.find((n) => n.id === 'exec-1');
+        expect(execNode?.executor?.name).toBe('ProvisioningExecutor');
+        expect(execNode?.executor?.inputs).toEqual(existingInputs);
+      });
     });
 
     describe('Event Type Derivation', () => {

--- a/frontend/apps/console/src/features/flows/utils/__tests__/resolveStepMetadata.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/resolveStepMetadata.test.ts
@@ -424,6 +424,72 @@ describe('resolveStepMetadata', () => {
       expect(result).toHaveLength(1);
     });
 
+    it('should coerce string property values to the type defined in executor defaults', () => {
+      const steps: Step[] = [
+        createMockStep({
+          id: 'provisioning-step',
+          type: 'TASK_EXECUTION',
+          data: {
+            action: {executor: {name: 'ProvisioningExecutor'}},
+            properties: {maxPerPrompt: '3', includeOptional: 'true', assignGroup: 'some-group'},
+          },
+        }),
+      ];
+
+      const resources = createMockResources({
+        executors: [
+          createMockStep({
+            display: {label: 'Provisioning', image: '', showOnResourcePanel: true},
+            data: {
+              action: {executor: {name: 'ProvisioningExecutor'}},
+              properties: {maxPerPrompt: 5, includeOptional: false, assignGroup: ''},
+            },
+          }),
+        ],
+      });
+
+      const result = resolveStepMetadata(resources, steps);
+      const props = (result[0].data as {properties?: Record<string, unknown>})?.properties;
+
+      expect(props?.maxPerPrompt).toBe(3);
+      expect(typeof props?.maxPerPrompt).toBe('number');
+      expect(props?.includeOptional).toBe(true);
+      expect(typeof props?.includeOptional).toBe('boolean');
+      expect(props?.assignGroup).toBe('some-group');
+    });
+
+    it('should leave property unchanged when string cannot be coerced to the expected type', () => {
+      const steps: Step[] = [
+        createMockStep({
+          id: 'provisioning-step',
+          type: 'TASK_EXECUTION',
+          data: {
+            action: {executor: {name: 'ProvisioningExecutor'}},
+            properties: {maxPerPrompt: 'not-a-number'},
+          },
+        }),
+      ];
+
+      const resources = createMockResources({
+        executors: [
+          createMockStep({
+            display: {label: 'Provisioning', image: '', showOnResourcePanel: true},
+            data: {
+              action: {executor: {name: 'ProvisioningExecutor'}},
+              properties: {maxPerPrompt: 5},
+            },
+          }),
+        ],
+      });
+
+      const result = resolveStepMetadata(resources, steps);
+      const props = (result[0].data as {properties?: Record<string, unknown>})?.properties;
+
+      expect(props?.maxPerPrompt).toBe('not-a-number');
+    });
+  });
+
+  describe('Executor Edge Cases', () => {
     it('should handle executor without matching name', () => {
       const steps: Step[] = [
         createMockStep({

--- a/frontend/apps/console/src/features/flows/utils/resolveStepMetadata.ts
+++ b/frontend/apps/console/src/features/flows/utils/resolveStepMetadata.ts
@@ -64,6 +64,26 @@ const resolveStepMetadata = (resources: Resources, steps: Step[]): Step[] => {
       });
 
       if (executorWithMeta) {
+        const defaultProps = (executorWithMeta.data as StepData & {properties?: Record<string, unknown>})?.properties;
+        const existingProps = (updatedStep.data as StepData & {properties?: Record<string, unknown>})?.properties;
+
+        if (defaultProps && existingProps) {
+          const coerced: Record<string, unknown> = Object.fromEntries(
+            Object.entries(existingProps).map(([k, v]) => {
+              const def = defaultProps[k];
+              if (typeof def === 'number' && typeof v === 'string') {
+                const n = Number(v);
+                return [k, isNaN(n) ? v : n];
+              }
+              if (typeof def === 'boolean' && typeof v === 'string') {
+                return [k, v === 'true'];
+              }
+              return [k, v];
+            }),
+          );
+          updatedStep = {...updatedStep, data: {...updatedStep.data, properties: coerced}};
+        }
+
         // Merge executor display metadata into the step (at root level and in data for React Flow access)
         updatedStep = {
           ...updatedStep,

--- a/frontend/apps/console/src/features/flows/utils/widgetUtils.ts
+++ b/frontend/apps/console/src/features/flows/utils/widgetUtils.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {Widget} from '../models/widget';
+
+export function widgetNeedsViewContainer(widget: Widget): boolean {
+  const widgetSteps =
+    (widget?.config?.data as {steps?: {__generationMeta__?: {strategy?: string}}[] | undefined} | undefined)?.steps ??
+    [];
+
+  return widgetSteps.some((step) => step?.__generationMeta__?.strategy === 'MERGE_WITH_DROP_POINT');
+}

--- a/frontend/apps/console/src/features/flows/validation/validation-rules.ts
+++ b/frontend/apps/console/src/features/flows/validation/validation-rules.ts
@@ -204,7 +204,8 @@ export const VALIDATION_RULES: ValidationRuleDefinition[] = [
       const formElement = resource as FlowElement;
 
       const hasInputFields = formElement.components?.some(
-        (element: FlowElement) => element.category === ElementCategories.Field,
+        (element: FlowElement) =>
+          element.category === ElementCategories.Field || element.type === ElementTypes.DynamicInputPlaceholder,
       );
 
       const hasSubmitButton = formElement.components?.some(

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/ResourceProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/ResourceProperties.tsx
@@ -38,14 +38,17 @@ import {StepCategories, StepTypes} from '@/features/flows/models/steps';
  * @param props - Props injected to the component.
  * @returns The ResourceProperties component.
  */
-const coerceValue = (newValue: unknown): string | boolean | object => {
+const coerceValue = (newValue: unknown): string | boolean | number | object => {
   if (typeof newValue === 'boolean') {
+    return newValue;
+  }
+  if (typeof newValue === 'number') {
     return newValue;
   }
   if (typeof newValue === 'object' && newValue !== null) {
     return newValue;
   }
-  if (typeof newValue === 'string' || typeof newValue === 'number') {
+  if (typeof newValue === 'string') {
     return String(newValue);
   }
   return '';
@@ -61,7 +64,8 @@ function ResourceProperties({
 
   const handleChange = useCallback(
     (propertyKey: string, newValue: unknown, changedResource: unknown, debounce?: boolean): void => {
-      onChange(propertyKey, coerceValue(newValue), changedResource as Resource, debounce);
+      const coercedValue = coerceValue(newValue);
+      onChange(propertyKey, coercedValue, changedResource as Resource, debounce);
     },
     [onChange],
   );

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
@@ -579,6 +579,23 @@ describe('ResourceProperties', () => {
       // This test verifies the component renders without errors
       expect(screen.getByTestId('field-extended-properties')).toBeInTheDocument();
     });
+
+    it('should preserve number values before calling onChange', () => {
+      const resource = createMockResource({category: ElementCategories.Field});
+
+      render(
+        <ResourceProperties
+          resource={resource}
+          properties={{maxPerPrompt: 3}}
+          onChange={mockOnChange}
+          onVariantChange={mockOnVariantChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('trigger-change-maxPerPrompt'));
+
+      expect(mockOnChange).toHaveBeenCalledWith('maxPerPrompt', 3, resource, undefined);
+    });
   });
 
   describe('Sync Selected Variant on Resource Change', () => {
@@ -1157,7 +1174,7 @@ describe('ResourceProperties', () => {
       expect(mockOnChange).toHaveBeenCalledWith('label', 'test string', resource, undefined);
     });
 
-    it('should convert number values to string in onChange', () => {
+    it('should preserve number values in onChange', () => {
       const resource = createMockResource({
         category: ElementCategories.Field,
       });
@@ -1174,7 +1191,7 @@ describe('ResourceProperties', () => {
       const triggerButton = screen.getByTestId('trigger-change-maxLength');
       fireEvent.click(triggerButton);
 
-      expect(mockOnChange).toHaveBeenCalledWith('maxLength', '100', resource, undefined);
+      expect(mockOnChange).toHaveBeenCalledWith('maxLength', 100, resource, undefined);
     });
 
     it('should convert null values to empty string in onChange', () => {

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
@@ -69,6 +69,13 @@ vi.mock('react-i18next', () => ({
         'flows:core.executions.identifying.mode.placeholder': 'Select a mode',
         'flows:core.executions.identifying.mode.identify': 'Identify',
         'flows:core.executions.identifying.mode.resolve': 'Resolve (Disambiguation)',
+        'flows:core.executions.provisioning.description': 'Configure the provisioning executor settings.',
+        'flows:core.executions.federation.allowCrossOUProvisioning.label': 'Allow Cross-OU Provisioning',
+        'flows:core.executions.provisioning.includeOptional.label': 'Allow Optional Non Credential',
+        'flows:core.executions.provisioning.maxPerPrompt.label': 'Max Per Prompt',
+        'flows:core.executions.provisioning.includeOptionalCredentials.label': 'Include Optional Credentials',
+        'flows:core.executions.provisioning.assignGroup.label': 'Assign Group',
+        'flows:core.executions.provisioning.assignRole.label': 'Assign Role',
       };
       return translations[key] || key;
     },
@@ -1316,6 +1323,9 @@ describe('ExecutionExtendedProperties', () => {
         },
         properties: {
           allowCrossOUProvisioning: false,
+          includeOptional: false,
+          includeOptionalCredentials: false,
+          maxPerPrompt: 5,
           assignGroup: '',
           assignRole: '',
         },
@@ -1325,13 +1335,13 @@ describe('ExecutionExtendedProperties', () => {
     it('should render provisioning configuration', () => {
       render(<ExecutionExtendedProperties resource={provisioningResource} onChange={mockOnChange} />);
 
-      expect(screen.getByText('flows:core.executions.provisioning.description')).toBeInTheDocument();
-      expect(screen.getByText('flows:core.executions.federation.allowCrossOUProvisioning.label')).toBeInTheDocument();
-      expect(
-        screen.getByText('flows:core.executions.provisioning.includeOptionalCredentials.label'),
-      ).toBeInTheDocument();
-      expect(screen.getByLabelText('flows:core.executions.provisioning.assignGroup.label')).toBeInTheDocument();
-      expect(screen.getByLabelText('flows:core.executions.provisioning.assignRole.label')).toBeInTheDocument();
+      expect(screen.getByText('Configure the provisioning executor settings.')).toBeInTheDocument();
+      expect(screen.getByText('Allow Cross-OU Provisioning')).toBeInTheDocument();
+      expect(screen.getByText('Allow Optional Non Credential')).toBeInTheDocument();
+      expect(screen.getByLabelText('Max Per Prompt')).toBeInTheDocument();
+      expect(screen.getByText('Include Optional Credentials')).toBeInTheDocument();
+      expect(screen.getByLabelText('Assign Group')).toBeInTheDocument();
+      expect(screen.getByLabelText('Assign Role')).toBeInTheDocument();
     });
 
     it('should call onChange without debounce when allowCrossOUProvisioning checkbox is toggled', () => {
@@ -1344,11 +1354,31 @@ describe('ExecutionExtendedProperties', () => {
       expect(mockOnChange).toHaveBeenCalledWith('data.properties.allowCrossOUProvisioning', true, provisioningResource);
     });
 
+    it('should call onChange without debounce when includeOptional checkbox is toggled', () => {
+      render(<ExecutionExtendedProperties resource={provisioningResource} onChange={mockOnChange} />);
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      const includeOptionalCheckbox = checkboxes[1];
+      fireEvent.click(includeOptionalCheckbox);
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.includeOptional', true, provisioningResource);
+    });
+
+    it('should call onChange with debounce when maxPerPrompt changes', () => {
+      render(<ExecutionExtendedProperties resource={provisioningResource} onChange={mockOnChange} />);
+
+      fireEvent.change(screen.getByLabelText('Max Per Prompt'), {
+        target: {value: '3'},
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.maxPerPrompt', 3, provisioningResource, true);
+    });
+
     it('should call onChange without debounce when includeOptionalCredentials checkbox is toggled', () => {
       render(<ExecutionExtendedProperties resource={provisioningResource} onChange={mockOnChange} />);
 
       const checkboxes = screen.getAllByRole('checkbox');
-      const includeOptionalCredentialsCheckbox = checkboxes[1];
+      const includeOptionalCredentialsCheckbox = checkboxes[2];
       fireEvent.click(includeOptionalCredentialsCheckbox);
 
       expect(mockOnChange).toHaveBeenCalledWith(
@@ -1361,7 +1391,7 @@ describe('ExecutionExtendedProperties', () => {
     it('should call onChange with debounce when assignGroup changes', () => {
       render(<ExecutionExtendedProperties resource={provisioningResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.provisioning.assignGroup.label'), {
+      fireEvent.change(screen.getByLabelText('Assign Group'), {
         target: {value: 'admin-group'},
       });
 
@@ -1376,7 +1406,7 @@ describe('ExecutionExtendedProperties', () => {
     it('should call onChange with debounce when assignRole changes', () => {
       render(<ExecutionExtendedProperties resource={provisioningResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.provisioning.assignRole.label'), {
+      fireEvent.change(screen.getByLabelText('Assign Role'), {
         target: {value: 'editor-role'},
       });
 

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/ProvisioningProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/ProvisioningProperties.tsx
@@ -44,6 +44,23 @@ function ProvisioningProperties({resource, onChange}: CommonResourcePropertiesPr
     [resource, onChange],
   );
 
+  const handleNumberPropertyChange = useCallback(
+    (propertyName: string, value: string): void => {
+      if (value === '') {
+        onChange(`data.properties.${propertyName}`, 0, resource, true);
+        return;
+      }
+
+      const num = Number(value);
+      if (Number.isNaN(num)) {
+        return;
+      }
+
+      onChange(`data.properties.${propertyName}`, Math.max(0, Math.floor(num)), resource, true);
+    },
+    [resource, onChange],
+  );
+
   return (
     <Stack gap={2}>
       <Typography variant="body2" color="text.secondary">
@@ -65,6 +82,23 @@ function ProvisioningProperties({resource, onChange}: CommonResourcePropertiesPr
       <FormControlLabel
         control={
           <Checkbox
+            checked={!!properties.includeOptional}
+            onChange={(e) => handleBooleanPropertyChange('includeOptional', e.target.checked)}
+            size="small"
+          />
+        }
+        label={t('flows:core.executions.provisioning.includeOptional.label', 'Allow Optional Non Credential')}
+      />
+      <FormHelperText>
+        {t(
+          'flows:core.executions.provisioning.includeOptional.hint',
+          'Prompt for optional non-credential attributes during dynamic input collection.',
+        )}
+      </FormHelperText>
+
+      <FormControlLabel
+        control={
+          <Checkbox
             checked={!!properties.includeOptionalCredentials}
             onChange={(e) => handleBooleanPropertyChange('includeOptionalCredentials', e.target.checked)}
             size="small"
@@ -73,6 +107,30 @@ function ProvisioningProperties({resource, onChange}: CommonResourcePropertiesPr
         label={t('flows:core.executions.provisioning.includeOptionalCredentials.label')}
       />
       <FormHelperText>{t('flows:core.executions.provisioning.includeOptionalCredentials.hint')}</FormHelperText>
+
+      <div>
+        <FormLabel htmlFor="max-per-prompt">
+          {t('flows:core.executions.provisioning.maxPerPrompt.label', 'Max Per Prompt')}
+        </FormLabel>
+        <TextField
+          id="max-per-prompt"
+          value={
+            typeof properties.maxPerPrompt === 'number' ? properties.maxPerPrompt : Number(properties.maxPerPrompt ?? 0)
+          }
+          onChange={(e) => handleNumberPropertyChange('maxPerPrompt', e.target.value)}
+          placeholder={t('flows:core.executions.provisioning.maxPerPrompt.placeholder', '0')}
+          fullWidth
+          size="small"
+          type="number"
+          inputProps={{min: 0}}
+        />
+        <FormHelperText>
+          {t(
+            'flows:core.executions.provisioning.maxPerPrompt.hint',
+            'Number of dynamic inputs to show per prompt when connected to this provisioning executor.',
+          )}
+        </FormHelperText>
+      </div>
 
       <div>
         <FormLabel htmlFor="assign-group">{t('flows:core.executions.provisioning.assignGroup.label')}</FormLabel>

--- a/frontend/apps/console/src/features/login-flow/data/executors.json
+++ b/frontend/apps/console/src/features/login-flow/data/executors.json
@@ -369,7 +369,10 @@
       "properties": {
         "allowCrossOUProvisioning": false,
         "assignGroup": "",
-        "assignRole": ""
+        "assignRole": "",
+        "includeOptional": false,
+        "includeOptionalCredentials": false,
+        "maxPerPrompt": 5
       }
     }
   },

--- a/frontend/apps/console/src/features/login-flow/data/widgets.json
+++ b/frontend/apps/console/src/features/login-flow/data/widgets.json
@@ -950,5 +950,123 @@
         ]
       }
     }
+  },
+  {
+    "resourceType": "WIDGET",
+    "category": "FLOW",
+    "type": "PROVISIONING",
+    "display": {
+      "label": "Provisioning",
+      "description": "Provision a user and prompt for any missing schema attributes using dynamic inputs",
+      "image": "assets/images/icons/user.svg",
+      "showOnResourcePanel": true
+    },
+    "config": {
+      "data": {
+        "__generationMeta__": {
+          "defaultPropertySelectorId": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
+          "replacers": [
+            {
+              "key": "PROVISIONING_EXECUTOR_STEP_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PROVISIONING_PROMPT_STEP_ID",
+              "type": "ID"
+            }
+          ]
+        },
+        "steps": [
+          {
+            "id": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 820,
+              "y": 800
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "ProvisioningExecutor"
+                },
+                "onSuccess": "",
+                "onFailure": "",
+                "onIncomplete": "{{PROVISIONING_PROMPT_STEP_ID}}"
+              },
+              "properties": {
+                "allowCrossOUProvisioning": false,
+                "assignGroup": "",
+                "assignRole": "",
+                "includeOptional": false,
+                "includeOptionalCredentials": false,
+                "maxPerPrompt": 5
+              }
+            }
+          },
+          {
+            "id": "{{PROVISIONING_PROMPT_STEP_ID}}",
+            "type": "VIEW",
+            "size": {
+              "width": 350,
+              "height": 430
+            },
+            "position": {
+              "x": 820,
+              "y": 100
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "IMAGE",
+                  "src": "{{ meta(application.logoUrl) }}",
+                  "alt": "{{ t(signup:images.app_logo.alt) }}",
+                  "height": "60",
+                  "width": ""
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "variant": "HEADING_1",
+                  "align": "center",
+                  "label": "{{ t(signup:forms.user_info.title) }}"
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "DISPLAY",
+                      "type": "DYNAMIC_INPUT_PLACEHOLDER"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "{{ t(signup:forms.user_info.actions.continue.label) }}",
+                      "action": {
+                        "type": "NEXT",
+                        "onSuccess": "{{PROVISIONING_EXECUTOR_STEP_ID}}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
   }
 ]

--- a/frontend/apps/console/src/features/login-flow/hooks/__tests__/useTemplateAndWidgetLoading.test.ts
+++ b/frontend/apps/console/src/features/login-flow/hooks/__tests__/useTemplateAndWidgetLoading.test.ts
@@ -370,7 +370,7 @@ describe('useTemplateAndWidgetLoading', () => {
           data: {
             steps: [createMockStep()],
             __generationMeta__: {
-              replacers: [{placeholder: '{{ID}}', value: 'new-id'}],
+              replacers: [{key: 'ID', type: 'ID'}],
             },
           },
         },
@@ -459,6 +459,109 @@ describe('useTemplateAndWidgetLoading', () => {
       const [nodes] = result.current.handleWidgetLoad(widget, {} as Resource, currentNodes, currentEdges);
 
       expect(nodes.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should remove a scaffolded drop-point view when a standalone widget does not merge into it', () => {
+      const {result} = renderUseTemplateAndWidgetLoading();
+
+      // Simulates the Provisioning widget: two standalone steps, neither merges into the drop point.
+      const widget = {
+        id: 'provisioning-widget',
+        config: {
+          data: {
+            steps: [
+              {
+                id: '{{EXECUTOR_STEP_ID}}',
+                type: StepTypes.Execution,
+                position: {x: 200, y: 200},
+                data: {
+                  action: {
+                    type: 'EXECUTOR',
+                    executor: {name: 'ProvisioningExecutor'},
+                    onIncomplete: '{{PROMPT_STEP_ID}}',
+                  },
+                },
+              },
+              {
+                id: '{{PROMPT_STEP_ID}}',
+                type: StepTypes.View,
+                position: {x: 200, y: 50},
+                data: {components: []},
+              },
+            ],
+            __generationMeta__: {
+              replacers: [
+                {key: 'EXECUTOR_STEP_ID', type: 'ID'},
+                {key: 'PROMPT_STEP_ID', type: 'ID'},
+              ],
+            },
+          },
+        },
+      } as unknown as Widget;
+
+      const targetView = createMockNode({id: 'drop-point-view', type: StepTypes.View});
+      const currentNodes = [createMockNode({id: 'existing-node'}), targetView];
+      const currentEdges: Edge[] = [];
+
+      const [nodes] = result.current.handleWidgetLoad(
+        widget,
+        targetView as unknown as Resource,
+        currentNodes,
+        currentEdges,
+        true,
+      );
+
+      // The empty drop-point VIEW must be removed; only the widget's own nodes should remain.
+      expect(nodes.find((n) => n.id === 'drop-point-view')).toBeUndefined();
+      // The two widget steps (still with placeholder IDs) should be present alongside existing nodes.
+      expect(nodes.find((n) => n.id === 'existing-node')).toBeDefined();
+      expect(nodes.length).toBe(3); // existing-node + executor step + prompt step
+    });
+
+    it('should preserve an existing target view when a standalone widget is added into the flow', () => {
+      const {result} = renderUseTemplateAndWidgetLoading();
+
+      const widget = {
+        id: 'provisioning-widget',
+        config: {
+          data: {
+            steps: [
+              {
+                id: '{{EXECUTOR_STEP_ID}}',
+                type: StepTypes.Execution,
+                position: {x: 200, y: 200},
+              },
+              {
+                id: '{{PROMPT_STEP_ID}}',
+                type: StepTypes.View,
+                position: {x: 200, y: 50},
+                data: {components: []},
+              },
+            ],
+            __generationMeta__: {
+              replacers: [
+                {key: 'EXECUTOR_STEP_ID', type: 'ID'},
+                {key: 'PROMPT_STEP_ID', type: 'ID'},
+              ],
+            },
+          },
+        },
+      } as unknown as Widget;
+
+      const existingTargetView = createMockNode({id: 'existing-target-view', type: StepTypes.View});
+      const currentNodes = [createMockNode({id: 'existing-node'}), existingTargetView];
+      const currentEdges: Edge[] = [];
+
+      const [nodes] = result.current.handleWidgetLoad(
+        widget,
+        existingTargetView as unknown as Resource,
+        currentNodes,
+        currentEdges,
+      );
+
+      expect(nodes.find((n) => n.id === 'existing-target-view')).toBeDefined();
+      expect(nodes.find((n) => n.id === 'existing-node')).toBeDefined();
+      expect(nodes.length).toBe(4);
     });
 
     it('should find default property selector at node level', () => {

--- a/frontend/apps/console/src/features/login-flow/hooks/useTemplateAndWidgetLoading.ts
+++ b/frontend/apps/console/src/features/login-flow/hooks/useTemplateAndWidgetLoading.ts
@@ -69,6 +69,7 @@ export interface UseTemplateAndWidgetLoadingReturn {
     targetResource: Resource,
     currentNodes: Node[],
     currentEdges: Edge[],
+    removeTargetViewWhenStandalone?: boolean,
   ) => [Node[], Edge[], Resource | null, string | null];
   /** Handle adding a resource from the panel. */
   handleResourceAdd: (resource: Resource) => void;
@@ -179,6 +180,7 @@ const useTemplateAndWidgetLoading = (props: UseTemplateAndWidgetLoadingProps): U
       targetResource: Resource,
       currentNodes: Node[],
       currentEdges: Edge[],
+      removeTargetViewWhenStandalone = false,
     ): [Node[], Edge[], Resource | null, string | null] => {
       const widgetFlow = widget.config.data as {
         steps?: Step[];
@@ -208,6 +210,8 @@ const useTemplateAndWidgetLoading = (props: UseTemplateAndWidgetLoadingProps): U
         return undefined;
       };
 
+      let mergedWithDropPoint = false;
+
       widgetFlow.steps.forEach((step: Step) => {
         if (
           step.__generationMeta__ &&
@@ -217,6 +221,7 @@ const useTemplateAndWidgetLoading = (props: UseTemplateAndWidgetLoadingProps): U
           const {strategy} = step.__generationMeta__ as {strategy?: string};
 
           if (strategy === 'MERGE_WITH_DROP_POINT') {
+            mergedWithDropPoint = true;
             newNodes = newNodes.map((node: Node) => {
               if (node.id === targetResource.id) {
                 // Use mergeWith with the custom merge function
@@ -230,6 +235,11 @@ const useTemplateAndWidgetLoading = (props: UseTemplateAndWidgetLoadingProps): U
           newNodes = [...newNodes, step] as Node[];
         }
       });
+
+      // Remove only a temporary scaffolded drop-point VIEW when no step merged into it.
+      if (!mergedWithDropPoint && removeTargetViewWhenStandalone) {
+        newNodes = newNodes.filter((node: Node) => node.id !== targetResource.id);
+      }
 
       const replacers = widgetFlow.__generationMeta__?.replacers ?? [];
 

--- a/frontend/apps/console/src/features/login-flow/utils/__tests__/edgeUtils.test.ts
+++ b/frontend/apps/console/src/features/login-flow/utils/__tests__/edgeUtils.test.ts
@@ -541,6 +541,69 @@ describe('generateUnconnectedEdges', () => {
       expect(result).toEqual([]);
     });
 
+    it('should handle action with falsy onIncomplete value', () => {
+      const nodes: Node[] = [createMockNode({id: 'step-1', data: {action: {onIncomplete: ''}}})];
+      expect(generateUnconnectedEdges([], nodes, 'default')).toEqual([]);
+    });
+  });
+
+  describe('onIncomplete edges', () => {
+    it('should generate onIncomplete edge for step-level action', () => {
+      const nodes: Node[] = [
+        createMockNode({id: 'executor-1', data: {action: {onIncomplete: 'prompt-1'}}}),
+        createMockNode({id: 'prompt-1'}),
+      ];
+
+      const result = generateUnconnectedEdges([], nodes, 'smoothstep');
+
+      const incompleteEdge = result.find((e) => e.id === 'executor-1_executor-1_INCOMPLETE_MISSING_EDGE');
+      expect(incompleteEdge).toBeDefined();
+      expect(incompleteEdge?.source).toBe('executor-1');
+      expect(incompleteEdge?.sourceHandle).toBe('executor-1_INCOMPLETE');
+      expect(incompleteEdge?.target).toBe('prompt-1');
+      expect(incompleteEdge?.type).toBe('smoothstep');
+    });
+
+    it('should not generate onIncomplete edge when target node does not exist', () => {
+      const nodes: Node[] = [createMockNode({id: 'executor-1', data: {action: {onIncomplete: 'non-existent'}}})];
+      expect(generateUnconnectedEdges([], nodes, 'default')).toEqual([]);
+    });
+
+    it('should not generate onIncomplete edge when correct edge already exists', () => {
+      const nodes: Node[] = [
+        createMockNode({id: 'executor-1', data: {action: {onIncomplete: 'prompt-1'}}}),
+        createMockNode({id: 'prompt-1'}),
+      ];
+      const existingEdges: Edge[] = [
+        {id: 'e1', source: 'executor-1', sourceHandle: 'executor-1_INCOMPLETE', target: 'prompt-1'} as Edge,
+      ];
+
+      expect(generateUnconnectedEdges(existingEdges, nodes, 'default')).toEqual([]);
+    });
+
+    it('should generate onIncomplete edge when existing edge points to wrong target', () => {
+      const nodes: Node[] = [
+        createMockNode({id: 'executor-1', data: {action: {onIncomplete: 'prompt-1'}}}),
+        createMockNode({id: 'prompt-1'}),
+        createMockNode({id: 'wrong-prompt'}),
+      ];
+      const existingEdges: Edge[] = [
+        {
+          id: 'e1',
+          source: 'executor-1',
+          sourceHandle: 'executor-1_INCOMPLETE',
+          target: 'wrong-prompt',
+        } as Edge,
+      ];
+
+      const result = generateUnconnectedEdges(existingEdges, nodes, 'default');
+      const incompleteEdge = result.find((e) => e.id === 'executor-1_executor-1_INCOMPLETE_MISSING_EDGE');
+      expect(incompleteEdge).toBeDefined();
+      expect(incompleteEdge?.target).toBe('prompt-1');
+    });
+  });
+
+  describe('Edge cases (continued)', () => {
     it('should handle components array being empty', () => {
       const nodes: Node[] = [
         createMockNode({

--- a/frontend/apps/console/src/features/login-flow/utils/edgeUtils.ts
+++ b/frontend/apps/console/src/features/login-flow/utils/edgeUtils.ts
@@ -92,6 +92,32 @@ const generateUnconnectedEdges = (currentEdges: Edge[], currentNodes: Node[], ed
           }
         }
       }
+
+      // Process onIncomplete edges
+      if ('onIncomplete' in action && action.onIncomplete) {
+        const expectedIncompleteTarget: string = action.onIncomplete as string;
+
+        if (nodeIds.has(expectedIncompleteTarget)) {
+          const incompleteHandle = `${resourceId}${VisualFlowConstants.FLOW_BUILDER_INCOMPLETE_HANDLE_SUFFIX}`;
+          const existingIncompleteEdge: Edge | undefined = currentEdges.find(
+            (edge: Edge) => edge.source === stepId && edge.sourceHandle === incompleteHandle,
+          );
+
+          if (existingIncompleteEdge?.target !== expectedIncompleteTarget) {
+            missingEdges.push({
+              animated: false,
+              id: `${stepId}_${resourceId}_INCOMPLETE_MISSING_EDGE`,
+              markerEnd: {
+                type: MarkerType.Arrow,
+              },
+              source: stepId,
+              sourceHandle: incompleteHandle,
+              target: expectedIncompleteTarget,
+              type: edgeStyle,
+            });
+          }
+        }
+      }
     }
   };
 

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -2325,6 +2325,13 @@ const translations = {
 
     // Provisioning executor
     'core.executions.provisioning.description': 'Configure the provisioning executor settings.',
+    'core.executions.provisioning.includeOptional.label': 'Allow Optional Non Credential',
+    'core.executions.provisioning.includeOptional.hint':
+      'Prompt for optional non-credential attributes during dynamic input collection.',
+    'core.executions.provisioning.maxPerPrompt.label': 'Max Per Prompt',
+    'core.executions.provisioning.maxPerPrompt.placeholder': '0',
+    'core.executions.provisioning.maxPerPrompt.hint':
+      'Number of dynamic inputs to show per prompt when connected to this provisioning executor.',
     'core.executions.provisioning.includeOptionalCredentials.label': 'Include Optional Credentials',
     'core.executions.provisioning.includeOptionalCredentials.hint':
       'Prompt for optional credential attributes during dynamic input collection.',


### PR DESCRIPTION
### Purpose

Adds provisioning **dynamic-input support** to the flow builder console.

Previously, registration flows required authors to manually design a **static user-info prompt** (with fixed fields like `given_name`, `email`, etc.) before the Provisioning executor. At runtime, the executor received those hardcoded inputs and created the user account.

This approach had limitations:

* Could not handle schemas that differ between deployments
* Missing attributes were **silently skipped**

#### Solution

This PR introduces:

* `DYNAMIC_INPUT_PLACEHOLDER`
* A **loop-back pattern** already supported by the backend

### How It Works

1. The Provisioning executor detects missing schema attributes at runtime
2. Routes execution to a `prompt_schema_attrs` node
3. The placeholder is replaced with actual missing input fields
4. User submits inputs
5. Executor re-runs
6. Repeats until all required attributes are collected

---

### Approach

#### 1. New Element Type and Widget

* `DYNAMIC_INPUT_PLACEHOLDER` added to:

  * `ElementTypes`
  * Canvas allowed-type lists

* Rendered using:

  * `DynamicInputPlaceholderAdapter`

* New widget:

  * `PROVISIONING`
  * Defined in `widgets.json`
  * Scaffolds:

    * Executor node
    * Dynamic-input VIEW node
    * Pre-wired `onIncomplete` connection

---

#### 2. Property Panel for Executor Nodes

Enhancements:

* `ResourceProperties` extracts:

  * `data.properties.*`

* `CommonStepPropertyFactory`:

  * Handles number types correctly using:

    ```js
    Number(value)
    ```

* Fix:

  * Prevents **string-number mismatch issues**

* `resolveStepMetadata`:

  * Ensures property values match declared types

---

#### 3. Flow Save Correctness

Fixes include:

* Removed:

  ```js
  inputs.length > 0
  ```

  → Prevents stale input persistence

* Executors now correctly store:

  ```json
  inputs: []
  ```

* Validation updates:

  * `DYNAMIC_INPUT_PLACEHOLDER` counts as valid input
  * Prevents false “missing input fields” errors

---

#### 4. Deletion Safety (Cascade Delete Fixes)

### Problem

Provisioning executor was incorrectly deleted when:

* VIEW → executor connection removed
* Even if other connections existed

### Fixes

1. Only delete edges with:

   ```
   sourceHandle.endsWith("_NEXT")
   ```

2. Added:

   * `otherIncoming` guard to prevent accidental deletion

3. Cleanup:

   * `setEdges` removes orphaned edges

4. Race condition fix:

   * Switched to **functional state updater** in `handleNodesDelete`

---

#### 5. Standalone Widget Drop

* Widgets without `MERGE_WITH_DROP_POINT`:

  * Bypass “Widget Requires a View” dialog

* Provisioning widget:

  * Creates independent nodes directly

* `handleWidgetLoad`:

  * Removes unused scaffold VIEW if nothing merges into it

---

#### 6. Edge Generation

* `generateUnconnectedEdges` updated to support:

  * `onIncomplete` edges

* Ensures:

  * Proper executor → dynamic-input VIEW connection
  * Correct loading from API

---

#### 7. Templates Update

All 9 templates updated:

### Changes

* Added:

  * `prompt_schema_attrs`

* Set:

  ```json
  provisioning.onIncomplete
  ```

* Added properties:

  ```json
  includeOptional: true
  maxPerPrompt: 2
  ```

* Removed:

  * Static user-info prompts

---

#### Special Case: Passkey + Basic Template

* Contains **two provisioning paths**
* Requires:

  * `prompt_schema_attrs`
  * `prompt_schema_attrs_passkey`

Each loops back to its respective executor independently.

---


### Related Issues
- https://github.com/asgardeo/thunder/issues/2561

### Related PRs
- https://github.com/asgardeo/thunder/pull/2450
- https://github.com/asgardeo/thunder/pull/2518


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numeric property support in flow property editors
  * Dynamic Input Placeholder element for runtime field collection
  * Provisioning widget enabling drag-and-drop provisioning flows (auto-scaffold vs. merge)
  * Dynamic schema-driven attribute collection in registration/onboarding flows

* **Bug Fixes**
  * Improved node/edge deletion and reconnection logic
  * Validation treats dynamic placeholders as input fields requiring submit actions

* **Tests**
  * Added coverage for numeric properties, dynamic placeholders, coercion, and drag/drop behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->