### PR TITLE
Add Minor Improvements to the Releases Page

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -206,16 +206,16 @@ const config: Config = {
           position: 'right',
         },
         {
+          label: 'Releases',
+          to: productConfig.project.source.github.releasesUrl,
+          position: 'right',
+        },
+        {
           label: 'Resources',
           type: 'dropdown',
           position: 'right',
           className: 'navbar__link--dropdown',
           items: [
-            {
-              label: 'Releases',
-              href: '/docs/next/releases',
-              className: 'navbar-resources__releases',
-            },
             {
               label: 'Discussions',
               href: productConfig.project.source.github.discussionsUrl,

--- a/docs/src/pages/docs/next/releases.tsx
+++ b/docs/src/pages/docs/next/releases.tsx
@@ -563,23 +563,13 @@ export default function ReleasesPage() {
       <main className="releases-shell">
         <section className="releases-hero">
           <h1>
-            {productName}{' '}
-            <span
-              style={{
-                background: 'linear-gradient(90deg, #FF6B00 0%, #FF8C00 100%)',
-                WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent',
-                backgroundClip: 'text',
-              }}
-            >
-              Releases
-            </span>
+            Releases
           </h1>
           <p>Explore every release with detailed changelogs, download options, and the people building {productName}.</p>
 
           <div className="releases-hero-actions">
             <a
-              className="button button--primary"
+              className="button button--secondary"
               href={repository?.releasesUrl ?? githubReleasesUrl}
               target="_blank"
               rel="noreferrer"


### PR DESCRIPTION
### Purpose
- Move ```Releases``` to a first class item in the navbar
- Change the heading
<img width="1440" height="780" alt="Screenshot 2026-05-15 at 12 25 06" src="https://github.com/user-attachments/assets/ddc322dc-2d8e-4905-995c-a200b7bd2961" />

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/pull/2415

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Releases link is now prominently displayed in the top-level navigation bar instead of being nested in a dropdown menu
  * Releases page header layout has been simplified
  * Button styling on the Releases page has been updated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2748)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->