### PR TITLE
Allow user disambiguation for more than two OUs

### DIFF
--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -112,6 +112,7 @@ const (
 	failureReasonUserNotFound         = "User not found"
 	failureReasonInvalidCredentials   = "Invalid credentials provided" // #nosec G101
 	failureReasonFailedToIdentifyUser = "Failed to identify user"
+	failureReasonAmbiguousUser        = "User identity is ambiguous"
 	failureReasonInvalidOTP           = "invalid OTP provided"
 	failureReasonInvalidMagicLink     = "Invalid magic link token"
 )

--- a/backend/internal/flow/executor/identifying_executor.go
+++ b/backend/internal/flow/executor/identifying_executor.go
@@ -96,7 +96,7 @@ func (i *identifyingExecutor) IdentifyUser(filters map[string]interface{},
 		} else if err.Code == entityprovider.ErrorCodeAmbiguousEntity {
 			logger.Debug("Multiple users found for the provided filters")
 			execResp.Status = common.ExecFailure
-			execResp.FailureReason = failureReasonFailedToIdentifyUser
+			execResp.FailureReason = failureReasonAmbiguousUser
 			return nil, nil
 		} else {
 			logger.Debug("Failed to identify user due to error: " + err.Error())

--- a/backend/internal/flow/executor/identifying_executor_test.go
+++ b/backend/internal/flow/executor/identifying_executor_test.go
@@ -745,7 +745,7 @@ func (suite *IdentifyingExecutorTestSuite) TestExecute_IdentifyMode_AmbiguousUse
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
-	assert.Equal(suite.T(), failureReasonFailedToIdentifyUser, resp.FailureReason)
+	assert.Equal(suite.T(), failureReasonAmbiguousUser, resp.FailureReason)
 	assert.Empty(suite.T(), resp.Inputs, "Inputs must not be populated for ambiguous user in identify mode")
 }
 

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -353,14 +353,7 @@ func (o *oAuthExecutor) getContextUserForAuthentication(ctx *core.NodeContext,
 
 	// If no local user is found, check if authentication without local user is allowed
 	if internalUser == nil {
-		allowAuthWithoutLocalUser := false
-		if val, ok := ctx.NodeProperties[common.NodePropertyAllowAuthenticationWithoutLocalUser]; ok {
-			if boolVal, ok := val.(bool); ok {
-				allowAuthWithoutLocalUser = boolVal
-			}
-		}
-
-		if allowAuthWithoutLocalUser {
+		if isAuthenticationWithoutLocalUserAllowed(ctx) {
 			if execResp.RuntimeData == nil {
 				execResp.RuntimeData = make(map[string]string)
 			}
@@ -428,6 +421,20 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	if isAmbiguous {
+		// An ambiguous user (exists in multiple OUs) can still be provisioned into a new target
+		// OU when cross-OU provisioning is explicitly allowed. The ProvisioningExecutor enforces
+		// the same-OU duplicate guard, so we don't need to fail here.
+		if isRegistrationWithExistingUserAllowed(ctx) && isCrossOUProvisioningAllowed(ctx) {
+			logger.Debug("Ambiguous user detected, proceeding with cross-OU provisioning eligibility")
+			execResp.Status = common.ExecComplete
+			execResp.FailureReason = ""
+			execResp.RuntimeData[userAttributeSub] = sub
+
+			return &authncm.AuthenticatedUser{
+				IsAuthenticated: false,
+			}, nil
+		}
+
 		logger.Debug("Ambiguous user detected in registration flow, cannot proceed with registration")
 		execResp.Status = common.ExecFailure
 		execResp.FailureReason = "User identity is ambiguous and cannot be registered."
@@ -447,23 +454,8 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 	}
 
 	// If a local user is found, check if registration with existing user is allowed
-	allowRegistrationWithExistingUser := false
-	if val, ok := ctx.NodeProperties[common.NodePropertyAllowRegistrationWithExistingUser]; ok {
-		if boolVal, ok := val.(bool); ok {
-			allowRegistrationWithExistingUser = boolVal
-		}
-	}
-
-	if allowRegistrationWithExistingUser {
-		// Check if cross-OU provisioning is enabled
-		allowCrossOUProvisioning := false
-		if val, ok := ctx.NodeProperties[common.NodePropertyAllowCrossOUProvisioning]; ok {
-			if boolVal, ok := val.(bool); ok {
-				allowCrossOUProvisioning = boolVal
-			}
-		}
-
-		if allowCrossOUProvisioning {
+	if isRegistrationWithExistingUserAllowed(ctx) {
+		if isCrossOUProvisioningAllowed(ctx) {
 			// Allow the flow to continue so the ProvisioningExecutor can create the user in
 			// the target OU. The same-OU duplicate guard is enforced by the ProvisioningExecutor
 			// itself, which has access to the target OU context. We intentionally do not set

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -975,7 +975,7 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_WithExist
 	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
 }
 
-func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_AmbiguousUser_NoLocalUser() {
+func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_AmbiguousUser_NoCrossOUProvisioning() {
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeRegistration,
@@ -998,7 +998,34 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_Ambiguous
 	assert.Equal(suite.T(), "User identity is ambiguous and cannot be registered.", execResp.FailureReason)
 }
 
-func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_AmbiguousUser_WithExistingUser() {
+func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_AmbiguousUser_AllowRegistrationOnly() {
+	// allowRegistrationWithExistingUser=true but allowCrossOUProvisioning=false — should still fail.
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		NodeProperties: map[string]interface{}{
+			"idpId":                             "idp-123",
+			"allowRegistrationWithExistingUser": true,
+			"allowCrossOUProvisioning":          false,
+		},
+	}
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	contextUser, err := suite.executor.(*oAuthExecutor).getContextUserForRegistration(
+		ctx, execResp, "ambiguous-sub", nil, true)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), contextUser)
+	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User identity is ambiguous and cannot be registered.", execResp.FailureReason)
+}
+
+func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_AmbiguousUser_CrossOUProvisioningAllowed() {
+	// allowRegistrationWithExistingUser=true AND allowCrossOUProvisioning=true — should proceed.
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",
 		FlowType:    common.FlowTypeRegistration,
@@ -1014,19 +1041,15 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserForRegistration_Ambiguous
 		RuntimeData:    make(map[string]string),
 	}
 
-	existingUser := &entityprovider.Entity{
-		ID:   "user-789",
-		OUID: "ou-789",
-		Type: "INTERNAL",
-	}
-
 	contextUser, err := suite.executor.(*oAuthExecutor).getContextUserForRegistration(
-		ctx, execResp, "ambiguous-sub", existingUser, true)
+		ctx, execResp, "ambiguous-sub", nil, true)
 
 	assert.NoError(suite.T(), err)
-	assert.Nil(suite.T(), contextUser)
-	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
-	assert.Equal(suite.T(), "User identity is ambiguous and cannot be registered.", execResp.FailureReason)
+	assert.NotNil(suite.T(), contextUser)
+	assert.False(suite.T(), contextUser.IsAuthenticated)
+	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
+	assert.Empty(suite.T(), execResp.FailureReason)
+	assert.Equal(suite.T(), "ambiguous-sub", execResp.RuntimeData[userAttributeSub])
 }
 
 func (suite *OAuthExecutorTestSuite) TestResolveUserTypeForAutoProvisioning_FailureScenarios() {

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -126,6 +126,17 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 		execResp.FailureReason = failureReasonFailedToIdentifyUser
 		return execResp, nil
 	}
+	if execResp.Status == common.ExecFailure &&
+		execResp.FailureReason == failureReasonAmbiguousUser &&
+		isCrossOUProvisioningAllowed(ctx) {
+		resolved, err := p.resolveAmbiguousUserForProvisioning(ctx, identifyingAttrs)
+		if err != nil {
+			return nil, err
+		}
+		userID = resolved
+		execResp.Status = ""
+		execResp.FailureReason = ""
+	}
 	if execResp.Status == common.ExecFailure && execResp.FailureReason != failureReasonUserNotFound {
 		return execResp, nil
 	}
@@ -139,7 +150,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 		}
 	}
 
-	// Merge identifying and credential attributes for user creation.
+	// Merge identifying and credential attributes for user creation
 	userAttributes := make(map[string]interface{}, len(identifyingAttrs)+len(credentialAttrs))
 	for k, v := range identifyingAttrs {
 		userAttributes[k] = v
@@ -219,15 +230,8 @@ func (p *provisioningExecutor) handleExistingUser(ctx *core.NodeContext, userID 
 		}
 	}
 
-	// Check if cross-OU provisioning is explicitly enabled for this node.
-	allowCrossOUProvisioning := false
-	if val, ok := ctx.NodeProperties[common.NodePropertyAllowCrossOUProvisioning]; ok {
-		if boolVal, ok := val.(bool); ok {
-			allowCrossOUProvisioning = boolVal
-		}
-	}
-
-	if !allowCrossOUProvisioning {
+	// Check if cross-OU provisioning is explicitly enabled for this node
+	if !isCrossOUProvisioningAllowed(ctx) {
 		if ctx.FlowType == common.FlowTypeRegistration {
 			execResp.Status = common.ExecUserInputRequired
 			execResp.Inputs = p.GetRequiredInputs(ctx)
@@ -266,6 +270,34 @@ func (p *provisioningExecutor) handleExistingUser(ctx *core.NodeContext, userID 
 		log.String("existingOUID", existingUser.OUID),
 		log.String("targetOUID", targetOUID))
 	return true, nil
+}
+
+// resolveAmbiguousUserForProvisioning is called when IdentifyUser reports ambiguity and cross-OU
+// provisioning is allowed. It searches for all matching users and returns the ID of the one in the
+// target OU, or nil if none exists there.
+func (p *provisioningExecutor) resolveAmbiguousUserForProvisioning(ctx *core.NodeContext,
+	identifyingAttrs map[string]interface{}) (*string, error) {
+	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+
+	matches, searchErr := p.entityProvider.SearchEntities(identifyingAttrs)
+	if searchErr != nil {
+		return nil, fmt.Errorf("failed to search for matching users: code=%s, description=%s",
+			searchErr.Code, searchErr.Description)
+	}
+
+	targetOUID := p.getOUID(ctx)
+	for _, m := range matches {
+		if m == nil || m.OUID == "" {
+			return nil, fmt.Errorf("ambiguous user search returned an entity with missing OUID")
+		}
+		if m.OUID == targetOUID {
+			logger.Debug("Ambiguous user has a match in the target OU", log.MaskedString(log.LoggerKeyUserID, m.ID))
+			return &m.ID, nil
+		}
+	}
+
+	logger.Debug("Ambiguous user has no match in target OU", log.Int("matchCount", len(matches)))
+	return nil, nil
 }
 
 // HasRequiredInputs checks whether all schema-driven provisioning inputs are satisfied and appends

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -3157,3 +3157,169 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_NoProperties_D
 	assert.Len(suite.T(), execResp.Inputs, 2,
 		"all required missing inputs must be prompted at once when maxPerPrompt is absent")
 }
+
+// Ambiguous user (exists in multiple OUs) + cross-OU allowed + no match in target OU → create.
+func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_AmbiguousUser_NoMatchInTargetOU_Creates() {
+	suite.expectSchemaForProvisioning()
+	attrs := map[string]interface{}{"sub": "user-sub-123"}
+	attrsJSON, _ := json.Marshal(attrs)
+
+	createdUser := &entityprovider.Entity{
+		ID:         testNewUserID,
+		Type:       testUserType,
+		OUID:       testOUID,
+		Attributes: attrsJSON,
+	}
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"sub": "user-sub-123"},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyAllowCrossOUProvisioning: true,
+		},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity", attrs).
+		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeAmbiguousEntity, "ambiguous", ""))
+	suite.mockEntityProvider.On("SearchEntities", attrs).
+		Return([]*entityprovider.Entity{
+			{ID: testExistingUserID, OUID: "ou-toyota"},
+			{ID: "other-user-id", OUID: "ou-honda"},
+		}, nil)
+	suite.mockEntityProvider.On("CreateEntity", mock.MatchedBy(func(u *entityprovider.Entity) bool {
+		return u.OUID == testOUID
+	}), mock.Anything).Return(createdUser, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), testNewUserID, resp.RuntimeData[userAttributeUserID])
+}
+
+// Ambiguous user + cross-OU allowed + match found in target OU → fail "already exists in target".
+func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_AmbiguousUser_MatchInTargetOU_Fails() {
+	suite.expectSchemaForProvisioning()
+	attrs := map[string]interface{}{"sub": "user-sub-123"}
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"sub": "user-sub-123"},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyAllowCrossOUProvisioning: true,
+		},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity", attrs).
+		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeAmbiguousEntity, "ambiguous", ""))
+	suite.mockEntityProvider.On("SearchEntities", attrs).
+		Return([]*entityprovider.Entity{
+			{ID: testExistingUserID, OUID: testOUID},
+			{ID: "other-user-id", OUID: "ou-honda"},
+		}, nil)
+	suite.mockEntityProvider.On("GetEntity", testExistingUserID).
+		Return(&entityprovider.Entity{ID: testExistingUserID, OUID: testOUID}, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), "User already exists in the target organization", resp.FailureReason)
+}
+
+// Ambiguous user + cross-OU NOT allowed → fail immediately without searching.
+func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_AmbiguousUser_CrossOUNotAllowed_Fails() {
+	suite.expectSchemaForProvisioning()
+	attrs := map[string]interface{}{"sub": "user-sub-123"}
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"sub": "user-sub-123"},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeProperties: map[string]interface{}{},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity", attrs).
+		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeAmbiguousEntity, "ambiguous", ""))
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), failureReasonAmbiguousUser, resp.FailureReason)
+}
+
+// Ambiguous user + cross-OU allowed + SearchEntities returns error
+func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_AmbiguousUser_SearchError_ReturnsServerError() {
+	suite.expectSchemaForProvisioning()
+	attrs := map[string]interface{}{"sub": "user-sub-123"}
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"sub": "user-sub-123"},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyAllowCrossOUProvisioning: true,
+		},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity", attrs).
+		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeAmbiguousEntity, "ambiguous", ""))
+	suite.mockEntityProvider.On("SearchEntities", attrs).
+		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeSystemError, "search failed", ""))
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), resp)
+}
+
+// Non-ambiguous system error + cross-OU allowed → fail immediately, no search attempted.
+func (suite *ProvisioningExecutorTestSuite) TestExecute_CrossOU_SystemError_NoSearchAttempted() {
+	suite.expectSchemaForProvisioning()
+	attrs := map[string]interface{}{"sub": "user-sub-123"}
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs:  map[string]string{"sub": "user-sub-123"},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyAllowCrossOUProvisioning: true,
+		},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity", attrs).
+		Return(nil, entityprovider.NewEntityProviderError(entityprovider.ErrorCodeSystemError, "db error", ""))
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), failureReasonFailedToIdentifyUser, resp.FailureReason)
+	suite.mockEntityProvider.AssertNotCalled(suite.T(), "SearchEntities", mock.Anything)
+}

