### PR TITLE
Fix unit tests in `frontend` workspace

### DIFF
--- a/frontend/packages/components/package.json
+++ b/frontend/packages/components/package.json
@@ -58,6 +58,7 @@
     "@thunderid/eslint-plugin": "workspace:^",
     "@thunderid/prettier-config": "workspace:^",
     "@thunderid/test-utils": "workspace:^",
+    "@vitest/browser-playwright": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "eslint": "catalog:",

--- a/frontend/packages/components/src/Helmet/Helmet.tsx
+++ b/frontend/packages/components/src/Helmet/Helmet.tsx
@@ -76,6 +76,7 @@ export default function Helmet({children}: HelmetProps): null {
       }
 
       const el = document.createElement(type as string);
+      el.setAttribute('data-helmet', 'true');
       applyAttributes(el, props);
 
       if (type === 'style' || type === 'script' || type === 'noscript') {

--- a/frontend/packages/components/src/Helmet/__tests__/Helmet.test.tsx
+++ b/frontend/packages/components/src/Helmet/__tests__/Helmet.test.tsx
@@ -61,7 +61,7 @@ describe('Helmet', () => {
       </Helmet>,
     );
     await waitFor(() => {
-      const link = document.querySelector('link[rel="icon"]');
+      const link = document.querySelector('link[data-helmet][rel="icon"]');
       expect(link).toBeTruthy();
       expect(link?.getAttribute('href')).toBe('/favicon.ico');
     });
@@ -109,7 +109,7 @@ describe('Helmet', () => {
       </Helmet>,
     );
     await waitFor(() => {
-      const style = document.querySelector('style');
+      const style = document.querySelector('style[data-helmet]');
       expect(style?.textContent).toBe('body { margin: 0; }');
     });
   });

--- a/frontend/packages/components/src/lab/components/EmojiPicker/__tests__/EmojiPicker.test.tsx
+++ b/frontend/packages/components/src/lab/components/EmojiPicker/__tests__/EmojiPicker.test.tsx
@@ -21,6 +21,22 @@ import userEvent from '@testing-library/user-event';
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import EmojiPicker from '../EmojiPicker';
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>, options?: Record<string, unknown>) => {
+      const str = typeof fallback === 'string' ? fallback : key;
+      const vars = typeof fallback === 'object' ? fallback : options;
+      if (vars && typeof vars === 'object') {
+        return str.replace(/\{\{(\w+)\}\}/g, (_, k: string) => {
+          const val = vars[k];
+          return typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean' ? String(val) : '';
+        });
+      }
+      return str;
+    },
+  }),
+}));
+
 // The module-level _supportedCategories cache needs to be reset between tests
 // so that the canvas mock only runs once per test. Since jsdom's canvas 2D
 // context is null, getSupportedCategories() falls through to returning all

--- a/frontend/packages/components/src/test-setup.ts
+++ b/frontend/packages/components/src/test-setup.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,16 +16,9 @@
  * under the License.
  */
 
-import {playwright} from '@vitest/browser-playwright';
-import {defineConfig} from 'vitest/config';
+import {cleanup} from '@testing-library/react';
+import {afterEach} from 'vitest';
 
-export default defineConfig({
-  test: {
-    browser: {
-      enabled: true,
-      headless: true,
-      instances: [{browser: 'chromium'}],
-      provider: playwright(),
-    },
-  },
+afterEach(() => {
+  cleanup();
 });

--- a/frontend/packages/components/vitest.config.ts
+++ b/frontend/packages/components/vitest.config.ts
@@ -17,6 +17,7 @@
  */
 
 import {resolve} from 'path';
+import {playwright} from '@vitest/browser-playwright';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
@@ -40,7 +41,8 @@ export default defineConfig({
       enabled: true,
       headless: true,
       instances: [{browser: 'chromium'}],
-      provider: 'playwright',
+      provider: playwright(),
     },
+    setupFiles: ['./src/test-setup.ts'],
   },
 });

--- a/frontend/packages/configure-agent-types/package.json
+++ b/frontend/packages/configure-agent-types/package.json
@@ -57,6 +57,7 @@
     "@thunderid/prettier-config": "workspace:^",
     "@thunderid/test-utils": "workspace:^",
     "@thunderid/types": "workspace:^",
+    "@vitest/browser-playwright": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "eslint": "catalog:",

--- a/frontend/packages/configure-agent-types/src/pages/__tests__/ViewAgentTypePage.test.tsx
+++ b/frontend/packages/configure-agent-types/src/pages/__tests__/ViewAgentTypePage.test.tsx
@@ -53,15 +53,15 @@ vi.mock('react-router', async () => {
   };
 });
 
