### PR TITLE
Add input validation for flow inputs

### DIFF
--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -161,3 +161,4 @@ Twilio
 [Rr]untimedb
 [Uu]serdb
 [Cc]onsentdb
+[Mm]ultibyte

--- a/api/flow-execution.yaml
+++ b/api/flow-execution.yaml
@@ -81,26 +81,66 @@ paths:
                     challengeToken: "a3f2e1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2"
                     type: "VIEW"
                     data:
-                      inputs: [
-                        {
-                          ref: "input_username",
-                          identifier: "username",
-                          type: "TEXT_INPUT",
+                      inputs:
+                        - ref: "input_username"
+                          identifier: "username"
+                          type: "TEXT_INPUT"
                           required: true
-                        },
-                        {
-                          ref: "input_password",
-                          identifier: "password",
-                          type: "PASSWORD_INPUT",
+                          validation:
+                            - type: "regex"
+                              value: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+                              message: "{{i18n(validation:email.invalid)}}"
+                        - ref: "input_password"
+                          identifier: "password"
+                          type: "PASSWORD_INPUT"
                           required: true
-                        }
-                      ]
-                      actions: [
-                        {
-                          "ref": "action_submit",
-                          "nextNode": "node_bs12",
-                        }
-                      ]
+                          validation:
+                            - type: "minLength"
+                              value: 8
+                              message: "{{i18n(validation:password.minLength.invalid)}}"
+                            - type: "maxLength"
+                              value: 128
+                              message: "{{i18n(validation:password.maxLength.invalid)}}"
+                      actions:
+                        - ref: "action_submit"
+                          nextNode: "node_bs12"
+                validationFailedFlow:
+                  summary: Incomplete flow (input validation failed)
+                  value:
+                    executionId: "2c6d4c45-3de9-4a70-ae6b-ba1d034af6bc"
+                    flowStatus: "INCOMPLETE"
+                    stepId: "3071b6c6-0119-465c-b00b-3a0e6f88a730"
+                    challengeToken: "b4f3e2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3"
+                    type: "VIEW"
+                    data:
+                      inputs:
+                        - ref: "input_username"
+                          identifier: "username"
+                          type: "TEXT_INPUT"
+                          required: true
+                          validation:
+                            - type: "regex"
+                              value: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+                              message: "{{i18n(validation:email.invalid)}}"
+                        - ref: "input_password"
+                          identifier: "password"
+                          type: "PASSWORD_INPUT"
+                          required: true
+                          validation:
+                            - type: "minLength"
+                              value: 8
+                              message: "{{i18n(validation:password.minLength.invalid)}}"
+                            - type: "maxLength"
+                              value: 128
+                              message: "{{i18n(validation:password.maxLength.invalid)}}"
+                      actions:
+                        - ref: "action_submit"
+                          nextNode: "node_bs12"
+                      fieldErrors:
+                        - identifier: "username"
+                          message: "{{i18n(validation:email.invalid)}}"
+                        - identifier: "password"
+                          message: "{{i18n(validation:password.minLength.invalid)}}"
                 displayOnlyFlow:
                   summary: Incomplete flow (display-only prompt)
                   value:
@@ -309,7 +349,7 @@ components:
         meta:
           type: object
           description: |
-            UI rendering metadata for display-only PROMPT nodes, returned when executing in verbose mode. 
+            UI rendering metadata for display-only PROMPT nodes, returned when executing in verbose mode.
             Contains a `components` array describing the elements to render (headings, body text, images, etc.).
           example:
             components:
@@ -323,6 +363,22 @@ components:
                 category: DISPLAY
                 variant: BODY_1
                 label: "You have successfully completed the registration."
+        fieldErrors:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldError'
+          description: >-
+            Per-field validation failures returned when one or more submitted
+            values violate the rules declared on `data.inputs[].validation`. Each
+            failing rule produces a separate entry. The server discards the
+            submitted values for the failing fields and re-presents the same step
+            (`inputs` and `actions` arrays remain populated) so the client can
+            re-render the form and the user can resubmit corrected values.
+          example:
+            - identifier: "username"
+              message: "{{i18n(validation:email.invalid)}}"
+            - identifier: "password"
+              message: "{{i18n(validation:password.minLength.invalid)}}"
 
     Action:
       type: object
@@ -368,6 +424,67 @@ components:
             type: string
           description: Allowed values for SELECT-type inputs
           example: ["option1", "option2"]
+        validation:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationRule'
+          description: >-
+            Server-enforced validation rules applied to the submitted value
+            after the required-input presence check. When any rule fails, the
+            response returns `flowStatus: INCOMPLETE` with the failing rules
+            listed under `data.fieldErrors`.
+
+    ValidationRule:
+      type: object
+      required:
+        - type
+        - value
+      properties:
+        type:
+          type: string
+          description: Constraint type. Each rule object carries exactly one constraint.
+          enum:
+            - regex
+            - minLength
+            - maxLength
+          example: "regex"
+        value:
+          description: |
+            Constraint parameter. `regex` takes a regex pattern string. `minLength` and
+            `maxLength` take a non-negative integer applied to the Unicode code point
+            count of the submitted value.
+          oneOf:
+            - type: string
+            - type: integer
+              minimum: 0
+          example: "^[0-9]{10}$"
+        message:
+          type: string
+          description: |
+            Message returned in `data.fieldErrors` when the rule fails. Accepts a
+            literal string or an i18n key (for example,
+            `{{i18n(validation:phone.pattern.invalid)}}`). The server returns the
+            value as is. When omitted, the server returns a default key for the
+            rule type (`validation.pattern.invalid`, `validation.minLength.invalid`,
+            or `validation.maxLength.invalid`).
+          example: "{{i18n(validation:phone.pattern.invalid)}}"
+
+    FieldError:
+      type: object
+      required:
+        - identifier
+        - message
+      properties:
+        identifier:
+          type: string
+          description: Identifier of the input field whose validation rule failed
+          example: "username"
+        message:
+          type: string
+          description: |
+            Message from the failing validation rule, returned as is from the
+            rule's `message` field or the default i18n key for the rule type.
+          example: "{{i18n(validation:email.invalid)}}"
 
     Error:
       type: object

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -316,3 +316,24 @@ const (
 	// ForwardedDataKeyTemplateData holds template parameters for notification executors
 	ForwardedDataKeyTemplateData = "templateData"
 )
+
+// ValidationType identifies the constraint type of a ValidationRule.
+type ValidationType string
+
+// Validation rule types.
+const (
+	// ValidationTypeRegex matches the submitted value against a regex pattern.
+	ValidationTypeRegex ValidationType = "regex"
+	// ValidationTypeMinLength enforces a minimum string length on the submitted value.
+	ValidationTypeMinLength ValidationType = "minLength"
+	// ValidationTypeMaxLength enforces a maximum string length on the submitted value.
+	ValidationTypeMaxLength ValidationType = "maxLength"
+)
+
+// Default i18n fallback message keys returned in fieldErrors when a validation
+// rule does not specify a message.
+const (
+	DefaultValidationMessageRegex     = "validation.pattern.invalid"
+	DefaultValidationMessageMinLength = "validation.minLength.invalid"
+	DefaultValidationMessageMaxLength = "validation.maxLength.invalid"
+)

