### PR TITLE
Add app name to invite email template data

### DIFF
--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -107,6 +107,7 @@ func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.Executo
 
 	execResp.ForwardedData[common.ForwardedDataKeyTemplateData] = map[string]interface{}{
 		"inviteLink": inviteLink,
+		"appName":    ctx.Application.Name,
 	}
 
 	if ctx.FlowType == common.FlowTypeUserOnboarding {

--- a/backend/internal/flow/executor/invite_executor_test.go
+++ b/backend/internal/flow/executor/invite_executor_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	appmodel "github.com/thunder-id/thunderid/internal/application/model"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
 	"github.com/thunder-id/thunderid/internal/system/config"
@@ -235,6 +236,9 @@ func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_PopulatesTemplate
 		ExecutorMode: ExecutorModeGenerate,
 		FlowType:     common.FlowTypeRegistration,
 		RuntimeData:  make(map[string]string),
+		Application: appmodel.Application{
+			Name: "Test App",
+		},
 	}
 
 	resp, err := suite.executor.Execute(ctx)
@@ -250,10 +254,7 @@ func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_PopulatesTemplate
 	templateData, ok := resp.ForwardedData[common.ForwardedDataKeyTemplateData].(map[string]interface{})
 	suite.True(ok, "Expected template data to be map[string]interface{}")
 	suite.NotEmpty(templateData["inviteLink"], "inviteLink must be present")
-
-	// 3. Ensure appName was removed
-	_, hasAppName := templateData["appName"]
-	suite.False(hasAppName, "appName should not be present")
+	suite.Equal("Test App", templateData["appName"])
 }
 
 func (suite *InviteExecutorTestSuite) TestGetExecutionPolicy_GenerateMode_ReturnsNil() {


### PR DESCRIPTION
### Purpose
Fix self-registration invite emails leaving `{{ctx(appName)}}` unresolved in the subject and body.

The `SELF_REGISTRATION` email template expects `appName`, but the invite flow only forwarded `inviteLink` to the email renderer. As a result, registration invite emails showed the raw placeholder instead of the actual application name.

### Approach
Updated the backend invite generation path to include `appName` in the forwarded template data produced by `InviteExecutor`.

This keeps the change in the invite-specific executor, which is already responsible for preparing invite template context, instead of broadening `EmailExecutor` with scenario-specific fallback logic.

Also updated the existing invite executor test coverage to verify that the generated template data now includes both:
- `inviteLink`
- `appName`

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2695


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application name is now included in invitation link template data.

* **Tests**
  * Updated invitation executor tests to verify application name is properly included in generated invitations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2699)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->