--- a/backend/internal/flow/executor/utils.go
+++ b/backend/internal/flow/executor/utils.go
@@ -25,6 +25,8 @@ import (
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
+	"github.com/thunder-id/thunderid/internal/flow/common"
+	"github.com/thunder-id/thunderid/internal/flow/core"
 )
 
 // getAuthnServiceName returns the authn service name for an executor.
@@ -59,4 +61,47 @@ func GetUserAttribute(user *entityprovider.Entity, attributeKey string) (string,
 	}
 
 	return "", fmt.Errorf("attribute '%s' not found or is empty", attributeKey)
+}
+
+// isAuthenticationWithoutLocalUserAllowed returns the value of the AllowAuthenticationWithoutLocalUser
+// node property, defaulting to false if absent or not a bool.
+// This is used to determine if authentication flow can proceed without a local user account.
+// Idea is to use this in authentication flows which has a ProvisioningExecutor attached at the end
+// to provision the user account and auto login without throwing an error for user not found.
+func isAuthenticationWithoutLocalUserAllowed(ctx *core.NodeContext) bool {
+	if val, ok := ctx.NodeProperties[common.NodePropertyAllowAuthenticationWithoutLocalUser]; ok {
+		if boolVal, ok := val.(bool); ok {
+			return boolVal
+		}
+	}
+	return false
+}
+
+// isRegistrationWithExistingUserAllowed returns the value of the AllowRegistrationWithExistingUser
+// node property, defaulting to false if absent or not a bool.
+// This is used to determine if registration flow can proceed when an existing user account is found.
+// Idea is to use this in registration flows which can continue with the existing user account
+// instead of throwing an error for user already exists and allow the flow to complete successfully.
+func isRegistrationWithExistingUserAllowed(ctx *core.NodeContext) bool {
+	if val, ok := ctx.NodeProperties[common.NodePropertyAllowRegistrationWithExistingUser]; ok {
+		if boolVal, ok := val.(bool); ok {
+			return boolVal
+		}
+	}
+	return false
+}
+
+// isCrossOUProvisioningAllowed returns the value of the AllowCrossOUProvisioning node property,
+// defaulting to false if absent or not a bool.
+// This is used to determine if provisioning can proceed across organizational units (OUs).
+// Idea is to use this in registration flows which can continue even if an existing user account
+// is found, but the provisioning executor is trying to provision the user to a different OU than
+// the one in the existing account.
+func isCrossOUProvisioningAllowed(ctx *core.NodeContext) bool {
+	if val, ok := ctx.NodeProperties[common.NodePropertyAllowCrossOUProvisioning]; ok {
+		if boolVal, ok := val.(bool); ok {
+			return boolVal
+		}
+	}
+	return false
 }

