### PR TITLE
Add composite store support for translations

### DIFF
--- a/backend/cmd/server/repository/resources/conf/default.json
+++ b/backend/cmd/server/repository/resources/conf/default.json
@@ -210,6 +210,9 @@
   "layout": {
     "store": "composite"
   },
+  "translation": {
+    "store": "composite"
+  },
   "authn_provider": {
     "type": "default",
     "rest": {

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -454,6 +454,16 @@ type LayoutConfig struct {
 	Store string `yaml:"store" json:"store"`
 }
 
+// TranslationConfig holds the translation service configuration.
+type TranslationConfig struct {
+	// Store defines the storage mode for translations.
+	// Valid values: "mutable", "declarative", "composite" (hybrid mode)
+	// If not specified, falls back to global DeclarativeResources.Enabled setting:
+	//   - If DeclarativeResources.Enabled = true: behaves as "declarative"
+	//   - If DeclarativeResources.Enabled = false: behaves as "mutable"
+	Store string `yaml:"store" json:"store"`
+}
+
 // PasskeyConfig holds the passkey configuration details.
 type PasskeyConfig struct {
 	AllowedOrigins []string `yaml:"allowed_origins" json:"allowed_origins"`
@@ -646,6 +656,7 @@ type Config struct {
 	Role                 RoleConfig             `yaml:"role" json:"role"`
 	Theme                ThemeConfig            `yaml:"theme" json:"theme"`
 	Layout               LayoutConfig           `yaml:"layout" json:"layout"`
+	Translation          TranslationConfig      `yaml:"translation" json:"translation"`
 	Email                EmailConfig            `yaml:"email" json:"email"`
 	Consent              ConsentConfig          `yaml:"consent" json:"consent"`
 }

--- a/backend/internal/system/i18n/mgt/composite_store.go
+++ b/backend/internal/system/i18n/mgt/composite_store.go
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package mgt
+
+import (
+	"context"
+)
+
+// compositeI18nStore combines a file-backed (declarative) store and a database-backed
+// (mutable) store for translations.
+//   - Read operations merge both stores; database values (overrides) take precedence over
+//     file-based values (base translations) for the same key and language.
+//   - Write operations target the database store only.
+type compositeI18nStore struct {
+	fileStore i18nStoreInterface
+	dbStore   i18nStoreInterface
+}
+
+func newCompositeI18nStore(fileStore, dbStore i18nStoreInterface) i18nStoreInterface {
+	return &compositeI18nStore{fileStore: fileStore, dbStore: dbStore}
+}
+
+// GetDistinctLanguages returns the union of languages from both stores.
+func (c *compositeI18nStore) GetDistinctLanguages() ([]string, error) {
+	dbLangs, err := c.dbStore.GetDistinctLanguages()
+	if err != nil {
+		return nil, err
+	}
+	fileLangs, err := c.fileStore.GetDistinctLanguages()
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]bool, len(dbLangs)+len(fileLangs))
+	result := make([]string, 0, len(dbLangs)+len(fileLangs))
+	for _, l := range dbLangs {
+		if !seen[l] {
+			seen[l] = true
+			result = append(result, l)
+		}
+	}
+	for _, l := range fileLangs {
+		if !seen[l] {
+			seen[l] = true
+			result = append(result, l)
+		}
+	}
+	return result, nil
+}
+
+// GetTranslations merges translations from both stores.
+// DB values (overrides) take precedence over file-based values for the same key+language.
+func (c *compositeI18nStore) GetTranslations() (map[string]map[string]Translation, error) {
+	fileTrans, err := c.fileStore.GetTranslations()
+	if err != nil {
+		return nil, err
+	}
+	dbTrans, err := c.dbStore.GetTranslations()
+	if err != nil {
+		return nil, err
+	}
+	return mergeTranslationMaps(fileTrans, dbTrans), nil
+}
+
+// GetTranslationsByNamespace merges translations for a namespace from both stores.
+// DB values take precedence over file-based values for the same key+language.
+func (c *compositeI18nStore) GetTranslationsByNamespace(namespace string) (
+	map[string]map[string]Translation, error,
+) {
+	fileTrans, err := c.fileStore.GetTranslationsByNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
+	dbTrans, err := c.dbStore.GetTranslationsByNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return mergeTranslationMaps(fileTrans, dbTrans), nil
+}
+
+// GetTranslationsByKey retrieves a translation for a specific key and namespace.
+// Returns the DB override if present, otherwise falls back to the file-based value.
+func (c *compositeI18nStore) GetTranslationsByKey(key string, namespace string) (
+	map[string]Translation, error,
+) {
+	fileTrans, err := c.fileStore.GetTranslationsByKey(key, namespace)
+	if err != nil {
+		return nil, err
+	}
+	dbTrans, err := c.dbStore.GetTranslationsByKey(key, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start with file-based values, then let DB override per language.
+	result := make(map[string]Translation, len(fileTrans)+len(dbTrans))
+	for lang, t := range fileTrans {
+		result[lang] = t
+	}
+	for lang, t := range dbTrans {
+		result[lang] = t
+	}
+	return result, nil
+}
+
+func (c *compositeI18nStore) UpsertTranslationsByLanguage(language string, translations []Translation) error {
+	return c.dbStore.UpsertTranslationsByLanguage(language, translations)
+}
+
+func (c *compositeI18nStore) UpsertTranslation(trans Translation) error {
+	return c.dbStore.UpsertTranslation(trans)
+}
+
+func (c *compositeI18nStore) UpsertTranslations(ctx context.Context, translations []Translation) error {
+	return c.dbStore.UpsertTranslations(ctx, translations)
+}
+
+func (c *compositeI18nStore) DeleteTranslationsByLanguage(language string) error {
+	return c.dbStore.DeleteTranslationsByLanguage(language)
+}
+
+func (c *compositeI18nStore) DeleteTranslation(language string, key string, namespace string) error {
+	return c.dbStore.DeleteTranslation(language, key, namespace)
+}
+
+func (c *compositeI18nStore) DeleteTranslationsByNamespace(ctx context.Context, namespace string) error {
+	return c.dbStore.DeleteTranslationsByNamespace(ctx, namespace)
+}
+
+func (c *compositeI18nStore) DeleteTranslationsByKey(ctx context.Context, namespace string, key string) error {
+	return c.dbStore.DeleteTranslationsByKey(ctx, namespace, key)
+}
+
+// mergeTranslationMaps merges base (file) and override (DB) translation maps.
+// For each compositeKey (namespace|key), DB values take precedence over file values
+// per language, so a DB override for a specific language replaces the file-based value.
+func mergeTranslationMaps(
+	base, overrides map[string]map[string]Translation,
+) map[string]map[string]Translation {
+	result := make(map[string]map[string]Translation, len(base)+len(overrides))
+
+	for compositeKey, langMap := range base {
+		result[compositeKey] = make(map[string]Translation, len(langMap))
+		for lang, t := range langMap {
+			result[compositeKey][lang] = t
+		}
+	}
+
+	for compositeKey, langMap := range overrides {
+		if result[compositeKey] == nil {
+			result[compositeKey] = make(map[string]Translation, len(langMap))
+		}
+		for lang, t := range langMap {
+			result[compositeKey][lang] = t
+		}
+	}
+
+	return result
+}

--- a/backend/internal/system/i18n/mgt/composite_store_test.go
+++ b/backend/internal/system/i18n/mgt/composite_store_test.go
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package mgt
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type CompositeStoreTestSuite struct {
+	suite.Suite
+	fileStore *i18nStoreInterfaceMock
+	dbStore   *i18nStoreInterfaceMock
+	store     i18nStoreInterface
+}
+
+func TestCompositeStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(CompositeStoreTestSuite))
+}
+
+func (s *CompositeStoreTestSuite) SetupTest() {
+	s.fileStore = newI18nStoreInterfaceMock(s.T())
+	s.dbStore = newI18nStoreInterfaceMock(s.T())
+	s.store = newCompositeI18nStore(s.fileStore, s.dbStore)
+}
+
+// GetDistinctLanguages
+
+func (s *CompositeStoreTestSuite) TestGetDistinctLanguages_MergesAndDeduplicates() {
+	s.dbStore.EXPECT().GetDistinctLanguages().Return([]string{"en-US", "fr-FR"}, nil)
+	s.fileStore.EXPECT().GetDistinctLanguages().Return([]string{"en-US", "es-ES"}, nil)
+
+	langs, err := s.store.GetDistinctLanguages()
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), langs, 3)
+	assert.Contains(s.T(), langs, "en-US")
+	assert.Contains(s.T(), langs, "fr-FR")
+	assert.Contains(s.T(), langs, "es-ES")
+}
+
+func (s *CompositeStoreTestSuite) TestGetDistinctLanguages_DBStoreError() {
+	s.dbStore.EXPECT().GetDistinctLanguages().Return(nil, errors.New("db error"))
+
+	langs, err := s.store.GetDistinctLanguages()
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), langs)
+}
+
+func (s *CompositeStoreTestSuite) TestGetDistinctLanguages_FileStoreError() {
+	s.dbStore.EXPECT().GetDistinctLanguages().Return([]string{"en-US"}, nil)
+	s.fileStore.EXPECT().GetDistinctLanguages().Return(nil, errors.New("file error"))
+
+	langs, err := s.store.GetDistinctLanguages()
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), langs)
+}
+
+// GetTranslations
+
+func (s *CompositeStoreTestSuite) TestGetTranslations_DBOverridesFile() {
+	fileTrans := map[string]map[string]Translation{
+		"ns1|key1": {
+			"en-US": {Key: "key1", Namespace: "ns1", Language: "en-US", Value: "file-value"},
+		},
+	}
+	dbTrans := map[string]map[string]Translation{
+		"ns1|key1": {
+			"en-US": {Key: "key1", Namespace: "ns1", Language: "en-US", Value: "db-override"},
+		},
+	}
+	s.fileStore.EXPECT().GetTranslations().Return(fileTrans, nil)
+	s.dbStore.EXPECT().GetTranslations().Return(dbTrans, nil)
+
+	result, err := s.store.GetTranslations()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "db-override", result["ns1|key1"]["en-US"].Value)
+}
+
+func (s *CompositeStoreTestSuite) TestGetTranslations_FileOnlyKeyPreserved() {
+	fileTrans := map[string]map[string]Translation{
+		"ns1|key1": {
+			"en-US": {Key: "key1", Namespace: "ns1", Language: "en-US", Value: "file-only"},
+		},
+	}
+	s.fileStore.EXPECT().GetTranslations().Return(fileTrans, nil)
+	s.dbStore.EXPECT().GetTranslations().Return(map[string]map[string]Translation{}, nil)
+
+	result, err := s.store.GetTranslations()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "file-only", result["ns1|key1"]["en-US"].Value)
+}
+
+func (s *CompositeStoreTestSuite) TestGetTranslations_DBOnlyKeyPreserved() {
+	dbTrans := map[string]map[string]Translation{
+		"ns1|key2": {
+			"en-US": {Key: "key2", Namespace: "ns1", Language: "en-US", Value: "db-only"},
+		},
+	}
+	s.fileStore.EXPECT().GetTranslations().Return(map[string]map[string]Translation{}, nil)
+	s.dbStore.EXPECT().GetTranslations().Return(dbTrans, nil)
+
+	result, err := s.store.GetTranslations()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "db-only", result["ns1|key2"]["en-US"].Value)
+}
+
+func (s *CompositeStoreTestSuite) TestGetTranslations_FileStoreError() {
+	s.fileStore.EXPECT().GetTranslations().Return(nil, errors.New("file error"))
+
+	result, err := s.store.GetTranslations()
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), result)
+}
+
+func (s *CompositeStoreTestSuite) TestGetTranslations_DBStoreError() {
+	s.fileStore.EXPECT().GetTranslations().Return(map[string]map[string]Translation{}, nil)
+	s.dbStore.EXPECT().GetTranslations().Return(nil, errors.New("db error"))
+
+	result, err := s.store.GetTranslations()
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), result)
+}
+
+// GetTranslationsByNamespace
+
+func (s *CompositeStoreTestSuite) TestGetTranslationsByNamespace_DBOverridesFile() {
+	fileTrans := map[string]map[string]Translation{
+		"signin|forms.title": {
+			"en-US": {Key: "forms.title", Namespace: "signin", Language: "en-US", Value: "Sign In"},
+		},
+	}
+	dbTrans := map[string]map[string]Translation{
+		"signin|forms.title": {
+			"en-US": {Key: "forms.title", Namespace: "signin", Language: "en-US", Value: "Log In"},
+		},
+	}
+	s.fileStore.EXPECT().GetTranslationsByNamespace("signin").Return(fileTrans, nil)
+	s.dbStore.EXPECT().GetTranslationsByNamespace("signin").Return(dbTrans, nil)
+
+	result, err := s.store.GetTranslationsByNamespace("signin")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "Log In", result["signin|forms.title"]["en-US"].Value)
+}
+
+func (s *CompositeStoreTestSuite) TestGetTranslationsByNamespace_FileStoreError() {
+	s.fileStore.EXPECT().GetTranslationsByNamespace("signin").Return(nil, errors.New("file error"))
+
+	result, err := s.store.GetTranslationsByNamespace("signin")
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), result)
+}
+
+func (s *CompositeStoreTestSuite) TestGetTranslationsByNamespace_DBStoreError() {
+	s.fileStore.EXPECT().GetTranslationsByNamespace("signin").Return(map[string]map[string]Translation{}, nil)
+	s.dbStore.EXPECT().GetTranslationsByNamespace("signin").Return(nil, errors.New("db error"))
+
+	result, err := s.store.GetTranslationsByNamespace("signin")
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), result)
+}
+
+// GetTranslationsByKey
+
+func (s *CompositeStoreTestSuite) TestGetTranslationsByKey_DBOverridesFilePerLanguage() {
+	fileTrans := map[string]Translation{
+		"en-US": {Key: "forms.title", Namespace: "signin", Language: "en-US", Value: "Sign In"},
+		"fr-FR": {Key: "forms.title", Namespace: "signin", Language: "fr-FR", Value: "Se connecter"},
+	}
+	dbTrans := map[string]Translation{
+		"en-US": {Key: "forms.title", Namespace: "signin", Language: "en-US", Value: "Log In"},
+	}
+	s.fileStore.EXPECT().GetTranslationsByKey("forms.title", "signin").Return(fileTrans, nil)
+	s.dbStore.EXPECT().GetTranslationsByKey("forms.title", "signin").Return(dbTrans, nil)
+
+	result, err := s.store.GetTranslationsByKey("forms.title", "signin")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "Log In", result["en-US"].Value)
+	assert.Equal(s.T(), "Se connecter", result["fr-FR"].Value)
+}
+
+func (s *CompositeStoreTestSuite) TestGetTranslationsByKey_FileOnlyLanguagePreserved() {
+	fileTrans := map[string]Translation{
+		"en-US": {Key: "key1", Namespace: "ns1", Language: "en-US", Value: "file-value"},
+	}
+	s.fileStore.EXPECT().GetTranslationsByKey("key1", "ns1").Return(fileTrans, nil)
+	s.dbStore.EXPECT().GetTranslationsByKey("key1", "ns1").Return(map[string]Translation{}, nil)
+
+	result, err := s.store.GetTranslationsByKey("key1", "ns1")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "file-value", result["en-US"].Value)
+}
+
+func (s *CompositeStoreTestSuite) TestGetTranslationsByKey_FileStoreError() {
+	s.fileStore.EXPECT().GetTranslationsByKey("key1", "ns1").Return(nil, errors.New("file error"))
+
+	result, err := s.store.GetTranslationsByKey("key1", "ns1")
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), result)
+}
+
+func (s *CompositeStoreTestSuite) TestGetTranslationsByKey_DBStoreError() {
+	s.fileStore.EXPECT().GetTranslationsByKey("key1", "ns1").Return(map[string]Translation{}, nil)
+	s.dbStore.EXPECT().GetTranslationsByKey("key1", "ns1").Return(nil, errors.New("db error"))
+
+	result, err := s.store.GetTranslationsByKey("key1", "ns1")
+	assert.Error(s.T(), err)
+	assert.Nil(s.T(), result)
+}
+
+// Write operations — all delegate to dbStore only
+
+func (s *CompositeStoreTestSuite) TestUpsertTranslationsByLanguage_DelegatesToDB() {
+	trans := []Translation{{Key: "key1", Language: "en-US", Namespace: "ns1", Value: "v1"}}
+	s.dbStore.EXPECT().UpsertTranslationsByLanguage("en-US", trans).Return(nil)
+
+	err := s.store.UpsertTranslationsByLanguage("en-US", trans)
+	assert.NoError(s.T(), err)
+}
+
+func (s *CompositeStoreTestSuite) TestUpsertTranslation_DelegatesToDB() {
+	trans := Translation{Key: "key1", Language: "en-US", Namespace: "ns1", Value: "v1"}
+	s.dbStore.EXPECT().UpsertTranslation(trans).Return(nil)
+
+	err := s.store.UpsertTranslation(trans)
+	assert.NoError(s.T(), err)
+}
+
+func (s *CompositeStoreTestSuite) TestUpsertTranslations_DelegatesToDB() {
+	ctx := context.Background()
+	trans := []Translation{{Key: "key1", Language: "en-US", Namespace: "ns1", Value: "v1"}}
+	s.dbStore.EXPECT().UpsertTranslations(ctx, trans).Return(nil)
+
+	err := s.store.UpsertTranslations(ctx, trans)
+	assert.NoError(s.T(), err)
+}
+
+func (s *CompositeStoreTestSuite) TestDeleteTranslationsByLanguage_DelegatesToDB() {
+	s.dbStore.EXPECT().DeleteTranslationsByLanguage("en-US").Return(nil)
+
+	err := s.store.DeleteTranslationsByLanguage("en-US")
+	assert.NoError(s.T(), err)
+}
+
+func (s *CompositeStoreTestSuite) TestDeleteTranslation_DelegatesToDB() {
+	s.dbStore.EXPECT().DeleteTranslation("en-US", "key1", "ns1").Return(nil)
+
+	err := s.store.DeleteTranslation("en-US", "key1", "ns1")
+	assert.NoError(s.T(), err)
+}
+
+func (s *CompositeStoreTestSuite) TestDeleteTranslationsByNamespace_DelegatesToDB() {
+	ctx := context.Background()
+	s.dbStore.EXPECT().DeleteTranslationsByNamespace(ctx, "ns1").Return(nil)
+
+	err := s.store.DeleteTranslationsByNamespace(ctx, "ns1")
+	assert.NoError(s.T(), err)
+}
+
+func (s *CompositeStoreTestSuite) TestDeleteTranslationsByKey_DelegatesToDB() {
+	ctx := context.Background()
+	s.dbStore.EXPECT().DeleteTranslationsByKey(ctx, "ns1", "key1").Return(nil)
+
+	err := s.store.DeleteTranslationsByKey(ctx, "ns1", "key1")
+	assert.NoError(s.T(), err)
+}
+
+// mergeTranslationMaps
+
+func (s *CompositeStoreTestSuite) TestMergeTranslationMaps_EmptyBase() {
+	overrides := map[string]map[string]Translation{
+		"ns1|key1": {"en-US": {Value: "override"}},
+	}
+	result := mergeTranslationMaps(map[string]map[string]Translation{}, overrides)
+	assert.Equal(s.T(), "override", result["ns1|key1"]["en-US"].Value)
+}
+
+func (s *CompositeStoreTestSuite) TestMergeTranslationMaps_EmptyOverrides() {
+	base := map[string]map[string]Translation{
+		"ns1|key1": {"en-US": {Value: "base"}},
+	}
+	result := mergeTranslationMaps(base, map[string]map[string]Translation{})
+	assert.Equal(s.T(), "base", result["ns1|key1"]["en-US"].Value)
+}
+
+func (s *CompositeStoreTestSuite) TestMergeTranslationMaps_OverrideWins() {
+	base := map[string]map[string]Translation{
+		"ns1|key1": {"en-US": {Value: "base"}},
+	}
+	overrides := map[string]map[string]Translation{
+		"ns1|key1": {"en-US": {Value: "override"}},
+	}
+	result := mergeTranslationMaps(base, overrides)
+	assert.Equal(s.T(), "override", result["ns1|key1"]["en-US"].Value)
+}
+
+func (s *CompositeStoreTestSuite) TestMergeTranslationMaps_PerLanguageOverride() {
+	base := map[string]map[string]Translation{
+		"ns1|key1": {
+			"en-US": {Value: "base-en"},
+			"fr-FR": {Value: "base-fr"},
+		},
+	}
+	overrides := map[string]map[string]Translation{
+		"ns1|key1": {
+			"en-US": {Value: "override-en"},
+		},
+	}
+	result := mergeTranslationMaps(base, overrides)
+	assert.Equal(s.T(), "override-en", result["ns1|key1"]["en-US"].Value)
+	assert.Equal(s.T(), "base-fr", result["ns1|key1"]["fr-FR"].Value)
+}
+
+func (s *CompositeStoreTestSuite) TestMergeTranslationMaps_DisjointKeys() {
+	base := map[string]map[string]Translation{
+		"ns1|key1": {"en-US": {Value: "v1"}},
+	}
+	overrides := map[string]map[string]Translation{
+		"ns1|key2": {"en-US": {Value: "v2"}},
+	}
+	result := mergeTranslationMaps(base, overrides)
+	assert.Len(s.T(), result, 2)
+	assert.Equal(s.T(), "v1", result["ns1|key1"]["en-US"].Value)
+	assert.Equal(s.T(), "v2", result["ns1|key2"]["en-US"].Value)
+}

