### PR TITLE
Migrate public key discovery to RuntimeCryptoProvider

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -349,8 +349,8 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	// Initialize OAuth services.
 	err = oauth.Initialize(mux, applicationService, inboundClientService, authnProvider, jwtService, jweService,
-		flowExecService, observabilitySvc, pkiService, ouService, attributeCacheService, authZService, entityProvider,
-		resourceService, i18nService, idpService)
+		flowExecService, observabilitySvc, runtimeCryptoSvc, ouService, attributeCacheService, authZService,
+		entityProvider, resourceService, i18nService, idpService)
 	if err != nil {
 		logger.Fatal("Failed to initialize OAuth services", log.Error(err))
 	}

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -48,7 +48,7 @@ import (
 	i18nmgt "github.com/thunder-id/thunderid/internal/system/i18n/mgt"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pkiservice"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/observability"
 )
 
@@ -62,7 +62,7 @@ func Initialize(
 	jweService jwe.JWEServiceInterface,
 	flowExecService flowexec.FlowExecServiceInterface,
 	observabilitySvc observability.ObservabilityServiceInterface,
-	pkiService pkiservice.PKIServiceInterface,
+	runtimeCrypto kmprovider.RuntimeCryptoProvider,
 	ouService ou.OrganizationUnitServiceInterface,
 	attributeCacheSvc attributecache.AttributeCacheServiceInterface,
 	authzService authz.AuthorizationServiceInterface,
@@ -77,14 +77,14 @@ func Initialize(
 		return err
 	}
 
-	jwks.Initialize(mux, pkiService)
+	jwks.Initialize(mux, runtimeCrypto)
 	httpClient := syshttp.NewHTTPClientWithCheckRedirect(func(req *http.Request, _ []*http.Request) error {
 		return syshttp.IsSSRFSafeURL(req.URL.String())
 	})
 	resolver := jwksresolver.Initialize(httpClient)
 	tokenBuilder, tokenValidator := tokenservice.Initialize(jwtService, jweService, resolver, idpService)
 	scopeValidator := scope.Initialize()
-	discoveryService := discovery.Initialize(mux, pkiService)
+	discoveryService := discovery.Initialize(mux, runtimeCrypto)
 	parService := par.Initialize(mux, inboundClient, authnProvider, jwtService, discoveryService,
 		resourceService)
 	grantHandlerProvider, err := granthandlers.Initialize(

--- a/backend/internal/oauth/jwks/init.go
+++ b/backend/internal/oauth/jwks/init.go
@@ -21,14 +21,14 @@ package jwks
 import (
 	"net/http"
 
-	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pkiservice"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
 )
 
 // Initialize initializes the JWKS service and registers its routes.
-func Initialize(mux *http.ServeMux, pkiService pkiservice.PKIServiceInterface) JWKSServiceInterface {
+func Initialize(mux *http.ServeMux, cryptoProvider kmprovider.RuntimeCryptoProvider) JWKSServiceInterface {
 	// Initialize the JWKS service
-	jwksService := newJWKSService(pkiService)
+	jwksService := newJWKSService(cryptoProvider)
 	jwksHandler := newJWKSHandler(jwksService)
 	registerRoutes(mux, jwksHandler)
 	return jwksService

--- a/backend/internal/oauth/jwks/init_test.go
+++ b/backend/internal/oauth/jwks/init_test.go
@@ -21,16 +21,19 @@ package jwks
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/x509"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
-	"github.com/thunder-id/thunderid/tests/mocks/crypto/pki/pkimock"
+	"github.com/thunder-id/thunderid/internal/system/cryptolab"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )
 
 type InitTestSuite struct {
@@ -42,7 +45,6 @@ func TestInitTestSuite(t *testing.T) {
 }
 
 func (suite *InitTestSuite) SetupTest() {
-	// Initialize Runtime config for CORS middleware
 	testConfig := &config.Config{}
 	_ = config.InitializeServerRuntime("test", testConfig)
 }
@@ -53,11 +55,9 @@ func (suite *InitTestSuite) TearDownTest() {
 
 func (suite *InitTestSuite) TestInitialize() {
 	mux := http.NewServeMux()
+	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
 
-	// Prepare PKI mock with minimal expectations
-	pkiMock := pkimock.NewPKIServiceInterfaceMock(suite.T())
-
-	service := Initialize(mux, pkiMock)
+	service := Initialize(mux, cryptoMock)
 
 	assert.NotNil(suite.T(), service)
 	assert.Implements(suite.T(), (*JWKSServiceInterface)(nil), service)
@@ -65,23 +65,28 @@ func (suite *InitTestSuite) TestInitialize() {
 
 func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 	mux := http.NewServeMux()
-	// Prepare PKI mock with expectations for handler invocation using new method
-	pkiMock := pkimock.NewPKIServiceInterfaceMock(suite.T())
-	key, _ := rsa.GenerateKey(rand.Reader, 2048)
-	cert := &x509.Certificate{Raw: []byte("raw-cert"), PublicKey: &key.PublicKey}
-	allCerts := map[string]*x509.Certificate{"test-kid": cert}
-	pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
-	pkiMock.EXPECT().GetCertThumbprint("test-kid").Return("test-kid")
+	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
 
-	_ = Initialize(mux, pkiMock)
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(suite.T(), err)
+	keys := []kmprovider.PublicKeyInfo{
+		{
+			KeyID:          "test-kid",
+			Algorithm:      cryptolab.AlgorithmRS256,
+			PublicKey:      &rsaKey.PublicKey,
+			Thumbprint:     "test-kid",
+			CertificateDER: []byte("raw-cert"),
+		},
+	}
+	cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).Return(keys, nil)
 
-	// Test that routes are registered by making requests
+	_ = Initialize(mux, cryptoMock)
+
 	req := httptest.NewRequest("GET", "/oauth2/jwks", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 	assert.NotEqual(suite.T(), http.StatusNotFound, w.Code)
 
-	// Test OPTIONS request
 	req = httptest.NewRequest("OPTIONS", "/oauth2/jwks", nil)
 	w = httptest.NewRecorder()
 	mux.ServeHTTP(w, req)

--- a/backend/internal/oauth/jwks/service.go
+++ b/backend/internal/oauth/jwks/service.go
@@ -20,6 +20,7 @@
 package jwks
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
@@ -31,7 +32,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/cryptolab/hash"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pkiservice"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
 
@@ -42,57 +43,53 @@ type JWKSServiceInterface interface {
 
 // jwksService implements the JWKSServiceInterface.
 type jwksService struct {
-	pkiService pkiservice.PKIServiceInterface
-	logger     *log.Logger
+	cryptoProvider kmprovider.RuntimeCryptoProvider
+	logger         *log.Logger
 }
 
 // newJWKSService creates a new instance of JWKSService.
-func newJWKSService(pkiService pkiservice.PKIServiceInterface) JWKSServiceInterface {
+func newJWKSService(cryptoProvider kmprovider.RuntimeCryptoProvider) JWKSServiceInterface {
 	return &jwksService{
-		pkiService: pkiService,
-		logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWKSService")),
+		cryptoProvider: cryptoProvider,
+		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWKSService")),
 	}
 }
 
-// GetJWKS retrieves the JSON Web Key Set (JWKS) from all server certificates.
+// GetJWKS retrieves the JSON Web Key Set (JWKS) from the runtime crypto provider.
 func (s *jwksService) GetJWKS() (*JWKSResponse, *serviceerror.ServiceError) {
-	// Get all certificates
-	allCerts, err := s.pkiService.GetAllX509Certificates()
+	publicKeys, err := s.cryptoProvider.GetPublicKeys(context.Background(), kmprovider.PublicKeyFilter{})
 	if err != nil {
-		return nil, err
+		s.logger.Error("Failed to retrieve public keys", log.Error(err))
+		return nil, &serviceerror.InternalServerError
 	}
 
-	if len(allCerts) == 0 {
+	if len(publicKeys) == 0 {
 		return nil, &serviceerror.InternalServerError
 	}
 
 	var jwksKeys []JWKS
 
-	for certID, parsedCert := range allCerts {
-		// Generate KID from certificate thumbprint
-		kid := s.pkiService.GetCertThumbprint(certID)
+	for _, keyInfo := range publicKeys {
+		kid := keyInfo.Thumbprint
 
-		// x5c: base64 DER encoding
-		x5c := []string{base64.StdEncoding.EncodeToString(parsedCert.Raw)}
+		var x5c []string
+		var x5t, x5tS256 string
+		if len(keyInfo.CertificateDER) > 0 {
+			x5c = []string{base64.StdEncoding.EncodeToString(keyInfo.CertificateDER)}
+			sha1Sum := sha1.Sum(keyInfo.CertificateDER) //nolint:gosec // x5t (SHA-1 thumbprint) is required by spec
+			x5t = encodeBase64URL(sha1Sum[:])
+			x5tS256 = hash.GenerateThumbprint(keyInfo.CertificateDER)
+		}
 
-		// x5t: SHA-1 thumbprint, x5t#S256: SHA-256 thumbprint
-		sha1Sum := sha1.Sum(parsedCert.Raw) //nolint:gosec // x5t (SHA-1 thumbprint) is required by spec
-		x5t := base64.StdEncoding.EncodeToString(sha1Sum[:])
-		x5tS256 := hash.GenerateThumbprint(parsedCert.Raw)
-
-		switch pub := parsedCert.PublicKey.(type) {
+		switch pub := keyInfo.PublicKey.(type) {
 		case *rsa.PublicKey:
-			jwk := getRSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256)
-			jwksKeys = append(jwksKeys, jwk)
+			jwksKeys = append(jwksKeys, getRSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256))
 		case *ecdsa.PublicKey:
-			jwk := getECDSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256)
-			jwksKeys = append(jwksKeys, jwk)
+			jwksKeys = append(jwksKeys, getECDSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256))
 		case ed25519.PublicKey:
-			jwk := getEdDSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256)
-			jwksKeys = append(jwksKeys, jwk)
+			jwksKeys = append(jwksKeys, getEdDSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256))
 		default:
-			s.logger.Debug("Unsupported public key type for JWKS", log.String("certID", certID))
-			// Skip unsupported public key types
+			s.logger.Debug("Unsupported public key type for JWKS", log.String("keyID", keyInfo.KeyID))
 			continue
 		}
 	}

--- a/backend/internal/oauth/jwks/service_test.go
+++ b/backend/internal/oauth/jwks/service_test.go
@@ -24,22 +24,23 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/x509"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/cryptolab"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
-	"github.com/thunder-id/thunderid/internal/system/i18n/core"
-	"github.com/thunder-id/thunderid/tests/mocks/crypto/pki/pkimock"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )
 
 type JWKSServiceTestSuite struct {
 	suite.Suite
 	jwksService JWKSServiceInterface
-	pkiMock     *pkimock.PKIServiceInterfaceMock
+	cryptoMock  *cryptomock.RuntimeCryptoProviderMock
 }
 
 func TestJWKSServiceSuite(t *testing.T) {
@@ -47,23 +48,21 @@ func TestJWKSServiceSuite(t *testing.T) {
 }
 
 func (suite *JWKSServiceTestSuite) SetupTest() {
-	// Reset runtime
-	config.ResetServerRuntime()
-	testConfig := &config.Config{}
-	_ = config.InitializeServerRuntime("", testConfig)
-
-	// Create PKI mock and service under test
-	suite.pkiMock = pkimock.NewPKIServiceInterfaceMock(suite.T())
-	suite.jwksService = newJWKSService(suite.pkiMock)
+	suite.cryptoMock = cryptomock.NewRuntimeCryptoProviderMock(suite.T())
+	suite.jwksService = newJWKSService(suite.cryptoMock)
 }
 
 func (suite *JWKSServiceTestSuite) TestGetJWKS_RSA_Success() {
-	// Prepare RSA cert and mock
 	key, _ := rsa.GenerateKey(rand.Reader, 2048)
-	cert := &x509.Certificate{Raw: []byte("rsa-cert-raw"), PublicKey: &key.PublicKey}
-	allCerts := map[string]*x509.Certificate{"kid-1": cert}
-	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
-	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("kid-1")
+	info := kmprovider.PublicKeyInfo{
+		KeyID:          "kid-1",
+		Algorithm:      cryptolab.AlgorithmRS256,
+		PublicKey:      &key.PublicKey,
+		Thumbprint:     "kid-1",
+		CertificateDER: []byte("rsa-cert-raw"),
+	}
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return([]kmprovider.PublicKeyInfo{info}, nil)
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), svcErr)
@@ -80,12 +79,16 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_RSA_Success() {
 }
 
 func (suite *JWKSServiceTestSuite) TestGetJWKS_ECDSA_P256_Success() {
-	// Prepare ECDSA P-256 cert and mock
 	ecdsaKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	cert := &x509.Certificate{Raw: []byte("ec-cert-raw"), PublicKey: &ecdsaKey.PublicKey}
-	allCerts := map[string]*x509.Certificate{"kid-1": cert}
-	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
-	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("kid-1")
+	info := kmprovider.PublicKeyInfo{
+		KeyID:          "kid-1",
+		Algorithm:      cryptolab.AlgorithmES256,
+		PublicKey:      &ecdsaKey.PublicKey,
+		Thumbprint:     "kid-1",
+		CertificateDER: []byte("ec-cert-raw"),
+	}
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return([]kmprovider.PublicKeyInfo{info}, nil)
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), svcErr)
@@ -103,12 +106,16 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_ECDSA_P256_Success() {
 }
 
 func (suite *JWKSServiceTestSuite) TestGetJWKS_EdDSA_Success() {
-	// Prepare EdDSA cert and mock
 	_, edPriv, _ := ed25519.GenerateKey(rand.Reader)
-	cert := &x509.Certificate{Raw: []byte("ed-cert-raw"), PublicKey: edPriv.Public()}
-	allCerts := map[string]*x509.Certificate{"kid-1": cert}
-	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
-	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("kid-1")
+	info := kmprovider.PublicKeyInfo{
+		KeyID:          "kid-1",
+		Algorithm:      cryptolab.AlgorithmEdDSA,
+		PublicKey:      edPriv.Public(),
+		Thumbprint:     "kid-1",
+		CertificateDER: []byte("ed-cert-raw"),
+	}
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return([]kmprovider.PublicKeyInfo{info}, nil)
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), svcErr)
@@ -124,26 +131,19 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_EdDSA_Success() {
 	assert.NotEmpty(suite.T(), k.X5tS256)
 }
 
-func (suite *JWKSServiceTestSuite) TestGetJWKS_CertParseError() {
-	// Mock parse error
-	parseErr := serviceerror.CustomServiceError(serviceerror.InternalServerError, core.I18nMessage{
-		Key:          "error.test.parse_error",
-		DefaultValue: "parse error",
-	})
-	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(nil, parseErr)
+func (suite *JWKSServiceTestSuite) TestGetJWKS_GetPublicKeysError() {
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return(nil, errors.New("provider error"))
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), resp)
 	assert.NotNil(suite.T(), svcErr)
-	// The error is passed through from PKI service, so we expect the PKI error code
-	assert.Equal(suite.T(), parseErr.Code, svcErr.Code)
-	assert.Equal(suite.T(), parseErr.ErrorDescription.DefaultValue, svcErr.ErrorDescription.DefaultValue)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
 }
 
 func (suite *JWKSServiceTestSuite) TestGetJWKS_NoCertificatesFound() {
-	// Mock empty certificates
-	allCerts := map[string]*x509.Certificate{}
-	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return([]kmprovider.PublicKeyInfo{}, nil)
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), resp)
@@ -152,44 +152,70 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_NoCertificatesFound() {
 }
 
 func (suite *JWKSServiceTestSuite) TestGetJWKS_UnsupportedPublicKeyType() {
-	key, _ := rsa.GenerateKey(rand.Reader, 2048)
-	cert := &x509.Certificate{Raw: []byte("rsa-cert-raw"), PublicKey: &key.PublicKey}
-	// Provide an unsupported public key type (using a string as an invalid example)
-	errCert := &x509.Certificate{Raw: []byte("unsupported-cert-raw"), PublicKey: "unsupported-key-type"}
-	allCerts := map[string]*x509.Certificate{"kid-1": errCert, "kid-2": cert}
-	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
-	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("kid-1")
-	suite.pkiMock.EXPECT().GetCertThumbprint("kid-2").Return("kid-2")
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	keys := []kmprovider.PublicKeyInfo{
+		{
+			KeyID:      "kid-1",
+			PublicKey:  "unsupported-key-type",
+			Thumbprint: "kid-1",
+		},
+		{
+			KeyID:          "kid-2",
+			Algorithm:      cryptolab.AlgorithmRS256,
+			PublicKey:      &rsaKey.PublicKey,
+			Thumbprint:     "kid-2",
+			CertificateDER: []byte("rsa-cert-raw"),
+		},
+	}
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return(keys, nil)
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), svcErr)
 	assert.NotNil(suite.T(), resp)
-	// The unsupported key should be skipped, so only one valid key should be present
 	assert.Len(suite.T(), resp.Keys, 1)
 }
 
