### PR TITLE
Migrate IDP PROPERTIES from JSON array to JSON object format

### DIFF
--- a/backend/dbscripts/configdb/postgres.sql
+++ b/backend/dbscripts/configdb/postgres.sql
@@ -140,8 +140,8 @@ CREATE TABLE "IDP" (
 -- Composite index for name-based IDP lookups
 CREATE INDEX idx_idp_name_deployment ON "IDP" (DEPLOYMENT_ID, NAME);
 
--- GIN index for JSONB containment queries on IDP properties (e.g. issuer lookup via @>)
-CREATE INDEX idx_idp_properties ON "IDP" USING GIN (PROPERTIES jsonb_path_ops);
+-- Expression index for issuer-based IDP lookups
+CREATE INDEX idx_idp_issuer ON "IDP" (DEPLOYMENT_ID, (PROPERTIES->'issuer'->>'value'));
 
 -- Table to store notification senders.
 CREATE TABLE "NOTIFICATION_SENDER" (

--- a/backend/dbscripts/configdb/sqlite.sql
+++ b/backend/dbscripts/configdb/sqlite.sql
@@ -140,6 +140,9 @@ CREATE TABLE "IDP" (
 -- Composite index for name-based IDP lookups
 CREATE INDEX idx_idp_name_deployment ON "IDP" (DEPLOYMENT_ID, NAME);
 
+-- Expression index for issuer-based IDP lookups
+CREATE INDEX idx_idp_issuer ON "IDP" (DEPLOYMENT_ID, json_extract(PROPERTIES, '$.issuer.value'));
+
 -- Table to store notification senders.
 CREATE TABLE "NOTIFICATION_SENDER" (
     DEPLOYMENT_ID VARCHAR(255) NOT NULL,

--- a/backend/internal/idp/IDPServiceInterface_mock_test.go
+++ b/backend/internal/idp/IDPServiceInterface_mock_test.go
@@ -237,76 +237,6 @@ func (_c *IDPServiceInterfaceMock_GetIdentityProvider_Call) RunAndReturn(run fun
 	return _c
 }
 
-// GetIdentityProviderByIssuer provides a mock function for the type IDPServiceInterfaceMock
-func (_mock *IDPServiceInterfaceMock) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, issuer)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetIdentityProviderByIssuer")
-	}
-
-	var r0 *IDPDTO
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*IDPDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, issuer)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *IDPDTO); ok {
-		r0 = returnFunc(ctx, issuer)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*IDPDTO)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, issuer)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProviderByIssuer'
-type IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call struct {
-	*mock.Call
-}
-
-// GetIdentityProviderByIssuer is a helper method to define mock.On call
-//   - ctx context.Context
-//   - issuer string
-func (_e *IDPServiceInterfaceMock_Expecter) GetIdentityProviderByIssuer(ctx interface{}, issuer interface{}) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
-	return &IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call{Call: _e.mock.On("GetIdentityProviderByIssuer", ctx, issuer)}
-}
-
-func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) Run(run func(ctx context.Context, issuer string)) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) Return(iDPDTO *IDPDTO, serviceError *serviceerror.ServiceError) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Return(iDPDTO, serviceError)
-	return _c
-}
-
-func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) RunAndReturn(run func(ctx context.Context, issuer string) (*IDPDTO, *serviceerror.ServiceError)) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetIdentityProviderByName provides a mock function for the type IDPServiceInterfaceMock
 func (_mock *IDPServiceInterfaceMock) GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, idpName)
@@ -437,6 +367,82 @@ func (_c *IDPServiceInterfaceMock_GetIdentityProviderList_Call) Return(basicIDPD
 }
 
 func (_c *IDPServiceInterfaceMock_GetIdentityProviderList_Call) RunAndReturn(run func(ctx context.Context) ([]BasicIDPDTO, *serviceerror.ServiceError)) *IDPServiceInterfaceMock_GetIdentityProviderList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetIdentityProvidersByProperty provides a mock function for the type IDPServiceInterfaceMock
