### PR TITLE
Add filter support to OrganizationUnit API 

### DIFF
--- a/api/ou.yaml
+++ b/api/ou.yaml
@@ -33,6 +33,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/offsetQueryParam'
+        - $ref: '#/components/parameters/filterParam'
       responses:
         "200":
           description: List of root organization units
@@ -85,6 +86,16 @@ paths:
                     description:
                       key: "error.ouservice.invalid_offset_parameter_description"
                       defaultValue: "The offset parameter must be a non-negative integer"
+                invalid-filter:
+                  summary: Invalid filter parameter
+                  value:
+                    code: "OU-1014"
+                    message:
+                      key: "error.ouservice.invalid_filter"
+                      defaultValue: "Invalid filter parameter"
+                    description:
+                      key: "error.ouservice.invalid_filter_description"
+                      defaultValue: "The filter parameter is invalid. Use format: attribute (eq|gt|lt) \"value\""
         "500":
           description: Internal server error
 
@@ -384,6 +395,7 @@ paths:
             format: uuid
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/offsetQueryParam'
+        - $ref: '#/components/parameters/filterParam'
       responses:
         "200":
           description: List of child organization units
@@ -436,6 +448,16 @@ paths:
                     description:
                       key: "error.ouservice.invalid_offset_parameter_description"
                       defaultValue: "The offset parameter must be a non-negative integer"
+                invalid-filter:
+                  summary: Invalid filter parameter
+                  value:
+                    code: "OU-1014"
+                    message:
+                      key: "error.ouservice.invalid_filter"
+                      defaultValue: "Invalid filter parameter"
+                    description:
+                      key: "error.ouservice.invalid_filter_description"
+                      defaultValue: "The filter parameter is invalid. Use format: attribute (eq|gt|lt) \"value\""
         "404":
           description: Organization unit not found
           content:
@@ -545,7 +567,6 @@ paths:
             format: uuid
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/offsetQueryParam'
-        - $ref: '#/components/parameters/includeGroupQueryParam'
       responses:
         "200":
           description: List of groups in the organization unit
@@ -1020,6 +1041,7 @@ paths:
           example: "engineering/frontend"
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/offsetQueryParam'
+        - $ref: '#/components/parameters/filterParam'
       responses:
         "200":
           description: List of child organization units
@@ -1072,6 +1094,16 @@ paths:
                     description:
                       key: "error.ouservice.invalid_offset_parameter_description"
                       defaultValue: "The offset parameter must be a non-negative integer"
+                invalid-filter:
+                  summary: Invalid filter parameter
+                  value:
+                    code: "OU-1014"
+                    message:
+                      key: "error.ouservice.invalid_filter"
+                      defaultValue: "Invalid filter parameter"
+                    description:
+                      key: "error.ouservice.invalid_filter_description"
+                      defaultValue: "The filter parameter is invalid. Use format: attribute (eq|gt|lt) \"value\""
         "404":
           description: Organization unit not found
           content:
@@ -1221,7 +1253,6 @@ paths:
           example: "engineering/frontend"
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/offsetQueryParam'
-        - $ref: '#/components/parameters/includeGroupQueryParam'
       responses:
         "200":
           description: List of groups in the organization unit
@@ -1343,17 +1374,28 @@ components:
         type: string
         enum:
           - display
-    includeGroupQueryParam:
+    filterParam:
       in: query
-      name: include
+      name: filter
       required: false
       description: |
-        Optional parameter to include additional display information.
-        - `display` - Include `ouHandle`, the human-readable handle of the organization unit, alongside the `ouId`.
+        Filter organization units by attribute values.
+        Supported operators: `eq`, `gt`, `lt`.
+        Filterable attributes: `name`, `handle`, `description`, `createdAt`, `updatedAt`.
+        Format: `attribute operator "value"`.
+        Examples:
+        - `name eq "Engineering"`
+        - `handle eq "frontend"`
+        - `createdAt gt "2026-01-01T00:00:00Z"`
       schema:
         type: string
-        enum:
-          - display
+      examples:
+        name-filter:
+          summary: Filter by name
+          value: 'name eq "Engineering"'
+        created-at-filter:
+          summary: Filter by creation timestamp
+          value: 'createdAt gt "2026-01-01T00:00:00Z"'
 
   schemas:
     OrganizationUnitBasic:
@@ -1396,6 +1438,26 @@ components:
           type: string
           format: uuid
           nullable: true
+        themeId:
+          type: string
+          format: uuid
+          description: "Theme configuration ID for the organization unit"
+        layoutId:
+          type: string
+          format: uuid
+          description: "Layout configuration ID for the organization unit"
+        tosUri:
+          type: string
+          format: uri
+          description: "Terms of Service URI"
+        policyUri:
+          type: string
+          format: uri
+          description: "Privacy Policy URI"
+        cookiePolicyUri:
+          type: string
+          format: uri
+          description: "Cookie Policy URI"
 
     User:
       type: object
@@ -1404,6 +1466,9 @@ components:
         id:
           type: string
           format: uuid
+        type:
+          type: string
+          description: "User type identifier"
         display:
           type: string
           description: >-
@@ -1421,13 +1486,6 @@ components:
           format: uuid
         name:
           type: string
-        ouId:
-          type: string
-          format: uuid
-        ouHandle:
-          type: string
-          readOnly: true
-          description: "Human-readable handle of the organization unit (only included when include=display query parameter is used)."
 
     Link:
       type: object

--- a/backend/internal/flow/executor/ou_resolver_executor.go
+++ b/backend/internal/flow/executor/ou_resolver_executor.go
@@ -177,7 +177,7 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
 	}
 
 	// Check if the parent OU has child OUs.
-	children, svcErr := e.ouService.GetOrganizationUnitChildren(ctx.Context, parentOUID, 1, 0)
+	children, svcErr := e.ouService.GetOrganizationUnitChildren(ctx.Context, parentOUID, 1, 0, nil)
 	if svcErr != nil {
 		return nil, errors.New("failed to check child organization units: " + svcErr.Error.DefaultValue)
 	}

--- a/backend/internal/flow/executor/ou_resolver_executor_test.go
+++ b/backend/internal/flow/executor/ou_resolver_executor_test.go
@@ -400,7 +400,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_NoChildOUs_Skips() 
 		UserInputs: map[string]string{},
 	}
 
-	suite.mockOUService.On("GetOrganizationUnitChildren", mock.Anything, parentOUID, 1, 0).
+	suite.mockOUService.On("GetOrganizationUnitChildren", mock.Anything, parentOUID, 1, 0, mock.Anything).
 		Return(&ou.OrganizationUnitListResponse{TotalResults: 0}, (*serviceerror.ServiceError)(nil))
 
 	result, err := suite.executor.Execute(ctx)
@@ -424,7 +424,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_HasChildOUs_Request
 		UserInputs: map[string]string{},
 	}
 
-	suite.mockOUService.On("GetOrganizationUnitChildren", mock.Anything, parentOUID, 1, 0).
+	suite.mockOUService.On("GetOrganizationUnitChildren", mock.Anything, parentOUID, 1, 0, mock.Anything).
 		Return(&ou.OrganizationUnitListResponse{TotalResults: 3}, (*serviceerror.ServiceError)(nil))
 
 	result, err := suite.executor.Execute(ctx)
@@ -457,7 +457,7 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_GetChildrenError_Re
 		Code:  "OU-50001",
 		Error: i18ncore.I18nMessage{Key: "error.test.internal_error", DefaultValue: "internal error"},
 	}
-	suite.mockOUService.On("GetOrganizationUnitChildren", mock.Anything, parentOUID, 1, 0).
+	suite.mockOUService.On("GetOrganizationUnitChildren", mock.Anything, parentOUID, 1, 0, mock.Anything).
 		Return((*ou.OrganizationUnitListResponse)(nil), svcErr)
 
 	result, err := suite.executor.Execute(ctx)

--- a/backend/internal/flow/flowmeta/service.go
+++ b/backend/internal/flow/flowmeta/service.go
@@ -190,7 +190,7 @@ func (fms *flowMetaService) populateTypeMetadata(
 	response.IsRecoveryFlowEnabled = client.IsRecoveryFlowEnabled
 	response.Application = buildApplicationMetadata(client.ID, entity, client.Properties)
 
-	ouList, ouErr := fms.ouService.GetOrganizationUnitList(ctx, 1, 0)
+	ouList, ouErr := fms.ouService.GetOrganizationUnitList(ctx, 1, 0, nil)
 	if ouErr != nil {
 		if ouErr.Code == ou.ErrorOrganizationUnitNotFound.Code {
 			return "", &ErrorOUNotFound

--- a/backend/internal/flow/flowmeta/service_test.go
+++ b/backend/internal/flow/flowmeta/service_test.go
@@ -150,7 +150,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_APP_Success() {
 		},
 	}
 
-	suite.mockOUService.On("GetOrganizationUnitList", mock.Anything, 1, 0).Return(mockOUList, nil)
+	suite.mockOUService.On("GetOrganizationUnitList", mock.Anything, 1, 0, mock.Anything).Return(mockOUList, nil)
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, ouID).Return(mockOU, nil)
 	suite.mockDesignResolve.On("ResolveDesign", mock.Anything, common.DesignResolveTypeAPP, appID).
 		Return(mockDesign, nil)
@@ -288,7 +288,7 @@ func (suite *FlowMetaServiceTestSuite) TestGetFlowMetadata_DesignResolveError_Co
 		Name:   "Default OU",
 	}
 
-	suite.mockOUService.On("GetOrganizationUnitList", mock.Anything, 1, 0).Return(mockOUList, nil)
+	suite.mockOUService.On("GetOrganizationUnitList", mock.Anything, 1, 0, mock.Anything).Return(mockOUList, nil)
 	suite.mockOUService.On("GetOrganizationUnit", mock.Anything, ouID).Return(mockOU, nil)
 	suite.mockDesignResolve.On("ResolveDesign", mock.Anything, common.DesignResolveTypeAPP, appID).
 		Return(nil, &serviceerror.InternalServerError)

--- a/backend/internal/oauth/oauth2/dcr/service.go
+++ b/backend/internal/oauth/oauth2/dcr/service.go
@@ -84,7 +84,7 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 
 	// TODO: Revisit OU for DCR apps
 	if request.OUID == "" {
-		rootOUs, svcErr := ds.ouService.GetOrganizationUnitList(ctx, 1, 0)
+		rootOUs, svcErr := ds.ouService.GetOrganizationUnitList(ctx, 1, 0, nil)
 		if svcErr != nil {
 			logger.Error("Failed to retrieve root organization units for DCR",
 				log.String("error", svcErr.Error.DefaultValue))

--- a/backend/internal/ou/ConfigurableOUService_mock_test.go
+++ b/backend/internal/ou/ConfigurableOUService_mock_test.go
@@ -9,6 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 )
 
 // NewConfigurableOUServiceMock creates a new instance of ConfigurableOUServiceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -361,8 +362,8 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitByPath_Call) RunAndReturn
 }
 
 // GetOrganizationUnitChildren provides a mock function for the type ConfigurableOUServiceMock
-func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildren(ctx context.Context, id string, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, id, limit, offset)
+func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildren(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildren")
@@ -370,18 +371,18 @@ func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildren(ctx context.
 
 	var r0 *OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) *OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -400,11 +401,12 @@ type ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call struct {
 //   - id string
 //   - limit int
 //   - offset int
-func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitChildren(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
-	return &ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call{Call: _e.mock.On("GetOrganizationUnitChildren", ctx, id, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitChildren(ctx interface{}, id interface{}, limit interface{}, offset interface{}, f interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
+	return &ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call{Call: _e.mock.On("GetOrganizationUnitChildren", ctx, id, limit, offset, f)}
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) Run(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup)) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -422,11 +424,16 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) Run(run fu
 		if args[3] != nil {
 			arg3 = args[3].(int)
 		}
+		var arg4 *filter.FilterGroup
+		if args[4] != nil {
+			arg4 = args[4].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -437,14 +444,14 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) Return(org
 	return _c
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitChildrenByPath provides a mock function for the type ConfigurableOUServiceMock
-func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildrenByPath(ctx context.Context, handlePath string, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, handlePath, limit, offset)
+func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildrenByPath(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, handlePath, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenByPath")
@@ -452,18 +459,18 @@ func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildrenByPath(ctx co
 
 	var r0 *OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, handlePath, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) *OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, handlePath, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, handlePath, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -482,11 +489,12 @@ type ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call struct {
 //   - handlePath string
 //   - limit int
 //   - offset int
-func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitChildrenByPath(ctx interface{}, handlePath interface{}, limit interface{}, offset interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
-	return &ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call{Call: _e.mock.On("GetOrganizationUnitChildrenByPath", ctx, handlePath, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitChildrenByPath(ctx interface{}, handlePath interface{}, limit interface{}, offset interface{}, f interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
+	return &ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call{Call: _e.mock.On("GetOrganizationUnitChildrenByPath", ctx, handlePath, limit, offset, f)}
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) Run(run func(ctx context.Context, handlePath string, limit int, offset int)) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) Run(run func(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup)) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -504,11 +512,16 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) Run(
 		if args[3] != nil {
 			arg3 = args[3].(int)
 		}
+		var arg4 *filter.FilterGroup
+		if args[4] != nil {
+			arg4 = args[4].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -519,7 +532,7 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) Retu
 	return _c
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -759,8 +772,8 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitHandlesByIDs_Call) RunAnd
 }
 
 // GetOrganizationUnitList provides a mock function for the type ConfigurableOUServiceMock
-func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, limit, offset)
+func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitList")
@@ -768,18 +781,18 @@ func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitList(ctx context.Cont
 
 	var r0 *OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) *OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) *OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -797,11 +810,12 @@ type ConfigurableOUServiceMock_GetOrganizationUnitList_Call struct {
 //   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
-	return &ConfigurableOUServiceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}, f interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
+	return &ConfigurableOUServiceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset, f)}
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int)) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup)) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -815,10 +829,15 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) Run(run func(c
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 *filter.FilterGroup
+		if args[3] != nil {
+			arg3 = args[3].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -829,7 +848,7 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) Return(organiz
 	return _c
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/ou/OrganizationUnitServiceInterface_mock_test.go
+++ b/backend/internal/ou/OrganizationUnitServiceInterface_mock_test.go
@@ -9,6 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 )
 
 // NewOrganizationUnitServiceInterfaceMock creates a new instance of OrganizationUnitServiceInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -361,8 +362,8 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitByPath_Call) R
 }
 
 // GetOrganizationUnitChildren provides a mock function for the type OrganizationUnitServiceInterfaceMock
-func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildren(ctx context.Context, id string, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, id, limit, offset)
+func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildren(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildren")
@@ -370,18 +371,18 @@ func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildren(c
 
 	var r0 *OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) *OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -400,11 +401,12 @@ type OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call struc
 //   - id string
 //   - limit int
 //   - offset int
-func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitChildren(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
-	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call{Call: _e.mock.On("GetOrganizationUnitChildren", ctx, id, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitChildren(ctx interface{}, id interface{}, limit interface{}, offset interface{}, f interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
+	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call{Call: _e.mock.On("GetOrganizationUnitChildren", ctx, id, limit, offset, f)}
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call) Run(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -422,11 +424,16 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call)
 		if args[3] != nil {
 			arg3 = args[3].(int)
 		}
+		var arg4 *filter.FilterGroup
+		if args[4] != nil {
+			arg4 = args[4].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -437,14 +444,14 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call)
 	return _c
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitChildrenByPath provides a mock function for the type OrganizationUnitServiceInterfaceMock
-func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildrenByPath(ctx context.Context, handlePath string, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, handlePath, limit, offset)
+func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildrenByPath(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, handlePath, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenByPath")
@@ -452,18 +459,18 @@ func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildrenBy
 
 	var r0 *OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, handlePath, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) *OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, handlePath, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, handlePath, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -482,11 +489,12 @@ type OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call
 //   - handlePath string
 //   - limit int
 //   - offset int
-func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitChildrenByPath(ctx interface{}, handlePath interface{}, limit interface{}, offset interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
-	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call{Call: _e.mock.On("GetOrganizationUnitChildrenByPath", ctx, handlePath, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitChildrenByPath(ctx interface{}, handlePath interface{}, limit interface{}, offset interface{}, f interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
+	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call{Call: _e.mock.On("GetOrganizationUnitChildrenByPath", ctx, handlePath, limit, offset, f)}
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call) Run(run func(ctx context.Context, handlePath string, limit int, offset int)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call) Run(run func(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -504,11 +512,16 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath
 		if args[3] != nil {
 			arg3 = args[3].(int)
 		}
+		var arg4 *filter.FilterGroup
+		if args[4] != nil {
+			arg4 = args[4].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -519,7 +532,7 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath
 	return _c
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -759,8 +772,8 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitHandlesByIDs_C
 }
 
 // GetOrganizationUnitList provides a mock function for the type OrganizationUnitServiceInterfaceMock
-func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, limit, offset)
+func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitList")
@@ -768,18 +781,18 @@ func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitList(ctx c
 
 	var r0 *OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) *OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) *OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -797,11 +810,12 @@ type OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call struct {
 //   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
-	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}, f interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
+	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset, f)}
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -815,10 +829,15 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) Run
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 *filter.FilterGroup
+		if args[3] != nil {
+			arg3 = args[3].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -829,7 +848,7 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) Ret
 	return _c
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup) (*OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/ou/composite_store.go
+++ b/backend/internal/ou/composite_store.go
@@ -23,6 +23,7 @@ import (
 
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 )
 
 // compositeOUStore implements a composite store that combines file-based (immutable) and database (mutable) stores.
@@ -43,10 +44,10 @@ func newCompositeOUStore(fileStore, dbStore organizationUnitStoreInterface) *com
 }
 
 // GetOrganizationUnitListCount retrieves the total count of organization units from both stores.
-func (c *compositeOUStore) GetOrganizationUnitListCount(ctx context.Context) (int, error) {
+func (c *compositeOUStore) GetOrganizationUnitListCount(ctx context.Context, f *filter.FilterGroup) (int, error) {
 	return declarativeresource.CompositeMergeCountHelper(
-		func() (int, error) { return c.dbStore.GetOrganizationUnitListCount(ctx) },
-		func() (int, error) { return c.fileStore.GetOrganizationUnitListCount(ctx) },
+		func() (int, error) { return c.dbStore.GetOrganizationUnitListCount(ctx, f) },
+		func() (int, error) { return c.fileStore.GetOrganizationUnitListCount(ctx, f) },
 	)
 }
 
@@ -54,26 +55,25 @@ func (c *compositeOUStore) GetOrganizationUnitListCount(ctx context.Context) (in
 // Applies the 1000-record limit in composite mode to prevent memory exhaustion.
 // Returns ErrResultLimitExceededInCompositeMode if the limit is exceeded.
 func (c *compositeOUStore) GetOrganizationUnitList(
-	ctx context.Context, limit, offset int,
+	ctx context.Context, limit, offset int, f *filter.FilterGroup,
 ) ([]OrganizationUnitBasic, error) {
 	items, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
-		func() (int, error) { return c.dbStore.GetOrganizationUnitListCount(ctx) },
-		func() (int, error) { return c.fileStore.GetOrganizationUnitListCount(ctx) },
+		func() (int, error) { return c.dbStore.GetOrganizationUnitListCount(ctx, f) },
+		func() (int, error) { return c.fileStore.GetOrganizationUnitListCount(ctx, f) },
 		func(count int) ([]OrganizationUnitBasic, error) {
-			return c.dbStore.GetOrganizationUnitList(ctx, count, 0)
+			return c.dbStore.GetOrganizationUnitList(ctx, count, 0, f)
 		},
 		func(count int) ([]OrganizationUnitBasic, error) {
-			return c.fileStore.GetOrganizationUnitList(ctx, count, 0)
+			return c.fileStore.GetOrganizationUnitList(ctx, count, 0, f)
 		},
 		mergeAndDeduplicateOUs,
 		limit,
 		offset,
-		serverconst.MaxCompositeStoreRecords, // Apply 1000-record limit
+		serverconst.MaxCompositeStoreRecords,
 	)
 	if err != nil {
 		return nil, err
 	}
-	// Return limit exceeded as an error
 	if limitExceeded {
 		return nil, ErrResultLimitExceededInCompositeMode
 	}
@@ -209,10 +209,12 @@ func (c *compositeOUStore) DeleteOrganizationUnit(ctx context.Context, id string
 }
 
 // GetOrganizationUnitChildrenCount retrieves the count of child OUs from both stores.
-func (c *compositeOUStore) GetOrganizationUnitChildrenCount(ctx context.Context, id string) (int, error) {
+func (c *compositeOUStore) GetOrganizationUnitChildrenCount(
+	ctx context.Context, id string, f *filter.FilterGroup,
+) (int, error) {
 	return declarativeresource.CompositeMergeCountHelper(
-		func() (int, error) { return c.dbStore.GetOrganizationUnitChildrenCount(ctx, id) },
-		func() (int, error) { return c.fileStore.GetOrganizationUnitChildrenCount(ctx, id) },
+		func() (int, error) { return c.dbStore.GetOrganizationUnitChildrenCount(ctx, id, f) },
+		func() (int, error) { return c.fileStore.GetOrganizationUnitChildrenCount(ctx, id, f) },
 	)
 }
 
@@ -220,25 +222,25 @@ func (c *compositeOUStore) GetOrganizationUnitChildrenCount(ctx context.Context,
 // Applies the 1000-record limit in composite mode to prevent memory exhaustion.
 // Returns ErrResultLimitExceededInCompositeMode if the limit is exceeded.
 func (c *compositeOUStore) GetOrganizationUnitChildrenList(ctx context.Context,
-	id string, limit, offset int) ([]OrganizationUnitBasic, error) {
+	id string, limit, offset int, f *filter.FilterGroup,
+) ([]OrganizationUnitBasic, error) {
 	items, limitExceeded, err := declarativeresource.CompositeMergeListHelperWithLimit(
-		func() (int, error) { return c.dbStore.GetOrganizationUnitChildrenCount(ctx, id) },
-		func() (int, error) { return c.fileStore.GetOrganizationUnitChildrenCount(ctx, id) },
+		func() (int, error) { return c.dbStore.GetOrganizationUnitChildrenCount(ctx, id, f) },
+		func() (int, error) { return c.fileStore.GetOrganizationUnitChildrenCount(ctx, id, f) },
 		func(count int) ([]OrganizationUnitBasic, error) {
-			return c.dbStore.GetOrganizationUnitChildrenList(ctx, id, count, 0)
+			return c.dbStore.GetOrganizationUnitChildrenList(ctx, id, count, 0, f)
 		},
 		func(count int) ([]OrganizationUnitBasic, error) {
-			return c.fileStore.GetOrganizationUnitChildrenList(ctx, id, count, 0)
+			return c.fileStore.GetOrganizationUnitChildrenList(ctx, id, count, 0, f)
 		},
 		mergeAndDeduplicateChildren,
 		limit,
 		offset,
-		serverconst.MaxCompositeStoreRecords, // Apply 1000-record limit
+		serverconst.MaxCompositeStoreRecords,
 	)
 	if err != nil {
 		return nil, err
 	}
-	// Return limit exceeded as an error
 	if limitExceeded {
 		return nil, ErrResultLimitExceededInCompositeMode
 	}

--- a/backend/internal/ou/composite_store_test.go
+++ b/backend/internal/ou/composite_store_test.go
@@ -282,7 +282,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ChildrenOperations() {
 		suite.SetupTest() // Fresh setup
 		parentID := "parent-ou"
 
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, parentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, parentID, mock.Anything).
 			Return(2, nil).
 			Once()
 
@@ -301,7 +301,7 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ChildrenOperations() {
 		})
 		suite.NoError(err)
 
-		count, err := suite.compositeStore.GetOrganizationUnitChildrenCount(context.Background(), parentID)
+		count, err := suite.compositeStore.GetOrganizationUnitChildrenCount(context.Background(), parentID, nil)
 		suite.NoError(err)
 		suite.Equal(3, count) // 2 from DB + 1 from file
 	})
@@ -319,9 +319,9 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ListOperations() {
 		})
 
 		// Mock DB store count - CompositeMergeCountHelper calls dbStore.GetOrganizationUnitListCount once
-		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything).Return(3, nil).Once()
+		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything, mock.Anything).Return(3, nil).Once()
 
-		count, err := suite.compositeStore.GetOrganizationUnitListCount(context.Background())
+		count, err := suite.compositeStore.GetOrganizationUnitListCount(context.Background(), nil)
 		suite.NoError(err)
 		suite.Equal(5, count) // 3 from DB + 2 from file
 	})
@@ -339,16 +339,18 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ListOperations() {
 
 		// Mock DB store - note that implementation calls count to determine how many to fetch from each
 		// dbCount will be called to fetch all from DB
-		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything).Return(2, nil).Once()
+		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything, mock.Anything).Return(2, nil).Once()
 		// Then fileCount from fileStore (real store) returns 1
 		// Total = 3, so it will try to fetch all 3 (dbCount=2, fileCount=1)