-func (suite *JWKSServiceTestSuite) TestGetJWKS_MultipleCertificates() {
-	// Prepare multiple certs (RSA and ECDSA)
-	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-	rsaCert := &x509.Certificate{Raw: []byte("rsa-cert-raw"), PublicKey: &rsaKey.PublicKey}
-
-	ecdsaKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	ecCert := &x509.Certificate{Raw: []byte("ec-cert-raw"), PublicKey: &ecdsaKey.PublicKey}
-
-	allCerts := map[string]*x509.Certificate{
-		"rsa-kid": rsaCert,
-		"ec-kid":  ecCert,
+func (suite *JWKSServiceTestSuite) TestGetJWKS_OnlyUnsupportedKeys() {
+	keys := []kmprovider.PublicKeyInfo{
+		{KeyID: "kid-1", PublicKey: "unsupported-key-type", Thumbprint: "kid-1"},
 	}
-	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
-	suite.pkiMock.EXPECT().GetCertThumbprint("rsa-kid").Return("rsa-kid")
-	suite.pkiMock.EXPECT().GetCertThumbprint("ec-kid").Return("ec-kid")
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return(keys, nil)
+
+	resp, svcErr := suite.jwksService.GetJWKS()
+	assert.Nil(suite.T(), resp)
+	assert.NotNil(suite.T(), svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *JWKSServiceTestSuite) TestGetJWKS_MultipleCertificates() {
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	ecdsaKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	keys := []kmprovider.PublicKeyInfo{
+		{
+			KeyID:          "rsa-kid",
+			Algorithm:      cryptolab.AlgorithmRS256,
+			PublicKey:      &rsaKey.PublicKey,
+			Thumbprint:     "rsa-kid",
+			CertificateDER: []byte("rsa-cert-raw"),
+		},
+		{
+			KeyID:          "ec-kid",
+			Algorithm:      cryptolab.AlgorithmES256,
+			PublicKey:      &ecdsaKey.PublicKey,
+			Thumbprint:     "ec-kid",
+			CertificateDER: []byte("ec-cert-raw"),
+		},
+	}
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return(keys, nil)
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), svcErr)
 	assert.NotNil(suite.T(), resp)
 	assert.Len(suite.T(), resp.Keys, 2)
 
-	// Check that both key types are present
 	rsaFound := false
 	ecFound := false
 	for _, k := range resp.Keys {
@@ -210,32 +236,25 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_ECDSA_AdditionalCurves() {
 	tests := []struct {
 		name  string
 		curve elliptic.Curve
-		alg   string
+		alg   cryptolab.Algorithm
 		crv   string
 	}{
-		{
-			name:  "P-384",
-			curve: elliptic.P384(),
-			alg:   "ES384",
-			crv:   "P-384",
-		},
-		{
-			name:  "P-521",
-			curve: elliptic.P521(),
-			alg:   "ES512",
-			crv:   "P-521",
-		},
+		{name: "P-384", curve: elliptic.P384(), alg: cryptolab.AlgorithmES384, crv: "P-384"},
+		{name: "P-521", curve: elliptic.P521(), alg: cryptolab.AlgorithmES512, crv: "P-521"},
 	}
 
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
 			ecdsaKey, _ := ecdsa.GenerateKey(tt.curve, rand.Reader)
-			cert := &x509.Certificate{Raw: []byte("ec-cert-raw-" + tt.name), PublicKey: &ecdsaKey.PublicKey}
-			kid := "kid-" + tt.name
-			allCerts := map[string]*x509.Certificate{kid: cert}
-
-			suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil).Once()
-			suite.pkiMock.EXPECT().GetCertThumbprint(kid).Return(kid).Once()
+			info := kmprovider.PublicKeyInfo{
+				KeyID:          "kid-" + tt.name,
+				Algorithm:      tt.alg,
+				PublicKey:      &ecdsaKey.PublicKey,
+				Thumbprint:     "kid-" + tt.name,
+				CertificateDER: []byte("ec-cert-raw-" + tt.name),
+			}
+			suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+				Return([]kmprovider.PublicKeyInfo{info}, nil).Once()
 
 			resp, svcErr := suite.jwksService.GetJWKS()
 			assert.Nil(suite.T(), svcErr)
@@ -243,7 +262,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_ECDSA_AdditionalCurves() {
 			assert.Len(suite.T(), resp.Keys, 1)
 			k := resp.Keys[0]
 			assert.Equal(suite.T(), "EC", k.Kty)
-			assert.Equal(suite.T(), tt.alg, k.Alg)
+			assert.Equal(suite.T(), string(tt.alg), k.Alg)
 			assert.Equal(suite.T(), tt.crv, k.Crv)
 			assert.NotEmpty(suite.T(), k.X)
 			assert.NotEmpty(suite.T(), k.Y)
@@ -251,27 +270,18 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_ECDSA_AdditionalCurves() {
 	}
 }
 
-func (suite *JWKSServiceTestSuite) TestGetJWKS_OnlyUnsupportedKeys() {
-	// Provide only an unsupported public key type
-	errCert := &x509.Certificate{Raw: []byte("unsupported-cert-raw"), PublicKey: "unsupported-key-type"}
-	allCerts := map[string]*x509.Certificate{"kid-1": errCert}
-	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
-	suite.pkiMock.EXPECT().GetCertThumbprint("kid-1").Return("kid-1")
-
-	resp, svcErr := suite.jwksService.GetJWKS()
-	assert.Nil(suite.T(), resp)
-	assert.NotNil(suite.T(), svcErr)
-	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
-}
-
 func (suite *JWKSServiceTestSuite) TestGetJWKS_RSA_ZeroExponent() {
-	// Prepare RSA cert with E=0 and mock
 	key, _ := rsa.GenerateKey(rand.Reader, 2048)
 	key.PublicKey.E = 0
-	cert := &x509.Certificate{Raw: []byte("rsa-cert-raw-zero"), PublicKey: &key.PublicKey}
-	allCerts := map[string]*x509.Certificate{"kid-zero": cert}
-	suite.pkiMock.EXPECT().GetAllX509Certificates().Return(allCerts, nil)
-	suite.pkiMock.EXPECT().GetCertThumbprint("kid-zero").Return("kid-zero")
+	info := kmprovider.PublicKeyInfo{
+		KeyID:          "kid-zero",
+		Algorithm:      cryptolab.AlgorithmRS256,
+		PublicKey:      &key.PublicKey,
+		Thumbprint:     "kid-zero",
+		CertificateDER: []byte("rsa-cert-raw-zero"),
+	}
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return([]kmprovider.PublicKeyInfo{info}, nil)
 
 	resp, svcErr := suite.jwksService.GetJWKS()
 	assert.Nil(suite.T(), svcErr)
@@ -279,9 +289,28 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_RSA_ZeroExponent() {
 	assert.Len(suite.T(), resp.Keys, 1)
 	k := resp.Keys[0]
 	assert.Equal(suite.T(), "RSA", k.Kty)
-	// Base64Url(0) -> "AA" (if []byte{0}) or ""?
-	// The code does:
-	// if len(eBytes) == 0 { eBytes = []byte{0} }
-	// encodeBase64URL([]byte{0}) -> "AA" (because base64 of 0 is AA==, trimmed =) -> "AA"
 	assert.Equal(suite.T(), "AA", k.E)
+}
+
+func (suite *JWKSServiceTestSuite) TestGetJWKS_NoCertificateDER() {
+	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	info := kmprovider.PublicKeyInfo{
+		KeyID:      "kid-1",
+		Algorithm:  cryptolab.AlgorithmRS256,
+		PublicKey:  &rsaKey.PublicKey,
+		Thumbprint: "kid-1",
+		// CertificateDER intentionally nil
+	}
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return([]kmprovider.PublicKeyInfo{info}, nil)
+
+	resp, svcErr := suite.jwksService.GetJWKS()
+	assert.Nil(suite.T(), svcErr)
+	assert.NotNil(suite.T(), resp)
+	assert.Len(suite.T(), resp.Keys, 1)
+	k := resp.Keys[0]
+	assert.Equal(suite.T(), "RSA", k.Kty)
+	assert.Empty(suite.T(), k.X5c)
+	assert.Empty(suite.T(), k.X5t)
+	assert.Empty(suite.T(), k.X5tS256)
 }

--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -21,47 +21,25 @@ package discovery
 
 import (
 	"context"
-	"crypto"
-	"crypto/x509"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/config"
-	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/internal/system/cryptolab"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )
-
-// testPKIService is a minimal PKIServiceInterface implementation for discovery tests.
-type testPKIService struct {
-	algorithms []string
-}
-
-func (m *testPKIService) GetSupportedSigningAlgorithms() []string {
-	return m.algorithms
-}
-
-func (m *testPKIService) GetPrivateKey(string) (crypto.PrivateKey, *serviceerror.ServiceError) {
-	return nil, nil
-}
-
-func (m *testPKIService) GetCertThumbprint(string) string { return "" }
-
-func (m *testPKIService) GetX509Certificate(string) (*x509.Certificate, *serviceerror.ServiceError) {
-	return nil, nil
-}
-
-func (m *testPKIService) GetAllX509Certificates() (map[string]*x509.Certificate, *serviceerror.ServiceError) {
-	return nil, nil
-}
 
 type DiscoveryTestSuite struct {
 	suite.Suite
-	pkiService       *testPKIService
+	cryptoMock       *cryptomock.RuntimeCryptoProviderMock
 	discoveryService DiscoveryServiceInterface
 	handler          discoveryHandlerInterface
 }
@@ -93,10 +71,8 @@ func (suite *DiscoveryTestSuite) SetupTest() {
 	}
 	_ = config.InitializeServerRuntime("test", testConfig)
 
-	suite.pkiService = &testPKIService{
-		algorithms: []string{"RS256"},
-	}
-	suite.discoveryService = newDiscoveryService(suite.pkiService)
+	suite.cryptoMock = cryptomock.NewRuntimeCryptoProviderMock(suite.T())
+	suite.discoveryService = newDiscoveryService(suite.cryptoMock)
 	suite.handler = newDiscoveryHandler(suite.discoveryService)
 }
 
@@ -142,6 +118,9 @@ func (suite *DiscoveryTestSuite) TestOAuth2AuthorizationServerMetadata() {
 }
 
 func (suite *DiscoveryTestSuite) TestOIDCDiscovery() {
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return([]kmprovider.PublicKeyInfo{{KeyID: "k1", Algorithm: cryptolab.AlgorithmRS256}}, nil)
+
 	req := httptest.NewRequest("GET", "/.well-known/openid-configuration", nil)
 	w := httptest.NewRecorder()
 
@@ -284,8 +263,11 @@ func TestGetStandardClaims(t *testing.T) {
 }
 
 func (suite *DiscoveryTestSuite) TestInitialize() {
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return([]kmprovider.PublicKeyInfo{{KeyID: "k1", Algorithm: cryptolab.AlgorithmRS256}}, nil)
+
 	mux := http.NewServeMux()
-	service := Initialize(mux, suite.pkiService)
+	service := Initialize(mux, suite.cryptoMock)
 
 	assert.NotNil(suite.T(), service)
 	assert.Implements(suite.T(), (*DiscoveryServiceInterface)(nil), service)
@@ -327,7 +309,7 @@ func (suite *DiscoveryTestSuite) TestGetBaseURL_WithPublicHostname() {
 	}
 	_ = config.InitializeServerRuntime("test", testConfig)
 
-	service := newDiscoveryService(suite.pkiService)
+	service := newDiscoveryService(suite.cryptoMock)
 	metadata := service.GetOAuth2AuthorizationServerMetadata(context.Background())
 	assert.Contains(suite.T(), metadata.AuthorizationEndpoint, "public.thunder.io")
 	config.ResetServerRuntime()
@@ -347,18 +329,24 @@ func (suite *DiscoveryTestSuite) TestGetBaseURL_WithHTTPOnly() {
 	}
 	_ = config.InitializeServerRuntime("test", testConfig)
 
-	service := newDiscoveryService(suite.pkiService)
+	service := newDiscoveryService(suite.cryptoMock)
 	metadata := service.GetOAuth2AuthorizationServerMetadata(context.Background())
 	assert.Contains(suite.T(), metadata.AuthorizationEndpoint, "http://")
 	config.ResetServerRuntime()
 }
 
 func (suite *DiscoveryTestSuite) TestOIDCDiscovery_MultipleKeyAlgorithms() {
-	multiPKI := &testPKIService{
-		algorithms: []string{"RS256", "ES256", "EdDSA"},
-	}
-	svc := newDiscoveryService(multiPKI)
-	algs := svc.GetOIDCMetadata(context.Background()).IDTokenSigningAlgValuesSupported
+	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
+	cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return([]kmprovider.PublicKeyInfo{
+			{KeyID: "k1", Algorithm: cryptolab.AlgorithmRS256},
+			{KeyID: "k2", Algorithm: cryptolab.AlgorithmES256},
+			{KeyID: "k3", Algorithm: cryptolab.AlgorithmEdDSA},
+		}, nil)
+	svc := newDiscoveryService(cryptoMock)
+	meta, err := svc.GetOIDCMetadata(context.Background())
+	assert.NoError(suite.T(), err)
+	algs := meta.IDTokenSigningAlgValuesSupported
 
 	assert.Equal(suite.T(), 3, len(algs))
 	assert.Contains(suite.T(), algs, "RS256")
@@ -367,11 +355,16 @@ func (suite *DiscoveryTestSuite) TestOIDCDiscovery_MultipleKeyAlgorithms() {
 }
 
 func (suite *DiscoveryTestSuite) TestOIDCDiscovery_DeduplicatesAlgorithms() {
-	multiRSA := &testPKIService{
-		algorithms: []string{"RS256"},
-	}
-	svc := newDiscoveryService(multiRSA)
-	algs := svc.GetOIDCMetadata(context.Background()).IDTokenSigningAlgValuesSupported
+	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
+	cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
+		Return([]kmprovider.PublicKeyInfo{
+			{KeyID: "k1", Algorithm: cryptolab.AlgorithmRS256},
+			{KeyID: "k2", Algorithm: cryptolab.AlgorithmRS256},
+		}, nil)
+	svc := newDiscoveryService(cryptoMock)
+	meta, err := svc.GetOIDCMetadata(context.Background())
+	assert.NoError(suite.T(), err)
+	algs := meta.IDTokenSigningAlgValuesSupported
 
 	assert.Equal(suite.T(), 1, len(algs))
 	assert.Contains(suite.T(), algs, "RS256")

--- a/backend/internal/oauth/oauth2/discovery/handler.go
+++ b/backend/internal/oauth/oauth2/discovery/handler.go
@@ -21,6 +21,7 @@ package discovery
 import (
 	"net/http"
 
+	"github.com/thunder-id/thunderid/internal/system/error/apierror"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
@@ -59,7 +60,11 @@ func (dh *discoveryHandler) HandleOIDCDiscovery(w http.ResponseWriter, r *http.R
 	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DiscoveryHandler"))
 
-	metadata := dh.discoveryService.GetOIDCMetadata(ctx)
+	metadata, err := dh.discoveryService.GetOIDCMetadata(ctx)
+	if err != nil {
+		sysutils.WriteErrorResponse(w, http.StatusInternalServerError, apierror.ErrorResponse{})
+		return
+	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, metadata)
 	logger.Debug("OIDC discovery response sent successfully")

--- a/backend/internal/oauth/oauth2/discovery/init.go
+++ b/backend/internal/oauth/oauth2/discovery/init.go
@@ -21,13 +21,13 @@ package discovery
 import (
 	"net/http"
 
-	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pkiservice"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
 )
 
 // Initialize initializes the discovery service and registers its routes
-func Initialize(mux *http.ServeMux, pkiService pkiservice.PKIServiceInterface) DiscoveryServiceInterface {
-	discoveryService := newDiscoveryService(pkiService)
+func Initialize(mux *http.ServeMux, cryptoProvider kmprovider.RuntimeCryptoProvider) DiscoveryServiceInterface {
+	discoveryService := newDiscoveryService(cryptoProvider)
 	discoveryHandler := newDiscoveryHandler(discoveryService)
 	registerRoutes(mux, discoveryHandler)
 	return discoveryService

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -20,31 +20,34 @@ package discovery
 
 import (
 	"context"
+	"errors"
+	"slices"
 	"sort"
 
 	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/pkce"
 	"github.com/thunder-id/thunderid/internal/system/config"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pkiservice"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	"github.com/thunder-id/thunderid/internal/system/log"
 )
 
 // DiscoveryServiceInterface defines the interface for discovery services
 type DiscoveryServiceInterface interface {
 	GetOAuth2AuthorizationServerMetadata(ctx context.Context) *OAuth2AuthorizationServerMetadata
-	GetOIDCMetadata(ctx context.Context) *OIDCProviderMetadata
+	GetOIDCMetadata(ctx context.Context) (*OIDCProviderMetadata, error)
 }
 
 // discoveryService implements DiscoveryServiceInterface
 type discoveryService struct {
-	baseURL    string
-	pkiService pkiservice.PKIServiceInterface
+	baseURL        string
+	cryptoProvider kmprovider.RuntimeCryptoProvider
 }
 
 // newDiscoveryService creates a new discovery service instance
-func newDiscoveryService(pkiService pkiservice.PKIServiceInterface) DiscoveryServiceInterface {
+func newDiscoveryService(cryptoProvider kmprovider.RuntimeCryptoProvider) DiscoveryServiceInterface {
 	runtime := config.GetServerRuntime()
-	ds := &discoveryService{pkiService: pkiService}
+	ds := &discoveryService{cryptoProvider: cryptoProvider}
 	ds.baseURL = config.GetServerURL(&runtime.Config.Server)
 	return ds
 }
@@ -75,14 +78,18 @@ func (ds *discoveryService) GetOAuth2AuthorizationServerMetadata(
 }
 
 // GetOIDCMetadata returns OpenID Connect Provider Metadata
-func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) *OIDCProviderMetadata {
+func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) (*OIDCProviderMetadata, error) {
 	oauth2Meta := ds.GetOAuth2AuthorizationServerMetadata(ctx)
 
+	signingAlgs, err := ds.getSupportedSigningAlgorithms(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return &OIDCProviderMetadata{
 		OAuth2AuthorizationServerMetadata:    *oauth2Meta,
 		SubjectTypesSupported:                ds.getSupportedSubjectTypes(),
-		IDTokenSigningAlgValuesSupported:     ds.pkiService.GetSupportedSigningAlgorithms(),
-		UserInfoSigningAlgValuesSupported:    ds.pkiService.GetSupportedSigningAlgorithms(),
+		IDTokenSigningAlgValuesSupported:     signingAlgs,
+		UserInfoSigningAlgValuesSupported:    signingAlgs,
 		UserInfoEncryptionAlgValuesSupported: inboundmodel.SupportedUserInfoEncryptionAlgs,
 		UserInfoEncryptionEncValuesSupported: inboundmodel.SupportedUserInfoEncryptionEncs,
 		IDTokenEncryptionAlgValuesSupported:  inboundmodel.SupportedIDTokenEncryptionAlgs,
@@ -90,7 +97,7 @@ func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) *OIDCProviderMe
 		ClaimsSupported:                      ds.getSupportedClaims(),
 		ClaimsParameterSupported:             true,
 		AcrValuesSupported:                   ds.getSupportedAcrValues(),
-	}
+	}, nil
 }
 
 func (ds *discoveryService) getIssuer() string {
@@ -157,7 +164,28 @@ func (ds *discoveryService) getSupportedSubjectTypes() []string {
 	return constants.GetSupportedSubjectTypes()
 }
 
-// getSupportedAcrValues returns the sorted ACR values from the auth_class.acr_amr mapping.
+func (ds *discoveryService) getSupportedSigningAlgorithms(ctx context.Context) ([]string, error) {
+	keys, err := ds.cryptoProvider.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
+	if err != nil {
+		log.GetLogger().Error("Failed to retrieve public keys for signing algorithm discovery", log.Error(err))
+		return nil, err
+	}
+	result := make([]string, 0, len(keys))
+	for _, k := range keys {
+		alg := string(k.Algorithm)
+		if alg == "" || slices.Contains(result, alg) {
+			continue
+		}
+		result = append(result, alg)
+	}
+	if len(result) == 0 {
+		err = errors.New("no valid signing algorithms found")
+		log.GetLogger().Error("No valid signing algorithms found in registered public keys", log.Error(err))
+		return nil, err
+	}
+	return result, nil
+}
+
 func (ds *discoveryService) getSupportedAcrValues() []string {
 	acrAMR := config.GetServerRuntime().Config.OAuth.AuthClass.AcrAMR
 	acrs := make([]string, 0, len(acrAMR))

--- a/backend/internal/system/kmprovider/defaultkm/runtime.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime.go
@@ -21,6 +21,7 @@ package defaultkm
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"errors"
 	"fmt"
@@ -130,9 +131,62 @@ func (s *runtimeCryptoService) Sign(
 }
 
 func (s *runtimeCryptoService) GetPublicKeys(
-	_ context.Context, _ kmprovider.PublicKeyFilter,
+	_ context.Context, filter kmprovider.PublicKeyFilter,
 ) ([]kmprovider.PublicKeyInfo, error) {
-	return nil, errors.New("not implemented")
+	if s.pkiService == nil {
+		return nil, errors.New("PKI service not initialized")
+	}
+
+	allCerts, svcErr := s.pkiService.GetAllX509Certificates()
+	if svcErr != nil {
+		return nil, fmt.Errorf("failed to retrieve certificates: [%s] %s",
+			svcErr.Code, svcErr.Error.DefaultValue)
+	}
+
+	keys := make([]kmprovider.PublicKeyInfo, 0, len(allCerts))
+	for id, cert := range allCerts {
+		var alg cryptolab.Algorithm
+		switch pub := cert.PublicKey.(type) {
+		case *rsa.PublicKey:
+			alg = cryptolab.AlgorithmRS256
+		case *ecdsa.PublicKey:
+			switch pub.Curve.Params().Name {
+			case "P-256":
+				alg = cryptolab.AlgorithmES256
+			case "P-384":
+				alg = cryptolab.AlgorithmES384
+			case "P-521":
+				alg = cryptolab.AlgorithmES512
+			default:
+				s.logger.Warn("Unsupported EC curve; skipping",
+					log.String("keyID", id),
+					log.String("curve", pub.Curve.Params().Name))
+				continue
+			}
+		case ed25519.PublicKey:
+			alg = cryptolab.AlgorithmEdDSA
+		default:
+			s.logger.Debug("Unsupported public key type; skipping", log.String("keyID", id))
+			continue
+		}
+
+		if filter.KeyID != "" && filter.KeyID != id {
+			continue
+		}
+		if filter.Algorithm != "" && filter.Algorithm != alg {
+			continue
+		}
+
+		keys = append(keys, kmprovider.PublicKeyInfo{
+			KeyID:          id,
+			Algorithm:      alg,
+			PublicKey:      cert.PublicKey,
+			Thumbprint:     s.pkiService.GetCertThumbprint(id),
+			CertificateDER: cert.Raw,
+		})
+	}
+
+	return keys, nil
 }
 
 func (s *runtimeCryptoService) GetTLSMaterial(

--- a/backend/internal/system/kmprovider/defaultkm/runtime_test.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_test.go
@@ -21,6 +21,7 @@ package defaultkm
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -34,6 +35,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	"github.com/thunder-id/thunderid/internal/system/i18n/core"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/pki/pkimock"
 )
 
@@ -44,6 +46,10 @@ func newTestSvcErr() *serviceerror.ServiceError {
 		Code:  "TEST-001",
 		Error: core.I18nMessage{DefaultValue: "key not found"},
 	}
+}
+
+func newTestLogger() *log.Logger {
+	return log.GetLogger()
 }
 
 func TestEncrypt_RSAOAEP256_SuccessViaConstructor(t *testing.T) {
@@ -431,4 +437,155 @@ func TestDecrypt_ECDHESVariants_RoundTrip(t *testing.T) {
 			assert.Equal(t, encDetails.CEK, derivedCEK)
 		})
 	}
+}
+
+// GetPublicKeys
+
+func TestGetPublicKeys_NilPKIService(t *testing.T) {
+	svc := &runtimeCryptoService{pkiService: nil}
+	_, err := svc.GetPublicKeys(context.Background(), kmprovider.PublicKeyFilter{})
+	assert.EqualError(t, err, "PKI service not initialized")
+}
+
+func TestGetPublicKeys_GetAllX509CertificatesError(t *testing.T) {
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetAllX509Certificates().Return(nil, &serviceerror.InternalServerError)
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	_, err := svc.GetPublicKeys(context.Background(), kmprovider.PublicKeyFilter{})
+	assert.Error(t, err)
+}
+
+func TestGetPublicKeys_RSA(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetAllX509Certificates().Return(
+		map[string]*x509.Certificate{"key1": {Raw: []byte("der"), PublicKey: &rsaKey.PublicKey}}, nil,
+	)
+	pki.EXPECT().GetCertThumbprint("key1").Return("thumbprint-1")
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	keys, err := svc.GetPublicKeys(context.Background(), kmprovider.PublicKeyFilter{})
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "key1", keys[0].KeyID)
+	assert.Equal(t, cryptolab.AlgorithmRS256, keys[0].Algorithm)
+	assert.Equal(t, &rsaKey.PublicKey, keys[0].PublicKey)
+	assert.Equal(t, "thumbprint-1", keys[0].Thumbprint)
+	assert.Equal(t, []byte("der"), keys[0].CertificateDER)
+}
+
+func TestGetPublicKeys_ECDSA(t *testing.T) {
+	tests := []struct {
+		name  string
+		curve elliptic.Curve
+		alg   cryptolab.Algorithm
+	}{
+		{"P-256", elliptic.P256(), cryptolab.AlgorithmES256},
+		{"P-384", elliptic.P384(), cryptolab.AlgorithmES384},
+		{"P-521", elliptic.P521(), cryptolab.AlgorithmES512},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ecKey, err := ecdsa.GenerateKey(tt.curve, rand.Reader)
+			require.NoError(t, err)
+
+			pki := pkimock.NewPKIServiceInterfaceMock(t)
+			pki.EXPECT().GetAllX509Certificates().Return(
+				map[string]*x509.Certificate{"key1": {Raw: []byte("der"), PublicKey: &ecKey.PublicKey}}, nil,
+			)
+			pki.EXPECT().GetCertThumbprint("key1").Return("tp")
+
+			svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+			keys, err := svc.GetPublicKeys(context.Background(), kmprovider.PublicKeyFilter{})
+			require.NoError(t, err)
+			require.Len(t, keys, 1)
+			assert.Equal(t, tt.alg, keys[0].Algorithm)
+		})
+	}
+}
+
+func TestGetPublicKeys_EdDSA(t *testing.T) {
+	_, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetAllX509Certificates().Return(
+		map[string]*x509.Certificate{"key1": {Raw: []byte("der"), PublicKey: edPriv.Public()}}, nil,
+	)
+	pki.EXPECT().GetCertThumbprint("key1").Return("tp")
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	keys, err := svc.GetPublicKeys(context.Background(), kmprovider.PublicKeyFilter{})
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, cryptolab.AlgorithmEdDSA, keys[0].Algorithm)
+}
+
+func TestGetPublicKeys_UnsupportedKeyTypeSkipped(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetAllX509Certificates().Return(
+		map[string]*x509.Certificate{
+			"good": {Raw: []byte("der"), PublicKey: &rsaKey.PublicKey},
+			"bad":  {PublicKey: "unsupported"},
+		}, nil,
+	)
+	pki.EXPECT().GetCertThumbprint("good").Return("tp")
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	keys, err := svc.GetPublicKeys(context.Background(), kmprovider.PublicKeyFilter{})
+	require.NoError(t, err)
+	assert.Len(t, keys, 1)
+	assert.Equal(t, "good", keys[0].KeyID)
+}
+
+func TestGetPublicKeys_FilterByKeyID(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetAllX509Certificates().Return(
+		map[string]*x509.Certificate{
+			"rsa-key": {Raw: []byte("rsa-der"), PublicKey: &rsaKey.PublicKey},
+			"ec-key":  {Raw: []byte("ec-der"), PublicKey: &ecKey.PublicKey},
+		}, nil,
+	)
+	pki.EXPECT().GetCertThumbprint("rsa-key").Return("rsa-tp")
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	keys, err := svc.GetPublicKeys(context.Background(), kmprovider.PublicKeyFilter{KeyID: "rsa-key"})
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "rsa-key", keys[0].KeyID)
+}
+
+func TestGetPublicKeys_FilterByAlgorithm(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetAllX509Certificates().Return(
+		map[string]*x509.Certificate{
+			"rsa-key": {Raw: []byte("rsa-der"), PublicKey: &rsaKey.PublicKey},
+			"ec-key":  {Raw: []byte("ec-der"), PublicKey: &ecKey.PublicKey},
+		}, nil,
+	)
+	pki.EXPECT().GetCertThumbprint("ec-key").Return("ec-tp")
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	keys, err := svc.GetPublicKeys(context.Background(),
+		kmprovider.PublicKeyFilter{Algorithm: cryptolab.AlgorithmES256})
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "ec-key", keys[0].KeyID)
 }

--- a/backend/internal/system/kmprovider/model.go
+++ b/backend/internal/system/kmprovider/model.go
@@ -38,10 +38,11 @@ type PublicKeyFilter struct {
 
 // PublicKeyInfo describes a public key returned by GetPublicKeys.
 type PublicKeyInfo struct {
-	KeyID      string
-	Algorithm  cryptolab.Algorithm
-	PublicKey  gocrypto.PublicKey
-	Thumbprint string
+	KeyID          string
+	Algorithm      cryptolab.Algorithm
+	PublicKey      gocrypto.PublicKey
+	Thumbprint     string
+	CertificateDER []byte // raw DER-encoded X.509 certificate; nil if not certificate-backed
 }
 
 // TLSMaterial holds the TLS certificate material for a key reference.

--- a/backend/tests/mocks/oauth/oauth2/discoverymock/DiscoveryServiceInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/discoverymock/DiscoveryServiceInterface_mock.go
@@ -92,7 +92,7 @@ func (_c *DiscoveryServiceInterfaceMock_GetOAuth2AuthorizationServerMetadata_Cal
 }
 
 // GetOIDCMetadata provides a mock function for the type DiscoveryServiceInterfaceMock
-func (_mock *DiscoveryServiceInterfaceMock) GetOIDCMetadata(ctx context.Context) *discovery.OIDCProviderMetadata {
+func (_mock *DiscoveryServiceInterfaceMock) GetOIDCMetadata(ctx context.Context) (*discovery.OIDCProviderMetadata, error) {
 	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
@@ -100,6 +100,10 @@ func (_mock *DiscoveryServiceInterfaceMock) GetOIDCMetadata(ctx context.Context)
 	}
 
 	var r0 *discovery.OIDCProviderMetadata
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (*discovery.OIDCProviderMetadata, error)); ok {
+		return returnFunc(ctx)
+	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context) *discovery.OIDCProviderMetadata); ok {
 		r0 = returnFunc(ctx)
 	} else {
@@ -107,7 +111,12 @@ func (_mock *DiscoveryServiceInterfaceMock) GetOIDCMetadata(ctx context.Context)
 			r0 = ret.Get(0).(*discovery.OIDCProviderMetadata)
 		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // DiscoveryServiceInterfaceMock_GetOIDCMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOIDCMetadata'
@@ -134,12 +143,12 @@ func (_c *DiscoveryServiceInterfaceMock_GetOIDCMetadata_Call) Run(run func(ctx c
 	return _c
 }
 
-func (_c *DiscoveryServiceInterfaceMock_GetOIDCMetadata_Call) Return(oIDCProviderMetadata *discovery.OIDCProviderMetadata) *DiscoveryServiceInterfaceMock_GetOIDCMetadata_Call {
-	_c.Call.Return(oIDCProviderMetadata)
+func (_c *DiscoveryServiceInterfaceMock_GetOIDCMetadata_Call) Return(oIDCProviderMetadata *discovery.OIDCProviderMetadata, err error) *DiscoveryServiceInterfaceMock_GetOIDCMetadata_Call {
+	_c.Call.Return(oIDCProviderMetadata, err)
 	return _c
 }
 
-func (_c *DiscoveryServiceInterfaceMock_GetOIDCMetadata_Call) RunAndReturn(run func(ctx context.Context) *discovery.OIDCProviderMetadata) *DiscoveryServiceInterfaceMock_GetOIDCMetadata_Call {
+func (_c *DiscoveryServiceInterfaceMock_GetOIDCMetadata_Call) RunAndReturn(run func(ctx context.Context) (*discovery.OIDCProviderMetadata, error)) *DiscoveryServiceInterfaceMock_GetOIDCMetadata_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
Removes direct dependencies on `PKIServiceInterface` from the JWKS and OIDC discovery layers by routing all public key access through `RuntimeCryptoProvider.GetPublicKeys`. This decouples the OAuth endpoints from the concrete PKI implementation, making the key provider genuinely substitutable.

Issue : https://github.com/thunder-id/thunder-id/issues/2349


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * JWKS and OIDC discovery now source public keys from a unified runtime crypto provider, improving accuracy of key material and algorithm detection.
  * Added Ed25519 support, expanded ECDSA curve coverage (P-256/P-384/P-521), better algorithm deduplication, and inclusion of certificate DER when available.
  * Discovery returns an error when crypto retrieval fails.

* **Tests**
  * Expanded coverage for RSA, ECDSA, Ed25519, filtering, error cases, and route/handler behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2657)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->