+func (_mock *IDPServiceInterfaceMock) GetIdentityProvidersByProperty(ctx context.Context, propertyKey string, propertyValue string) ([]IDPDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, propertyKey, propertyValue)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentityProvidersByProperty")
+	}
+
+	var r0 []IDPDTO
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]IDPDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, propertyKey, propertyValue)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []IDPDTO); ok {
+		r0 = returnFunc(ctx, propertyKey, propertyValue)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]IDPDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, propertyKey, propertyValue)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProvidersByProperty'
+type IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call struct {
+	*mock.Call
+}
+
+// GetIdentityProvidersByProperty is a helper method to define mock.On call
+//   - ctx context.Context
+//   - propertyKey string
+//   - propertyValue string
+func (_e *IDPServiceInterfaceMock_Expecter) GetIdentityProvidersByProperty(ctx interface{}, propertyKey interface{}, propertyValue interface{}) *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call {
+	return &IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call{Call: _e.mock.On("GetIdentityProvidersByProperty", ctx, propertyKey, propertyValue)}
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call) Run(run func(ctx context.Context, propertyKey string, propertyValue string)) *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call) Return(iDPDTOs []IDPDTO, serviceError *serviceerror.ServiceError) *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call {
+	_c.Call.Return(iDPDTOs, serviceError)
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call) RunAndReturn(run func(ctx context.Context, propertyKey string, propertyValue string) ([]IDPDTO, *serviceerror.ServiceError)) *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/idp/cache_backed_store.go
+++ b/backend/internal/idp/cache_backed_store.go
@@ -28,23 +28,30 @@ import (
 
 const cacheBackedIDPStoreLoggerComponentName = "CacheBackedIDPStore"
 
+// cacheablePropertyKeys lists the property keys whose lookup results are cached.
+// Adding a key here means every distinct value for that key gets a cache entry —
+// keep the list small to avoid unbounded cache growth.
+var cacheablePropertyKeys = map[string]bool{
+	PropIssuer: true,
+}
+
 // cacheBackedIDPStore wraps any idpStoreInterface with two in-memory caches.
 type cacheBackedIDPStore struct {
-	idpByIDCache     cache.CacheInterface[*IDPDTO]
-	idpByIssuerCache cache.CacheInterface[*IDPDTO]
-	inner            idpStoreInterface
+	idpByIDCache       cache.CacheInterface[*IDPDTO]
+	idpByPropertyCache cache.CacheInterface[[]IDPDTO]
+	inner              idpStoreInterface
 }
 
 // newCacheBackedIDPStore creates a new cache-backed IDP store wrapping the provided inner store.
 func newCacheBackedIDPStore(
 	idpByIDCache cache.CacheInterface[*IDPDTO],
-	idpByIssuerCache cache.CacheInterface[*IDPDTO],
+	idpByPropertyCache cache.CacheInterface[[]IDPDTO],
 	inner idpStoreInterface,
 ) idpStoreInterface {
 	return &cacheBackedIDPStore{
-		idpByIDCache:     idpByIDCache,
-		idpByIssuerCache: idpByIssuerCache,
-		inner:            inner,
+		idpByIDCache:       idpByIDCache,
+		idpByPropertyCache: idpByPropertyCache,
+		inner:              inner,
 	}
 }
 
@@ -82,7 +89,7 @@ func (s *cacheBackedIDPStore) GetIdentityProvider(ctx context.Context, idpID str
 	return idp, nil
 }
 
-// GetIdentityProviderByName delegates to inner store and populates the ID and issuer caches with the result.
+// GetIdentityProviderByName delegates to inner store and populates the ID cache with the result.
 func (s *cacheBackedIDPStore) GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, error) {
 	idp, err := s.inner.GetIdentityProviderByName(ctx, idpName)
 	if err != nil || idp == nil {
@@ -92,33 +99,34 @@ func (s *cacheBackedIDPStore) GetIdentityProviderByName(ctx context.Context, idp
 	return idp, nil
 }
 
-// GetIdentityProviderByIssuer retrieves an IDP by its issuer property, using the issuer cache on a hit.
-// A nil cached value means the absence of an IDP for that issuer was previously recorded.
-func (s *cacheBackedIDPStore) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error) {
-	cacheKey := cache.CacheKey{Key: issuer}
-	if cached, ok := s.idpByIssuerCache.Get(ctx, cacheKey); ok {
+// GetIdentityProvidersByProperty retrieves IDPs by property, using the property cache on a hit.
+// Only property keys listed in cacheablePropertyKeys are cached; all others bypass the cache.
+func (s *cacheBackedIDPStore) GetIdentityProvidersByProperty(ctx context.Context,
+	propertyKey, propertyValue string) ([]IDPDTO, error) {
+	if !cacheablePropertyKeys[propertyKey] {
+		return s.inner.GetIdentityProvidersByProperty(ctx, propertyKey, propertyValue)
+	}
+
+	cacheKey := cache.CacheKey{Key: propertyKey + ":" + propertyValue}
+	if cached, ok := s.idpByPropertyCache.Get(ctx, cacheKey); ok {
 		if cached == nil {
 			return nil, ErrIDPNotFound
 		}
 		return cached, nil
 	}
 
-	idp, err := s.inner.GetIdentityProviderByIssuer(ctx, issuer)
+	idps, err := s.inner.GetIdentityProvidersByProperty(ctx, propertyKey, propertyValue)
 	if err != nil {
 		if errors.Is(err, ErrIDPNotFound) {
-			_ = s.idpByIssuerCache.Set(ctx, cacheKey, nil)
+			_ = s.idpByPropertyCache.Set(ctx, cacheKey, nil)
 		}
 		return nil, err
 	}
-	if idp == nil {
-		_ = s.idpByIssuerCache.Set(ctx, cacheKey, nil)
-		return nil, ErrIDPNotFound
-	}
-	s.cacheIDP(ctx, idp)
-	return idp, nil
+	_ = s.idpByPropertyCache.Set(ctx, cacheKey, idps)
+	return idps, nil
 }
 
-// UpdateIdentityProvider fetches the old IDP to capture its issuer, delegates the update, then
+// UpdateIdentityProvider fetches the old IDP to capture its properties, delegates the update, then
 // invalidates old cache entries and caches the new state.
 func (s *cacheBackedIDPStore) UpdateIdentityProvider(ctx context.Context, idp *IDPDTO) error {
 	oldIDP, err := s.inner.GetIdentityProvider(ctx, idp.ID)
@@ -126,21 +134,16 @@ func (s *cacheBackedIDPStore) UpdateIdentityProvider(ctx context.Context, idp *I
 		return err
 	}
 
-	var oldIssuer string
-	if oldIDP != nil {
-		oldIssuer = GetPropertyValue(oldIDP.Properties, PropIssuer)
-	}
-
 	if err := s.inner.UpdateIdentityProvider(ctx, idp); err != nil {
 		return err
 	}
 
-	s.invalidateIDP(ctx, idp.ID, oldIssuer)
+	s.invalidateIDP(ctx, oldIDP)
 	s.cacheIDP(ctx, idp)
 	return nil
 }
 
-// DeleteIdentityProvider fetches the IDP to get its issuer before delegating deletion,
+// DeleteIdentityProvider fetches the IDP to get its properties before delegating deletion,
 // then invalidates the relevant cache entries.
 func (s *cacheBackedIDPStore) DeleteIdentityProvider(ctx context.Context, id string) error {
 	existing, err := s.inner.GetIdentityProvider(ctx, id)
@@ -148,57 +151,51 @@ func (s *cacheBackedIDPStore) DeleteIdentityProvider(ctx context.Context, id str
 		return err
 	}
 
-	var issuer string
-	if existing != nil {
-		issuer = GetPropertyValue(existing.Properties, PropIssuer)
-	}
-
 	if err := s.inner.DeleteIdentityProvider(ctx, id); err != nil {
 		return err
 	}
 
-	s.invalidateIDP(ctx, id, issuer)
+	s.invalidateIDP(ctx, existing)
 	return nil
 }
 
-// cacheIDP stores the IDP in both the ID cache and (when an issuer is present) the issuer cache.
+// cacheIDP stores the IDP in the ID cache only.
+// Property cache is populated lazily on read (GetIdentityProvidersByProperty).
 func (s *cacheBackedIDPStore) cacheIDP(ctx context.Context, idp *IDPDTO) {
-	if idp == nil {
+	if idp == nil || idp.ID == "" {
 		return
 	}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, cacheBackedIDPStoreLoggerComponentName))
 
-	if idp.ID != "" {
-		idKey := cache.CacheKey{Key: idp.ID}
-		if err := s.idpByIDCache.Set(ctx, idKey, idp); err != nil {
-			logger.Error("Failed to cache IDP by ID", log.Error(err), log.String("idpID", idp.ID))
-		}
-	}
-
-	issuer := GetPropertyValue(idp.Properties, PropIssuer)
-	if issuer != "" {
-		issuerKey := cache.CacheKey{Key: issuer}
-		if err := s.idpByIssuerCache.Set(ctx, issuerKey, idp); err != nil {
-			logger.Error("Failed to cache IDP by issuer", log.Error(err), log.String("issuer", issuer))
-		}
+	idKey := cache.CacheKey{Key: idp.ID}
+	if err := s.idpByIDCache.Set(ctx, idKey, idp); err != nil {
+		logger.Error("Failed to cache IDP by ID", log.Error(err), log.String("idpID", idp.ID))
 	}
 }
 
-// invalidateIDP removes the IDP from both the ID cache and the issuer cache.
-func (s *cacheBackedIDPStore) invalidateIDP(ctx context.Context, id, issuer string) {
+// invalidateIDP removes the IDP from ID cache and invalidates property cache entries.
+func (s *cacheBackedIDPStore) invalidateIDP(ctx context.Context, idp *IDPDTO) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, cacheBackedIDPStoreLoggerComponentName))
-
-	if id != "" {
-		idKey := cache.CacheKey{Key: id}
+	if idp == nil {
+		return
+	}
+	if idp.ID != "" {
+		idKey := cache.CacheKey{Key: idp.ID}
 		if err := s.idpByIDCache.Delete(ctx, idKey); err != nil {
-			logger.Error("Failed to invalidate IDP cache by ID", log.Error(err), log.String("idpID", id))
+			logger.Error("Failed to invalidate IDP cache by ID", log.Error(err), log.String("idpID", idp.ID))
 		}
 	}
-
-	if issuer != "" {
-		issuerKey := cache.CacheKey{Key: issuer}
-		if err := s.idpByIssuerCache.Delete(ctx, issuerKey); err != nil {
-			logger.Error("Failed to invalidate IDP cache by issuer", log.Error(err), log.String("issuer", issuer))
+	for _, prop := range idp.Properties {
+		if !cacheablePropertyKeys[prop.GetName()] {
+			continue
+		}
+		val, err := prop.GetValue()
+		if err != nil || val == "" {
+			continue
+		}
+		propKey := cache.CacheKey{Key: prop.GetName() + ":" + val}
+		if err := s.idpByPropertyCache.Delete(ctx, propKey); err != nil {
+			logger.Error("Failed to invalidate IDP property cache", log.Error(err))
 		}
 	}
 }

--- a/backend/internal/idp/cache_backed_store_test.go
+++ b/backend/internal/idp/cache_backed_store_test.go
@@ -28,41 +28,15 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/cache"
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
+	"github.com/thunder-id/thunderid/tests/mocks/cachemock"
 )
-
-// mockIDPCache is a test mock for cache.CacheInterface[*IDPDTO].
-type mockIDPCache struct {
-	mock.Mock
-}
-
-func (m *mockIDPCache) GetName() string               { return "test" }
-func (m *mockIDPCache) IsEnabled() bool               { return true }
-func (m *mockIDPCache) GetStats() cache.CacheStat     { return cache.CacheStat{} }
-func (m *mockIDPCache) CleanupExpired()               {}
-func (m *mockIDPCache) Clear(_ context.Context) error { return nil }
-
-func (m *mockIDPCache) Set(ctx context.Context, key cache.CacheKey, value *IDPDTO) error {
-	args := m.Called(ctx, key, value)
-	return args.Error(0)
-}
-
-func (m *mockIDPCache) Get(ctx context.Context, key cache.CacheKey) (*IDPDTO, bool) {
-	args := m.Called(ctx, key)
-	v, _ := args.Get(0).(*IDPDTO)
-	return v, args.Bool(1)
-}
-
-func (m *mockIDPCache) Delete(ctx context.Context, key cache.CacheKey) error {
-	args := m.Called(ctx, key)
-	return args.Error(0)
-}
 
 type CacheBackedIDPStoreTestSuite struct {
 	suite.Suite
-	mockInner   *idpStoreInterfaceMock
-	idCache     *mockIDPCache
-	issuerCache *mockIDPCache
-	cachedStore *cacheBackedIDPStore
+	mockInner     *idpStoreInterfaceMock
+	idCache       *cachemock.CacheInterfaceMock[*IDPDTO]
+	propertyCache *cachemock.CacheInterfaceMock[[]IDPDTO]
+	cachedStore   *cacheBackedIDPStore
 }
 
 func TestCacheBackedIDPStoreTestSuite(t *testing.T) {
@@ -71,12 +45,12 @@ func TestCacheBackedIDPStoreTestSuite(t *testing.T) {
 
 func (s *CacheBackedIDPStoreTestSuite) SetupTest() {
 	s.mockInner = newIdpStoreInterfaceMock(s.T())
-	s.idCache = &mockIDPCache{}
-	s.issuerCache = &mockIDPCache{}
+	s.idCache = cachemock.NewCacheInterfaceMock[*IDPDTO](s.T())
+	s.propertyCache = cachemock.NewCacheInterfaceMock[[]IDPDTO](s.T())
 	s.cachedStore = &cacheBackedIDPStore{
-		idpByIDCache:     s.idCache,
-		idpByIssuerCache: s.issuerCache,
-		inner:            s.mockInner,
+		idpByIDCache:       s.idCache,
+		idpByPropertyCache: s.propertyCache,
+		inner:              s.mockInner,
 	}
 }
 
@@ -102,13 +76,12 @@ func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvider_CacheHit() {
 	s.mockInner.AssertNotCalled(s.T(), "GetIdentityProvider")
 }
 
-// TestGetIdentityProvider_CacheMiss tests a cache miss delegates to inner and populates both caches.
+// TestGetIdentityProvider_CacheMiss tests a cache miss delegates to inner and populates the ID cache.
 func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvider_CacheMiss() {
 	idp := makeIDPWithIssuer("idp-1", "IDP 1", "https://idp.example.com")
 	s.idCache.On("Get", mock.Anything, cache.CacheKey{Key: "idp-1"}).Return((*IDPDTO)(nil), false)
 	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").Return(idp, nil)
 	s.idCache.On("Set", mock.Anything, cache.CacheKey{Key: "idp-1"}, idp).Return(nil)
-	s.issuerCache.On("Set", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}, idp).Return(nil)
 
 	result, err := s.cachedStore.GetIdentityProvider(context.Background(), "idp-1")
 
@@ -116,63 +89,70 @@ func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvider_CacheMiss() {
 	s.Equal(idp, result)
 	s.mockInner.AssertExpectations(s.T())
 	s.idCache.AssertExpectations(s.T())
-	s.issuerCache.AssertExpectations(s.T())
 }
 
-// TestGetIdentityProviderByIssuer_CacheHit tests that an issuer cache hit returns without hitting inner store.
-func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByIssuer_CacheHit() {
+// TestGetIdentityProvidersByProperty_CacheHit tests that a property cache hit returns without hitting inner store.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvidersByProperty_CacheHit() {
 	idp := makeIDPWithIssuer("idp-1", "IDP 1", "https://idp.example.com")
-	s.issuerCache.On("Get", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}).Return(idp, true)
+	cached := []IDPDTO{*idp}
+	s.propertyCache.On("Get", mock.Anything, cache.CacheKey{Key: "issuer:https://idp.example.com"}).
+		Return(cached, true)
 
-	result, err := s.cachedStore.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+	result, err := s.cachedStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://idp.example.com")
 
 	s.NoError(err)
-	s.Equal(idp, result)
-	s.mockInner.AssertNotCalled(s.T(), "GetIdentityProviderByIssuer")
+	s.Equal(cached, result)
+	s.mockInner.AssertNotCalled(s.T(), "GetIdentityProvidersByProperty")
 }
 
-// TestGetIdentityProviderByIssuer_AbsenceCacheHit tests a nil-value cache hit returns ErrIDPNotFound.
-func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByIssuer_AbsenceCacheHit() {
-	s.issuerCache.On("Get", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}).
-		Return((*IDPDTO)(nil), true)
+// TestGetIdentityProvidersByProperty_AbsenceCacheHit tests a nil-value cache hit returns ErrIDPNotFound.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvidersByProperty_AbsenceCacheHit() {
+	s.propertyCache.On("Get", mock.Anything, cache.CacheKey{Key: "issuer:https://idp.example.com"}).
+		Return([]IDPDTO(nil), true)
 
-	result, err := s.cachedStore.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+	result, err := s.cachedStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://idp.example.com")
 
 	s.Nil(result)
 	s.ErrorIs(err, ErrIDPNotFound)
-	s.mockInner.AssertNotCalled(s.T(), "GetIdentityProviderByIssuer")
+	s.mockInner.AssertNotCalled(s.T(), "GetIdentityProvidersByProperty")
 }
 
-// TestGetIdentityProviderByIssuer_CacheMiss tests a cache miss delegates to inner and populates caches.
-func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByIssuer_CacheMiss() {
+// TestGetIdentityProvidersByProperty_CacheMiss tests a cache miss delegates to inner and populates cache.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvidersByProperty_CacheMiss() {
 	idp := makeIDPWithIssuer("idp-1", "IDP 1", "https://idp.example.com")
-	s.issuerCache.On("Get", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}).
-		Return((*IDPDTO)(nil), false)
-	s.mockInner.On("GetIdentityProviderByIssuer", mock.Anything, "https://idp.example.com").Return(idp, nil)
-	s.idCache.On("Set", mock.Anything, cache.CacheKey{Key: "idp-1"}, idp).Return(nil)
-	s.issuerCache.On("Set", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}, idp).Return(nil)
+	idps := []IDPDTO{*idp}
+	s.propertyCache.On("Get", mock.Anything, cache.CacheKey{Key: "issuer:https://idp.example.com"}).
+		Return([]IDPDTO(nil), false)
+	s.mockInner.On("GetIdentityProvidersByProperty", mock.Anything, "issuer", "https://idp.example.com").
+		Return(idps, nil)
+	s.propertyCache.On("Set", mock.Anything, cache.CacheKey{Key: "issuer:https://idp.example.com"}, idps).
+		Return(nil)
 
-	result, err := s.cachedStore.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+	result, err := s.cachedStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://idp.example.com")
 
 	s.NoError(err)
-	s.Equal(idp, result)
+	s.Equal(idps, result)
 	s.mockInner.AssertExpectations(s.T())
 }
 
-// TestGetIdentityProviderByIssuer_CachesAbsenceOnNotFound tests that ErrIDPNotFound is cached as nil.
-func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByIssuer_CachesAbsenceOnNotFound() {
-	s.issuerCache.On("Get", mock.Anything, cache.CacheKey{Key: "https://unknown.example.com"}).
-		Return((*IDPDTO)(nil), false)
-	s.mockInner.On("GetIdentityProviderByIssuer", mock.Anything, "https://unknown.example.com").
-		Return((*IDPDTO)(nil), ErrIDPNotFound)
-	s.issuerCache.On("Set", mock.Anything, cache.CacheKey{Key: "https://unknown.example.com"}, (*IDPDTO)(nil)).
-		Return(nil)
+// TestGetIdentityProvidersByProperty_CachesAbsenceOnNotFound tests that ErrIDPNotFound is cached as nil.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvidersByProperty_CachesAbsenceOnNotFound() {
+	s.propertyCache.On("Get", mock.Anything, cache.CacheKey{Key: "issuer:https://unknown.example.com"}).
+		Return([]IDPDTO(nil), false)
+	s.mockInner.On("GetIdentityProvidersByProperty", mock.Anything, "issuer", "https://unknown.example.com").
+		Return([]IDPDTO(nil), ErrIDPNotFound)
+	s.propertyCache.On("Set", mock.Anything, cache.CacheKey{Key: "issuer:https://unknown.example.com"},
+		[]IDPDTO(nil)).Return(nil)
 
-	result, err := s.cachedStore.GetIdentityProviderByIssuer(context.Background(), "https://unknown.example.com")
+	result, err := s.cachedStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://unknown.example.com")
 
 	s.Nil(result)
 	s.ErrorIs(err, ErrIDPNotFound)
-	s.issuerCache.AssertExpectations(s.T())
+	s.propertyCache.AssertExpectations(s.T())
 }
 
 // TestCreateIdentityProvider_CachesResult tests create delegates to inner and caches the result.
@@ -188,7 +168,7 @@ func (s *CacheBackedIDPStoreTestSuite) TestCreateIdentityProvider_CachesResult()
 	s.idCache.AssertExpectations(s.T())
 }
 