-		suite.dbStoreMock.On("GetOrganizationUnitList", mock.Anything, 2, 0).Return([]OrganizationUnitBasic{
-			{ID: "db-ou-1", Handle: "db-1", Name: "DB OU 1"},
-			{ID: "db-ou-2", Handle: "db-2", Name: "DB OU 2"},
-		}, nil).Once()
+		suite.dbStoreMock.On("GetOrganizationUnitList", mock.Anything, 2, 0, mock.Anything).
+			Return([]OrganizationUnitBasic{
+				{ID: "db-ou-1", Handle: "db-1", Name: "DB OU 1"},
+				{ID: "db-ou-2", Handle: "db-2", Name: "DB OU 2"},
+			}, nil).
+			Once()
 		// fileStore.GetOrganizationUnitList will be called with (1, 0) and return the file OU
 
-		list, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 10, 0)
+		list, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 10, 0, nil)
 		suite.NoError(err)
 		suite.Len(list, 3) // 2 from DB + 1 from file
 
@@ -373,10 +375,10 @@ func (suite *CompositeStoreTestSuite) TestCompositeStore_ListOperations() {
 		suite.dbStoreMock = newOrganizationUnitStoreInterfaceMock(suite.T())
 		suite.compositeStore = newCompositeOUStore(fileStoreMock, suite.dbStoreMock)
 
-		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything).Return(600, nil).Once()
-		fileStoreMock.On("GetOrganizationUnitListCount", mock.Anything).Return(700, nil).Once()
+		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything, mock.Anything).Return(600, nil).Once()
+		fileStoreMock.On("GetOrganizationUnitListCount", mock.Anything, mock.Anything).Return(700, nil).Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 100, 900)
+		result, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 100, 900, nil)
 		// When limit is exceeded (1300 > 1000), should return error
 		suite.Error(err)
 		suite.ErrorIs(err, ErrResultLimitExceededInCompositeMode)
@@ -451,25 +453,25 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 			{ID: "ou-2", Handle: "handle-2", Name: "OU 2"},
 		}
 
-		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything).
+		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything, mock.Anything).
 			Return(2, nil).
 			Once()
-		suite.dbStoreMock.On("GetOrganizationUnitList", mock.Anything, 2, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitList", mock.Anything, 2, 0, mock.Anything).
 			Return(expectedList, nil).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 10, 0, nil)
 		suite.NoError(err)
 		suite.Equal(expectedList, result)
 	})
 
 	suite.Run("propagates DB store error", func() {
 		dbErr := errors.New("database error")
-		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything).
+		suite.dbStoreMock.On("GetOrganizationUnitListCount", mock.Anything, mock.Anything).
 			Return(0, dbErr).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitList(context.Background(), 10, 0, nil)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.Empty(result)
@@ -679,25 +681,27 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		})
 		suite.NoError(err)
 
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, parentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, parentID, mock.Anything).
 			Return(2, nil).
 			Once()
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, parentID, 2, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, parentID, 2, 0, mock.Anything).
 			Return(dbChildren, nil).
 			Once()
 
 		// Request first 2 items
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), parentID, 2, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), parentID, 2, 0, nil)
 		suite.NoError(err)
 		suite.Len(result, 2)
 	})
 
 	suite.Run("handles offset beyond total count", func() {
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, parentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, parentID, mock.Anything).
 			Return(2, nil).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), parentID, 10, 100)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(
+			context.Background(), parentID, 10, 100, nil,
+		)
 		suite.NoError(err)
 		suite.Empty(result)
 	})
@@ -719,15 +723,17 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		})
 		suite.NoError(err)
 
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, testParentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, testParentID, mock.Anything).
 			Return(3, nil).
 			Once()
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, testParentID, 3, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, testParentID, 3, 0, mock.Anything).
 			Return(dbChildren, nil).
 			Once()
 
 		// Get second page (offset=2, limit=2)
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), testParentID, 2, 2)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(
+			context.Background(), testParentID, 2, 2, nil,
+		)
 		suite.NoError(err)
 		suite.Len(result, 1) // Only 1 item remaining
 		suite.Equal("db-child-3", result[0].ID)
@@ -744,11 +750,13 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		suite.NoError(err)
 
 		dbErr := errors.New("count error")
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, testParentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, testParentID, mock.Anything).
 			Return(0, dbErr).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), testParentID, 10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(
+			context.Background(), testParentID, 10, 0, nil,
+		)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.Nil(result)
@@ -766,14 +774,16 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		suite.NoError(err)
 
 		dbErr := errors.New("list error")
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, testParentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, testParentID, mock.Anything).
 			Return(2, nil).
 			Once()
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, testParentID, 2, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, testParentID, 2, 0, mock.Anything).
 			Return([]OrganizationUnitBasic{}, dbErr).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), testParentID, 10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(
+			context.Background(), testParentID, 10, 0, nil,
+		)
 		suite.Error(err)
 		suite.Equal(dbErr, err)
 		suite.Nil(result)
@@ -804,14 +814,16 @@ func (suite *CompositeStoreCoverageTestSuite) TestCompositeStore_GetOrganization
 		})
 		suite.NoError(err)
 
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, dedupeParentID).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenCount", mock.Anything, dedupeParentID, mock.Anything).
 			Return(2, nil).
 			Once()
-		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, dedupeParentID, 2, 0).
+		suite.dbStoreMock.On("GetOrganizationUnitChildrenList", mock.Anything, dedupeParentID, 2, 0, mock.Anything).
 			Return(dbChildren, nil).
 			Once()
 
-		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(context.Background(), dedupeParentID, 10, 0)
+		result, err := suite.compositeStore.GetOrganizationUnitChildrenList(
+			context.Background(), dedupeParentID, 10, 0, nil,
+		)
 		suite.NoError(err)
 		// Should have 2 children (duplicate removed)
 		suite.Len(result, 2)

--- a/backend/internal/ou/declarative_resource.go
+++ b/backend/internal/ou/declarative_resource.go
@@ -70,7 +70,7 @@ func (e *ouExporter) GetParameterizerType() string {
 func (e *ouExporter) GetAllResourceIDs(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	// Get all OUs by requesting a large limit from the service
 	// In composite mode, this returns OUs from both file-based and database stores
-	ous, err := e.service.GetOrganizationUnitList(ctx, serverconst.MaxPageSize, 0)
+	ous, err := e.service.GetOrganizationUnitList(ctx, serverconst.MaxPageSize, 0, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (e *ouExporter) GetAllResourceIDs(ctx context.Context) ([]string, *servicee
 
 // getAllChildIDs recursively retrieves all child OU IDs (excluding immutable ones).
 func (e *ouExporter) getAllChildIDs(ctx context.Context, parentID string) ([]string, *serviceerror.ServiceError) {
-	children, err := e.service.GetOrganizationUnitChildren(ctx, parentID, serverconst.MaxPageSize, 0)
+	children, err := e.service.GetOrganizationUnitChildren(ctx, parentID, serverconst.MaxPageSize, 0, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/ou/declarative_resource_test.go
+++ b/backend/internal/ou/declarative_resource_test.go
@@ -300,9 +300,11 @@ func (s *DeclarativeResourceTestSuite) TestGetResourceRules() {
 
 func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_NoOUs() {
 	// Test with empty result
-	s.mockService.EXPECT().GetOrganizationUnitList(mock.Anything, 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitList(mock.Anything, 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{},
+		}, (*serviceerror.ServiceError)(nil))
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
@@ -322,24 +324,28 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_RootOUsOnly() {
 		Name:   "Root 2",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(mock.Anything, 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{rootOU1, rootOU2},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitList(mock.Anything, 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{rootOU1, rootOU2},
+		}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative to indicate these are mutable OUs
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-2").Return(false)
 
 	// Mock GetOrganizationUnitChildren to return empty lists for both roots
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "root-1", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "root-1", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{},
+		}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "root-2", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "root-2", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{},
+		}, (*serviceerror.ServiceError)(nil))
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
@@ -366,32 +372,37 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_WithChildren() {
 		Name:   "Grandchild OU",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(mock.Anything, 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{rootOU},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitList(mock.Anything, 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{rootOU},
+		}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative to indicate these are mutable OUs
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
 
 	// Mock children at each level
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "root-1", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{childOU},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "root-1", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{childOU},
+		}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "child-1", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{grandchildOU},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "child-1", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{grandchildOU},
+		}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "grandchild-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "grandchild-1", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "grandchild-1", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{},
+		}, (*serviceerror.ServiceError)(nil))
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
@@ -424,37 +435,43 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_MultipleRootsWithCh
 		Name:   "Child 2",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(mock.Anything, 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{rootOU1, rootOU2},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitList(mock.Anything, 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{rootOU1, rootOU2},
+		}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative to indicate these are mutable OUs
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-2").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "root-1", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{child1},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "root-1", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{child1},
+		}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "child-1", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "child-1", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{},
+		}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "root-2", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{child2},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "root-2", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{child2},
+		}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-2").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "child-2", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "child-2", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{},
+		}, (*serviceerror.ServiceError)(nil))
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
@@ -467,10 +484,12 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_MultipleRootsWithCh
 
 func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_ErrorGettingList() {
 	// Test error handling when getting the OU list fails
-	s.mockService.EXPECT().GetOrganizationUnitList(mock.Anything, 100, 0).Return(
-		(*OrganizationUnitListResponse)(nil),
-		&serviceerror.InternalServerError,
-	)
+	s.mockService.EXPECT().
+		GetOrganizationUnitList(mock.Anything, 100, 0, mock.Anything).
+		Return(
+			(*OrganizationUnitListResponse)(nil),
+			&serviceerror.InternalServerError,
+		)
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.NotNil(s.T(), err)
@@ -486,17 +505,21 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_ErrorGettingChildre
 		Name:   "Root OU",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(mock.Anything, 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{rootOU},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitList(mock.Anything, 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{rootOU},
+		}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative to indicate this is a mutable OU
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(mock.Anything, "root-1", 100, 0).Return(
-		(*OrganizationUnitListResponse)(nil),
-		&serviceerror.InternalServerError,
-	)
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "root-1", 100, 0, mock.Anything).
+		Return(
+			(*OrganizationUnitListResponse)(nil),
+			&serviceerror.InternalServerError,
+		)
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.NotNil(s.T(), err)
@@ -511,45 +534,52 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_DeepNesting() {
 	level4 := OrganizationUnitBasic{ID: "level-4", Handle: "l4", Name: "Level 4"}
 	level5 := OrganizationUnitBasic{ID: "level-5", Handle: "l5", Name: "Level 5"}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(mock.Anything, 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{level1},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitList(mock.Anything, 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{level1},
+		}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative for all levels
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "level-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "level-1", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{level2},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "level-1", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{level2},
+		}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "level-2").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "level-2", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{level3},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "level-2", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{level3},
+		}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "level-3").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "level-3", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{level4},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "level-3", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{level4},
+		}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "level-4").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "level-4", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{level5},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "level-4", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{level5},
+		}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "level-5").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "level-5", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "level-5", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{},
+		}, (*serviceerror.ServiceError)(nil))
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
@@ -582,17 +612,20 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_MultipleChildrenPer
 		Name:   "Child 3",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(mock.Anything, 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{rootOU},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitList(mock.Anything, 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{rootOU},
+		}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative for root
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "root-1", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{child1, child2, child3},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "root-1", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{child1, child2, child3},
+		}, (*serviceerror.ServiceError)(nil))
 
 	// Mock IsOrganizationUnitDeclarative for all children
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-1").Return(false)
@@ -600,20 +633,23 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_MultipleChildrenPer
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-3").Return(false)
 
 	// Each child has no children
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "child-1", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "child-1", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{},
+		}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "child-2", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "child-2", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{},
+		}, (*serviceerror.ServiceError)(nil))
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "child-3", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "child-3", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{},
+		}, (*serviceerror.ServiceError)(nil))
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.Nil(s.T(), err)
@@ -636,24 +672,28 @@ func (s *DeclarativeResourceTestSuite) TestGetAllResourceIDs_ErrorGettingGrandch
 		Name:   "Child OU",
 	}
 
-	s.mockService.EXPECT().GetOrganizationUnitList(mock.Anything, 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{rootOU},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitList(mock.Anything, 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{rootOU},
+		}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "root-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "root-1", 100, 0).Return(&OrganizationUnitListResponse{
-		OrganizationUnits: []OrganizationUnitBasic{childOU},
-	}, (*serviceerror.ServiceError)(nil))
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "root-1", 100, 0, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			OrganizationUnits: []OrganizationUnitBasic{childOU},
+		}, (*serviceerror.ServiceError)(nil))
 
 	s.mockService.EXPECT().IsOrganizationUnitDeclarative(mock.Anything, "child-1").Return(false)
 
-	s.mockService.EXPECT().GetOrganizationUnitChildren(
-		mock.Anything, "child-1", 100, 0).Return(
-		(*OrganizationUnitListResponse)(nil),
-		&serviceerror.InternalServerError,
-	)
+	s.mockService.EXPECT().
+		GetOrganizationUnitChildren(mock.Anything, "child-1", 100, 0, mock.Anything).
+		Return(
+			(*OrganizationUnitListResponse)(nil),
+			&serviceerror.InternalServerError,
+		)
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 	assert.NotNil(s.T(), err)

--- a/backend/internal/ou/error_constants.go
+++ b/backend/internal/ou/error_constants.go
@@ -197,6 +197,19 @@ var (
 			DefaultValue: serverconst.CompositeStoreLimitWarning,
 		},
 	}
+	// ErrorInvalidFilter is the error returned when the filter parameter is invalid.
+	ErrorInvalidFilter = serviceerror.ServiceError{
+		Type: serviceerror.ClientErrorType,
+		Code: "OU-1014",
+		Error: core.I18nMessage{
+			Key:          "error.ouservice.invalid_filter",
+			DefaultValue: "Invalid filter parameter",
+		},
+		ErrorDescription: core.I18nMessage{
+			Key:          "error.ouservice.invalid_filter_description",
+			DefaultValue: "The filter parameter is invalid. Use format: attribute (eq|gt|lt) \"value\"",
+		},
+	}
 )
 
 // Error variables

--- a/backend/internal/ou/file_based_store.go
+++ b/backend/internal/ou/file_based_store.go
@@ -21,9 +21,11 @@ package ou
 import (
 	"context"
 	"errors"
+	"strings"
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/declarative_resource/entity"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
 )
 
@@ -118,7 +120,7 @@ func (f *fileBasedStore) GetOrganizationUnitByPath(ctx context.Context, handles 
 
 // GetOrganizationUnitList implements organizationUnitStoreInterface.
 func (f *fileBasedStore) GetOrganizationUnitList(
-	ctx context.Context, limit, offset int,
+	ctx context.Context, limit, offset int, fe *filter.FilterGroup,
 ) ([]OrganizationUnitBasic, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
@@ -128,21 +130,18 @@ func (f *fileBasedStore) GetOrganizationUnitList(
 	var ouList []OrganizationUnitBasic
 	for _, item := range list {
 		if ou, ok := item.Data.(*OrganizationUnit); ok {
-			// Only include root OUs (those without a parent)
-			if ou.Parent == nil {
-				basicOU := OrganizationUnitBasic{
+			if ou.Parent == nil && matchesOUFilter(ou, fe) {
+				ouList = append(ouList, OrganizationUnitBasic{
 					ID:          ou.ID,
 					Handle:      ou.Handle,
 					Name:        ou.Name,
 					Description: ou.Description,
 					LogoURL:     ou.LogoURL,
-				}
-				ouList = append(ouList, basicOU)
+				})
 			}
 		}
 	}
 
-	// Apply pagination
 	start := offset
 	if start > len(ouList) {
 		return []OrganizationUnitBasic{}, nil
@@ -156,7 +155,7 @@ func (f *fileBasedStore) GetOrganizationUnitList(
 }
 
 // GetOrganizationUnitListCount implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitListCount(ctx context.Context) (int, error) {
+func (f *fileBasedStore) GetOrganizationUnitListCount(ctx context.Context, fe *filter.FilterGroup) (int, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return 0, err
@@ -165,8 +164,7 @@ func (f *fileBasedStore) GetOrganizationUnitListCount(ctx context.Context) (int,
 	count := 0
 	for _, item := range list {
 		if ou, ok := item.Data.(*OrganizationUnit); ok {
-			// Only count root OUs (those without a parent)
-			if ou.Parent == nil {
+			if ou.Parent == nil && matchesOUFilter(ou, fe) {
 				count++
 			}
 		}
@@ -280,7 +278,9 @@ func (f *fileBasedStore) UpdateOrganizationUnit(ctx context.Context, ou Organiza
 }
 
 // GetOrganizationUnitChildrenCount implements organizationUnitStoreInterface.
-func (f *fileBasedStore) GetOrganizationUnitChildrenCount(ctx context.Context, id string) (int, error) {
+func (f *fileBasedStore) GetOrganizationUnitChildrenCount(
+	ctx context.Context, id string, fe *filter.FilterGroup,
+) (int, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return 0, err
@@ -289,7 +289,7 @@ func (f *fileBasedStore) GetOrganizationUnitChildrenCount(ctx context.Context, i
 	count := 0
 	for _, item := range list {
 		if ou, ok := item.Data.(*OrganizationUnit); ok {
-			if ou.Parent != nil && *ou.Parent == id {
+			if ou.Parent != nil && *ou.Parent == id && matchesOUFilter(ou, fe) {
 				count++
 			}
 		}
@@ -300,7 +300,8 @@ func (f *fileBasedStore) GetOrganizationUnitChildrenCount(ctx context.Context, i
 
 // GetOrganizationUnitChildrenList implements organizationUnitStoreInterface.
 func (f *fileBasedStore) GetOrganizationUnitChildrenList(
-	ctx context.Context, id string, limit, offset int) ([]OrganizationUnitBasic, error) {
+	ctx context.Context, id string, limit, offset int, fe *filter.FilterGroup,
+) ([]OrganizationUnitBasic, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return nil, err
@@ -309,20 +310,18 @@ func (f *fileBasedStore) GetOrganizationUnitChildrenList(
 	var children []OrganizationUnitBasic
 	for _, item := range list {
 		if ou, ok := item.Data.(*OrganizationUnit); ok {
-			if ou.Parent != nil && *ou.Parent == id {
-				basicOU := OrganizationUnitBasic{
+			if ou.Parent != nil && *ou.Parent == id && matchesOUFilter(ou, fe) {
+				children = append(children, OrganizationUnitBasic{
 					ID:          ou.ID,
 					Handle:      ou.Handle,
 					Name:        ou.Name,
 					Description: ou.Description,
 					LogoURL:     ou.LogoURL,
-				}
-				children = append(children, basicOU)
+				})
 			}
 		}
 	}
 
-	// Apply pagination
 	start := offset
 	if start > len(children) {
 		return []OrganizationUnitBasic{}, nil
@@ -333,4 +332,77 @@ func (f *fileBasedStore) GetOrganizationUnitChildrenList(
 	}
 
 	return children[start:end], nil
+}
+
+// matchesOUFilter reports whether an OU satisfies all clauses in the filter group.
+// Returns true when g is nil (no filter applied).
+// AND has higher precedence than OR, matching standard SQL behavior.
+func matchesOUFilter(ou *OrganizationUnit, g *filter.FilterGroup) bool {
+	if g == nil || len(g.Clauses) == 0 {
+		return true
+	}
+
+	// Walk clauses left to right. OR boundaries commit the current AND-group result
+	// and start a fresh one — implementing AND-before-OR precedence.
+	andGroupResult := evaluateSingleClause(ou, &g.Clauses[0].Expr)
+	for _, clause := range g.Clauses[1:] {
+		exprResult := evaluateSingleClause(ou, &clause.Expr)
+		switch clause.Connector {
+		case filter.LogicalAnd:
+			andGroupResult = andGroupResult && exprResult
+		case filter.LogicalOr:
+			if andGroupResult {
+				return true
+			}
+			andGroupResult = exprResult
+		}
+	}
+	return andGroupResult
+}
+
+// matchesOUBasicFilter reports whether an OrganizationUnitBasic satisfies all clauses in the filter group.
+// Used by the service layer when filtering the authorization-restricted ID set in memory.
+func matchesOUBasicFilter(ou OrganizationUnitBasic, g *filter.FilterGroup) bool {
+	ouFull := &OrganizationUnit{
+		Handle:      ou.Handle,
+		Name:        ou.Name,
+		Description: ou.Description,
+		CreatedAt:   ou.CreatedAt,
+		UpdatedAt:   ou.UpdatedAt,
+	}
+	return matchesOUFilter(ouFull, g)
+}
+
+// evaluateSingleClause tests one FilterExpression against an OU.
+func evaluateSingleClause(ou *OrganizationUnit, expr *filter.FilterExpression) bool {
+	var fieldVal string
+	switch expr.Attribute {
+	case "name":
+		fieldVal = ou.Name
+	case "handle":
+		fieldVal = ou.Handle
+	case "description":
+		fieldVal = ou.Description
+	case "createdAt":
+		fieldVal = ou.CreatedAt.UTC().Format("2006-01-02T15:04:05Z")
+	case "updatedAt":
+		fieldVal = ou.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z")
+	default:
+		return false
+	}
+
+	strTarget, ok := expr.Value.(string)
+	if !ok {
+		return false
+	}
+
+	switch expr.Operator {
+	case filter.OperatorEq:
+		return strings.EqualFold(fieldVal, strTarget)
+	case filter.OperatorGt:
+		return fieldVal > strTarget
+	case filter.OperatorLt:
+		return fieldVal < strTarget
+	}
+	return false
 }

--- a/backend/internal/ou/file_based_store_test.go
+++ b/backend/internal/ou/file_based_store_test.go
@@ -23,9 +23,11 @@ import (
 
 	"strconv"
 	"testing"
+	"time"
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/declarative_resource/entity"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -111,7 +113,7 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitList() {
 	assert.NoError(s.T(), err)
 
 	// Get list should only return root OUs
-	list, err := s.store.GetOrganizationUnitList(context.Background(), 10, 0)
+	list, err := s.store.GetOrganizationUnitList(context.Background(), 10, 0, nil)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), list, 2)
 }
@@ -188,12 +190,12 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitChildren() {
 	assert.NoError(s.T(), err)
 
 	// Get children
-	children, err := s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 10, 0)
+	children, err := s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 10, 0, nil)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), children, 2)
 
 	// Get children count
-	count, err := s.store.GetOrganizationUnitChildrenCount(context.Background(), testParentOUID)
+	count, err := s.store.GetOrganizationUnitChildrenCount(context.Background(), testParentOUID, nil)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 2, count)
 }
@@ -206,7 +208,7 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitByPath() {
 		Name:   "Root",
 		Parent: nil,
 	}
-	rootID := "root-1"
+	rootID := testRootOUID
 	engineering := OrganizationUnit{
 		ID:     "eng-1",
 		Handle: "engineering",
@@ -365,7 +367,7 @@ func (s *FileBasedStoreTestSuite) TestCheckOrganizationUnitNameConflict_WithPare
 
 func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitListCount() {
 	// Initially empty
-	count, err := s.store.GetOrganizationUnitListCount(context.Background())
+	count, err := s.store.GetOrganizationUnitListCount(context.Background(), nil)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 0, count)
 
@@ -388,12 +390,12 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitListCount() {
 	assert.NoError(s.T(), err)
 
 	// Should count only root OUs
-	count, err = s.store.GetOrganizationUnitListCount(context.Background())
+	count, err = s.store.GetOrganizationUnitListCount(context.Background(), nil)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 2, count)
 
 	// Add child OU (should not be counted)
-	parentID := "root-1"
+	parentID := testRootOUID
 	child := OrganizationUnit{
 		ID:     "child-1",
 		Handle: "child",
@@ -404,7 +406,7 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitListCount() {
 	assert.NoError(s.T(), err)
 
 	// Count should still be 2
-	count, err = s.store.GetOrganizationUnitListCount(context.Background())
+	count, err = s.store.GetOrganizationUnitListCount(context.Background(), nil)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 2, count)
 }
@@ -424,22 +426,22 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitList_Pagination() {
 	}
 
 	// Test pagination - first page
-	list, err := s.store.GetOrganizationUnitList(context.Background(), 2, 0)
+	list, err := s.store.GetOrganizationUnitList(context.Background(), 2, 0, nil)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), list, 2)
 
 	// Test pagination - second page
-	list, err = s.store.GetOrganizationUnitList(context.Background(), 2, 2)
+	list, err = s.store.GetOrganizationUnitList(context.Background(), 2, 2, nil)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), list, 2)
 
 	// Test pagination - last page
-	list, err = s.store.GetOrganizationUnitList(context.Background(), 2, 4)
+	list, err = s.store.GetOrganizationUnitList(context.Background(), 2, 4, nil)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), list, 1)
 
 	// Test offset beyond range
-	list, err = s.store.GetOrganizationUnitList(context.Background(), 10, 100)
+	list, err = s.store.GetOrganizationUnitList(context.Background(), 10, 100, nil)
 	assert.NoError(s.T(), err)
 	assert.Empty(s.T(), list)
 }
@@ -470,16 +472,16 @@ func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitChildrenList_Pagination
 	}
 
 	// Test pagination
-	children, err := s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 2, 0)
+	children, err := s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 2, 0, nil)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), children, 2)
 
