### PR TITLE
Update GitHub Actions workflow to use Codecov v5 and adjust permissions

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -236,6 +236,9 @@ jobs:
     if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -306,9 +309,11 @@ jobs:
           if-no-files-found: error
 
       - name: 📊 Upload Unit Test Coverage Report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
+        timeout-minutes: 5
+        continue-on-error: true
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: backend/coverage_unit.out
           disable_search: true
           flags: backend-unit
@@ -403,6 +408,9 @@ jobs:
     if: always() && needs.test-frontend.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -424,9 +432,11 @@ jobs:
           cat coverage/console/console-coverage-shard-*/lcov.info > coverage/console-merged-lcov.info
 
       - name: 📊 Upload `@thunderid/console` Unit Test Coverage Report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
+        timeout-minutes: 5
+        continue-on-error: true
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: coverage/console-merged-lcov.info
           disable_search: true
           flags: frontend-apps-console-unit
@@ -434,9 +444,11 @@ jobs:
           fail_ci_if_error: false
 
       - name: 📊 Upload `@thunderid/gate` Unit Test Coverage Report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
+        timeout-minutes: 5
+        continue-on-error: true
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: coverage/gate/lcov.info
           disable_search: true
           flags: frontend-apps-gate-unit
@@ -485,6 +497,9 @@ jobs:
     if: ${{ always() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         database: [sqlite, postgres, redis]
@@ -557,9 +572,11 @@ jobs:
           coverage-enabled: true
 
       - name: 📊 Upload Integration Test Coverage Report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
+        timeout-minutes: 5
+        continue-on-error: true
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: target/coverage_integration.out
           disable_search: true
           flags: backend-integration-${{ matrix.database }}


### PR DESCRIPTION
### Purpose
`codecov/codecov-action@v4` uses an old bash uploader internally. When Codecov's servers are slow or unresponsive, it just hangs — no timeout, no retry, no exit. Since your workflow has no step-level timeout either, the job sits frozen until GitHub's 6-hour hard limit kills it. You can't re-run or cancel individual steps, only the whole job.

**What upgrading to v5 does**
`@v5` replaced the bash uploader with the Codecov CLI, which has built-in retry logic and better error handling. It's less likely to hang, and when it does fail it fails fast with a proper exit code.

Additionally, brings OIDC support as this is a public repo, and Codecov themselves recommend OIDC for public repos. It eliminates the CODECOV_TOKEN secret entirely. Short-lived OIDC tokens are minted per-run by GitHub and verified by Codecov.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