-vi.mock('../../api/useGetAgentType', () => ({
+vi.mock('@/api/useGetAgentType', () => ({
   default: (id?: string): unknown => mockUseGetAgentType(id) as unknown,
 }));
 
-vi.mock('../../api/useUpdateAgentType', () => ({
+vi.mock('@/api/useUpdateAgentType', () => ({
   default: (): unknown => mockUseUpdateAgentType() as unknown,
 }));
 
-vi.mock('../../components/edit-agent-type/schema-settings/EditSchemaSettings', () => ({
+vi.mock('@/components/edit-agent-type/schema-settings/EditSchemaSettings', () => ({
   default: ({onPropertiesChange}: {onPropertiesChange: (props: unknown[]) => void}) => (
     <div data-testid="edit-schema-settings">
       <button

--- a/frontend/packages/configure-agent-types/vitest.config.ts
+++ b/frontend/packages/configure-agent-types/vitest.config.ts
@@ -17,6 +17,7 @@
  */
 
 import {resolve} from 'path';
+import {playwright} from '@vitest/browser-playwright';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
@@ -40,7 +41,8 @@ export default defineConfig({
       enabled: true,
       headless: true,
       instances: [{browser: 'chromium'}],
-      provider: 'playwright',
+      provider: playwright(),
     },
+    setupFiles: ['@thunderid/test-utils/setup'],
   },
 });

--- a/frontend/packages/configure-organization-units/package.json
+++ b/frontend/packages/configure-organization-units/package.json
@@ -57,6 +57,7 @@
     "@thunderid/prettier-config": "workspace:^",
     "@thunderid/test-utils": "workspace:^",
     "@thunderid/types": "workspace:^",
+    "@vitest/browser-playwright": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "eslint": "catalog:",

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitDeleteDialog.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitDeleteDialog.test.tsx
@@ -23,29 +23,33 @@ import OrganizationUnitDeleteDialog from '../OrganizationUnitDeleteDialog';
 // Mock the delete hook — controllable per test
 const mockMutate = vi.fn();
 const mockDeleteHook = {mutate: mockMutate, isPending: false};
-vi.mock('../../api/useDeleteOrganizationUnit', () => ({
+vi.mock('@/api/useDeleteOrganizationUnit', () => ({
   default: () => mockDeleteHook,
 }));
 
 // Mock translations
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      const translations: Record<string, string> = {
-        'organizationUnits:delete.dialog.title': 'Delete Organization Unit',
-        'organizationUnits:delete.dialog.message':
-          'Are you sure you want to delete this organization unit? This action cannot be undone.',
-        'organizationUnits:delete.dialog.disclaimer':
-          'Warning: All associated data, configurations, and user assignments will be permanently removed.',
-        'organizationUnits:delete.dialog.error': 'Failed to delete organization unit. Please try again.',
-        'common:actions.cancel': 'Cancel',
-        'common:actions.delete': 'Delete',
-        'common:status.deleting': 'Deleting...',
-      };
-      return translations[key] ?? key;
-    },
-  }),
-}));
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    useTranslation: () => ({
+      t: (key: string) => {
+        const translations: Record<string, string> = {
+          'organizationUnits:delete.dialog.title': 'Delete Organization Unit',
+          'organizationUnits:delete.dialog.message':
+            'Are you sure you want to delete this organization unit? This action cannot be undone.',
+          'organizationUnits:delete.dialog.disclaimer':
+            'Warning: All associated data, configurations, and user assignments will be permanently removed.',
+          'organizationUnits:delete.dialog.error': 'Failed to delete organization unit. Please try again.',
+          'common:actions.cancel': 'Cancel',
+          'common:actions.delete': 'Delete',
+          'common:status.deleting': 'Deleting...',
+        };
+        return translations[key] ?? key;
+      },
+    }),
+  };
+});
 
 describe('OrganizationUnitDeleteDialog', () => {
   const defaultProps = {

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitTreePicker.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitTreePicker.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@thunderid/logger/react', () => ({
 
 // Mock the API hooks
 const mockUseGetOrganizationUnits = vi.fn();
-vi.mock('../../api/useGetOrganizationUnits', () => ({
+vi.mock('@/api/useGetOrganizationUnits', () => ({
   default: () =>
     mockUseGetOrganizationUnits() as {
       data: OrganizationUnitListResponse | undefined;
@@ -40,7 +40,7 @@ vi.mock('../../api/useGetOrganizationUnits', () => ({
 }));
 
 const mockUseGetOrganizationUnit = vi.fn();
-vi.mock('../../api/useGetOrganizationUnit', () => ({
+vi.mock('@/api/useGetOrganizationUnit', () => ({
   default: () =>
     mockUseGetOrganizationUnit() as {
       data: OrganizationUnit | undefined;
@@ -50,7 +50,7 @@ vi.mock('../../api/useGetOrganizationUnit', () => ({
 }));
 
 const mockUseGetChildOrganizationUnits = vi.fn();
-vi.mock('../../api/useGetChildOrganizationUnits', () => ({
+vi.mock('@/api/useGetChildOrganizationUnits', () => ({
   default: () =>
     mockUseGetChildOrganizationUnits() as {
       data: OrganizationUnitListResponse | undefined;

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitsTreeView.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitsTreeView.test.tsx
@@ -40,7 +40,7 @@ vi.mock('@thunderid/logger/react', () => ({
 
 // Mock the API hook
 const mockUseGetOrganizationUnits = vi.fn();
-vi.mock('../../api/useGetOrganizationUnits', () => ({
+vi.mock('@/api/useGetOrganizationUnits', () => ({
   default: () =>
     mockUseGetOrganizationUnits() as {
       data: OrganizationUnitListResponse | undefined;
@@ -59,7 +59,7 @@ vi.mock('@asgardeo/react', () => ({
 // Mock useOrganizationUnit hook with React state for reactivity
 // Allow tests to pre-seed expandedItems via mockOrganizationUnitConfig.initialExpandedItems
 const mockOrganizationUnitConfig = {initialExpandedItems: [] as string[]};
-vi.mock('../../contexts/useOrganizationUnit', async () => {
+vi.mock('@/contexts/useOrganizationUnit', async () => {
   const {useState, useCallback} = await import('react');
   type OrganizationUnitTreeItem = import('../../models/organization-unit-tree').OrganizationUnitTreeItem;
   function useOrganizationUnit() {
@@ -88,7 +88,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
 // Mock delete hook — controllable per test
 const mockDeleteMutate = vi.fn();
 const mockDeleteHook = {mutate: mockDeleteMutate, isPending: false};
-vi.mock('../../api/useDeleteOrganizationUnit', () => ({
+vi.mock('@/api/useDeleteOrganizationUnit', () => ({
   default: () => mockDeleteHook,
 }));
 

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/EditChildOrganizationUnitSettings.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/EditChildOrganizationUnitSettings.test.tsx
@@ -16,8 +16,8 @@
  * under the License.
  */
 
-import { screen, renderWithProviders } from '@thunderid/test-utils';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {screen, renderWithProviders} from '@thunderid/test-utils';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import EditChildOrganizationUnitSettings from '../EditChildOrganizationUnitSettings';
 
 // Mock child component
@@ -68,7 +68,7 @@ describe('EditChildOrganizationUnitSettings', () => {
   });
 
   it('should handle different organization unit IDs and names', () => {
-    const { rerender } = renderWithProviders(
+    const {rerender} = renderWithProviders(
       <EditChildOrganizationUnitSettings organizationUnitId="ou-123" organizationUnitName="Engineering" />,
     );
 

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/EditChildOrganizationUnitSettings.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/EditChildOrganizationUnitSettings.test.tsx
@@ -16,18 +16,27 @@
  * under the License.
  */
 
-import {screen, renderWithProviders} from '@thunderid/test-utils';
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import { screen, renderWithProviders } from '@thunderid/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import EditChildOrganizationUnitSettings from '../EditChildOrganizationUnitSettings';
 
 // Mock child component
-vi.mock('@/components/edit-organization-unit/child-organization-unit-settings/ManageChildOrganizationUnitSection', () => ({
-  default: ({organizationUnitId, organizationUnitName}: {organizationUnitId: string; organizationUnitName: string}) => (
-    <div data-testid="manage-child-ous-section">
-      ManageChildOUsSection - {organizationUnitId} - {organizationUnitName}
-    </div>
-  ),
-}));
+vi.mock(
+  '@/components/edit-organization-unit/child-organization-unit-settings/ManageChildOrganizationUnitSection',
+  () => ({
+    default: ({
+      organizationUnitId,
+      organizationUnitName,
+    }: {
+      organizationUnitId: string;
+      organizationUnitName: string;
+    }) => (
+      <div data-testid="manage-child-ous-section">
+        ManageChildOUsSection - {organizationUnitId} - {organizationUnitName}
+      </div>
+    ),
+  }),
+);
 
 describe('EditChildOrganizationUnitSettings', () => {
   beforeEach(() => {
@@ -59,7 +68,7 @@ describe('EditChildOrganizationUnitSettings', () => {
   });
 
   it('should handle different organization unit IDs and names', () => {
-    const {rerender} = renderWithProviders(
+    const { rerender } = renderWithProviders(
       <EditChildOrganizationUnitSettings organizationUnitId="ou-123" organizationUnitName="Engineering" />,
     );
 

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/EditChildOrganizationUnitSettings.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/EditChildOrganizationUnitSettings.test.tsx
@@ -21,7 +21,7 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import EditChildOrganizationUnitSettings from '../EditChildOrganizationUnitSettings';
 
 // Mock child component
-vi.mock('../ManageChildOrganizationUnitSection', () => ({
+vi.mock('@/components/edit-organization-unit/child-organization-unit-settings/ManageChildOrganizationUnitSection', () => ({
   default: ({organizationUnitId, organizationUnitName}: {organizationUnitId: string; organizationUnitName: string}) => (
     <div data-testid="manage-child-ous-section">
       ManageChildOUsSection - {organizationUnitId} - {organizationUnitName}

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/ManageChildOrganizationUnitSection.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/ManageChildOrganizationUnitSection.test.tsx
@@ -23,14 +23,15 @@ import ManageChildOrganizationUnitSection from '../ManageChildOrganizationUnitSe
 
 // Mock the useGetChildOrganizationUnits hook
 const mockUseGetChildOrganizationUnits = vi.fn();
-vi.mock('../../../../api/useGetChildOrganizationUnits', () => ({
+vi.mock('@/api/useGetChildOrganizationUnits', () => ({
   default: (id: string): unknown => mockUseGetChildOrganizationUnits(id),
 }));
 
 // Mock useDataGridLocaleText hook
-vi.mock('@thunderid/hooks', () => ({
-  useDataGridLocaleText: () => ({}),
-}));
+vi.mock('@thunderid/hooks', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {...(actual as object), useDataGridLocaleText: () => ({})};
+});
 
 // Mock navigate function
 const mockNavigate = vi.fn();

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/customization-settings/__tests__/EditCustomizationSettings.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/customization-settings/__tests__/EditCustomizationSettings.test.tsx
@@ -22,7 +22,7 @@ import type {OrganizationUnit} from '../../../../models/organization-unit';
 import EditCustomizationSettings from '../EditCustomizationSettings';
 
 // Mock child components
-vi.mock('../AppearanceSection', () => ({
+vi.mock('@/components/edit-organization-unit/customization-settings/AppearanceSection', () => ({
   default: ({
     organizationUnit,
     editedOU,

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/general-settings/__tests__/EditGeneralSettings.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/general-settings/__tests__/EditGeneralSettings.test.tsx
@@ -22,7 +22,7 @@ import type {OrganizationUnit} from '../../../../models/organization-unit';
 import EditGeneralSettings from '../EditGeneralSettings';
 
 // Mock child components
-vi.mock('../QuickCopySection', () => ({
+vi.mock('@/components/edit-organization-unit/general-settings/QuickCopySection', () => ({
   default: ({
     organizationUnit,
     copiedField,
@@ -42,13 +42,13 @@ vi.mock('../QuickCopySection', () => ({
   ),
 }));
 
-vi.mock('../ParentSettingsSection', () => ({
+vi.mock('@/components/edit-organization-unit/general-settings/ParentSettingsSection', () => ({
   default: ({organizationUnit}: {organizationUnit: OrganizationUnit}) => (
     <div data-testid="parent-settings-section">ParentSettingsSection - {organizationUnit.name}</div>
   ),
 }));
 
-vi.mock('../DangerZoneSection', () => ({
+vi.mock('@/components/edit-organization-unit/general-settings/DangerZoneSection', () => ({
   default: ({onDeleteClick}: {onDeleteClick: () => void}) => (
     <div data-testid="danger-zone-section">
       DangerZoneSection

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/general-settings/__tests__/ParentSettingsSection.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/general-settings/__tests__/ParentSettingsSection.test.tsx
@@ -23,7 +23,7 @@ import ParentSettingsSection from '../ParentSettingsSection';
 
 // Mock the useGetOrganizationUnit hook
 const mockUseGetOrganizationUnit = vi.fn();
-vi.mock('../../../../api/useGetOrganizationUnit', () => ({
+vi.mock('@/api/useGetOrganizationUnit', () => ({
   default: (id?: string, enabled?: boolean): unknown => mockUseGetOrganizationUnit(id, enabled),
 }));
 

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/group-settings/__tests__/EditGroupSettings.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/group-settings/__tests__/EditGroupSettings.test.tsx
@@ -21,7 +21,7 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import EditGroupSettings from '../EditGroupSettings';
 
 // Mock child component
-vi.mock('../ManageGroupsSection', () => ({
+vi.mock('@/components/edit-organization-unit/group-settings/ManageGroupsSection', () => ({
   default: ({organizationUnitId}: {organizationUnitId: string}) => (
     <div data-testid="manage-groups-section">ManageGroupsSection - {organizationUnitId}</div>
   ),

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/group-settings/__tests__/ManageGroupsSection.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/group-settings/__tests__/ManageGroupsSection.test.tsx
@@ -23,14 +23,15 @@ import ManageGroupsSection from '../ManageGroupsSection';
 
 // Mock the useGetOrganizationUnitGroups hook
 const mockUseGetOrganizationUnitGroups = vi.fn();
-vi.mock('../../../../api/useGetOrganizationUnitGroups', () => ({
+vi.mock('@/api/useGetOrganizationUnitGroups', () => ({
   default: (id: string): unknown => mockUseGetOrganizationUnitGroups(id),
 }));
 
 // Mock useDataGridLocaleText hook
-vi.mock('@thunderid/hooks', () => ({
-  useDataGridLocaleText: () => ({}),
-}));
+vi.mock('@thunderid/hooks', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {...(actual as object), useDataGridLocaleText: () => ({})};
+});
 
 // Mock translations
 vi.mock('react-i18next', () => ({

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/user-settings/__tests__/EditUserSettings.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/user-settings/__tests__/EditUserSettings.test.tsx
@@ -21,7 +21,7 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import EditUserSettings from '../EditUserSettings';
 
 // Mock child component
-vi.mock('../ManageUsersSection', () => ({
+vi.mock('@/components/edit-organization-unit/user-settings/ManageUsersSection', () => ({
   default: ({organizationUnitId}: {organizationUnitId: string}) => (
     <div data-testid="manage-users-section">ManageUsersSection - {organizationUnitId}</div>
   ),

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/user-settings/__tests__/ManageUsersSection.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/user-settings/__tests__/ManageUsersSection.test.tsx
@@ -23,14 +23,15 @@ import ManageUsersSection from '../ManageUsersSection';
 
 // Mock the useGetOrganizationUnitUsers hook
 const mockUseGetOrganizationUnitUsers = vi.fn();
-vi.mock('../../../../api/useGetOrganizationUnitUsers', () => ({
+vi.mock('@/api/useGetOrganizationUnitUsers', () => ({
   default: (id: string): unknown => mockUseGetOrganizationUnitUsers(id),
 }));
 
 // Mock useDataGridLocaleText hook
-vi.mock('@thunderid/hooks', () => ({
-  useDataGridLocaleText: () => ({}),
-}));
+vi.mock('@thunderid/hooks', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {...(actual as object), useDataGridLocaleText: () => ({})};
+});
 
 // Mock translations
 vi.mock('react-i18next', () => ({

--- a/frontend/packages/configure-organization-units/src/pages/__tests__/CreateOrganizationUnitPage.test.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/__tests__/CreateOrganizationUnitPage.test.tsx
@@ -49,7 +49,7 @@ vi.mock('@thunderid/logger/react', () => ({
 
 // Mock create hook
 const mockMutate = vi.fn();
-vi.mock('../../api/useCreateOrganizationUnit', () => ({
+vi.mock('@/api/useCreateOrganizationUnit', () => ({
   default: () => ({
     mutate: mockMutate,
     isPending: false,
@@ -57,7 +57,7 @@ vi.mock('../../api/useCreateOrganizationUnit', () => ({
 }));
 
 // Mock useOrganizationUnit hook
-vi.mock('../../contexts/useOrganizationUnit', () => ({
+vi.mock('@/contexts/useOrganizationUnit', () => ({
   default: () => ({
     resetTreeState: vi.fn(),
   }),

--- a/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitEditPage.test.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitEditPage.test.tsx
@@ -59,7 +59,7 @@ vi.mock('@thunderid/logger/react', () => ({
 // Mock get OU hook
 const mockRefetch = vi.fn();
 const mockUseGetOrganizationUnit = vi.fn();
-vi.mock('../../api/useGetOrganizationUnit', () => ({
+vi.mock('@/api/useGetOrganizationUnit', () => ({
   default: () =>
     mockUseGetOrganizationUnit() as {
       data: OrganizationUnit | undefined;
@@ -71,7 +71,7 @@ vi.mock('../../api/useGetOrganizationUnit', () => ({
 
 // Mock update hook
 const mockMutateAsync = vi.fn();
-vi.mock('../../api/useUpdateOrganizationUnit', () => ({
+vi.mock('@/api/useUpdateOrganizationUnit', () => ({
   default: () => ({
     mutateAsync: mockMutateAsync,
     isPending: false,
@@ -80,7 +80,7 @@ vi.mock('../../api/useUpdateOrganizationUnit', () => ({
 
 // Mock delete hook
 const mockDeleteMutate = vi.fn();
-vi.mock('../../api/useDeleteOrganizationUnit', () => ({
+vi.mock('@/api/useDeleteOrganizationUnit', () => ({
   default: () => ({
     mutate: mockDeleteMutate,
     isPending: false,
@@ -88,21 +88,21 @@ vi.mock('../../api/useDeleteOrganizationUnit', () => ({
 }));
 
 // Mock child hooks
-vi.mock('../../api/useGetChildOrganizationUnits', () => ({
+vi.mock('@/api/useGetChildOrganizationUnits', () => ({
   default: () => ({
     data: {organizationUnits: [], totalResults: 0, startIndex: 1, count: 0},
     isLoading: false,
   }),
 }));
 
-vi.mock('../../api/useGetOrganizationUnitUsers', () => ({
+vi.mock('@/api/useGetOrganizationUnitUsers', () => ({
   default: () => ({
     data: {users: [], totalResults: 0, startIndex: 1, count: 0},
     isLoading: false,
   }),
 }));
 
-vi.mock('../../api/useGetOrganizationUnitGroups', () => ({
+vi.mock('@/api/useGetOrganizationUnitGroups', () => ({
   default: () => ({
     data: {groups: [], totalResults: 0, startIndex: 1, count: 0},
     isLoading: false,
@@ -110,16 +110,17 @@ vi.mock('../../api/useGetOrganizationUnitGroups', () => ({
 }));
 
 // Mock useOrganizationUnit hook
-vi.mock('../../contexts/useOrganizationUnit', () => ({
+vi.mock('@/contexts/useOrganizationUnit', () => ({
   default: () => ({
     resetTreeState: vi.fn(),
   }),
 }));
 
 // Mock useDataGridLocaleText
-vi.mock('@thunderid/hooks', () => ({
-  useDataGridLocaleText: () => ({}),
-}));
+vi.mock('@thunderid/hooks', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {...(actual as object), useDataGridLocaleText: () => ({})};
+});
 
 // Mock EmojiPicker
 vi.mock('@thunderid/components', async () => {

--- a/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitsListPage.test.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitsListPage.test.tsx
@@ -48,7 +48,7 @@ const mockOUData: OrganizationUnitListResponse = {
   ],
 };
 
-vi.mock('../../api/useGetOrganizationUnits', () => ({
+vi.mock('@/api/useGetOrganizationUnits', () => ({
   default: () => ({
     data: mockOUData,
     isLoading: false,
@@ -57,7 +57,7 @@ vi.mock('../../api/useGetOrganizationUnits', () => ({
 }));
 
 // Mock delete hook
-vi.mock('../../api/useDeleteOrganizationUnit', () => ({
+vi.mock('@/api/useDeleteOrganizationUnit', () => ({
   default: () => ({
     mutate: vi.fn(),
     isPending: false,
@@ -71,7 +71,7 @@ vi.mock('@asgardeo/react', () => ({
 }));
 
 // Mock useOrganizationUnit hook with React state for reactivity
-vi.mock('../../contexts/useOrganizationUnit', async () => {
+vi.mock('@/contexts/useOrganizationUnit', async () => {
   const {useState, useCallback} = await import('react');
   type OrganizationUnitTreeItem = import('../../models/organization-unit-tree').OrganizationUnitTreeItem;
   function useOrganizationUnit() {

--- a/frontend/packages/configure-organization-units/vitest.config.ts
+++ b/frontend/packages/configure-organization-units/vitest.config.ts
@@ -17,6 +17,7 @@
  */
 
 import {resolve} from 'path';
+import {playwright} from '@vitest/browser-playwright';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
@@ -40,7 +41,8 @@ export default defineConfig({
       enabled: true,
       headless: true,
       instances: [{browser: 'chromium'}],
-      provider: 'playwright',
+      provider: playwright(),
     },
+    setupFiles: ['@thunderid/test-utils/setup'],
   },
 });

--- a/frontend/packages/configure-translations/package.json
+++ b/frontend/packages/configure-translations/package.json
@@ -56,6 +56,7 @@
     "@thunderid/eslint-plugin": "workspace:^",
     "@thunderid/prettier-config": "workspace:^",
     "@thunderid/test-utils": "workspace:^",
+    "@vitest/browser-playwright": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "eslint": "catalog:",

--- a/frontend/packages/configure-translations/src/components/__tests__/TranslationsList.test.tsx
+++ b/frontend/packages/configure-translations/src/components/__tests__/TranslationsList.test.tsx
@@ -43,15 +43,19 @@ vi.mock('../../../../hooks/useDataGridLocaleText', () => ({
 }));
 
 const mockMutate = vi.fn();
-vi.mock('@thunderid/i18n', () => ({
-  useGetLanguages: vi.fn().mockReturnValue({
-    data: {languages: ['fr-FR', 'de-DE']},
-    isLoading: false,
-  }),
-  useDeleteTranslations: () => ({mutate: mockMutate, isPending: false}),
-  getDisplayNameForCode: (code: string) => `Language(${code})`,
-  toFlagEmoji: (code: string) => `Flag(${code})`,
-}));
+vi.mock('@thunderid/i18n', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    useGetLanguages: vi.fn().mockReturnValue({
+      data: {languages: ['fr-FR', 'de-DE']},
+      isLoading: false,
+    }),
+    useDeleteTranslations: () => ({mutate: mockMutate, isPending: false}),
+    getDisplayNameForCode: (code: string) => `Language(${code})`,
+    toFlagEmoji: (code: string) => `Flag(${code})`,
+  };
+});
 
 vi.mock('@thunderid/logger/react', () => ({
   useLogger: () => ({error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn()}),

--- a/frontend/packages/configure-translations/src/components/edit-translation/__tests__/TranslationEditorCard.test.tsx
+++ b/frontend/packages/configure-translations/src/components/edit-translation/__tests__/TranslationEditorCard.test.tsx
@@ -29,11 +29,11 @@ vi.mock('react-i18next', async () => {
   };
 });
 
-vi.mock('../TranslationFieldsView', () => ({
+vi.mock('@/components/edit-translation/TranslationFieldsView', () => ({
   default: () => <div data-testid="fields-view" />,
 }));
 
-vi.mock('../TranslationJsonEditor', () => ({
+vi.mock('@/components/edit-translation/TranslationJsonEditor', () => ({
   default: () => <div data-testid="json-editor" />,
 }));
 

--- a/frontend/packages/configure-translations/src/pages/__tests__/TranslationsListPage.test.tsx
+++ b/frontend/packages/configure-translations/src/pages/__tests__/TranslationsListPage.test.tsx
@@ -43,12 +43,16 @@ vi.mock('../../../../hooks/useDataGridLocaleText', () => ({
   default: () => ({}),
 }));
 
-vi.mock('@thunderid/i18n', () => ({
-  useGetLanguages: vi.fn(),
-  useDeleteTranslations: vi.fn().mockReturnValue({mutate: vi.fn(), isPending: false}),
-  getDisplayNameForCode: (code: string) => `Language(${code})`,
-  toFlagEmoji: (code: string) => `Flag(${code})`,
-}));
+vi.mock('@thunderid/i18n', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    useGetLanguages: vi.fn(),
+    useDeleteTranslations: vi.fn().mockReturnValue({mutate: vi.fn(), isPending: false}),
+    getDisplayNameForCode: (code: string) => `Language(${code})`,
+    toFlagEmoji: (code: string) => `Flag(${code})`,
+  };
+});
 
 vi.mock('@thunderid/logger/react', () => ({
   useLogger: () => ({error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn()}),

--- a/frontend/packages/configure-translations/vitest.config.ts
+++ b/frontend/packages/configure-translations/vitest.config.ts
@@ -17,6 +17,7 @@
  */
 
 import {resolve} from 'path';
+import {playwright} from '@vitest/browser-playwright';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
@@ -40,7 +41,8 @@ export default defineConfig({
       enabled: true,
       headless: true,
       instances: [{browser: 'chromium'}],
-      provider: 'playwright',
+      provider: playwright(),
     },
+    setupFiles: ['@thunderid/test-utils/setup'],
   },
 });

--- a/frontend/packages/configure-users/package.json
+++ b/frontend/packages/configure-users/package.json
@@ -58,6 +58,7 @@
     "@thunderid/prettier-config": "workspace:^",
     "@thunderid/test-utils": "workspace:^",
     "@thunderid/types": "workspace:^",
+    "@vitest/browser-playwright": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "eslint": "catalog:",

--- a/frontend/packages/configure-users/src/api/__tests__/useGetUserType.test.ts
+++ b/frontend/packages/configure-users/src/api/__tests__/useGetUserType.test.ts
@@ -105,7 +105,7 @@ describe('useGetUserType', () => {
 
     expect(mockHttpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: `https://api.test.com/user-types/`,
+        url: `https://api.test.com/user-types/schema-1`,
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/packages/configure-users/src/components/__tests__/UsersList.test.tsx
+++ b/frontend/packages/configure-users/src/components/__tests__/UsersList.test.tsx
@@ -182,11 +182,11 @@ interface UseDeleteUserReturn {
 const mockUseGetUsers = vi.fn<() => UseGetUsersReturn>();
 const mockUseDeleteUser = vi.fn<() => UseDeleteUserReturn>();
 
-vi.mock('../../api/useGetUsers', () => ({
+vi.mock('@/api/useGetUsers', () => ({
   default: () => mockUseGetUsers(),
 }));
 
-vi.mock('../../api/useDeleteUser', () => ({
+vi.mock('@/api/useDeleteUser', () => ({
   default: () => mockUseDeleteUser(),
 }));
 

--- a/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
@@ -88,15 +88,15 @@ const mockUseCreateUser = vi.fn<() => UseCreateUserReturn>();
 const mockUseGetUserTypes = vi.fn<() => UseGetUserTypesReturn>();
 const mockUseGetUserType = vi.fn<() => UseGetUserTypeReturn>();
 
-vi.mock('../../api/useCreateUser', () => ({
+vi.mock('@/api/useCreateUser', () => ({
   default: () => mockUseCreateUser(),
 }));
 
-vi.mock('../../api/useGetUserTypes', () => ({
+vi.mock('@/api/useGetUserTypes', () => ({
   default: () => mockUseGetUserTypes(),
 }));
 
-vi.mock('../../api/useGetUserType', () => ({
+vi.mock('@/api/useGetUserType', () => ({
   default: () => mockUseGetUserType(),
 }));
 
@@ -113,12 +113,16 @@ vi.mock('../../../organization-units/api/useGetChildOrganizationUnits', () => ({
 
 // Mock useAsgardeo
 const mockUseAsgardeo = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => mockUseAsgardeo() as {user: {ouId?: string} | null | undefined},
-}));
+vi.mock('@asgardeo/react', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    useAsgardeo: () => mockUseAsgardeo() as {user: {ouId?: string} | null | undefined},
+  };
+});
 
 // Mock ConfigureOrganizationUnit — mirrors real component's auto-select behavior
-vi.mock('../../components/create-user/ConfigureOrganizationUnit', async () => {
+vi.mock('@/components/create-user/ConfigureOrganizationUnit', async () => {
   const React = await import('react');
 
   function MockConfigureOrganizationUnit({
@@ -174,7 +178,7 @@ vi.mock('../../components/create-user/ConfigureOrganizationUnit', async () => {
 });
 
 // Mock child components with controlled test behavior
-vi.mock('../../components/create-user/ConfigureUserType', () => ({
+vi.mock('@/components/create-user/ConfigureUserType', () => ({
   default: ({
     schemas,
     selectedSchema,
@@ -205,7 +209,7 @@ vi.mock('../../components/create-user/ConfigureUserType', () => ({
   ),
 }));
 
-vi.mock('../../components/create-user/ConfigureUserDetails', () => ({
+vi.mock('@/components/create-user/ConfigureUserDetails', () => ({
   default: ({
     onFormValuesChange,
     onReadyChange,

--- a/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
@@ -122,23 +122,23 @@ const mockUseGetUserType = vi.fn<() => UseGetUserTypeReturn>();
 const mockUseUpdateUser = vi.fn<() => UseUpdateUserReturn>();
 const mockUseDeleteUser = vi.fn<() => UseDeleteUserReturn>();
 
-vi.mock('../../api/useGetUser', () => ({
+vi.mock('@/api/useGetUser', () => ({
   default: () => mockUseGetUser(),
 }));
 
-vi.mock('../../api/useGetUserTypes', () => ({
+vi.mock('@/api/useGetUserTypes', () => ({
   default: () => mockUseGetUserTypes(),
 }));
 
-vi.mock('../../api/useGetUserType', () => ({
+vi.mock('@/api/useGetUserType', () => ({
   default: () => mockUseGetUserType(),
 }));
 
-vi.mock('../../api/useUpdateUser', () => ({
+vi.mock('@/api/useUpdateUser', () => ({
   default: () => mockUseUpdateUser(),
 }));
 
-vi.mock('../../api/useDeleteUser', () => ({
+vi.mock('@/api/useDeleteUser', () => ({
   default: () => mockUseDeleteUser(),
 }));
 

--- a/frontend/packages/configure-users/src/pages/__tests__/UserInvitePage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserInvitePage.test.tsx
@@ -120,11 +120,15 @@ vi.mock('@asgardeo/react', async () => {
   };
 });
 
-vi.mock('@thunderid/hooks', () => ({
-  useTemplateLiteralResolver: () => ({
-    resolve: (key: string) => key,
-  }),
-}));
+vi.mock('@thunderid/hooks', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    useTemplateLiteralResolver: () => ({
+      resolve: (key: string) => key,
+    }),
+  };
+});
 
 vi.mock('../../../organization-units/components/OrganizationUnitTreePicker', () => ({
   default: ({value, onChange, rootOuId}: {value: string; onChange: (id: string) => void; rootOuId?: string}) => (

--- a/frontend/packages/configure-users/src/pages/__tests__/UsersListPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UsersListPage.test.tsx
@@ -43,7 +43,7 @@ vi.mock('react-router', async () => {
 });
 
 // Mock the UsersList component
-vi.mock('../../components/UsersList', () => ({
+vi.mock('@/components/UsersList', () => ({
   default: () => <div data-testid="users-list">Users List Component</div>,
 }));
 

--- a/frontend/packages/configure-users/vitest.config.ts
+++ b/frontend/packages/configure-users/vitest.config.ts
@@ -17,6 +17,7 @@
  */
 
 import {resolve} from 'path';
+import {playwright} from '@vitest/browser-playwright';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
@@ -40,7 +41,8 @@ export default defineConfig({
       enabled: true,
       headless: true,
       instances: [{browser: 'chromium'}],
-      provider: 'playwright',
+      provider: playwright(),
     },
+    setupFiles: ['@thunderid/test-utils/setup'],
   },
 });

--- a/frontend/packages/contexts/package.json
+++ b/frontend/packages/contexts/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@thunderid/eslint-plugin": "workspace:^",
     "@thunderid/prettier-config": "workspace:^",
+    "@vitest/browser-playwright": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
@@ -62,7 +63,6 @@
     "rimraf": "catalog:",
     "rolldown": "catalog:",
     "typescript": "catalog:",
-    "@vitest/browser-playwright": "catalog:",
     "playwright": "catalog:",
     "vitest": "catalog:"
   },

--- a/frontend/packages/contexts/src/Config/__tests__/ConfigProvider.test.tsx
+++ b/frontend/packages/contexts/src/Config/__tests__/ConfigProvider.test.tsx
@@ -98,7 +98,7 @@ describe('ConfigProvider', () => {
           </ConfigProvider>,
         );
       });
-    }).toThrow('Runtime configuration is not available');
+    }).toThrow('ThunderID runtime configuration is not available on window.__THUNDERID_RUNTIME_CONFIG__');
   });
 
   it('provides server URL with HTTPS when http_only is false', () => {

--- a/frontend/packages/create/src/templates/feature/vitest.config.ts.hbs
+++ b/frontend/packages/create/src/templates/feature/vitest.config.ts.hbs
@@ -17,6 +17,7 @@
  */
 
 import {defineConfig} from 'vitest/config';
+import {playwright} from '@vitest/browser-playwright';
 
 export default defineConfig({
   test: {
@@ -24,7 +25,7 @@ export default defineConfig({
       enabled: true,
       headless: true,
       instances: [{browser: 'chromium'}],
-      provider: 'playwright',
+      provider: playwright(),
     },
   },
 });

--- a/frontend/packages/create/src/utils/getWorkspaceInfo.ts
+++ b/frontend/packages/create/src/utils/getWorkspaceInfo.ts
@@ -61,7 +61,7 @@ export default function getWorkspaceInfo(): WorkspaceInfo {
           typeof parsed === 'object' && parsed !== null && 'name' in parsed
             ? (parsed as Record<string, unknown>)['name']
             : undefined;
-        if (typeof name === 'string' && name.includes('thunderid')) {
+        if (typeof name === 'string' && (name.includes('thunderid') || name.startsWith('@'))) {
           thunderRoot = currentDir;
           break;
         }

--- a/frontend/packages/design/src/components/flow/__tests__/AuthPageLayout.test.tsx
+++ b/frontend/packages/design/src/components/flow/__tests__/AuthPageLayout.test.tsx
@@ -73,7 +73,7 @@ describe('AuthPageLayout', () => {
         </AuthPageLayout>,
       );
       const main = screen.getByRole('main');
-      expect(main.classList.contains('ThunderSignIn--root')).toBe(true);
+      expect(main.classList.contains('ThunderIDSignIn--root')).toBe(true);
     });
 
     it('does not apply product prefix CSS class when variant is not provided', () => {
@@ -125,7 +125,7 @@ describe('AuthPageLayout', () => {
         </AuthPageLayout>,
       );
       const main = screen.getByRole('main');
-      expect(main.classList.contains('ThunderSignUp--root')).toBe(true);
+      expect(main.classList.contains('ThunderIDSignUp--root')).toBe(true);
       expect(screen.getByText('Sign up form')).toBeTruthy();
     });
 

--- a/frontend/packages/design/src/components/flow/adapters/StackAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/StackAdapter.tsx
@@ -21,7 +21,6 @@ import {cn} from '@thunderid/utils';
 import {Stack} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import type {FlowComponent} from '../../../models/flow';
-// eslint-disable-next-line import-x/no-cycle
 import FlowComponentRenderer from '../FlowComponentRenderer';
 
 const STACK_IMAGE_MAX_SIZE = 80;

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/CopyableTextAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/CopyableTextAdapter.test.tsx
@@ -26,6 +26,7 @@ import CopyableTextAdapter from '../CopyableTextAdapter';
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 const baseComponent: FlowComponent = {
@@ -115,7 +116,6 @@ describe('CopyableTextAdapter', () => {
     });
 
     it('shows "Copied!" feedback after clicking Copy', async () => {
-      vi.useFakeTimers();
       renderWithProviders(
         <CopyableTextAdapter component={baseComponent} resolve={(s) => s} additionalData={additionalData} />,
       );
@@ -123,14 +123,11 @@ describe('CopyableTextAdapter', () => {
       fireEvent.click(screen.getByRole('button'));
 
       await waitFor(() => {
-        expect(screen.getByRole('button').textContent).toContain('Copied!');
+        expect(screen.getByRole('button').textContent).toContain('actions.copied');
       });
-
-      vi.useRealTimers();
     });
 
     it('resets back to "Copy" label after 3 seconds', async () => {
-      vi.useFakeTimers();
       renderWithProviders(
         <CopyableTextAdapter component={baseComponent} resolve={(s) => s} additionalData={additionalData} />,
       );
@@ -138,17 +135,16 @@ describe('CopyableTextAdapter', () => {
       fireEvent.click(screen.getByRole('button'));
 
       await waitFor(() => {
-        expect(screen.getByRole('button').textContent).toContain('Copied!');
+        expect(screen.getByRole('button').textContent).toContain('actions.copied');
       });
 
-      vi.advanceTimersByTime(3000);
-
-      await waitFor(() => {
-        expect(screen.getByRole('button').textContent).toContain('Copy');
-      });
-
-      vi.useRealTimers();
-    });
+      await waitFor(
+        () => {
+          expect(screen.getByRole('button').textContent).toContain('actions.copy');
+        },
+        {timeout: 5000},
+      );
+    }, 10000);
 
     it('falls back to execCommand when clipboard API throws', async () => {
       Object.defineProperty(navigator, 'clipboard', {

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/RichTextAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/RichTextAdapter.test.tsx
@@ -21,14 +21,18 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
-import {render} from '@testing-library/react';
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {cleanup} from '@testing-library/react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import type {FlowComponent} from '../../../../models/flow';
+import renderWithProviders from '../../../../test/renderWithProviders';
 import RichTextAdapter from '../RichTextAdapter';
 
-const mockUseDesign = vi.fn();
+afterEach(() => {
+  cleanup();
+});
 
 vi.mock('@wso2/oxygen-ui', () => ({
+  Alert: ({children}: any) => children,
   Box: ({sx, dangerouslySetInnerHTML}: any) => (
     <div
       data-testid="rich-text-box"
@@ -37,10 +41,9 @@ vi.mock('@wso2/oxygen-ui', () => ({
       dangerouslySetInnerHTML={dangerouslySetInnerHTML}
     />
   ),
-}));
-
-vi.mock('../../../../contexts/Design/useDesign', () => ({
-  default: () => mockUseDesign(),
+  extendTheme: vi.fn(),
+  OxygenUIThemeProvider: ({children}: any) => children,
+  Snackbar: ({children}: any) => children,
 }));
 
 const baseComponent: FlowComponent = {
@@ -50,39 +53,43 @@ const baseComponent: FlowComponent = {
 };
 
 describe('RichTextAdapter', () => {
-  beforeEach(() => {
-    mockUseDesign.mockReturnValue({isDesignEnabled: false});
-  });
-
   it('renders resolved HTML content', () => {
-    const {getByTestId} = render(<RichTextAdapter component={baseComponent} resolve={(s: string | undefined) => s} />);
+    const {getByTestId} = renderWithProviders(
+      <RichTextAdapter component={baseComponent} resolve={(s: string | undefined) => s} />,
+    );
     expect(getByTestId('rich-text-box').innerHTML).toBe('<p>Hello <strong>World</strong></p>');
   });
 
   it('uses resolved label from resolve function', () => {
-    const {getByTestId} = render(<RichTextAdapter component={baseComponent} resolve={() => '<em>Resolved</em>'} />);
+    const {getByTestId} = renderWithProviders(
+      <RichTextAdapter component={baseComponent} resolve={() => '<em>Resolved</em>'} />,
+    );
     expect(getByTestId('rich-text-box').innerHTML).toBe('<em>Resolved</em>');
   });
 
   it('falls back to component.label when resolve returns undefined', () => {
-    const {getByTestId} = render(<RichTextAdapter component={baseComponent} resolve={() => undefined} />);
+    const {getByTestId} = renderWithProviders(<RichTextAdapter component={baseComponent} resolve={() => undefined} />);
     expect(getByTestId('rich-text-box').innerHTML).toBe('<p>Hello <strong>World</strong></p>');
   });
 
   it('renders empty string when resolve returns undefined and label is not a string', () => {
     const component = {...baseComponent, label: undefined};
-    const {getByTestId} = render(<RichTextAdapter component={component} resolve={() => undefined} />);
+    const {getByTestId} = renderWithProviders(<RichTextAdapter component={component} resolve={() => undefined} />);
     expect(getByTestId('rich-text-box').innerHTML).toBe('');
   });
 
   it('aligns text to center when isDesignEnabled is true', () => {
-    mockUseDesign.mockReturnValue({isDesignEnabled: true});
-    const {getByTestId} = render(<RichTextAdapter component={baseComponent} resolve={(s: string | undefined) => s} />);
+    const {getByTestId} = renderWithProviders(
+      <RichTextAdapter component={baseComponent} resolve={(s: string | undefined) => s} />,
+      {designContext: {isDesignEnabled: true}},
+    );
     expect(getByTestId('rich-text-box')).toHaveAttribute('data-align', 'center');
   });
 
   it('aligns text to left when isDesignEnabled is false', () => {
-    const {getByTestId} = render(<RichTextAdapter component={baseComponent} resolve={(s: string | undefined) => s} />);
+    const {getByTestId} = renderWithProviders(
+      <RichTextAdapter component={baseComponent} resolve={(s: string | undefined) => s} />,
+    );
     expect(getByTestId('rich-text-box')).toHaveAttribute('data-align', 'left');
   });
 
@@ -98,7 +105,7 @@ describe('RichTextAdapter', () => {
       const resolve = (template: string | undefined) =>
         template?.includes('isRegistrationFlowEnabled') ? 'false' : template;
 
-      const {queryByTestId} = render(
+      const {queryByTestId} = renderWithProviders(
         <RichTextAdapter component={signUpComponent} resolve={resolve} signUpFallbackUrl="/signup" />,
       );
       expect(queryByTestId('rich-text-box')).not.toBeInTheDocument();
@@ -110,7 +117,7 @@ describe('RichTextAdapter', () => {
         return template?.replace('{{meta(application.sign_up_url)}}', '/custom/signup');
       };
 
-      const {getByTestId} = render(<RichTextAdapter component={signUpComponent} resolve={resolve} />);
+      const {getByTestId} = renderWithProviders(<RichTextAdapter component={signUpComponent} resolve={resolve} />);
       const box = getByTestId('rich-text-box');
       expect(box).toBeInTheDocument();
       expect(box.innerHTML).toContain('/custom/signup');
@@ -120,7 +127,7 @@ describe('RichTextAdapter', () => {
       const resolve = (template: string | undefined) =>
         template?.includes('isRegistrationFlowEnabled') ? 'true' : template;
 
-      const {getByTestId} = render(
+      const {getByTestId} = renderWithProviders(
         <RichTextAdapter component={signUpComponent} resolve={resolve} signUpFallbackUrl="/signup?client_id=abc" />,
       );
       expect(getByTestId('rich-text-box').innerHTML).toContain('/signup?client_id=abc');
@@ -130,7 +137,7 @@ describe('RichTextAdapter', () => {
       const resolve = (template: string | undefined) =>
         template?.includes('isRegistrationFlowEnabled') ? 'true' : template;
 
-      const {getByTestId} = render(<RichTextAdapter component={signUpComponent} resolve={resolve} />);
+      const {getByTestId} = renderWithProviders(<RichTextAdapter component={signUpComponent} resolve={resolve} />);
       // Component renders (registration enabled) but no fallback URL is substituted
       expect(getByTestId('rich-text-box')).toBeInTheDocument();
       expect(getByTestId('rich-text-box').innerHTML).not.toContain('/signup?');

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/TextAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/TextAdapter.test.tsx
@@ -48,7 +48,7 @@ describe('TextAdapter', () => {
   it('applies product prefix CSS class names', () => {
     renderWithProviders(<TextAdapter component={baseComponent} resolve={(s) => s} />);
     const el = screen.getByText('Hello World');
-    expect(el.className).toContain('ThunderFlow--text');
+    expect(el.className).toContain('ThunderIDFlow--text');
   });
 
   it('uses center alignment when design mode is enabled and no align prop', () => {
@@ -56,7 +56,7 @@ describe('TextAdapter', () => {
       designContext: {isDesignEnabled: true},
     });
     const el = screen.getByText('Hello World');
-    expect(el.style.textAlign).toBe('center');
+    expect(window.getComputedStyle(el).textAlign).toBe('center');
   });
 
   it('uses component.align when provided, overriding design mode', () => {
@@ -65,7 +65,7 @@ describe('TextAdapter', () => {
       designContext: {isDesignEnabled: false},
     });
     const el = screen.getByText('Hello World');
-    expect(el.style.textAlign).toBe('center');
+    expect(window.getComputedStyle(el).textAlign).toBe('center');
   });
 
   it('falls back to left alignment when no align and design mode is disabled', () => {
@@ -73,6 +73,6 @@ describe('TextAdapter', () => {
       designContext: {isDesignEnabled: false},
     });
     const el = screen.getByText('Hello World');
-    expect(el.style.textAlign).toBe('left');
+    expect(window.getComputedStyle(el).textAlign).toBe('left');
   });
 });

--- a/frontend/packages/eslint-plugin/src/rules/__tests__/copyright-header.test.ts
+++ b/frontend/packages/eslint-plugin/src/rules/__tests__/copyright-header.test.ts
@@ -20,11 +20,11 @@ import {Linter, RuleTester} from 'eslint';
 import copyrightHeaderRule from '../copyright-header.js';
 
 const ruleTester = new RuleTester({
-  parserOptions: {
+  languageOptions: {
     ecmaVersion: 2020,
     sourceType: 'module',
   },
-} as unknown as Linter.Config);
+} as Linter.Config);
 
 const getCurrentYear = (): number => new Date().getFullYear();
 

--- a/frontend/packages/hooks/vitest.config.ts
+++ b/frontend/packages/hooks/vitest.config.ts
@@ -20,7 +20,12 @@ import {playwright} from '@vitest/browser-playwright';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
+  define: {
+    global: 'globalThis',
+  },
   test: {
+    globals: true,
+    setupFiles: ['@thunderid/test-utils/setup'],
     browser: {
       enabled: true,
       headless: true,

--- a/frontend/packages/i18n/package.json
+++ b/frontend/packages/i18n/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@thunderid/eslint-plugin": "workspace:^",
     "@thunderid/prettier-config": "workspace:^",
+    "@vitest/browser-playwright": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "eslint": "catalog:",

--- a/frontend/packages/test-utils/src/setup.ts
+++ b/frontend/packages/test-utils/src/setup.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import {cleanup} from '@testing-library/react';
 import enUS from '@thunderid/i18n/locales/en-US';
 import i18n from 'i18next';
@@ -99,7 +99,7 @@ Object.defineProperty(window.HTMLMediaElement.prototype, 'load', {
 });
 
 // Mock IntersectionObserver
-global.IntersectionObserver = class IntersectionObserver {
+globalThis.IntersectionObserver = class IntersectionObserver {
   readonly root = null;
 
   readonly rootMargin = '';
@@ -124,7 +124,7 @@ global.IntersectionObserver = class IntersectionObserver {
 } as unknown as typeof IntersectionObserver;
 
 // Mock ResizeObserver
-global.ResizeObserver = class ResizeObserver {
+globalThis.ResizeObserver = class ResizeObserver {
   observe() {
     return this;
   }
@@ -144,21 +144,25 @@ if (typeof window !== 'undefined') {
 }
 
 // Mock @asgardeo/react to avoid buffer import issues in tests
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(() => ({
-    http: {
-      request: vi.fn(),
-    },
-    signIn: vi.fn(),
-    signOut: vi.fn(),
-    getAccessToken: vi.fn(),
-    getIDToken: vi.fn(),
-    getDecodedIDToken: vi.fn(),
-    isAuthenticated: false,
-    isLoading: false,
-  })),
-  AsgardeoProvider: ({children}: {children: React.ReactNode}) => children,
-}));
+vi.mock('@asgardeo/react', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    useAsgardeo: vi.fn(() => ({
+      http: {
+        request: vi.fn(),
+      },
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      getAccessToken: vi.fn(),
+      getIDToken: vi.fn(),
+      getDecodedIDToken: vi.fn(),
+      isAuthenticated: false,
+      isLoading: false,
+    })),
+    AsgardeoProvider: ({children}: {children: React.ReactNode}) => children,
+  };
+});
 
 // Mock MUI transition components to prevent RAF-based animation hangs in tests.
 vi.mock('@mui/material/Fade', () => ({

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -685,6 +685,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.7
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.3(playwright@1.58.1)(vite@8.0.7(@types/node@24.7.2)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.3)
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.6.1)
@@ -770,6 +773,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.7
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.3(playwright@1.58.1)(vite@8.0.7(@types/node@24.7.2)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.3)
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.6.1)
@@ -876,6 +882,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.7
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.3(playwright@1.58.1)(vite@8.0.7(@types/node@24.7.2)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.3)
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.6.1)
@@ -967,6 +976,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.7
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.3(playwright@1.58.1)(vite@8.0.7(@types/node@24.7.2)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.3)
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.6.1)
@@ -1073,6 +1085,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.7
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.3(playwright@1.58.1)(vite@8.0.7(@types/node@24.7.2)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.3)
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.6.1)
@@ -1496,6 +1511,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.7
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.3(playwright@1.58.1)(vite@8.0.7(@types/node@24.7.2)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.3)
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.6.1)


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request introduces several improvements to testing infrastructure and code consistency across the `components` and `configure-organization-units` packages. The main changes include adding and configuring the `@vitest/browser-playwright` provider, standardizing the use of absolute imports in test mocks, and enhancing test setup and mocking strategies for better maintainability and reliability.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

**Testing infrastructure improvements:**

* Added `@vitest/browser-playwright` as a dependency in `package.json` files and updated `vitest.config.ts` to use the Playwright provider for browser-based tests in both `components` and `configure-agent-types` packages. Also, added or updated `setupFiles` to ensure proper test environment initialization. [[1]](diffhunk://#diff-44e22f5bf3be2d85ea2c35f93fc1ee0d6508c4aab84f783954ef600eb2738da9R61) [[2]](diffhunk://#diff-1ed97a19d879901d94b9bf692b5aa3d240535bb7e7019070debdbb1159cc7fdfR60) [[3]](diffhunk://#diff-920f410a256d41332bdc18179d42211e5cdf58f62839fb48fee9a4026daf6ef9R60) [[4]](diffhunk://#diff-952026cb92ec0b4f4a2e14697363688e6398bb34ce70f218db82e7ceeea45d71R20) [[5]](diffhunk://#diff-952026cb92ec0b4f4a2e14697363688e6398bb34ce70f218db82e7ceeea45d71L43-R46) [[6]](diffhunk://#diff-99d6f87ea7303ed1edf1f3133cc863358c6481dd282abc04624fb7f6fc82acc1R20) [[7]](diffhunk://#diff-99d6f87ea7303ed1edf1f3133cc863358c6481dd282abc04624fb7f6fc82acc1L43-R46) [[8]](diffhunk://#diff-72cffc4a80ec29951ba0ee5ee1bb105cf8a90cf29ec0a829043c45440c5da5bfR1-R24)

**Test code improvements and consistency:**

* Refactored test files in `configure-organization-units` to use absolute imports (with `@/` alias) for all `vi.mock` calls, improving code clarity and maintainability. [[1]](diffhunk://#diff-edaa13cb27ed8b2960ba042eeefff177778f4ee8b24d1c08d0e7903a9dc34671L56-R64) [[2]](diffhunk://#diff-18598a7b822cfaf4f0dd12bb0aef479d9bd6072f08f1a46e85e244004f580fd7L26-R34) [[3]](diffhunk://#diff-18598a7b822cfaf4f0dd12bb0aef479d9bd6072f08f1a46e85e244004f580fd7L48-R52) [[4]](diffhunk://#diff-ffa4894961f1bbc8dabf93a0906618c4706ecfcc50f11c56d3292d01e772e805L33-R33) [[5]](diffhunk://#diff-ffa4894961f1bbc8dabf93a0906618c4706ecfcc50f11c56d3292d01e772e805L43-R43) [[6]](diffhunk://#diff-ffa4894961f1bbc8dabf93a0906618c4706ecfcc50f11c56d3292d01e772e805L53-R53) [[7]](diffhunk://#diff-e690c7344a575b228e64ebab8a5891aa626c5ebf2a5c598505f3dc4a35e5b463L43-R43) [[8]](diffhunk://#diff-e690c7344a575b228e64ebab8a5891aa626c5ebf2a5c598505f3dc4a35e5b463L62-R62) [[9]](diffhunk://#diff-e690c7344a575b228e64ebab8a5891aa626c5ebf2a5c598505f3dc4a35e5b463L91-R91) [[10]](diffhunk://#diff-9a159f3464205cb8bb6e46df2954f3c81855408a35b2b6d7fd8ec6bb4db7c38bL24-R24) [[11]](diffhunk://#diff-0bc27a6cd65405df4689a68fbd526925ea19870a84b1e488aa6ab0c2acd03845L26-R34) [[12]](diffhunk://#diff-a59c439c5b87b3e5ebd9c453f2c5a0d4aeb1c5db8921cf920ac5b8e3f0cd5e8aL25-R25) [[13]](diffhunk://#diff-2193f5c86e9e206725f6cb9b7f4dd838863f5c1297311aa0ce60aa99a046679eL25-R25) [[14]](diffhunk://#diff-2193f5c86e9e206725f6cb9b7f4dd838863f5c1297311aa0ce60aa99a046679eL45-R51) [[15]](diffhunk://#diff-21d86ddc8a6cef0f68fd8b44e328931d71c533f389fe80ffc342b7c7bafa21edL26-R26) [[16]](diffhunk://#diff-dac44991614fcda53184d27947ced8b0641b907a7caee853fe23ebd83b0dc05fL24-R24) [[17]](diffhunk://#diff-5d5c633a977a57d9c79a7e8a3594840212d442f0899bd978eea7074dae63e34bL26-R34)

* Improved mocking strategies in tests, such as using `async (importOriginal)` to extend or wrap original modules (notably for `react-i18next` and `@thunderid/hooks`), ensuring more robust and flexible mocks. [[1]](diffhunk://#diff-18598a7b822cfaf4f0dd12bb0aef479d9bd6072f08f1a46e85e244004f580fd7L26-R34) [[2]](diffhunk://#diff-18598a7b822cfaf4f0dd12bb0aef479d9bd6072f08f1a46e85e244004f580fd7L48-R52) [[3]](diffhunk://#diff-0bc27a6cd65405df4689a68fbd526925ea19870a84b1e488aa6ab0c2acd03845L26-R34) [[4]](diffhunk://#diff-5d5c633a977a57d9c79a7e8a3594840212d442f0899bd978eea7074dae63e34bL26-R34)

**Helmet component and test updates:**

* Updated the `Helmet` component to add a `data-helmet="true"` attribute to dynamically created elements, and updated corresponding tests to query elements using this attribute, making tests more reliable and less prone to false positives. [[1]](diffhunk://#diff-652c510789957606a31d7627ab5c7e318605f22be6fa93559f0183a0f289dcedR79) [[2]](diffhunk://#diff-ad4d0364e2b43c0434319b825cf49ed093a9dacce4295a02304658daaa8734acL64-R64) [[3]](diffhunk://#diff-ad4d0364e2b43c0434319b825cf49ed093a9dacce4295a02304658daaa8734acL112-R112)

**Test setup enhancements:**

* Added a new `test-setup.ts` file in `components` to automatically clean up the DOM after each test, reducing test interference and improving reliability.

**Additional test improvements:**

* Improved i18n mocking in `EmojiPicker.test.tsx` by providing a more robust implementation of the `t` function, supporting variable interpolation and fallback values.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2694

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized product CSS class prefixes to "ThunderID" for consistent branding.

* **Bug Fixes**
  * Helmet now tags head elements it manages for more reliable head handling.
  * More specific runtime configuration error messaging.

* **Chores**
  * Test infrastructure improvements: stable deterministic mocks, global test setup/cleanup, Playwright-based browser provider, path-alias alignment, and test utilities updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2692)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->