### PR TITLE
Ignore empty credential values during provisioning

### DIFF
--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -392,7 +392,7 @@ func (p *provisioningExecutor) buildMissingInputs(
 	promptOptionalCredentials := p.isPromptOptionalCredentialsEnabled(ctx)
 
 	for _, attr := range schemaAttrs {
-		if p.isAttrSatisfied(ctx, attr.Attribute) {
+		if p.isAttrSatisfied(ctx, attr.Attribute, attr.Credential) {
 			continue
 		}
 		nodeInp, inNodeInputs := nodeInputMap[attr.Attribute]
@@ -549,17 +549,21 @@ func (p *provisioningExecutor) storePresentedOptionalAttrs(
 	execResp.RuntimeData[common.RuntimeKeyPresentedOptionalAttrs] = strings.Join(ids, " ")
 }
 
-// isAttrSatisfied returns true if the attribute has a non-empty usable value in any context source.
-func (p *provisioningExecutor) isAttrSatisfied(ctx *core.NodeContext, attr string) bool {
+// isAttrSatisfied returns true if the attribute has a non-empty usable value.
+// Credential attrs are satisfied only by UserInputs or RuntimeData.
+// Non-credential attrs also fall back to AuthenticatedUser.Attributes.
+func (p *provisioningExecutor) isAttrSatisfied(ctx *core.NodeContext, attr string, credential bool) bool {
 	if val, ok := ctx.UserInputs[attr]; ok && val != "" {
 		return true
 	}
 	if val, ok := ctx.RuntimeData[attr]; ok && val != "" {
 		return true
 	}
-	if val, ok := ctx.AuthenticatedUser.Attributes[attr]; ok {
-		if strVal, ok := val.(string); ok && strVal != "" {
-			return true
+	if !credential {
+		if val, ok := ctx.AuthenticatedUser.Attributes[attr]; ok {
+			if strVal, ok := val.(string); ok && strVal != "" {
+				return true
+			}
 		}
 	}
 	return false
@@ -568,7 +572,7 @@ func (p *provisioningExecutor) isAttrSatisfied(ctx *core.NodeContext, attr strin
 // getAttributesForProvisioning collects user attributes from context in a single schema pass,
 // returning identifying (non-credential) and credential attributes as separate maps.
 // Schema is the whitelist for both maps.
-// Credential values are resolved from UserInputs then RuntimeData only.
+// Credential values are resolved from non-empty UserInputs then non-empty RuntimeData only.
 // Non-credential values additionally fall back to AuthenticatedUser.Attributes.
 func (p *provisioningExecutor) getAttributesForProvisioning(
 	ctx *core.NodeContext,
@@ -587,9 +591,9 @@ func (p *provisioningExecutor) getAttributesForProvisioning(
 
 	for _, a := range schemaAttrs {
 		if a.Credential {
-			if value, exists := ctx.UserInputs[a.Attribute]; exists {
+			if value, exists := ctx.UserInputs[a.Attribute]; exists && value != "" {
 				credentialAttrs[a.Attribute] = value
-			} else if runtimeValue, exists := ctx.RuntimeData[a.Attribute]; exists {
+			} else if runtimeValue, exists := ctx.RuntimeData[a.Attribute]; exists && runtimeValue != "" {
 				credentialAttrs[a.Attribute] = runtimeValue
 			}
 		} else {

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -480,6 +480,52 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Opt
 		"optional attr in node inputs must be collected")
 }
 
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_EmptyCredentialFallsBackToRuntime() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: attributePassword, Required: true, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs: map[string]string{
+			attributePassword: "",
+		},
+		RuntimeData: map[string]string{
+			userTypeKey:       testUserType,
+			attributePassword: "runtime-secret",
+		},
+		NodeInputs: []common.Input{},
+	}
+
+	_, credentialAttrs, err := suite.executor.getAttributesForProvisioning(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "runtime-secret", credentialAttrs[attributePassword])
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_CredentialFromUserInputs() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: attributePassword, Required: true, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		UserInputs: map[string]string{
+			attributePassword: "input-secret",
+		},
+		RuntimeData: map[string]string{
+			userTypeKey:       testUserType,
+			attributePassword: "runtime-secret",
+		},
+		NodeInputs: []common.Input{},
+	}
+
+	_, credentialAttrs, err := suite.executor.getAttributesForProvisioning(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "input-secret", credentialAttrs[attributePassword])
+}
+
 // newExecutorWithNodeInputs creates a provisioningExecutor whose embedded ExecutorInterface
 // returns the given inputs from GetRequiredInputs.
 func (suite *ProvisioningExecutorTestSuite) newExecutorWithNodeInputs(inputs []common.Input) *provisioningExecutor {
@@ -2140,6 +2186,31 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_RequiredCreden
 
 	assert.True(suite.T(), result)
 	assert.Empty(suite.T(), execResp.Inputs)
+}
+
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_RequiredCredentialInAuthnAttrs_StillPrompted() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
+		Return([]model.AttributeInfo{
+			{Attribute: attributePassword, DisplayName: "Password", Required: true, Credential: true},
+		}, nil).Once()
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		AuthenticatedUser: authncm.AuthenticatedUser{
+			Attributes: map[string]interface{}{
+				attributePassword: "profile-secret",
+			},
+		},
+	}
+	execResp := &common.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	assert.Len(suite.T(), execResp.Inputs, 1)
+	assert.Equal(suite.T(), attributePassword, execResp.Inputs[0].Identifier)
 }
 
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AllCredentials_PromptedByDefault() {


### PR DESCRIPTION
### Purpose
Fix provisioning credential handling so credential attributes are processed only when they contain usable non-empty values, and so credential availability checks do not rely on profile-style authenticated user attributes.

Previously, provisioning could still pick empty credential values during attribute collection, and prompt-time credential satisfaction checks could incorrectly treat `AuthenticatedUser.Attributes` as a valid credential source. Together, these issues could cause inconsistent provisioning behavior around required credential prompting and credential persistence.

### Approach
Addressed both sides of credential handling in the provisioning executor.

First, tightened credential attribute collection so empty credential values are ignored instead of being selected for provisioning. Second, aligned the prompt-time satisfaction check so credential attributes are considered satisfied only when they have a non-empty value from actual provisioning sources such as `UserInputs` or `RuntimeData`, and not from `AuthenticatedUser.Attributes`.

Added focused tests to cover:
- ignoring empty credential values during provisioning attribute selection
- accepting non-empty credential values from supported provisioning sources
- ensuring credential values in `AuthenticatedUser.Attributes` do not incorrectly satisfy required provisioning credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined credential attribute satisfaction logic to ensure proper prompting based on value presence and type.
  * Improved fallback behavior for credential values during attribute resolution.

* **Tests**
  * Added comprehensive test coverage for credential attribute resolution and required input prompting scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2669)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->