--- a/backend/internal/flow/common/model.go
+++ b/backend/internal/flow/common/model.go
@@ -19,6 +19,8 @@
 package common
 
 import (
+	"fmt"
+	"regexp"
 	"slices"
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
@@ -27,12 +29,48 @@ import (
 
 // Input represents the inputs required for a node
 type Input struct {
-	Ref         string   `json:"ref,omitempty"`
-	Identifier  string   `json:"identifier"`
-	Type        string   `json:"type"`
-	Required    bool     `json:"required"`
-	Options     []string `json:"options,omitempty"`
-	DisplayName string   `json:"-"`
+	Ref         string           `json:"ref,omitempty"`
+	Identifier  string           `json:"identifier"`
+	Type        string           `json:"type"`
+	Required    bool             `json:"required"`
+	Options     []string         `json:"options,omitempty"`
+	DisplayName string           `json:"-"`
+	Validation  []ValidationRule `json:"validation,omitempty"`
+}
+
+// ValidationRule defines a single constraint on a flow input. CompiledRegex is
+// populated by PrepareValidationRules at graph-build time and excluded from JSON.
+type ValidationRule struct {
+	Type          ValidationType `json:"type"`
+	Value         interface{}    `json:"value"`
+	Message       string         `json:"message,omitempty"`
+	CompiledRegex *regexp.Regexp `json:"-"`
+}
+
+// PrepareValidationRules compiles the regex pattern of every regex rule in place.
+// An empty or non-string regex value is treated as a no-op.
+func PrepareValidationRules(rules []ValidationRule) error {
+	for i := range rules {
+		if rules[i].Type != ValidationTypeRegex {
+			continue
+		}
+		pattern, ok := rules[i].Value.(string)
+		if !ok || pattern == "" {
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return fmt.Errorf("invalid validation regex %q: %w", pattern, err)
+		}
+		rules[i].CompiledRegex = re
+	}
+	return nil
+}
+
+// FieldError represents a single validation rule failure for a specific input field.
+type FieldError struct {
+	Identifier string `json:"identifier"`
+	Message    string `json:"message"`
 }
 
 // IsSensitive checks whether this input's type is considered sensitive.
@@ -68,6 +106,7 @@ type NodeResponse struct {
 	ForwardedData     map[string]interface{}    `json:"forwardedData,omitempty"`
 	AuthenticatedUser authncm.AuthenticatedUser `json:"authenticatedUser,omitempty"`
 	Assertion         string                    `json:"assertion,omitempty"`
+	FieldErrors       []FieldError              `json:"fieldErrors,omitempty"`
 	AuthUser          authnprovidermgr.AuthUser `json:"-"`
 }
 

--- a/backend/internal/flow/core/input_validation.go
+++ b/backend/internal/flow/core/input_validation.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package core
+
+import (
+	"unicode/utf8"
+
+	"github.com/thunder-id/thunderid/internal/flow/common"
+	"github.com/thunder-id/thunderid/internal/system/utils"
+)
+
+// validateInputValues returns a FieldError per failing rule across the given inputs.
+func validateInputValues(inputs []common.Input, userInputs map[string]string) []common.FieldError {
+	var fieldErrors []common.FieldError
+
+	for _, input := range inputs {
+		if len(input.Validation) == 0 {
+			continue
+		}
+		value, ok := userInputs[input.Identifier]
+		if !ok {
+			continue
+		}
+
+		for _, rule := range input.Validation {
+			if validateInput(rule, value) {
+				continue
+			}
+			fieldErrors = append(fieldErrors, common.FieldError{
+				Identifier: input.Identifier,
+				Message:    resolveRuleMessage(rule),
+			})
+		}
+	}
+
+	return fieldErrors
+}
+
+// validateInput returns false when the value violates the rule. Unknown rule
+// types and regex rules without a CompiledRegex pass through.
+func validateInput(rule common.ValidationRule, value string) bool {
+	switch rule.Type {
+	case common.ValidationTypeRegex:
+		if rule.CompiledRegex == nil {
+			return true
+		}
+		return rule.CompiledRegex.MatchString(value)
+
+	case common.ValidationTypeMinLength:
+		minLen, ok := utils.ToFloat64(rule.Value)
+		if !ok {
+			return true
+		}
+		return utf8.RuneCountInString(value) >= int(minLen)
+
+	case common.ValidationTypeMaxLength:
+		maxLen, ok := utils.ToFloat64(rule.Value)
+		if !ok {
+			return true
+		}
+		return utf8.RuneCountInString(value) <= int(maxLen)
+	}
+	return true
+}
+
+// resolveRuleMessage returns the rule's Message or the default key for its type.
+func resolveRuleMessage(rule common.ValidationRule) string {
+	if rule.Message != "" {
+		return rule.Message
+	}
+	switch rule.Type {
+	case common.ValidationTypeMinLength:
+		return common.DefaultValidationMessageMinLength
+	case common.ValidationTypeMaxLength:
+		return common.DefaultValidationMessageMaxLength
+	default:
+		return common.DefaultValidationMessageRegex
+	}
+}

--- a/backend/internal/flow/core/input_validation_test.go
+++ b/backend/internal/flow/core/input_validation_test.go
@@ -1,0 +1,832 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/internal/flow/common"
+)
+
+type InputValidationTestSuite struct {
+	suite.Suite
+}
+
+func TestInputValidationTestSuite(t *testing.T) {
+	suite.Run(t, new(InputValidationTestSuite))
+}
+
+// preparedRules pre-compiles regex patterns so tests bypassing the graph builder
+// still exercise the regex code path.
+func preparedRules(rules []common.ValidationRule) []common.ValidationRule {
+	if err := common.PrepareValidationRules(rules); err != nil {
+		panic(err)
+	}
+	return rules
+}
+
+func (s *InputValidationTestSuite) TestRegexPass() {
+	inputs := []common.Input{
+		{
+			Identifier: "email",
+			Validation: preparedRules([]common.ValidationRule{
+				{Type: common.ValidationTypeRegex, Value: "^[^@]+@[^@]+\\.[^@]+$",
+					Message: "validation.email.invalid"},
+			}),
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"email": "user@example.com"})
+	s.Empty(errs)
+}
+
+func (s *InputValidationTestSuite) TestRegexFail() {
+	inputs := []common.Input{
+		{
+			Identifier: "email",
+			Validation: preparedRules([]common.ValidationRule{
+				{Type: common.ValidationTypeRegex, Value: "^[^@]+@[^@]+\\.[^@]+$",
+					Message: "validation.email.invalid"},
+			}),
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"email": "not-an-email"})
+	s.Len(errs, 1)
+	s.Equal("email", errs[0].Identifier)
+	s.Equal("validation.email.invalid", errs[0].Message)
+}
+
+func (s *InputValidationTestSuite) TestMinLengthPass() {
+	inputs := []common.Input{
+		{
+			Identifier: "password",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMinLength, Value: float64(8),
+					Message: "validation.password.minLength"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"password": "12345678"})
+	s.Empty(errs)
+}
+
+func (s *InputValidationTestSuite) TestMinLengthFail() {
+	inputs := []common.Input{
+		{
+			Identifier: "password",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMinLength, Value: float64(8),
+					Message: "validation.password.minLength"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"password": "abc"})
+	s.Len(errs, 1)
+	s.Equal("password", errs[0].Identifier)
+	s.Equal("validation.password.minLength", errs[0].Message)
+}
+
+func (s *InputValidationTestSuite) TestMaxLengthPass() {
+	inputs := []common.Input{
+		{
+			Identifier: "username",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMaxLength, Value: float64(10),
+					Message: "validation.username.maxLength"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"username": "ten_chars_"})
+	s.Empty(errs)
+}
+
+func (s *InputValidationTestSuite) TestMaxLengthFail() {
+	inputs := []common.Input{
+		{
+			Identifier: "username",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMaxLength, Value: float64(5),
+					Message: "validation.username.maxLength"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"username": "way_too_long"})
+	s.Len(errs, 1)
+	s.Equal("validation.username.maxLength", errs[0].Message)
+}
+
+func (s *InputValidationTestSuite) TestMultipleRulesPerFieldProduceSeparateEntries() {
+	// Perl-style lookahead patterns are not supported by the regex engine; use alternation instead.
+	inputs := []common.Input{
+		{
+			Identifier: "password",
+			Validation: preparedRules([]common.ValidationRule{
+				{Type: common.ValidationTypeMinLength, Value: float64(8),
+					Message: "validation.password.minLength"},
+				{Type: common.ValidationTypeRegex,
+					Value:   "^(?:[^A-Z]*[A-Z][^0-9]*[0-9].*|[^0-9]*[0-9][^A-Z]*[A-Z].*)$",
+					Message: "validation.password.complexity"},
+			}),
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"password": "abc"})
+	s.Len(errs, 2)
+	s.Equal("password", errs[0].Identifier)
+	s.Equal("validation.password.minLength", errs[0].Message)
+	s.Equal("password", errs[1].Identifier)
+	s.Equal("validation.password.complexity", errs[1].Message)
+}
+
+func (s *InputValidationTestSuite) TestMultipleFieldsErrorsInSinglePass() {
+	inputs := []common.Input{
+		{
+			Identifier: "username",
+			Validation: preparedRules([]common.ValidationRule{
+				{Type: common.ValidationTypeRegex, Value: "^[^@]+@[^@]+$",
+					Message: "validation.email.invalid"},
+			}),
+		},
+		{
+			Identifier: "password",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMinLength, Value: float64(8),
+					Message: "validation.password.minLength"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{
+		"username": "no-at-sign",
+		"password": "abc",
+	})
+	s.Len(errs, 2)
+}
+
+func (s *InputValidationTestSuite) TestDefaultMessageUsedWhenAbsent() {
+	inputs := []common.Input{
+		{
+			Identifier: "email",
+			Validation: preparedRules([]common.ValidationRule{
+				{Type: common.ValidationTypeRegex, Value: "^X+$"},
+			}),
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"email": "abc"})
+	s.Len(errs, 1)
+	s.Equal(common.DefaultValidationMessageRegex, errs[0].Message)
+}
+
+func (s *InputValidationTestSuite) TestMessagePassthroughI18nKey() {
+	i18nKey := "{{i18n(validation:email.invalid)}}"
+	inputs := []common.Input{
+		{
+			Identifier: "email",
+			Validation: preparedRules([]common.ValidationRule{
+				{Type: common.ValidationTypeRegex, Value: "^X+$", Message: i18nKey},
+			}),
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"email": "abc"})
+	s.Len(errs, 1)
+	s.Equal(i18nKey, errs[0].Message)
+}
+
+func (s *InputValidationTestSuite) TestAbsentInputSkipsValidation() {
+	inputs := []common.Input{
+		{
+			Identifier: "email",
+			Validation: preparedRules([]common.ValidationRule{
+				{Type: common.ValidationTypeRegex, Value: "^X+$",
+					Message: "validation.email.invalid"},
+			}),
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{})
+	s.Empty(errs)
+}
+
+func (s *InputValidationTestSuite) TestUnknownRuleTypeIgnored() {
+	inputs := []common.Input{
+		{
+			Identifier: "field",
+			Validation: []common.ValidationRule{
+				{Type: "unknownRuleType", Value: "anything", Message: "should.not.appear"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"field": "any value"})
+	s.Empty(errs)
+}
+
+// An empty regex pattern has no effective constraint, so the rule passes any submitted value.
+func (s *InputValidationTestSuite) TestRegexEmptyPatternPasses() {
+	inputs := []common.Input{
+		{
+			Identifier: "field",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeRegex, Value: "", Message: "should.not.appear"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"field": "anything"})
+	s.Empty(errs)
+}
+
+// A non-numeric value (malformed flow definition) is treated as passing rather than failing every submission.
+func (s *InputValidationTestSuite) TestMinLengthNonNumericValuePasses() {
+	inputs := []common.Input{
+		{
+			Identifier: "field",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMinLength, Value: "not-a-number", Message: "should.not.appear"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"field": "abc"})
+	s.Empty(errs)
+}
+
+func (s *InputValidationTestSuite) TestMaxLengthNonNumericValuePasses() {
+	inputs := []common.Input{
+		{
+			Identifier: "field",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMaxLength, Value: []int{1, 2}, Message: "should.not.appear"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"field": "abcdefg"})
+	s.Empty(errs)
+}
+
+func (s *InputValidationTestSuite) TestMinLengthDefaultMessageWhenMessageAbsent() {
+	inputs := []common.Input{
+		{
+			Identifier: "field",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMinLength, Value: float64(8)},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"field": "abc"})
+	s.Len(errs, 1)
+	s.Equal(common.DefaultValidationMessageMinLength, errs[0].Message)
+}
+
+func (s *InputValidationTestSuite) TestMaxLengthDefaultMessageWhenMessageAbsent() {
+	inputs := []common.Input{
+		{
+			Identifier: "field",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMaxLength, Value: float64(3)},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"field": "abcdef"})
+	s.Len(errs, 1)
+	s.Equal(common.DefaultValidationMessageMaxLength, errs[0].Message)
+}
+
+func (s *InputValidationTestSuite) TestNumericRuleValueAcceptsInt() {
+	inputs := []common.Input{
+		{
+			Identifier: "field",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMinLength, Value: 8, Message: "too short"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"field": "abc"})
+	s.Len(errs, 1)
+	s.Equal("too short", errs[0].Message)
+}
+
+func (s *InputValidationTestSuite) TestNumericRuleValueAcceptsInt64() {
+	inputs := []common.Input{
+		{
+			Identifier: "field",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMaxLength, Value: int64(3), Message: "too long"},
+			},
+		},
+	}
+	errs := validateInputValues(inputs, map[string]string{"field": "abcdef"})
+	s.Len(errs, 1)
+	s.Equal("too long", errs[0].Message)
+}
+
+// Multi-byte UTF-8 values must be counted by rune (code point) length, not by bytes.
+func (s *InputValidationTestSuite) TestMinLengthCountsRunesNotBytes() {
+	inputs := []common.Input{
+		{
+			Identifier: "field",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMinLength, Value: float64(5), Message: "too short"},
+			},
+		},
+	}
+
+	errs := validateInputValues(inputs, map[string]string{"field": "café"})
+	s.Len(errs, 1, "café is 4 runes; must fail minLength: 5 even though byte length is 5")
+
+	errs = validateInputValues(inputs, map[string]string{"field": "日本語!!"})
+	s.Empty(errs, "日本語!! is 5 runes; must pass minLength: 5")
+}
+
+func (s *InputValidationTestSuite) TestMaxLengthCountsRunesNotBytes() {
+	inputs := []common.Input{
+		{
+			Identifier: "field",
+			Validation: []common.ValidationRule{
+				{Type: common.ValidationTypeMaxLength, Value: float64(3), Message: "too long"},
+			},
+		},
+	}
+
+	errs := validateInputValues(inputs, map[string]string{"field": "abcd"})
+	s.Len(errs, 1, "abcd is 4 runes; must fail maxLength: 3")
+
+	errs = validateInputValues(inputs, map[string]string{"field": "日本語"})
+	s.Empty(errs, "日本語 is 3 runes; must pass maxLength: 3")
+
+	// "𠮷𠮷" contains two non-BMP characters: each is one rune but four bytes, exercising 4-byte UTF-8.
+	errs = validateInputValues(inputs, map[string]string{"field": "𠮷𠮷"})
+	s.Empty(errs, "two non-BMP chars are 2 runes (8 bytes); must pass maxLength: 3")
+}
+
+// On a multi-prompt node sharing input identifiers, only the selected action's rules must fire.
+func (s *InputValidationTestSuite) TestPromptNodeValidatesOnlySelectedActionInputs() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			// Prompt A: the "credential" field must contain '@'.
+			Inputs: []common.Input{
+				{
+					Identifier: "credential",
+					Required:   true,
+					Validation: preparedRules([]common.ValidationRule{
+						{Type: common.ValidationTypeRegex, Value: "@",
+							Message: "must.contain.at.sign"},
+					}),
+				},
+			},
+			Action: &common.Action{Ref: "submit_email", NextNode: "next"},
+		},
+		{
+			// Prompt B: the same "credential" field must be all digits.
+			Inputs: []common.Input{
+				{
+					Identifier: "credential",
+					Required:   true,
+					Validation: preparedRules([]common.ValidationRule{
+						{Type: common.ValidationTypeRegex, Value: "^[0-9]+$",
+							Message: "must.be.digits"},
+					}),
+				},
+			},
+			Action: &common.Action{Ref: "submit_phone", NextNode: "next"},
+		},
+	})
+
+	// submit_phone with an all-digit value must pass; the previous dedup behavior would
+	// have applied Prompt A's '@' rule.
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit_phone",
+		UserInputs:    map[string]string{"credential": "5551234"},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Empty(resp.FieldErrors, "phone-style value must not be validated against the email prompt's rule")
+}
+
+// The validation-failure response must include `meta` when `ctx.Verbose` is true.
+func (s *InputValidationTestSuite) TestPromptNodeValidationFailureIncludesMetaWhenVerbose() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{
+					Ref:        "input_password",
+					Identifier: "password",
+					Required:   true,
+					Validation: []common.ValidationRule{
+						{Type: common.ValidationTypeMinLength, Value: float64(8),
+							Message: "validation.password.minLength"},
+					},
+				},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+	pn.SetMeta(map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{
+				"id":   "input_password",
+				"ref":  "input_password",
+				"type": "PASSWORD_INPUT",
+			},
+			map[string]interface{}{
+				"id":   "submit",
+				"ref":  "submit",
+				"type": "ACTION",
+			},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{"password": "short"},
+		Verbose:       true,
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.NotEmpty(resp.FieldErrors)
+	s.NotNil(resp.Meta, "Meta should be present in the response when verbose mode is enabled")
+}
+
+func (s *InputValidationTestSuite) TestInputWithoutValidationRulesNoOp() {
+	inputs := []common.Input{
+		{Identifier: "any", Required: true},
+	}
+	errs := validateInputValues(inputs, map[string]string{"any": "value"})
+	s.Empty(errs)
+}
+
+func (s *InputValidationTestSuite) TestPromptNodeReturnsFieldErrorsOnFailure() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{
+					Identifier: "password",
+					Required:   true,
+					Validation: []common.ValidationRule{
+						{Type: common.ValidationTypeMinLength, Value: float64(8),
+							Message: "validation.password.minLength"},
+					},
+				},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{"password": "short"},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Equal(common.NodeResponseTypeView, resp.Type)
+	s.Len(resp.FieldErrors, 1)
+	s.Equal("password", resp.FieldErrors[0].Identifier)
+	s.Equal("validation.password.minLength", resp.FieldErrors[0].Message)
+	_, stillPresent := ctx.UserInputs["password"]
+	s.False(stillPresent, "failed input should be cleared from UserInputs")
+}
+
+// A validation failure must re-prompt the same field set the user saw in the initial
+// prompt (preserving form structure) and must include the selected action so the form
+// can be re-submitted.
+func (s *InputValidationTestSuite) TestPromptNodeRePromptsInitialFieldSetOnValidationFailure() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "username", Required: true},
+				{
+					Identifier: "password",
+					Required:   true,
+					Validation: []common.ValidationRule{
+						{Type: common.ValidationTypeMinLength, Value: float64(8),
+							Message: "validation.password.minLength"},
+					},
+				},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{"username": "valid_user", "password": "short"},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Equal(common.NodeResponseTypeView, resp.Type)
+
+	s.Len(resp.FieldErrors, 1)
+	s.Equal("password", resp.FieldErrors[0].Identifier)
+
+	s.Len(resp.Inputs, 2, "the entire initial-prompt set must be re-prompted to preserve form structure")
+	identifiers := map[string]bool{}
+	for _, in := range resp.Inputs {
+		identifiers[in.Identifier] = true
+	}
+	s.True(identifiers["username"], "username (in the initial prompt) must remain in the re-prompted inputs")
+	s.True(identifiers["password"], "password (in the initial prompt) must remain in the re-prompted inputs")
+
+	s.Len(resp.Actions, 1)
+	s.Equal("submit", resp.Actions[0].Ref)
+
+	_, passwordPresent := ctx.UserInputs["password"]
+	s.False(passwordPresent, "failed input cleared from UserInputs")
+	s.Equal("valid_user", ctx.UserInputs["username"], "passing input retained in UserInputs")
+}
+
+func (s *InputValidationTestSuite) TestPromptNodeAdvancesOnValidSubmission() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{
+					Identifier: "password",
+					Required:   true,
+					Validation: []common.ValidationRule{
+						{Type: common.ValidationTypeMinLength, Value: float64(8),
+							Message: "validation.password.minLength"},
+					},
+				},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{"password": "longenough"},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusComplete, resp.Status)
+	s.Empty(resp.FieldErrors)
+	s.Equal("next", resp.NextNodeID)
+}
+
+// The LOGIN_OPTIONS variant must enforce validation rules and must not advance the flow on invalid inputs.
+func (s *InputValidationTestSuite) TestLoginOptionsVariantReturnsFieldErrorsOnValidationFailure() {
+	node := newPromptNode("login-chooser", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetVariant(common.NodeVariantLoginOptions)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{
+					Identifier: "password",
+					Required:   true,
+					Validation: []common.ValidationRule{
+						{Type: common.ValidationTypeMinLength, Value: float64(8),
+							Message: "validation.password.minLength"},
+					},
+				},
+			},
+			Action: &common.Action{Ref: "pwd", NextNode: "pwd-node"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "pwd",
+		UserInputs:    map[string]string{"password": "short"},
+		RuntimeData:   map[string]string{},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status, "invalid input must not advance the LOGIN_OPTIONS flow")
+	s.Len(resp.FieldErrors, 1)
+	s.Equal("password", resp.FieldErrors[0].Identifier)
+	s.Empty(resp.NextNodeID, "NextNodeID must be empty on validation failure")
+}
+
+func (s *InputValidationTestSuite) TestPromptNodeValidationDoesNotRunWhenRequiredInputMissing() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{
+					Identifier: "password",
+					Required:   true,
+					Validation: []common.ValidationRule{
+						{Type: common.ValidationTypeMinLength, Value: float64(8),
+							Message: "validation.password.minLength"},
+					},
+				},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusIncomplete, resp.Status)
+	s.Empty(resp.FieldErrors)
+	s.Len(resp.Inputs, 1)
+}
+
+// applyValidationFailureRePrompt direct unit tests below.
+
+// newPromptNodeForReprompt builds a single-prompt node with one minLength rule
+// on `password`, used by the focused tests of applyValidationFailureRePrompt.
+func (s *InputValidationTestSuite) newPromptNodeForReprompt() (*promptNode, *common.NodeResponse) {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "username", Required: true},
+				{
+					Identifier: "password",
+					Required:   true,
+					Validation: []common.ValidationRule{
+						{Type: common.ValidationTypeMinLength, Value: float64(8),
+							Message: "validation.password.minLength"},
+					},
+				},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+	return node.(*promptNode), &common.NodeResponse{
+		Inputs:  make([]common.Input, 0),
+		Actions: make([]common.Action, 0),
+	}
+}
+
+// Returns false and leaves nodeResp untouched when every rule passes.
+func (s *InputValidationTestSuite) TestApplyValidationFailureRePrompt_ReturnsFalseWhenAllRulesPass() {
+	n, nodeResp := s.newPromptNodeForReprompt()
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{"username": "alice", "password": "longenough"},
+	}
+
+	handled := n.applyValidationFailureRePrompt(ctx, nodeResp)
+
+	s.False(handled)
+	s.Empty(nodeResp.FieldErrors)
+	s.Empty(nodeResp.Inputs)
+	s.Empty(nodeResp.Actions)
+	s.Equal("submit", ctx.CurrentAction, "passing validation must not clear the selected action")
+}
+
+// Returns true, populates FieldErrors, clears the failing input value, resets
+// CurrentAction, and re-prompts the initial field set (preserving form structure).
+func (s *InputValidationTestSuite) TestApplyValidationFailureRePrompt_HandlesFailureAndRePromptsInitialFieldSet() {
+	n, nodeResp := s.newPromptNodeForReprompt()
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{"username": "alice", "password": "short"},
+	}
+
+	handled := n.applyValidationFailureRePrompt(ctx, nodeResp)
+
+	s.True(handled)
+	s.Len(nodeResp.FieldErrors, 1)
+	s.Equal("password", nodeResp.FieldErrors[0].Identifier)
+	s.Equal("validation.password.minLength", nodeResp.FieldErrors[0].Message)
+	s.Equal(common.NodeStatusIncomplete, nodeResp.Status)
+	s.Equal(common.NodeResponseTypeView, nodeResp.Type)
+	s.Len(nodeResp.Inputs, 2, "re-prompt must return the same field set the user saw initially")
+	s.Len(nodeResp.Actions, 1, "re-prompt must return the action so the form has a submit button")
+	s.Equal("", ctx.CurrentAction, "failing validation must reset CurrentAction")
+	_, passwordPresent := ctx.UserInputs["password"]
+	s.False(passwordPresent, "failing input value must be cleared from UserInputs")
+	s.Equal("alice", ctx.UserInputs["username"], "passing input value must be retained in UserInputs")
+}
+
+// Inputs pre-satisfied from RuntimeData must not be re-prompted on validation failure.
+func (s *InputValidationTestSuite) TestApplyValidationFailureRePrompt_PreservesStrippedDownInitialSet() {
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []common.Input{
+				{Identifier: "tenant", Required: true},
+				{
+					Identifier: "password",
+					Required:   true,
+					Validation: []common.ValidationRule{
+						{Type: common.ValidationTypeMinLength, Value: float64(8),
+							Message: "validation.password.minLength"},
+					},
+				},
+			},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+	pn2 := node.(*promptNode)
+	nodeResp := &common.NodeResponse{
+		Inputs:  make([]common.Input, 0),
+		Actions: make([]common.Action, 0),
+	}
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{"password": "short"},
+		RuntimeData:   map[string]string{"tenant": "acme"}, // tenant pre-satisfied
+	}
+
+	handled := pn2.applyValidationFailureRePrompt(ctx, nodeResp)
+
+	s.True(handled)
+	s.Len(nodeResp.Inputs, 1, "tenant came from RuntimeData and must NOT be re-prompted")
+	s.Equal("password", nodeResp.Inputs[0].Identifier,
+		"only the failing password (initially prompted) must be re-prompted")
+	s.Equal("acme", ctx.RuntimeData["tenant"], "passing identifiers in RuntimeData must remain untouched")
+}
+
+// Failing values stored in RuntimeData and ForwardedData must also be cleared so the
+// engine does not fall back to them on the next iteration. collectMissingInputs reads
+// all three sources; missing any would mask the validation failure.
+func (s *InputValidationTestSuite) TestApplyValidationFailureRePrompt_ClearsRuntimeDataAndForwardedData() {
+	n, nodeResp := s.newPromptNodeForReprompt()
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{"username": "alice", "password": "short"},
+		RuntimeData:   map[string]string{"password": "stale-from-runtime"},
+		ForwardedData: map[string]interface{}{"password": "stale-from-forwarded"},
+	}
+
+	handled := n.applyValidationFailureRePrompt(ctx, nodeResp)
+
+	s.True(handled)
+	_, inUserInputs := ctx.UserInputs["password"]
+	_, inRuntime := ctx.RuntimeData["password"]
+	_, inForwarded := ctx.ForwardedData["password"]
+	s.False(inUserInputs, "failing identifier must be cleared from UserInputs")
+	s.False(inRuntime, "failing identifier must be cleared from RuntimeData")
+	s.False(inForwarded, "failing identifier must be cleared from ForwardedData")
+}
+
+// Populates nodeResp.Meta when ctx.Verbose is true and the node has meta set.
+func (s *InputValidationTestSuite) TestApplyValidationFailureRePrompt_PopulatesMetaWhenVerbose() {
+	n, nodeResp := s.newPromptNodeForReprompt()
+	n.SetMeta(map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{"id": "input_password", "ref": "input_password", "type": "PASSWORD_INPUT"},
+			map[string]interface{}{"id": "submit", "ref": "submit", "type": "ACTION"},
+		},
+	})
+	ctx := &NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{"username": "alice", "password": "short"},
+		Verbose:       true,
+	}
+
+	handled := n.applyValidationFailureRePrompt(ctx, nodeResp)
+
+	s.True(handled)
+	s.NotNil(nodeResp.Meta, "verbose mode must populate Meta on the re-prompt response")
+}

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -126,7 +126,10 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 	}
 
 	if n.resolvePromptInputs(ctx, nodeResp) {
-		logger.Debug("All required inputs and action are available, returning complete status")
+		logger.Debug("All required inputs and actions are available")
+		if n.applyValidationFailureRePrompt(ctx, nodeResp) {
+			return nodeResp, nil
+		}
 
 		if ctx.CurrentAction != "" {
 			if nextNode := n.getNextNodeForActionRef(ctx.CurrentAction); nextNode != "" {
@@ -167,6 +170,76 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 	return nodeResp, nil
 }
 
+// applyValidationFailureRePrompt re-validates the current submission. When any rule
+// fails, it populates nodeResp with the initial-prompt field set and returns true;
+// otherwise it returns false and leaves nodeResp unchanged.
+func (n *promptNode) applyValidationFailureRePrompt(ctx *NodeContext, nodeResp *common.NodeResponse) bool {
+	actionInputs := n.getInputsForCurrentAction(ctx.CurrentAction)
+	fieldErrors := validateInputValues(actionInputs, ctx.UserInputs)
+	if len(fieldErrors) == 0 {
+		return false
+	}
+	n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID)).
+		Debug("Input validation failed", log.Int("errorCount", len(fieldErrors)))
+
+	matchingAction := n.findActionByRef(ctx.CurrentAction)
+
+	// Clear failing values from every source resolvePromptInputs reads, so the engine
+	// cannot fall back to a stale value on the next iteration.
+	for _, fe := range fieldErrors {
+		delete(ctx.UserInputs, fe.Identifier)
+		delete(ctx.RuntimeData, fe.Identifier)
+		delete(ctx.ForwardedData, fe.Identifier)
+	}
+	ctx.CurrentAction = ""
+
+	// Rebuild the initial-prompt set: the action's inputs minus those pre-satisfied
+	// via RuntimeData or ForwardedData. UserInputs holds the current submission and
+	// is excluded here because it was empty when the initial prompt was rendered.
+	rePromptInputs := make([]common.Input, 0, len(actionInputs))
+	for _, input := range actionInputs {
+		if _, inRuntime := ctx.RuntimeData[input.Identifier]; inRuntime {
+			continue
+		}
+		if val, inForwarded := ctx.ForwardedData[input.Identifier]; inForwarded {
+			if _, isString := val.(string); isString {
+				continue
+			}
+		}
+		rePromptInputs = append(rePromptInputs, input)
+	}
+	nodeResp.Inputs = rePromptInputs
+
+	if matchingAction != nil {
+		nodeResp.Actions = []common.Action{*matchingAction}
+	} else {
+		nodeResp.Actions = n.getAllActions()
+	}
+
+	nodeResp.FieldErrors = fieldErrors
+	nodeResp.Status = common.NodeStatusIncomplete
+	nodeResp.Type = common.NodeResponseTypeView
+	if ctx.Verbose && n.GetMeta() != nil {
+		trimmed := n.trimMetaToRequestedInputs(n.meta, nodeResp.Inputs, nodeResp.Actions)
+		nodeResp.Meta = n.appendSyntheticMetaComponents(trimmed, nodeResp.Inputs)
+	}
+	return true
+}
+
+// findActionByRef returns a copy of the action with the given ref, or nil if no match exists.
+func (n *promptNode) findActionByRef(ref string) *common.Action {
+	if ref == "" {
+		return nil
+	}
+	for _, p := range n.prompts {
+		if p.Action != nil && p.Action.Ref == ref {
+			action := *p.Action
+			return &action
+		}
+	}
+	return nil
+}
+
 // executeLoginOptions handles the LOGIN_OPTIONS variant.
 func (n *promptNode) executeLoginOptions(ctx *NodeContext,
 	nodeResp *common.NodeResponse) (*common.NodeResponse, *serviceerror.ServiceError) {
@@ -184,6 +257,9 @@ func (n *promptNode) executeLoginOptions(ctx *NodeContext,
 			}
 		}
 		if n.resolvePromptInputs(ctx, nodeResp) {
+			if n.applyValidationFailureRePrompt(ctx, nodeResp) {
+				return nodeResp, nil
+			}
 			return n.finalizeLoginOptionsAction(ctx, nodeResp, authClassToAction)
 		}
 		n.applyMetaForLoginOptions(ctx, nodeResp, nil)