-// TestUpdateIdentityProvider_InvalidatesOldCacheAndCachesNew tests update invalidates old issuer and caches new.
+// TestUpdateIdentityProvider_InvalidatesOldCacheAndCachesNew tests update invalidates old properties and caches new.
 func (s *CacheBackedIDPStoreTestSuite) TestUpdateIdentityProvider_InvalidatesOldCacheAndCachesNew() {
 	oldIssuer := "https://old.example.com"
 	newIssuer := "https://new.example.com"
@@ -204,16 +184,15 @@ func (s *CacheBackedIDPStoreTestSuite) TestUpdateIdentityProvider_InvalidatesOld
 	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").Return(oldIDP, nil)
 	s.mockInner.On("UpdateIdentityProvider", mock.Anything, newIDP).Return(nil)
 	s.idCache.On("Delete", mock.Anything, cache.CacheKey{Key: "idp-1"}).Return(nil)
-	s.issuerCache.On("Delete", mock.Anything, cache.CacheKey{Key: oldIssuer}).Return(nil)
+	s.propertyCache.On("Delete", mock.Anything, cache.CacheKey{Key: "issuer:" + oldIssuer}).Return(nil)
 	s.idCache.On("Set", mock.Anything, cache.CacheKey{Key: "idp-1"}, newIDP).Return(nil)
-	s.issuerCache.On("Set", mock.Anything, cache.CacheKey{Key: newIssuer}, newIDP).Return(nil)
 
 	err := s.cachedStore.UpdateIdentityProvider(context.Background(), newIDP)
 
 	s.NoError(err)
 	s.mockInner.AssertExpectations(s.T())
 	s.idCache.AssertExpectations(s.T())
-	s.issuerCache.AssertExpectations(s.T())
+	s.propertyCache.AssertExpectations(s.T())
 }
 
 // TestDeleteIdentityProvider_InvalidatesCacheEntries tests delete fetches old IDP and invalidates cache.
@@ -224,21 +203,20 @@ func (s *CacheBackedIDPStoreTestSuite) TestDeleteIdentityProvider_InvalidatesCac
 	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").Return(idp, nil)
 	s.mockInner.On("DeleteIdentityProvider", mock.Anything, "idp-1").Return(nil)
 	s.idCache.On("Delete", mock.Anything, cache.CacheKey{Key: "idp-1"}).Return(nil)
-	s.issuerCache.On("Delete", mock.Anything, cache.CacheKey{Key: issuer}).Return(nil)
+	s.propertyCache.On("Delete", mock.Anything, cache.CacheKey{Key: "issuer:" + issuer}).Return(nil)
 
 	err := s.cachedStore.DeleteIdentityProvider(context.Background(), "idp-1")
 
 	s.NoError(err)
 	s.mockInner.AssertExpectations(s.T())
 	s.idCache.AssertExpectations(s.T())
-	s.issuerCache.AssertExpectations(s.T())
+	s.propertyCache.AssertExpectations(s.T())
 }
 
 // TestDeleteIdentityProvider_StillDeletesWhenNotFound tests delete succeeds when inner store has no record.
 func (s *CacheBackedIDPStoreTestSuite) TestDeleteIdentityProvider_StillDeletesWhenNotFound() {
 	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").Return((*IDPDTO)(nil), ErrIDPNotFound)
 	s.mockInner.On("DeleteIdentityProvider", mock.Anything, "idp-1").Return(nil)
-	s.idCache.On("Delete", mock.Anything, cache.CacheKey{Key: "idp-1"}).Return(nil)
 
 	err := s.cachedStore.DeleteIdentityProvider(context.Background(), "idp-1")
 
@@ -246,12 +224,11 @@ func (s *CacheBackedIDPStoreTestSuite) TestDeleteIdentityProvider_StillDeletesWh
 	s.mockInner.AssertExpectations(s.T())
 }
 
-// TestGetIdentityProviderByName_PopulatesCaches tests GetByName populates ID and issuer caches.
-func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByName_PopulatesCaches() {
+// TestGetIdentityProviderByName_PopulatesIDCache tests GetByName populates the ID cache.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByName_PopulatesIDCache() {
 	idp := makeIDPWithIssuer("idp-2", "IDP 2", "https://other.example.com")
 	s.mockInner.On("GetIdentityProviderByName", mock.Anything, "IDP 2").Return(idp, nil)
 	s.idCache.On("Set", mock.Anything, cache.CacheKey{Key: "idp-2"}, idp).Return(nil)
-	s.issuerCache.On("Set", mock.Anything, cache.CacheKey{Key: "https://other.example.com"}, idp).Return(nil)
 
 	result, err := s.cachedStore.GetIdentityProviderByName(context.Background(), "IDP 2")
 
@@ -259,7 +236,6 @@ func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByName_PopulatesCa
 	s.Equal(idp, result)
 	s.mockInner.AssertExpectations(s.T())
 	s.idCache.AssertExpectations(s.T())
-	s.issuerCache.AssertExpectations(s.T())
 }
 
 // TestGetIdentityProviderList_NoCaching tests GetIdentityProviderList is a pure delegate.
@@ -272,7 +248,6 @@ func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderList_NoCaching() {
 	s.NoError(err)
 	s.Equal(list, result)
 	s.idCache.AssertNotCalled(s.T(), "Set")
-	s.issuerCache.AssertNotCalled(s.T(), "Set")
 }
 
 // TestGetIdentityProviderListCount_NoCaching tests GetIdentityProviderListCount is a pure delegate.
@@ -286,17 +261,140 @@ func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderListCount_NoCachin
 	s.idCache.AssertNotCalled(s.T(), "Set")
 }
 
-// TestGetIdentityProviderByIssuer_InnerStoreError tests that a non-NotFound error is propagated.
-func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProviderByIssuer_InnerStoreError() {
-	s.issuerCache.On("Get", mock.Anything, cache.CacheKey{Key: "https://idp.example.com"}).
-		Return((*IDPDTO)(nil), false)
-	s.mockInner.On("GetIdentityProviderByIssuer", mock.Anything, "https://idp.example.com").
-		Return((*IDPDTO)(nil), errors.New("db error"))
+// TestGetIdentityProvidersByProperty_InnerStoreError tests that a non-NotFound error is propagated.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvidersByProperty_InnerStoreError() {
+	s.propertyCache.On("Get", mock.Anything, cache.CacheKey{Key: "issuer:https://idp.example.com"}).
+		Return([]IDPDTO(nil), false)
+	s.mockInner.On("GetIdentityProvidersByProperty", mock.Anything, "issuer", "https://idp.example.com").
+		Return([]IDPDTO(nil), errors.New("db error"))
 
-	result, err := s.cachedStore.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+	result, err := s.cachedStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://idp.example.com")
 
 	s.Nil(result)
 	s.Error(err)
 	s.NotErrorIs(err, ErrIDPNotFound)
-	s.issuerCache.AssertNotCalled(s.T(), "Set")
+	s.propertyCache.AssertNotCalled(s.T(), "Set")
+}
+
+// TestGetIdentityProvidersByProperty_NonCacheableKeyBypassesCache tests that a non-cacheable property
+// key bypasses the cache entirely and delegates directly to the inner store.
+func (s *CacheBackedIDPStoreTestSuite) TestGetIdentityProvidersByProperty_NonCacheableKeyBypassesCache() {
+	idp := makeIDPWithIssuer("idp-1", "IDP 1", "https://idp.example.com")
+	s.mockInner.On("GetIdentityProvidersByProperty", mock.Anything, "client_id", "some-client").
+		Return([]IDPDTO{*idp}, nil)
+
+	result, err := s.cachedStore.GetIdentityProvidersByProperty(context.Background(), "client_id", "some-client")
+
+	s.NoError(err)
+	s.Len(result, 1)
+	s.mockInner.AssertCalled(s.T(), "GetIdentityProvidersByProperty", mock.Anything, "client_id", "some-client")
+	s.propertyCache.AssertNotCalled(s.T(), "Get", mock.Anything, mock.Anything)
+	s.propertyCache.AssertNotCalled(s.T(), "Set", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// --- cacheIDP edge cases ---
+
+func (s *CacheBackedIDPStoreTestSuite) TestCacheIDP_NilIDP() {
+	s.cachedStore.cacheIDP(context.Background(), nil)
+	s.idCache.AssertNotCalled(s.T(), "Set")
+}
+
+func (s *CacheBackedIDPStoreTestSuite) TestCacheIDP_EmptyID() {
+	idp := &IDPDTO{ID: "", Name: "No ID", Type: IDPTypeOIDC}
+	s.cachedStore.cacheIDP(context.Background(), idp)
+	s.idCache.AssertNotCalled(s.T(), "Set")
+}
+
+// --- invalidateIDP edge cases ---
+
+func (s *CacheBackedIDPStoreTestSuite) TestInvalidateIDP_NilIDP() {
+	s.cachedStore.invalidateIDP(context.Background(), nil)
+	s.idCache.AssertNotCalled(s.T(), "Delete")
+	s.propertyCache.AssertNotCalled(s.T(), "Delete")
+}
+
+func (s *CacheBackedIDPStoreTestSuite) TestInvalidateIDP_PropertyWithEmptyValue() {
+	prop, _ := cmodels.NewProperty("empty_prop", "", false)
+	idp := &IDPDTO{
+		ID:         "idp-empty-prop",
+		Name:       "IDP Empty Prop",
+		Type:       IDPTypeOIDC,
+		Properties: []cmodels.Property{*prop},
+	}
+
+	s.idCache.On("Delete", mock.Anything, cache.CacheKey{Key: "idp-empty-prop"}).Return(nil)
+
+	s.cachedStore.invalidateIDP(context.Background(), idp)
+
+	s.idCache.AssertCalled(s.T(), "Delete", mock.Anything, cache.CacheKey{Key: "idp-empty-prop"})
+	s.propertyCache.AssertNotCalled(s.T(), "Delete")
+}
+
+// --- CreateIdentityProvider error branch ---
+
+func (s *CacheBackedIDPStoreTestSuite) TestCreateIdentityProvider_InnerStoreError() {
+	idp := IDPDTO{ID: "idp-fail", Name: "Fail IDP", Type: IDPTypeOIDC}
+	s.mockInner.On("CreateIdentityProvider", mock.Anything, idp).Return(errors.New("create failed"))
+
+	err := s.cachedStore.CreateIdentityProvider(context.Background(), idp)
+
+	s.Error(err)
+	s.idCache.AssertNotCalled(s.T(), "Set")
+}
+
+// --- UpdateIdentityProvider error branches ---
+
+func (s *CacheBackedIDPStoreTestSuite) TestUpdateIdentityProvider_InnerGetError() {
+	idp := &IDPDTO{ID: "idp-1", Name: "Updated", Type: IDPTypeOIDC}
+	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").
+		Return((*IDPDTO)(nil), errors.New("get failed"))
+
+	err := s.cachedStore.UpdateIdentityProvider(context.Background(), idp)
+
+	s.Error(err)
+	s.mockInner.AssertNotCalled(s.T(), "UpdateIdentityProvider")
+	s.idCache.AssertNotCalled(s.T(), "Set")
+	s.idCache.AssertNotCalled(s.T(), "Delete")
+}
+
+func (s *CacheBackedIDPStoreTestSuite) TestUpdateIdentityProvider_InnerUpdateError() {
+	oldProp, _ := cmodels.NewProperty(PropIssuer, "https://old.example.com", false)
+	oldIDP := &IDPDTO{ID: "idp-1", Name: "Old", Type: IDPTypeOIDC,
+		Properties: []cmodels.Property{*oldProp}}
+
+	newIDP := &IDPDTO{ID: "idp-1", Name: "New", Type: IDPTypeOIDC}
+
+	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").Return(oldIDP, nil)
+	s.mockInner.On("UpdateIdentityProvider", mock.Anything, newIDP).Return(errors.New("update failed"))
+
+	err := s.cachedStore.UpdateIdentityProvider(context.Background(), newIDP)
+
+	s.Error(err)
+	s.idCache.AssertNotCalled(s.T(), "Delete")
+	s.idCache.AssertNotCalled(s.T(), "Set")
+}
+
+// --- DeleteIdentityProvider error branches ---
+
+func (s *CacheBackedIDPStoreTestSuite) TestDeleteIdentityProvider_InnerGetGenericError() {
+	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").
+		Return((*IDPDTO)(nil), errors.New("connection refused"))
+
+	err := s.cachedStore.DeleteIdentityProvider(context.Background(), "idp-1")
+
+	s.Error(err)
+	s.mockInner.AssertNotCalled(s.T(), "DeleteIdentityProvider")
+}
+
+func (s *CacheBackedIDPStoreTestSuite) TestDeleteIdentityProvider_InnerDeleteError() {
+	idp := makeIDPWithIssuer("idp-1", "IDP 1", "https://idp.example.com")
+	s.mockInner.On("GetIdentityProvider", mock.Anything, "idp-1").Return(idp, nil)
+	s.mockInner.On("DeleteIdentityProvider", mock.Anything, "idp-1").Return(errors.New("delete failed"))
+
+	err := s.cachedStore.DeleteIdentityProvider(context.Background(), "idp-1")
+
+	s.Error(err)
+	s.idCache.AssertNotCalled(s.T(), "Delete")
+	s.propertyCache.AssertNotCalled(s.T(), "Delete")
 }

--- a/backend/internal/idp/composite_store.go
+++ b/backend/internal/idp/composite_store.go
@@ -122,14 +122,31 @@ func (c *compositeIDPStore) GetIdentityProviderByName(ctx context.Context, idpNa
 	)
 }
 
-// GetIdentityProviderByIssuer retrieves an identity provider by its issuer property from either store.
-// Checks database store first, then falls back to file store.
-func (c *compositeIDPStore) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error) {
-	return declarativeresource.CompositeGetHelper(
-		func() (*IDPDTO, error) { return c.dbStore.GetIdentityProviderByIssuer(ctx, issuer) },
-		func() (*IDPDTO, error) { return c.fileStore.GetIdentityProviderByIssuer(ctx, issuer) },
-		ErrIDPNotFound,
-	)
+// GetIdentityProvidersByProperty retrieves identity providers matching a property from both stores.
+func (c *compositeIDPStore) GetIdentityProvidersByProperty(ctx context.Context,
+	propertyKey, propertyValue string) ([]IDPDTO, error) {
+	var allIDPs []IDPDTO
+
+	dbIDPs, err := c.dbStore.GetIdentityProvidersByProperty(ctx, propertyKey, propertyValue)
+	if err != nil && !errors.Is(err, ErrIDPNotFound) {
+		return nil, err
+	}
+	if dbIDPs != nil {
+		allIDPs = append(allIDPs, dbIDPs...)
+	}
+
+	fileIDPs, err := c.fileStore.GetIdentityProvidersByProperty(ctx, propertyKey, propertyValue)
+	if err != nil && !errors.Is(err, ErrIDPNotFound) {
+		return nil, err
+	}
+	if fileIDPs != nil {
+		allIDPs = append(allIDPs, fileIDPs...)
+	}
+
+	if len(allIDPs) == 0 {
+		return nil, ErrIDPNotFound
+	}
+	return allIDPs, nil
 }
 
 // UpdateIdentityProvider updates an identity provider in the database store only.

--- a/backend/internal/idp/composite_store_test.go
+++ b/backend/internal/idp/composite_store_test.go
@@ -362,3 +362,124 @@ func (s *CompositeIDPStoreTestSuite) TestMergeAndDeduplicateIDPs_PreservesDuplic
 	s.Equal("DB Name", result[0].Name)
 	s.False(result[0].IsReadOnly)
 }
