### PR TITLE
fix: Add missing repo name to Codecov URL and Release Badge not showing properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![GitHub last commit](https://img.shields.io/github/last-commit/thunder-id/thunder-id.svg)](https://github.com/thunder-id/thunder-id/commits/main)
 [![GitHub issues](https://img.shields.io/github/issues/thunder-id/thunder-id.svg)](https://github.com/thunder-id/thunder-id/issues)
-[![codecov.io](https://codecov.io/github/thunder-id/coverage.svg?branch=main)](https://codecov.io/github/thunder-id?branch=main)
-[![GitHub Release](https://img.shields.io/github/v/release/thunder-id?color=blue)](https://github.com/thunder-id/releases/latest)
+[![codecov.io](https://codecov.io/github/thunder-id/thunder-id/coverage.svg?branch=main)](https://codecov.io/github/thunder-id/thunder-id?branch=main)
+[![GitHub Release](https://img.shields.io/github/v/release/thunder-id/thunder-id?color=blue)](https://github.com/thunder-id/thunder-id/releases/latest)
 
 ThunderID is a lightweight, open-source Identity and Access Management (IAM) engine built to secure access for humans, AI agents, and machines.
 
@@ -240,7 +240,7 @@ curl -k -X POST 'https://localhost:8090/flow/execute' \
 ```
 2. Extract the `executionId` value from the response.
 ```json
-{"executionId":"<execution_id>","flowStatus":"INCOMPLETE", ...}
+{"executionId":"<execution_id>","flowStatus":"INCOMPLETE"}
 ```
 
 3. Run the following command, replacing `<execution_id>` with the `executionId` value you extracted above.


### PR DESCRIPTION
<img width="888" height="107" alt="Screenshot from 2026-05-12 09-09-15" src="https://github.com/user-attachments/assets/3b6a1b0e-0d16-43b0-9e79-a0af6881f238" />

## Summary

* Fixed the Code Coverage badge not showing properly in the README file.
* Fixed the Release badge not showing properly in the README file.

## Investigation & Fixes

* Investigated the Codecov badge issue and identified that the repository name was missing from the badge URL.

* Added the missing repository name to the Codecov URL to render the coverage badge correctly.

* Investigated the Release badge issue and identified that the repository name was also missing from the release badge URL.

* Added the missing repository name to the release badge URL.

## Additional Fix

* Noticed an additional Markdown rendering issue caused by a JSON formatting error around line 242 and fixed it as well.