@@ -206,6 +282,9 @@ func (n *promptNode) executeLoginOptions(ctx *NodeContext,
 		ctx.CurrentAction = actions[0].Ref
 		logger.Debug("Auto-selected single login option", log.String("actionRef", ctx.CurrentAction))
 		if n.resolvePromptInputs(ctx, nodeResp) {
+			if n.applyValidationFailureRePrompt(ctx, nodeResp) {
+				return nodeResp, nil
+			}
 			return n.finalizeLoginOptionsAction(ctx, nodeResp, authClassToAction)
 		}
 		nodeResp.RuntimeData[common.RuntimeKeyAllowedLoginOptions] = ctx.CurrentAction
@@ -501,6 +580,22 @@ func (n *promptNode) tryAutoSelectSingleAction(ctx *NodeContext) bool {
 		return true
 	}
 	return false
+}
+
+// getInputsForCurrentAction returns the inputs of the prompt whose action matches
+// the given actionRef. When no action is selected, or no prompt matches the given
+// ref, it falls back to getAllInputs() — preserving the historical behavior for
+// single-prompt nodes and the no-action-selected path.
+func (n *promptNode) getInputsForCurrentAction(actionRef string) []common.Input {
+	if actionRef == "" {
+		return n.getAllInputs()
+	}
+	for _, prompt := range n.prompts {
+		if prompt.Action != nil && prompt.Action.Ref == actionRef {
+			return prompt.Inputs
+		}
+	}
+	return n.getAllInputs()
 }
 
 // getAllInputs returns all unique inputs from prompts, deduplicated by Identifier.

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -796,6 +796,10 @@ func (fe *flowEngine) resolveStepDetailsForPrompt(ctx *EngineContext, nodeResp *
 		flowStep.FailureReason = nodeResp.FailureReason
 	}
 
