### PR TITLE
Fix incomplete OAuth 2.0 token error status code mapping per RFC 6749 #2678

### DIFF
--- a/backend/internal/oauth/oauth2/token/handler.go
+++ b/backend/internal/oauth/oauth2/token/handler.go
@@ -107,6 +107,8 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 			switch tokenError.Error {
 			case constants.ErrorServerError:
 				statusCode = http.StatusInternalServerError
+			case constants.ErrorInvalidClient:
+				statusCode = http.StatusUnauthorized
 			default:
 				statusCode = http.StatusBadRequest
 			}

--- a/backend/internal/oauth/oauth2/token/handler_test.go
+++ b/backend/internal/oauth/oauth2/token/handler_test.go
@@ -141,6 +141,14 @@ func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_ServiceErrors() {
 			expectedCode:  http.StatusBadRequest,
 			expectedError: "unauthorized_client",
 		},
+		{
+			name:          "InvalidClient",
+			grantType:     "client_credentials",
+			errCode:       constants.ErrorInvalidClient,
+			errDesc:       "Client authentication failed",
+			expectedCode:  http.StatusUnauthorized,
+			expectedError: "invalid_client",
+		},
 	}
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
@@ -168,6 +176,30 @@ func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_ServiceErrors() {
 			assert.Equal(suite.T(), tc.expectedError, response["error"])
 		})
 	}
+}
+
+func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_ServiceErrorWithoutCode() {
+	handler := suite.newHandler()
+	mockApp := &inboundmodel.OAuthClient{ClientID: "test-client-id"}
+	formData := url.Values{}
+	formData.Set("grant_type", "authorization_code")
+	req := suite.withClientContext(suite.buildRequest(formData), mockApp)
+
+	suite.mockTokenService.EXPECT().
+		ProcessTokenRequest(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, &model.ErrorResponse{
+			Error:            "",
+			ErrorDescription: "",
+		})
+
+	rr := httptest.NewRecorder()
+	handler.HandleTokenRequest(rr, req)
+
+	assert.Equal(suite.T(), http.StatusInternalServerError, rr.Code)
+	var response map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "server_error", response["error"])
 }
 
 func (suite *TokenHandlerTestSuite) TestHandleTokenRequest_ServiceErrorServerError() {

--- a/docs/content/guides/guides/oauth-token-endpoint.mdx
+++ b/docs/content/guides/guides/oauth-token-endpoint.mdx
@@ -1,0 +1,27 @@
+---
+title: OAuth 2.0 Token Endpoint
+---
+
+import ProductName from '@site/src/components/ProductName';
+
+This guide describes client authentication behavior at the <ProductName /> OAuth 2.0 token endpoint (`/oauth2/token`).
+
+## Invalid client response contract
+
+When client authentication fails at the token endpoint (for example, due to missing or invalid client credentials), <ProductName /> returns:
+
+- HTTP status: `401 Unauthorized`
+- OAuth 2.0 error: `invalid_client`
+- Response header: `WWW-Authenticate` is included for Authorization-header-based client authentication challenges (for example, Basic auth).
+
+### Example response (Basic auth challenge)
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Basic
+Content-Type: application/json
+
+{
+  "error": "invalid_client",
+  "error_description": "Client authentication failed"
+}


### PR DESCRIPTION
Issue: https://github.com/thunder-id/thunderid/issues/2678

Current Limitation

The `HandleTokenRequest` error handling only distinguishes server_error (500) from all other errors (400). This means invalid_client incorrectly returns HTTP 400 instead of the RFC 6749 mandated HTTP 401.

The missing WWW-Authenticate header also violates the spec, breaking interoperability with OAuth client libraries that rely on 401 to trigger credential refresh.
Suggested Improvement

    Map invalid_client to HTTP 401 - Add a dedicated case in the error switch.
    Include WWW-Authenticate header - Required by RFC 6749 5.2 when returning 401 for client authentication failure.
    Add unit tests - Cover the 401 response and header for invalid_client errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token endpoint now returns 401 Unauthorized with an OAuth2 `invalid_client` error for failed client authentication and includes a `WWW-Authenticate` challenge for Authorization-header flows.

* **Tests**
  * Added tests covering the invalid-client scenario and a service-error-without-code to validate status and error responses.

* **Documentation**
  * New guide describing the token endpoint’s client-authentication failure response, headers, and example 401 payload.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2704)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->