### PR TITLE
Update GitHub repository references

### DIFF
--- a/docs/scripts/generate-changelog.mjs
+++ b/docs/scripts/generate-changelog.mjs
@@ -25,7 +25,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const OUTPUT_FILE = join(__dirname, '..', 'static', 'data', 'releases.json');
-const GITHUB_REPO = 'asgardeo/thunder';
+const GITHUB_REPO = 'thunder-id/thunderid';
 const GITHUB_REPO_API_URL = `https://api.github.com/repos/${GITHUB_REPO}`;
 const GITHUB_RELEASES_API_URL = `${GITHUB_REPO_API_URL}/releases`;
 
@@ -126,7 +126,7 @@ function sanitizeReleaseBody(body = '', releaseTag) {
 
   sanitized = sanitized.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt, src) => {
     if (!src.startsWith('http')) {
-      const githubRawUrl = `https://raw.githubusercontent.com/asgardeo/thunder/${releaseTag}/${src}`;
+      const githubRawUrl = `https://raw.githubusercontent.com/${GITHUB_REPO}/${releaseTag}/${src}`;
 
       return `![${alt}](${githubRawUrl})`;
     }
@@ -360,25 +360,45 @@ async function buildChangelogData(repository, releases) {
   };
 }
 
+function buildFallbackChangelogData() {
+  return {
+    generatedAt: new Date().toISOString(),
+    latestRelease: null,
+    releases: [],
+    repository: {
+      description: 'Thunder release notes and downloads.',
+      forks: 0,
+      fullName: GITHUB_REPO,
+      stars: 0,
+      subscribers: 0,
+      url: `https://github.com/${GITHUB_REPO}`,
+      releasesUrl: `https://github.com/${GITHUB_REPO}/releases`,
+    },
+  };
+}
+
+function writeChangelogData(changelogData) {
+  mkdirSync(dirname(OUTPUT_FILE), {recursive: true});
+  writeFileSync(OUTPUT_FILE, `${JSON.stringify(changelogData, null, 2)}\n`, 'utf8');
+}
+
 async function generate() {
   try {
     const [repository, releases] = await Promise.all([fetchRepository(), fetchReleases()]);
-
-    if (!repository && releases.length === 0) {
-      if (existsSync(OUTPUT_FILE)) {
-        logger.warn(`Skipping changelog data update because GitHub data is unavailable. Preserving ${OUTPUT_FILE}.`);
-
-        return;
-      }
-    }
-
     const changelogData = await buildChangelogData(repository, releases);
 
-    mkdirSync(dirname(OUTPUT_FILE), {recursive: true});
-    writeFileSync(OUTPUT_FILE, `${JSON.stringify(changelogData, null, 2)}\n`, 'utf8');
+    writeChangelogData(changelogData);
     logger.info(`Changelog data generated at ${OUTPUT_FILE}`);
   } catch (error) {
-    logger.error('❌ Failed to generate changelog — keeping existing file:', error);
+    if (existsSync(OUTPUT_FILE)) {
+      logger.error('❌ Failed to generate changelog — keeping existing file:', error);
+
+      return;
+    }
+
+    logger.error('❌ Failed to generate changelog — writing fallback release data:', error);
+    writeChangelogData(buildFallbackChangelogData());
+    logger.info(`Fallback changelog data generated at ${OUTPUT_FILE}`);
   }
 }
 

--- a/docs/src/pages/docs/next/releases.tsx
+++ b/docs/src/pages/docs/next/releases.tsx
@@ -575,7 +575,7 @@ export default function ReleasesPage() {
           <div className="releases-hero-actions">
             <a
               className="button button--primary"
-              href={repository?.releasesUrl ?? 'https://github.com/asgardeo/thunder/releases'}
+              href={repository?.releasesUrl ?? 'https://github.com/thunder-id/thunderid/releases'}
               target="_blank"
               rel="noreferrer"
             >
@@ -626,7 +626,7 @@ export default function ReleasesPage() {
         <section className="releases-footer-note">
           <p>
             Source:{' '}
-            <Link to={repository?.url ?? 'https://github.com/asgardeo/thunder'}>
+            <Link to={repository?.url ?? 'https://github.com/thunder-id/thunderid'}>
               {repository?.fullName ?? siteConfig.title}
             </Link>
             {data?.generatedAt ? ` · Updated ${new Date(data.generatedAt).toLocaleString('en-US')}` : ''}


### PR DESCRIPTION
### Purpose
- Update GitHub repository references in changelog and releases page
---

### Approach
```asgardeo/thunder``` --> ```thunder-id/thunderid```

### Related Issues
- N/A

### Related PRs
- [N/A](https://github.com/thunder-id/thunderid/pull/2420)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub repository links and references throughout the documentation to point to the correct repository.
  * Improved changelog generation robustness with automatic fallback data handling to ensure reliability when repository metadata retrieval encounters issues.
  * Updated release page to consistently display correct repository links for all GitHub-related actions and references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2707)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->