### PR TITLE
Add federated user consistency validation

### DIFF
--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -256,6 +256,17 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		return errors.New("federated authentication failed")
 	}
 
+	if basicResult == nil {
+		logger.Error("authnProvider.AuthenticateUser returned nil result")
+		return errors.New("OAuth authentication failed")
+	}
+
+	if !validateFederatedIdentifierConsistency(ctx, basicResult) {
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Invalid federated user"
+		return nil
+	}
+
 	sub := basicResult.ExternalSub
 
 	if basicResult.IsAmbiguousUser {

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -193,6 +193,82 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_IDPNotConfigured() {
 	assert.Contains(suite.T(), err.Error(), "idpId is not configured")
 }
 
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailMismatch_Fails() { //nolint:dupl
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"code":  "auth_code_123",
+			"email": "invited@example.com",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-123",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "user-sub-123",
+				"email": "authenticated@example.com",
+			},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "Invalid federated user", execResp.FailureReason)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_SubMismatch_Fails() { //nolint:dupl
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"code": "auth_code_123",
+		},
+		RuntimeData: map[string]string{
+			"sub": "stored-sub-123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "authenticated-sub-456",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "authenticated-sub-456",
+				"email": "user@example.com",
+			},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "Invalid federated user", execResp.FailureReason)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
 func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLClientError() {
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -192,6 +192,12 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		}
 	}
 
