### PR TITLE
Remove flow type constraint from OAuth executor

### DIFF
--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -129,12 +129,6 @@ func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 		RuntimeData:    make(map[string]string),
 	}
 
-	if ctx.FlowType != common.FlowTypeAuthentication && ctx.FlowType != common.FlowTypeRegistration {
-		logger.Warn("Invalid flow type for OAuth executor. Skipping execution")
-		execResp.Status = common.ExecComplete
-		return execResp, nil
-	}
-
 	if !o.HasRequiredInputs(ctx, execResp) {
 		logger.Debug("Required inputs for OAuth authentication executor is not provided")
 		err := o.BuildAuthorizeFlow(ctx, execResp)

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -1237,16 +1237,3 @@ func (suite *OAuthExecutorTestSuite) TestGetContextUserForAuthentication_Without
 	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
 	assert.Equal(suite.T(), "User not found", execResp.FailureReason)
 }
-
-func (suite *OAuthExecutorTestSuite) TestExecute_InvalidFlowType() {
-	ctx := &core.NodeContext{
-		ExecutionID: "flow-123",
-		FlowType:    "InvalidFlowType",
-	}
-
-	resp, err := suite.executor.Execute(ctx)
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), resp)
-	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
-}


### PR DESCRIPTION
### Purpose
This pull request simplifies the `oAuthExecutor` logic by removing a flow type check that previously prevented execution for flow types other than authentication and registration. Now, the executor will proceed regardless of the flow type, which may allow for broader use cases or more flexible execution.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2733

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth handling no longer incorrectly aborts certain flows; authentication/registration and related flows proceed as expected.

* **Tests**
  * Strengthened test coverage to assert explicit failure reason when authentication is disallowed without a local user.
  * Removed an outdated invalid-flow test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2734)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->