### PR TITLE
Track presented optional inputs across prompt and executor flows

### DIFF
--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -215,12 +215,9 @@ const (
 	RuntimeKeySkipDelivery = "skipDelivery"
 	// RuntimeKeyCandidateUsers holds serialized candidate users during disambiguation in resolve mode.
 	RuntimeKeyCandidateUsers = "candidateUsers"
-	// RuntimeKeyPresentedOptionalAttrs holds a space-separated list of optional schema attribute
-	// identifiers that have already been prompted to the user. ProvisioningExecutor uses this to
-	// skip optional attrs the user has already been shown, even if they left the value empty.
-	// TODO: Revisit optional input tracking — if the flow engine gains a mechanism to detect whether
-	// an optional field was intentionally skipped, remove this key and its associated helper methods.
-	RuntimeKeyPresentedOptionalAttrs = "provisioningPresentedOptionalAttrs"
+	// RuntimeKeyPresentedOptionalInputs holds a space-separated list of optional input identifiers
+	// that have already been prompted to the user, even if the user left them empty.
+	RuntimeKeyPresentedOptionalInputs = "presentedOptionalInputs"
 	// RuntimeKeySMSOTPMobileNumber holds the resolved mobile number for SMS OTP verification.
 	// TODO: Revisit when the generic OTP executor is implemented.
 	RuntimeKeySMSOTPMobileNumber = "smsOTPMobileNumber"

--- a/backend/internal/flow/core/executor.go
+++ b/backend/internal/flow/core/executor.go
@@ -186,37 +186,15 @@ func (e *executor) GetExecutionPolicy(mode string) *ExecutionPolicy {
 	return nil
 }
 
-// appendMissingInputs appends the missing required inputs to the executor response.
-// Returns true if any required input is found missing, otherwise false.
+// appendMissingInputs appends the missing executor inputs to the response.
+// Returns true when execution should pause for user input.
 func (e *executor) appendMissingInputs(ctx *NodeContext, execResp *common.ExecutorResponse,
 	requiredInputs []common.Input) bool {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "Executor"),
 		log.String(log.LoggerKeyExecutorName, e.GetName()),
 		log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
-	requireData := false
-	for _, input := range requiredInputs {
-		if _, ok := ctx.UserInputs[input.Identifier]; !ok {
-			if _, ok := ctx.RuntimeData[input.Identifier]; ok {
-				logger.Debug("Input available in runtime data, skipping",
-					log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
-				continue
-			}
-
-			if value, ok := ctx.ForwardedData[input.Identifier]; ok {
-				if _, isString := value.(string); isString {
-					logger.Debug("Input available in forwarded data, skipping",
-						log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
-					continue
-				}
-			}
-
-			requireData = true
-			execResp.Inputs = append(execResp.Inputs, input)
-			logger.Debug("Input not available in the context",
-				log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
-		}
-	}
-
-	return requireData
+	missing := collectMissingInputs(ctx, GetPresentedOptionalInputs(ctx.RuntimeData), requiredInputs, logger)
+	execResp.Inputs = append(execResp.Inputs, missing...)
+	return len(missing) > 0
 }

--- a/backend/internal/flow/core/executor_test.go
+++ b/backend/internal/flow/core/executor_test.go
@@ -182,6 +182,22 @@ func (s *ExecutorTestSuite) TestHasRequiredInputs() {
 			false,
 			1,
 		},
+		{
+			"Optional input prompts once",
+			[]common.Input{{Identifier: "nickname", Required: false}},
+			map[string]string{},
+			map[string]string{},
+			false,
+			1,
+		},
+		{
+			"Optional input already prompted",
+			[]common.Input{{Identifier: "nickname", Required: false}},
+			map[string]string{},
+			map[string]string{common.RuntimeKeyPresentedOptionalInputs: "nickname"},
+			true,
+			0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -379,37 +379,15 @@ func (n *promptNode) hasRequiredInputs(ctx *NodeContext, nodeResp *common.NodeRe
 	return !n.appendMissingInputs(ctx, nodeResp, n.getAllInputs())
 }
 
-// appendMissingInputs appends the missing required inputs to the node response.
-// Returns true if any required data is found missing, otherwise false.
+// appendMissingInputs appends the missing prompt inputs to the node response.
+// Returns true when the prompt should pause for user input.
 func (n *promptNode) appendMissingInputs(ctx *NodeContext, nodeResp *common.NodeResponse,
 	requiredInputs []common.Input) bool {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
-	requireInputs := false
-	for _, input := range requiredInputs {
-		if _, ok := ctx.UserInputs[input.Identifier]; !ok {
-			if _, ok := ctx.RuntimeData[input.Identifier]; ok {
-				logger.Debug("Input available in runtime data, skipping",
-					log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
-				continue
-			}
-			if value, ok := ctx.ForwardedData[input.Identifier]; ok {
-				if _, isString := value.(string); isString {
-					logger.Debug("Input available in forwarded data, skipping",
-						log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
-					continue
-				}
-			}
-			if input.Required {
-				requireInputs = true
-			}
-			nodeResp.Inputs = append(nodeResp.Inputs, input)
-			logger.Debug("Input not available in the context",
-				log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
-		}
-	}
-
-	return requireInputs
+	missing := collectMissingInputs(ctx, GetPresentedOptionalInputs(ctx.RuntimeData), requiredInputs, logger)
+	nodeResp.Inputs = append(nodeResp.Inputs, missing...)
+	return len(missing) > 0
 }
 
 // enrichInputsFromForwardedData enriches the inputs in the node response with dynamic data

--- a/backend/internal/flow/core/prompt_node_test.go
+++ b/backend/internal/flow/core/prompt_node_test.go
@@ -129,6 +129,38 @@ func (s *PromptOnlyNodeTestSuite) TestExecuteWithOptionalData() {
 
 	s.Nil(err)
 	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Equal(common.NodeResponseTypeView, resp.Type)
+	s.Len(resp.Inputs, 1)
+	s.Equal("nickname", resp.Inputs[0].Identifier)
+	s.False(resp.Inputs[0].Required)
+}
+
+func (s *PromptOnlyNodeTestSuite) TestExecuteWithAlreadyPromptedOptionalData() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	promptNode := node.(PromptNodeInterface)
+	promptNode.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "username", Required: true},
+				{Identifier: "nickname", Required: false},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{"username": "testuser"},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyPresentedOptionalInputs: "nickname",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
 	s.Equal(common.NodeStatusComplete, resp.Status)
 	s.Equal(common.NodeResponseType(""), resp.Type)
 }

--- a/backend/internal/flow/core/utils.go
+++ b/backend/internal/flow/core/utils.go
@@ -20,6 +20,10 @@ package core
 
 import (
 	"regexp"
+	"strings"
+
+	"github.com/thunder-id/thunderid/internal/flow/common"
+	"github.com/thunder-id/thunderid/internal/system/log"
 )
 
 // placeholderPattern matches {{ context.key }} with optional whitespace.
@@ -77,4 +81,90 @@ func ResolvePlaceholder(ctx *NodeContext, value string) string {
 		// If not found, keep the placeholder as-is
 		return match
 	})
+}
+
+// ParsePresentedOptionalInputIdentifiers converts a space-separated identifier list into a set.
+func ParsePresentedOptionalInputIdentifiers(raw string) map[string]struct{} {
+	result := make(map[string]struct{})
+	if raw == "" {
+		return result
+	}
+
+	for _, identifier := range strings.Fields(raw) {
+		if identifier != "" {
+			result[identifier] = struct{}{}
+		}
+	}
+
+	return result
+}
+
+// GetPresentedOptionalInputs extracts and parses the presented optional input identifiers from
+// runtime data into a set. Call this once before a loop to avoid repeated string parsing.
+func GetPresentedOptionalInputs(runtimeData map[string]string) map[string]struct{} {
+	return ParsePresentedOptionalInputIdentifiers(runtimeData[common.RuntimeKeyPresentedOptionalInputs])
+}
+
+// hasPresentedOptionalInput returns true when the given identifier appears in the presented-input set.
+func hasPresentedOptionalInput(presentedInputs map[string]struct{}, identifier string) bool {
+	if identifier == "" || len(presentedInputs) == 0 {
+		return false
+	}
+
+	_, ok := presentedInputs[identifier]
+	return ok
+}
+
+// IsOptionalInputPrompted returns true when an optional input identifier has already been shown
+// to the user in a prior prompt step.
+func IsOptionalInputPrompted(presentedOptionalInputs map[string]struct{}, identifier string) bool {
+	return hasPresentedOptionalInput(presentedOptionalInputs, identifier)
+}
+
+// collectMissingInputs returns inputs from requiredInputs that are not satisfied by user inputs,
+// runtime data, forwarded data, or already-presented optional inputs.
+func collectMissingInputs(ctx *NodeContext, presentedOptionalInputs map[string]struct{},
+	requiredInputs []common.Input, logger *log.Logger) []common.Input {
+	missing := make([]common.Input, 0, len(requiredInputs))
+	for _, input := range requiredInputs {
+		if _, ok := ctx.UserInputs[input.Identifier]; ok {
+			continue
+		}
+		if _, ok := ctx.RuntimeData[input.Identifier]; ok {
+			logger.Debug("Input available in runtime data, skipping",
+				log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
+			continue
+		}
+		if value, ok := ctx.ForwardedData[input.Identifier]; ok {
+			if _, isString := value.(string); isString {
+				logger.Debug("Input available in forwarded data, skipping",
+					log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
+				continue
+			}
+		}
+		if !input.Required && IsOptionalInputPrompted(presentedOptionalInputs, input.Identifier) {
+			logger.Debug("Optional input already prompted, skipping",
+				log.String("identifier", input.Identifier))
+			continue
+		}
+		logger.Debug("Input not available in the context",
+			log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
+		missing = append(missing, input)
+	}
+	return missing
+}
+
+// MergePresentedOptionalInputIdentifiers appends identifiers to an existing serialized identifier string.
+// Duplicates are acceptable since ParsePresentedOptionalInputIdentifiers deduplicates on read.
+func MergePresentedOptionalInputIdentifiers(raw string, identifiers []string) string {
+	parts := make([]string, 0, len(identifiers)+1)
+	if raw != "" {
+		parts = append(parts, raw)
+	}
+	for _, identifier := range identifiers {
+		if identifier != "" {
+			parts = append(parts, identifier)
+		}
+	}
+	return strings.Join(parts, " ")
 }

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -23,8 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
-	"strings"
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
@@ -338,12 +336,8 @@ func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 		return true
 	}
 
-	// Load the set of optional attrs already prompted in previous iterations so they are not
-	// re-prompted even when the user left them empty.
-	alreadyPromptedOptionalAttrs := p.getPresentedOptionalAttrs(ctx)
-
 	credRequiredMissing, credOptionalMissing, ncRequiredMissing, ncOptionalMissing :=
-		p.buildMissingInputs(ctx, allSchemaAttrs, nodeInputMap, alreadyPromptedOptionalAttrs)
+		p.buildMissingInputs(ctx, allSchemaAttrs, nodeInputMap)
 
 	// Build the full schema missing list: required non-creds first, then optional non-creds,
 	// followed by required creds, then optional creds.
@@ -366,10 +360,6 @@ func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 		toForward = toForward[:maxInputs]
 	}
 
-	// Record which optional schema attrs are being presented this iteration so future
-	// iterations know not to re-prompt them if the user left them empty.
-	p.storePresentedOptionalAttrs(execResp, toForward, alreadyPromptedOptionalAttrs)
-
 	execResp.Inputs = allSchemaMissing
 	if execResp.ForwardedData == nil {
 		execResp.ForwardedData = make(map[string]interface{})
@@ -386,10 +376,10 @@ func (p *provisioningExecutor) buildMissingInputs(
 	ctx *core.NodeContext,
 	schemaAttrs []entitytype.AttributeInfo,
 	nodeInputMap map[string]common.Input,
-	alreadyPromptedOptionalAttrs map[string]bool,
 ) (credRequired, credOptional, ncRequired, ncOptional []common.Input) {
 	promptOptional := p.isPromptOptionalAttributesEnabled(ctx)
 	promptOptionalCredentials := p.isPromptOptionalCredentialsEnabled(ctx)
+	presentedOptionalInputs := core.GetPresentedOptionalInputs(ctx.RuntimeData)
 
 	for _, attr := range schemaAttrs {
 		if p.isAttrSatisfied(ctx, attr.Attribute, attr.Credential) {
@@ -405,7 +395,7 @@ func (p *provisioningExecutor) buildMissingInputs(
 			if !effectiveRequired && !promptOptionalCredentials && !inNodeInputs {
 				continue
 			}
-			if !effectiveRequired && alreadyPromptedOptionalAttrs[attr.Attribute] {
+			if !effectiveRequired && core.IsOptionalInputPrompted(presentedOptionalInputs, attr.Attribute) {
 				continue
 			}
 			input := common.Input{
@@ -423,7 +413,7 @@ func (p *provisioningExecutor) buildMissingInputs(
 			if !attr.Required && !promptOptional && !inNodeInputs {
 				continue
 			}
-			if !effectiveRequired && alreadyPromptedOptionalAttrs[attr.Attribute] {
+			if !effectiveRequired && core.IsOptionalInputPrompted(presentedOptionalInputs, attr.Attribute) {
 				continue
 			}
 			input := common.Input{
@@ -508,45 +498,6 @@ func (p *provisioningExecutor) getMaxDynamicInputs(ctx *core.NodeContext) int {
 		}
 	}
 	return 0
-}
-
-// getPresentedOptionalAttrs returns the set of optional attr identifiers that have already been
-// prompted to the user in previous iterations, loaded from RuntimeData.
-func (p *provisioningExecutor) getPresentedOptionalAttrs(ctx *core.NodeContext) map[string]bool {
-	result := make(map[string]bool)
-	raw, ok := ctx.RuntimeData[common.RuntimeKeyPresentedOptionalAttrs]
-	if !ok || raw == "" {
-		return result
-	}
-	for _, id := range strings.Split(raw, " ") {
-		if id != "" {
-			result[id] = true
-		}
-	}
-	return result
-}
-
-// storePresentedOptionalAttrs accumulates the optional attrs being shown in this iteration into
-// RuntimeData so the next iteration can skip them.
-func (p *provisioningExecutor) storePresentedOptionalAttrs(
-	execResp *common.ExecutorResponse,
-	toPrompt []common.Input,
-	alreadyPresented map[string]bool,
-) {
-	for _, inp := range toPrompt {
-		if !inp.Required {
-			alreadyPresented[inp.Identifier] = true
-		}
-	}
-	if len(alreadyPresented) == 0 {
-		return
-	}
-	ids := make([]string, 0, len(alreadyPresented))
-	for id := range alreadyPresented {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	execResp.RuntimeData[common.RuntimeKeyPresentedOptionalAttrs] = strings.Join(ids, " ")
 }
 
 // isAttrSatisfied returns true if the attribute has a non-empty usable value.

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -2004,7 +2004,7 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptiona
 		RuntimeData: map[string]string{
 			userTypeKey: testUserType,
 			// nickname was presented in the previous iteration and the user left it blank.
-			common.RuntimeKeyPresentedOptionalAttrs: "nickname",
+			common.RuntimeKeyPresentedOptionalInputs: "nickname",
 		},
 		NodeProperties: map[string]interface{}{
 			propertyKeyDynamicInputsIncludeOptional: true,
@@ -2020,9 +2020,9 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptiona
 		"nickname must not be re-prompted once it appears in the presented list")
 }
 
-// TestHasRequiredInputs_IncludeOptionalTrue_StoresPresentedOptionals verifies that optional attrs
-// included in the prompt batch are written to RuntimeData for tracking across iterations.
-func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_StoresPresentedOptionals() {
+// TestHasRequiredInputs_IncludeOptionalTrue_DoesNotStorePresentedOptionals verifies that
+// presented-input tracking is now owned by the flow engine, not provisioning.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptionalTrue_DoesNotStorePresentedOptionals() {
 	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{
 			{Attribute: attributeEmail, DisplayName: "Email", Required: true},
@@ -2041,11 +2041,8 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptiona
 
 	suite.executor.HasRequiredInputs(ctx, execResp)
 
-	stored := execResp.RuntimeData[common.RuntimeKeyPresentedOptionalAttrs]
-	assert.Contains(suite.T(), stored, "nickname",
-		"presented optional attrs must be written to RuntimeData for subsequent iterations")
-	assert.NotContains(suite.T(), stored, attributeEmail,
-		"required attrs must not be written to the presented-optionals tracking key")
+	_, ok := execResp.RuntimeData[common.RuntimeKeyPresentedOptionalInputs]
+	assert.False(suite.T(), ok, "provisioning should not write presented-input tracking directly")
 }
 
 // TestHasRequiredInputs_IncludeOptionalTrue_RequiredBeforeOptional verifies that required missing
@@ -2371,8 +2368,8 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AlreadyPrompte
 		ExecutionID: "flow-123",
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
-			userTypeKey:                             testUserType,
-			common.RuntimeKeyPresentedOptionalAttrs: attributePin,
+			userTypeKey:                              testUserType,
+			common.RuntimeKeyPresentedOptionalInputs: attributePin,
 		},
 		NodeInputs: []common.Input{{Identifier: attributePin, Type: common.InputTypePassword, Required: false}},
 	}
@@ -2438,8 +2435,8 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_IncludeOptiona
 		ExecutionID: "flow-123",
 		UserInputs:  map[string]string{},
 		RuntimeData: map[string]string{
-			userTypeKey:                             testUserType,
-			common.RuntimeKeyPresentedOptionalAttrs: attributePin,
+			userTypeKey:                              testUserType,
+			common.RuntimeKeyPresentedOptionalInputs: attributePin,
 		},
 		NodeProperties: map[string]interface{}{
 			propertyKeyDynamicInputsIncludeOptionalCredentials: true,

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -178,6 +178,7 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 			return flowStep, nodeErr
 		}
 
+		fe.trackPresentedOptionalInputs(ctx, nodeResp)
 		fe.updateContextWithNodeResponse(ctx, nodeResp)
 
 		nextNode, continueExecution, svcErr := fe.processNodeResponse(ctx, nodeResp, &flowStep, logger)
@@ -216,6 +217,37 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 	publishFlowCompletedEvent(ctx, flowStartTime, flowEndTime, fe.observabilitySvc)
 
 	return flowStep, nil
+}
+
+// trackPresentedOptionalInputs records the optional inputs presented in an incomplete view response
+// into the node response's runtime data so they can be skipped in subsequent execution steps.
+func (fe *flowEngine) trackPresentedOptionalInputs(ctx *EngineContext, nodeResp *common.NodeResponse) {
+	if nodeResp == nil || nodeResp.Status != common.NodeStatusIncomplete ||
+		nodeResp.Type != common.NodeResponseTypeView || len(nodeResp.Inputs) == 0 {
+		return
+	}
+
+	optionalIdentifiers := make([]string, 0, len(nodeResp.Inputs))
+	for _, input := range nodeResp.Inputs {
+		if !input.Required {
+			optionalIdentifiers = append(optionalIdentifiers, input.Identifier)
+		}
+	}
+	if len(optionalIdentifiers) == 0 {
+		return
+	}
+
+	if nodeResp.RuntimeData == nil {
+		nodeResp.RuntimeData = make(map[string]string)
+	}
+
+	raw := nodeResp.RuntimeData[common.RuntimeKeyPresentedOptionalInputs]
+	if raw == "" && ctx != nil {
+		raw = ctx.RuntimeData[common.RuntimeKeyPresentedOptionalInputs]
+	}
+
+	nodeResp.RuntimeData[common.RuntimeKeyPresentedOptionalInputs] =
+		core.MergePresentedOptionalInputIdentifiers(raw, optionalIdentifiers)
 }
 
 // setCurrentExecutionNode sets the current execution node in the context.

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -224,6 +224,50 @@ func (s *EngineTestSuite) TestUpdateContextWithNodeResponse_PreservesActionOnInc
 	s.Equal("passkeyChallenge", ctx.CurrentAction)
 }
 
+func (s *EngineTestSuite) TestTrackPresentedOptionalInputs_MergesOptionalInputIdentifiers() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		RuntimeData: map[string]string{
+			common.RuntimeKeyPresentedOptionalInputs: "nickname",
+		},
+	}
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusIncomplete,
+		Type:   common.NodeResponseTypeView,
+		Inputs: []common.Input{
+			{Identifier: "given_name", Required: false},
+			{Identifier: "username", Required: true},
+		},
+	}
+
+	fe.trackPresentedOptionalInputs(ctx, nodeResp)
+
+	presented := core.ParsePresentedOptionalInputIdentifiers(
+		nodeResp.RuntimeData[common.RuntimeKeyPresentedOptionalInputs])
+	s.Contains(presented, "nickname")
+	s.Contains(presented, "given_name")
+}
+
+func (s *EngineTestSuite) TestTrackPresentedOptionalInputs_SkipsNonPromptResponses() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		RuntimeData: map[string]string{
+			common.RuntimeKeyPresentedOptionalInputs: "nickname",
+		},
+	}
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusForward,
+		Type:   common.NodeResponseTypeView,
+		Inputs: []common.Input{
+			{Identifier: "given_name", Required: false},
+		},
+	}
+
+	fe.trackPresentedOptionalInputs(ctx, nodeResp)
+
+	s.Nil(nodeResp.RuntimeData)
+}
+
 func (s *EngineTestSuite) TestResolveStepForRedirection_WithAdditionalData() {
 	fe := &flowEngine{}
 


### PR DESCRIPTION
### Purpose
This PR fixes flow execution behavior for optional inputs that were already shown to the user but left empty.

Previously, the backend only checked whether a value existed. Because of that:
- optional prompt-node inputs could be skipped entirely
- optional inputs that were already shown once could be re-prompted again later
- provisioning had its own executor-local tracking for optional schema inputs instead of using a shared flow-level mechanism

This change introduces shared runtime tracking for optional inputs that were already presented to the user, so optional inputs are prompted once and do not block or reappear again after being skipped.

### Approach
The implementation moves optional-input presentation tracking to the flow engine and makes prompt/executor input checks read from that shared runtime state.

Key changes:
- Added a new generic runtime key, `RuntimeKeyPresentedOptionalInputs`, to store optional input identifiers that were already shown to the user.
- Added shared helper logic in `core/utils.go` to parse, check, and merge the presented-optional-input identifier set.
- Updated the flow engine to record optional inputs into runtime data when a user-visible `INCOMPLETE + VIEW` response is returned.
- Updated `prompt_node` input resolution so optional prompt inputs:
  - block once when first missing
  - stop blocking after they have already been presented
- Updated shared executor input handling with the same presented-optional-input check.
- Updated `ProvisioningExecutor` to stop writing its own provisioning-specific optional-input tracking and instead use the shared runtime-key-based logic only for re-prompt suppression.

This keeps actual input values and prompt-state metadata separate:
- real values still determine whether an attribute is satisfied
- the runtime key only determines whether an optional input has already been shown once

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2574

### Related PRs
- https://github.com/thunder-id/thunderid/pull/2518


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The system records which optional inputs have been presented to the user (including when left empty) to avoid re-prompting.

* **Behavior Changes**
  * Flow engine centrally tracks and updates presented optional inputs; provisioning no longer persists that tracking itself.
  * Missing-input prompting now skips optional inputs already recorded as presented; required inputs remain unaffected.

* **Tests**
  * Added and updated tests covering presented-optional tracking, prompt behavior, merge/update logic, and non-prompt responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->