-	children, err = s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 2, 2)
+	children, err = s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 2, 2, nil)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), children, 2)
 
 	// Test offset beyond range
-	children, err = s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 10, 100)
+	children, err = s.store.GetOrganizationUnitChildrenList(context.Background(), testParentOUID, 10, 100, nil)
 	assert.NoError(s.T(), err)
 	assert.Empty(s.T(), children)
 }
@@ -538,7 +540,7 @@ func (s *FileBasedStoreTestSuite) TestListIncludesDesignFields() {
 	err := s.store.CreateOrganizationUnit(context.Background(), ou)
 	assert.NoError(s.T(), err)
 
-	list, err := s.store.GetOrganizationUnitList(context.Background(), 10, 0)
+	list, err := s.store.GetOrganizationUnitList(context.Background(), 10, 0, nil)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), list, 1)
 	assert.Equal(s.T(), "https://example.com/list-logo.png", list[0].LogoURL)
@@ -567,7 +569,7 @@ func (s *FileBasedStoreTestSuite) TestChildrenListIncludesDesignFields() {
 	err = s.store.CreateOrganizationUnit(context.Background(), child)
 	assert.NoError(s.T(), err)
 
-	children, err := s.store.GetOrganizationUnitChildrenList(context.Background(), parentID, 10, 0)
+	children, err := s.store.GetOrganizationUnitChildrenList(context.Background(), parentID, 10, 0, nil)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), children, 1)
 	assert.Equal(s.T(), "https://example.com/child-logo.png", children[0].LogoURL)
@@ -652,4 +654,120 @@ func (s *FileBasedStoreTestSuite) TestFileBasedStore_IsOrganizationUnitDeclarati
 	// Test non-existent OU
 	isDecl = s.store.IsOrganizationUnitDeclarative(context.Background(), "non-existent")
 	s.Require().False(isDecl)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnit_CorruptedData() {
+	err := s.store.GenericFileBasedStore.Create("bad-ou", "not-an-ou")
+	s.Require().NoError(err)
+
+	_, err = s.store.GetOrganizationUnit(context.Background(), "bad-ou")
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "organization unit data corrupted")
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitByHandle() {
+	root := OrganizationUnit{ID: "root-1", Handle: "root", Name: "Root", Parent: nil}
+	rootID := testRootOUID
+	child := OrganizationUnit{ID: "child-1", Handle: "child", Name: "Child", Parent: &rootID}
+
+	err := s.store.CreateOrganizationUnit(context.Background(), root)
+	s.Require().NoError(err)
+	err = s.store.CreateOrganizationUnit(context.Background(), child)
+	s.Require().NoError(err)
+
+	ou, err := s.store.GetOrganizationUnitByHandle(context.Background(), "root", nil)
+	s.Require().NoError(err)
+	s.Require().Equal("root-1", ou.ID)
+
+	ou, err = s.store.GetOrganizationUnitByHandle(context.Background(), "child", &rootID)
+	s.Require().NoError(err)
+	s.Require().Equal("child-1", ou.ID)
+
+	_, err = s.store.GetOrganizationUnitByHandle(context.Background(), "child", nil)
+	s.Require().ErrorIs(err, ErrOrganizationUnitNotFound)
+}
+
+func (s *FileBasedStoreTestSuite) TestGetOrganizationUnitByPath_EmptyPath() {
+	_, err := s.store.GetOrganizationUnitByPath(context.Background(), []string{})
+	s.Require().ErrorIs(err, ErrOrganizationUnitNotFound)
+}
+
+// singleFilterGroup builds a one-clause FilterGroup for test brevity.
+func singleFilterGroup(attr string, op filter.Operator, val interface{}) *filter.FilterGroup {
+	return &filter.FilterGroup{Clauses: []filter.FilterClause{
+		{Expr: filter.FilterExpression{Attribute: attr, Operator: op, Value: val}},
+	}}
+}
+
+func TestMatchesOUFilter(t *testing.T) {
+	baseTime := time.Date(2025, time.January, 1, 10, 0, 0, 0, time.UTC)
+	ou := &OrganizationUnit{
+		ID:          "ou-1",
+		Handle:      "finance",
+		Name:        "Finance",
+		Description: "Finance OU",
+		CreatedAt:   baseTime,
+		UpdatedAt:   baseTime.Add(2 * time.Hour),
+	}
+
+	tests := []struct {
+		name string
+		f    *filter.FilterGroup
+		want bool
+	}{
+		{
+			name: "nil filter",
+			f:    nil,
+			want: true,
+		},
+		{
+			name: "name eq case insensitive",
+			f:    singleFilterGroup("name", filter.OperatorEq, "finance"),
+			want: true,
+		},
+		{
+			name: "handle eq",
+			f:    singleFilterGroup("handle", filter.OperatorEq, "finance"),
+			want: true,
+		},
+		{
+			name: "description eq",
+			f:    singleFilterGroup("description", filter.OperatorEq, "Finance OU"),
+			want: true,
+		},
+		{
+			name: "createdAt gt",
+			f:    singleFilterGroup("createdAt", filter.OperatorGt, "2025-01-01T09:59:59Z"),
+			want: true,
+		},
+		{
+			name: "updatedAt lt",
+			f:    singleFilterGroup("updatedAt", filter.OperatorLt, "2025-01-01T12:00:01Z"),
+			want: true,
+		},
+		{
+			name: "unknown attribute",
+			f:    singleFilterGroup("id", filter.OperatorEq, "ou-1"),
+			want: false,
+		},
+		{
+			name: "non string value",
+			f: &filter.FilterGroup{Clauses: []filter.FilterClause{
+				{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.OperatorEq, Value: 10}},
+			}},
+			want: false,
+		},
+		{
+			name: "unsupported operator",
+			f:    singleFilterGroup("name", filter.Operator("co"), "Finance"),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, matchesOUFilter(ou, tc.f))
+		})
+	}
 }

--- a/backend/internal/ou/handler.go
+++ b/backend/internal/ou/handler.go
@@ -26,6 +26,7 @@ import (
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
@@ -59,7 +60,13 @@ func (ouh *organizationUnitHandler) HandleOUListRequest(w http.ResponseWriter, r
 		limit = serverconst.DefaultPageSize
 	}
 
-	ouListResponse, svcErr := ouh.service.GetOrganizationUnitList(ctx, limit, offset)
+	f, err := filter.ParseFilterParam(r.URL.Query())
+	if err != nil {
+		ouh.handleError(w, &ErrorInvalidFilter)
+		return
+	}
+
+	ouListResponse, svcErr := ouh.service.GetOrganizationUnitList(ctx, limit, offset, f)
 	if svcErr != nil {
 		ouh.handleError(w, svcErr)
 		return
@@ -171,9 +178,14 @@ func (ouh *organizationUnitHandler) HandleOUDeleteRequest(w http.ResponseWriter,
 // HandleOUChildrenListRequest handles the list child organization units request.
 func (ouh *organizationUnitHandler) HandleOUChildrenListRequest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	f, err := filter.ParseFilterParam(r.URL.Query())
+	if err != nil {
+		ouh.handleError(w, &ErrorInvalidFilter)
+		return
+	}
 	ouh.handleResourceListRequest(w, r, "child organization units",
 		func(id string, limit, offset int) (interface{}, *serviceerror.ServiceError) {
-			return ouh.service.GetOrganizationUnitChildren(ctx, id, limit, offset)
+			return ouh.service.GetOrganizationUnitChildren(ctx, id, limit, offset, f)
 		})
 }
 
@@ -209,7 +221,8 @@ func (ouh *organizationUnitHandler) handleError(w http.ResponseWriter, svcErr *s
 			statusCode = http.StatusConflict
 		} else if svcErr.Code == ErrorInvalidLimit.Code ||
 			svcErr.Code == ErrorInvalidOffset.Code ||
-			svcErr.Code == ErrorInvalidHandlePath.Code {
+			svcErr.Code == ErrorInvalidHandlePath.Code ||
+			svcErr.Code == ErrorInvalidFilter.Code {
 			statusCode = http.StatusBadRequest
 		} else if svcErr.Code == serviceerror.ErrorUnauthorized.Code {
 			statusCode = http.StatusForbidden
@@ -468,9 +481,14 @@ func (ouh *organizationUnitHandler) handleResourceListByPathRequest(
 // HandleOUChildrenListByPathRequest handles the list child organization units by path request.
 func (ouh *organizationUnitHandler) HandleOUChildrenListByPathRequest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	f, err := filter.ParseFilterParam(r.URL.Query())
+	if err != nil {
+		ouh.handleError(w, &ErrorInvalidFilter)
+		return
+	}
 	ouh.handleResourceListByPathRequest(w, r, "child organization units",
 		func(path string, limit, offset int) (interface{}, *serviceerror.ServiceError) {
-			return ouh.service.GetOrganizationUnitChildrenByPath(ctx, path, limit, offset)
+			return ouh.service.GetOrganizationUnitChildrenByPath(ctx, path, limit, offset, f)
 		})
 }
 

--- a/backend/internal/ou/handler_test.go
+++ b/backend/internal/ou/handler_test.go
@@ -189,7 +189,10 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_RegisterRoutes() {
 			path:   "/organization-units/ou-123/ous",
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On("GetOrganizationUnitChildren", mock.Anything, "ou-123", serverconst.DefaultPageSize, 0).
+					On(
+						"GetOrganizationUnitChildren", mock.Anything, "ou-123",
+						serverconst.DefaultPageSize, 0, mock.Anything,
+					).
 					Return(&OrganizationUnitListResponse{}, nil).
 					Once()
 			},
@@ -270,7 +273,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUListRequest
 			url:  "/organization-units?limit=3&offset=2",
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On("GetOrganizationUnitList", mock.Anything, 3, 2).
+					On("GetOrganizationUnitList", mock.Anything, 3, 2, mock.Anything).
 					Return(&OrganizationUnitListResponse{
 						TotalResults: 4,
 						Count:        2,
@@ -295,7 +298,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUListRequest
 			url:  "/organization-units?offset=1",
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On("GetOrganizationUnitList", mock.Anything, serverconst.DefaultPageSize, 1).
+					On("GetOrganizationUnitList", mock.Anything, serverconst.DefaultPageSize, 1, mock.Anything).
 					Return(&OrganizationUnitListResponse{}, nil).
 					Once()
 			},
@@ -330,11 +333,24 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUListRequest
 			},
 		},
 		{
+			name: "invalid filter",
+			url:  "/organization-units?filter=invalid",
+			assert: func(recorder *httptest.ResponseRecorder) {
+				suite.Equal(http.StatusBadRequest, recorder.Code)
+				var body apierror.ErrorResponse
+				suite.NoError(json.Unmarshal(recorder.Body.Bytes(), &body))
+				suite.Equal(ErrorInvalidFilter.Code, body.Code)
+			},
+			assertService: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
+				serviceMock.AssertNotCalled(suite.T(), "GetOrganizationUnitList", mock.Anything)
+			},
+		},
+		{
 			name: "service error",
 			url:  "/organization-units",
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On("GetOrganizationUnitList", mock.Anything, serverconst.DefaultPageSize, 0).
+					On("GetOrganizationUnitList", mock.Anything, serverconst.DefaultPageSize, 0, mock.Anything).
 					Return((*OrganizationUnitListResponse)(nil), &serviceerror.InternalServerError).
 					Once()
 			},
@@ -351,7 +367,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUListRequest
 			useFlaky: true,
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On("GetOrganizationUnitList", mock.Anything, serverconst.DefaultPageSize, 0).
+					On("GetOrganizationUnitList", mock.Anything, serverconst.DefaultPageSize, 0, mock.Anything).
 					Return(&OrganizationUnitListResponse{}, nil).
 					Once()
 			},
@@ -1078,6 +1094,28 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUChildrenLis
 			},
 		},
 		{
+			name:           "invalid filter",
+			url:            "/organization-units/" + defaultOURequestID + "/ous?filter=invalid",
+			pathParamKey:   "id",
+			pathParamValue: defaultOURequestID,
+			assert: func(recorder *httptest.ResponseRecorder) {
+				suite.Equal(http.StatusBadRequest, recorder.Code)
+				var resp apierror.ErrorResponse
+				suite.NoError(json.Unmarshal(recorder.Body.Bytes(), &resp))
+				suite.Equal(ErrorInvalidFilter.Code, resp.Code)
+			},
+			assertService: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
+				serviceMock.AssertNotCalled(
+					suite.T(),
+					"GetOrganizationUnitChildren",
+					mock.Anything,
+					mock.Anything,
+					mock.Anything,
+					mock.Anything,
+				)
+			},
+		},
+		{
 			name:           "service error",
 			url:            "/organization-units/" + defaultOURequestID + "/ous",
 			pathParamKey:   "id",
@@ -1085,7 +1123,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUChildrenLis
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
 					On("GetOrganizationUnitChildren", mock.Anything,
-						defaultOURequestID, serverconst.DefaultPageSize, 0).
+						defaultOURequestID, serverconst.DefaultPageSize, 0, mock.Anything).
 					Return((*OrganizationUnitListResponse)(nil), &serviceerror.InternalServerError).
 					Once()
 			},
@@ -1105,7 +1143,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUChildrenLis
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
 					On("GetOrganizationUnitChildren", mock.Anything,
-						defaultOURequestID, serverconst.DefaultPageSize, 0).
+						defaultOURequestID, serverconst.DefaultPageSize, 0, mock.Anything).
 					Return(&OrganizationUnitListResponse{}, nil).
 					Once()
 			},
@@ -1121,7 +1159,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUChildrenLis
 			pathParamValue: defaultOURequestID,
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
-					On("GetOrganizationUnitChildren", mock.Anything, defaultOURequestID, 2, 1).
+					On("GetOrganizationUnitChildren", mock.Anything, defaultOURequestID, 2, 1, mock.Anything).
 					Return(&OrganizationUnitListResponse{TotalResults: 1}, nil).
 					Once()
 			},
@@ -1163,6 +1201,28 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUChildrenLis
 			},
 		},
 		{
+			name:           "path invalid filter",
+			url:            "/organization-units/tree/" + defaultOUPath + "/ous?filter=invalid",
+			pathParamKey:   "path",
+			pathParamValue: defaultOUPath,
+			assert: func(recorder *httptest.ResponseRecorder) {
+				suite.Equal(http.StatusBadRequest, recorder.Code)
+				var resp apierror.ErrorResponse
+				suite.NoError(json.Unmarshal(recorder.Body.Bytes(), &resp))
+				suite.Equal(ErrorInvalidFilter.Code, resp.Code)
+			},
+			assertService: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
+				serviceMock.AssertNotCalled(
+					suite.T(),
+					"GetOrganizationUnitChildrenByPath",
+					mock.Anything,
+					mock.Anything,
+					mock.Anything,
+					mock.Anything,
+				)
+			},
+		},
+		{
 			name:           "path success",
 			url:            "/organization-units/tree/" + defaultOUPath + "/ous",
 			pathParamKey:   "path",
@@ -1170,7 +1230,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUChildrenLis
 			setup: func(serviceMock *OrganizationUnitServiceInterfaceMock) {
 				serviceMock.
 					On("GetOrganizationUnitChildrenByPath", mock.Anything,
-						defaultOUPath, serverconst.DefaultPageSize, 0).
+						defaultOUPath, serverconst.DefaultPageSize, 0, mock.Anything).
 					Return(&OrganizationUnitListResponse{TotalResults: 2, Count: 2}, nil).
 					Once()
 			},
@@ -1866,4 +1926,54 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUGroupsListR
 		func(handler *organizationUnitHandler, writer http.ResponseWriter, req *http.Request) {
 			handler.HandleOUGroupsListRequest(writer, req)
 		})
+}
+
+func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_handleErrorStatusMapping() {
+	handler := newOrganizationUnitHandler(NewOrganizationUnitServiceInterfaceMock(suite.T()))
+
+	tests := []struct {
+		name       string
+		err        *serviceerror.ServiceError
+		wantStatus int
+	}{
+		{
+			name:       "not found maps 404",
+			err:        &ErrorOrganizationUnitNotFound,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "name conflict maps 409",
+			err:        &ErrorOrganizationUnitNameConflict,
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name:       "unauthorized maps 403",
+			err:        &serviceerror.ErrorUnauthorized,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "invalid filter maps 400",
+			err:        &ErrorInvalidFilter,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "server error maps 500",
+			err:        &serviceerror.InternalServerError,
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		suite.Run(tc.name, func() {
+			recorder := httptest.NewRecorder()
+
+			handler.handleError(recorder, tc.err)
+
+			suite.Equal(tc.wantStatus, recorder.Code)
+			var body apierror.ErrorResponse
+			suite.NoError(json.Unmarshal(recorder.Body.Bytes(), &body))
+			suite.Equal(tc.err.Code, body.Code)
+		})
+	}
 }

--- a/backend/internal/ou/organizationUnitStoreInterface_mock_test.go
+++ b/backend/internal/ou/organizationUnitStoreInterface_mock_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 )
 
 // newOrganizationUnitStoreInterfaceMock creates a new instance of organizationUnitStoreInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -500,8 +501,8 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) Run
 }
 
 // GetOrganizationUnitChildrenCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCount(ctx context.Context, id string) (int, error) {