--- a/backend/internal/system/i18n/mgt/config.go
+++ b/backend/internal/system/i18n/mgt/config.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package mgt
+
+import (
+	"strings"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
+)
+
+// getI18nStoreMode determines the store mode for translations.
+//
+// Resolution order:
+//  1. If Translation.Store is explicitly configured, use it
+//  2. Otherwise, fall back to global DeclarativeResources.Enabled:
+//     - If enabled: return "declarative"
+//     - If disabled: return "mutable"
+//
+// Returns normalized store mode: "mutable", "declarative", or "composite"
+func getI18nStoreMode() serverconst.StoreMode {
+	cfg := config.GetServerRuntime().Config
+	if cfg.Translation.Store != "" {
+		mode := serverconst.StoreMode(strings.ToLower(strings.TrimSpace(cfg.Translation.Store)))
+		switch mode {
+		case serverconst.StoreModeMutable, serverconst.StoreModeDeclarative, serverconst.StoreModeComposite:
+			return mode
+		}
+	}
+
+	if declarativeresource.IsDeclarativeModeEnabled() {
+		return serverconst.StoreModeDeclarative
+	}
+
+	return serverconst.StoreModeMutable
+}

--- a/backend/internal/system/i18n/mgt/file_based_store.go
+++ b/backend/internal/system/i18n/mgt/file_based_store.go
@@ -72,10 +72,11 @@ func (f *fileBasedStore) GetTranslations() (map[string]map[string]Translation, e
 		if langTrans, ok := item.Data.(*LanguageTranslations); ok {
 			for ns, nsTrans := range langTrans.Translations {
 				for key, value := range nsTrans {
-					if translations[key] == nil {
-						translations[key] = make(map[string]Translation)
+					compositeKey := ns + "|" + key
+					if translations[compositeKey] == nil {
+						translations[compositeKey] = make(map[string]Translation)
 					}
-					translations[key][langTrans.Language] = Translation{
+					translations[compositeKey][langTrans.Language] = Translation{
 						Key:       key,
 						Language:  langTrans.Language,
 						Namespace: ns,
@@ -103,10 +104,11 @@ func (f *fileBasedStore) GetTranslationsByNamespace(namespace string) (map[strin
 					continue
 				}
 				for k, v := range nsTrans {
-					if translations[k] == nil {
-						translations[k] = make(map[string]Translation)
+					compositeKey := ns + "|" + k
+					if translations[compositeKey] == nil {
+						translations[compositeKey] = make(map[string]Translation)
 					}
-					translations[k][langTrans.Language] = Translation{
+					translations[compositeKey][langTrans.Language] = Translation{
 						Key:       k,
 						Language:  langTrans.Language,
 						Namespace: ns,

--- a/backend/internal/system/i18n/mgt/file_based_store_test.go
+++ b/backend/internal/system/i18n/mgt/file_based_store_test.go
@@ -111,18 +111,18 @@ func (s *FileBasedStoreTestSuite) TestGetTranslations() {
 	assert.NoError(s.T(), err)
 
 	// Verify structure
-	assert.Contains(s.T(), translations, "key1")
-	assert.Contains(s.T(), translations, "key2")
+	assert.Contains(s.T(), translations, "ns1|key1")
+	assert.Contains(s.T(), translations, "ns2|key2")
 
-	assert.Contains(s.T(), translations["key1"], "en-US")
-	assert.Equal(s.T(), "value1-en", translations["key1"]["en-US"].Value)
-	assert.Equal(s.T(), "ns1", translations["key1"]["en-US"].Namespace)
+	assert.Contains(s.T(), translations["ns1|key1"], "en-US")
+	assert.Equal(s.T(), "value1-en", translations["ns1|key1"]["en-US"].Value)
+	assert.Equal(s.T(), "ns1", translations["ns1|key1"]["en-US"].Namespace)
 
-	assert.Contains(s.T(), translations["key1"], "fr-FR")
-	assert.Equal(s.T(), "value1-fr", translations["key1"]["fr-FR"].Value)
+	assert.Contains(s.T(), translations["ns1|key1"], "fr-FR")
+	assert.Equal(s.T(), "value1-fr", translations["ns1|key1"]["fr-FR"].Value)
 
-	assert.Contains(s.T(), translations["key2"], "fr-FR")
-	assert.Equal(s.T(), "value2-fr", translations["key2"]["fr-FR"].Value)
+	assert.Contains(s.T(), translations["ns2|key2"], "fr-FR")
+	assert.Equal(s.T(), "value2-fr", translations["ns2|key2"]["fr-FR"].Value)
 }
 
 func (s *FileBasedStoreTestSuite) TestGetTranslationsByNamespace() {
@@ -145,9 +145,9 @@ func (s *FileBasedStoreTestSuite) TestGetTranslationsByNamespace() {
 	translations, err := s.store.GetTranslationsByNamespace("ns1")
 	assert.NoError(s.T(), err)
 
-	assert.Contains(s.T(), translations, "key1")
-	assert.NotContains(s.T(), translations, "key2")
-	assert.Equal(s.T(), "value1-en", translations["key1"]["en-US"].Value)
+	assert.Contains(s.T(), translations, "ns1|key1")
+	assert.NotContains(s.T(), translations, "ns2|key2")
+	assert.Equal(s.T(), "value1-en", translations["ns1|key1"]["en-US"].Value)
 }
 
 func (s *FileBasedStoreTestSuite) TestGetTranslationsByKey() {

--- a/backend/internal/system/i18n/mgt/init.go
+++ b/backend/internal/system/i18n/mgt/init.go
@@ -21,6 +21,7 @@ package mgt
 import (
 	"net/http"
 
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
 )
@@ -28,19 +29,26 @@ import (
 // Initialize initializes the i18n service and registers its routes.
 func Initialize(mux *http.ServeMux) (I18nServiceInterface, declarativeresource.ResourceExporter, error) {
 	var store i18nStoreInterface
-	if declarativeresource.IsDeclarativeModeEnabled() {
-		store = newFileBasedStore()
-	} else {
+
+	storeMode := getI18nStoreMode()
+	switch storeMode {
+	case serverconst.StoreModeDeclarative:
+		fileStore := newFileBasedStore()
+		if err := loadDeclarativeResources(fileStore); err != nil {
+			return nil, nil, err
+		}
+		store = fileStore
+	case serverconst.StoreModeComposite:
+		fileStore := newFileBasedStore()
+		if err := loadDeclarativeResources(fileStore); err != nil {
+			return nil, nil, err
+		}
+		store = newCompositeI18nStore(fileStore, newI18nStore())
+	default:
 		store = newI18nStore()
 	}
 
 	service := newI18nService(store)
-
-	if declarativeresource.IsDeclarativeModeEnabled() {
-		if err := loadDeclarativeResources(store); err != nil {
-			return nil, nil, err
-		}
-	}
 
 	handler := newI18nHandler(service)
 	registerRoutes(mux, handler)


### PR DESCRIPTION
### Purpose
Add composite store support for translations

### Approach
This pull request introduces a new "composite" translation store mode that combines file-based (declarative) and database-backed (mutable) translation storage, allowing the system to read from both sources and write to the database. It also refactors the translation storage configuration to be more flexible and updates the translation key structure for better namespace handling. The changes include updates to configuration, initialization logic, and translation store implementations, as well as corresponding unit tests.

**Translation Store Architecture:**

* Added a new `compositeI18nStore` implementation in `composite_store.go` that merges file-based and database-backed translation stores. Read operations merge both sources (with DB values taking precedence), while write operations target only the database.
* Introduced a `getI18nStoreMode` function in `config.go` to determine the translation store mode based on configuration or global declarative resource settings, supporting "mutable", "declarative", and the new "composite" mode.
* Updated the i18n service initialization in `init.go` to use the new store mode logic, properly initializing the appropriate store(s) and loading declarative resources when needed.

**Configuration Changes:**

* Added `translation.store` configuration to `default.json` and corresponding `TranslationConfig` struct in Go, allowing explicit selection of translation store mode. This supports the new "composite" mode and provides backward compatibility. [[1]](diffhunk://#diff-beec713bb8f44ef8633de8d745de6dcd555593b5cd0758d7788470fee3b2d974R213-R215) [[2]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR457-R466) [[3]](diffhunk://#diff-70ef91d44215280f2234659532a25f97986a90f9f6e8e798167394efdfe0bacbR659)

**Translation Key Structure:**

* Changed the translation map key structure in `file_based_store.go` to use a composite key of `namespace|key` instead of just `key`, ensuring translations are properly namespaced and preventing key collisions. [[1]](diffhunk://#diff-b8987aa601fa42dd1ca5306233e3691159c25f43ed49417f0a9cd33f5c836f2bL75-R79) [[2]](diffhunk://#diff-b8987aa601fa42dd1ca5306233e3691159c25f43ed49417f0a9cd33f5c836f2bL106-R111)
* Updated unit tests in `file_based_store_test.go` to reflect the new composite key structure for translations. [[1]](diffhunk://#diff-f90879952aa7fd0191587a51b53e002446fce0dbad579fb9d2c0ccd04be760beL114-R125) [[2]](diffhunk://#diff-f90879952aa7fd0191587a51b53e002446fce0dbad579fb9d2c0ccd04be760beL148-R150)



### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added composite translation storage mode combining file-based and database-backed translations, with database translations taking precedence over file-based ones.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2711)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->