+
+// --- GetIdentityProviderListCount tests ---
+
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderListCount_ReturnsSumFromBothStores() {
+	s.dbStore.On("GetIdentityProviderListCount", context.Background()).Return(3, nil)
+	s.fileStore.On("GetIdentityProviderListCount", context.Background()).Return(2, nil)
+
+	count, err := s.compositeStore.GetIdentityProviderListCount(context.Background())
+
+	s.NoError(err)
+	s.Equal(5, count)
+}
+
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderListCount_ReturnsErrorWhenDBFails() {
+	s.dbStore.On("GetIdentityProviderListCount", context.Background()).Return(0, errors.New("db error"))
+
+	count, err := s.compositeStore.GetIdentityProviderListCount(context.Background())
+
+	s.Error(err)
+	s.Equal(0, count)
+}
+
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProviderListCount_ReturnsErrorWhenFileFails() {
+	s.dbStore.On("GetIdentityProviderListCount", context.Background()).Return(3, nil)
+	s.fileStore.On("GetIdentityProviderListCount", context.Background()).Return(0, errors.New("file error"))
+
+	count, err := s.compositeStore.GetIdentityProviderListCount(context.Background())
+
+	s.Error(err)
+	s.Equal(0, count)
+}
+
+// --- GetIdentityProvidersByProperty tests ---
+
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProvidersByProperty_DBReturnsResultsFileNotFound() {
+	dbIDPs := []IDPDTO{{ID: "db-1", Name: "DB IDP", Type: IDPTypeOIDC}}
+
+	s.dbStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return(dbIDPs, nil)
+	s.fileStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return([]IDPDTO(nil), ErrIDPNotFound)
+
+	result, err := s.compositeStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://example.com")
+
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("db-1", result[0].ID)
+}
+
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProvidersByProperty_DBNotFoundFileReturnsResults() {
+	fileIDPs := []IDPDTO{{ID: "file-1", Name: "File IDP", Type: IDPTypeOIDC}}
+
+	s.dbStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return([]IDPDTO(nil), ErrIDPNotFound)
+	s.fileStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return(fileIDPs, nil)
+
+	result, err := s.compositeStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://example.com")
+
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("file-1", result[0].ID)
+}
+
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProvidersByProperty_BothReturnResults() {
+	dbIDPs := []IDPDTO{{ID: "db-1", Name: "DB IDP", Type: IDPTypeOIDC}}
+	fileIDPs := []IDPDTO{{ID: "file-1", Name: "File IDP", Type: IDPTypeOIDC}}
+
+	s.dbStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return(dbIDPs, nil)
+	s.fileStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return(fileIDPs, nil)
+
+	result, err := s.compositeStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://example.com")
+
+	s.NoError(err)
+	s.Len(result, 2)
+}
+
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProvidersByProperty_BothNotFound() {
+	s.dbStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return([]IDPDTO(nil), ErrIDPNotFound)
+	s.fileStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return([]IDPDTO(nil), ErrIDPNotFound)
+
+	result, err := s.compositeStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://example.com")
+
+	s.Nil(result)
+	s.ErrorIs(err, ErrIDPNotFound)
+}
+
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProvidersByProperty_DBReturnsNonNotFoundError() {
+	s.dbStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return([]IDPDTO(nil), errors.New("db connection error"))
+
+	result, err := s.compositeStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://example.com")
+
+	s.Nil(result)
+	s.Error(err)
+	s.NotErrorIs(err, ErrIDPNotFound)
+}
+
+func (s *CompositeIDPStoreTestSuite) TestGetIdentityProvidersByProperty_FileReturnsNonNotFoundError() {
+	dbIDPs := []IDPDTO{{ID: "db-1", Name: "DB IDP", Type: IDPTypeOIDC}}
+	s.dbStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return(dbIDPs, nil)
+	s.fileStore.On("GetIdentityProvidersByProperty", context.Background(), "issuer", "https://example.com").
+		Return([]IDPDTO(nil), errors.New("file read error"))
+
+	result, err := s.compositeStore.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://example.com")
+
+	s.Nil(result)
+	s.Error(err)
+	s.NotErrorIs(err, ErrIDPNotFound)
+}

--- a/backend/internal/idp/file_based_store.go
+++ b/backend/internal/idp/file_based_store.go
@@ -94,15 +94,26 @@ func (f *idpFileBasedStore) GetIdentityProviderList(ctx context.Context) ([]Basi
 	return idpList, nil
 }
 
-// GetIdentityProviderByIssuer retrieves an identity provider by its issuer property from the file-based store.
-func (f *idpFileBasedStore) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error) {
-	data, err := f.GenericFileBasedStore.GetByField(issuer, func(d interface{}) string {
-		return GetPropertyValue(d.(*IDPDTO).Properties, PropIssuer)
-	})
+// GetIdentityProvidersByProperty retrieves identity providers matching a property from the file-based store.
+func (f *idpFileBasedStore) GetIdentityProvidersByProperty(ctx context.Context,
+	propertyKey, propertyValue string) ([]IDPDTO, error) {
+	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
+		return nil, err
+	}
+
+	var idps []IDPDTO
+	for _, item := range list {
+		if idpItem, ok := item.Data.(*IDPDTO); ok {
+			if GetPropertyValue(idpItem.Properties, propertyKey) == propertyValue {
+				idps = append(idps, *idpItem)
+			}
+		}
+	}
+	if len(idps) == 0 {
 		return nil, ErrIDPNotFound
 	}
-	return data.(*IDPDTO), nil
+	return idps, nil
 }
 
 // GetIdentityProviderListCount retrieves the total count of identity providers.

--- a/backend/internal/idp/file_based_store_test.go
+++ b/backend/internal/idp/file_based_store_test.go
@@ -195,3 +195,100 @@ func (suite *FileBasedStoreTestSuite) TestDeleteIdentityProvider_NotSupported() 
 	suite.Error(err)
 	suite.Contains(err.Error(), "not supported in file-based store")
 }
+
+func (suite *FileBasedStoreTestSuite) TestGetIdentityProvidersByProperty_ReturnsMatchingIDPs() {
+	prop1, _ := cmodels.NewProperty("issuer", "https://example.com", false)
+	prop2, _ := cmodels.NewProperty("client_id", "client1", false)
+
+	idp1 := IDPDTO{
+		ID:         "test-idp-prop-1",
+		Name:       "IDP Prop 1",
+		Type:       IDPTypeOIDC,
+		Properties: []cmodels.Property{*prop1, *prop2},
+	}
+
+	prop3, _ := cmodels.NewProperty("issuer", "https://other.com", false)
+	idp2 := IDPDTO{
+		ID:         "test-idp-prop-2",
+		Name:       "IDP Prop 2",
+		Type:       IDPTypeOIDC,
+		Properties: []cmodels.Property{*prop3},
+	}
+
+	suite.NoError(suite.store.CreateIdentityProvider(context.Background(), idp1))
+	suite.NoError(suite.store.CreateIdentityProvider(context.Background(), idp2))
+
+	result, err := suite.store.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://example.com")
+	suite.NoError(err)
+	suite.Len(result, 1)
+	suite.Equal("test-idp-prop-1", result[0].ID)
+}
+
+func (suite *FileBasedStoreTestSuite) TestGetIdentityProvidersByProperty_NonMatchingValue() {
+	prop, _ := cmodels.NewProperty("issuer", "https://example.com", false)
+	idp := IDPDTO{
+		ID:         "test-idp-prop-3",
+		Name:       "IDP Prop 3",
+		Type:       IDPTypeOIDC,
+		Properties: []cmodels.Property{*prop},
+	}
+
+	suite.NoError(suite.store.CreateIdentityProvider(context.Background(), idp))
+
+	result, err := suite.store.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://nomatch.com")
+	suite.ErrorIs(err, ErrIDPNotFound)
+	suite.Nil(result)
+}
+
+func (suite *FileBasedStoreTestSuite) TestGetIdentityProvidersByProperty_MultipleMatches() {
+	prop1, _ := cmodels.NewProperty("issuer", "https://shared.com", false)
+	idp1 := IDPDTO{
+		ID:         "test-idp-prop-4",
+		Name:       "IDP Prop 4",
+		Type:       IDPTypeOIDC,
+		Properties: []cmodels.Property{*prop1},
+	}
+
+	prop2, _ := cmodels.NewProperty("issuer", "https://shared.com", false)
+	idp2 := IDPDTO{
+		ID:         "test-idp-prop-5",
+		Name:       "IDP Prop 5",
+		Type:       IDPTypeOIDC,
+		Properties: []cmodels.Property{*prop2},
+	}
+
+	suite.NoError(suite.store.CreateIdentityProvider(context.Background(), idp1))
+	suite.NoError(suite.store.CreateIdentityProvider(context.Background(), idp2))
+
+	result, err := suite.store.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://shared.com")
+	suite.NoError(err)
+	suite.Len(result, 2)
+}
+
+func (suite *FileBasedStoreTestSuite) TestGetIdentityProviderListCount() {
+	prop1, _ := cmodels.NewProperty("client_id", "client1", false)
+	prop2, _ := cmodels.NewProperty("client_id", "client2", false)
+
+	idp1 := IDPDTO{
+		ID:         "test-idp-count-1",
+		Name:       "Count IDP 1",
+		Type:       IDPTypeOIDC,
+		Properties: []cmodels.Property{*prop1},
+	}
+	idp2 := IDPDTO{
+		ID:         "test-idp-count-2",
+		Name:       "Count IDP 2",
+		Type:       IDPTypeOIDC,
+		Properties: []cmodels.Property{*prop2},
+	}
+
+	suite.NoError(suite.store.CreateIdentityProvider(context.Background(), idp1))
+	suite.NoError(suite.store.CreateIdentityProvider(context.Background(), idp2))
+
+	count, err := suite.store.GetIdentityProviderListCount(context.Background())
+	suite.NoError(err)
+	suite.Equal(2, count)
+}