+	if !validateFederatedIdentifierConsistency(ctx, basicResult) {
+		execResp.Status = common.ExecFailure
+		execResp.FailureReason = "Invalid federated user"
+		return nil
+	}
+
 	sub := basicResult.ExternalSub
 
 	if basicResult.IsAmbiguousUser {

--- a/backend/internal/flow/executor/oidc_auth_executor_test.go
+++ b/backend/internal/flow/executor/oidc_auth_executor_test.go
@@ -220,6 +220,82 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_InvalidNonce
 	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_EmailMismatch_Fails() { //nolint:dupl
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"code":  "auth_code_123",
+			"email": "invited@example.com",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "user-sub-123",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "user-sub-123",
+				"email": "authenticated@example.com",
+			},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "Invalid federated user", execResp.FailureReason)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_SubMismatch_Fails() { //nolint:dupl
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"code": "auth_code_123",
+		},
+		RuntimeData: map[string]string{
+			"sub": "stored-sub-123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &common.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			ExternalSub: "authenticated-sub-456",
+			ExternalClaims: map[string]interface{}{
+				"sub":   "authenticated-sub-456",
+				"email": "user@example.com",
+			},
+			IsExistingUser: false,
+		}, (*serviceerror.ServiceError)(nil))
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "Invalid federated user", execResp.FailureReason)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ProviderClientError() { //nolint:dupl
 	ctx := &core.NodeContext{
 		ExecutionID: "flow-123",

--- a/backend/internal/flow/executor/utils.go
+++ b/backend/internal/flow/executor/utils.go
@@ -24,9 +24,11 @@ import (
 	"fmt"
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
+	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
+	systemutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
 
 // getAuthnServiceName returns the authn service name for an executor.
@@ -104,4 +106,56 @@ func isCrossOUProvisioningAllowed(ctx *core.NodeContext) bool {
 		}
 	}
 	return false
+}
+
+// validateFederatedIdentifierConsistency checks if the federated identifiers from the authentication result
+// are consistent with any existing identifiers in the context (runtime data, user inputs, authenticated
+// user attributes).
+func validateFederatedIdentifierConsistency(ctx *core.NodeContext,
+	basicResult *authnprovidermgr.AuthnBasicResult) bool {
+	if basicResult == nil {
+		return true
+	}
+
+	federatedIdentifiers := map[string]string{
+		userAttributeSub: basicResult.ExternalSub,
+	}
+	if email, ok := basicResult.ExternalClaims[userAttributeEmail]; ok {
+		federatedIdentifiers[userAttributeEmail] = systemutils.ConvertInterfaceValueToString(email)
+	}
+
+	// TODO: Refine this well-known-key comparison when IDP-to-local attribute mapping is supported
+	fedIdfConsistencyKeys := []string{userAttributeEmail, userAttributeSub}
+	for _, key := range fedIdfConsistencyKeys {
+		federatedValue := federatedIdentifiers[key]
+		if federatedValue == "" {
+			continue
+		}
+
+		if value, ok := ctx.RuntimeData[key]; ok && value != "" && value != federatedValue {
+			return false
+		}
+		if value, ok := ctx.UserInputs[key]; ok && value != "" && value != federatedValue {
+			return false
+		}
+		if value := getAuthenticatedIdentifierValue(ctx, key); value != "" && value != federatedValue {
+			return false
+		}
+	}
+
+	return true
+}
+
+// getAuthenticatedIdentifierValue retrieves the value of a specific identifier key from the
+// authenticated user's attributes in the context.
+func getAuthenticatedIdentifierValue(ctx *core.NodeContext, key string) string {
+	if ctx.AuthenticatedUser.Attributes == nil {
+		return ""
+	}
+	value, ok := ctx.AuthenticatedUser.Attributes[key]
+	if !ok {
+		return ""
+	}
+
+	return systemutils.ConvertInterfaceValueToString(value)
 }

--- a/backend/internal/flow/executor/utils_test.go
+++ b/backend/internal/flow/executor/utils_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
+	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
@@ -289,6 +290,334 @@ func (s *UtilsTestSuite) TestIsCrossOUProvisioningAllowed() {
 			ctx := &core.NodeContext{NodeProperties: tt.properties}
 			result := isCrossOUProvisioningAllowed(ctx)
 			s.Equal(tt.expected, result)
+		})
+	}
+}
+
+func (s *UtilsTestSuite) TestValidateFederatedIdentifierConsistency() {
+	tests := []struct {
+		name          string
+		basicResult   *authnprovidermgr.AuthnBasicResult
+		ctx           *core.NodeContext
+		expectedValid bool
+		expectError   bool
+	}{
+		{
+			name:          "Nil basicResult returns true",
+			basicResult:   nil,
+			ctx:           &core.NodeContext{},
+			expectedValid: true,
+			expectError:   false,
+		},
+		{
+			name: "No federated identifiers returns true",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub:    "",
+				ExternalClaims: map[string]interface{}{},
+			},
+			ctx:           &core.NodeContext{},
+			expectedValid: true,
+			expectError:   false,
+		},
+		{
+			name: "Email matches UserInputs returns true",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				UserInputs: map[string]string{
+					"email": "user@example.com",
+				},
+			},
+			expectedValid: true,
+			expectError:   false,
+		},
+		{
+			name: "Email mismatch with UserInputs returns false",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user1@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				UserInputs: map[string]string{
+					"email": "user2@example.com",
+				},
+			},
+			expectedValid: false,
+			expectError:   false,
+		},
+		{
+			name: "Email matches RuntimeData returns true",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				RuntimeData: map[string]string{
+					"email": "user@example.com",
+				},
+			},
+			expectedValid: true,
+			expectError:   false,
+		},
+		{
+			name: "Email mismatch with RuntimeData returns false",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user1@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				RuntimeData: map[string]string{
+					"email": "user2@example.com",
+				},
+			},
+			expectedValid: false,
+			expectError:   false,
+		},
+		{
+			name: "Email matches AuthenticatedUser.Attributes returns true",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					Attributes: map[string]interface{}{
+						"email": "user@example.com",
+					},
+				},
+			},
+			expectedValid: true,
+			expectError:   false,
+		},
+		{
+			name: "Email mismatch with AuthenticatedUser.Attributes returns false",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user1@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					Attributes: map[string]interface{}{
+						"email": "user2@example.com",
+					},
+				},
+			},
+			expectedValid: false,
+			expectError:   false,
+		},
+		{
+			name: "Sub matches RuntimeData returns true",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				RuntimeData: map[string]string{
+					"sub": "sub123",
+				},
+			},
+			expectedValid: true,
+			expectError:   false,
+		},
+		{
+			name: "Sub mismatch with RuntimeData returns false",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				RuntimeData: map[string]string{
+					"sub": "sub456",
+				},
+			},
+			expectedValid: false,
+			expectError:   false,
+		},
+		{
+			name: "Empty UserInputs email is skipped",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				UserInputs: map[string]string{
+					"email": "",
+				},
+			},
+			expectedValid: true,
+			expectError:   false,
+		},
+		{
+			name: "Empty RuntimeData email is skipped",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				RuntimeData: map[string]string{
+					"email": "",
+				},
+			},
+			expectedValid: true,
+			expectError:   false,
+		},
+		{
+			name: "Missing email from UserInputs and RuntimeData is allowed",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user@example.com",
+				},
+			},
+			ctx:           &core.NodeContext{},
+			expectedValid: true,
+			expectError:   false,
+		},
+		{
+			name: "Multiple attributes with one mismatch returns false",
+			basicResult: &authnprovidermgr.AuthnBasicResult{
+				ExternalSub: "sub123",
+				ExternalClaims: map[string]interface{}{
+					"email": "user1@example.com",
+				},
+			},
+			ctx: &core.NodeContext{
+				UserInputs: map[string]string{
+					"email": "user1@example.com",
+					"sub":   "sub456",
+				},
+				RuntimeData: map[string]string{
+					"sub": "sub123",
+				},
+			},
+			expectedValid: false,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			valid := validateFederatedIdentifierConsistency(tt.ctx, tt.basicResult)
+			s.Equal(tt.expectedValid, valid)
+		})
+	}
+}
+
+func (s *UtilsTestSuite) TestGetAuthenticatedIdentifierValue() {
+	tests := []struct {
+		name          string
+		ctx           *core.NodeContext
+		key           string
+		expectedValue string
+	}{
+		{
+			name: "Nil Attributes map returns empty string",
+			ctx: &core.NodeContext{
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					Attributes: nil,
+				},
+			},
+			key:           "email",
+			expectedValue: "",
+		},
+		{
+			name: "Empty Attributes map returns empty string",
+			ctx: &core.NodeContext{
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					Attributes: map[string]interface{}{},
+				},
+			},
+			key:           "email",
+			expectedValue: "",
+		},
+		{
+			name: "Key not found returns empty string",
+			ctx: &core.NodeContext{
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					Attributes: map[string]interface{}{
+						"other": "value",
+					},
+				},
+			},
+			key:           "email",
+			expectedValue: "",
+		},
+		{
+			name: "String value is returned",
+			ctx: &core.NodeContext{
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					Attributes: map[string]interface{}{
+						"email": "user@example.com",
+					},
+				},
+			},
+			key:           "email",
+			expectedValue: "user@example.com",
+		},
+		{
+			name: "Sub string value is returned",
+			ctx: &core.NodeContext{
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					Attributes: map[string]interface{}{
+						"sub": "sub123",
+					},
+				},
+			},
+			key:           "sub",
+			expectedValue: "sub123",
+		},
+		{
+			name: "Non-string value is converted to string",
+			ctx: &core.NodeContext{
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					Attributes: map[string]interface{}{
+						"id": 123,
+					},
+				},
+			},
+			key:           "id",
+			expectedValue: "123",
+		},
+		{
+			name: "Boolean value is converted to string",
+			ctx: &core.NodeContext{
+				AuthenticatedUser: authncm.AuthenticatedUser{
+					Attributes: map[string]interface{}{
+						"active": true,
+					},
+				},
+			},
+			key:           "active",
+			expectedValue: "true",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			value := getAuthenticatedIdentifierValue(tt.ctx, tt.key)
+			s.Equal(tt.expectedValue, value)
 		})
 	}
 }


### PR DESCRIPTION
### Purpose
This pull request introduces a new validation step to ensure consistency between federated identifiers (such as email and subject) provided by an external authentication provider and those already present in the authentication flow context. This helps prevent user mismatches during federated authentication.

### Approach
**Federated Identifier Consistency Validation:**

* Added the `validateFederatedIdentifierConsistency` function in `utils.go` to compare federated identifiers (`email`, `sub`) from the authentication result with those in `UserInputs`, `RuntimeData`, and the authenticated user's attributes. If a mismatch is detected, the authentication flow fails with a clear reason.

* Integrated this validation step into both `ProcessAuthFlowResponse` methods in `oauth_executor.go` and `oidc_auth_executor.go`, causing the flow to fail with `Invalid federated user` if inconsistencies are found.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2716

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of federated identifiers in OAuth/OIDC flows to ensure claims (e.g., sub/email) match stored/expected values.
  * Improved handling of failed authentication and registration attempts with explicit "Invalid federated user" failure reporting to halt processing on inconsistencies.

* **Tests**
  * Added unit tests covering federated authentication failure scenarios for mismatched claims and identifier inconsistencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2717)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->