-	ret := _mock.Called(ctx, id)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCount(ctx context.Context, id string, f *filter.FilterGroup) (int, error) {
+	ret := _mock.Called(ctx, id, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenCount")
@@ -509,16 +510,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCoun
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
-		return returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *filter.FilterGroup) (int, error)); ok {
+		return returnFunc(ctx, id, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
-		r0 = returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *filter.FilterGroup) int); ok {
+		r0 = returnFunc(ctx, id, f)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *filter.FilterGroup) error); ok {
+		r1 = returnFunc(ctx, id, f)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -533,11 +534,12 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call st
 // GetOrganizationUnitChildrenCount is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenCount(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call{Call: _e.mock.On("GetOrganizationUnitChildrenCount", ctx, id)}
+//   - f *filter.FilterGroup
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenCount(ctx interface{}, id interface{}, f interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call{Call: _e.mock.On("GetOrganizationUnitChildrenCount", ctx, id, f)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) Run(run func(ctx context.Context, id string, f *filter.FilterGroup)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -547,9 +549,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Ca
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 *filter.FilterGroup
+		if args[2] != nil {
+			arg2 = args[2].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -560,14 +567,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Ca
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) RunAndReturn(run func(ctx context.Context, id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) RunAndReturn(run func(ctx context.Context, id string, f *filter.FilterGroup) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitChildrenList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList(ctx context.Context, id string, limit int, offset int) ([]OrganizationUnitBasic, error) {
-	ret := _mock.Called(ctx, id, limit, offset)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) ([]OrganizationUnitBasic, error) {
+	ret := _mock.Called(ctx, id, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenList")
@@ -575,18 +582,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList
 
 	var r0 []OrganizationUnitBasic
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]OrganizationUnitBasic, error)); ok {
-		return returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) ([]OrganizationUnitBasic, error)); ok {
+		return returnFunc(ctx, id, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []OrganizationUnitBasic); ok {
-		r0 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) []OrganizationUnitBasic); ok {
+		r0 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]OrganizationUnitBasic)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
-		r1 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, *filter.FilterGroup) error); ok {
+		r1 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -603,11 +610,12 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call str
 //   - id string
 //   - limit int
 //   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenList(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call{Call: _e.mock.On("GetOrganizationUnitChildrenList", ctx, id, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenList(ctx interface{}, id interface{}, limit interface{}, offset interface{}, f interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call{Call: _e.mock.On("GetOrganizationUnitChildrenList", ctx, id, limit, offset, f)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) Run(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -625,11 +633,16 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Cal
 		if args[3] != nil {
 			arg3 = args[3].(int)
 		}
+		var arg4 *filter.FilterGroup
+		if args[4] != nil {
+			arg4 = args[4].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -640,14 +653,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Cal
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) ([]OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) ([]OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int) ([]OrganizationUnitBasic, error) {
-	ret := _mock.Called(ctx, limit, offset)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int, f *filter.FilterGroup) ([]OrganizationUnitBasic, error) {
+	ret := _mock.Called(ctx, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitList")
@@ -655,18 +668,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(ctx con
 
 	var r0 []OrganizationUnitBasic
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]OrganizationUnitBasic, error)); ok {
-		return returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) ([]OrganizationUnitBasic, error)); ok {
+		return returnFunc(ctx, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []OrganizationUnitBasic); ok {
-		r0 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) []OrganizationUnitBasic); ok {
+		r0 = returnFunc(ctx, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]OrganizationUnitBasic)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
-		r1 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int, *filter.FilterGroup) error); ok {
+		r1 = returnFunc(ctx, limit, offset, f)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -682,11 +695,12 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call struct {
 //   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}, f interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset, f)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -700,10 +714,15 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Run(r
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 *filter.FilterGroup
+		if args[3] != nil {
+			arg3 = args[3].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -714,14 +733,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Retur
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup) ([]OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitListCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitListCount(ctx context.Context) (int, error) {
-	ret := _mock.Called(ctx)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitListCount(ctx context.Context, f *filter.FilterGroup) (int, error) {
+	ret := _mock.Called(ctx, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitListCount")
@@ -729,16 +748,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitListCount(ct
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
-		return returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *filter.FilterGroup) (int, error)); ok {
+		return returnFunc(ctx, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
-		r0 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *filter.FilterGroup) int); ok {
+		r0 = returnFunc(ctx, f)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *filter.FilterGroup) error); ok {
+		r1 = returnFunc(ctx, f)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -752,18 +771,24 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call struct
 
 // GetOrganizationUnitListCount is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitListCount(ctx interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call{Call: _e.mock.On("GetOrganizationUnitListCount", ctx)}
+//   - f *filter.FilterGroup
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitListCount(ctx interface{}, f interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call{Call: _e.mock.On("GetOrganizationUnitListCount", ctx, f)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Run(run func(ctx context.Context)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Run(run func(ctx context.Context, f *filter.FilterGroup)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
+		var arg1 *filter.FilterGroup
+		if args[1] != nil {
+			arg1 = args[1].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -774,7 +799,7 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) 
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) RunAndReturn(run func(ctx context.Context, f *filter.FilterGroup) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/ou/service.go
+++ b/backend/internal/ou/service.go
@@ -28,6 +28,7 @@ import (
 
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/system/sysauthz"
@@ -40,7 +41,7 @@ const loggerComponentNameService = "OrganizationUnitService"
 // OrganizationUnitServiceInterface defines the interface for organization unit service operations.
 type OrganizationUnitServiceInterface interface {
 	GetOrganizationUnitList(
-		ctx context.Context, limit, offset int,
+		ctx context.Context, limit, offset int, f *filter.FilterGroup,
 	) (*OrganizationUnitListResponse, *serviceerror.ServiceError)
 	CreateOrganizationUnit(
 		ctx context.Context, request OrganizationUnitRequestWithID,
@@ -59,10 +60,10 @@ type OrganizationUnitServiceInterface interface {
 	DeleteOrganizationUnit(ctx context.Context, id string) *serviceerror.ServiceError
 	DeleteOrganizationUnitByPath(ctx context.Context, handlePath string) *serviceerror.ServiceError
 	GetOrganizationUnitChildren(
-		ctx context.Context, id string, limit, offset int,
+		ctx context.Context, id string, limit, offset int, f *filter.FilterGroup,
 	) (*OrganizationUnitListResponse, *serviceerror.ServiceError)
 	GetOrganizationUnitChildrenByPath(
-		ctx context.Context, handlePath string, limit, offset int,
+		ctx context.Context, handlePath string, limit, offset int, f *filter.FilterGroup,
 	) (*OrganizationUnitListResponse, *serviceerror.ServiceError)
 	GetOrganizationUnitUsers(
 		ctx context.Context, id string, limit, offset int, includeDisplay bool,
@@ -122,11 +123,21 @@ func newOrganizationUnitService(
 
 // GetOrganizationUnitList retrieves a list of organization units.
 // limit should be a positive integer and offset should be non-negative.
-func (ous *organizationUnitService) GetOrganizationUnitList(ctx context.Context, limit, offset int) (
+func (ous *organizationUnitService) GetOrganizationUnitList(
+	ctx context.Context, limit, offset int, f *filter.FilterGroup,
+) (
 	*OrganizationUnitListResponse, *serviceerror.ServiceError,
 ) {
 	if err := validatePaginationParams(limit, offset); err != nil {
 		return nil, err
+	}
+
+	if f != nil {
+		for _, clause := range f.Clauses {
+			if _, ok := ouFilterableColumns[clause.Expr.Attribute]; !ok {
+				return nil, &ErrorInvalidFilter
+			}
+		}
 	}
 
 	// Resolve the set of organization units the caller is authorized to see.
@@ -138,25 +149,25 @@ func (ous *organizationUnitService) GetOrganizationUnitList(ctx context.Context,
 
 	// Unfiltered path: the caller can see all organization units.
 	if accessible.AllAllowed {
-		return ous.listAllOrganizationUnits(ctx, limit, offset)
+		return ous.listAllOrganizationUnits(ctx, limit, offset, f)
 	}
 
 	// Filtered path: the caller has a restricted set of accessible organization units.
-	return ous.listAccessibleOrganizationUnits(ctx, accessible.IDs, limit, offset)
+	return ous.listAccessibleOrganizationUnits(ctx, accessible.IDs, limit, offset, f)
 }
 
 // listAllOrganizationUnits retrieves organization units without authorization filtering.
 func (ous *organizationUnitService) listAllOrganizationUnits(
-	ctx context.Context, limit, offset int,
+	ctx context.Context, limit, offset int, f *filter.FilterGroup,
 ) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	totalCount, err := ous.ouStore.GetOrganizationUnitListCount(ctx)
+	totalCount, err := ous.ouStore.GetOrganizationUnitListCount(ctx, f)
 	if err != nil {
 		logger.Error("Failed to get organization unit count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	ouList, err := ous.ouStore.GetOrganizationUnitList(ctx, limit, offset)
+	ouList, err := ous.ouStore.GetOrganizationUnitList(ctx, limit, offset, f)
 	if err != nil {
 		// Check if it's a limit exceeded error
 		if errors.Is(err, ErrResultLimitExceededInCompositeMode) {
@@ -176,12 +187,14 @@ func (ous *organizationUnitService) listAllOrganizationUnits(
 }
 
 // listAccessibleOrganizationUnits retrieves only the organization units the caller is authorized to access.
+// When g is nil it paginates the ID slice first and fetches only the needed page (efficient path).
+// When g is non-nil it fetches all authorized OUs, applies the filter in memory, then paginates.
 func (ous *organizationUnitService) listAccessibleOrganizationUnits(
-	ctx context.Context, ids []string, limit, offset int,
+	ctx context.Context, ids []string, limit, offset int, g *filter.FilterGroup,
 ) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	total := len(ids)
-	if total == 0 {
+
+	if len(ids) == 0 {
 		return &OrganizationUnitListResponse{
 			TotalResults:      0,
 			OrganizationUnits: []OrganizationUnitBasic{},
@@ -191,7 +204,44 @@ func (ous *organizationUnitService) listAccessibleOrganizationUnits(
 		}, nil
 	}
 
-	// Paginate the ID list before hitting the store.
+	if g != nil {
+		// Fetch all authorized OUs then apply the filter in memory so TotalResults
+		// reflects the filtered count, not the raw authorized-ID count.
+		allOUs, err := ous.ouStore.GetOrganizationUnitsByIDs(ctx, ids)
+		if err != nil {
+			logger.Error("Failed to get organization units by IDs", log.Error(err))
+			return nil, &serviceerror.InternalServerError
+		}
+
+		filtered := make([]OrganizationUnitBasic, 0, len(allOUs))
+		for _, ou := range allOUs {
+			if matchesOUBasicFilter(ou, g) {
+				filtered = append(filtered, ou)
+			}
+		}
+
+		total := len(filtered)
+		start := offset
+		if start > total {
+			start = total
+		}
+		end := start + limit
+		if end > total {
+			end = total
+		}
+		page := filtered[start:end]
+
+		return &OrganizationUnitListResponse{
+			TotalResults:      total,
+			OrganizationUnits: page,
+			StartIndex:        offset + 1,
+			Count:             len(page),
+			Links:             utils.BuildPaginationLinks("/organization-units", limit, offset, total, ""),
+		}, nil
+	}
+
+	// No filter: paginate the ID list before hitting the store (efficient path).
+	total := len(ids)
 	start := offset
 	if start > total {
 		start = total
@@ -212,7 +262,6 @@ func (ous *organizationUnitService) listAccessibleOrganizationUnits(
 		}, nil
 	}
 
-	// Fetch only the organization units needed for this page.
 	pageOUs, err := ous.ouStore.GetOrganizationUnitsByIDs(ctx, pageIDs)
 	if err != nil {
 		logger.Error("Failed to get organization units by IDs", log.Error(err))
@@ -741,7 +790,7 @@ func (ous *organizationUnitService) deleteOUInternal(
 	}
 
 	// Check child OUs (own table).
-	childCount, err := ous.ouStore.GetOrganizationUnitChildrenCount(ctx, id)
+	childCount, err := ous.ouStore.GetOrganizationUnitChildrenCount(ctx, id, nil)
 	if err != nil {
 		logger.Error("Failed to check child organization units", log.Error(err))
 		return &serviceerror.InternalServerError
@@ -867,19 +916,29 @@ func (ous *organizationUnitService) GetOrganizationUnitGroups(
 
 // GetOrganizationUnitChildren retrieves a list of child organization units for a given organization unit ID.
 func (ous *organizationUnitService) GetOrganizationUnitChildren(
-	ctx context.Context, id string, limit, offset int,
+	ctx context.Context, id string, limit, offset int, f *filter.FilterGroup,
 ) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
 	if svcErr := ous.checkOUAccess(ctx, security.ActionListChildOUs, id); svcErr != nil {
 		return nil, svcErr
 	}
 
+	if f != nil {
+		for _, clause := range f.Clauses {
+			if _, ok := ouFilterableColumns[clause.Expr.Attribute]; !ok {
+				return nil, &ErrorInvalidFilter
+			}
+		}
+	}
+
 	items, totalCount, svcErr := ous.getResourceListWithExistenceCheck(
 		ctx, id, limit, offset, "child organization units",
 		func(ctx context.Context, id string, limit, offset int) (interface{}, error) {
-			return ous.ouStore.GetOrganizationUnitChildrenList(ctx, id, limit, offset)
+			return ous.ouStore.GetOrganizationUnitChildrenList(ctx, id, limit, offset, f)
 		},
-		ous.ouStore.GetOrganizationUnitChildrenCount,
-		true, // Map composite limit error for children
+		func(ctx context.Context, id string) (int, error) {
+			return ous.ouStore.GetOrganizationUnitChildrenCount(ctx, id, f)
+		},
+		true,
 	)
 	if svcErr != nil {
 		return nil, svcErr
@@ -890,7 +949,7 @@ func (ous *organizationUnitService) GetOrganizationUnitChildren(
 
 // GetOrganizationUnitChildrenByPath retrieves a list of child organization units by hierarchical handle path.
 func (ous *organizationUnitService) GetOrganizationUnitChildrenByPath(
-	ctx context.Context, handlePath string, limit, offset int,
+	ctx context.Context, handlePath string, limit, offset int, f *filter.FilterGroup,
 ) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
 	logger.Debug("Getting organization unit children by path", log.String("path", handlePath))
@@ -909,7 +968,7 @@ func (ous *organizationUnitService) GetOrganizationUnitChildrenByPath(
 		return nil, &serviceerror.InternalServerError
 	}
 
-	return ous.GetOrganizationUnitChildren(ctx, ou.ID, limit, offset)
+	return ous.GetOrganizationUnitChildren(ctx, ou.ID, limit, offset, f)
 }
 
 // GetOrganizationUnitUsersByPath retrieves a list of users by hierarchical handle path.

--- a/backend/internal/ou/service_test.go
+++ b/backend/internal/ou/service_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/config"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 	i18ncore "github.com/thunder-id/thunderid/internal/system/i18n/core"
 	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/internal/system/utils"
@@ -150,7 +151,7 @@ func setupDefaultPathSuccess(
 	listReturn interface{},
 	countMethod string,
 	countReturn interface{},
-	extraListArgs ...interface{},
+	extraArgs ...interface{},
 ) {
 	store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 		Return(OrganizationUnit{ID: "ou-1"}, nil).
@@ -159,11 +160,13 @@ func setupDefaultPathSuccess(
 		Return(true, nil).
 		Once()
 	listArgs := []interface{}{mock.Anything, "ou-1", limit, offset}
-	listArgs = append(listArgs, extraListArgs...)
+	listArgs = append(listArgs, extraArgs...)
 	store.On(listMethod, listArgs...).
 		Return(listReturn, nil).
 		Once()
-	store.On(countMethod, mock.Anything, "ou-1").
+	countArgs := []interface{}{mock.Anything, "ou-1"}
+	countArgs = append(countArgs, extraArgs...)
+	store.On(countMethod, countArgs...).
 		Return(countReturn, nil).
 		Once()
 }
@@ -200,7 +203,7 @@ func invokeChildrenByPath(
 	path string,
 	limit, offset int,
 ) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	return service.GetOrganizationUnitChildrenByPath(context.Background(), path, limit, offset)
+	return service.GetOrganizationUnitChildrenByPath(context.Background(), path, limit, offset, nil)
 }
 
 func (suite *OrganizationUnitServiceTestSuite) newService(
@@ -275,6 +278,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 		name       string
 		limit      int
 		offset     int
+		filterExpr *filter.FilterGroup
 		setup      func(*organizationUnitStoreInterfaceMock)
 		wantErr    *serviceerror.ServiceError
 		wantResult *ouListExpectations
@@ -284,10 +288,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			limit:  2,
 			offset: 1,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitListCount", mock.Anything).
+				store.On("GetOrganizationUnitListCount", mock.Anything, mock.Anything).
 					Return(3, nil).
 					Once()
-				store.On("GetOrganizationUnitList", mock.Anything, 2, 1).
+				store.On("GetOrganizationUnitList", mock.Anything, 2, 1, mock.Anything).
 					Return([]OrganizationUnitBasic{
 						{ID: "ou-1", Handle: "root", Name: "Root"},
 						{ID: "ou-2", Handle: "child", Name: "Child"},
@@ -314,11 +318,20 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			wantErr: &ErrorInvalidLimit,
 		},
 		{
+			name:   "invalid filter attribute",
+			limit:  5,
+			offset: 0,
+			filterExpr: &filter.FilterGroup{Clauses: []filter.FilterClause{
+				{Expr: filter.FilterExpression{Attribute: "id", Operator: filter.OperatorEq, Value: "ou-1"}},
+			}},
+			wantErr: &ErrorInvalidFilter,
+		},
+		{
 			name:   "count failure",
 			limit:  5,
 			offset: 0,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitListCount", mock.Anything).
+				store.On("GetOrganizationUnitListCount", mock.Anything, mock.Anything).
 					Return(0, errors.New("count failed")).
 					Once()
 			},
@@ -329,10 +342,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			limit:  5,
 			offset: 0,
 			setup: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitListCount", mock.Anything).
+				store.On("GetOrganizationUnitListCount", mock.Anything, mock.Anything).
 					Return(10, nil).
 					Once()
-				store.On("GetOrganizationUnitList", mock.Anything, 5, 0).
+				store.On("GetOrganizationUnitList", mock.Anything, 5, 0, mock.Anything).
 					Return(nil, errors.New("list failed")).
 					Once()
 			},
@@ -349,7 +362,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			}
 
 			service := suite.newService(store, newAllowAllAuthz(suite.T()))
-			resp, err := service.GetOrganizationUnitList(context.Background(), tc.limit, tc.offset)
+			resp, err := service.GetOrganizationUnitList(context.Background(), tc.limit, tc.offset, tc.filterExpr)
 
 			if tc.wantErr != nil {
 				suite.Require().Nil(resp)
@@ -360,12 +373,25 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 				suite.assertOUListResponse(resp, tc.wantResult)
 			}
 
-			if tc.wantErr == &ErrorInvalidLimit {
+			if tc.wantErr == &ErrorInvalidLimit || tc.wantErr == &ErrorInvalidFilter {
 				store.AssertNumberOfCalls(suite.T(), "GetOrganizationUnitListCount", 0)
 			}
 			store.AssertExpectations(suite.T())
 		})
 	}
+}
+
+func (suite *OrganizationUnitServiceTestSuite) TestOUService_SetResolvers() {
+	service := &organizationUnitService{}
+
+	userResolver := new(OUUserResolverMock)
+	groupResolver := new(OUGroupResolverMock)
+
+	service.SetOUUserResolver(userResolver)
+	service.SetOUGroupResolver(groupResolver)
+
+	suite.Require().Equal(userResolver, service.userResolver)
+	suite.Require().Equal(groupResolver, service.groupResolver)
 }
 
 func (suite *OrganizationUnitServiceTestSuite) TestOUService_CreateOrganizationUnit() {
@@ -1268,7 +1294,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 					Return(true, nil).Once()
 				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).Once()
-				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 					Return(1, nil).Once()
 			},
 			wantErr: &ErrorCannotDeleteOrganizationUnit,
@@ -1280,7 +1306,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 					Return(true, nil).Once()
 				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).Once()
-				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 					Return(0, errors.New("boom")).Once()
 			},
 			wantErr: &serviceerror.InternalServerError,
@@ -1292,7 +1318,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 					Return(true, nil).Once()
 				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).Once()
-				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 					Return(0, nil).Once()
 			},
 			resolverSetup: func(rs *resolverSetup) {
@@ -1308,7 +1334,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 					Return(true, nil).Once()
 				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).Once()
-				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 					Return(0, nil).Once()
 			},
 			resolverSetup: func(rs *resolverSetup) {
@@ -1326,7 +1352,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 					Return(true, nil).Once()
 				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).Once()
-				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 					Return(0, nil).Once()
 				store.On("DeleteOrganizationUnit", mock.Anything, "ou-1").
 					Return(errors.New("boom")).Once()
@@ -1346,7 +1372,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 					Return(true, nil).Once()
 				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).Once()
-				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 					Return(0, nil).Once()
 				store.On("DeleteOrganizationUnit", mock.Anything, "ou-1").
 					Return(ErrOrganizationUnitNotFound).Once()
@@ -1366,7 +1392,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 					Return(true, nil).Once()
 				store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 					Return(false).Once()
-				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 					Return(0, nil).Once()
 				store.On("DeleteOrganizationUnit", mock.Anything, "ou-1").
 					Return(nil).Once()
@@ -1449,7 +1475,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 			Return(OrganizationUnit{ID: "ou-1"}, nil).Once()
 		store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 			Return(false).Twice()
-		store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+		store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 			Return(1, nil).Once()
 
 		userRes := new(OUUserResolverMock)
@@ -1468,7 +1494,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_DeleteOrganizationU
 			Return(OrganizationUnit{ID: "ou-1"}, nil).Once()
 		store.On("IsOrganizationUnitDeclarative", mock.Anything, "ou-1").
 			Return(false).Twice()
-		store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+		store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 			Return(0, nil).Once()
 		store.On("DeleteOrganizationUnit", mock.Anything, "ou-1").
 			Return(nil).Once()
@@ -1507,6 +1533,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 		name       string
 		limit      int
 		offset     int
+		filterExpr *filter.FilterGroup
 		setup      func(*organizationUnitStoreInterfaceMock)
 		wantErr    *serviceerror.ServiceError
 		wantResult *ouListExpectations
@@ -1516,6 +1543,14 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			limit:   0,
 			offset:  0,
 			wantErr: &ErrorInvalidLimit,
+		},
+		{
+			name:  "invalid filter attribute",
+			limit: 5,
+			filterExpr: &filter.FilterGroup{Clauses: []filter.FilterClause{
+				{Expr: filter.FilterExpression{Attribute: "id", Operator: filter.OperatorEq, Value: "ou-1"}},
+			}},
+			wantErr: &ErrorInvalidFilter,
 		},
 		{
 			name:  "ou not found",
@@ -1544,11 +1579,24 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitChildrenList", mock.Anything, "ou-1", 5, 0).
+				store.On("GetOrganizationUnitChildrenList", mock.Anything, "ou-1", 5, 0, mock.Anything).
 					Return(nil, errors.New("list fail")).
 					Once()
 			},
 			wantErr: &serviceerror.InternalServerError,
+		},
+		{
+			name:  "composite limit exceeded",
+			limit: 5,
+			setup: func(store *organizationUnitStoreInterfaceMock) {
+				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
+					Return(true, nil).
+					Once()
+				store.On("GetOrganizationUnitChildrenList", mock.Anything, "ou-1", 5, 0, mock.Anything).
+					Return(nil, ErrResultLimitExceededInCompositeMode).
+					Once()
+			},
+			wantErr: &ErrorResultLimitExceeded,
 		},
 		{
 			name:  "count failure",
@@ -1557,10 +1605,10 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitChildrenList", mock.Anything, "ou-1", 5, 0).
+				store.On("GetOrganizationUnitChildrenList", mock.Anything, "ou-1", 5, 0, mock.Anything).
 					Return([]OrganizationUnitBasic{}, nil).
 					Once()
-				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 					Return(0, errors.New("count fail")).
 					Once()
 			},
@@ -1573,12 +1621,12 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 				store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
 					Return(true, nil).
 					Once()
-				store.On("GetOrganizationUnitChildrenList", mock.Anything, "ou-1", 2, 0).
+				store.On("GetOrganizationUnitChildrenList", mock.Anything, "ou-1", 2, 0, mock.Anything).
 					Return([]OrganizationUnitBasic{
 						{ID: "child-1", Handle: "finance", Name: "Finance"},
 					}, nil).
 					Once()
-				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1").
+				store.On("GetOrganizationUnitChildrenCount", mock.Anything, "ou-1", mock.Anything).
 					Return(1, nil).
 					Once()
 			},
@@ -1602,7 +1650,9 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			}
 
 			service := suite.newService(store, newAllowAllAuthz(suite.T()))
-			resp, err := service.GetOrganizationUnitChildren(context.Background(), "ou-1", tc.limit, tc.offset)
+			resp, err := service.GetOrganizationUnitChildren(
+				context.Background(), "ou-1", tc.limit, tc.offset, tc.filterExpr,
+			)
 
 			if tc.wantErr != nil {
 				suite.Require().NotNil(err)
@@ -1612,11 +1662,30 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 				suite.assertOUListResponse(resp, tc.wantResult)
 			}
 
-			if tc.wantErr == &ErrorInvalidLimit {
+			if tc.wantErr == &ErrorInvalidLimit || tc.wantErr == &ErrorInvalidFilter {
 				store.AssertNumberOfCalls(suite.T(), "IsOrganizationUnitExists", 0)
 			}
 		})
 	}
+}
+
+func (suite *OrganizationUnitServiceTestSuite) TestOUService_validateOUHandle() {
+	service := &organizationUnitService{}
+
+	suite.Run("blank handle", func() {
+		err := service.validateOUHandle("   ")
+		suite.Require().Equal(ErrorInvalidRequestFormat, *err)
+	})
+
+	suite.Run("handle with slash", func() {
+		err := service.validateOUHandle("root/child")
+		suite.Require().Equal(ErrorInvalidRequestFormat, *err)
+	})
+
+	suite.Run("valid handle", func() {
+		err := service.validateOUHandle("finance")
+		suite.Require().Nil(err)
+	})
 }
 
 func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnitChildrenByPath() {
@@ -1632,6 +1701,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			suite.Require().NotNil(resp)
 		},
 		invokeChildrenByPath,
+		mock.Anything, // filter arg
 	)
 	runOUPathListTests(suite, config)
 }
@@ -1876,7 +1946,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 
 	service := suite.newService(store, authzMock)
 
-	resp, err := service.GetOrganizationUnitChildren(context.Background(), "ou-1", 5, 0)
+	resp, err := service.GetOrganizationUnitChildren(context.Background(), "ou-1", 5, 0, nil)
 	suite.Require().Nil(resp)
 	suite.Require().Equal(serviceerror.ErrorUnauthorized.Code, err.Code)
 	suite.Require().Equal(serviceerror.ErrorUnauthorized.Type, err.Type)
@@ -1898,7 +1968,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 
 	service := suite.newService(store, authzMock)
 
-	resp, err := service.GetOrganizationUnitChildren(context.Background(), "ou-1", 5, 0)
+	resp, err := service.GetOrganizationUnitChildren(context.Background(), "ou-1", 5, 0, nil)
 	suite.Require().Nil(resp)
 	suite.Require().Equal(serviceerror.InternalServerError, *err)
 }
@@ -2471,8 +2541,8 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 					Once()
 			},
 			setupStore: func(store *organizationUnitStoreInterfaceMock) {
-				store.On("GetOrganizationUnitListCount", mock.Anything).Return(0, nil).Once()
-				store.On("GetOrganizationUnitList", mock.Anything, 10, 0).
+				store.On("GetOrganizationUnitListCount", mock.Anything, mock.Anything).Return(0, nil).Once()
+				store.On("GetOrganizationUnitList", mock.Anything, 10, 0, mock.Anything).
 					Return([]OrganizationUnitBasic{}, ErrResultLimitExceededInCompositeMode).
 					Once()
 			},
@@ -2494,7 +2564,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			}
 
 			service := &organizationUnitService{ouStore: store, authzService: authz}
-			resp, err := service.GetOrganizationUnitList(context.Background(), tc.limit, tc.offset)
+			resp, err := service.GetOrganizationUnitList(context.Background(), tc.limit, tc.offset, nil)
 
 			if tc.wantErr != nil {
 				suite.Require().NotNil(err)
@@ -2516,6 +2586,7 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_listAccessibleOrgan
 		ids        []string
 		limit      int
 		offset     int
+		filter     *filter.FilterGroup
 		setupStore func(*organizationUnitStoreInterfaceMock)
 		wantErr    *serviceerror.ServiceError
 		wantTotal  int
@@ -2562,6 +2633,59 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_listAccessibleOrgan
 			wantTotal: 3,
 			wantCount: 2,
 		},
+		{
+			name:   "filter match — returns filtered subset",
+			ids:    []string{"ou-1", "ou-2"},
+			limit:  10,
+			offset: 0,
+			filter: &filter.FilterGroup{Clauses: []filter.FilterClause{
+				{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.OperatorEq, Value: "Engineering"}},
+			}},
+			setupStore: func(store *organizationUnitStoreInterfaceMock) {
+				store.On("GetOrganizationUnitsByIDs", mock.Anything, []string{"ou-1", "ou-2"}).
+					Return([]OrganizationUnitBasic{
+						{ID: "ou-1", Name: "Engineering"},
+						{ID: "ou-2", Name: "Sales"},
+					}, nil).
+					Once()
+			},
+			wantTotal: 1,
+			wantCount: 1,
+		},
+		{
+			name:   "filter no match — returns empty",
+			ids:    []string{"ou-1", "ou-2"},
+			limit:  10,
+			offset: 0,
+			filter: &filter.FilterGroup{Clauses: []filter.FilterClause{
+				{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.OperatorEq, Value: "__no_match__"}},
+			}},
+			setupStore: func(store *organizationUnitStoreInterfaceMock) {
+				store.On("GetOrganizationUnitsByIDs", mock.Anything, []string{"ou-1", "ou-2"}).
+					Return([]OrganizationUnitBasic{
+						{ID: "ou-1", Name: "Engineering"},
+						{ID: "ou-2", Name: "Sales"},
+					}, nil).
+					Once()
+			},
+			wantTotal: 0,
+			wantCount: 0,
+		},
+		{
+			name:   "filter store error",
+			ids:    []string{"ou-1"},
+			limit:  10,
+			offset: 0,
+			filter: &filter.FilterGroup{Clauses: []filter.FilterClause{
+				{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.OperatorEq, Value: "Engineering"}},
+			}},
+			setupStore: func(store *organizationUnitStoreInterfaceMock) {
+				store.On("GetOrganizationUnitsByIDs", mock.Anything, []string{"ou-1"}).
+					Return(nil, errors.New("db error")).
+					Once()
+			},
+			wantErr: &serviceerror.InternalServerError,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2572,7 +2696,8 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_listAccessibleOrgan
 				tc.setupStore(store)
 			}
 			service := &organizationUnitService{ouStore: store}
-			resp, err := service.listAccessibleOrganizationUnits(context.Background(), tc.ids, tc.limit, tc.offset)
+			resp, err := service.listAccessibleOrganizationUnits(
+				context.Background(), tc.ids, tc.limit, tc.offset, tc.filter)
 
 			if tc.wantErr != nil {
 				suite.Require().NotNil(err)

--- a/backend/internal/ou/store.go
+++ b/backend/internal/ou/store.go
@@ -29,6 +29,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/config"
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
 )
@@ -37,8 +38,10 @@ const storeLoggerComponentName = "OrganizationUnitStore"
 
 // organizationUnitStoreInterface defines the interface for organization unit store operations.
 type organizationUnitStoreInterface interface {
-	GetOrganizationUnitListCount(ctx context.Context) (int, error)
-	GetOrganizationUnitList(ctx context.Context, limit, offset int) ([]OrganizationUnitBasic, error)
+	GetOrganizationUnitListCount(ctx context.Context, f *filter.FilterGroup) (int, error)
+	GetOrganizationUnitList(
+		ctx context.Context, limit, offset int, f *filter.FilterGroup,
+	) ([]OrganizationUnitBasic, error)
 	GetOrganizationUnitsByIDs(ctx context.Context, ids []string) ([]OrganizationUnitBasic, error)
 	CreateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error
 	GetOrganizationUnit(ctx context.Context, id string) (OrganizationUnit, error)
@@ -50,8 +53,10 @@ type organizationUnitStoreInterface interface {
 	CheckOrganizationUnitHandleConflict(ctx context.Context, handle string, parent *string) (bool, error)
 	UpdateOrganizationUnit(ctx context.Context, ou OrganizationUnit) error
 	DeleteOrganizationUnit(ctx context.Context, id string) error
-	GetOrganizationUnitChildrenCount(ctx context.Context, id string) (int, error)
-	GetOrganizationUnitChildrenList(ctx context.Context, id string, limit, offset int) ([]OrganizationUnitBasic, error)
+	GetOrganizationUnitChildrenCount(ctx context.Context, id string, f *filter.FilterGroup) (int, error)
+	GetOrganizationUnitChildrenList(
+		ctx context.Context, id string, limit, offset int, f *filter.FilterGroup,
+	) ([]OrganizationUnitBasic, error)
 }
 
 var getDBProvider = provider.GetDBProvider
@@ -76,13 +81,21 @@ func newOrganizationUnitStore() (organizationUnitStoreInterface, transaction.Tra
 }
 
 // GetOrganizationUnitListCount retrieves the total count of organization units.
-func (s *organizationUnitStore) GetOrganizationUnitListCount(ctx context.Context) (int, error) {
+func (s *organizationUnitStore) GetOrganizationUnitListCount(
+	ctx context.Context, f *filter.FilterGroup,
+) (int, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetRootOrganizationUnitListCount, s.deploymentID)
+	query, filterArgs, err := buildRootOUCountQuery(f)
+	if err != nil {
+		return 0, fmt.Errorf("failed to build count query: %w", err)
+	}
+	args := append([]interface{}{s.deploymentID}, filterArgs...)
+
+	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -101,14 +114,20 @@ func (s *organizationUnitStore) GetOrganizationUnitListCount(ctx context.Context
 
 // GetOrganizationUnitList retrieves organization units with pagination.
 func (s *organizationUnitStore) GetOrganizationUnitList(
-	ctx context.Context, limit, offset int,
+	ctx context.Context, limit, offset int, f *filter.FilterGroup,
 ) ([]OrganizationUnitBasic, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetRootOrganizationUnitList, limit, offset, s.deploymentID)
+	query, filterArgs, err := buildRootOUListQuery(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build list query: %w", err)
+	}
+	args := append([]interface{}{limit, offset, s.deploymentID}, filterArgs...)
+
+	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -398,13 +417,21 @@ func (s *organizationUnitStore) DeleteOrganizationUnit(ctx context.Context, id s
 }
 
 // GetOrganizationUnitChildrenCount retrieves the total count of child organization units for a given parent ID.
-func (s *organizationUnitStore) GetOrganizationUnitChildrenCount(ctx context.Context, parentID string) (int, error) {
+func (s *organizationUnitStore) GetOrganizationUnitChildrenCount(
+	ctx context.Context, parentID string, f *filter.FilterGroup,
+) (int, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetOrganizationUnitChildrenCount, parentID, s.deploymentID)
+	query, filterArgs, err := buildChildrenOUCountQuery(f)
+	if err != nil {
+		return 0, fmt.Errorf("failed to build count query: %w", err)
+	}
+	args := append([]interface{}{parentID, s.deploymentID}, filterArgs...)
+
+	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -424,16 +451,20 @@ func (s *organizationUnitStore) GetOrganizationUnitChildrenCount(ctx context.Con
 
 // GetOrganizationUnitChildrenList retrieves a paginated list of child organization units for a given parent ID.
 func (s *organizationUnitStore) GetOrganizationUnitChildrenList(ctx context.Context,
-	parentID string, limit, offset int,
+	parentID string, limit, offset int, f *filter.FilterGroup,
 ) ([]OrganizationUnitBasic, error) {
 	dbClient, err := s.dbProvider.GetUserDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	results, err := dbClient.QueryContext(
-		ctx, queryGetOrganizationUnitChildrenList, parentID, limit, offset, s.deploymentID,
-	)
+	query, filterArgs, err := buildChildrenOUListQuery(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build list query: %w", err)
+	}
+	args := append([]interface{}{parentID, limit, offset, s.deploymentID}, filterArgs...)
+
+	results, err := dbClient.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}

--- a/backend/internal/ou/store_constants.go
+++ b/backend/internal/ou/store_constants.go
@@ -23,23 +23,157 @@ import (
 	"strings"
 
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 )
 
+// ouFilterableColumns maps API attribute names to ORGANIZATION_UNIT table column names.
+var ouFilterableColumns = map[string]string{
+	"name":        "NAME",
+	"handle":      "HANDLE",
+	"description": "DESCRIPTION",
+	"createdAt":   "CREATED_AT",
+	"updatedAt":   "UPDATED_AT",
+}
+
+// ouTextColumns is the set of ORGANIZATION_UNIT columns that hold free-form text.
+// The eq operator on these columns uses LOWER() for case-insensitive matching,
+// keeping the DB store consistent with the in-memory file-based store (strings.EqualFold).
+var ouTextColumns = map[string]bool{
+	"NAME":        true,
+	"HANDLE":      true,
+	"DESCRIPTION": true,
+}
+
+// buildOUFilterGroup generates a SQL WHERE fragment for a FilterGroup and returns the bound args.
+// startParamIdx is the positional parameter index for the first filter value.
+// Returns an empty string and no args when g is nil.
+// For multi-clause groups the fragment is wrapped in AND (...); single-clause groups omit the parens.
+func buildOUFilterGroup(g *filter.FilterGroup, startParamIdx int) (cond string, args []interface{}, err error) {
+	if g == nil || len(g.Clauses) == 0 {
+		return "", nil, nil
+	}
+
+	var sb strings.Builder
+	idx := startParamIdx
+
+	for i, clause := range g.Clauses {
+		col, ok := ouFilterableColumns[clause.Expr.Attribute]
+		if !ok {
+			return "", nil, fmt.Errorf("attribute %q is not filterable", clause.Expr.Attribute)
+		}
+
+		var clauseCond string
+		switch clause.Expr.Operator {
+		case filter.OperatorEq:
+			if ouTextColumns[col] {
+				clauseCond = fmt.Sprintf("LOWER(%s) = LOWER($%d)", col, idx)
+			} else {
+				clauseCond = fmt.Sprintf("%s = $%d", col, idx)
+			}
+		case filter.OperatorGt:
+			clauseCond = fmt.Sprintf("%s > $%d", col, idx)
+		case filter.OperatorLt:
+			clauseCond = fmt.Sprintf("%s < $%d", col, idx)
+		default:
+			return "", nil, fmt.Errorf("unsupported operator %q", clause.Expr.Operator)
+		}
+
+		if i > 0 {
+			sb.WriteString(" ")
+			sb.WriteString(string(clause.Connector))
+			sb.WriteString(" ")
+		}
+		sb.WriteString(clauseCond)
+		args = append(args, clause.Expr.Value)
+		idx++
+	}
+
+	if len(g.Clauses) == 1 {
+		cond = " AND " + sb.String()
+	} else {
+		cond = " AND (" + sb.String() + ")"
+	}
+	return cond, args, nil
+}
+
+// buildRootOUCountQuery constructs a count query for root-level OUs with an optional filter group.
+// Args order: deploymentID=$1 [, filterArgs...]
+func buildRootOUCountQuery(g *filter.FilterGroup) (dbmodel.DBQuery, []interface{}, error) {
+	query := `SELECT COUNT(*) as total FROM "ORGANIZATION_UNIT" WHERE PARENT_ID IS NULL AND DEPLOYMENT_ID = $1`
+
+	filterArgs := []interface{}{}
+	if g != nil {
+		cond, args, err := buildOUFilterGroup(g, 2)
+		if err != nil {
+			return dbmodel.DBQuery{}, nil, err
+		}
+		query += cond
+		filterArgs = append(filterArgs, args...)
+	}
+
+	return dbmodel.DBQuery{ID: "OUQ-OU_MGT-01", Query: query}, filterArgs, nil
+}
+
+// buildRootOUListQuery constructs the paginated root-OU list query with an optional filter group.
+// Args order: limit=$1, offset=$2, deploymentID=$3 [, filterArgs...]
+func buildRootOUListQuery(g *filter.FilterGroup) (dbmodel.DBQuery, []interface{}, error) {
+	query := `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, PARENT_ID, METADATA, CREATED_AT, UPDATED_AT ` +
+		`FROM "ORGANIZATION_UNIT" ` +
+		`WHERE PARENT_ID IS NULL AND DEPLOYMENT_ID = $3`
+
+	filterArgs := []interface{}{}
+	if g != nil {
+		cond, args, err := buildOUFilterGroup(g, 4)
+		if err != nil {
+			return dbmodel.DBQuery{}, nil, err
+		}
+		query += cond
+		filterArgs = append(filterArgs, args...)
+	}
+
+	query += " ORDER BY NAME LIMIT $1 OFFSET $2"
+	return dbmodel.DBQuery{ID: "OUQ-OU_MGT-02", Query: query}, filterArgs, nil
+}
+
+// buildChildrenOUCountQuery constructs a count query for child OUs under a parent with an optional filter group.
+// Args order: parentID=$1, deploymentID=$2 [, filterArgs...]
+func buildChildrenOUCountQuery(g *filter.FilterGroup) (dbmodel.DBQuery, []interface{}, error) {
+	query := `SELECT COUNT(*) as total FROM "ORGANIZATION_UNIT" WHERE PARENT_ID = $1 AND DEPLOYMENT_ID = $2`
+
+	filterArgs := []interface{}{}
+	if g != nil {
+		cond, args, err := buildOUFilterGroup(g, 3)
+		if err != nil {
+			return dbmodel.DBQuery{}, nil, err
+		}
+		query += cond
+		filterArgs = append(filterArgs, args...)
+	}
+
+	return dbmodel.DBQuery{ID: "OUQ-OU_MGT-10", Query: query}, filterArgs, nil
+}
+
+// buildChildrenOUListQuery constructs the paginated child-OU list query with an optional filter group.
+// Args order: parentID=$1, limit=$2, offset=$3, deploymentID=$4 [, filterArgs...]
+func buildChildrenOUListQuery(g *filter.FilterGroup) (dbmodel.DBQuery, []interface{}, error) {
+	query := `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, METADATA, CREATED_AT, UPDATED_AT FROM "ORGANIZATION_UNIT" ` +
+		`WHERE PARENT_ID = $1 AND DEPLOYMENT_ID = $4`
+
+	filterArgs := []interface{}{}
+	if g != nil {
+		cond, args, err := buildOUFilterGroup(g, 5)
+		if err != nil {
+			return dbmodel.DBQuery{}, nil, err
+		}
+		query += cond
+		filterArgs = append(filterArgs, args...)
+	}
+
+	query += " ORDER BY NAME LIMIT $2 OFFSET $3"
+	return dbmodel.DBQuery{ID: "OUQ-OU_MGT-11", Query: query}, filterArgs, nil
+}
+
 var (
-	// queryGetRootOrganizationUnitListCount is the query to get total count of organization units.
-	queryGetRootOrganizationUnitListCount = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-01",
-		Query: `SELECT COUNT(*) as total FROM "ORGANIZATION_UNIT" WHERE PARENT_ID IS NULL AND DEPLOYMENT_ID = $1`,
-	}
-
-	// queryGetRootOrganizationUnitList is the query to get organization units with pagination.
-	queryGetRootOrganizationUnitList = dbmodel.DBQuery{
-		ID: "OUQ-OU_MGT-02",
-		Query: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, PARENT_ID, METADATA, CREATED_AT, UPDATED_AT ` +
-			`FROM "ORGANIZATION_UNIT" ` +
-			`WHERE PARENT_ID IS NULL AND DEPLOYMENT_ID = $3 ORDER BY NAME LIMIT $1 OFFSET $2`,
-	}
-
 	// queryCreateOrganizationUnit is the query to create a new organization unit.
 	queryCreateOrganizationUnit = dbmodel.DBQuery{
 		ID: "OUQ-OU_MGT-03",
@@ -95,19 +229,6 @@ var (
 	queryDeleteOrganizationUnit = dbmodel.DBQuery{
 		ID:    "OUQ-OU_MGT-09",
 		Query: `DELETE FROM "ORGANIZATION_UNIT" WHERE OU_ID = $1 AND DEPLOYMENT_ID = $2`,
-	}
-
-	// queryGetOrganizationUnitChildrenCount is the query to get total count of child organization units.
-	queryGetOrganizationUnitChildrenCount = dbmodel.DBQuery{
-		ID:    "OUQ-OU_MGT-10",
-		Query: `SELECT COUNT(*) as total FROM "ORGANIZATION_UNIT" WHERE PARENT_ID = $1 AND DEPLOYMENT_ID = $2`,
-	}
-
-	// queryGetOrganizationUnitChildrenList is the query to get child organization units with pagination.
-	queryGetOrganizationUnitChildrenList = dbmodel.DBQuery{
-		ID: "OUQ-OU_MGT-11",
-		Query: `SELECT OU_ID, HANDLE, NAME, DESCRIPTION, METADATA, CREATED_AT, UPDATED_AT FROM "ORGANIZATION_UNIT" ` +
-			`WHERE PARENT_ID = $1 AND DEPLOYMENT_ID = $4 ORDER BY NAME LIMIT $2 OFFSET $3`,
 	}
 
 	// queryCheckOrganizationUnitNameConflict is the query to check if an organization

--- a/backend/internal/ou/store_test.go
+++ b/backend/internal/ou/store_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
 )
 
@@ -513,14 +515,43 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_CheckOrganizationUnitHa
 
 func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChildrenCount() {
 	suite.runCountQueryScenario(
-		queryGetOrganizationUnitChildrenCount,
+		mock.Anything,
 		"root",
 		testDeploymentID,
 		5,
 		func() (int, error) {
-			return suite.store.GetOrganizationUnitChildrenCount(context.Background(), "root")
+			return suite.store.GetOrganizationUnitChildrenCount(context.Background(), "root", nil)
 		},
 	)
+
+	suite.Run("build count query error", func() {
+		suite.SetupTest()
+		suite.expectDBClient()
+		badFilter := &filter.FilterGroup{Clauses: []filter.FilterClause{
+			{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.Operator("co"), Value: "x"}},
+		}}
+
+		count, err := suite.store.GetOrganizationUnitChildrenCount(context.Background(), "root", badFilter)
+
+		suite.Require().Error(err)
+		suite.Zero(count)
+		suite.Contains(err.Error(), "failed to build count query")
+	})
+
+	suite.Run("missing total field", func() {
+		suite.SetupTest()
+		suite.expectDBClient()
+		suite.dbClientMock.
+			On("QueryContext", mock.Anything, mock.Anything, "root", testDeploymentID).
+			Return([]map[string]interface{}{{}}, nil).
+			Once()
+
+		count, err := suite.store.GetOrganizationUnitChildrenCount(context.Background(), "root", nil)
+
+		suite.Require().Error(err)
+		suite.Zero(count)
+		suite.Contains(err.Error(), "failed to parse count result")
+	})
 }
 
 func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChildrenList() {
@@ -543,7 +574,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 				suite.dbClientMock.
 					On(
 						"QueryContext", mock.Anything,
-						queryGetOrganizationUnitChildrenList, parent, limit, offset, testDeploymentID).
+						mock.Anything, parent, limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{
 						makeOUResultRow("child1", "child1", "Child 1", "", &parent),
 						makeOUResultRow("child2", "child2", "Child 2", "desc", &parent),
@@ -565,7 +596,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 				suite.dbClientMock.
 					On(
 						"QueryContext", mock.Anything,
-						queryGetOrganizationUnitChildrenList, parent, limit, offset, testDeploymentID).
+						mock.Anything, parent, limit, offset, testDeploymentID).
 					Return(nil, errors.New("query err")).
 					Once()
 			},
@@ -581,7 +612,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 				suite.dbClientMock.
 					On(
 						"QueryContext", mock.Anything,
-						queryGetOrganizationUnitChildrenList, parent, limit, offset, testDeploymentID).
+						mock.Anything, parent, limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{{"ou_id": 1}}, nil).
 					Once()
 			},
@@ -600,6 +631,16 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 			},
 			wantErr: "failed to get database client",
 		},
+		{
+			name:   "build list query error",
+			parent: "root",
+			limit:  1,
+			offset: 0,
+			setup: func(parent string, limit, offset int) {
+				suite.expectDBClient()
+			},
+			wantErr: "failed to build list query",
+		},
 	}
 
 	for _, tc := range tests {
@@ -608,8 +649,15 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitChil
 			suite.SetupTest()
 			tc.setup(tc.parent, tc.limit, tc.offset)
 
+			filterExpr := (*filter.FilterGroup)(nil)
+			if tc.name == "build list query error" {
+				filterExpr = &filter.FilterGroup{Clauses: []filter.FilterClause{
+					{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.Operator("co"), Value: "x"}},
+				}}
+			}
+
 			children, err := suite.store.GetOrganizationUnitChildrenList(
-				context.Background(), tc.parent, tc.limit, tc.offset,
+				context.Background(), tc.parent, tc.limit, tc.offset, filterExpr,
 			)
 
 			if tc.wantErr != "" {
@@ -1459,7 +1507,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 				suite.dbClientMock.
 					On(
 						"QueryContext", mock.Anything,
-						queryGetRootOrganizationUnitList, limit, offset, testDeploymentID).
+						mock.Anything, limit, offset, testDeploymentID).
 					Return(rows, nil).
 					Once()
 			},
@@ -1480,7 +1528,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 				suite.dbClientMock.
 					On(
 						"QueryContext", mock.Anything,
-						queryGetRootOrganizationUnitList, limit, offset, testDeploymentID).
+						mock.Anything, limit, offset, testDeploymentID).
 					Return(nil, errors.New("query error")).
 					Once()
 			},
@@ -1495,7 +1543,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 				suite.dbClientMock.
 					On(
 						"QueryContext", mock.Anything,
-						queryGetRootOrganizationUnitList, limit, offset, testDeploymentID).
+						mock.Anything, limit, offset, testDeploymentID).
 					Return([]map[string]interface{}{{"ou_id": 123}}, nil).
 					Once()
 			},
@@ -1513,6 +1561,15 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			},
 			wantErrString: "failed to get database client",
 		},
+		{
+			name:   "build list query error",
+			limit:  1,
+			offset: 0,
+			setup: func(limit, offset int) {
+				suite.expectDBClient()
+			},
+			wantErrString: "failed to build list query",
+		},
 	}
 
 	for _, tc := range tests {
@@ -1521,7 +1578,14 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			suite.SetupTest()
 			tc.setup(tc.limit, tc.offset)
 
-			ous, err := suite.store.GetOrganizationUnitList(context.Background(), tc.limit, tc.offset)
+			filterExpr := (*filter.FilterGroup)(nil)
+			if tc.name == "build list query error" {
+				filterExpr = &filter.FilterGroup{Clauses: []filter.FilterClause{
+					{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.Operator("co"), Value: "x"}},
+				}}
+			}
+
+			ous, err := suite.store.GetOrganizationUnitList(context.Background(), tc.limit, tc.offset, filterExpr)
 
 			if tc.wantErrString != "" {
 				suite.Require().Error(err)
@@ -1551,7 +1615,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 				suite.expectDBClient()
 				suite.dbClientMock.
 					On(
-						"QueryContext", mock.Anything, queryGetRootOrganizationUnitListCount, testDeploymentID).
+						"QueryContext", mock.Anything, mock.Anything, testDeploymentID).
 					Return([]map[string]interface{}{{"total": int64(3)}}, nil).
 					Once()
 			},
@@ -1563,7 +1627,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 				suite.expectDBClient()
 				suite.dbClientMock.
 					On(
-						"QueryContext", mock.Anything, queryGetRootOrganizationUnitListCount, testDeploymentID).
+						"QueryContext", mock.Anything, mock.Anything, testDeploymentID).
 					Return(nil, errors.New("boom")).
 					Once()
 			},
@@ -1575,7 +1639,7 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 				suite.expectDBClient()
 				suite.dbClientMock.
 					On(
-						"QueryContext", mock.Anything, queryGetRootOrganizationUnitListCount, testDeploymentID).
+						"QueryContext", mock.Anything, mock.Anything, testDeploymentID).
 					Return([]map[string]interface{}{{"total": "3"}}, nil).
 					Once()
 			},
@@ -1591,6 +1655,25 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			},
 			wantErr: "failed to get database client",
 		},
+		{
+			name: "build count query error",
+			setup: func() {
+				suite.expectDBClient()
+			},
+			wantErr: "failed to build count query",
+		},
+		{
+			name: "empty result",
+			setup: func() {
+				suite.expectDBClient()
+				suite.dbClientMock.
+					On(
+						"QueryContext", mock.Anything, mock.Anything, testDeploymentID).
+					Return([]map[string]interface{}{}, nil).
+					Once()
+			},
+			want: 0,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1599,7 +1682,14 @@ func (suite *OrganizationUnitStoreTestSuite) TestOUStore_GetOrganizationUnitList
 			suite.SetupTest()
 			tc.setup()
 
-			count, err := suite.store.GetOrganizationUnitListCount(context.Background())
+			filterExpr := (*filter.FilterGroup)(nil)
+			if tc.name == "build count query error" {
+				filterExpr = &filter.FilterGroup{Clauses: []filter.FilterClause{
+					{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.Operator("co"), Value: "x"}},
+				}}
+			}
+
+			count, err := suite.store.GetOrganizationUnitListCount(context.Background(), filterExpr)
 
 			if tc.wantErr != "" {
 				suite.Require().Error(err)
@@ -1981,4 +2071,292 @@ func TestBuildOrganizationUnitFromResultRow_MetadataFieldErrors(t *testing.T) {
 			require.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
+}
+
+func TestBuildOrganizationUnitFromResultRow_NonStringThemeAndLayout(t *testing.T) {
+	row := map[string]interface{}{
+		"ou_id":       "ou1",
+		"handle":      "root",
+		"name":        "Root",
+		"description": "desc",
+		"parent_id":   nil,
+		"theme_id":    123,
+		"layout_id":   true,
+		"metadata":    []byte(`{"logo_url":"https://example.com/logo.png"}`),
+		"created_at":  "2025-01-01 10:00:00",
+		"updated_at":  "2025-01-01 10:00:00",
+	}
+
+	ou, err := buildOrganizationUnitFromResultRow(row)
+
+	require.NoError(t, err)
+	require.Equal(t, "", ou.ThemeID)
+	require.Equal(t, "", ou.LayoutID)
+	require.Equal(t, "https://example.com/logo.png", ou.LogoURL)
+}
+
+func TestBuildOUFilterGroup(t *testing.T) {
+	sg := func(attr string, op filter.Operator, val interface{}) *filter.FilterGroup {
+		return &filter.FilterGroup{Clauses: []filter.FilterClause{
+			{Expr: filter.FilterExpression{Attribute: attr, Operator: op, Value: val}},
+		}}
+	}
+	twoClause := func(
+		attr1 string, op1 filter.Operator, val1 interface{},
+		conn filter.LogicalOperator,
+		attr2 string, op2 filter.Operator, val2 interface{},
+	) *filter.FilterGroup {
+		return &filter.FilterGroup{Clauses: []filter.FilterClause{
+			{Expr: filter.FilterExpression{Attribute: attr1, Operator: op1, Value: val1}},
+			{Connector: conn, Expr: filter.FilterExpression{Attribute: attr2, Operator: op2, Value: val2}},
+		}}
+	}
+
+	tests := []struct {
+		name      string
+		g         *filter.FilterGroup
+		startIdx  int
+		wantCond  string
+		wantArgs  []interface{}
+		wantError string
+	}{
+		{
+			name:     "eq on text column uses LOWER",
+			g:        sg("name", filter.OperatorEq, "Finance"),
+			startIdx: 2,
+			wantCond: " AND LOWER(NAME) = LOWER($2)",
+			wantArgs: []interface{}{"Finance"},
+		},
+		{
+			name:     "eq on timestamp column uses plain equals",
+			g:        sg("createdAt", filter.OperatorEq, "2025-01-01"),
+			startIdx: 3,
+			wantCond: " AND CREATED_AT = $3",
+			wantArgs: []interface{}{"2025-01-01"},
+		},
+		{
+			name:     "gt operator",
+			g:        sg("createdAt", filter.OperatorGt, "2025-01-01"),
+			startIdx: 4,
+			wantCond: " AND CREATED_AT > $4",
+			wantArgs: []interface{}{"2025-01-01"},
+		},
+		{
+			name:     "lt operator",
+			g:        sg("updatedAt", filter.OperatorLt, "2026-01-01"),
+			startIdx: 5,
+			wantCond: " AND UPDATED_AT < $5",
+			wantArgs: []interface{}{"2026-01-01"},
+		},
+		{
+			name: "two AND clauses wrapped in parens",
+			g: twoClause(
+				"name", filter.OperatorEq, "Eng", filter.LogicalAnd, "createdAt", filter.OperatorGt, "2024"),
+			startIdx: 2,
+			wantCond: " AND (LOWER(NAME) = LOWER($2) AND CREATED_AT > $3)",
+			wantArgs: []interface{}{"Eng", "2024"},
+		},
+		{
+			name:     "two OR clauses wrapped in parens",
+			g:        twoClause("name", filter.OperatorEq, "A", filter.LogicalOr, "handle", filter.OperatorEq, "a"),
+			startIdx: 2,
+			wantCond: " AND (LOWER(NAME) = LOWER($2) OR LOWER(HANDLE) = LOWER($3))",
+			wantArgs: []interface{}{"A", "a"},
+		},
+		{
+			name:      "non filterable attribute",
+			g:         sg("id", filter.OperatorEq, "ou1"),
+			startIdx:  2,
+			wantError: `attribute "id" is not filterable`,
+		},
+		{
+			name:      "unsupported operator",
+			g:         sg("name", filter.Operator("co"), "Finance"),
+			startIdx:  2,
+			wantError: `unsupported operator "co"`,
+		},
+		{
+			name:     "nil group returns empty cond and nil args",
+			g:        nil,
+			startIdx: 2,
+			wantCond: "",
+			wantArgs: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cond, args, err := buildOUFilterGroup(tc.g, tc.startIdx)
+
+			if tc.wantError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantCond, cond)
+			require.Equal(t, tc.wantArgs, args)
+		})
+	}
+}
+
+func TestBuildOUCountQueries(t *testing.T) {
+	type countQueryCase struct {
+		name           string
+		buildFn        func(*filter.FilterGroup) (dbmodel.DBQuery, []interface{}, error)
+		queryID        string
+		noFilterClause string
+		withFilter     *filter.FilterGroup
+		wantClause     string
+		wantArgs       []interface{}
+	}
+
+	cases := []countQueryCase{
+		{
+			name:           "root OU count",
+			buildFn:        buildRootOUCountQuery,
+			queryID:        "OUQ-OU_MGT-01",
+			noFilterClause: "PARENT_ID IS NULL AND DEPLOYMENT_ID = $1",
+			withFilter: &filter.FilterGroup{Clauses: []filter.FilterClause{
+				{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.OperatorEq, Value: "Finance"}},
+			}},
+			wantClause: "LOWER(NAME) = LOWER($2)",
+			wantArgs:   []interface{}{"Finance"},
+		},
+		{
+			name:           "children OU count",
+			buildFn:        buildChildrenOUCountQuery,
+			queryID:        "OUQ-OU_MGT-10",
+			noFilterClause: "PARENT_ID = $1 AND DEPLOYMENT_ID = $2",
+			withFilter: &filter.FilterGroup{Clauses: []filter.FilterClause{
+				{Expr: filter.FilterExpression{Attribute: "description", Operator: filter.OperatorEq, Value: "desc"}},
+			}},
+			wantClause: "LOWER(DESCRIPTION) = LOWER($3)",
+			wantArgs:   []interface{}{"desc"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/without filter", func(t *testing.T) {
+			q, args, err := tc.buildFn(nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.queryID, q.ID)
+			require.Contains(t, q.Query, tc.noFilterClause)
+			require.Empty(t, args)
+		})
+		t.Run(tc.name+"/with filter", func(t *testing.T) {
+			q, args, err := tc.buildFn(tc.withFilter)
+			require.NoError(t, err)
+			require.Contains(t, q.Query, tc.wantClause)
+			require.Equal(t, tc.wantArgs, args)
+		})
+		t.Run(tc.name+"/filter error", func(t *testing.T) {
+			badF := &filter.FilterGroup{Clauses: []filter.FilterClause{
+				{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.Operator("co"), Value: "x"}},
+			}}
+			_, _, err := tc.buildFn(badF)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "unsupported operator")
+		})
+	}
+}
+
+func TestBuildRootOUListQuery(t *testing.T) {
+	t.Run("without filter", func(t *testing.T) {
+		q, args, err := buildRootOUListQuery(nil)
+
+		require.NoError(t, err)
+		require.Equal(t, "OUQ-OU_MGT-02", q.ID)
+		require.Contains(t, q.Query, "PARENT_ID IS NULL AND DEPLOYMENT_ID = $3")
+		require.Contains(t, q.Query, "ORDER BY NAME LIMIT $1 OFFSET $2")
+		require.Empty(t, args)
+	})
+
+	t.Run("with filter", func(t *testing.T) {
+		f := &filter.FilterGroup{Clauses: []filter.FilterClause{
+			{Expr: filter.FilterExpression{Attribute: "handle", Operator: filter.OperatorEq, Value: "root"}},
+		}}
+		q, args, err := buildRootOUListQuery(f)
+
+		require.NoError(t, err)
+		require.Contains(t, q.Query, "LOWER(HANDLE) = LOWER($4)")
+		require.Equal(t, []interface{}{"root"}, args)
+	})
+
+	t.Run("filter error", func(t *testing.T) {
+		f := &filter.FilterGroup{Clauses: []filter.FilterClause{
+			{Expr: filter.FilterExpression{Attribute: "invalid", Operator: filter.OperatorEq, Value: "x"}},
+		}}
+		_, _, err := buildRootOUListQuery(f)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is not filterable")
+	})
+}
+
+func TestBuildChildrenOUCountQuery(t *testing.T) {
+	t.Run("without filter", func(t *testing.T) {
+		q, args, err := buildChildrenOUCountQuery(nil)
+
+		require.NoError(t, err)
+		require.Equal(t, "OUQ-OU_MGT-10", q.ID)
+		require.Contains(t, q.Query, "PARENT_ID = $1 AND DEPLOYMENT_ID = $2")
+		require.Empty(t, args)
+	})
+
+	t.Run("with filter", func(t *testing.T) {
+		f := &filter.FilterGroup{Clauses: []filter.FilterClause{
+			{Expr: filter.FilterExpression{Attribute: "description", Operator: filter.OperatorEq, Value: "desc"}},
+		}}
+		q, args, err := buildChildrenOUCountQuery(f)
+
+		require.NoError(t, err)
+		require.Contains(t, q.Query, "LOWER(DESCRIPTION) = LOWER($3)")
+		require.Equal(t, []interface{}{"desc"}, args)
+	})
+
+	t.Run("filter error", func(t *testing.T) {
+		f := &filter.FilterGroup{Clauses: []filter.FilterClause{
+			{Expr: filter.FilterExpression{Attribute: "name", Operator: filter.Operator("co"), Value: "Finance"}},
+		}}
+		_, _, err := buildChildrenOUCountQuery(f)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported operator")
+	})
+}
+
+func TestBuildChildrenOUListQuery(t *testing.T) {
+	t.Run("without filter", func(t *testing.T) {
+		q, args, err := buildChildrenOUListQuery(nil)
+
+		require.NoError(t, err)
+		require.Equal(t, "OUQ-OU_MGT-11", q.ID)
+		require.Contains(t, q.Query, "PARENT_ID = $1 AND DEPLOYMENT_ID = $4")
+		require.Contains(t, q.Query, "ORDER BY NAME LIMIT $2 OFFSET $3")
+		require.Empty(t, args)
+	})
+
+	t.Run("with filter", func(t *testing.T) {
+		f := &filter.FilterGroup{Clauses: []filter.FilterClause{
+			{Expr: filter.FilterExpression{Attribute: "createdAt", Operator: filter.OperatorGt, Value: "2025-01-01"}},
+		}}
+		q, args, err := buildChildrenOUListQuery(f)
+
+		require.NoError(t, err)
+		require.Contains(t, q.Query, "AND CREATED_AT > $5")
+		require.Equal(t, []interface{}{"2025-01-01"}, args)
+	})
+
+	t.Run("filter error", func(t *testing.T) {
+		f := &filter.FilterGroup{Clauses: []filter.FilterClause{
+			{Expr: filter.FilterExpression{Attribute: "updatedAt", Operator: filter.Operator("co"), Value: "x"}},
+		}}
+		_, _, err := buildChildrenOUListQuery(f)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported operator")
+	})
 }

--- a/backend/internal/system/filter/model.go
+++ b/backend/internal/system/filter/model.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package filter provides common types and parsing utilities for API filter expressions.
+package filter
+
+// Operator represents a comparison operator in a filter expression.
+type Operator string
+
+const (
+	// OperatorEq represents the equality operator.
+	OperatorEq Operator = "eq"
+	// OperatorGt represents the greater-than operator.
+	OperatorGt Operator = "gt"
+	// OperatorLt represents the less-than operator.
+	OperatorLt Operator = "lt"
+)
+
+// FilterExpression holds a parsed filter expression from an API request.
+// Value is typed as string, int64, float64, or bool depending on the literal.
+type FilterExpression struct {
+	Attribute string
+	Operator  Operator
+	Value     interface{}
+}
+
+// LogicalOperator is the connector between consecutive filter clauses.
+type LogicalOperator string
+
+const (
+	// LogicalAnd requires both the preceding and the current clause to be true.
+	LogicalAnd LogicalOperator = "AND"
+	// LogicalOr requires either the preceding or the current clause to be true.
+	LogicalOr LogicalOperator = "OR"
+)
+
+// FilterClause pairs a logical connector with a single FilterExpression.
+// The Connector field on the first clause in a FilterGroup is always ignored.
+type FilterClause struct {
+	Connector LogicalOperator
+	Expr      FilterExpression
+}
+
+// FilterGroup holds one or more clauses evaluated with their logical connectors.
+// AND has higher precedence than OR, matching standard SQL behavior.
+type FilterGroup struct {
+	Clauses []FilterClause
+}

--- a/backend/internal/system/filter/parser.go
+++ b/backend/internal/system/filter/parser.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package filter
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// filterPattern matches a complete single expression (with end anchor) for validation.
+var filterPattern = regexp.MustCompile(`^(\w+(?:\.\w+)*)\s+(eq|gt|lt)\s+(?:"([^"]*)"|(\S+))$`)
+
+// singleExprPrefix matches one expression from the start of the string without an end anchor,
+// used during iterative multi-expression parsing.
+var singleExprPrefix = regexp.MustCompile(`^(\w+(?:\.\w+)*)\s+(eq|gt|lt)\s+(?:"([^"]*)"|(\S+))`)
+
+// connectorPrefix matches a leading AND or OR connector (case-insensitive) surrounded by whitespace.
+var connectorPrefix = regexp.MustCompile(`(?i)^\s+(AND|OR)\s+`)
+
+// ParseFilterParam reads the "filter" query parameter and parses it into a FilterGroup.
+// Returns nil when no filter parameter is present.
+func ParseFilterParam(query url.Values) (*FilterGroup, error) {
+	if !query.Has("filter") {
+		return nil, nil
+	}
+
+	filterStr := strings.TrimSpace(query.Get("filter"))
+	if filterStr == "" {
+		return nil, fmt.Errorf("filter parameter is empty")
+	}
+
+	return ParseFilterGroup(filterStr)
+}
+
+// ParseFilterGroup parses a filter string that may contain multiple expressions joined by AND or OR.
+// AND has higher precedence than OR, matching standard SQL behavior.
+// Examples:
+//
+//	name eq "Engineering"
+//	name eq "Engineering" AND createdAt gt "2024-01-01T00:00:00Z"
+//	name eq "A" OR name eq "B"
+func ParseFilterGroup(filterStr string) (*FilterGroup, error) {
+	remaining := filterStr
+	connector := LogicalOperator("")
+	var clauses []FilterClause
+
+	for remaining != "" {
+		loc := singleExprPrefix.FindStringIndex(remaining)
+		if len(loc) == 0 || loc[0] != 0 {
+			return nil, fmt.Errorf("invalid filter format near: %q", remaining)
+		}
+
+		expr, err := parseExpressionFromMatches(singleExprPrefix.FindStringSubmatch(remaining))
+		if err != nil {
+			return nil, err
+		}
+		clauses = append(clauses, FilterClause{Connector: connector, Expr: *expr})
+		remaining = remaining[loc[1]:]
+
+		if remaining == "" {
+			break
+		}
+
+		m := connectorPrefix.FindStringSubmatch(remaining)
+		if m == nil {
+			return nil, fmt.Errorf("expected AND or OR after expression, got: %q", remaining)
+		}
+		connector = LogicalOperator(strings.ToUpper(m[1]))
+		remaining = remaining[len(m[0]):]
+	}
+
+	if len(clauses) == 0 {
+		return nil, fmt.Errorf("no filter expressions found")
+	}
+
+	return &FilterGroup{Clauses: clauses}, nil
+}
+
+// ParseFilterExpression parses a single filter expression string of the form:
+//
+//	attribute (eq|gt|lt) "value"
+//	attribute (eq|gt|lt) value
+func ParseFilterExpression(filterStr string) (*FilterExpression, error) {
+	matches := filterPattern.FindStringSubmatch(filterStr)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("invalid filter format: %q", filterStr)
+	}
+	return parseExpressionFromMatches(matches)
+}
+
+// parseExpressionFromMatches extracts a FilterExpression from a regex match slice.
+// Slot layout: [full, attribute, operator, quotedValue, unquotedValue].
+func parseExpressionFromMatches(matches []string) (*FilterExpression, error) {
+	if len(matches) < 5 {
+		return nil, fmt.Errorf("invalid filter format")
+	}
+
+	attribute := matches[1]
+	op := Operator(matches[2])
+
+	var value interface{}
+	if matches[3] != "" {
+		value = matches[3]
+	} else {
+		raw := matches[4]
+		if intVal, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			value = intVal
+		} else if floatVal, err := strconv.ParseFloat(raw, 64); err == nil {
+			value = floatVal
+		} else if boolVal, err := strconv.ParseBool(raw); err == nil {
+			value = boolVal
+		} else {
+			return nil, fmt.Errorf("invalid filter value: %q", raw)
+		}
+	}
+
+	return &FilterExpression{
+		Attribute: attribute,
+		Operator:  op,
+		Value:     value,
+	}, nil
+}

--- a/backend/internal/system/filter/parser_test.go
+++ b/backend/internal/system/filter/parser_test.go
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package filter
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFilterExpression(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantAttr  string
+		wantOp    Operator
+		wantValue interface{}
+		wantErr   bool
+	}{
+		{
+			name:      "eq with quoted string",
+			input:     `name eq "engineering"`,
+			wantAttr:  "name",
+			wantOp:    OperatorEq,
+			wantValue: "engineering",
+		},
+		{
+			name:      "gt with quoted timestamp",
+			input:     `createdAt gt "2024-01-01T00:00:00Z"`,
+			wantAttr:  "createdAt",
+			wantOp:    OperatorGt,
+			wantValue: "2024-01-01T00:00:00Z",
+		},
+		{
+			name:      "lt with quoted timestamp",
+			input:     `updatedAt lt "2025-12-31T23:59:59Z"`,
+			wantAttr:  "updatedAt",
+			wantOp:    OperatorLt,
+			wantValue: "2025-12-31T23:59:59Z",
+		},
+		{
+			name:      "eq with unquoted integer",
+			input:     `count eq 42`,
+			wantAttr:  "count",
+			wantOp:    OperatorEq,
+			wantValue: int64(42),
+		},
+		{
+			name:      "gt with unquoted integer",
+			input:     `size gt 100`,
+			wantAttr:  "size",
+			wantOp:    OperatorGt,
+			wantValue: int64(100),
+		},
+		{
+			name:      "lt with unquoted float",
+			input:     `score lt 3.14`,
+			wantAttr:  "score",
+			wantOp:    OperatorLt,
+			wantValue: float64(3.14),
+		},
+		{
+			name:      "eq with boolean true",
+			input:     `active eq true`,
+			wantAttr:  "active",
+			wantOp:    OperatorEq,
+			wantValue: true,
+		},
+		{
+			name:      "eq with boolean false",
+			input:     `enabled eq false`,
+			wantAttr:  "enabled",
+			wantOp:    OperatorEq,
+			wantValue: false,
+		},
+		{
+			name:      "nested attribute with dot notation",
+			input:     `address.city eq "Colombo"`,
+			wantAttr:  "address.city",
+			wantOp:    OperatorEq,
+			wantValue: "Colombo",
+		},
+		{
+			name:    "unsupported operator",
+			input:   `name gte "foo"`,
+			wantErr: true,
+		},
+		{
+			name:    "missing value",
+			input:   `name eq`,
+			wantErr: true,
+		},
+		{
+			name:    "empty input",
+			input:   ``,
+			wantErr: true,
+		},
+		{
+			name:    "invalid format",
+			input:   `not-valid`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid unquoted token value",
+			input:   `name eq foo`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseFilterExpression(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantAttr, got.Attribute)
+			assert.Equal(t, tc.wantOp, got.Operator)
+			assert.Equal(t, tc.wantValue, got.Value)
+		})
+	}
+}
+
+func TestParseFilterGroup(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantClauses int
+		wantFirst   FilterExpression
+		wantSecond  *FilterExpression
+		wantConn    LogicalOperator
+		wantErr     bool
+	}{
+		{
+			name:        "single expression",
+			input:       `name eq "Engineering"`,
+			wantClauses: 1,
+			wantFirst:   FilterExpression{Attribute: "name", Operator: OperatorEq, Value: "Engineering"},
+		},
+		{
+			name:        "two clauses with AND",
+			input:       `name eq "Engineering" AND handle eq "eng"`,
+			wantClauses: 2,
+			wantFirst:   FilterExpression{Attribute: "name", Operator: OperatorEq, Value: "Engineering"},
+			wantSecond:  &FilterExpression{Attribute: "handle", Operator: OperatorEq, Value: "eng"},
+			wantConn:    LogicalAnd,
+		},
+		{
+			name:        "two clauses with OR",
+			input:       `name eq "A" OR name eq "B"`,
+			wantClauses: 2,
+			wantFirst:   FilterExpression{Attribute: "name", Operator: OperatorEq, Value: "A"},
+			wantSecond:  &FilterExpression{Attribute: "name", Operator: OperatorEq, Value: "B"},
+			wantConn:    LogicalOr,
+		},
+		{
+			name:        "three clauses mixed AND OR",
+			input:       `name eq "A" AND createdAt gt "2024" OR handle eq "b"`,
+			wantClauses: 3,
+			wantFirst:   FilterExpression{Attribute: "name", Operator: OperatorEq, Value: "A"},
+		},
+		{
+			name:        "gt with timestamp",
+			input:       `createdAt gt "2024-01-01T00:00:00Z"`,
+			wantClauses: 1,
+			wantFirst:   FilterExpression{Attribute: "createdAt", Operator: OperatorGt, Value: "2024-01-01T00:00:00Z"},
+		},
+		{
+			name:    "invalid connector",
+			input:   `name eq "A" XOR name eq "B"`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed second expression",
+			input:   `name eq "A" AND bad`,
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   ``,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseFilterGroup(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Len(t, got.Clauses, tc.wantClauses)
+			assert.Equal(t, tc.wantFirst.Attribute, got.Clauses[0].Expr.Attribute)
+			assert.Equal(t, tc.wantFirst.Operator, got.Clauses[0].Expr.Operator)
+			assert.Equal(t, tc.wantFirst.Value, got.Clauses[0].Expr.Value)
+			assert.Equal(t, LogicalOperator(""), got.Clauses[0].Connector)
+
+			if tc.wantSecond != nil {
+				assert.Equal(t, tc.wantSecond.Attribute, got.Clauses[1].Expr.Attribute)
+				assert.Equal(t, tc.wantSecond.Operator, got.Clauses[1].Expr.Operator)
+				assert.Equal(t, tc.wantSecond.Value, got.Clauses[1].Expr.Value)
+				assert.Equal(t, tc.wantConn, got.Clauses[1].Connector)
+			}
+		})
+	}
+}
+
+func TestParseFilterParam(t *testing.T) {
+	t.Run("no filter parameter returns nil", func(t *testing.T) {
+		q := url.Values{}
+		got, err := ParseFilterParam(q)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("valid filter parameter is parsed", func(t *testing.T) {
+		q := url.Values{"filter": []string{`name eq "eng"`}}
+		got, err := ParseFilterParam(q)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Len(t, got.Clauses, 1)
+		assert.Equal(t, "name", got.Clauses[0].Expr.Attribute)
+		assert.Equal(t, OperatorEq, got.Clauses[0].Expr.Operator)
+		assert.Equal(t, "eng", got.Clauses[0].Expr.Value)
+	})
+
+	t.Run("empty filter string returns error", func(t *testing.T) {
+		q := url.Values{"filter": []string{"   "}}
+		_, err := ParseFilterParam(q)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid filter expression returns error", func(t *testing.T) {
+		q := url.Values{"filter": []string{"bad filter"}}
+		_, err := ParseFilterParam(q)
+		assert.Error(t, err)
+	})
+}

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -727,6 +727,8 @@ var defaultMessages = map[string]string{
 	"error.ouservice.cannot_modify_declarative_resource_description": "The organization unit is declarative and cannot be modified or deleted",
 	"error.ouservice.circular_dependency_detected": "Circular dependency detected",
 	"error.ouservice.circular_dependency_detected_description": "Setting this parent would create a circular dependency",
+	"error.ouservice.invalid_filter": "Invalid filter parameter",
+	"error.ouservice.invalid_filter_description": "The filter parameter is invalid. Use format: attribute (eq|gt|lt) \"value\"",
 	"error.ouservice.invalid_handle_path": "Invalid handle path",
 	"error.ouservice.invalid_handle_path_description": "The specified handle path does not exist",
 	"error.ouservice.invalid_limit_parameter": "Invalid limit parameter",

--- a/backend/tests/mocks/oumock/ConfigurableOUService_mock.go
+++ b/backend/tests/mocks/oumock/ConfigurableOUService_mock.go
@@ -10,6 +10,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 )
 
 // NewConfigurableOUServiceMock creates a new instance of ConfigurableOUServiceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -362,8 +363,8 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitByPath_Call) RunAndReturn
 }
 
 // GetOrganizationUnitChildren provides a mock function for the type ConfigurableOUServiceMock
-func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildren(ctx context.Context, id string, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, id, limit, offset)
+func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildren(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildren")
@@ -371,18 +372,18 @@ func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildren(ctx context.
 
 	var r0 *ou.OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *ou.OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) *ou.OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ou.OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -401,11 +402,12 @@ type ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call struct {
 //   - id string
 //   - limit int
 //   - offset int
-func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitChildren(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
-	return &ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call{Call: _e.mock.On("GetOrganizationUnitChildren", ctx, id, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitChildren(ctx interface{}, id interface{}, limit interface{}, offset interface{}, f interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
+	return &ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call{Call: _e.mock.On("GetOrganizationUnitChildren", ctx, id, limit, offset, f)}
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) Run(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup)) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -423,11 +425,16 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) Run(run fu
 		if args[3] != nil {
 			arg3 = args[3].(int)
 		}
+		var arg4 *filter.FilterGroup
+		if args[4] != nil {
+			arg4 = args[4].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -438,14 +445,14 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) Return(org
 	return _c
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitChildren_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitChildrenByPath provides a mock function for the type ConfigurableOUServiceMock
-func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildrenByPath(ctx context.Context, handlePath string, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, handlePath, limit, offset)
+func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildrenByPath(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, handlePath, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenByPath")
@@ -453,18 +460,18 @@ func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitChildrenByPath(ctx co
 
 	var r0 *ou.OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, handlePath, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *ou.OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) *ou.OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, handlePath, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ou.OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, handlePath, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -483,11 +490,12 @@ type ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call struct {
 //   - handlePath string
 //   - limit int
 //   - offset int
-func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitChildrenByPath(ctx interface{}, handlePath interface{}, limit interface{}, offset interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
-	return &ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call{Call: _e.mock.On("GetOrganizationUnitChildrenByPath", ctx, handlePath, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitChildrenByPath(ctx interface{}, handlePath interface{}, limit interface{}, offset interface{}, f interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
+	return &ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call{Call: _e.mock.On("GetOrganizationUnitChildrenByPath", ctx, handlePath, limit, offset, f)}
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) Run(run func(ctx context.Context, handlePath string, limit int, offset int)) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) Run(run func(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup)) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -505,11 +513,16 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) Run(
 		if args[3] != nil {
 			arg3 = args[3].(int)
 		}
+		var arg4 *filter.FilterGroup
+		if args[4] != nil {
+			arg4 = args[4].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -520,7 +533,7 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) Retu
 	return _c
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitChildrenByPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -760,8 +773,8 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitHandlesByIDs_Call) RunAnd
 }
 
 // GetOrganizationUnitList provides a mock function for the type ConfigurableOUServiceMock
-func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, limit, offset)
+func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitList")
@@ -769,18 +782,18 @@ func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitList(ctx context.Cont
 
 	var r0 *ou.OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) *ou.OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) *ou.OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ou.OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -798,11 +811,12 @@ type ConfigurableOUServiceMock_GetOrganizationUnitList_Call struct {
 //   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
-	return &ConfigurableOUServiceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}, f interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
+	return &ConfigurableOUServiceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset, f)}
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int)) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup)) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -816,10 +830,15 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) Run(run func(c
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 *filter.FilterGroup
+		if args[3] != nil {
+			arg3 = args[3].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -830,7 +849,7 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) Return(organiz
 	return _c
 }
 
-func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitList_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/oumock/OrganizationUnitServiceInterface_mock.go
+++ b/backend/tests/mocks/oumock/OrganizationUnitServiceInterface_mock.go
@@ -10,6 +10,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 )
 
 // NewOrganizationUnitServiceInterfaceMock creates a new instance of OrganizationUnitServiceInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -362,8 +363,8 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitByPath_Call) R
 }
 
 // GetOrganizationUnitChildren provides a mock function for the type OrganizationUnitServiceInterfaceMock
-func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildren(ctx context.Context, id string, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, id, limit, offset)
+func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildren(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildren")
@@ -371,18 +372,18 @@ func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildren(c
 
 	var r0 *ou.OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *ou.OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) *ou.OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ou.OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -401,11 +402,12 @@ type OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call struc
 //   - id string
 //   - limit int
 //   - offset int
-func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitChildren(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
-	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call{Call: _e.mock.On("GetOrganizationUnitChildren", ctx, id, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitChildren(ctx interface{}, id interface{}, limit interface{}, offset interface{}, f interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
+	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call{Call: _e.mock.On("GetOrganizationUnitChildren", ctx, id, limit, offset, f)}
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call) Run(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -423,11 +425,16 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call)
 		if args[3] != nil {
 			arg3 = args[3].(int)
 		}
+		var arg4 *filter.FilterGroup
+		if args[4] != nil {
+			arg4 = args[4].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -438,14 +445,14 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call)
 	return _c
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildren_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitChildrenByPath provides a mock function for the type OrganizationUnitServiceInterfaceMock
-func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildrenByPath(ctx context.Context, handlePath string, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, handlePath, limit, offset)
+func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildrenByPath(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, handlePath, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenByPath")
@@ -453,18 +460,18 @@ func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitChildrenBy
 
 	var r0 *ou.OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, handlePath, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) *ou.OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) *ou.OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, handlePath, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ou.OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, handlePath, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, handlePath, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -483,11 +490,12 @@ type OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call
 //   - handlePath string
 //   - limit int
 //   - offset int
-func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitChildrenByPath(ctx interface{}, handlePath interface{}, limit interface{}, offset interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
-	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call{Call: _e.mock.On("GetOrganizationUnitChildrenByPath", ctx, handlePath, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitChildrenByPath(ctx interface{}, handlePath interface{}, limit interface{}, offset interface{}, f interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
+	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call{Call: _e.mock.On("GetOrganizationUnitChildrenByPath", ctx, handlePath, limit, offset, f)}
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call) Run(run func(ctx context.Context, handlePath string, limit int, offset int)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call) Run(run func(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -505,11 +513,16 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath
 		if args[3] != nil {
 			arg3 = args[3].(int)
 		}
+		var arg4 *filter.FilterGroup
+		if args[4] != nil {
+			arg4 = args[4].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -520,7 +533,7 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath
 	return _c
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitChildrenByPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -760,8 +773,8 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitHandlesByIDs_C
 }
 
 // GetOrganizationUnitList provides a mock function for the type OrganizationUnitServiceInterfaceMock
-func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, limit, offset)
+func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitList")
@@ -769,18 +782,18 @@ func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitList(ctx c
 
 	var r0 *ou.OrganizationUnitListResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) *ou.OrganizationUnitListResponse); ok {
-		r0 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) *ou.OrganizationUnitListResponse); ok {
+		r0 = returnFunc(ctx, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ou.OrganizationUnitListResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int, *filter.FilterGroup) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, limit, offset, f)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -798,11 +811,12 @@ type OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call struct {
 //   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
-	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}, f interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
+	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset, f)}
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -816,10 +830,15 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) Run
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 *filter.FilterGroup
+		if args[3] != nil {
+			arg3 = args[3].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -830,7 +849,7 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) Ret
 	return _c
 }
 
-func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup) (*ou.OrganizationUnitListResponse, *serviceerror.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitList_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/oumock/organizationUnitStoreInterface_mock.go
+++ b/backend/tests/mocks/oumock/organizationUnitStoreInterface_mock.go
@@ -9,6 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/ou"
+	"github.com/thunder-id/thunderid/internal/system/filter"
 )
 
 // newOrganizationUnitStoreInterfaceMock creates a new instance of organizationUnitStoreInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -501,8 +502,8 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitByPath_Call) Run
 }
 
 // GetOrganizationUnitChildrenCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCount(ctx context.Context, id string) (int, error) {
