### PR TITLE
Fix handling of ECDSA keys

### DIFF
--- a/backend/internal/system/cryptolib/sign.go
+++ b/backend/internal/system/cryptolib/sign.go
@@ -28,6 +28,7 @@ import (
 	"crypto/sha512"
 	"errors"
 	"hash"
+	"math/big"
 )
 
 // Sign errors.
@@ -149,7 +150,16 @@ func newECDSASign(hashed []byte, privateKey crypto.PrivateKey) ([]byte, error) {
 	if !ok {
 		return nil, ErrInvalidPrivateKey
 	}
-	return ecdsa.SignASN1(rand.Reader, ecdsaKey, hashed)
+	r, s, err := ecdsa.Sign(rand.Reader, ecdsaKey, hashed)
+	if err != nil {
+		return nil, err
+	}
+	// RFC 7518 §3.4: encode as fixed-size R || S (each zero-padded to curve coordinate size).
+	coordSize := (ecdsaKey.Curve.Params().BitSize + 7) / 8
+	sig := make([]byte, 2*coordSize)
+	r.FillBytes(sig[:coordSize])
+	s.FillBytes(sig[coordSize:])
+	return sig, nil
 }
 
 func verifyECDSA(hashed, signature []byte, publicKey crypto.PublicKey) error {
@@ -157,7 +167,14 @@ func verifyECDSA(hashed, signature []byte, publicKey crypto.PublicKey) error {
 	if !ok {
 		return ErrInvalidPublicKey
 	}
-	if !ecdsa.VerifyASN1(ecdsaPub, hashed, signature) {
+	// RFC 7518 §3.4: signature is fixed-size R || S (each zero-padded to curve coordinate size).
+	coordSize := (ecdsaPub.Curve.Params().BitSize + 7) / 8
+	if len(signature) != 2*coordSize {
+		return ErrInvalidSignature
+	}
+	r := new(big.Int).SetBytes(signature[:coordSize])
+	s := new(big.Int).SetBytes(signature[coordSize:])
+	if !ecdsa.Verify(ecdsaPub, hashed, r, s) {
 		return ErrInvalidSignature
 	}
 	return nil

--- a/backend/internal/system/cryptolib/sign_test.go
+++ b/backend/internal/system/cryptolib/sign_test.go
@@ -355,9 +355,11 @@ func (suite *SignUtilsTestSuite) TestRoundTrip() {
 	}
 }
 
-func (suite *SignUtilsTestSuite) TestSignECDSAASN1Format() {
+func (suite *SignUtilsTestSuite) TestSignECDSARawFormat() {
 	signature, err := Generate(suite.testData, ECDSASHA256, suite.ecdsaPrivateKey)
 	assert.NoError(suite.T(), err)
+	// RFC 7518 §3.4: ES256 signature must be exactly 64 bytes (2 × 32-byte coord).
+	assert.Equal(suite.T(), 64, len(signature))
 	err = Verify(suite.testData, signature, ECDSASHA256, &suite.ecdsaPrivateKey.PublicKey)
 	assert.NoError(suite.T(), err)
 }

--- a/backend/internal/system/jose/jwe/utils.go
+++ b/backend/internal/system/jose/jwe/utils.go
@@ -260,6 +260,55 @@ func pkcs7Unpad(data []byte) ([]byte, error) {
 	return data[:len(data)-padding], nil
 }
 
+// jwkToECPublicKey converts a JWK to an ECDH public key for key agreement (e.g. ECDH-ES).
+func jwkToECPublicKey(jwk map[string]interface{}) (*ecdh.PublicKey, error) {
+	crv, crvOK := jwk["crv"].(string)
+	xStr, xOK := jwk["x"].(string)
+	yStr, yOK := jwk["y"].(string)
+	if !crvOK || !xOK || !yOK {
+		return nil, errors.New("JWK missing EC parameters")
+	}
+
+	curve, expectedKeySize, err := getECCurveInfo(crv)
+	if err != nil {
+		return nil, err
+	}
+
+	xBytes, err := base64.RawURLEncoding.DecodeString(xStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EC x: %w", err)
+	}
+	yBytes, err := base64.RawURLEncoding.DecodeString(yStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EC y: %w", err)
+	}
+
+	if len(xBytes) != expectedKeySize || len(yBytes) != expectedKeySize {
+		return nil, errors.New("invalid EC coordinate length")
+	}
+
+	uncompressed := make([]byte, 1+len(xBytes)+len(yBytes))
+	uncompressed[0] = 0x04
+	copy(uncompressed[1:], xBytes)
+	copy(uncompressed[1+len(xBytes):], yBytes)
+
+	return curve.NewPublicKey(uncompressed)
+}
+
+// getECCurveInfo returns the ECDH curve and expected coordinate byte size for a given curve name.
+func getECCurveInfo(crv string) (ecdh.Curve, int, error) {
+	switch crv {
+	case jws.P256:
+		return ecdh.P256(), 32, nil
+	case jws.P384:
+		return ecdh.P384(), 48, nil
+	case jws.P521:
+		return ecdh.P521(), 66, nil
+	default:
+		return nil, 0, fmt.Errorf("unsupported EC curve: %s", crv)
+	}
+}
+
 // extractEPKFromHeader parses the "epk" field from the JWE protected header and returns
 // the ephemeral public key as *ecdh.PublicKey required by cryptolib.
 func extractEPKFromHeader(header map[string]interface{}) (crypto.PublicKey, error) {
@@ -267,7 +316,7 @@ func extractEPKFromHeader(header map[string]interface{}) (crypto.PublicKey, erro
 	if !ok {
 		return nil, fmt.Errorf("missing or invalid epk in JWE header")
 	}
-	ecdhPub, err := jws.JWKToECPublicKey(epkMap)
+	ecdhPub, err := jwkToECPublicKey(epkMap)
 	if err != nil {
 		return nil, fmt.Errorf("invalid epk in header: %w", err)
 	}

--- a/backend/internal/system/jose/jwe/utils_test.go
+++ b/backend/internal/system/jose/jwe/utils_test.go
@@ -20,6 +20,7 @@ package jwe
 
 import (
 	"crypto/aes"
+	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -437,4 +438,78 @@ func (s *JEWUtilsTestSuite) TestExtractEPKFromHeader() {
 	})
 	s.Error(err)
 	s.Contains(err.Error(), "invalid epk in header")
+}
+
+func (s *JEWUtilsTestSuite) TestGetECCurveInfoP256() {
+	curve, keySize, err := getECCurveInfo("P-256")
+	s.NoError(err)
+	s.Equal(ecdh.P256(), curve)
+	s.Equal(32, keySize)
+}
+
+func (s *JEWUtilsTestSuite) TestGetECCurveInfoP384() {
+	curve, keySize, err := getECCurveInfo("P-384")
+	s.NoError(err)
+	s.Equal(ecdh.P384(), curve)
+	s.Equal(48, keySize)
+}
+
+func (s *JEWUtilsTestSuite) TestGetECCurveInfoP521() {
+	curve, keySize, err := getECCurveInfo("P-521")
+	s.NoError(err)
+	s.Equal(ecdh.P521(), curve)
+	s.Equal(66, keySize)
+}
+
+func (s *JEWUtilsTestSuite) TestGetECCurveInfoUnsupported() {
+	curve, keySize, err := getECCurveInfo("P-999")
+	s.Error(err)
+	s.Nil(curve)
+	s.Equal(0, keySize)
+	s.Contains(err.Error(), "unsupported EC curve")
+}
+
+func (s *JEWUtilsTestSuite) TestJWKToECPublicKeyMissingParams() {
+	_, err := jwkToECPublicKey(map[string]interface{}{"x": "val", "y": "val"})
+	s.Error(err)
+	s.Contains(err.Error(), "JWK missing EC parameters")
+}
+
+func (s *JEWUtilsTestSuite) TestJWKToECPublicKeyUnsupportedCurve() {
+	_, err := jwkToECPublicKey(map[string]interface{}{
+		"crv": "P-999",
+		"x":   base64.RawURLEncoding.EncodeToString([]byte("value")),
+		"y":   base64.RawURLEncoding.EncodeToString([]byte("value")),
+	})
+	s.Error(err)
+	s.Contains(err.Error(), "unsupported EC curve")
+}
+
+func (s *JEWUtilsTestSuite) TestJWKToECPublicKeyInvalidCoordinateLength() {
+	_, err := jwkToECPublicKey(map[string]interface{}{
+		"crv": "P-256",
+		"x":   base64.RawURLEncoding.EncodeToString([]byte("short")),
+		"y":   base64.RawURLEncoding.EncodeToString([]byte("short")),
+	})
+	s.Error(err)
+	s.Contains(err.Error(), "invalid EC coordinate length")
+}
+
+func (s *JEWUtilsTestSuite) TestJWKToECPublicKeyValid() {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	s.NoError(err)
+	ecdhPub, err := privKey.PublicKey.ECDH()
+	s.NoError(err)
+
+	raw := ecdhPub.Bytes() // 0x04 || x || y
+	jwk := map[string]interface{}{
+		"crv": "P-256",
+		"x":   base64.RawURLEncoding.EncodeToString(raw[1:33]),
+		"y":   base64.RawURLEncoding.EncodeToString(raw[33:]),
+	}
+
+	pub, err := jwkToECPublicKey(jwk)
+	s.NoError(err)
+	s.NotNil(pub)
+	s.Equal(ecdhPub, pub)
 }

--- a/backend/internal/system/jose/jws/utils.go
+++ b/backend/internal/system/jose/jws/utils.go
@@ -22,7 +22,9 @@ package jws
 import (
 	"crypto"
 	"crypto/ecdh"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
@@ -91,7 +93,7 @@ func JWKToPublicKey(jwk map[string]interface{}) (crypto.PublicKey, error) {
 	case "RSA":
 		return jwkToRSAPublicKey(jwk)
 	case "EC":
-		return JWKToECPublicKey(jwk)
+		return jwkToECDSAPublicKey(jwk)
 	case "OKP":
 		return jwkToOKPPublicKey(jwk)
 	default:
@@ -125,8 +127,8 @@ func jwkToRSAPublicKey(jwk map[string]interface{}) (*rsa.PublicKey, error) {
 	return &rsa.PublicKey{N: n, E: int(e)}, nil
 }
 
-// JWKToECPublicKey converts a JWK to an EC public key.
-func JWKToECPublicKey(jwk map[string]interface{}) (*ecdh.PublicKey, error) {
+// jwkToECDSAPublicKey converts a JWK to an ECDSA public key for JWS signature verification.
+func jwkToECDSAPublicKey(jwk map[string]interface{}) (*ecdsa.PublicKey, error) {
 	crv, crvOK := jwk["crv"].(string)
 	xStr, xOK := jwk["x"].(string)
 	yStr, yOK := jwk["y"].(string)
@@ -134,9 +136,18 @@ func JWKToECPublicKey(jwk map[string]interface{}) (*ecdh.PublicKey, error) {
 		return nil, errors.New("JWK missing EC parameters")
 	}
 
-	curve, expectedKeySize, err := getECCurveInfo(crv)
-	if err != nil {
-		return nil, err
+	var curve elliptic.Curve
+	var ecdhCurve ecdh.Curve
+	var expectedKeySize int
+	switch crv {
+	case P256:
+		curve, ecdhCurve, expectedKeySize = elliptic.P256(), ecdh.P256(), 32
+	case P384:
+		curve, ecdhCurve, expectedKeySize = elliptic.P384(), ecdh.P384(), 48
+	case P521:
+		curve, ecdhCurve, expectedKeySize = elliptic.P521(), ecdh.P521(), 66
+	default:
+		return nil, fmt.Errorf("unsupported EC curve: %s", crv)
 	}
 
 	xBytes, err := base64.RawURLEncoding.DecodeString(xStr)
@@ -152,28 +163,20 @@ func JWKToECPublicKey(jwk map[string]interface{}) (*ecdh.PublicKey, error) {
 		return nil, errors.New("invalid EC coordinate length")
 	}
 
-	// Construct the uncompressed point encoding: 0x04 || x || y
-	uncompressed := make([]byte, 1+len(xBytes)+len(yBytes))
-	uncompressed[0] = 0x04 // uncompressed point marker
+	// Use crypto/ecdh to validate the point is on the curve.
+	uncompressed := make([]byte, 1+2*expectedKeySize)
+	uncompressed[0] = 0x04
 	copy(uncompressed[1:], xBytes)
-	copy(uncompressed[1+len(xBytes):], yBytes)
-
-	// NewPublicKey performs on-curve validation automatically
-	return curve.NewPublicKey(uncompressed)
-}
-
-// getECCurveInfo returns the elliptic curve and expected key size for a given curve name.
-func getECCurveInfo(crv string) (ecdh.Curve, int, error) {
-	switch crv {
-	case P256:
-		return ecdh.P256(), 32, nil
-	case P384:
-		return ecdh.P384(), 48, nil
-	case P521:
-		return ecdh.P521(), 66, nil
-	default:
-		return nil, 0, fmt.Errorf("unsupported EC curve: %s", crv)
+	copy(uncompressed[1+expectedKeySize:], yBytes)
+	if _, err := ecdhCurve.NewPublicKey(uncompressed); err != nil {
+		return nil, errors.New("point not on curve")
 	}
+
+	return &ecdsa.PublicKey{
+		Curve: curve,
+		X:     new(big.Int).SetBytes(xBytes),
+		Y:     new(big.Int).SetBytes(yBytes),
+	}, nil
 }
 
 // jwkToOKPPublicKey converts a JWK to an OKP public key.

--- a/backend/internal/system/jose/jws/utils_test.go
+++ b/backend/internal/system/jose/jws/utils_test.go
@@ -19,7 +19,6 @@
 package jws
 
 import (
-	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -357,37 +356,27 @@ func (suite *JWSUtilsTestSuite) TestJWKToOKPPublicKeyInvalidKeyLength() {
 	assert.Contains(suite.T(), err.Error(), "invalid Ed25519 public key length")
 }
 
-func (suite *JWSUtilsTestSuite) TestGetECCurveInfoP256() {
-	curve, keySize, err := getECCurveInfo(P256)
+func (suite *JWSUtilsTestSuite) TestJWKToPublicKeyEC() {
+	xBytes := make([]byte, 32)
+	yBytes := make([]byte, 32)
+	suite.ecPublicKey.X.FillBytes(xBytes)
+	suite.ecPublicKey.Y.FillBytes(yBytes)
+
+	jwk := map[string]interface{}{
+		"kty": "EC",
+		"crv": "P-256",
+		"x":   base64.RawURLEncoding.EncodeToString(xBytes),
+		"y":   base64.RawURLEncoding.EncodeToString(yBytes),
+	}
+
+	publicKey, err := JWKToPublicKey(jwk)
 
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), ecdh.P256(), curve)
-	assert.Equal(suite.T(), 32, keySize)
-}
-
-func (suite *JWSUtilsTestSuite) TestGetECCurveInfoP384() {
-	curve, keySize, err := getECCurveInfo(P384)
-
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), ecdh.P384(), curve)
-	assert.Equal(suite.T(), 48, keySize)
-}
-
-func (suite *JWSUtilsTestSuite) TestGetECCurveInfoP521() {
-	curve, keySize, err := getECCurveInfo(P521)
-
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), ecdh.P521(), curve)
-	assert.Equal(suite.T(), 66, keySize)
-}
-
-func (suite *JWSUtilsTestSuite) TestGetECCurveInfoUnsupported() {
-	curve, keySize, err := getECCurveInfo("P-999")
-
-	assert.Error(suite.T(), err)
-	assert.Nil(suite.T(), curve)
-	assert.Equal(suite.T(), 0, keySize)
-	assert.Contains(suite.T(), err.Error(), "unsupported EC curve")
+	assert.NotNil(suite.T(), publicKey)
+	ecKey, ok := publicKey.(*ecdsa.PublicKey)
+	assert.True(suite.T(), ok)
+	assert.Equal(suite.T(), suite.ecPublicKey.X, ecKey.X)
+	assert.Equal(suite.T(), suite.ecPublicKey.Y, ecKey.Y)
 }
 
 func (suite *JWSUtilsTestSuite) TestJWKToPublicKeyInvalidEC() {

--- a/backend/internal/system/jose/sdjwt/sdjwt.go
+++ b/backend/internal/system/jose/sdjwt/sdjwt.go
@@ -22,11 +22,9 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"encoding/asn1"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"strings"
 	"time"
 
@@ -490,29 +488,7 @@ func verifyJWS(token string, key crypto.PublicKey) error {
 	}
 	signingInput := parts[0] + "." + parts[1]
 
-	// JWS ECDSA signatures use fixed-length P1363 format (r||s per RFC 7518 §3.4).
-	// cryptolib.Verify calls ecdsa.VerifyASN1, so convert to ASN.1/DER first.
-	switch signAlg {
-	case cryptolib.ECDSASHA256, cryptolib.ECDSASHA384, cryptolib.ECDSASHA512:
-		signature, err = p1363ToDER(signature)
-		if err != nil {
-			return fmt.Errorf("invalid ECDSA signature encoding: %w", err)
-		}
-	}
-
 	return cryptolib.Verify([]byte(signingInput), signature, signAlg, key)
-}
-
-// p1363ToDER converts a JWS ECDSA signature from fixed-length P1363 (r||s)
-// to ASN.1/DER format as expected by ecdsa.VerifyASN1.
-func p1363ToDER(sig []byte) ([]byte, error) {
-	if len(sig) == 0 || len(sig)%2 != 0 {
-		return nil, fmt.Errorf("P1363 signature must have even non-zero length, got %d", len(sig))
-	}
-	n := len(sig) / 2
-	r := new(big.Int).SetBytes(sig[:n])
-	s := new(big.Int).SetBytes(sig[n:])
-	return asn1.Marshal(struct{ R, S *big.Int }{r, s})
 }
 
 // decodeJWTPayload decodes the JSON claims set (the second segment) of a compact JWS.


### PR DESCRIPTION
### Purpose
This pull request makes several important improvements to ECDSA signature handling and JWK (JSON Web Key) EC public key support. The main changes include switching ECDSA signatures from ASN.1 to raw format, adding robust conversion from JWK to ECDSA public keys, and expanding test coverage for these new behaviors.

**ECDSA Signature Format Update:**

- Changed ECDSA signature generation and verification in `sign.go` to use a raw concatenation of `r` and `s` values instead of ASN.1 encoding, ensuring interoperability with systems expecting raw signatures. The code now manually serializes and deserializes the signature components.
- Updated related test in `sign_test.go` to reflect the new raw format, renaming the test accordingly.

**JWK EC Public Key Support:**

- Added a new function `jwkToECDSAPublicKey` in `jws/utils.go` to convert JWK EC keys into Go ECDSA public keys, including validation that the key coordinates are the correct length and lie on the expected curve.
- Updated `JWKToPublicKey` to use the new `jwkToECDSAPublicKey` for EC keys, replacing the old function.
- Added imports for `ecdsa` and `elliptic` to support the new functionality.

**Test Coverage and Validation:**

- Added a test (`TestJWKToPublicKeyEC`) to ensure correct conversion from JWK to ECDSA public key, including proper coordinate padding and curve validation.
- Improved the invalid EC JWK test to check for points not on the curve, using padded coordinates that are guaranteed to be invalid, and verifying the error message.

**Dependency Updates:**

- Added `math/big` import in `sign.go` for big integer operations needed for signature serialization.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
This change switches ECDSA signatures from ASN.1 DER encoding (via ecdsa.SignASN1/VerifyASN1) to raw fixed-size encoding with FillBytes (RFC 7518 §3.4).

#### 💥 Impact
Any signature produced under the previous ASN.1 format will fail verification with ErrInvalidSignature because the length check at line 170 will reject non-fixed-size signatures.

#### 🔄 Migration Guide
N/A

---


### Related Issues
- https://github.com/asgardeo/thunder/issues/2624

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated ECDSA signature encoding format from ASN.1 to fixed-size raw byte representation.
  * Modified elliptic curve public key handling in authentication and encryption operations.

* **Tests**
  * Updated test suite to validate new signature encoding format and elliptic curve key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->