--- a/backend/internal/idp/idpStoreInterface_mock_test.go
+++ b/backend/internal/idp/idpStoreInterface_mock_test.go
@@ -219,74 +219,6 @@ func (_c *idpStoreInterfaceMock_GetIdentityProvider_Call) RunAndReturn(run func(
 	return _c
 }
 
-// GetIdentityProviderByIssuer provides a mock function for the type idpStoreInterfaceMock
-func (_mock *idpStoreInterfaceMock) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error) {
-	ret := _mock.Called(ctx, issuer)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetIdentityProviderByIssuer")
-	}
-
-	var r0 *IDPDTO
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*IDPDTO, error)); ok {
-		return returnFunc(ctx, issuer)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *IDPDTO); ok {
-		r0 = returnFunc(ctx, issuer)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*IDPDTO)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, issuer)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProviderByIssuer'
-type idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call struct {
-	*mock.Call
-}
-
-// GetIdentityProviderByIssuer is a helper method to define mock.On call
-//   - ctx context.Context
-//   - issuer string
-func (_e *idpStoreInterfaceMock_Expecter) GetIdentityProviderByIssuer(ctx interface{}, issuer interface{}) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
-	return &idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call{Call: _e.mock.On("GetIdentityProviderByIssuer", ctx, issuer)}
-}
-
-func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) Run(run func(ctx context.Context, issuer string)) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) Return(iDPDTO *IDPDTO, err error) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Return(iDPDTO, err)
-	return _c
-}
-
-func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) RunAndReturn(run func(ctx context.Context, issuer string) (*IDPDTO, error)) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetIdentityProviderByName provides a mock function for the type idpStoreInterfaceMock
 func (_mock *idpStoreInterfaceMock) GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, error) {
 	ret := _mock.Called(ctx, idpName)
@@ -473,6 +405,80 @@ func (_c *idpStoreInterfaceMock_GetIdentityProviderListCount_Call) Return(n int,
 }
 
 func (_c *idpStoreInterfaceMock_GetIdentityProviderListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *idpStoreInterfaceMock_GetIdentityProviderListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetIdentityProvidersByProperty provides a mock function for the type idpStoreInterfaceMock
+func (_mock *idpStoreInterfaceMock) GetIdentityProvidersByProperty(ctx context.Context, propertyKey string, propertyValue string) ([]IDPDTO, error) {
+	ret := _mock.Called(ctx, propertyKey, propertyValue)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentityProvidersByProperty")
+	}
+
+	var r0 []IDPDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]IDPDTO, error)); ok {
+		return returnFunc(ctx, propertyKey, propertyValue)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []IDPDTO); ok {
+		r0 = returnFunc(ctx, propertyKey, propertyValue)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]IDPDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, propertyKey, propertyValue)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProvidersByProperty'
+type idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call struct {
+	*mock.Call
+}
+
+// GetIdentityProvidersByProperty is a helper method to define mock.On call
+//   - ctx context.Context
+//   - propertyKey string
+//   - propertyValue string
+func (_e *idpStoreInterfaceMock_Expecter) GetIdentityProvidersByProperty(ctx interface{}, propertyKey interface{}, propertyValue interface{}) *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call {
+	return &idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call{Call: _e.mock.On("GetIdentityProvidersByProperty", ctx, propertyKey, propertyValue)}
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call) Run(run func(ctx context.Context, propertyKey string, propertyValue string)) *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call) Return(iDPDTOs []IDPDTO, err error) *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call {
+	_c.Call.Return(iDPDTOs, err)
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call) RunAndReturn(run func(ctx context.Context, propertyKey string, propertyValue string) ([]IDPDTO, error)) *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/idp/init.go
+++ b/backend/internal/idp/init.go
@@ -82,7 +82,7 @@ func initializeStore(cacheManager cache.CacheManagerInterface) (idpStoreInterfac
 	storeMode := getIdentityProviderStoreMode()
 
 	idpByIDCache := cache.GetCache[*IDPDTO](cacheManager, "IDPByIDCache")
-	idpByIssuerCache := cache.GetCache[*IDPDTO](cacheManager, "IDPByIssuerCache")
+	idpByPropertyCache := cache.GetCache[[]IDPDTO](cacheManager, "IDPByPropertyCache")
 
 	switch storeMode {
 	case serverconst.StoreModeComposite:
@@ -95,21 +95,21 @@ func initializeStore(cacheManager cache.CacheManagerInterface) (idpStoreInterfac
 		if err := loadDeclarativeResources(fileStore); err != nil {
 			return nil, nil, err
 		}
-		return newCacheBackedIDPStore(idpByIDCache, idpByIssuerCache, idpStore), transactioner, nil
+		return newCacheBackedIDPStore(idpByIDCache, idpByPropertyCache, idpStore), transactioner, nil
 
 	case serverconst.StoreModeDeclarative:
 		fileStore, transactioner := newIDPFileBasedStore()
 		if err := loadDeclarativeResources(fileStore); err != nil {
 			return nil, nil, err
 		}
-		return newCacheBackedIDPStore(idpByIDCache, idpByIssuerCache, fileStore), transactioner, nil
+		return newCacheBackedIDPStore(idpByIDCache, idpByPropertyCache, fileStore), transactioner, nil
 
 	default:
 		store, transactioner, err := newIDPStore()
 		if err != nil {
 			return nil, nil, err
 		}
-		return newCacheBackedIDPStore(idpByIDCache, idpByIssuerCache, store), transactioner, nil
+		return newCacheBackedIDPStore(idpByIDCache, idpByPropertyCache, store), transactioner, nil
 	}
 }
 

--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -37,7 +37,8 @@ type IDPServiceInterface interface {
 	GetIdentityProviderList(ctx context.Context) ([]BasicIDPDTO, *serviceerror.ServiceError)
 	GetIdentityProvider(ctx context.Context, idpID string) (*IDPDTO, *serviceerror.ServiceError)
 	GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, *serviceerror.ServiceError)
-	GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, *serviceerror.ServiceError)
+	GetIdentityProvidersByProperty(ctx context.Context, propertyKey,
+		propertyValue string) ([]IDPDTO, *serviceerror.ServiceError)
 	UpdateIdentityProvider(ctx context.Context, idpID string, idp *IDPDTO) (*IDPDTO, *serviceerror.ServiceError)
 	DeleteIdentityProvider(ctx context.Context, idpID string) *serviceerror.ServiceError
 }
@@ -169,24 +170,26 @@ func (is *idpService) GetIdentityProviderByName(ctx context.Context,
 	return idp, nil
 }
 