-	ret := _mock.Called(ctx, id)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCount(ctx context.Context, id string, f *filter.FilterGroup) (int, error) {
+	ret := _mock.Called(ctx, id, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenCount")
@@ -510,16 +511,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenCoun
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int, error)); ok {
-		return returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *filter.FilterGroup) (int, error)); ok {
+		return returnFunc(ctx, id, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int); ok {
-		r0 = returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *filter.FilterGroup) int); ok {
+		r0 = returnFunc(ctx, id, f)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *filter.FilterGroup) error); ok {
+		r1 = returnFunc(ctx, id, f)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -534,11 +535,12 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call st
 // GetOrganizationUnitChildrenCount is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenCount(ctx interface{}, id interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call{Call: _e.mock.On("GetOrganizationUnitChildrenCount", ctx, id)}
+//   - f *filter.FilterGroup
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenCount(ctx interface{}, id interface{}, f interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call{Call: _e.mock.On("GetOrganizationUnitChildrenCount", ctx, id, f)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) Run(run func(ctx context.Context, id string)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) Run(run func(ctx context.Context, id string, f *filter.FilterGroup)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -548,9 +550,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Ca
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 *filter.FilterGroup
+		if args[2] != nil {
+			arg2 = args[2].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -561,14 +568,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Ca
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) RunAndReturn(run func(ctx context.Context, id string) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call) RunAndReturn(run func(ctx context.Context, id string, f *filter.FilterGroup) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenCount_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitChildrenList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList(ctx context.Context, id string, limit int, offset int) ([]ou.OrganizationUnitBasic, error) {
-	ret := _mock.Called(ctx, id, limit, offset)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) ([]ou.OrganizationUnitBasic, error) {
+	ret := _mock.Called(ctx, id, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitChildrenList")
@@ -576,18 +583,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitChildrenList
 
 	var r0 []ou.OrganizationUnitBasic
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]ou.OrganizationUnitBasic, error)); ok {
-		return returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) ([]ou.OrganizationUnitBasic, error)); ok {
+		return returnFunc(ctx, id, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []ou.OrganizationUnitBasic); ok {
-		r0 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int, *filter.FilterGroup) []ou.OrganizationUnitBasic); ok {
+		r0 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ou.OrganizationUnitBasic)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) error); ok {
-		r1 = returnFunc(ctx, id, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int, *filter.FilterGroup) error); ok {
+		r1 = returnFunc(ctx, id, limit, offset, f)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -604,11 +611,12 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call str
 //   - id string
 //   - limit int
 //   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenList(ctx interface{}, id interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call{Call: _e.mock.On("GetOrganizationUnitChildrenList", ctx, id, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitChildrenList(ctx interface{}, id interface{}, limit interface{}, offset interface{}, f interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call{Call: _e.mock.On("GetOrganizationUnitChildrenList", ctx, id, limit, offset, f)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) Run(run func(ctx context.Context, id string, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) Run(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -626,11 +634,16 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Cal
 		if args[3] != nil {
 			arg3 = args[3].(int)
 		}
+		var arg4 *filter.FilterGroup
+		if args[4] != nil {
+			arg4 = args[4].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -641,14 +654,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Cal
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int) ([]ou.OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call) RunAndReturn(run func(ctx context.Context, id string, limit int, offset int, f *filter.FilterGroup) ([]ou.OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitChildrenList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitList provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int) ([]ou.OrganizationUnitBasic, error) {
-	ret := _mock.Called(ctx, limit, offset)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int, f *filter.FilterGroup) ([]ou.OrganizationUnitBasic, error) {
+	ret := _mock.Called(ctx, limit, offset, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitList")
@@ -656,18 +669,18 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitList(ctx con
 
 	var r0 []ou.OrganizationUnitBasic
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]ou.OrganizationUnitBasic, error)); ok {
-		return returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) ([]ou.OrganizationUnitBasic, error)); ok {
+		return returnFunc(ctx, limit, offset, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []ou.OrganizationUnitBasic); ok {
-		r0 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, *filter.FilterGroup) []ou.OrganizationUnitBasic); ok {
+		r0 = returnFunc(ctx, limit, offset, f)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ou.OrganizationUnitBasic)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
-		r1 = returnFunc(ctx, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int, *filter.FilterGroup) error); ok {
+		r1 = returnFunc(ctx, limit, offset, f)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -683,11 +696,12 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call struct {
 //   - ctx context.Context
 //   - limit int
 //   - offset int
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset)}
+//   - f *filter.FilterGroup
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitList(ctx interface{}, limit interface{}, offset interface{}, f interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call{Call: _e.mock.On("GetOrganizationUnitList", ctx, limit, offset, f)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Run(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -701,10 +715,15 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Run(r
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
+		var arg3 *filter.FilterGroup
+		if args[3] != nil {
+			arg3 = args[3].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -715,14 +734,14 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) Retur
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int) ([]ou.OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int, f *filter.FilterGroup) ([]ou.OrganizationUnitBasic, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitList_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetOrganizationUnitListCount provides a mock function for the type organizationUnitStoreInterfaceMock
-func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitListCount(ctx context.Context) (int, error) {
-	ret := _mock.Called(ctx)
+func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitListCount(ctx context.Context, f *filter.FilterGroup) (int, error) {
+	ret := _mock.Called(ctx, f)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetOrganizationUnitListCount")
@@ -730,16 +749,16 @@ func (_mock *organizationUnitStoreInterfaceMock) GetOrganizationUnitListCount(ct
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) (int, error)); ok {
-		return returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *filter.FilterGroup) (int, error)); ok {
+		return returnFunc(ctx, f)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) int); ok {
-		r0 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *filter.FilterGroup) int); ok {
+		r0 = returnFunc(ctx, f)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *filter.FilterGroup) error); ok {
+		r1 = returnFunc(ctx, f)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -753,18 +772,24 @@ type organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call struct
 
 // GetOrganizationUnitListCount is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitListCount(ctx interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
-	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call{Call: _e.mock.On("GetOrganizationUnitListCount", ctx)}
+//   - f *filter.FilterGroup
+func (_e *organizationUnitStoreInterfaceMock_Expecter) GetOrganizationUnitListCount(ctx interface{}, f interface{}) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+	return &organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call{Call: _e.mock.On("GetOrganizationUnitListCount", ctx, f)}
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Run(run func(ctx context.Context)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) Run(run func(ctx context.Context, f *filter.FilterGroup)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
+		var arg1 *filter.FilterGroup
+		if args[1] != nil {
+			arg1 = args[1].(*filter.FilterGroup)
+		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -775,7 +800,7 @@ func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) 
 	return _c
 }
 
-func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
+func (_c *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call) RunAndReturn(run func(ctx context.Context, f *filter.FilterGroup) (int, error)) *organizationUnitStoreInterfaceMock_GetOrganizationUnitListCount_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/content/guides/guides/organization-units.mdx
+++ b/docs/content/guides/guides/organization-units.mdx
@@ -116,6 +116,94 @@ When using the Organization Unit APIs, each OU response also includes system met
 - **createdAt** - UTC timestamp when the OU was created.
 - **updatedAt** - UTC timestamp when the OU was last updated.
 
+## List and Filter Organization Units
+
+The Organization Unit API returns paginated results on all list endpoints. Append a `filter` query parameter to narrow results.
+
+### Supported Endpoints
+
+Filtering applies to the following endpoints:
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /organization-units` | List all root-level organization units |
+| `GET /organization-units/{id}/ous` | List child organization units by parent ID |
+| `GET /organization-units/tree/{path}/ous` | List child organization units by hierarchical path |
+
+### Filter Expression Syntax
+
+A filter expression can contain one or more conditions joined by `AND` or `OR`:
+
+```
+attribute operator "value" [AND|OR attribute operator "value" ...]
+```
+
+- **attribute** — the OU field to filter on.
+- **operator** — the comparison operator (`eq`, `gt`, or `lt`).
+- **value** — the value to compare against. Enclose string values in double quotes.
+- **AND / OR** — logical connectors between conditions. `AND` has higher precedence than `OR`, matching standard SQL behaviour.
+
+### Supported Operators
+
+| Operator | Meaning |
+|----------|---------|
+| `eq` | Equals (case-insensitive for text attributes) |
+| `gt` | Greater than |
+| `lt` | Less than |
+
+### Filterable Attributes
+
+| Attribute | Type | Notes |
+|-----------|------|-------|
+| `name` | text | Case-insensitive equality |
+| `handle` | text | Case-insensitive equality |
+| `description` | text | Case-insensitive equality |
+| `createdAt` | timestamp | Compared lexicographically; use ISO 8601 format |
+| `updatedAt` | timestamp | Compared lexicographically; use ISO 8601 format |
+
+### Filter Examples
+
+**Filter by exact name:**
+
+```bash
+curl -kL "https://localhost:8090/organization-units?filter=name%20eq%20%22Engineering%22" \
+  -H 'Authorization: Bearer <access-token>'
+```
+
+**Filter with AND — both conditions must match:**
+
+```bash
+curl -kL "https://localhost:8090/organization-units?filter=name%20eq%20%22Engineering%22%20AND%20handle%20eq%20%22engineering%22" \
+  -H 'Authorization: Bearer <access-token>'
+```
+
+**Filter with OR — either condition may match:**
+
+```bash
+curl -kL "https://localhost:8090/organization-units?filter=name%20eq%20%22Engineering%22%20OR%20name%20eq%20%22Sales%22" \
+  -H 'Authorization: Bearer <access-token>'
+```
+
+**Filter children by timestamp range:**
+
+```bash
+curl -kL "https://localhost:8090/organization-units/<parent-id>/ous?filter=createdAt%20gt%20%222024-01-01T00:00:00Z%22" \
+  -H 'Authorization: Bearer <access-token>'
+```
+
+**Combine filter with pagination:**
+
+```bash
+curl -kL "https://localhost:8090/organization-units?filter=name%20eq%20%22Engineering%22&limit=10&offset=0" \
+  -H 'Authorization: Bearer <access-token>'
+```
+
+### Filter Error Responses
+
+| Error Code | HTTP Status | Cause |
+|------------|-------------|-------|
+| `OU-1014` | 400 | The filter expression is malformed, uses an unsupported connector, or references an unsupported attribute |
+
 ## Delete an Organization Unit
 
 1. Open the OU from the **Organization Units** list.

--- a/docs/static/api/next/combined.yaml
+++ b/docs/static/api/next/combined.yaml
@@ -6616,6 +6616,34 @@ paths:
       parameters:
         - $ref: "#/components/parameters/limitQueryParam"
         - $ref: "#/components/parameters/offsetQueryParam"
+        - in: query
+          name: filter
+          required: false
+          description: >
+            Filter organization units by attribute values.
+
+            Supported operators: `eq`, `gt`, `lt`.
+
+            Filterable attributes: `name`, `handle`, `description`, `createdAt`, `updatedAt`.
+
+            Format: `attribute operator "value"`.
+
+            Examples:
+
+            - `name eq "Engineering"`
+
+            - `handle eq "frontend"`
+
+            - `createdAt gt "2026-01-01T00:00:00Z"`
+          schema:
+            type: string
+          examples:
+            name-filter:
+              summary: Filter by name
+              value: name eq "Engineering"
+            created-at-filter:
+              summary: Filter by creation timestamp
+              value: createdAt gt "2026-01-01T00:00:00Z"
       responses:
         "200":
           description: List of root organization units
@@ -6668,6 +6696,16 @@ paths:
                     description:
                       key: error.ouservice.invalid_offset_parameter_description
                       defaultValue: The offset parameter must be a non-negative integer
+                invalid-filter:
+                  summary: Invalid filter parameter
+                  value:
+                    code: OU-1014
+                    message:
+                      key: error.ouservice.invalid_filter
+                      defaultValue: Invalid filter parameter
+                    description:
+                      key: error.ouservice.invalid_filter_description
+                      defaultValue: 'The filter parameter is invalid. Use format: attribute (eq|gt|lt) "value"'
         "500":
           description: Internal server error
     post:
@@ -6966,6 +7004,34 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/limitQueryParam"
         - $ref: "#/components/parameters/offsetQueryParam"
+        - in: query
+          name: filter
+          required: false
+          description: >
+            Filter organization units by attribute values.
+
+            Supported operators: `eq`, `gt`, `lt`.
+
+            Filterable attributes: `name`, `handle`, `description`, `createdAt`, `updatedAt`.
+
+            Format: `attribute operator "value"`.
+
+            Examples:
+
+            - `name eq "Engineering"`
+
+            - `handle eq "frontend"`
+
+            - `createdAt gt "2026-01-01T00:00:00Z"`
+          schema:
+            type: string
+          examples:
+            name-filter:
+              summary: Filter by name
+              value: name eq "Engineering"
+            created-at-filter:
+              summary: Filter by creation timestamp
+              value: createdAt gt "2026-01-01T00:00:00Z"
       responses:
         "200":
           description: List of child organization units
@@ -7018,6 +7084,16 @@ paths:
                     description:
                       key: error.ouservice.invalid_offset_parameter_description
                       defaultValue: The offset parameter must be a non-negative integer
+                invalid-filter:
+                  summary: Invalid filter parameter
+                  value:
+                    code: OU-1014
+                    message:
+                      key: error.ouservice.invalid_filter
+                      defaultValue: Invalid filter parameter
+                    description:
+                      key: error.ouservice.invalid_filter_description
+                      defaultValue: 'The filter parameter is invalid. Use format: attribute (eq|gt|lt) "value"'
         "404":
           description: Organization unit not found
           content:
@@ -7125,7 +7201,6 @@ paths:
             format: uuid
         - $ref: "#/components/parameters/limitQueryParam"
         - $ref: "#/components/parameters/offsetQueryParam"
-        - $ref: "#/components/parameters/includeGroupQueryParam"
       responses:
         "200":
           description: List of groups in the organization unit
@@ -7638,6 +7713,34 @@ paths:
           example: engineering/frontend
         - $ref: "#/components/parameters/limitQueryParam"
         - $ref: "#/components/parameters/offsetQueryParam"
+        - in: query
+          name: filter
+          required: false
+          description: >
+            Filter organization units by attribute values.
+
+            Supported operators: `eq`, `gt`, `lt`.
+
+            Filterable attributes: `name`, `handle`, `description`, `createdAt`, `updatedAt`.
+
+            Format: `attribute operator "value"`.
+
+            Examples:
+
+            - `name eq "Engineering"`
+
+            - `handle eq "frontend"`
+
+            - `createdAt gt "2026-01-01T00:00:00Z"`
+          schema:
+            type: string
+          examples:
+            name-filter:
+              summary: Filter by name
+              value: name eq "Engineering"
+            created-at-filter:
+              summary: Filter by creation timestamp
+              value: createdAt gt "2026-01-01T00:00:00Z"
       responses:
         "200":
           description: List of child organization units
@@ -7690,6 +7793,16 @@ paths:
                     description:
                       key: error.ouservice.invalid_offset_parameter_description
                       defaultValue: The offset parameter must be a non-negative integer
+                invalid-filter:
+                  summary: Invalid filter parameter
+                  value:
+                    code: OU-1014
+                    message:
+                      key: error.ouservice.invalid_filter
+                      defaultValue: Invalid filter parameter
+                    description:
+                      key: error.ouservice.invalid_filter_description
+                      defaultValue: 'The filter parameter is invalid. Use format: attribute (eq|gt|lt) "value"'
         "404":
           description: Organization unit not found
           content:
@@ -7849,7 +7962,6 @@ paths:
           example: engineering/frontend
         - $ref: "#/components/parameters/limitQueryParam"
         - $ref: "#/components/parameters/offsetQueryParam"
-        - $ref: "#/components/parameters/includeGroupQueryParam"
       responses:
         "200":
           description: List of groups in the organization unit
@@ -17034,6 +17146,9 @@ components:
         - id
         - handle
         - name
+        - isReadOnly
+        - createdAt
+        - updatedAt
       properties:
         id:
           type: string
@@ -17048,6 +17163,20 @@ components:
           type: string
           format: uri
           description: Logo URL for the organization unit
+        isReadOnly:
+          type: boolean
+          readOnly: true
+          description: Whether the organization unit is immutable by clients.
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Creation timestamp in UTC.
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Last update timestamp in UTC.
     OrganizationUnit:
       allOf:
         - $ref: "#/components/schemas/OrganizationUnitBasic"
@@ -17056,6 +17185,26 @@ components:
           type: string
           format: uuid
           nullable: true
+        themeId:
+          type: string
+          format: uuid
+          description: Theme configuration ID for the organization unit
+        layoutId:
+          type: string
+          format: uuid
+          description: Layout configuration ID for the organization unit
+        tosUri:
+          type: string
+          format: uri
+          description: Terms of Service URI
+        policyUri:
+          type: string
+          format: uri
+          description: Privacy Policy URI
+        cookiePolicyUri:
+          type: string
+          format: uri
+          description: Cookie Policy URI
     User:
       type: object
       required:

--- a/tests/integration/flow/common/utils.go
+++ b/tests/integration/flow/common/utils.go
@@ -514,6 +514,29 @@ func WaitAndValidateNotification(mockServer interface{}, expectedCount int, time
 	return fmt.Errorf("notification validation not implemented - should be customized per mock server type")
 }
 
+// RetryWithBackoff retries an operation with exponential backoff
+// This helps handle transient failures that may occur under resource constraints
+func RetryWithBackoff(operation func() error, maxRetries int, initialDelay time.Duration) error {
+	var lastErr error
+	delay := initialDelay
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		lastErr = operation()
+		if lastErr == nil {
+			return nil
+		}
+
+		// Don't sleep after the last attempt
+		if attempt < maxRetries-1 {
+			time.Sleep(delay)
+			// Exponential backoff: double the delay for next attempt
+			delay *= 2
+		}
+	}
+
+	return fmt.Errorf("operation failed after %d attempts: %w", maxRetries, lastErr)
+}
+
 // GenerateUniqueUsername generates a unique username using the given prefix
 func GenerateUniqueUsername(prefix string) string {
 	return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())

--- a/tests/integration/flow/registration/ou_registration_test.go
+++ b/tests/integration/flow/registration/ou_registration_test.go
@@ -754,8 +754,8 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreation() {
 			ts.Require().NoError(err)
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
-			// Wait for OTP to be sent
-			time.Sleep(1 * time.Second)
+			// Wait for OTP to be sent - increased timeout for resource-constrained environments
+			time.Sleep(2 * time.Second)
 
 			lastMessage := ts.mockServer.GetLastMessage()
 			ts.Require().NotNil(lastMessage)
@@ -881,9 +881,29 @@ func (ts *OURegistrationFlowTestSuite) TestSMSRegistrationFlowWithOUCreationDupl
 			// Wait for OTP to be sent
 			time.Sleep(1 * time.Second)
 
-			flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
-				flowStep.ChallengeToken)
+			// Retry flow completion with backoff to handle resource constraints
+			// Only retry if flow doesn't complete (INCOMPLETE status expected), not on ERROR
+			err = common.RetryWithBackoff(func() error {
+				flowStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+					flowStep.ChallengeToken)
+				if err != nil {
+					return err
+				}
+				// Don't retry on ERROR status - these are permanent errors
+				if flowStep.FlowStatus == "ERROR" {
+					return nil // Stop retrying, let the test assertion handle it
+				}
+				if flowStep.FlowStatus != "INCOMPLETE" {
+					return fmt.Errorf("unexpected flow status: %s", flowStep.FlowStatus)
+				}
+				return nil
+			}, 3, 1*time.Second)
 			ts.Require().NoError(err)
+
+			// Wait for OTP to be sent - increased timeout for resource-constrained environments
+			if flowStep.FlowStatus == "INCOMPLETE" {
+				time.Sleep(2 * time.Second)
+			}
 			ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 
 			lastMessage := ts.mockServer.GetLastMessage()
@@ -926,5 +946,5 @@ func generateUniqueHandle(prefix string) string {
 
 // Helper function to generate unique mobile numbers
 func generateUniqueMobileNumber() string {
-	return fmt.Sprintf("+1234567%d", time.Now().UnixNano()%10000)
+	return fmt.Sprintf("+1%d", time.Now().UnixNano())
 }

--- a/tests/integration/flow/registration/sms_registration_test.go
+++ b/tests/integration/flow/registration/sms_registration_test.go
@@ -444,8 +444,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlow() {
 	ts.Require().NotEmpty(otpFlowStep.Data.Inputs, "Flow should require inputs")
 	ts.Require().True(common.HasInput(otpFlowStep.Data.Inputs, "otp"), "OTP input should be required")
 
-	// Wait for SMS to be sent
-	time.Sleep(1 * time.Second)
+	// Wait for SMS to be sent - increased timeout for resource-constrained environments
+	time.Sleep(2 * time.Second)
 
 	// Verify SMS was sent
 	lastMessage := ts.mockServer.GetLastMessage()
@@ -557,8 +557,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowInvalidOTP() {
 
 	ts.Require().Equal("INCOMPLETE", otpFlowStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 
-	// Wait for SMS to be sent
-	time.Sleep(1 * time.Second)
+	// Wait for SMS to be sent - increased timeout for resource-constrained environments
+	time.Sleep(2 * time.Second)
 
 	// Step 2: Try with invalid OTP
 	invalidOTPInputs := map[string]string{
@@ -607,8 +607,24 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 		"mobileNumber": mobileNumber,
 	}
 
-	otpStep, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
-		flowStep.ChallengeToken)
+	// Retry flow completion with backoff to handle resource constraints
+	// Only retry if flow doesn't complete, not on ERROR status
+	var otpStep *common.FlowStep
+	err = common.RetryWithBackoff(func() error {
+		otpStep, err = common.CompleteFlow(flowStep.ExecutionID, inputs, "action_001",
+			flowStep.ChallengeToken)
+		if err != nil {
+			return err
+		}
+		// Don't retry on ERROR status - these are permanent errors
+		if otpStep.FlowStatus == "ERROR" {
+			return nil // Stop retrying, let the test assertion handle it
+		}
+		if otpStep.FlowStatus != "INCOMPLETE" {
+			return fmt.Errorf("unexpected flow status: %s", otpStep.FlowStatus)
+		}
+		return nil
+	}, 3, 1*time.Second)
 	if err != nil {
 		ts.T().Fatalf("Failed to provide mobile number: %v", err)
 	}
@@ -617,8 +633,8 @@ func (ts *SMSRegistrationFlowTestSuite) TestSMSRegistrationFlowSingleRequestWith
 	ts.Require().Equal("INCOMPLETE", otpStep.FlowStatus, "Expected flow status to be INCOMPLETE")
 	ts.Require().Equal("VIEW", otpStep.Type, "Expected flow type to be VIEW")
 
-	// Wait for SMS to be sent
-	time.Sleep(1 * time.Second)
+	// Wait for SMS to be sent - increased timeout for resource-constrained environments
+	time.Sleep(2 * time.Second)
 
 	// Get the OTP from mock server
 	lastMessage := ts.mockServer.GetLastMessage()

--- a/tests/integration/ou/ou_authz_test.go
+++ b/tests/integration/ou/ou_authz_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/thunder-id/thunderid/tests/integration/testutils"
@@ -384,4 +385,61 @@ func (ts *OUAuthzTestSuite) TestDeleteOwnOU() {
 
 	ts.Equal(http.StatusForbidden, resp.StatusCode,
 		"view-only OU-admin must not delete own OU (system:ou required)")
+}
+
+// TestListOUsWithFilterMatch verifies that a filter applied over the restricted
+// OU set returns only the OUs that both the caller is authorized to see AND
+// match the filter expression.
+func (ts *OUAuthzTestSuite) TestListOUsWithFilterMatch() {
+	// "Authz Test OU1" is the name set in SetupSuite for OU1.
+	resp := ts.doWithFilter("/organization-units", `name eq "Authz Test OU1"`)
+	defer closeBody(resp)
+
+	ts.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResp))
+
+	ids := make([]string, 0, len(listResp.OrganizationUnits))
+	for _, ou := range listResp.OrganizationUnits {
+		ids = append(ids, ou.ID)
+	}
+
+	ts.Containsf(ids, ts.ou1ID,
+		"filter matching OU1's name should return OU1; got IDs: %v", ids)
+}
+
+// TestListOUsWithFilterNoMatch verifies that a filter that matches no authorized
+// OU returns an empty list, even though the caller is authorized to see OU1.
+func (ts *OUAuthzTestSuite) TestListOUsWithFilterNoMatch() {
+	resp := ts.doWithFilter("/organization-units", `name eq "__no_match__"`)
+	defer closeBody(resp)
+
+	ts.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResp))
+
+	ts.Equal(0, listResp.TotalResults,
+		"filter that matches no authorized OU should return empty results")
+	ts.Empty(listResp.OrganizationUnits)
+}
+
+// doWithFilter issues a GET request using the scoped OU-admin client with the
+// given filter expression as the "filter" query parameter.
+func (ts *OUAuthzTestSuite) doWithFilter(path, filterExpr string) *http.Response {
+	ts.T().Helper()
+
+	u, err := url.Parse(authzTestServerURL + path)
+	ts.Require().NoError(err)
+	q := u.Query()
+	q.Set("filter", filterExpr)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	ts.Require().NoError(err)
+
+	resp, err := ts.ouViewClient.Do(req)
+	ts.Require().NoError(err)
+	return resp
 }

--- a/tests/integration/ou/ou_filter_api_test.go
+++ b/tests/integration/ou/ou_filter_api_test.go
@@ -1,0 +1,649 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ou
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// --- Root-level OU list AND/OR multi-expression filter tests ---
+
+// TestListOrganizationUnitsWithFilterAndExpression verifies that an AND filter
+// narrows results: both conditions must match.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithFilterAndExpression() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	// Both name and handle match the created OU — should include it.
+	resp := suite.doFilterRequest(
+		"/organization-units",
+		`name eq "`+ouToCreate.Name+`" AND handle eq "`+ouToCreate.Handle+`"`,
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdOUID {
+			found = true
+		}
+	}
+	suite.True(found, "AND filter with both matching conditions should include the OU")
+
+	// Name matches but handle does not — should return empty.
+	resp2 := suite.doFilterRequest(
+		"/organization-units",
+		`name eq "`+ouToCreate.Name+`" AND handle eq "__no_match__"`,
+	)
+	defer resp2.Body.Close()
+	suite.Equal(http.StatusOK, resp2.StatusCode)
+
+	var emptyResp OrganizationUnitListResponse
+	suite.decodeBody(resp2, &emptyResp)
+	for _, ou := range emptyResp.OrganizationUnits {
+		suite.NotEqual(createdOUID, ou.ID, "AND filter with non-matching handle should exclude the OU")
+	}
+}
+
+// TestListOrganizationUnitsWithFilterOrExpression verifies that an OR filter
+// returns OUs matching either condition.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithFilterOrExpression() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	// Create a second root OU for this test.
+	secondOU := CreateOURequest{
+		Name:   "Second Filter Test OU",
+		Handle: "second-filter-test-ou",
+	}
+	secondID, err := createOU(suite, secondOU)
+	suite.Require().NoError(err, "Failed to create second OU for OR test")
+	defer func() {
+		if err := deleteOU(secondID); err != nil {
+			suite.T().Logf("Failed to delete second OU %s: %v", secondID, err)
+		}
+	}()
+
+	resp := suite.doFilterRequest(
+		"/organization-units",
+		`name eq "`+ouToCreate.Name+`" OR name eq "`+secondOU.Name+`"`,
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	foundFirst, foundSecond := false, false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdOUID {
+			foundFirst = true
+		}
+		if ou.ID == secondID {
+			foundSecond = true
+		}
+	}
+	suite.True(foundFirst, "OR filter should include the first OU")
+	suite.True(foundSecond, "OR filter should include the second OU")
+}
+
+// TestListOrganizationUnitsWithFilterMixedAndOr verifies AND-before-OR precedence:
+// (name match AND createdAt match) OR __no_match__ resolves to true for the OU.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithFilterMixedAndOr() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest(
+		"/organization-units",
+		`name eq "`+ouToCreate.Name+`" AND createdAt gt "2000-01-01T00:00:00Z" OR name eq "__no_match__"`,
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdOUID {
+			found = true
+		}
+	}
+	suite.True(found, "Mixed AND/OR filter should include the OU (AND group evaluates to true)")
+}
+
+// TestListOrganizationUnitsWithInvalidConnector verifies that an unsupported connector
+// returns 400 OU-1014.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithInvalidConnector() {
+	resp := suite.doFilterRequest("/organization-units", `name eq "A" XOR name eq "B"`)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errResp ErrorResponse
+	suite.decodeBody(resp, &errResp)
+	suite.Equal("OU-1014", errResp.Code)
+}
+
+// --- Children list AND/OR filter tests ---
+
+// TestGetOrganizationUnitChildrenWithFilterAndExpression verifies AND filtering on children.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenWithFilterAndExpression() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	// Both name and handle match the child OU.
+	resp := suite.doFilterRequest(
+		"/organization-units/"+createdOUID+"/ous",
+		`name eq "`+childOUToCreate.Name+`" AND handle eq "`+childOUToCreate.Handle+`"`,
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	suite.GreaterOrEqual(listResp.TotalResults, 1)
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdChildOUID {
+			found = true
+		}
+	}
+	suite.True(found, "AND filter should include the matching child OU")
+
+	// Name matches but handle does not — should return empty.
+	resp2 := suite.doFilterRequest(
+		"/organization-units/"+createdOUID+"/ous",
+		`name eq "`+childOUToCreate.Name+`" AND handle eq "__no_match__"`,
+	)
+	defer resp2.Body.Close()
+	suite.Equal(http.StatusOK, resp2.StatusCode)
+
+	var emptyResp OrganizationUnitListResponse
+	suite.decodeBody(resp2, &emptyResp)
+	suite.Equal(0, emptyResp.TotalResults)
+}
+
+// TestGetOrganizationUnitChildrenWithFilterOrExpression verifies OR filtering on children.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenWithFilterOrExpression() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest(
+		"/organization-units/"+createdOUID+"/ous",
+		`name eq "`+childOUToCreate.Name+`" OR name eq "__no_match__"`,
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdChildOUID {
+			found = true
+		}
+	}
+	suite.True(found, "OR filter should include the matching child OU")
+}
+
+// --- Path-based children AND filter test ---
+
+// TestGetOrganizationUnitChildrenByPathWithFilterAndExpression verifies AND filtering
+// via the path-based endpoint.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenByPathWithFilterAndExpression() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest(
+		"/organization-units/tree/"+ouToCreate.Handle+"/ous",
+		`name eq "`+childOUToCreate.Name+`" AND handle eq "`+childOUToCreate.Handle+`"`,
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdChildOUID {
+			found = true
+		}
+	}
+	suite.True(found, "path-based AND filter should return the matching child OU")
+}
+
+// --- Root-level OU list filter tests ---
+
+// TestListOrganizationUnitsWithFilterEqMatch verifies that filtering by exact name returns only matching OUs.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithFilterEqMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest("/organization-units", "name eq \""+ouToCreate.Name+"\"")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	suite.GreaterOrEqual(listResp.TotalResults, 1)
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdOUID {
+			found = true
+			suite.Equal(ouToCreate.Name, ou.Name)
+		}
+	}
+	suite.True(found, "filter eq should include the matching OU")
+}
+
+// TestListOrganizationUnitsWithFilterEqNoMatch verifies that filtering with a non-matching name returns empty.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithFilterEqNoMatch() {
+	resp := suite.doFilterRequest("/organization-units", "name eq \"__no_such_ou_xyz__\"")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	suite.Equal(0, listResp.TotalResults)
+	suite.Empty(listResp.OrganizationUnits)
+}
+
+// TestListOrganizationUnitsWithFilterGtMatch verifies that gt filtering by name returns OUs whose name
+// sorts after the threshold.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithFilterGtMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	// "OU API Test Organization Unit" starts with "O" which is > "L"
+	resp := suite.doFilterRequest("/organization-units", "name gt \"L\"")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdOUID {
+			found = true
+		}
+	}
+	suite.True(found, "filter gt should include OU whose name sorts after the threshold")
+}
+
+// TestListOrganizationUnitsWithFilterGtNoMatch verifies that gt filtering with a threshold above all
+// names returns an empty list.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithFilterGtNoMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	// "OU API Test Organization Unit" starts with "O" which is NOT > "P"
+	resp := suite.doFilterRequest("/organization-units", "name gt \"P\"")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	for _, ou := range listResp.OrganizationUnits {
+		suite.NotEqual(createdOUID, ou.ID, "filter gt should exclude OU whose name sorts at or before the threshold")
+	}
+}
+
+// TestListOrganizationUnitsWithFilterLtMatch verifies that lt filtering by name returns OUs whose name
+// sorts before the threshold.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithFilterLtMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	// "OU API Test Organization Unit" starts with "O" which is < "P"
+	resp := suite.doFilterRequest("/organization-units", "name lt \"P\"")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdOUID {
+			found = true
+		}
+	}
+	suite.True(found, "filter lt should include OU whose name sorts before the threshold")
+}
+
+// TestListOrganizationUnitsWithFilterLtNoMatch verifies that lt filtering with a threshold below all
+// names returns an empty list.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithFilterLtNoMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	// "OU API Test Organization Unit" starts with "O" which is NOT < "L"
+	resp := suite.doFilterRequest("/organization-units", "name lt \"L\"")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	for _, ou := range listResp.OrganizationUnits {
+		suite.NotEqual(createdOUID, ou.ID, "filter lt should exclude OU whose name sorts at or after the threshold")
+	}
+}
+
+// TestListOrganizationUnitsWithFilterByHandle verifies eq filtering on the handle attribute.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithFilterByHandle() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest("/organization-units", "handle eq \""+ouToCreate.Handle+"\"")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	suite.GreaterOrEqual(listResp.TotalResults, 1)
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdOUID {
+			found = true
+		}
+	}
+	suite.True(found, "filter by handle eq should return the matching OU")
+}
+
+// TestListOrganizationUnitsWithInvalidFilter verifies that a malformed filter expression returns 400.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithInvalidFilter() {
+	resp := suite.doFilterRequest("/organization-units", "not a valid filter")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errResp ErrorResponse
+	suite.decodeBody(resp, &errResp)
+	suite.Equal("OU-1014", errResp.Code)
+}
+
+// TestListOrganizationUnitsWithUnsupportedFilterAttribute verifies that filtering on an unknown attribute
+// returns 400.
+func (suite *OUAPITestSuite) TestListOrganizationUnitsWithUnsupportedFilterAttribute() {
+	resp := suite.doFilterRequest("/organization-units", "unknownField eq \"foo\"")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errResp ErrorResponse
+	suite.decodeBody(resp, &errResp)
+	suite.Equal("OU-1014", errResp.Code)
+}
+
+// --- Children list filter tests ---
+
+// TestGetOrganizationUnitChildrenWithFilterEqMatch verifies that filtering children by name returns
+// only the matching child OU.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenWithFilterEqMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest(
+		"/organization-units/"+createdOUID+"/ous",
+		"name eq \""+childOUToCreate.Name+"\"",
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	suite.GreaterOrEqual(listResp.TotalResults, 1)
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdChildOUID {
+			found = true
+			suite.Equal(childOUToCreate.Name, ou.Name)
+		}
+	}
+	suite.True(found, "filter eq should include the matching child OU")
+}
+
+// TestGetOrganizationUnitChildrenWithFilterEqNoMatch verifies that a non-matching filter returns an
+// empty children list.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenWithFilterEqNoMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest(
+		"/organization-units/"+createdOUID+"/ous",
+		"name eq \"__no_such_child__\"",
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	suite.Equal(0, listResp.TotalResults)
+	suite.Empty(listResp.OrganizationUnits)
+}
+
+// TestGetOrganizationUnitChildrenWithFilterGtMatch verifies that gt filtering on children returns
+// children whose name sorts after the threshold.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenWithFilterGtMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	// "Child Test OU" starts with "C" which is > "B"
+	resp := suite.doFilterRequest(
+		"/organization-units/"+createdOUID+"/ous",
+		"name gt \"B\"",
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdChildOUID {
+			found = true
+		}
+	}
+	suite.True(found, "filter gt should include child OU whose name sorts after the threshold")
+}
+
+// TestGetOrganizationUnitChildrenWithFilterLtMatch verifies that lt filtering on children returns
+// children whose name sorts before the threshold.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenWithFilterLtMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	// "Child Test OU" starts with "C" which is < "D"
+	resp := suite.doFilterRequest(
+		"/organization-units/"+createdOUID+"/ous",
+		"name lt \"D\"",
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdChildOUID {
+			found = true
+		}
+	}
+	suite.True(found, "filter lt should include child OU whose name sorts before the threshold")
+}
+
+// TestGetOrganizationUnitChildrenWithInvalidFilter verifies that a malformed filter on the children
+// endpoint returns 400.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenWithInvalidFilter() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest("/organization-units/"+createdOUID+"/ous", "bad filter")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errResp ErrorResponse
+	suite.decodeBody(resp, &errResp)
+	suite.Equal("OU-1014", errResp.Code)
+}
+
+// TestGetOrganizationUnitChildrenWithUnsupportedFilterAttribute verifies that filtering children on
+// an unknown attribute returns 400.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenWithUnsupportedFilterAttribute() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest("/organization-units/"+createdOUID+"/ous", "unknownAttr eq \"foo\"")
+	defer resp.Body.Close()
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errResp ErrorResponse
+	suite.decodeBody(resp, &errResp)
+	suite.Equal("OU-1014", errResp.Code)
+}
+
+// --- Path-based children filter tests ---
+
+// TestGetOrganizationUnitChildrenByPathWithFilterEqMatch verifies eq filtering on the path-based
+// children endpoint.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenByPathWithFilterEqMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest(
+		"/organization-units/tree/"+ouToCreate.Handle+"/ous",
+		"name eq \""+childOUToCreate.Name+"\"",
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	suite.GreaterOrEqual(listResp.TotalResults, 1)
+	found := false
+	for _, ou := range listResp.OrganizationUnits {
+		if ou.ID == createdChildOUID {
+			found = true
+		}
+	}
+	suite.True(found, "path filter eq should return the matching child OU")
+}
+
+// TestGetOrganizationUnitChildrenByPathWithFilterEqNoMatch verifies that a non-matching filter on
+// the path-based endpoint returns an empty list.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenByPathWithFilterEqNoMatch() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest(
+		"/organization-units/tree/"+ouToCreate.Handle+"/ous",
+		"name eq \"__no_match__\"",
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp OrganizationUnitListResponse
+	suite.decodeBody(resp, &listResp)
+
+	suite.Equal(0, listResp.TotalResults)
+}
+
+// TestGetOrganizationUnitChildrenByPathWithInvalidFilter verifies that a malformed filter on the
+// path-based children endpoint returns 400.
+func (suite *OUAPITestSuite) TestGetOrganizationUnitChildrenByPathWithInvalidFilter() {
+	if createdOUID == "" {
+		suite.T().Fatal("OU ID not available")
+	}
+
+	resp := suite.doFilterRequest(
+		"/organization-units/tree/"+ouToCreate.Handle+"/ous",
+		"not valid",
+	)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errResp ErrorResponse
+	suite.decodeBody(resp, &errResp)
+	suite.Equal("OU-1014", errResp.Code)
+}
+
+// --- Helpers ---
+
+// doFilterRequest issues a GET request to path with the given filter expression as the "filter"
+// query parameter.
+func (suite *OUAPITestSuite) doFilterRequest(path, filterExpr string) *http.Response {
+	client := testutils.GetHTTPClient()
+	u, err := url.Parse(testServerURL + path)
+	suite.Require().NoError(err)
+	q := u.Query()
+	q.Set("filter", filterExpr)
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	suite.Require().NoError(err)
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	return resp
+}
+
+// decodeBody reads and JSON-decodes the response body into dst.
+func (suite *OUAPITestSuite) decodeBody(resp *http.Response, dst interface{}) {
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	suite.Require().NoError(json.Unmarshal(body, dst))
+}

--- a/tests/integration/testutils/mock_notification_server.go
+++ b/tests/integration/testutils/mock_notification_server.go
@@ -171,8 +171,8 @@ func (m *MockNotificationServer) handleClearMessages(w http.ResponseWriter, r *h
 
 // GetLastMessage returns the last received message
 func (m *MockNotificationServer) GetLastMessage() *SMSMessage {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
 
 	if len(m.messages) == 0 {
 		return nil


### PR DESCRIPTION
### Purpose
This pull request introduces enhancements to the Organization Unit (OU) API and backend services, primarily by adding metadata fields to the OU schema and updating service and mock signatures to support filtering. It also updates tests and documentation to align with these changes.

**API and Schema Enhancements:**

- Added `isReadOnly`, `createdAt`, and `updatedAt` fields to the `OrganizationUnitBasic` schema in `ou.yaml`, making these fields required and providing additional metadata for OUs. (`api/ou.yaml`) [[1]](diffhunk://#diff-d00c6a10ef313a9255dd26ef070f9f1be173103c9ac8eedfd4976f90e6e0b716L1361-R1361) [[2]](diffhunk://#diff-d00c6a10ef313a9255dd26ef070f9f1be173103c9ac8eedfd4976f90e6e0b716R1376-R1389)
- Updated the vocabulary file to include `CreatedAt` and `UpdatedAt` as accepted terms. (`.vale/styles/config/vocabularies/vocab/accept.txt`)

**Backend Service and Mock Updates:**

- Modified the signatures of `GetOrganizationUnitList`, `GetOrganizationUnitChildren`, and related mock methods to accept an optional `*filter.FilterExpression` parameter, enabling filtering capabilities for OU retrieval. (`backend/internal/ou/ConfigurableOUService_mock_test.go`) [[1]](diffhunk://#diff-9be92032271f551eb50ad79da765d6b2376e6872e0d655283f6515598b25af76L364-R385) [[2]](diffhunk://#diff-9be92032271f551eb50ad79da765d6b2376e6872e0d655283f6515598b25af76L403-R409) [[3]](diffhunk://#diff-9be92032271f551eb50ad79da765d6b2376e6872e0d655283f6515598b25af76L440-R473) [[4]](diffhunk://#diff-9be92032271f551eb50ad79da765d6b2376e6872e0d655283f6515598b25af76L485-R497) [[5]](diffhunk://#diff-9be92032271f551eb50ad79da765d6b2376e6872e0d655283f6515598b25af76L522-R535) [[6]](diffhunk://#diff-9be92032271f551eb50ad79da765d6b2376e6872e0d655283f6515598b25af76L762-R795) [[7]](diffhunk://#diff-9be92032271f551eb50ad79da765d6b2376e6872e0d655283f6515598b25af76L800-R818) [[8]](diffhunk://#diff-9be92032271f551eb50ad79da765d6b2376e6872e0d655283f6515598b25af76R832-R840)

**Backend Logic and Test Adjustments:**

- Updated calls to `GetOrganizationUnitList` and `GetOrganizationUnitChildren` in business logic and tests to pass the new filter argument, ensuring compatibility with the updated service interface. (`backend/internal/flow/executor/ou_resolver_executor.go`, `backend/internal/flow/flowmeta/service.go`, `backend/internal/oauth/oauth2/dcr/service.go`, and corresponding test files) [[1]](diffhunk://#diff-dd1ff3b70fa4ff161c24b7381b628191e924507196fcc749158b873a0419826bL180-R180) [[2]](diffhunk://#diff-ed5708e09c73de04b55f559b5137e5aa013f8f8a23c02490d44419e7d430c82dL192-R192) [[3]](diffhunk://#diff-c90505b092e6daf68c09890ccde66aad958d98ab69da3e4eada3beebe4f59af3L153-R153) [[4]](diffhunk://#diff-c90505b092e6daf68c09890ccde66aad958d98ab69da3e4eada3beebe4f59af3L291-R291) [[5]](diffhunk://#diff-b78bad56732c50275afd4c7ae6b5e6a99f03a21199b06b5c0b3c0b0cefe2c2cbL403-R403) [[6]](diffhunk://#diff-b78bad56732c50275afd4c7ae6b5e6a99f03a21199b06b5c0b3c0b0cefe2c2cbL427-R427) [[7]](diffhunk://#diff-b78bad56732c50275afd4c7ae6b5e6a99f03a21199b06b5c0b3c0b0cefe2c2cbL460-R460)

**Other:**

- Added necessary imports for the new filter functionality. (`backend/internal/ou/ConfigurableOUService_mock_test.go`)

These changes improve the flexibility and expressiveness of the OU API and backend, laying the groundwork for more advanced filtering and metadata-driven features.

### Related Issues
- https://github.com/thunder-id/thunder-id/issues/2643

### Merge After Related PRs
- https://github.com/thunder-id/thunder-id/pull/2649

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add attribute-based filtering to Organization Unit list endpoints (filter param supporting eq, gt, lt for name, handle, description, createdAt, updatedAt).
  * Organization Unit responses include metadata fields: isReadOnly, createdAt, updatedAt; new config fields: themeId, layoutId, tosUri, policyUri, cookiePolicyUri.

* **Changes**
  * Removed includeGroup query parameter from OU group listing endpoints.
  * New 400 error for invalid filter requests (code OU-1014).

* **Documentation & Tests**
  * Docs updated; extensive unit and integration tests added for filtering and timestamps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2670)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->