### PR TITLE
Fix OU dropdown handling in ambiguous login flow

### DIFF
--- a/backend/internal/flow/executor/identifying_executor.go
+++ b/backend/internal/flow/executor/identifying_executor.go
@@ -437,6 +437,7 @@ func extractDisambiguationOptions(candidates []*entityprovider.Entity) []common.
 		}
 		inputs = append(inputs, common.Input{
 			Identifier: key,
+			Type:       common.InputTypeSelect,
 			Options:    options,
 		})
 	}

--- a/backend/internal/flow/executor/identifying_executor_test.go
+++ b/backend/internal/flow/executor/identifying_executor_test.go
@@ -904,16 +904,18 @@ func TestExtractDisambiguationOptions(t *testing.T) {
 
 	inputs := extractDisambiguationOptions(candidates)
 
-	optionsByKey := make(map[string][]string)
+	inputsByKey := make(map[string]common.Input)
 	for _, input := range inputs {
-		optionsByKey[input.Identifier] = input.Options
+		inputsByKey[input.Identifier] = input
 	}
 
-	assert.Contains(t, optionsByKey, "userType")
-	assert.ElementsMatch(t, []string{"Person", "Engineer"}, optionsByKey["userType"])
+	assert.Contains(t, inputsByKey, "userType")
+	assert.ElementsMatch(t, []string{"Person", "Engineer"}, inputsByKey["userType"].Options)
+	assert.Equal(t, common.InputTypeSelect, inputsByKey["userType"].Type)
 
-	assert.Contains(t, optionsByKey, "family_name")
-	assert.ElementsMatch(t, []string{"Johnson", "Smith"}, optionsByKey["family_name"])
+	assert.Contains(t, inputsByKey, "family_name")
+	assert.ElementsMatch(t, []string{"Johnson", "Smith"}, inputsByKey["family_name"].Options)
+	assert.Equal(t, common.InputTypeSelect, inputsByKey["family_name"].Type)
 
-	assert.NotContains(t, optionsByKey, "given_name")
+	assert.NotContains(t, inputsByKey, "given_name")
 }


### PR DESCRIPTION
### Purpose
This pull request fixes an issue of not showing the OU dropdown during user disambiguation flow login.

### Approach

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2673

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed disambiguation options to display as dropdown selections for improved user clarity and experience during attribute disambiguation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2701)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->