### PR TITLE
Fix ThunderID docs Docker Compose URL for release updates

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -173,7 +173,10 @@ jobs:
           sed -i -E "s|(https://raw\.githubusercontent\.com/thunder-id/thunderid/)v[0-9]+\.[0-9]+\.[0-9]+(/.+docker-compose\.yml)|\1${VERSION}\2|g" docs/content/guides/getting-started/get-thunderid.mdx
 
           echo "✅ Updated get-thunderid.mdx curl URL to $VERSION"
-          grep 'docker-compose.yml' docs/content/guides/getting-started/get-thunderid.mdx
+          grep -q "thunder-id/thunderid/${VERSION}/install/quick-start/docker-compose.yml" docs/content/guides/getting-started/get-thunderid.mdx || {
+            echo "❌ Error: Failed to update get-thunderid.mdx docker-compose URL to $VERSION"
+            exit 1
+          }
 
       - name: 📝 Update Helm and Sample App Versions
         if: ${{ steps.get_version.outputs.use_existing_version != 'true' }}

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -167,6 +167,14 @@ jobs:
           echo "✅ Updated README.md curl URL to $VERSION"
           grep 'docker-compose.yml' README.md
 
+          echo "📝 Updating get-thunderid.mdx docker-compose curl URL to $VERSION"
+
+          # Update the docker-compose.yml curl URL in docs
+          sed -i -E "s|(https://raw\.githubusercontent\.com/thunder-id/thunderid/)v[0-9]+\.[0-9]+\.[0-9]+(/.+docker-compose\.yml)|\1${VERSION}\2|g" docs/content/guides/getting-started/get-thunderid.mdx
+
+          echo "✅ Updated get-thunderid.mdx curl URL to $VERSION"
+          grep 'docker-compose.yml' docs/content/guides/getting-started/get-thunderid.mdx
+
       - name: 📝 Update Helm and Sample App Versions
         if: ${{ steps.get_version.outputs.use_existing_version != 'true' }}
         run: |
@@ -212,6 +220,7 @@ jobs:
           git add \
             version.txt \
             README.md \
+            docs/content/guides/getting-started/get-thunderid.mdx \
             install/helm/Chart.yaml \
             install/openchoreo/helm/Chart.yaml \
             install/openchoreo/helm/charts/${PRODUCT_NAME_LOWER}-oc-componenttype/Chart.yaml \

--- a/docs/content/guides/getting-started/get-thunderid.mdx
+++ b/docs/content/guides/getting-started/get-thunderid.mdx
@@ -112,7 +112,7 @@ The quickest way to get <ProductName /> up and running with all dependencies con
 
 Download the `docker-compose.yml` file from the <ProductName /> repository:
 
-{/* TODO: Fix the version in the URL below */}
+{/* The release workflow keeps this versioned URL in sync. */}
 ```bash
 curl -o docker-compose.yml https://raw.githubusercontent.com/thunder-id/thunderid/v0.37.0/install/quick-start/docker-compose.yml
 ```

--- a/docs/content/guides/getting-started/get-thunderid.mdx
+++ b/docs/content/guides/getting-started/get-thunderid.mdx
@@ -114,7 +114,7 @@ Download the `docker-compose.yml` file from the <ProductName /> repository:
 
 {/* TODO: Fix the version in the URL below */}
 ```bash
-curl -o docker-compose.yml https://raw.githubusercontent.com/thunder-id/thunderid/v0.16.0/install/quick-start/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/thunder-id/thunderid/v0.37.0/install/quick-start/docker-compose.yml
 ```
 
 ### Step 2: Start <ProductName />


### PR DESCRIPTION
This pull request updates the release automation and documentation to ensure the correct version of the `docker-compose.yml` file is referenced in both the main README and the getting started guide. The changes automate the version update in documentation during releases and ensure that the updated file is committed.

Documentation automation improvements:

* The release workflow now automatically updates the `docker-compose.yml` curl URL in `docs/content/guides/getting-started/get-thunderid.mdx` to match the current release version, ensuring documentation always points to the latest version.
* The workflow adds `get-thunderid.mdx` to the list of files to commit after updating version references, so the change is included in the release commit.

Documentation update:

* The hardcoded version in the `docker-compose.yml` download URL in `get-thunderid.mdx` is updated from `v0.16.0` to `v0.37.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the getting-started guide to reference Thunder ID v0.37.0 for the Docker Compose quick-start and added a note about the workflow keeping the URL in sync.
* **Chores**
  * Release workflow now updates the versioned Docker Compose URL in docs and includes that docs change when committing version bumps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2703)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->