+	if len(nodeResp.FieldErrors) > 0 {
+		flowStep.Data.FieldErrors = nodeResp.FieldErrors
+	}
+
 	flowStep.Status = common.FlowStatusIncomplete
 	flowStep.Type = common.StepTypeView
 	return nil

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -78,11 +78,12 @@ type FlowStep struct {
 
 // FlowData holds the data returned by a flow execution step
 type FlowData struct {
-	Inputs         []common.Input    `json:"inputs,omitempty"`
-	RedirectURL    string            `json:"redirectURL,omitempty"`
-	Actions        []common.Action   `json:"actions,omitempty"`
-	Meta           interface{}       `json:"meta,omitempty"`
-	AdditionalData map[string]string `json:"additionalData,omitempty"`
+	Inputs         []common.Input      `json:"inputs,omitempty"`
+	RedirectURL    string              `json:"redirectURL,omitempty"`
+	Actions        []common.Action     `json:"actions,omitempty"`
+	Meta           interface{}         `json:"meta,omitempty"`
+	AdditionalData map[string]string   `json:"additionalData,omitempty"`
+	FieldErrors    []common.FieldError `json:"fieldErrors,omitempty"`
 }
 
 // FlowResponse represents the flow execution API response body

--- a/backend/internal/flow/mgt/graph_builder.go
+++ b/backend/internal/flow/mgt/graph_builder.go
@@ -257,6 +257,9 @@ func (b *graphBuilder) validateOnIncompleteTarget(nodes []NodeDefinition, target
 }
 
 // configureNodeInputs configures the inputs for executor-backed nodes.
+// Validation rules on executor inputs are intentionally not propagated:
+// executor inputs are read from runtime context (already validated at the
+// preceding PROMPT node), so per-rule re-validation here would be redundant.
 func (b *graphBuilder) configureNodeInputs(nodeDef *NodeDefinition, node core.NodeInterface) {
 	logger := b.logger.With(log.String("nodeID", nodeDef.ID))
 
@@ -266,7 +269,6 @@ func (b *graphBuilder) configureNodeInputs(nodeDef *NodeDefinition, node core.No
 		return
 	}
 
-	// Get inputs from executor definition if available
 	if nodeDef.Executor == nil || len(nodeDef.Executor.Inputs) == 0 {
 		logger.Debug("No inputs defined for executor; setting empty input list")
 		executorNode.SetInputs([]common.Input{})
@@ -283,6 +285,26 @@ func (b *graphBuilder) configureNodeInputs(nodeDef *NodeDefinition, node core.No
 		}
 	}
 	executorNode.SetInputs(inputs)
+}
+
+// toValidationRules converts mgt rule definitions to runtime ValidationRule
+// values and pre-compiles their regex patterns. Returns nil for an empty input.
+func toValidationRules(defs []ValidationRuleDefinition) ([]common.ValidationRule, error) {
+	if len(defs) == 0 {
+		return nil, nil
+	}
+	rules := make([]common.ValidationRule, len(defs))
+	for i, d := range defs {
+		rules[i] = common.ValidationRule{
+			Type:    common.ValidationType(d.Type),
+			Value:   d.Value,
+			Message: d.Message,
+		}
+	}
+	if err := common.PrepareValidationRules(rules); err != nil {
+		return nil, err
+	}
+	return rules, nil
 }
 
 // configureNodeVariant sets the prompt node's variant from the node definition.
@@ -339,11 +361,17 @@ func (b *graphBuilder) configureNodePrompts(nodeDef *NodeDefinition, node core.N
 		// Convert inputs
 		inputs := make([]common.Input, len(promptDef.Inputs))
 		for j, inputDef := range promptDef.Inputs {
+			validation, err := toValidationRules(inputDef.Validation)
+			if err != nil {
+				return fmt.Errorf("node %s, prompt %d, input %s: %w",
+					nodeDef.ID, i, inputDef.Identifier, err)
+			}
 			inputs[j] = common.Input{
 				Ref:        inputDef.Ref,
 				Identifier: inputDef.Identifier,
 				Type:       inputDef.Type,
 				Required:   inputDef.Required,
+				Validation: validation,
 			}
 		}
 		prompts[i].Inputs = inputs

--- a/backend/internal/flow/mgt/graph_builder_test.go
+++ b/backend/internal/flow/mgt/graph_builder_test.go
@@ -1490,3 +1490,67 @@ func (s *GraphBuilderTestSuite) TestComputeSegments_GetStartNodeFails() {
 		{boundaryNodeID: "prompt", nextNodeID: "task"},
 	})
 }
