### PR TITLE
Add Clickable Option for the user when consent is timeout.

### DIFF
--- a/frontend/apps/console/src/features/login-flow/data/steps.json
+++ b/frontend/apps/console/src/features/login-flow/data/steps.json
@@ -114,6 +114,12 @@
               }
             }
           ]
+        },
+        {
+          "id": "{{ID}}",
+          "category": "DISPLAY",
+          "type": "RICH_TEXT",
+          "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Go back to </span><a href=\"{{meta(application.url)}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Application</span></a></p>"
         }
       ]
     }

--- a/frontend/packages/design/src/components/flow/adapters/RichTextAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/RichTextAdapter.tsx
@@ -32,6 +32,9 @@ const SIGN_IN_URL_META_KEY = 'application.sign_in_url';
 /** The meta key used by the server to embed the application's forgot-password URL. */
 const FORGOT_PASSWORD_URL_META_KEY = 'application.forgot_password_url';
 
+/** The meta key used by the server to embed the application's access URL. */
+const APPLICATION_URL_META_KEY = 'application.url';
+
 const REGISTRATION_ENABLED_META_KEY = 'isRegistrationFlowEnabled';
 
 const RECOVERY_ENABLED_META_KEY = 'isRecoveryFlowEnabled';
@@ -128,6 +131,31 @@ export default function RichTextAdapter({
 
     if (containsMetaTemplate(resolvedLabel, SIGN_IN_URL_META_KEY) && signInFallbackUrl) {
       resolvedLabel = replaceMetaTemplate(resolvedLabel, SIGN_IN_URL_META_KEY, signInFallbackUrl);
+    }
+
+    return (
+      <Box
+        className={cn('Flow--richText')}
+        sx={{mb: 1, textAlign: isDesignEnabled ? 'center' : 'left'}}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(resolvedLabel)}}
+      />
+    );
+  }
+
+  // When any component label embeds the application's URL, render it only when
+  // the URL is present. There is no sensible local fallback route for this.
+  if (rawLabel && containsMetaTemplate(rawLabel, APPLICATION_URL_META_KEY)) {
+    const resolvedUrl = resolve(`{{meta(${APPLICATION_URL_META_KEY})}}`);
+
+    if (!resolvedUrl || containsMetaTemplate(resolvedUrl, APPLICATION_URL_META_KEY)) {
+      return null;
+    }
+
+    let resolvedLabel = resolve(rawLabel) ?? rawLabel;
+
+    if (containsMetaTemplate(resolvedLabel, APPLICATION_URL_META_KEY)) {
+      resolvedLabel = replaceMetaTemplate(resolvedLabel, APPLICATION_URL_META_KEY, resolvedUrl);
     }
 
     return (

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/RichTextAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/RichTextAdapter.test.tsx
@@ -143,4 +143,61 @@ describe('RichTextAdapter', () => {
       expect(getByTestId('rich-text-box').innerHTML).not.toContain('/signup?');
     });
   });
+
+  describe('sign-in URL handling', () => {
+    const signInLabel = '<p>Go back to <a href="{{meta(application.sign_in_url)}}">Sign in</a></p>';
+    const signInComponent: FlowComponent = {
+      id: 'signin-richtext',
+      type: 'RICH_TEXT',
+      label: signInLabel,
+    };
+
+    it('renders the sign-in link when the server resolves the URL', () => {
+      const resolve = (template: string | undefined) =>
+        template?.replace('{{meta(application.sign_in_url)}}', '/custom/signin');
+
+      const {getByTestId} = renderWithProviders(<RichTextAdapter component={signInComponent} resolve={resolve} />);
+      expect(getByTestId('rich-text-box').innerHTML).toContain('/custom/signin');
+    });
+
+    it('uses signInFallbackUrl when the server does not resolve the sign-in URL template', () => {
+      const {getByTestId} = renderWithProviders(
+        <RichTextAdapter
+          component={signInComponent}
+          resolve={(template: string | undefined) => template}
+          signInFallbackUrl="/signin?client_id=abc"
+        />,
+      );
+
+      expect(getByTestId('rich-text-box').innerHTML).toContain('/signin?client_id=abc');
+    });
+  });
+
+  describe('application URL handling', () => {
+    const applicationUrlLabel = '<p>Go back to <a href="{{meta(application.url)}}">Application</a></p>';
+    const applicationUrlComponent: FlowComponent = {
+      id: 'application-url-richtext',
+      type: 'RICH_TEXT',
+      label: applicationUrlLabel,
+    };
+
+    it('renders the application link when the server resolves the URL', () => {
+      const resolve = (template: string | undefined) =>
+        template?.replace('{{meta(application.url)}}', 'https://app.example.com');
+
+      const {getByTestId} = renderWithProviders(
+        <RichTextAdapter component={applicationUrlComponent} resolve={resolve} />,
+      );
+
+      expect(getByTestId('rich-text-box').innerHTML).toContain('https://app.example.com');
+    });
+
+    it('returns null when the application URL is missing', () => {
+      const {queryByTestId} = renderWithProviders(
+        <RichTextAdapter component={applicationUrlComponent} resolve={(template: string | undefined) => template} />,
+      );
+
+      expect(queryByTestId('rich-text-box')).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
### Purpose
Add an application-return link to the Consent View so users can navigate back to the application when the app exposes `application.url` in flow metadata. The change also avoids rendering a broken or misleading link when that URL is missing.

### Approach
Updated the login-flow Consent View definition to include a `RICH_TEXT` link that points to `{{meta(application.url)}}`. In the design `RichTextAdapter`, added handling for `application.url` so the link renders only when the value resolves successfully; if the metadata is missing or unresolved, the block is hidden instead of falling back to Sign In. Added focused adapter tests to cover both the resolved and missing `application.url` cases.

<img width="622" height="712" alt="image" src="https://github.com/user-attachments/assets/42ac06bd-6b85-4bfd-80cd-3be778ccefcd" />


### Related Issues
- https://github.com/thunder-id/thunderid/issues/1834


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Go back to Application" link to the consent screen, enabling users to navigate back to their application during the login flow
  * The link opens in a new tab with appropriate security settings and displays only when the application URL is configured

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2722)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->