### PR TITLE
Refactor changelog generation to use product configuration

### DIFF
--- a/docs/scripts/generate-changelog.mjs
+++ b/docs/scripts/generate-changelog.mjs
@@ -20,12 +20,16 @@ import {existsSync, mkdirSync, writeFileSync} from 'fs';
 import {join, dirname} from 'path';
 import {fileURLToPath} from 'url';
 import {createLogger} from '@thunderid/logger';
+import DocusaurusProductConfig from '../docusaurus.product.config.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const OUTPUT_FILE = join(__dirname, '..', 'static', 'data', 'releases.json');
-const GITHUB_REPO = 'thunder-id/thunderid';
+
+const GITHUB_REPO = DocusaurusProductConfig.project.source.github.fullName;
+const GITHUB_REPO_URL = DocusaurusProductConfig.project.source.github.url;
+const PROJECT_NAME = DocusaurusProductConfig.project.name;
 const GITHUB_REPO_API_URL = `https://api.github.com/repos/${GITHUB_REPO}`;
 const GITHUB_RELEASES_API_URL = `${GITHUB_REPO_API_URL}/releases`;
 
@@ -271,7 +275,7 @@ function pickPrimaryAsset(assets) {
   }
 
   return (
-    assets.find((asset) => /thunder-.*\.(zip|tgz|tar\.gz)$/i.test(asset.name)) ||
+    assets.find((asset) => /thunder(?:id)?-.*\.(zip|tgz|tar\.gz)$/i.test(asset.name)) ||
     assets.find((asset) => /\.(zip|tgz|tar\.gz)$/i.test(asset.name)) ||
     assets[0]
   );
@@ -349,13 +353,13 @@ async function buildChangelogData(repository, releases) {
     latestRelease: latestEntry || null,
     releases: releaseEntries,
     repository: {
-      description: repository?.description || 'Thunder release notes and downloads.',
+      description: repository?.description || `${PROJECT_NAME} release notes and downloads.`,
       forks: repository?.forks_count || 0,
       fullName: repository?.full_name || GITHUB_REPO,
       stars: repository?.stargazers_count || 0,
       subscribers: repository?.subscribers_count || 0,
-      url: repository?.html_url || `https://github.com/${GITHUB_REPO}`,
-      releasesUrl: `${repository?.html_url || `https://github.com/${GITHUB_REPO}`}/releases`,
+      url: repository?.html_url || GITHUB_REPO_URL,
+      releasesUrl: `${repository?.html_url || GITHUB_REPO_URL}/releases`,
     },
   };
 }
@@ -366,13 +370,13 @@ function buildFallbackChangelogData() {
     latestRelease: null,
     releases: [],
     repository: {
-      description: 'Thunder release notes and downloads.',
+      description: `${PROJECT_NAME} release notes and downloads.`,
       forks: 0,
       fullName: GITHUB_REPO,
       stars: 0,
       subscribers: 0,
-      url: `https://github.com/${GITHUB_REPO}`,
-      releasesUrl: `https://github.com/${GITHUB_REPO}/releases`,
+      url: GITHUB_REPO_URL,
+      releasesUrl: `${GITHUB_REPO_URL}/releases`,
     },
   };
 }

--- a/docs/src/pages/docs/next/releases.tsx
+++ b/docs/src/pages/docs/next/releases.tsx
@@ -21,6 +21,7 @@ import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import type {DocusaurusProductConfig} from '@site/docusaurus.product.config';
 import {Avatar, AvatarGroup, Tooltip} from '@wso2/oxygen-ui';
 import GithubIcon from '@site/src/components/icons/GithubIcon';
 import IOSLogo from '@site/src/components/icons/IOSLogo';
@@ -119,7 +120,7 @@ interface ReleasesData {
 const RELEASES_UNAVAILABLE_MESSAGE = 'Release information is currently unavailable. Please check back soon.';
 
 function getDistributionAsset(asset: ReleaseAsset): DistributionAsset | null {
-  const match = /^thunder-[0-9A-Za-z.+-]+-(macos|linux|win)-(arm64|x64)\.zip$/i.exec(asset.name);
+  const match = /^thunder(?:id)?-[0-9A-Za-z.+-]+-(macos|linux|win)-(arm64|x64)\.zip$/i.exec(asset.name);
 
   if (!match) {
     return null;
@@ -497,6 +498,10 @@ function ReleaseCard({release}: {release: ReleaseEntry}) {
 
 export default function ReleasesPage() {
   const {siteConfig} = useDocusaurusContext();
+  const project = siteConfig.customFields?.product as DocusaurusProductConfig | undefined;
+  const productName = project?.project?.name ?? siteConfig.title;
+  const repoUrl = project?.project?.source?.github?.url ?? '';
+  const githubReleasesUrl = repoUrl ? `${repoUrl}/releases` : '#';
   const {withBaseUrl} = useBaseUrlUtils();
   const [data, setData] = useState<ReleasesData | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -552,13 +557,13 @@ export default function ReleasesPage() {
   return (
     <Layout
       title="Releases"
-      description="Explore ThunderID releases, changelogs, and downloads."
+      description={`Explore ${productName} releases, changelogs, and downloads.`}
       wrapperClassName="releases-page"
     >
       <main className="releases-shell">
         <section className="releases-hero">
           <h1>
-            ThunderID{' '}
+            {productName}{' '}
             <span
               style={{
                 background: 'linear-gradient(90deg, #FF6B00 0%, #FF8C00 100%)',
@@ -570,12 +575,12 @@ export default function ReleasesPage() {
               Releases
             </span>
           </h1>
-          <p>Explore every release with detailed changelogs, download options, and the people building ThunderID.</p>
+          <p>Explore every release with detailed changelogs, download options, and the people building {productName}.</p>
 
           <div className="releases-hero-actions">
             <a
               className="button button--primary"
-              href={repository?.releasesUrl ?? 'https://github.com/thunder-id/thunderid/releases'}
+              href={repository?.releasesUrl ?? githubReleasesUrl}
               target="_blank"
               rel="noreferrer"
             >
@@ -626,7 +631,7 @@ export default function ReleasesPage() {
         <section className="releases-footer-note">
           <p>
             Source:{' '}
-            <Link to={repository?.url ?? 'https://github.com/thunder-id/thunderid'}>
+            <Link to={repository?.url ?? repoUrl}>
               {repository?.fullName ?? siteConfig.title}
             </Link>
             {data?.generatedAt ? ` · Updated ${new Date(data.generatedAt).toLocaleString('en-US')}` : ''}


### PR DESCRIPTION
### Purpose
$subject

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Used docusaurus.product.config.ts get product configs

### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/pull/2415

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changelog generator and releases page now read project name and repository URL from site configuration instead of hardcoded values, making metadata configurable per project.
  * Release asset selection broadened to recognize multiple archive naming patterns (e.g., thunder- and thunderid-), improving detection of primary artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2720)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->