+
+// Prompt inputs' regex rules must be compiled at graph-build time so the
+// request-path validator never recompiles.
+func (s *GraphBuilderTestSuite) TestConfigureNodePrompts_ValidationRulesCompiled() {
+	nodeDef := &NodeDefinition{
+		ID:   "prompt-1",
+		Type: "PROMPT",
+		Prompts: []PromptDefinition{
+			{
+				Inputs: []InputDefinition{
+					{
+						Identifier: "password",
+						Validation: []ValidationRuleDefinition{
+							{Type: "regex", Value: "[A-Z]+", Message: "needs.upper"},
+						},
+					},
+				},
+				Action: &ActionDefinition{Ref: "submit", NextNode: "next"},
+			},
+		},
+	}
+
+	mockPromptNode := coremock.NewPromptNodeInterfaceMock(s.T())
+	mockPromptNode.EXPECT().SetPrompts(mock.MatchedBy(func(prompts []common.Prompt) bool {
+		if len(prompts) != 1 || len(prompts[0].Inputs) != 1 || len(prompts[0].Inputs[0].Validation) != 1 {
+			return false
+		}
+		rule := prompts[0].Inputs[0].Validation[0]
+		return rule.Type == common.ValidationTypeRegex && rule.CompiledRegex != nil
+	}))
+
+	err := s.builder.configureNodePrompts(nodeDef, mockPromptNode, map[string][]string{})
+	s.Nil(err)
+}
+
+// Invalid regex on a prompt input must fail the build with a useful error message.
+func (s *GraphBuilderTestSuite) TestConfigureNodePrompts_InvalidRegexFailsBuild() {
+	nodeDef := &NodeDefinition{
+		ID:   "prompt-1",
+		Type: "PROMPT",
+		Prompts: []PromptDefinition{
+			{
+				Inputs: []InputDefinition{
+					{
+						Identifier: "password",
+						Validation: []ValidationRuleDefinition{
+							{Type: "regex", Value: "[unterminated", Message: "bad"},
+						},
+					},
+				},
+				Action: &ActionDefinition{Ref: "submit", NextNode: "next"},
+			},
+		},
+	}
+
+	mockPromptNode := coremock.NewPromptNodeInterfaceMock(s.T())
+	// SetPrompts must NOT be called.
+
+	err := s.builder.configureNodePrompts(nodeDef, mockPromptNode, map[string][]string{})
+	s.NotNil(err)
+	s.Contains(err.Error(), "prompt-1")
+	s.Contains(err.Error(), "password")
+	s.Contains(err.Error(), "invalid validation regex")
+}