-// GetIdentityProviderByIssuer retrieves an identity provider by its issuer property.
-func (is *idpService) GetIdentityProviderByIssuer(ctx context.Context,
-	issuer string) (*IDPDTO, *serviceerror.ServiceError) {
+// GetIdentityProvidersByProperty retrieves identity providers matching a given property key and value.
+func (is *idpService) GetIdentityProvidersByProperty(ctx context.Context,
+	propertyKey, propertyValue string) ([]IDPDTO, *serviceerror.ServiceError) {
 	logger := is.logger
-	if strings.TrimSpace(issuer) == "" {
+	if strings.TrimSpace(propertyKey) == "" || strings.TrimSpace(propertyValue) == "" {
 		return nil, &ErrorInvalidIDPID
 	}
 
-	idp, err := is.idpStore.GetIdentityProviderByIssuer(ctx, issuer)
+	idps, err := is.idpStore.GetIdentityProvidersByProperty(ctx, propertyKey, propertyValue)
 	if err != nil {
 		if errors.Is(err, ErrIDPNotFound) {
 			return nil, &ErrorIDPNotFound
 		}
-		logger.Error("Failed to get identity provider by issuer", log.String("issuer", issuer), log.Error(err))
+		logger.Error("Failed to get identity providers by property",
+			log.String("propertyKey", propertyKey),
+			log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	return idp, nil
+	return idps, nil
 }
 
 // UpdateIdentityProvider updates an existing Identity Provider.

--- a/backend/internal/idp/service_test.go
+++ b/backend/internal/idp/service_test.go
@@ -418,41 +418,56 @@ func (s *IDPServiceTestSuite) TestGetIdentityProviderByName_StoreError() {
 	s.mockStore.AssertExpectations(s.T())
 }
 
-// TestGetIdentityProviderByIssuer_Success tests successful IDP retrieval by issuer
-func (s *IDPServiceTestSuite) TestGetIdentityProviderByIssuer_Success() {
+// TestGetIdentityProvidersByProperty_Success tests successful IDP retrieval by property
+func (s *IDPServiceTestSuite) TestGetIdentityProvidersByProperty_Success() {
 	prop, _ := cmodels.NewProperty(PropIssuer, "https://idp.example.com", false)
-	idp := &IDPDTO{
-		ID:         "idp-123",
-		Name:       "Test IDP",
-		Type:       IDPTypeOIDC,
-		Properties: []cmodels.Property{*prop},
+	idps := []IDPDTO{
+		{
+			ID:         "idp-123",
+			Name:       "Test IDP",
+			Type:       IDPTypeOIDC,
+			Properties: []cmodels.Property{*prop},
+		},
 	}
 
-	s.mockStore.On("GetIdentityProviderByIssuer", mock.Anything, "https://idp.example.com").Return(idp, nil)
+	s.mockStore.On("GetIdentityProvidersByProperty", mock.Anything, "issuer", "https://idp.example.com").
+		Return(idps, nil)
 
-	result, err := s.idpService.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+	result, err := s.idpService.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://idp.example.com")
 
 	s.Nil(err)
 	s.NotNil(result)
-	s.Equal("idp-123", result.ID)
+	s.Len(result, 1)
+	s.Equal("idp-123", result[0].ID)
 	s.mockStore.AssertExpectations(s.T())
 }
 
-// TestGetIdentityProviderByIssuer_EmptyIssuer tests empty issuer validation
-func (s *IDPServiceTestSuite) TestGetIdentityProviderByIssuer_EmptyIssuer() {
-	result, err := s.idpService.GetIdentityProviderByIssuer(context.Background(), "")
+// TestGetIdentityProvidersByProperty_EmptyKey tests empty property key validation
+func (s *IDPServiceTestSuite) TestGetIdentityProvidersByProperty_EmptyKey() {
+	result, err := s.idpService.GetIdentityProvidersByProperty(context.Background(), "", "some-value")
 
 	s.Nil(result)
 	s.NotNil(err)
 	s.Equal(ErrorInvalidIDPID.Code, err.Code)
 }
 
-// TestGetIdentityProviderByIssuer_NotFound tests IDP not found by issuer
-func (s *IDPServiceTestSuite) TestGetIdentityProviderByIssuer_NotFound() {
-	s.mockStore.On("GetIdentityProviderByIssuer", mock.Anything, "https://unknown.example.com").
-		Return((*IDPDTO)(nil), ErrIDPNotFound)
+// TestGetIdentityProvidersByProperty_EmptyValue tests empty property value validation
+func (s *IDPServiceTestSuite) TestGetIdentityProvidersByProperty_EmptyValue() {
+	result, err := s.idpService.GetIdentityProvidersByProperty(context.Background(), "issuer", "")
 
-	result, err := s.idpService.GetIdentityProviderByIssuer(context.Background(), "https://unknown.example.com")
+	s.Nil(result)
+	s.NotNil(err)
+	s.Equal(ErrorInvalidIDPID.Code, err.Code)
+}
+
+// TestGetIdentityProvidersByProperty_NotFound tests IDP not found by property
+func (s *IDPServiceTestSuite) TestGetIdentityProvidersByProperty_NotFound() {
+	s.mockStore.On("GetIdentityProvidersByProperty", mock.Anything, "issuer", "https://unknown.example.com").
+		Return([]IDPDTO(nil), ErrIDPNotFound)
+
+	result, err := s.idpService.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://unknown.example.com")
 
 	s.Nil(result)
 	s.NotNil(err)
@@ -460,12 +475,13 @@ func (s *IDPServiceTestSuite) TestGetIdentityProviderByIssuer_NotFound() {
 	s.mockStore.AssertExpectations(s.T())
 }
 
-// TestGetIdentityProviderByIssuer_StoreError tests store error handling
-func (s *IDPServiceTestSuite) TestGetIdentityProviderByIssuer_StoreError() {
-	s.mockStore.On("GetIdentityProviderByIssuer", mock.Anything, "https://idp.example.com").
-		Return((*IDPDTO)(nil), errors.New("database error"))
+// TestGetIdentityProvidersByProperty_StoreError tests store error handling
+func (s *IDPServiceTestSuite) TestGetIdentityProvidersByProperty_StoreError() {
+	s.mockStore.On("GetIdentityProvidersByProperty", mock.Anything, "issuer", "https://idp.example.com").
+		Return([]IDPDTO(nil), errors.New("database error"))
 
-	result, err := s.idpService.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+	result, err := s.idpService.GetIdentityProvidersByProperty(
+		context.Background(), "issuer", "https://idp.example.com")
 
 	s.Nil(result)
 	s.NotNil(err)

--- a/backend/internal/idp/store.go
+++ b/backend/internal/idp/store.go
@@ -20,7 +20,6 @@ package idp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
@@ -40,7 +39,7 @@ type idpStoreInterface interface {
 	GetIdentityProviderListCount(ctx context.Context) (int, error)
 	GetIdentityProvider(ctx context.Context, idpID string) (*IDPDTO, error)
 	GetIdentityProviderByName(ctx context.Context, idpName string) (*IDPDTO, error)
-	GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error)
+	GetIdentityProvidersByProperty(ctx context.Context, propertyKey, propertyValue string) ([]IDPDTO, error)
 	UpdateIdentityProvider(ctx context.Context, idp *IDPDTO) error
 	DeleteIdentityProvider(ctx context.Context, idpID string) error
 }
@@ -77,7 +76,7 @@ func (s *idpStore) CreateIdentityProvider(ctx context.Context, idp IDPDTO) error
 
 	var propertiesJSON string
 	if len(idp.Properties) > 0 {
-		propertiesJSON, err = cmodels.SerializePropertiesToJSONArray(idp.Properties)
+		propertiesJSON, err = cmodels.SerializePropertiesToJSONObject(idp.Properties)
 		if err != nil {
 			return fmt.Errorf("failed to serialize properties to JSON: %w", err)
 		}
@@ -160,34 +159,16 @@ func (s *idpStore) GetIdentityProviderByName(ctx context.Context, name string) (
 	return s.getIDP(ctx, queryGetIdentityProviderByName, name)
 }
 
-// GetIdentityProviderByIssuer retrieves a specific idp by its issuer property from the database.
-func (s *idpStore) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*IDPDTO, error) {
+// GetIdentityProvidersByProperty retrieves IDPs matching a given property key and value.
+func (s *idpStore) GetIdentityProvidersByProperty(ctx context.Context,
+	propertyKey, propertyValue string) ([]IDPDTO, error) {
 	dbClient, err := s.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	// For Postgres the $1 placeholder expects a JSON fragment; for SQLite it expects the raw string value.
-	// Build the JSON fragment safely via json.Marshal to avoid injection.
-	type issuerEntry struct {
-		Name  string `json:"name"`
-		Value string `json:"value"`
-	}
-	pgParam, err := json.Marshal([]issuerEntry{{Name: "issuer", Value: issuer}})
-	if err != nil {
-		return nil, fmt.Errorf("failed to build issuer query parameter: %w", err)
-	}
-
-	// Select the right argument for the dialect. The DBClient picks the correct query string
-	// internally, but we must supply the matching arg for that query's $1 placeholder.
-	var param string
-	if config.GetServerRuntime().Config.Database.Config.Type == "postgres" {
-		param = string(pgParam)
-	} else {
-		param = issuer
-	}
-
-	results, err := dbClient.QueryContext(ctx, queryGetIdentityProviderByIssuer, param, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, queryGetIdentityProvidersByProperty,
+		propertyKey, propertyValue, s.deploymentID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -195,37 +176,37 @@ func (s *idpStore) GetIdentityProviderByIssuer(ctx context.Context, issuer strin
 		return nil, ErrIDPNotFound
 	}
 
-	row := results[0]
-
-	basicIDP, err := buildIDPFromResultRow(row)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build idp from result row: %w", err)
-	}
-
-	var properties []cmodels.Property
-	var propertiesJSON string
-
-	switch v := row["properties"].(type) {
-	case string:
-		propertiesJSON = v
-	case []byte:
-		propertiesJSON = string(v)
-	}
-
-	if propertiesJSON != "" {
-		properties, err = cmodels.DeserializePropertiesFromJSON(propertiesJSON)
+	idps := make([]IDPDTO, 0, len(results))
+	for _, row := range results {
+		basicIDP, err := buildIDPFromResultRow(row)
 		if err != nil {
-			return nil, fmt.Errorf("failed to deserialize properties from JSON: %w", err)
+			return nil, fmt.Errorf("failed to build idp from result row: %w", err)
 		}
-	}
 
-	return &IDPDTO{
-		ID:          basicIDP.ID,
-		Name:        basicIDP.Name,
-		Description: basicIDP.Description,
-		Type:        basicIDP.Type,
-		Properties:  properties,
-	}, nil
+		var properties []cmodels.Property
+		var propertiesJSON string
+		switch v := row["properties"].(type) {
+		case string:
+			propertiesJSON = v
+		case []byte:
+			propertiesJSON = string(v)
+		}
+		if propertiesJSON != "" {
+			properties, err = cmodels.DeserializePropertiesFromJSONObject(propertiesJSON)
+			if err != nil {
+				return nil, fmt.Errorf("failed to deserialize properties from JSON: %w", err)
+			}
+		}
+
+		idps = append(idps, IDPDTO{
+			ID:          basicIDP.ID,
+			Name:        basicIDP.Name,
+			Description: basicIDP.Description,
+			Type:        basicIDP.Type,
+			Properties:  properties,
+		})
+	}
+	return idps, nil
 }
 
 // getIDP retrieves an IDP based on the provided query and identifier.
@@ -266,7 +247,7 @@ func (s *idpStore) getIDP(ctx context.Context, query dbmodel.DBQuery, identifier
 
 	if propertiesJSON != "" {
 		var err error
-		properties, err = cmodels.DeserializePropertiesFromJSON(propertiesJSON)
+		properties, err = cmodels.DeserializePropertiesFromJSONObject(propertiesJSON)
 		if err != nil {
 			return nil, fmt.Errorf("failed to deserialize properties from JSON: %w", err)
 		}
@@ -292,7 +273,7 @@ func (s *idpStore) UpdateIdentityProvider(ctx context.Context, idp *IDPDTO) erro
 
 	var propertiesJSON string
 	if len(idp.Properties) > 0 {
-		propertiesJSON, err = cmodels.SerializePropertiesToJSONArray(idp.Properties)
+		propertiesJSON, err = cmodels.SerializePropertiesToJSONObject(idp.Properties)
 		if err != nil {
 			return fmt.Errorf("failed to serialize properties to JSON: %w", err)
 		}

--- a/backend/internal/idp/store_constants.go
+++ b/backend/internal/idp/store_constants.go
@@ -58,15 +58,12 @@ var (
 		ID:    "IPQ-IDP_MGT-07",
 		Query: `SELECT COUNT(*) AS count FROM "IDP" WHERE DEPLOYMENT_ID = $1`,
 	}
-	// queryGetIdentityProviderByIssuer is the query to get an IDP by its issuer property value.
-	queryGetIdentityProviderByIssuer = model.DBQuery{
+	// queryGetIdentityProvidersByProperty is the query to get IDPs by a property key and value.
+	queryGetIdentityProvidersByProperty = model.DBQuery{
 		ID: "IPQ-IDP_MGT-08",
-		PostgresQuery: "SELECT ID, NAME, DESCRIPTION, TYPE, PROPERTIES FROM IDP " +
-			"WHERE PROPERTIES @> $1::jsonb AND DEPLOYMENT_ID = $2 LIMIT 1",
-		SQLiteQuery: "SELECT ID, NAME, DESCRIPTION, TYPE, PROPERTIES FROM IDP " +
-			"WHERE EXISTS (SELECT 1 FROM json_each(PROPERTIES) " +
-			"WHERE json_extract(value, '$.name') = 'issuer' " +
-			"AND json_extract(value, '$.value') = $1) " +
-			"AND DEPLOYMENT_ID = $2 LIMIT 1",
+		PostgresQuery: `SELECT ID, NAME, DESCRIPTION, TYPE, PROPERTIES FROM "IDP" ` +
+			`WHERE PROPERTIES->$1->>'value' = $2 AND DEPLOYMENT_ID = $3`,
+		SQLiteQuery: `SELECT ID, NAME, DESCRIPTION, TYPE, PROPERTIES FROM "IDP" ` +
+			`WHERE json_extract(PROPERTIES, '$.' || $1 || '.value') = $2 AND DEPLOYMENT_ID = $3`,
 	}
 )

--- a/backend/internal/idp/store_test.go
+++ b/backend/internal/idp/store_test.go
@@ -89,7 +89,7 @@ func (s *IDPStoreTestSuite) TestCreateIdentityProvider_Success() {
 
 	s.mockDBProvider.On("GetConfigDBClient").Return(s.mockDBClient, nil)
 	s.mockDBClient.On("ExecuteContext", context.Background(), queryCreateIdentityProvider, idp.ID, idp.Name,
-		idp.Description, idp.Type, `[{"name":"client_id","value":"test-client","isSecret":false}]`, testDeploymentID).
+		idp.Description, idp.Type, `{"client_id":{"value":"test-client","isSecret":false}}`, testDeploymentID).
 		Return(int64(1), nil)
 
 	err := s.store.CreateIdentityProvider(context.Background(), idp)
@@ -253,7 +253,7 @@ func (s *IDPStoreTestSuite) TestGetIdentityProvider_Success() {
 			"name":        "Test IDP",
 			"description": "Test Description",
 			"type":        "OIDC",
-			"properties":  `[{"name":"client_id","value":"test","is_secret":false}]`,
+			"properties":  `{"client_id":{"value":"test","isSecret":false}}`,
 		},
 	}
 
@@ -410,7 +410,7 @@ func (s *IDPStoreTestSuite) TestUpdateIdentityProvider_WithProperties() {
 
 	s.mockDBProvider.On("GetConfigDBClient").Return(s.mockDBClient, nil)
 	s.mockDBClient.On("ExecuteContext", context.Background(), queryUpdateIdentityProviderByID, idp.ID, idp.Name,
-		idp.Description, idp.Type, `[{"name":"client_id","value":"test","isSecret":false}]`, testDeploymentID).
+		idp.Description, idp.Type, `{"client_id":{"value":"test","isSecret":false}}`, testDeploymentID).
 		Return(int64(1), nil)
 
 	err := s.store.UpdateIdentityProvider(context.Background(), idp)
@@ -605,7 +605,7 @@ func (s *IDPStoreTestSuite) TestGetIdentityProvider_WithByteProperties() {
 			"name":        "Test IDP",
 			"description": "Test Description",
 			"type":        "OIDC",
-			"properties":  []byte(`[{"name":"client_id","value":"test","is_secret":false}]`),
+			"properties":  []byte(`{"client_id":{"value":"test","isSecret":false}}`),
 		},
 	}
 
@@ -699,71 +699,71 @@ func (s *IDPStoreTestSuite) TestGetIdentityProvider_BuildRowError() {
 	s.mockDBClient.AssertExpectations(s.T())
 }
 
-// TestGetIdentityProviderByIssuer_Success tests successful IDP retrieval by issuer.
-func (s *IDPStoreTestSuite) TestGetIdentityProviderByIssuer_Success() {
+// TestGetIdentityProvidersByProperty_Success tests successful IDP retrieval by property.
+func (s *IDPStoreTestSuite) TestGetIdentityProvidersByProperty_Success() {
 	results := []map[string]interface{}{
 		{
 			"id":          "idp-1",
 			"name":        "IDP 1",
 			"description": "Desc 1",
 			"type":        "OIDC",
-			"properties":  `[{"name":"issuer","value":"https://idp.example.com","isSecret":false}]`,
+			"properties":  `{"issuer":{"value":"https://idp.example.com","isSecret":false}}`,
 		},
 	}
 
 	s.mockDBProvider.On("GetConfigDBClient").Return(s.mockDBClient, nil)
-	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProviderByIssuer,
-		"https://idp.example.com", testDeploymentID).Return(results, nil)
+	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProvidersByProperty,
+		"issuer", "https://idp.example.com", testDeploymentID).Return(results, nil)
 
-	idp, err := s.store.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+	idps, err := s.store.GetIdentityProvidersByProperty(context.Background(), "issuer", "https://idp.example.com")
 
 	s.NoError(err)
-	s.NotNil(idp)
-	s.Equal("idp-1", idp.ID)
-	s.Equal("IDP 1", idp.Name)
-	s.Len(idp.Properties, 1)
-	s.Equal("issuer", idp.Properties[0].GetName())
+	s.Len(idps, 1)
+	s.Equal("idp-1", idps[0].ID)
+	s.Equal("IDP 1", idps[0].Name)
+	s.Len(idps[0].Properties, 1)
+	s.Equal("issuer", idps[0].Properties[0].GetName())
 	s.mockDBProvider.AssertExpectations(s.T())
 	s.mockDBClient.AssertExpectations(s.T())
 }
 
-// TestGetIdentityProviderByIssuer_NotFound tests IDP not found by issuer.
-func (s *IDPStoreTestSuite) TestGetIdentityProviderByIssuer_NotFound() {
+// TestGetIdentityProvidersByProperty_NotFound tests IDP not found by property.
+func (s *IDPStoreTestSuite) TestGetIdentityProvidersByProperty_NotFound() {
 	s.mockDBProvider.On("GetConfigDBClient").Return(s.mockDBClient, nil)
-	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProviderByIssuer,
-		"https://unknown.example.com", testDeploymentID).Return([]map[string]interface{}{}, nil)
+	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProvidersByProperty,
+		"issuer", "https://unknown.example.com", testDeploymentID).Return([]map[string]interface{}{}, nil)
 
-	idp, err := s.store.GetIdentityProviderByIssuer(context.Background(), "https://unknown.example.com")
+	idps, err := s.store.GetIdentityProvidersByProperty(context.Background(), "issuer", "https://unknown.example.com")
 
 	s.Error(err)
-	s.Nil(idp)
+	s.Nil(idps)
 	s.ErrorIs(err, ErrIDPNotFound)
 	s.mockDBProvider.AssertExpectations(s.T())
 	s.mockDBClient.AssertExpectations(s.T())
 }
 
-// TestGetIdentityProviderByIssuer_DBClientError tests DB client error.
-func (s *IDPStoreTestSuite) TestGetIdentityProviderByIssuer_DBClientError() {
+// TestGetIdentityProvidersByProperty_DBClientError tests DB client error.
+func (s *IDPStoreTestSuite) TestGetIdentityProvidersByProperty_DBClientError() {
 	s.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("db error"))
 
-	idp, err := s.store.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+	idps, err := s.store.GetIdentityProvidersByProperty(context.Background(), "issuer", "https://idp.example.com")
 
 	s.Error(err)
-	s.Nil(idp)
+	s.Nil(idps)
 	s.Contains(err.Error(), "failed to get database client")
 	s.mockDBProvider.AssertExpectations(s.T())
 }
 
-// TestGetIdentityProviderByIssuer_QueryError tests query execution error.
-func (s *IDPStoreTestSuite) TestGetIdentityProviderByIssuer_QueryError() {
+// TestGetIdentityProvidersByProperty_QueryError tests query execution error.
+func (s *IDPStoreTestSuite) TestGetIdentityProvidersByProperty_QueryError() {
 	s.mockDBProvider.On("GetConfigDBClient").Return(s.mockDBClient, nil)
-	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProviderByIssuer,
-		"https://idp.example.com", testDeploymentID).Return(nil, errors.New("query error"))
+	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProvidersByProperty,
+		"issuer", "https://idp.example.com", testDeploymentID).Return(nil, errors.New("query error"))
 
-	idp, err := s.store.GetIdentityProviderByIssuer(context.Background(), "https://idp.example.com")
+	idps, err := s.store.GetIdentityProvidersByProperty(context.Background(), "issuer", "https://idp.example.com")
 
 	s.Error(err)
-	s.Nil(idp)
+	s.Nil(idps)
 	s.Contains(err.Error(), "failed to execute query")
 	s.mockDBProvider.AssertExpectations(s.T())
 	s.mockDBClient.AssertExpectations(s.T())

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -235,11 +235,12 @@ func (tv *tokenValidator) resolveExternalIssuer(ctx context.Context, issuer stri
 		return nil, fmt.Errorf("no external issuers configured")
 	}
 
-	idpDTO, svcErr := tv.idpService.GetIdentityProviderByIssuer(ctx, issuer)
-	if svcErr != nil {
+	idpDTOs, svcErr := tv.idpService.GetIdentityProvidersByProperty(ctx, idp.PropIssuer, issuer)
+	if svcErr != nil || len(idpDTOs) == 0 {
 		return nil, fmt.Errorf("no external issuer configured for '%s'", issuer)
 	}
 
+	idpDTO := idpDTOs[0]
 	if idp.GetPropertyValue(idpDTO.Properties, idp.PropTokenExchangeEnabled) != "true" {
 		return nil, fmt.Errorf("token exchange not enabled for issuer '%s'", issuer)
 	}

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -2033,13 +2033,13 @@ func (suite *ExternalIDPValidatorTestSuite) SetupTest() {
 	}
 }
 
-// buildExternalIDPDTO builds a minimal idp.IDPDTO for the standard test external IDP.
-func buildExternalIDPDTO() *idp.IDPDTO {
+// buildExternalIDPDTOs builds a minimal []idp.IDPDTO for the standard test external IDP.
+func buildExternalIDPDTOs() []idp.IDPDTO {
 	propTokenExchange, _ := cmodels.NewProperty(idp.PropTokenExchangeEnabled, "true", false)
 	propJWKS, _ := cmodels.NewProperty(idp.PropJwksEndpoint, testExternalJWKS, false)
 	propIssuer, _ := cmodels.NewProperty(idp.PropIssuer, testExternalIssuer, false)
-	return &idp.IDPDTO{
-		Properties: []cmodels.Property{*propTokenExchange, *propJWKS, *propIssuer},
+	return []idp.IDPDTO{
+		{Properties: []cmodels.Property{*propTokenExchange, *propJWKS, *propIssuer}},
 	}
 }
 
@@ -2058,15 +2058,15 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 	claims := map[string]interface{}{
 		"sub": "ext-user-123",
 		"iss": testExternalIssuer,
-		"aud": "https://example.com", // audience is this server's own issuer
+		"aud": "https://example.com",
 		"exp": float64(now + 3600),
 		"nbf": float64(now - 60),
 	}
 	token := suite.createExternalJWT(claims)
-	idpDTO := buildExternalIDPDTO()
+	idpDTOs := buildExternalIDPDTOs()
 
-	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
-		Return(idpDTO, nil)
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", token, testExternalJWKS).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
@@ -2084,15 +2084,15 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 	claims := map[string]interface{}{
 		"sub": "ext-user-123",
 		"iss": testExternalIssuer,
-		"aud": []interface{}{"https://example.com", "other-audience"}, // array including server issuer
+		"aud": []interface{}{"https://example.com", "other-audience"},
 		"exp": float64(now + 3600),
 		"nbf": float64(now - 60),
 	}
 	token := suite.createExternalJWT(claims)
-	idpDTO := buildExternalIDPDTO()
+	idpDTOs := buildExternalIDPDTOs()
 
-	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
-		Return(idpDTO, nil)
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", token, testExternalJWKS).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
@@ -2109,15 +2109,15 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 	claims := map[string]interface{}{
 		"sub": "ext-user-123",
 		"iss": testExternalIssuer,
-		"aud": "some-client-id", // audience is a client_id, not the server issuer
+		"aud": "some-client-id",
 		"exp": float64(now + 3600),
 		"nbf": float64(now - 60),
 	}
 	token := suite.createExternalJWT(claims)
-	idpDTO := buildExternalIDPDTO()
+	idpDTOs := buildExternalIDPDTOs()
 
-	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
-		Return(idpDTO, nil)
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", token, testExternalJWKS).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
@@ -2134,14 +2134,13 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 	claims := map[string]interface{}{
 		"sub": "ext-user-123",
 		"iss": testExternalIssuer,
-		// no aud claim
 		"exp": float64(now + 3600),
 	}
 	token := suite.createExternalJWT(claims)
-	idpDTO := buildExternalIDPDTO()
+	idpDTOs := buildExternalIDPDTOs()
 
-	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
-		Return(idpDTO, nil)
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", token, testExternalJWKS).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
@@ -2162,10 +2161,10 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 		"exp": float64(now + 3600),
 	}
 	token := suite.createExternalJWT(claims)
-	idpDTO := buildExternalIDPDTO()
+	idpDTOs := buildExternalIDPDTOs()
 
-	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
-		Return(idpDTO, nil)
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", token, testExternalJWKS).
 		Return(&serviceerror.ServiceError{
 			Type:  serviceerror.ServerErrorType,
@@ -2198,12 +2197,12 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 	propTokenExchange, _ := cmodels.NewProperty(idp.PropTokenExchangeEnabled, "false", false)
 	propJWKS, _ := cmodels.NewProperty(idp.PropJwksEndpoint, testExternalJWKS, false)
 	propIssuer, _ := cmodels.NewProperty(idp.PropIssuer, testExternalIssuer, false)
-	idpDTO := &idp.IDPDTO{
-		Properties: []cmodels.Property{*propTokenExchange, *propJWKS, *propIssuer},
+	idpDTOs := []idp.IDPDTO{
+		{Properties: []cmodels.Property{*propTokenExchange, *propJWKS, *propIssuer}},
 	}
 
-	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
-		Return(idpDTO, nil)
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -2225,12 +2224,12 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 
 	propTokenExchange, _ := cmodels.NewProperty(idp.PropTokenExchangeEnabled, "true", false)
 	propIssuer, _ := cmodels.NewProperty(idp.PropIssuer, testExternalIssuer, false)
-	idpDTO := &idp.IDPDTO{
-		Properties: []cmodels.Property{*propTokenExchange, *propIssuer},
+	idpDTOs := []idp.IDPDTO{
+		{Properties: []cmodels.Property{*propTokenExchange, *propIssuer}},
 	}
 
-	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), testExternalIssuer).
-		Return(idpDTO, nil)
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -2252,7 +2251,8 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 	}
 	token := suite.createExternalJWT(claims)
 
-	suite.mockIDPService.On("GetIdentityProviderByIssuer", context.Background(), unknownIssuer).
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, unknownIssuer).
 		Return(nil, &serviceerror.ServiceError{
 			Type:  serviceerror.ClientErrorType,
 			Code:  "IDP_NOT_FOUND",

--- a/backend/internal/system/cmodels/property.go
+++ b/backend/internal/system/cmodels/property.go
@@ -154,6 +154,62 @@ func DeserializePropertiesFromJSON(propertiesJSON string) ([]Property, error) {
 	return properties, nil
 }
 
+// SerializePropertiesToJSONObject serializes an array of properties to a JSON object string
+func SerializePropertiesToJSONObject(properties []Property) (string, error) {
+	if len(properties) == 0 {
+		return "", nil
+	}
+
+	type propertyEntry struct {
+		Value    string `json:"value"`
+		IsSecret bool   `json:"isSecret"`
+	}
+
+	obj := make(map[string]propertyEntry, len(properties))
+	for _, property := range properties {
+		obj[property.GetName()] = propertyEntry{
+			Value:    property.value,
+			IsSecret: property.IsSecret(),
+		}
+	}
+
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize properties to JSON object: %w", err)
+	}
+
+	return string(jsonBytes), nil
+}
+
+// DeserializePropertiesFromJSONObject deserializes properties from a JSON object string
+func DeserializePropertiesFromJSONObject(propertiesJSON string) ([]Property, error) {
+	if propertiesJSON == "" {
+		return []Property{}, nil
+	}
+
+	type propertyEntry struct {
+		Value    string `json:"value"`
+		IsSecret bool   `json:"isSecret"`
+	}
+
+	var obj map[string]propertyEntry
+	if err := json.Unmarshal([]byte(propertiesJSON), &obj); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal properties JSON object: %w", err)
+	}
+
+	properties := make([]Property, 0, len(obj))
+	for name, entry := range obj {
+		property := Property{
+			name:     name,
+			value:    entry.Value,
+			isSecret: entry.IsSecret,
+		}
+		properties = append(properties, property)
+	}
+
+	return properties, nil
+}
+
 // ToProperty converts PropertyDTO to Property.
 func (dto *PropertyDTO) ToProperty() (*Property, error) {
 	return NewProperty(dto.Name, dto.Value, dto.IsSecret)

--- a/backend/internal/system/cmodels/property_test.go
+++ b/backend/internal/system/cmodels/property_test.go
@@ -1,0 +1,131 @@
+package cmodels
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PropertyTestSuite struct {
+	suite.Suite
+}
+
+func TestPropertyTestSuite(t *testing.T) {
+	suite.Run(t, new(PropertyTestSuite))
+}
+
+func (s *PropertyTestSuite) TestSerializePropertiesToJSONObject_EmptySlice() {
+	result, err := SerializePropertiesToJSONObject([]Property{})
+	s.NoError(err)
+	s.Equal("", result)
+}
+
+func (s *PropertyTestSuite) TestSerializePropertiesToJSONObject_NilSlice() {
+	result, err := SerializePropertiesToJSONObject(nil)
+	s.NoError(err)
+	s.Equal("", result)
+}
+
+func (s *PropertyTestSuite) TestSerializePropertiesToJSONObject_MultipleProperties() {
+	props := []Property{
+		{name: "client_id", value: "my-client", isSecret: false},
+		{name: "api_key", value: "secret-val", isSecret: true},
+	}
+
+	result, err := SerializePropertiesToJSONObject(props)
+	s.Require().NoError(err)
+	s.NotEmpty(result)
+
+	deserialized, err := DeserializePropertiesFromJSONObject(result)
+	s.Require().NoError(err)
+	s.Len(deserialized, 2)
+
+	byName := make(map[string]Property, len(deserialized))
+	for _, p := range deserialized {
+		byName[p.name] = p
+	}
+
+	clientProp := byName["client_id"]
+	s.Equal("my-client", clientProp.value)
+	s.False(clientProp.isSecret)
+
+	apiKeyProp := byName["api_key"]
+	s.Equal("secret-val", apiKeyProp.value)
+	s.True(apiKeyProp.isSecret)
+}
+
+func (s *PropertyTestSuite) TestSerializePropertiesToJSONObject_PreservesIsSecretFlag() {
+	props := []Property{
+		{name: "secret_prop", value: "hidden", isSecret: true},
+		{name: "plain_prop", value: "visible", isSecret: false},
+	}
+
+	result, err := SerializePropertiesToJSONObject(props)
+	s.Require().NoError(err)
+
+	deserialized, err := DeserializePropertiesFromJSONObject(result)
+	s.Require().NoError(err)
+
+	byName := make(map[string]Property, len(deserialized))
+	for _, p := range deserialized {
+		byName[p.name] = p
+	}
+
+	s.True(byName["secret_prop"].isSecret)
+	s.False(byName["plain_prop"].isSecret)
+}
+
+func (s *PropertyTestSuite) TestDeserializePropertiesFromJSONObject_EmptyString() {
+	result, err := DeserializePropertiesFromJSONObject("")
+	s.NoError(err)
+	s.Empty(result)
+}
+
+func (s *PropertyTestSuite) TestDeserializePropertiesFromJSONObject_ValidJSON() {
+	jsonStr := `{"client_id":{"value":"my-client","isSecret":false},"token":{"value":"abc","isSecret":true}}`
+
+	result, err := DeserializePropertiesFromJSONObject(jsonStr)
+	s.Require().NoError(err)
+	s.Len(result, 2)
+
+	sort.Slice(result, func(i, j int) bool { return result[i].name < result[j].name })
+
+	s.Equal("client_id", result[0].name)
+	s.Equal("my-client", result[0].value)
+	s.False(result[0].isSecret)
+
+	s.Equal("token", result[1].name)
+	s.Equal("abc", result[1].value)
+	s.True(result[1].isSecret)
+}
+
+func (s *PropertyTestSuite) TestDeserializePropertiesFromJSONObject_InvalidJSON() {
+	result, err := DeserializePropertiesFromJSONObject("{invalid")
+	s.Error(err)
+	s.Nil(result)
+}
+
+func (s *PropertyTestSuite) TestSerializeDeserializePropertiesFromJSONObject_Roundtrip() {
+	original := []Property{
+		{name: "key1", value: "val1", isSecret: false},
+		{name: "key2", value: "val2", isSecret: true},
+		{name: "key3", value: "val3", isSecret: false},
+	}
+
+	serialized, err := SerializePropertiesToJSONObject(original)
+	s.Require().NoError(err)
+
+	deserialized, err := DeserializePropertiesFromJSONObject(serialized)
+	s.Require().NoError(err)
+	s.Len(deserialized, len(original))
+
+	sort.Slice(original, func(i, j int) bool { return original[i].name < original[j].name })
+	sort.Slice(deserialized, func(i, j int) bool { return deserialized[i].name < deserialized[j].name })
+
+	for i := range original {
+		s.Equal(original[i].name, deserialized[i].name)
+		s.Equal(original[i].value, deserialized[i].value)
+		s.Equal(original[i].isSecret, deserialized[i].isSecret)
+	}
+}

--- a/backend/tests/mocks/idp/idpmock/IDPServiceInterface_mock.go
+++ b/backend/tests/mocks/idp/idpmock/IDPServiceInterface_mock.go
@@ -238,76 +238,6 @@ func (_c *IDPServiceInterfaceMock_GetIdentityProvider_Call) RunAndReturn(run fun
 	return _c
 }
 
-// GetIdentityProviderByIssuer provides a mock function for the type IDPServiceInterfaceMock
-func (_mock *IDPServiceInterfaceMock) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*idp.IDPDTO, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, issuer)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetIdentityProviderByIssuer")
-	}
-
-	var r0 *idp.IDPDTO
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*idp.IDPDTO, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, issuer)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *idp.IDPDTO); ok {
-		r0 = returnFunc(ctx, issuer)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*idp.IDPDTO)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, issuer)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProviderByIssuer'
-type IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call struct {
-	*mock.Call
-}
-
-// GetIdentityProviderByIssuer is a helper method to define mock.On call
-//   - ctx context.Context
-//   - issuer string
-func (_e *IDPServiceInterfaceMock_Expecter) GetIdentityProviderByIssuer(ctx interface{}, issuer interface{}) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
-	return &IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call{Call: _e.mock.On("GetIdentityProviderByIssuer", ctx, issuer)}
-}
-
-func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) Run(run func(ctx context.Context, issuer string)) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) Return(iDPDTO *idp.IDPDTO, serviceError *serviceerror.ServiceError) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Return(iDPDTO, serviceError)
-	return _c
-}
-
-func (_c *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call) RunAndReturn(run func(ctx context.Context, issuer string) (*idp.IDPDTO, *serviceerror.ServiceError)) *IDPServiceInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetIdentityProviderByName provides a mock function for the type IDPServiceInterfaceMock
 func (_mock *IDPServiceInterfaceMock) GetIdentityProviderByName(ctx context.Context, idpName string) (*idp.IDPDTO, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, idpName)
@@ -438,6 +368,82 @@ func (_c *IDPServiceInterfaceMock_GetIdentityProviderList_Call) Return(basicIDPD
 }
 
 func (_c *IDPServiceInterfaceMock_GetIdentityProviderList_Call) RunAndReturn(run func(ctx context.Context) ([]idp.BasicIDPDTO, *serviceerror.ServiceError)) *IDPServiceInterfaceMock_GetIdentityProviderList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetIdentityProvidersByProperty provides a mock function for the type IDPServiceInterfaceMock
+func (_mock *IDPServiceInterfaceMock) GetIdentityProvidersByProperty(ctx context.Context, propertyKey string, propertyValue string) ([]idp.IDPDTO, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, propertyKey, propertyValue)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentityProvidersByProperty")
+	}
+
+	var r0 []idp.IDPDTO
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]idp.IDPDTO, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, propertyKey, propertyValue)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []idp.IDPDTO); ok {
+		r0 = returnFunc(ctx, propertyKey, propertyValue)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]idp.IDPDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, propertyKey, propertyValue)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProvidersByProperty'
+type IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call struct {
+	*mock.Call
+}
+
+// GetIdentityProvidersByProperty is a helper method to define mock.On call
+//   - ctx context.Context
+//   - propertyKey string
+//   - propertyValue string
+func (_e *IDPServiceInterfaceMock_Expecter) GetIdentityProvidersByProperty(ctx interface{}, propertyKey interface{}, propertyValue interface{}) *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call {
+	return &IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call{Call: _e.mock.On("GetIdentityProvidersByProperty", ctx, propertyKey, propertyValue)}
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call) Run(run func(ctx context.Context, propertyKey string, propertyValue string)) *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call) Return(iDPDTOs []idp.IDPDTO, serviceError *serviceerror.ServiceError) *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call {
+	_c.Call.Return(iDPDTOs, serviceError)
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call) RunAndReturn(run func(ctx context.Context, propertyKey string, propertyValue string) ([]idp.IDPDTO, *serviceerror.ServiceError)) *IDPServiceInterfaceMock_GetIdentityProvidersByProperty_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/idp/idpmock/idpStoreInterface_mock.go
+++ b/backend/tests/mocks/idp/idpmock/idpStoreInterface_mock.go
@@ -220,74 +220,6 @@ func (_c *idpStoreInterfaceMock_GetIdentityProvider_Call) RunAndReturn(run func(
 	return _c
 }
 
-// GetIdentityProviderByIssuer provides a mock function for the type idpStoreInterfaceMock
-func (_mock *idpStoreInterfaceMock) GetIdentityProviderByIssuer(ctx context.Context, issuer string) (*idp.IDPDTO, error) {
-	ret := _mock.Called(ctx, issuer)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetIdentityProviderByIssuer")
-	}
-
-	var r0 *idp.IDPDTO
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*idp.IDPDTO, error)); ok {
-		return returnFunc(ctx, issuer)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *idp.IDPDTO); ok {
-		r0 = returnFunc(ctx, issuer)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*idp.IDPDTO)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, issuer)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProviderByIssuer'
-type idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call struct {
-	*mock.Call
-}
-
-// GetIdentityProviderByIssuer is a helper method to define mock.On call
-//   - ctx context.Context
-//   - issuer string
-func (_e *idpStoreInterfaceMock_Expecter) GetIdentityProviderByIssuer(ctx interface{}, issuer interface{}) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
-	return &idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call{Call: _e.mock.On("GetIdentityProviderByIssuer", ctx, issuer)}
-}
-
-func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) Run(run func(ctx context.Context, issuer string)) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) Return(iDPDTO *idp.IDPDTO, err error) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Return(iDPDTO, err)
-	return _c
-}
-
-func (_c *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call) RunAndReturn(run func(ctx context.Context, issuer string) (*idp.IDPDTO, error)) *idpStoreInterfaceMock_GetIdentityProviderByIssuer_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetIdentityProviderByName provides a mock function for the type idpStoreInterfaceMock
 func (_mock *idpStoreInterfaceMock) GetIdentityProviderByName(ctx context.Context, idpName string) (*idp.IDPDTO, error) {
 	ret := _mock.Called(ctx, idpName)
@@ -474,6 +406,80 @@ func (_c *idpStoreInterfaceMock_GetIdentityProviderListCount_Call) Return(n int,
 }
 
 func (_c *idpStoreInterfaceMock_GetIdentityProviderListCount_Call) RunAndReturn(run func(ctx context.Context) (int, error)) *idpStoreInterfaceMock_GetIdentityProviderListCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetIdentityProvidersByProperty provides a mock function for the type idpStoreInterfaceMock
+func (_mock *idpStoreInterfaceMock) GetIdentityProvidersByProperty(ctx context.Context, propertyKey string, propertyValue string) ([]idp.IDPDTO, error) {
+	ret := _mock.Called(ctx, propertyKey, propertyValue)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIdentityProvidersByProperty")
+	}
+
+	var r0 []idp.IDPDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]idp.IDPDTO, error)); ok {
+		return returnFunc(ctx, propertyKey, propertyValue)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []idp.IDPDTO); ok {
+		r0 = returnFunc(ctx, propertyKey, propertyValue)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]idp.IDPDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, propertyKey, propertyValue)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIdentityProvidersByProperty'
+type idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call struct {
+	*mock.Call
+}
+
+// GetIdentityProvidersByProperty is a helper method to define mock.On call
+//   - ctx context.Context
+//   - propertyKey string
+//   - propertyValue string
+func (_e *idpStoreInterfaceMock_Expecter) GetIdentityProvidersByProperty(ctx interface{}, propertyKey interface{}, propertyValue interface{}) *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call {
+	return &idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call{Call: _e.mock.On("GetIdentityProvidersByProperty", ctx, propertyKey, propertyValue)}
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call) Run(run func(ctx context.Context, propertyKey string, propertyValue string)) *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call) Return(iDPDTOs []idp.IDPDTO, err error) *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call {
+	_c.Call.Return(iDPDTOs, err)
+	return _c
+}
+
+func (_c *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call) RunAndReturn(run func(ctx context.Context, propertyKey string, propertyValue string) ([]idp.IDPDTO, error)) *idpStoreInterfaceMock_GetIdentityProvidersByProperty_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose

Migrate the IDP table's `PROPERTIES` column from a JSON array of `[{name, value, isSecret}]` objects to a JSON object keyed by property name with `{value, isSecret}` metadata. This enables clean expression-based indexing and a generic property lookup method.

**Before (JSON array):**
```json
[{"name":"issuer","value":"https://accounts.google.com","isSecret":false}]
```

**After (JSON object):**
```json
{"issuer":{"value":"https://accounts.google.com","isSecret":false}}
```

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
- IDP `PROPERTIES` DB column format changed from JSON array to JSON object. **Existing data requires migration**.

#### 💥 Impact
- Existing IDP rows in the database need a one-time data migration (array → object format).

#### 🔄 Migration Guide
- Run the DB schema migration to replace the GIN index with the expression index.

---

### Approach

1. **New serialization** — Added `SerializePropertiesToJSONObject` / `DeserializePropertiesFromJSONObject` in `cmodels/property.go`. Existing array functions retained for NOTIFICATION_SENDER (separate migration in #2750).
2. **DB index** — Replaced the broad `GIN jsonb_path_ops` index with a targeted expression index on `PROPERTIES->'issuer'->>'value'` (Postgres) / `json_extract(PROPERTIES, '$.issuer.value')` (SQLite).
3. **Generic property lookup** — `GetIdentityProvidersByProperty(key, value)` works across all store layers (DB, file-based, composite, cache-backed). Returns `[]IDPDTO` to support multi-result lookups.
4. **Cache** — Replaced single-IDP `idpByIssuerCache` with list-based `idpByPropertyCache` keyed by `propertyKey:propertyValue`. Lazily populated on reads; invalidated per-property on writes.
5. **Caller update** — Token validator's `resolveExternalIssuer` updated to use the generic method.

### Related Issues
- Fixes #2623

### Related PRs
- #2546 (original token exchange PR that added the GIN index)
- #2750 (follow-up: NOTIFICATION_SENDER migration)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query identity providers by arbitrary property key/value pairs; returns multiple matches.

* **Refactor**
  * Replaced issuer-specific single-lookups with property-based multi-lookup across stores and service layers.

* **Performance**
  * Added expression indexes to speed property-based lookups.
  * Cache updated to support property-based queries and cache “not found” results.

* **Tests**
  * Replaced issuer-based tests with property-based tests across service, store, cache, composite, file, and token validation suites.

* **Data**
  * IDP properties now persist as an object-shaped JSON format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->