--- a/backend/internal/flow/executor/utils_test.go
+++ b/backend/internal/flow/executor/utils_test.go
@@ -157,3 +157,138 @@ func (s *UtilsTestSuite) TestGetUserAttribute() {
 		})
 	}
 }
+
+func (s *UtilsTestSuite) TestIsAuthenticationWithoutLocalUserAllowed() {
+	tests := []struct {
+		name       string
+		properties map[string]interface{}
+		expected   bool
+	}{
+		{
+			name: "Property true",
+			properties: map[string]interface{}{
+				common.NodePropertyAllowAuthenticationWithoutLocalUser: true,
+			},
+			expected: true,
+		},
+		{
+			name: "Property false",
+			properties: map[string]interface{}{
+				common.NodePropertyAllowAuthenticationWithoutLocalUser: false,
+			},
+			expected: false,
+		},
+		{
+			name: "Property missing",
+			properties: map[string]interface{}{
+				"other": true,
+			},
+			expected: false,
+		},
+		{
+			name: "Property invalid type",
+			properties: map[string]interface{}{
+				common.NodePropertyAllowAuthenticationWithoutLocalUser: "true",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			ctx := &core.NodeContext{NodeProperties: tt.properties}
+			result := isAuthenticationWithoutLocalUserAllowed(ctx)
+			s.Equal(tt.expected, result)
+		})
+	}
+}
+
+func (s *UtilsTestSuite) TestIsRegistrationWithExistingUserAllowed() {
+	tests := []struct {
+		name       string
+		properties map[string]interface{}
+		expected   bool
+	}{
+		{
+			name: "Property true",
+			properties: map[string]interface{}{
+				common.NodePropertyAllowRegistrationWithExistingUser: true,
+			},
+			expected: true,
+		},
+		{
+			name: "Property false",
+			properties: map[string]interface{}{
+				common.NodePropertyAllowRegistrationWithExistingUser: false,
+			},
+			expected: false,
+		},
+		{
+			name: "Property missing",
+			properties: map[string]interface{}{
+				"other": true,
+			},
+			expected: false,
+		},
+		{
+			name: "Property invalid type",
+			properties: map[string]interface{}{
+				common.NodePropertyAllowRegistrationWithExistingUser: 1,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			ctx := &core.NodeContext{NodeProperties: tt.properties}
+			result := isRegistrationWithExistingUserAllowed(ctx)
+			s.Equal(tt.expected, result)
+		})
+	}
+}
+
+func (s *UtilsTestSuite) TestIsCrossOUProvisioningAllowed() {
+	tests := []struct {
+		name       string
+		properties map[string]interface{}
+		expected   bool
+	}{
+		{
+			name: "Property true",
+			properties: map[string]interface{}{
+				common.NodePropertyAllowCrossOUProvisioning: true,
+			},
+			expected: true,
+		},
+		{
+			name: "Property false",
+			properties: map[string]interface{}{
+				common.NodePropertyAllowCrossOUProvisioning: false,
+			},
+			expected: false,
+		},
+		{
+			name: "Property missing",
+			properties: map[string]interface{}{
+				"other": true,
+			},
+			expected: false,
+		},
+		{
+			name: "Property invalid type",
+			properties: map[string]interface{}{
+				common.NodePropertyAllowCrossOUProvisioning: []string{"true"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			ctx := &core.NodeContext{NodeProperties: tt.properties}
+			result := isCrossOUProvisioningAllowed(ctx)
+			s.Equal(tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
### Purpose
This pull request enhances the handling of ambiguous user identities and cross-organizational unit (OU) provisioning in the authentication and registration flows. The changes introduce clearer distinction and logic for ambiguous users, allow for more flexible registration scenarios (especially when cross-OU provisioning is enabled), and refactor configuration checks for better maintainability. Comprehensive tests have been added to cover these new scenarios.

Mainly this fixes the issue with user disambiguation where it doesn't allow to provision same user for more than two OUs.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2674

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced handling for ambiguous user identity scenarios with dedicated error messaging.
  * Added support for cross-organizational unit provisioning when resolving ambiguous user identities.

* **Tests**
  * Expanded test coverage for ambiguous user identification and cross-OU provisioning scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2702)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->