--- a/backend/internal/flow/mgt/model.go
+++ b/backend/internal/flow/mgt/model.go
@@ -156,10 +156,21 @@ type NodeDefinition struct {
 
 // InputDefinition represents an input parameter for a node.
 type InputDefinition struct {
-	Ref        string `json:"ref,omitempty" yaml:"ref,omitempty" jsonschema:"Reference ID for the input."`
-	Type       string `json:"type" yaml:"type" jsonschema:"Input type (e.g., 'text', 'password', 'email')."`
-	Identifier string `json:"identifier" yaml:"identifier" jsonschema:"Field identifier or name."`
-	Required   bool   `json:"required" yaml:"required" jsonschema:"Whether this input is mandatory."`
+	Ref        string                     `json:"ref,omitempty" yaml:"ref,omitempty" jsonschema:"Reference ID for the input."`
+	Type       string                     `json:"type" yaml:"type" jsonschema:"Input type (e.g., 'text', 'password', 'email')."`
+	Identifier string                     `json:"identifier" yaml:"identifier" jsonschema:"Field identifier or name."`
+	Required   bool                       `json:"required" yaml:"required" jsonschema:"Whether this input is mandatory."`
+	Validation []ValidationRuleDefinition `json:"validation,omitempty" yaml:"validation,omitempty" jsonschema:"Server-enforced validation rules applied to the submitted value."`
+}
+
+// ValidationRuleDefinition represents a single validation constraint on an input.
+// Type is one of "regex", "minLength", or "maxLength"; Value holds the constraint
+// parameter (string for regex, number for length types); Message is an i18n key or
+// literal string returned in fieldErrors when the rule fails.
+type ValidationRuleDefinition struct {
+	Type    string      `json:"type" yaml:"type" jsonschema:"Rule type: 'regex', 'minLength', or 'maxLength'."`
+	Value   interface{} `json:"value" yaml:"value" jsonschema:"Constraint value: regex pattern (string) or length (number)."`
+	Message string      `json:"message,omitempty" yaml:"message,omitempty" jsonschema:"i18n key or literal message returned when the rule fails."`
 }
 
 // ActionDefinition represents an action to be executed by a node.

--- a/docs/content/guides/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/guides/flows/advanced-configurations.mdx
@@ -2046,6 +2046,67 @@ Checks that unique schema attributes supplied in user inputs are not already hel
 
 </details>
 
+## Input Validation Rules
+
+Input components can declare a `validation` array that the server enforces when the user submits the form. The server evaluates these rules after the required-input presence check and before the View advances to the next node.
+
+The `validation` array attaches to two places in the flow definition:
+
+- `meta.components[].validation` - returned in the verbose flow execution response embedded inside `meta` so that clients can optionally pre-validate values before submission.
+- `prompts[].inputs[].validation` - the authoritative copy that the server evaluates on each submission and that API-only clients receive in the prompt response.
+
+Each rule is a single-constraint object with a discriminated `type` field:
+
+| `type` | `value` Type | Behavior |
+|---|---|---|
+| `regex` | `string` | The submitted value must match the regex pattern. The server uses a regex engine that guarantees linear-time matching. |
+| `minLength` | `integer` | The submitted value must contain at least `value` Unicode code points. The server counts code points rather than bytes so multibyte characters count as one. |
+| `maxLength` | `integer` | The submitted value must contain at most `value` Unicode code points. |
+
+Each rule may set a `message` field that the server returns as is in `data.fieldErrors` when the rule fails. The `message` field accepts a literal string or an i18n key such as `{{i18n(validation:email.invalid)}}`. The server does not resolve i18n keys; the client renders them. When `message` is absent, the server returns a default key for the rule type: `validation.pattern.invalid`, `validation.minLength.invalid`, or `validation.maxLength.invalid`.
+
+```json title="Example: Phone Input with validation rules"
+{
+  "id": "input_phone",
+  "type": "PHONE_INPUT",
+  "category": "FIELD",
+  "required": true,
+  "validation": [
+    {
+      "type": "regex",
+      "value": "^[0-9]{10}$",
+      "message": "{{i18n(validation:phone.pattern.invalid)}}"
+    },
+    {
+      "type": "maxLength",
+      "value": 10,
+      "message": "{{i18n(validation:phone.maxLength.invalid)}}"
+    }
+  ],
+  "resourceType": "ELEMENT"
+}
+```
+
+When one or more rules fail on a submission, the server returns `flowStatus: INCOMPLETE` with a `data.fieldErrors` array. Each failing rule produces a separate entry that pairs the input `identifier` with the rule's `message`. The server clears the failing inputs from the submission and re-presents the same step. The response returns the full `inputs` and `actions` arrays so the client can re-render the original form alongside the errors. The user then resubmits corrected values.
+
+```json title="Example: Validation failure response (abbreviated)"
+{
+  "flowStatus": "INCOMPLETE",
+  "type": "VIEW",
+  "data": {
+    "inputs": [
+      { "ref": "input_username", "identifier": "username", "type": "TEXT_INPUT", "required": true, "validation": [ /* ... */ ] },
+      { "ref": "input_password", "identifier": "password", "type": "PASSWORD_INPUT", "required": true, "validation": [ /* ... */ ] }
+    ],
+    "actions": [ { "ref": "action_submit", "nextNode": "node_bs12" } ],
+    "fieldErrors": [
+      { "identifier": "username", "message": "{{i18n(validation:email.invalid)}}" },
+      { "identifier": "password", "message": "{{i18n(validation:password.minLength.invalid)}}" }
+    ]
+  }
+}
+```
+
 ## ACR Values in Flows
 
 Use the `acr_values` parameter in an authorization request to specify which authentication methods are acceptable for the session.

--- a/tests/integration/flow/authentication/input_validation_test.go
+++ b/tests/integration/flow/authentication/input_validation_test.go
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	validationEmailRegexPattern = `^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`
+	validationEmailInvalidMsg   = "validation.email.invalid"
+	validationPasswordMinMsg    = "validation.password.minLength"
+	validationPasswordRegexMsg  = "validation.password.complexity"
+	validationPasswordRegex     = `[0-9]`
+)
+
+var (
+	validationTestOU = testutils.OrganizationUnit{
+		Handle:      "input_validation_flow_test_ou",
+		Name:        "Test OU for Input Validation Flow",
+		Description: "Organization unit created for input validation flow testing",
+		Parent:      nil,
+	}
+
+	validationFlow = testutils.Flow{
+		Name:     "Input Validation Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_input_validation_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+								"validation": []map[string]interface{}{
+									{
+										"type":    "regex",
+										"value":   validationEmailRegexPattern,
+										"message": validationEmailInvalidMsg,
+									},
+								},
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+								"validation": []map[string]interface{}{
+									{
+										"type":    "minLength",
+										"value":   8,
+										"message": validationPasswordMinMsg,
+									},
+									{
+										"type":    "regex",
+										"value":   validationPasswordRegex,
+										"message": validationPasswordRegexMsg,
+									},
+								},
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "basic_auth",
+						},
+					},
+				},
+			},
+			{
+				"id":   "basic_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "BasicAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+				},
+				"onSuccess":    "auth_assert",
+				"onIncomplete": "prompt_credentials",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
+	validationTestApp = testutils.Application{
+		Name:                      "Input Validation Test Application",
+		Description:               "Application for testing input validation flows",
+		IsRegistrationFlowEnabled: false,
+		ClientID:                  "input_validation_test_client",
+		ClientSecret:              "input_validation_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{"input_validation_user"},
+	}
+
+	validationTestUserType = testutils.UserType{
+		Name: "input_validation_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
+		},
+	}
+
+	validationTestUser = testutils.User{
+		Type: validationTestUserType.Name,
+		Attributes: json.RawMessage(`{
+			"username": "validuser@example.com",
+			"password": "Validpass1"
+		}`),
+	}
+)
+
+type InputValidationFlowTestSuite struct {
+	suite.Suite
+	config       *common.TestSuiteConfig
+	ouID         string
+	appID        string
+	entityTypeID string
+}
+
+func TestInputValidationFlowTestSuite(t *testing.T) {
+	suite.Run(t, new(InputValidationFlowTestSuite))
+}
+
+func (ts *InputValidationFlowTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(validationTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	validationTestUserType.OUID = ts.ouID
+	schemaID, err := testutils.CreateUserType(validationTestUserType)
+	ts.Require().NoError(err, "Failed to create test user type")
+	ts.entityTypeID = schemaID
+
+	flowID, err := testutils.CreateFlow(validationFlow)
+	ts.Require().NoError(err, "Failed to create input validation test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+	validationTestApp.AuthFlowID = flowID
+
+	validationTestApp.OUID = ts.ouID
+	appID, err := testutils.CreateApplication(validationTestApp)
+	ts.Require().NoError(err, "Failed to create test application")
+	ts.appID = appID
+
+	testUser := validationTestUser
+	testUser.OUID = ts.ouID
+	userIDs, err := testutils.CreateMultipleUsers(testUser)
+	ts.Require().NoError(err, "Failed to create test user")
+	ts.config.CreatedUserIDs = userIDs
+}
+
+func (ts *InputValidationFlowTestSuite) TearDownSuite() {
+	if err := testutils.CleanupUsers(ts.config.CreatedUserIDs); err != nil {
+		ts.T().Logf("Failed to cleanup users during teardown: %v", err)
+	}
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow %s during teardown: %v", flowID, err)
+		}
+	}
+	if ts.entityTypeID != "" {
+		if err := testutils.DeleteUserType(ts.entityTypeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// TestInitialPromptReturnsValidationRules tests that validation rules are returned in
+// `data.inputs[].validation` in the initial prompt response for API-only clients.
+func (ts *InputValidationFlowTestSuite) TestInitialPromptReturnsValidationRules() {
+	err := common.UpdateAppConfig(ts.appID, ts.config.CreatedFlowIDs[0], "")
+	ts.Require().NoError(err, "App config update should succeed")
+
+	flowStep, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Data.Inputs)
+
+	usernameInput := findInput(flowStep.Data.Inputs, "username")
+	ts.Require().NotNil(usernameInput, "username input should be present")
+	ts.Require().Len(usernameInput.Validation, 1, "username should have 1 validation rule")
+	ts.Equal("regex", usernameInput.Validation[0].Type)
+	ts.Equal(validationEmailInvalidMsg, usernameInput.Validation[0].Message)
+
+	passwordInput := findInput(flowStep.Data.Inputs, "password")
+	ts.Require().NotNil(passwordInput, "password input should be present")
+	ts.Require().Len(passwordInput.Validation, 2, "password should have 2 validation rules")
+	ts.Equal("minLength", passwordInput.Validation[0].Type)
+	ts.Equal("regex", passwordInput.Validation[1].Type)
+}
+
+// TestInvalidInputReturnsFieldErrors tests that when validation fails, the server returns
+// `flowStatus: INCOMPLETE` and `data.fieldErrors` with one entry per failed rule.
+func (ts *InputValidationFlowTestSuite) TestInvalidInputReturnsFieldErrors() {
+	err := common.UpdateAppConfig(ts.appID, ts.config.CreatedFlowIDs[0], "")
+	ts.Require().NoError(err, "App config update should succeed")
+
+	flowStep, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	resp, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username": "not-an-email",
+		"password": "abc",
+	}, "action_001", flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit invalid inputs")
+
+	ts.Equal("INCOMPLETE", resp.FlowStatus, "Expected INCOMPLETE on validation failure")
+	ts.Equal("VIEW", resp.Type, "Expected VIEW for reprompt")
+	ts.Empty(resp.Assertion, "No assertion on validation failure")
+	ts.Empty(resp.FailureReason, "FailureReason should not be set for input validation failures")
+
+	ts.Require().NotEmpty(resp.Data.FieldErrors, "fieldErrors should be populated")
+	usernameErrors := filterFieldErrors(resp.Data.FieldErrors, "username")
+	passwordErrors := filterFieldErrors(resp.Data.FieldErrors, "password")
+	ts.Len(usernameErrors, 1, "username should have 1 validation error")
+	ts.Equal(validationEmailInvalidMsg, usernameErrors[0].Message)
+	ts.Len(passwordErrors, 2, "password should have 2 validation errors (minLength and regex)")
+}
+
+// TestValidationFailureRePromptsInitialFieldSet tests that on validation failure the
+// response re-prompts the same field set the user saw initially (preserving form
+// structure) with errors attached only to the failing fields, and returns the action
+// so the form can be re-submitted.
+func (ts *InputValidationFlowTestSuite) TestValidationFailureRePromptsInitialFieldSet() {
+	err := common.UpdateAppConfig(ts.appID, ts.config.CreatedFlowIDs[0], "")
+	ts.Require().NoError(err, "App config update should succeed")
+
+	flowStep, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	// Submit with a valid username and an invalid password. The response should
+	// re-prompt the same form (both fields) with the error attached to the password.
+	resp, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username": "validuser@example.com",
+		"password": "abc",
+	}, "action_001", flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit invalid inputs")
+
+	ts.Equal("INCOMPLETE", resp.FlowStatus)
+	ts.Equal("VIEW", resp.Type)
+
+	// fieldErrors should mention only the failing field.
+	usernameErrors := filterFieldErrors(resp.Data.FieldErrors, "username")
+	passwordErrors := filterFieldErrors(resp.Data.FieldErrors, "password")
+	ts.Empty(usernameErrors, "username passed; should have no field errors")
+	ts.NotEmpty(passwordErrors, "password failed; should have field errors")
+
+	// The same field set the user saw initially should be re-prompted.
+	ts.NotNil(findInput(resp.Data.Inputs, "username"), "username (in initial prompt) should be re-prompted")
+	ts.NotNil(findInput(resp.Data.Inputs, "password"), "password (in initial prompt) should be re-prompted")
+	ts.Len(resp.Data.Inputs, 2, "both initially-prompted inputs should be re-prompted")
+
+	// The action should also be re-returned so the submit button can be re-rendered.
+	ts.NotEmpty(resp.Data.Actions, "actions should be re-prompted")
+}
+
+// TestMultipleRulesPerFieldProduceSeparateEntries tests that when two rules fail on the
+// same field, each produces a separate `fieldErrors` entry.
+func (ts *InputValidationFlowTestSuite) TestMultipleRulesPerFieldProduceSeparateEntries() {
+	err := common.UpdateAppConfig(ts.appID, ts.config.CreatedFlowIDs[0], "")
+	ts.Require().NoError(err, "App config update should succeed")
+
+	flowStep, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	resp, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username": "validuser@example.com",
+		"password": "abc",
+	}, "action_001", flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit invalid inputs")
+
+	ts.Equal("INCOMPLETE", resp.FlowStatus)
+	passwordErrors := filterFieldErrors(resp.Data.FieldErrors, "password")
+	ts.Require().Len(passwordErrors, 2, "two failing rules should produce two entries")
+	ts.Equal(validationPasswordMinMsg, passwordErrors[0].Message)
+	ts.Equal(validationPasswordRegexMsg, passwordErrors[1].Message)
+}
+
+// TestValidSubmissionAdvancesFlow tests the happy path: valid inputs pass validation,
+// the flow advances, and `data.fieldErrors` is not present in the response.
+func (ts *InputValidationFlowTestSuite) TestValidSubmissionAdvancesFlow() {
+	err := common.UpdateAppConfig(ts.appID, ts.config.CreatedFlowIDs[0], "")
+	ts.Require().NoError(err, "App config update should succeed")
+
+	flowStep, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	resp, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username": "validuser@example.com",
+		"password": "Validpass1",
+	}, "action_001", flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit valid inputs")
+
+	ts.Equal("COMPLETE", resp.FlowStatus, "Expected COMPLETE for valid submission")
+	ts.NotEmpty(resp.Assertion, "JWT assertion should be issued on successful auth")
+	ts.Empty(resp.Data.FieldErrors, "fieldErrors should be absent when all rules pass")
+}
+
+// TestValidationRunsAfterRequiredCheck tests that validation runs only after the
+// required-input presence check passes. A submission missing a required field must
+// return the existing missing-input response, not a validation error.
+func (ts *InputValidationFlowTestSuite) TestValidationRunsAfterRequiredCheck() {
+	err := common.UpdateAppConfig(ts.appID, ts.config.CreatedFlowIDs[0], "")
+	ts.Require().NoError(err, "App config update should succeed")
+
+	flowStep, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	resp, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username": "validuser@example.com",
+	}, "action_001", flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit partial inputs")
+
+	ts.Equal("INCOMPLETE", resp.FlowStatus, "Expected INCOMPLETE for missing required input")
+	ts.Empty(resp.Data.FieldErrors, "fieldErrors should NOT be set when a required field is missing")
+	ts.NotEmpty(resp.Data.Inputs, "Missing required input should be re-prompted")
+}
+
+// findInput returns the first input in inputs matching identifier, or nil if absent.
+func findInput(inputs []common.Inputs, identifier string) *common.Inputs {
+	for i := range inputs {
+		if inputs[i].Identifier == identifier {
+			return &inputs[i]
+		}
+	}
+	return nil
+}
+
+// filterFieldErrors returns all field errors targeting the given identifier.
+func filterFieldErrors(errs []common.FieldError, identifier string) []common.FieldError {
+	var out []common.FieldError
+	for _, e := range errs {
+		if e.Identifier == identifier {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/tests/integration/flow/common/model.go
+++ b/tests/integration/flow/common/model.go
@@ -51,14 +51,27 @@ type FlowData struct {
 	RedirectURL    string            `json:"redirectURL,omitempty"`
 	AdditionalData map[string]string `json:"additionalData,omitempty"`
 	Meta           interface{}       `json:"meta,omitempty"`
+	FieldErrors    []FieldError      `json:"fieldErrors,omitempty"`
 }
 
 type Inputs struct {
-	Ref        string   `json:"ref,omitempty"`
-	Identifier string   `json:"identifier"`
-	Type       string   `json:"type"`
-	Required   bool     `json:"required"`
-	Options    []string `json:"options,omitempty"`
+	Ref        string           `json:"ref,omitempty"`
+	Identifier string           `json:"identifier"`
+	Type       string           `json:"type"`
+	Required   bool             `json:"required"`
+	Options    []string         `json:"options,omitempty"`
+	Validation []ValidationRule `json:"validation,omitempty"`
+}
+
+type ValidationRule struct {
+	Type    string      `json:"type"`
+	Value   interface{} `json:"value"`
+	Message string      `json:"message,omitempty"`
+}
+
+type FieldError struct {
+	Identifier string `json:"identifier"`
+	Message    string `json:"message"`
 }
 
 type Action struct {


### PR DESCRIPTION
 ### Purpose
 
 The flow system currently validates only the **presence** of required inputs — it never validates their **content**. Invalid data (e.g. a malformed email, a password shorter than the minimum length, a phone number that does not match the required pattern) passes silently through to executors, producing cryptic downstream failures or confusing error messages for end users.
 
 This PR introduces declarative input validation at the prompt-node level:
 
 - Adds a `validation` array on flow input definitions with three Phase 1 rule types: `regex`, `minLength`, `maxLength`.
 - The server enforces these rules after the existing required-input presence check, and returns structured per-field errors (`data.fieldErrors`) on failure.
 - On validation failure the **entire prompt** is re-returned (all inputs + actions, full meta) so clients can re-render the same form the user just submitted with errors attached.
 
 Backward compatible: every new field (`validation`, `fieldErrors`) uses `omitempty`, so flows that don't define validation rules behave exactly as before.
 
 ### Approach
 
 Key design decisions, mirroring the agreed design in [#2410](https://github.com/thunder-id/thunder-id/discussions/2410):
 
 1. **Discriminated `{ type, value, message }` rule shape** — exactly one constraint per rule object. Each failing rule produces its own `fieldErrors` entry. Replaces the original multi-constraint flat-key proposal — unambiguous, extensible to future rule types without struct changes.
 
 2. **Validation runs in the prompt node, after the required-input check.** Missing required fields still take the existing "tell me what's missing" path; validation only fires once all required fields are present, so the two layers don't conflict.
 
 3. **`INCOMPLETE` status pattern is reused.** Validation failures use the existing `INCOMPLETE` + `VIEW` response — `failureReason` stays empty (`fieldErrors` is user feedback, not a system error), `challengeToken` rotates as on any other re-prompt. No new flow status.
 
 4. **`fieldErrors` lives in `data`, not in a top-level `error` object.** It represents user feedback on input, not a server-side failure. Multiple failing rules on the same field produce multiple `fieldErrors` entries, preserving the order declared on the input.
 
 5. **Regex safety.** Patterns are compiled via Go's `regexp` (RE2 engine — linear-time matching, no ReDoS) and cached so repeat requests don't recompile. Invalid patterns are not pre-validated at flow-creation time today; a request hitting an unparseable pattern is treated as a rule failure (defensive — prefers safe-by-default over silent pass).
 
 6. **Dual data paths** for the rule definitions:
    - `meta.components[].validation` — UI/SDK consumption (the Asgardeo JS SDK reads this for optional client-side validation).
    - `prompts[].inputs[].validation` — server-side enforcement and API-only customers.
    The flow author/tooling is responsible for keeping the two in sync; the engine never enriches one from the other.
 
 #### Testing
 
 - **18 unit tests** in `backend/internal/flow/core/input_validation_test.go` covering: each rule type pass/fail, multi-rule per field, default-message fallback, i18n key passthrough, absent input no-op, unknown rule type ignored, regex cache reuse, prompt-node integration on failure, validation-doesn't-run-when-required-missing, and the new full-prompt re-prompt on failure.
 - **6 integration tests** in `tests/integration/flow/authentication/input_validation_test.go` hitting the live `/flow/execute` endpoint and asserting: validation rules present in initial prompt response, fieldErrors populated on invalid submission, multiple rules per field, full prompt re-returned on failure, valid submission advances the flow, and validation runs only after the required-input check.
 - All existing tests across `internal/...` pass.
 
 ### Related Issues
 
 Refs [#2619](https://github.com/asgardeo/thunder/issues/2619).
 
 ### Related PRs
 - N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-input validation rules (regex, min/max length) with default fallback messages; field-level errors returned and included in step/view payloads; failing inputs cleared on error
* **Behavior Changes**
  * Validation runs for inputs of the selected action (or all inputs if none); length measured by Unicode code points; unknown rules ignored
* **Tests**
  * Extensive unit and integration tests covering rule handling, error aggregation, prompt re-rendering, and regex caching
* **Documentation**
  * Flow reference and API examples updated to document validation and response schema changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2709)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->