### PR TITLE
Fix release build failure and update sample app version step

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -656,13 +656,13 @@ jobs:
 
           # Update the react-sdk sample app package.json
           cd samples/apps/react-sdk-sample
-          pnpm version $NEXT_VERSION --no-git-tag-version --allow-same-version
+          pnpm version $NEXT_VERSION --no-git-tag-version --no-git-checks --allow-same-version
 
           cd "$GITHUB_WORKSPACE"
 
           # Update the react-api-based sample app package.json
           cd samples/apps/react-api-based-sample
-          pnpm version $NEXT_VERSION --no-git-tag-version --allow-same-version
+          pnpm version $NEXT_VERSION --no-git-tag-version --no-git-checks --allow-same-version
 
           cd "$GITHUB_WORKSPACE"
           echo "✅ Updated sample apps version to $NEXT_VERSION"

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -396,6 +396,18 @@ jobs:
           show-cert-info: 'true'
           product-name: ${{ env.PRODUCT_NAME }}
 
+      - name: ⚙️ Set up Node.js for Frontend Build
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager: 'npm'
+          dependency-path: 'samples/apps/react-vanilla-sample'
+
+      - name: 📦 Install pnpm for Frontend Build
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          run_install: false
+
       - name: 🔨 Build Release Artifacts
         uses: ./.github/actions/build-multiplatform
 


### PR DESCRIPTION
This pull request updates the release workflow to improve the frontend build setup and ensure smoother versioning of sample apps. The main changes focus on setting up the correct Node.js environment, installing the required package manager, and making the versioning process more robust.

**Frontend build environment improvements:**

* Added a step to set up Node.js using the custom `setup-node` GitHub Action, specifying the Node.js version, package manager (`npm`), and dependency path for the `react-vanilla-sample` app.
* Added a step to install `pnpm` using the `pnpm/action-setup` action before building frontend artifacts, ensuring the correct package manager is available.

**Sample app versioning enhancements:**

* Updated the `pnpm version` commands for `react-sdk-sample` and `react-api-based-sample` apps to include the `--no-git-checks` flag, preventing Git-related errors during version bumps in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release build workflow to include explicit frontend build tooling setup with Node.js and pnpm configuration
  * Modified version bump commands for sample applications to include additional flags for improved release processing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2760)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->