### PR TITLE
Fix release builder to pick latest Node.js version

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -396,6 +396,17 @@ jobs:
           show-cert-info: 'true'
           product-name: ${{ env.PRODUCT_NAME }}
 
+      - name: ⚙️ Set up Node.js for Frontend Build
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager: 'npm'
+
+      - name: 📦 Install pnpm for Frontend Build
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          run_install: false
+
       - name: 🔨 Build Release Artifacts
         uses: ./.github/actions/build-multiplatform
 
@@ -644,13 +655,13 @@ jobs:
 
           # Update the react-sdk sample app package.json
           cd samples/apps/react-sdk-sample
-          pnpm version $NEXT_VERSION --no-git-tag-version --allow-same-version
+          pnpm version $NEXT_VERSION --no-git-tag-version --allow-same-version --no-git-checks
 
           cd "$GITHUB_WORKSPACE"
 
           # Update the react-api-based sample app package.json
           cd samples/apps/react-api-based-sample
-          pnpm version $NEXT_VERSION --no-git-tag-version --allow-same-version
+          pnpm version $NEXT_VERSION --no-git-tag-version --allow-same-version --no-git-checks
 
           cd "$GITHUB_WORKSPACE"
           echo "✅ Updated sample apps version to $NEXT_VERSION"

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -400,7 +400,8 @@ jobs:
         uses: ./.github/actions/setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager: 'npm'
+          package-manager: 'pnpm'
+          dependency-path: '.'
 
       - name: 📦 Install pnpm for Frontend Build
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0

--- a/.github/workflows/windows-build-validation.yml
+++ b/.github/workflows/windows-build-validation.yml
@@ -154,7 +154,12 @@ jobs:
       - name: ⚙️ Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 'lts/*'
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: 📦 Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          run_install: false
 
       - name: 🧩 Build and Package Sample Apps
         shell: pwsh
@@ -237,7 +242,7 @@ jobs:
       - name: ⚙️ Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 'lts/*'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: 📥 Download Built Distribution
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
This pull request updates the release builder GitHub Actions workflow to improve the frontend build setup. The main changes focus on explicitly configuring the Node.js environment and package manager before building release artifacts.

**Frontend build environment setup:**

* Added a step to set up Node.js using the custom `setup-node` action, ensuring the correct Node.js version and specifying `npm` as the package manager.
* Added a step to install `pnpm` using the `pnpm/action-setup` action, preparing the environment for projects that require `pnpm` for frontend builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow: added explicit frontend Node.js setup and pnpm installation step for builds.
  * Updated package versioning commands to skip Git checks during sample app version bumps.
  * Standardized Windows CI to use the centralized Node.js version configuration across build and test jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2753)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->