### PR TITLE
Fix syntax for GIN index creation on IDP properties

### DIFF
--- a/backend/dbscripts/configdb/postgres.sql
+++ b/backend/dbscripts/configdb/postgres.sql
@@ -141,7 +141,7 @@ CREATE TABLE "IDP" (
 CREATE INDEX idx_idp_name_deployment ON "IDP" (DEPLOYMENT_ID, NAME);
 
 -- GIN index for JSONB containment queries on IDP properties (e.g. issuer lookup via @>)
-CREATE INDEX idx_idp_properties ON "IDP" USING GIN ("PROPERTIES" jsonb_path_ops);
+CREATE INDEX idx_idp_properties ON "IDP" USING GIN (PROPERTIES jsonb_path_ops);
 
 -- Table to store notification senders.
 CREATE TABLE "NOTIFICATION_SENDER" (


### PR DESCRIPTION
### Purpose
This pull request makes a minor update to the `postgres.sql` database schema. The change corrects the syntax for the GIN index on the `PROPERTIES` column in the `IDP` table to remove unnecessary double quotes, ensuring proper index creation.

- Database schema correction:
  * Fixed the GIN index creation on the `PROPERTIES` column in the `IDP` table by removing the double quotes around the column name. (`backend/dbscripts/configdb/postgres.sql`)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination params to applications list, export-by-groups option, verbose flow mode, and read-only indicators across several APIs (apps, themes, flows, IDPs, roles, users).
* **Behavior / API**
  * Standardized error codes/messages and tightened request/response examples across authentication, flows, design, resources, notifications, and i18n.
* **Documentation**
  * Improved API reference grouping, sidebar behavior, and mobile scrolling/spacing fixes.
* **Chores**
  * Optimized database index for identity-provider JSONB queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2732)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->