### PR TITLE
Improve declarative resource usertype parsing

### DIFF
--- a/backend/internal/entitytype/declarative_resource.go
+++ b/backend/internal/entitytype/declarative_resource.go
@@ -177,7 +177,19 @@ func parseToEntityTypeDTO(data []byte) (*EntityType, error) {
 		return nil, err
 	}
 
-	schemaBytes := []byte(schemaRequest.Schema)
+	var schemaBytes []byte
+	if schemaRequest.Schema != nil {
+		switch v := schemaRequest.Schema.(type) {
+		case string:
+			schemaBytes = []byte(v)
+		default:
+			var err error
+			schemaBytes, err = json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal schema to JSON: %w", err)
+			}
+		}
+	}
 	if !json.Valid(schemaBytes) {
 		return nil, fmt.Errorf("schema field contains invalid JSON")
 	}
@@ -197,7 +209,7 @@ func parseToEntityTypeDTO(data []byte) (*EntityType, error) {
 		OUID:                  schemaRequest.OUID,
 		AllowSelfRegistration: schemaRequest.AllowSelfRegistration,
 		SystemAttributes:      schemaRequest.SystemAttributes,
-		Schema:                []byte(schemaRequest.Schema),
+		Schema:                schemaBytes,
 	}
 
 	return schemaDTO, nil

--- a/backend/internal/entitytype/declarative_resource_internal_test.go
+++ b/backend/internal/entitytype/declarative_resource_internal_test.go
@@ -228,11 +228,12 @@ func TestValidateEntityTypeWrapper(t *testing.T) {
 // TestParseToEntityTypeDTO tests the parseToEntityTypeDTO function.
 func TestParseToEntityTypeDTO(t *testing.T) {
 	testCases := []struct {
-		name    string
-		yaml    string
-		want    *EntityType
-		wantErr bool
-		errMsg  string
+		name           string
+		yaml           string
+		want           *EntityType
+		wantErr        bool
+		errMsg         string
+		validateSchema bool
 	}{
 		{
 			name: "valid YAML",
@@ -287,6 +288,38 @@ schema: '{invalid json}'
 			wantErr: true,
 			errMsg:  "schema field contains invalid JSON",
 		},
+		{
+			name: "schema as YAML object",
+			yaml: `
+id: schema-1
+name: Test Schema
+organization_unit_id: ou-1
+schema:
+  username:
+    type: string
+    required: true
+`,
+			want: &EntityType{
+				ID:   "schema-1",
+				Name: "Test Schema",
+				OUID: "ou-1",
+				Schema: json.RawMessage(
+					`{"username":{"required":true,"type":"string"}}`,
+				),
+			},
+			wantErr:        false,
+			validateSchema: true,
+		},
+		{
+			name: "missing schema field",
+			yaml: `
+id: schema-1
+name: Test Schema
+organization_unit_id: ou-1
+`,
+			wantErr: true,
+			errMsg:  "schema field contains invalid JSON",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -304,6 +337,14 @@ schema: '{invalid json}'
 				assert.Equal(t, tc.want.Name, result.Name)
 				assert.Equal(t, tc.want.OUID, result.OUID)
 				assert.Equal(t, tc.want.AllowSelfRegistration, result.AllowSelfRegistration)
+				if tc.validateSchema {
+					var got, expected map[string]interface{}
+					assert.NoError(t, json.Unmarshal(result.Schema, &got), "result schema must decode to JSON object")
+					assert.NoError(t, json.Unmarshal(tc.want.Schema, &expected),
+						"test fixture schema must decode to JSON object")
+					assert.Equal(t, expected, got, "decoded schema must deep-equal the expected value")
+					assert.NotEqual(t, map[string]interface{}{}, got, "schema must not decode to an empty object")
+				}
 			}
 		})
 	}

--- a/backend/internal/entitytype/model.go
+++ b/backend/internal/entitytype/model.go
@@ -129,5 +129,5 @@ type EntityTypeRequestWithID struct {
 	OUID                  string            `yaml:"organization_unit_id"`
 	AllowSelfRegistration bool              `yaml:"allow_self_registration,omitempty"`
 	SystemAttributes      *SystemAttributes `yaml:"system_attributes,omitempty"`
-	Schema                string            `yaml:"schema"`
+	Schema                interface{}       `yaml:"schema"`
 }


### PR DESCRIPTION
### Purpose
Improve declarative resource usertype parsing

### Approach
This pull request improves the flexibility and robustness of schema handling in the entity type parsing logic. The main change is to allow the `Schema` field to accept either a string or a structured object, and to properly handle both cases during parsing and marshaling.

Schema handling improvements:

* Changed the `Schema` field in the `EntityTypeRequestWithID` struct from `string` to `interface{}` to support both string and object types for schema definitions.
* Updated the `parseToEntityTypeDTO` function to handle cases where `Schema` is a string or another type, marshaling non-string schemas to JSON and ensuring the resulting bytes are valid JSON.
* Modified the assignment of the `Schema` field in the resulting DTO to use the processed `schemaBytes`, ensuring consistent handling regardless of the input type.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2715

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schema handling improved: schema is now optional, accepts richer structured formats (e.g., YAML/JSON objects), and produces clearer error messages when schema content is invalid JSON.
* **Tests**
  * Expanded test coverage for schema parsing, including structured-schema cases and stronger error assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2718)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->