### PR TITLE
Resolve declarative role permissions for API-added assignments

### DIFF
--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -20,6 +20,8 @@ package role
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
@@ -330,13 +332,29 @@ func (c *compositeRoleStore) CheckRoleNameExistsExcludingID(
 	)
 }
 
-// GetAuthorizedPermissions retrieves authorized permissions from both stores.
+// GetAuthorizedPermissions retrieves authorized permissions assembled from three sources:
+//
+//  1. dbStore — DB-managed roles, where both ROLE_PERMISSION and ROLE_ASSIGNMENT rows exist.
+//     The single SQL INNER JOIN resolves these.
+//  2. fileStore (static) — declarative roles whose YAML carries an explicit `assignments:`
+//     list for the entity/group. Returned by fileStore.GetAuthorizedPermissions.
+//  3. Cross-store (file/db) — declarative roles whose definition lives in the file store
+//     but whose assignment was added at runtime via the role assignments API and therefore
+//     lives in the DB. Neither store can answer this alone: dbStore drops the row in its
+//     INNER JOIN against the (absent) ROLE_PERMISSION rows, and fileStore's matching only
+//     consults the YAML-declared assignments. The composite resolves it by reading the
+//     DB-stored role IDs for the entity, looking each role up in the file store, and
+//     intersecting its permissions with the requested set.
 func (c *compositeRoleStore) GetAuthorizedPermissions(
 	ctx context.Context,
 	entityID string,
 	groupIDs []string,
 	requestPermissions []string,
 ) ([]string, error) {
+	if len(requestPermissions) == 0 {
+		return []string{}, nil
+	}
+
 	dbPerms, err := c.dbStore.GetAuthorizedPermissions(ctx, entityID, groupIDs, requestPermissions)
 	if err != nil {
 		return nil, err
@@ -347,8 +365,91 @@ func (c *compositeRoleStore) GetAuthorizedPermissions(
 		return nil, err
 	}
 
-	// Merge permissions from both stores and deduplicate
-	return mergePermissions(dbPerms, filePerms), nil
+	crossStorePerms, err := c.crossStoreAuthorizedPermissions(ctx, entityID, groupIDs, requestPermissions)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergePermissions(mergePermissions(dbPerms, filePerms), crossStorePerms), nil
+}
+
+// crossStoreAuthorizedPermissions resolves permissions for the (declarative role definition
+// in file store) + (runtime assignment row in DB) case. It is intentionally narrow: it skips
+// any role ID that does not exist in the file store, because such roles are entirely DB-backed
+// and were already covered by dbStore.GetAuthorizedPermissions.
+func (c *compositeRoleStore) crossStoreAuthorizedPermissions(
+	ctx context.Context,
+	entityID string,
+	groupIDs []string,
+	requestPermissions []string,
+) ([]string, error) {
+	if entityID == "" && len(groupIDs) == 0 {
+		return []string{}, nil
+	}
+
+	roleIDs, err := c.dbStore.GetEntityRoleIDs(ctx, entityID, groupIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(roleIDs) == 0 {
+		return []string{}, nil
+	}
+
+	requestedSet := make(map[string]bool, len(requestPermissions))
+	for _, p := range requestPermissions {
+		requestedSet[p] = true
+	}
+
+	granted := make(map[string]bool)
+	for _, id := range roleIDs {
+		exists, err := c.fileStore.IsRoleExist(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			// Role is DB-only; permissions already covered by dbStore.GetAuthorizedPermissions.
+			continue
+		}
+		role, err := c.fileStore.GetRole(ctx, id)
+		if err != nil {
+			// Benign cases — skip silently:
+			//   * ErrRoleNotFound: YAML was removed between assignment-time and lookup-time.
+			//   * ErrRoleDataCorrupted: parse/type-assertion failure, already logged by fileStore.
+			// Anything else is an actionable storage/IO error and must not be dropped:
+			// authorization decisions made on a silently-empty permission set could
+			// over- or under-authorize, so propagate with context.
+			if errors.Is(err, ErrRoleNotFound) || errors.Is(err, ErrRoleDataCorrupted) {
+				continue
+			}
+			log.GetLogger().Error("Failed to load declarative role for cross-store permission resolution",
+				log.String("roleID", id), log.Error(err))
+			return nil, fmt.Errorf("composite role store: load declarative role %q: %w", id, err)
+		}
+		for _, rp := range role.Permissions {
+			for _, perm := range rp.Permissions {
+				if requestedSet[perm] {
+					granted[perm] = true
+				}
+			}
+		}
+	}
+
+	result := make([]string, 0, len(granted))
+	for _, perm := range requestPermissions {
+		if granted[perm] {
+			result = append(result, perm)
+		}
+	}
+	return result, nil
+}
+
+// GetEntityRoleIDs returns the IDs of roles assigned to an entity (directly or via groups).
+// Delegates to the database store since assignments are persisted there even for declarative
+// roles. The file store has no independent record of API-added assignments.
+func (c *compositeRoleStore) GetEntityRoleIDs(
+	ctx context.Context, entityID string, groupIDs []string,
+) ([]string, error) {
+	return c.dbStore.GetEntityRoleIDs(ctx, entityID, groupIDs)
 }
 
 // GetUserRoles retrieves role names assigned to an entity from both stores.

--- a/backend/internal/role/composite_store_edge_cases_test.go
+++ b/backend/internal/role/composite_store_edge_cases_test.go
@@ -407,6 +407,10 @@ func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_C
 	suite.mockFileStore.On(
 		"GetAuthorizedPermissions", suite.ctx, "user1", []string{"group1"}, perms,
 	).Return([]string{"perm1", "perm2"}, nil)
+	// Cross-store lookup: no DB-recorded role IDs to fold in.
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{"group1"},
+	).Return([]string{}, nil)
 
 	result, err := suite.store.GetAuthorizedPermissions(
 		suite.ctx, "user1", []string{"group1"}, perms,
@@ -429,6 +433,9 @@ func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_C
 	suite.mockFileStore.On(
 		"GetAuthorizedPermissions", suite.ctx, "user1", []string{"group1"}, perms,
 	).Return([]string{"p2", "p3"}, nil)
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{"group1"},
+	).Return([]string{}, nil)
 
 	result, err := suite.store.GetAuthorizedPermissions(
 		suite.ctx, "user1", []string{"group1"}, perms,
@@ -451,6 +458,9 @@ func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_E
 	suite.mockFileStore.On(
 		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, perms,
 	).Return([]string{}, nil)
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{},
+	).Return([]string{}, nil)
 
 	result, err := suite.store.GetAuthorizedPermissions(
 		suite.ctx, "user1", []string{}, perms,
@@ -458,6 +468,186 @@ func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_E
 
 	assert.NoError(suite.T(), err)
 	assert.Len(suite.T(), result, 0)
+}
+
+// Test GetAuthorizedPermissions resolves a declarative role whose definition lives in the
+// file store and whose assignment lives in the DB (the bug fixed by this change).
+// dbStore.GetAuthorizedPermissions returns nothing because there are no DB-side ROLE_PERMISSION
+// rows for the declarative role; fileStore.GetAuthorizedPermissions returns nothing because the
+// YAML carries no static assignments. The composite must fold in the role's file-store
+// permissions by following the DB-recorded role ID assignment.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_DeclarativeRoleWithDynamicAssignment() {
+	perms := []string{"tenant_instance:system", "system:user:view"}
+	declarativeRoleID := "a1c00000-0000-0000-0000-000000000004"
+
+	suite.mockDBStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, perms,
+	).Return([]string{}, nil)
+	suite.mockFileStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, perms,
+	).Return([]string{}, nil)
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{},
+	).Return([]string{declarativeRoleID}, nil)
+	suite.mockFileStore.On(
+		"IsRoleExist", suite.ctx, declarativeRoleID,
+	).Return(true, nil)
+	suite.mockFileStore.On(
+		"GetRole", suite.ctx, declarativeRoleID,
+	).Return(RoleWithPermissions{
+		ID: declarativeRoleID, Name: "TenantInstanceAdmin",
+		Permissions: []ResourcePermissions{
+			{ResourceServerID: "rs", Permissions: []string{"tenant_instance:system"}},
+		},
+	}, nil)
+
+	result, err := suite.store.GetAuthorizedPermissions(
+		suite.ctx, "user1", []string{}, perms,
+	)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"tenant_instance:system"}, result)
+}
+
+// Test that the cross-store lookup ignores role IDs that exist only in the DB. Those
+// roles' permissions are already covered by dbStore.GetAuthorizedPermissions, and looking
+// them up in the file store would be wasted work.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_DBRoleNotDoubleResolved() {
+	perms := []string{"perm1"}
+	dbOnlyRoleID := "db-role-only"
+
+	suite.mockDBStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, perms,
+	).Return([]string{"perm1"}, nil)
+	suite.mockFileStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, perms,
+	).Return([]string{}, nil)
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{},
+	).Return([]string{dbOnlyRoleID}, nil)
+	suite.mockFileStore.On(
+		"IsRoleExist", suite.ctx, dbOnlyRoleID,
+	).Return(false, nil)
+	// fileStore.GetRole MUST NOT be called for DB-only roles.
+
+	result, err := suite.store.GetAuthorizedPermissions(
+		suite.ctx, "user1", []string{}, perms,
+	)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"perm1"}, result)
+	suite.mockFileStore.AssertNotCalled(suite.T(), "GetRole", mock.Anything, dbOnlyRoleID)
+}
+
+// Test that an unexpected storage error from fileStore.GetRole in the cross-store path is
+// propagated (wrapped) rather than silently swallowed. Silently dropping a real I/O error
+// here would yield an empty permission set and could lead to under-authorization decisions.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_CrossStorePropagatesGetRoleError() {
+	requested := []string{"perm1"}
+	roleID := "declarative-role"
+	storageErr := errors.New("disk read failure")
+
+	suite.mockDBStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return([]string{}, nil)
+	suite.mockFileStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return([]string{}, nil)
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{},
+	).Return([]string{roleID}, nil)
+	suite.mockFileStore.On(
+		"IsRoleExist", suite.ctx, roleID,
+	).Return(true, nil)
+	suite.mockFileStore.On(
+		"GetRole", suite.ctx, roleID,
+	).Return(RoleWithPermissions{}, storageErr)
+
+	result, err := suite.store.GetAuthorizedPermissions(suite.ctx, "user1", []string{}, requested)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.ErrorIs(suite.T(), err, storageErr, "underlying storage error must be wrapped, not dropped")
+}
+
+// Test that benign GetRole errors from fileStore are silently skipped:
+//   - ErrRoleNotFound: YAML removed between assignment-time and lookup-time (race).
+//   - ErrRoleDataCorrupted: parse/type-assertion failure already logged by fileStore.
+//
+// Both cases must not bubble up; the cross-store path treats the role as absent and
+// returns an empty result without error.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_CrossStoreSkipsBenignGetRoleErrors() {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"ErrRoleNotFound", ErrRoleNotFound},
+		{"ErrRoleDataCorrupted", ErrRoleDataCorrupted},
+	}
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest() // fresh mocks per subtest
+			requested := []string{"perm1"}
+			roleID := "role-" + tc.name
+
+			suite.mockDBStore.On(
+				"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+			).Return([]string{}, nil)
+			suite.mockFileStore.On(
+				"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+			).Return([]string{}, nil)
+			suite.mockDBStore.On(
+				"GetEntityRoleIDs", suite.ctx, "user1", []string{},
+			).Return([]string{roleID}, nil)
+			suite.mockFileStore.On(
+				"IsRoleExist", suite.ctx, roleID,
+			).Return(true, nil)
+			suite.mockFileStore.On(
+				"GetRole", suite.ctx, roleID,
+			).Return(RoleWithPermissions{}, tc.err)
+
+			result, err := suite.store.GetAuthorizedPermissions(
+				suite.ctx, "user1", []string{}, requested,
+			)
+
+			assert.NoError(suite.T(), err)
+			assert.Empty(suite.T(), result)
+		})
+	}
+}
+
+// Test that the cross-store lookup respects requestPermissions narrowing: permissions on
+// the role that aren't in the request are silently dropped.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_CrossStoreRespectsRequestedSet() {
+	requested := []string{"tenant_instance:system"}
+	roleID := "declarative-role"
+
+	suite.mockDBStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return([]string{}, nil)
+	suite.mockFileStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return([]string{}, nil)
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{},
+	).Return([]string{roleID}, nil)
+	suite.mockFileStore.On(
+		"IsRoleExist", suite.ctx, roleID,
+	).Return(true, nil)
+	suite.mockFileStore.On(
+		"GetRole", suite.ctx, roleID,
+	).Return(RoleWithPermissions{
+		ID: roleID,
+		Permissions: []ResourcePermissions{{
+			ResourceServerID: "rs",
+			Permissions:      []string{"tenant_instance:system", "system:user:view", "something_else"},
+		}},
+	}, nil)
+
+	result, err := suite.store.GetAuthorizedPermissions(suite.ctx, "user1", []string{}, requested)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"tenant_instance:system"}, result)
 }
 
 // Test DB precedence in deduplication
@@ -504,4 +694,155 @@ func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetRoleList_PropagatesFile
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
 	assert.Equal(suite.T(), fileErr, err)
+}
+
+// Test GetEntityRoleIDs delegates directly to the DB store; the file store is never
+// consulted (assignments are never persisted in YAML).
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetEntityRoleIDs_DelegatesToDB() {
+	expected := []string{"role-a", "role-b"}
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{"group1"},
+	).Return(expected, nil)
+
+	result, err := suite.store.GetEntityRoleIDs(suite.ctx, "user1", []string{"group1"})
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), expected, result)
+	suite.mockFileStore.AssertNotCalled(suite.T(), "GetEntityRoleIDs", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// Test GetEntityRoleIDs propagates DB errors.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetEntityRoleIDs_PropagatesDBError() {
+	dbErr := errors.New("db error")
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{},
+	).Return(nil, dbErr)
+
+	result, err := suite.store.GetEntityRoleIDs(suite.ctx, "user1", []string{})
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), dbErr, err)
+}
+
+// Test that GetAuthorizedPermissions short-circuits when no permissions are requested.
+// Without this, every downstream store would be queried even though the result is
+// guaranteed to be empty.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_EmptyRequestedShortCircuits() {
+	result, err := suite.store.GetAuthorizedPermissions(suite.ctx, "user1", []string{"group1"}, []string{})
+
+	assert.NoError(suite.T(), err)
+	assert.Empty(suite.T(), result)
+	// Neither store should have been called.
+	suite.mockDBStore.AssertNotCalled(
+		suite.T(), "GetAuthorizedPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	)
+	suite.mockFileStore.AssertNotCalled(
+		suite.T(), "GetAuthorizedPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	)
+	suite.mockDBStore.AssertNotCalled(
+		suite.T(), "GetEntityRoleIDs", mock.Anything, mock.Anything, mock.Anything,
+	)
+}
+
+// Test GetAuthorizedPermissions propagates a DB store error from the first call.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_PropagatesDBStoreError() {
+	dbErr := errors.New("db unreachable")
+	requested := []string{"perm1"}
+	suite.mockDBStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return(nil, dbErr)
+
+	result, err := suite.store.GetAuthorizedPermissions(suite.ctx, "user1", []string{}, requested)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), dbErr, err)
+}
+
+// Test GetAuthorizedPermissions propagates a file store error from the second call.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_PropagatesFileStoreError() {
+	fileErr := errors.New("file read failure")
+	requested := []string{"perm1"}
+	suite.mockDBStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return([]string{}, nil)
+	suite.mockFileStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return(nil, fileErr)
+
+	result, err := suite.store.GetAuthorizedPermissions(suite.ctx, "user1", []string{}, requested)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), fileErr, err)
+}
+
+// Test the cross-store path short-circuits when neither entity nor groups are supplied.
+// The first two source paths might still return data based on store-internal logic, but
+// the cross-store path itself has nothing to look up.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_CrossStoreNoEntityNoGroups() {
+	requested := []string{"perm1"}
+	suite.mockDBStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "", []string{}, requested,
+	).Return([]string{}, nil)
+	suite.mockFileStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "", []string{}, requested,
+	).Return([]string{}, nil)
+	// Cross-store path must not call GetEntityRoleIDs when there's no assignee to look up.
+
+	result, err := suite.store.GetAuthorizedPermissions(suite.ctx, "", []string{}, requested)
+
+	assert.NoError(suite.T(), err)
+	assert.Empty(suite.T(), result)
+	suite.mockDBStore.AssertNotCalled(
+		suite.T(), "GetEntityRoleIDs", mock.Anything, mock.Anything, mock.Anything,
+	)
+}
+
+// Test cross-store path propagates GetEntityRoleIDs errors.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_CrossStoreRoleIDsErrorPropagates() {
+	requested := []string{"perm1"}
+	rolesErr := errors.New("assignment table unreachable")
+	suite.mockDBStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return([]string{}, nil)
+	suite.mockFileStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return([]string{}, nil)
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{},
+	).Return(nil, rolesErr)
+
+	result, err := suite.store.GetAuthorizedPermissions(suite.ctx, "user1", []string{}, requested)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), rolesErr, err)
+}
+
+// Test cross-store path propagates a file-store IsRoleExist error so token issuance
+// fails loudly instead of silently dropping a role.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_CrossStorePropagatesIsRoleExistError() {
+	requested := []string{"perm1"}
+	existErr := errors.New("file lookup failure")
+	roleID := "some-role"
+	suite.mockDBStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return([]string{}, nil)
+	suite.mockFileStore.On(
+		"GetAuthorizedPermissions", suite.ctx, "user1", []string{}, requested,
+	).Return([]string{}, nil)
+	suite.mockDBStore.On(
+		"GetEntityRoleIDs", suite.ctx, "user1", []string{},
+	).Return([]string{roleID}, nil)
+	suite.mockFileStore.On(
+		"IsRoleExist", suite.ctx, roleID,
+	).Return(false, existErr)
+
+	result, err := suite.store.GetAuthorizedPermissions(suite.ctx, "user1", []string{}, requested)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), existErr, err)
 }

--- a/backend/internal/role/error_constants.go
+++ b/backend/internal/role/error_constants.go
@@ -290,6 +290,12 @@ var (
 	// ErrRoleNotFound is returned when the role is not found in the system.
 	ErrRoleNotFound = errors.New("role not found")
 
+	// ErrRoleDataCorrupted is returned by the file-based store when a stored entry cannot
+	// be converted into a role (type assertion / parse failure). Exposed as a sentinel so
+	// callers can use errors.Is to skip these benign cases without conflating them with
+	// actionable I/O errors. The originating site already logs the underlying details.
+	ErrRoleDataCorrupted = errors.New("role data corrupted")
+
 	// errResultLimitExceededInCompositeMode is the internal sentinel error for composite mode limit exceeded.
 	errResultLimitExceededInCompositeMode = errors.New("result limit exceeded in composite mode")
 )

--- a/backend/internal/role/file_based_store.go
+++ b/backend/internal/role/file_based_store.go
@@ -44,7 +44,7 @@ func newFileBasedStore() (roleStoreInterface, transaction.Transactioner) {
 func (f *fileBasedStore) Create(id string, data interface{}) error {
 	role, ok := data.(*RoleWithPermissionsAndAssignments)
 	if !ok {
-		return errors.New("role data corrupted")
+		return ErrRoleDataCorrupted
 	}
 	if role.ID == "" {
 		role.ID = id
@@ -416,6 +416,16 @@ func (f *fileBasedStore) GetUserRoles(
 	return roleNames, nil
 }
 
+// GetEntityRoleIDs is a no-op for the file-based store. Role assignments are persisted in the
+// database store and queried from there by the composite store; the file store has no
+// independent record of API-added assignments. Returning an empty slice keeps the composite
+// merge correct (callers union the result with the DB store's output).
+func (f *fileBasedStore) GetEntityRoleIDs(
+	ctx context.Context, entityID string, groupIDs []string,
+) ([]string, error) {
+	return []string{}, nil
+}
+
 // IsRoleDeclarative returns true for roles in the file-based store because they are declarative.
 func (f *fileBasedStore) IsRoleDeclarative(ctx context.Context, roleID string) (bool, error) {
 	exists, err := f.IsRoleExist(ctx, roleID)
@@ -430,7 +440,7 @@ func roleFromDeclarativeData(id string, data interface{}) (RoleWithPermissionsAn
 	role, ok := data.(*RoleWithPermissionsAndAssignments)
 	if !ok || role == nil {
 		declarativeresource.LogTypeAssertionError("role", id)
-		return RoleWithPermissionsAndAssignments{}, errors.New("role data corrupted")
+		return RoleWithPermissionsAndAssignments{}, ErrRoleDataCorrupted
 	}
 
 	return *role, nil

--- a/backend/internal/role/file_based_store_test.go
+++ b/backend/internal/role/file_based_store_test.go
@@ -310,3 +310,36 @@ func (suite *RoleFileBasedStoreTestSuite) TestCreate_SetsIDFromParameter() {
 	suite.NoError(err)
 	suite.Equal("param-role-id", retrievedRole.ID)
 }
+
+// GetEntityRoleIDs on the file-based store is a deliberate no-op: API-added role
+// assignments are persisted in the DB, never in YAML, so the file store has no record
+// to surface. Composite callers rely on this returning an empty (non-nil) slice so
+// the union of (db, file) sources stays correct.
+func (suite *RoleFileBasedStoreTestSuite) TestGetEntityRoleIDs_AlwaysEmpty() {
+	suite.seedRole(RoleWithPermissionsAndAssignments{
+		ID: "r1", Name: "R1", OUID: "ou1",
+		Assignments: []RoleAssignment{
+			{ID: "user-x", Type: assigneeTypeEntity},
+			{ID: "group-y", Type: AssigneeTypeGroup},
+		},
+	})
+
+	cases := []struct {
+		name     string
+		entityID string
+		groupIDs []string
+	}{
+		{"populated entity matches YAML", "user-x", []string{"group-y"}},
+		{"populated entity no match", "user-z", []string{"group-z"}},
+		{"empty entity, populated groups", "", []string{"group-y"}},
+		{"empty both", "", nil},
+	}
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			roleIDs, err := suite.store.GetEntityRoleIDs(context.Background(), tc.entityID, tc.groupIDs)
+			suite.NoError(err)
+			suite.Empty(roleIDs)
+			suite.NotNil(roleIDs, "must return [] not nil for safe composite union")
+		})
+	}
+}

--- a/backend/internal/role/roleStoreInterface_mock_test.go
+++ b/backend/internal/role/roleStoreInterface_mock_test.go
@@ -507,6 +507,80 @@ func (_c *roleStoreInterfaceMock_GetAuthorizedPermissions_Call) RunAndReturn(run
 	return _c
 }
 
+// GetEntityRoleIDs provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) GetEntityRoleIDs(ctx context.Context, entityID string, groupIDs []string) ([]string, error) {
+	ret := _mock.Called(ctx, entityID, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEntityRoleIDs")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) ([]string, error)); ok {
+		return returnFunc(ctx, entityID, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) []string); ok {
+		r0 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string) error); ok {
+		r1 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_GetEntityRoleIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityRoleIDs'
+type roleStoreInterfaceMock_GetEntityRoleIDs_Call struct {
+	*mock.Call
+}
+
+// GetEntityRoleIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - entityID string
+//   - groupIDs []string
+func (_e *roleStoreInterfaceMock_Expecter) GetEntityRoleIDs(ctx interface{}, entityID interface{}, groupIDs interface{}) *roleStoreInterfaceMock_GetEntityRoleIDs_Call {
+	return &roleStoreInterfaceMock_GetEntityRoleIDs_Call{Call: _e.mock.On("GetEntityRoleIDs", ctx, entityID, groupIDs)}
+}
+
+func (_c *roleStoreInterfaceMock_GetEntityRoleIDs_Call) Run(run func(ctx context.Context, entityID string, groupIDs []string)) *roleStoreInterfaceMock_GetEntityRoleIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetEntityRoleIDs_Call) Return(strings []string, err error) *roleStoreInterfaceMock_GetEntityRoleIDs_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetEntityRoleIDs_Call) RunAndReturn(run func(ctx context.Context, entityID string, groupIDs []string) ([]string, error)) *roleStoreInterfaceMock_GetEntityRoleIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRole provides a mock function for the type roleStoreInterfaceMock
 func (_mock *roleStoreInterfaceMock) GetRole(ctx context.Context, id string) (RoleWithPermissions, error) {
 	ret := _mock.Called(ctx, id)

--- a/backend/internal/role/store.go
+++ b/backend/internal/role/store.go
@@ -55,6 +55,12 @@ type roleStoreInterface interface {
 	GetAuthorizedPermissions(
 		ctx context.Context, entityID string, groupIDs []string, requestedPermissions []string) ([]string, error)
 	GetUserRoles(ctx context.Context, entityID string, groupIDs []string) ([]string, error)
+	// GetEntityRoleIDs returns the set of role IDs assigned to the entity directly or via
+	// group membership. Unlike GetUserRoles this does not require the role to exist in the
+	// underlying store; it returns raw assignee->role bindings. Used by the composite store
+	// to resolve permissions for declarative roles whose definitions live in the file store
+	// while their assignments live in the DB.
+	GetEntityRoleIDs(ctx context.Context, entityID string, groupIDs []string) ([]string, error)
 	IsRoleDeclarative(ctx context.Context, roleID string) (bool, error)
 }
 
@@ -596,6 +602,44 @@ func (s *roleStore) GetUserRoles(
 	}
 
 	return roles, nil
+}
+
+// GetEntityRoleIDs retrieves the IDs of roles assigned to an entity directly and/or via
+// group membership, without joining the ROLE table. This surfaces assignments to roles
+// whose definitions live only in the file-based declarative store. Callers (notably the
+// composite store) use this to resolve permissions for declarative roles whose permission
+// rows are absent from the DB.
+func (s *roleStore) GetEntityRoleIDs(
+	ctx context.Context, entityID string, groupIDs []string,
+) ([]string, error) {
+	if groupIDs == nil {
+		groupIDs = []string{}
+	}
+	// Short-circuit before touching the DB when there's nothing to look up.
+	if entityID == "" && len(groupIDs) == 0 {
+		return []string{}, nil
+	}
+
+	dbClient, err := s.getConfigDBClient()
+	if err != nil {
+		return nil, err
+	}
+
+	query, args := buildEntityRoleIDsQuery(entityID, groupIDs, s.deploymentID)
+
+	results, err := dbClient.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get entity role IDs: %w", err)
+	}
+
+	roleIDs := make([]string, 0, len(results))
+	for _, row := range results {
+		if id, ok := row["role_id"].(string); ok {
+			roleIDs = append(roleIDs, id)
+		}
+	}
+
+	return roleIDs, nil
 }
 
 // IsRoleDeclarative checks if a role is defined in declarative configuration.

--- a/backend/internal/role/store_constants.go
+++ b/backend/internal/role/store_constants.go
@@ -310,3 +310,70 @@ func buildUserRolesQuery(
 
 	return query, args
 }
+
+// buildEntityRoleIDsQuery constructs a database-specific query to retrieve the IDs of roles
+// assigned to an entity directly and/or through group membership. Unlike buildUserRolesQuery
+// this does not join the ROLE table, so it returns assignments even when the role itself
+// lives only in a declarative file-based store. Used by the composite store to bridge the
+// gap between DB-stored assignments and file-stored role definitions for permission lookup.
+func buildEntityRoleIDsQuery(
+	entityID string,
+	groupIDs []string,
+	deploymentID string,
+) (dbmodel.DBQuery, []interface{}) {
+	baseQuery := `SELECT DISTINCT ra.ROLE_ID
+		FROM "ROLE_ASSIGNMENT" ra
+		WHERE ra.DEPLOYMENT_ID = $1 AND `
+
+	var postgresWhere []string
+	var sqliteWhere []string
+
+	argsCapacity := 1 + len(groupIDs)
+	if entityID != "" {
+		argsCapacity++
+	}
+	args := make([]interface{}, 0, argsCapacity)
+	args = append(args, deploymentID)
+	paramIndex := 2
+
+	if entityID != "" {
+		postgresWhere = append(postgresWhere,
+			fmt.Sprintf("(ra.ASSIGNEE_TYPE = 'entity' AND ra.ASSIGNEE_ID = $%d)", paramIndex))
+		sqliteWhere = append(sqliteWhere,
+			"(ra.ASSIGNEE_TYPE = 'entity' AND ra.ASSIGNEE_ID = ?)")
+		args = append(args, entityID)
+		paramIndex++
+	}
+
+	if len(groupIDs) > 0 {
+		groupPlaceholdersPostgres := make([]string, len(groupIDs))
+		groupPlaceholdersSqlite := make([]string, len(groupIDs))
+
+		for i, groupID := range groupIDs {
+			groupPlaceholdersPostgres[i] = fmt.Sprintf("$%d", paramIndex+i)
+			groupPlaceholdersSqlite[i] = "?"
+			args = append(args, groupID)
+		}
+
+		postgresWhere = append(postgresWhere,
+			fmt.Sprintf("(ra.ASSIGNEE_TYPE = 'group' AND ra.ASSIGNEE_ID IN (%s))",
+				strings.Join(groupPlaceholdersPostgres, ",")))
+		sqliteWhere = append(sqliteWhere,
+			fmt.Sprintf("(ra.ASSIGNEE_TYPE = 'group' AND ra.ASSIGNEE_ID IN (%s))",
+				strings.Join(groupPlaceholdersSqlite, ",")))
+	}
+
+	postgresQuery := baseQuery +
+		"(" + strings.Join(postgresWhere, " OR ") + ")"
+	sqliteQuery := baseQuery +
+		"(" + strings.Join(sqliteWhere, " OR ") + ")"
+
+	query := dbmodel.DBQuery{
+		ID:            "RLQ-ROLE_MGT-22",
+		Query:         postgresQuery,
+		PostgresQuery: postgresQuery,
+		SQLiteQuery:   sqliteQuery,
+	}
+
+	return query, args
+}

--- a/backend/internal/role/store_test.go
+++ b/backend/internal/role/store_test.go
@@ -1802,3 +1802,106 @@ func (suite *RoleStoreTestSuite) TestGetRoleAssignmentsCount_DBClientError() {
 	suite.Error(err)
 	suite.Equal(0, count)
 }
+
+// --- GetEntityRoleIDs ---
+
+func (suite *RoleStoreTestSuite) TestGetEntityRoleIDs_Success() {
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
+	suite.mockDBClient.On(
+		"QueryContext", mock.Anything, mock.Anything,
+		testDeploymentID, testUserID1, "group1",
+	).Return(
+		[]map[string]interface{}{
+			{"role_id": "role-a"},
+			{"role_id": "role-b"},
+		}, nil)
+
+	roleIDs, err := suite.store.GetEntityRoleIDs(context.Background(), testUserID1, []string{"group1"})
+
+	suite.NoError(err)
+	suite.Equal([]string{"role-a", "role-b"}, roleIDs)
+}
+
+func (suite *RoleStoreTestSuite) TestGetEntityRoleIDs_EntityOnly() {
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
+	suite.mockDBClient.On(
+		"QueryContext", mock.Anything, mock.Anything, testDeploymentID, testUserID1,
+	).Return(
+		[]map[string]interface{}{{"role_id": "role-a"}},
+		nil,
+	)
+
+	roleIDs, err := suite.store.GetEntityRoleIDs(context.Background(), testUserID1, nil)
+
+	suite.NoError(err)
+	suite.Equal([]string{"role-a"}, roleIDs)
+}
+
+func (suite *RoleStoreTestSuite) TestGetEntityRoleIDs_GroupsOnly() {
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
+	suite.mockDBClient.On(
+		"QueryContext", mock.Anything, mock.Anything, testDeploymentID, "group1", "group2",
+	).Return(
+		[]map[string]interface{}{{"role_id": "role-c"}},
+		nil,
+	)
+
+	roleIDs, err := suite.store.GetEntityRoleIDs(context.Background(), "", []string{"group1", "group2"})
+
+	suite.NoError(err)
+	suite.Equal([]string{"role-c"}, roleIDs)
+}
+
+func (suite *RoleStoreTestSuite) TestGetEntityRoleIDs_EmptyEntityAndGroups_ReturnsEmpty() {
+	// Neither entity nor groups → short-circuits without hitting the DB.
+	roleIDs, err := suite.store.GetEntityRoleIDs(context.Background(), "", nil)
+
+	suite.NoError(err)
+	suite.Empty(roleIDs)
+	suite.mockDBProvider.AssertNotCalled(suite.T(), "GetConfigDBClient")
+}
+
+func (suite *RoleStoreTestSuite) TestGetEntityRoleIDs_QueryError() {
+	queryError := errors.New("query failed")
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
+	suite.mockDBClient.On(
+		"QueryContext", mock.Anything, mock.Anything, testDeploymentID, testUserID1,
+	).Return(nil, queryError)
+
+	roleIDs, err := suite.store.GetEntityRoleIDs(context.Background(), testUserID1, nil)
+
+	suite.Error(err)
+	suite.Nil(roleIDs)
+	suite.Contains(err.Error(), "failed to get entity role IDs")
+}
+
+func (suite *RoleStoreTestSuite) TestGetEntityRoleIDs_DBClientError() {
+	dbError := errors.New("db client error")
+	suite.mockDBProvider.On("GetConfigDBClient").Return(nil, dbError)
+
+	roleIDs, err := suite.store.GetEntityRoleIDs(context.Background(), testUserID1, nil)
+
+	suite.Error(err)
+	suite.Nil(roleIDs)
+}
+
+func (suite *RoleStoreTestSuite) TestGetEntityRoleIDs_IgnoresMalformedRows() {
+	// Rows whose role_id is not a string are skipped silently — defensive, mirrors
+	// GetUserRoles' behavior for malformed column values.
+	suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil)
+	suite.mockDBClient.On(
+		"QueryContext", mock.Anything, mock.Anything, testDeploymentID, testUserID1,
+	).Return(
+		[]map[string]interface{}{
+			{"role_id": "role-a"},
+			{"role_id": 123},           // wrong type
+			{"other_column": "role-b"}, // wrong column
+			{"role_id": "role-c"},
+		}, nil,
+	)
+
+	roleIDs, err := suite.store.GetEntityRoleIDs(context.Background(), testUserID1, nil)
+
+	suite.NoError(err)
+	suite.Equal([]string{"role-a", "role-c"}, roleIDs)
+}

--- a/backend/tests/mocks/rolemock/roleStoreInterface_mock.go
+++ b/backend/tests/mocks/rolemock/roleStoreInterface_mock.go
@@ -508,6 +508,80 @@ func (_c *roleStoreInterfaceMock_GetAuthorizedPermissions_Call) RunAndReturn(run
 	return _c
 }
 
+// GetEntityRoleIDs provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) GetEntityRoleIDs(ctx context.Context, entityID string, groupIDs []string) ([]string, error) {
+	ret := _mock.Called(ctx, entityID, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEntityRoleIDs")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) ([]string, error)); ok {
+		return returnFunc(ctx, entityID, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) []string); ok {
+		r0 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string) error); ok {
+		r1 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_GetEntityRoleIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityRoleIDs'
+type roleStoreInterfaceMock_GetEntityRoleIDs_Call struct {
+	*mock.Call
+}
+
+// GetEntityRoleIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - entityID string
+//   - groupIDs []string
+func (_e *roleStoreInterfaceMock_Expecter) GetEntityRoleIDs(ctx interface{}, entityID interface{}, groupIDs interface{}) *roleStoreInterfaceMock_GetEntityRoleIDs_Call {
+	return &roleStoreInterfaceMock_GetEntityRoleIDs_Call{Call: _e.mock.On("GetEntityRoleIDs", ctx, entityID, groupIDs)}
+}
+
+func (_c *roleStoreInterfaceMock_GetEntityRoleIDs_Call) Run(run func(ctx context.Context, entityID string, groupIDs []string)) *roleStoreInterfaceMock_GetEntityRoleIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetEntityRoleIDs_Call) Return(strings []string, err error) *roleStoreInterfaceMock_GetEntityRoleIDs_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetEntityRoleIDs_Call) RunAndReturn(run func(ctx context.Context, entityID string, groupIDs []string) ([]string, error)) *roleStoreInterfaceMock_GetEntityRoleIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRole provides a mock function for the type roleStoreInterfaceMock
 func (_mock *roleStoreInterfaceMock) GetRole(ctx context.Context, id string) (role.RoleWithPermissions, error) {
 	ret := _mock.Called(ctx, id)


### PR DESCRIPTION
### Purpose

When a role is declared via YAML (under `repository/resources/roles/`) and `role.store` is set to `composite` or `declarative`, a user assigned to that role via `POST /roles/{id}/assignments/add` does not receive any of the role's permissions at token issuance. The issued access token carries only the OIDC scopes (`openid profile email`) regardless of what `tenant_instance:system`-style permissions the role grants.

The assignment write path works correctly (the `ROLE_ASSIGNMENT` row is persisted, and `GET /roles/{id}/assignments` returns it). The break is in the read path. Declarative role definitions live only in the file-based store, so the DB tables `ROLE` and `ROLE_PERMISSION` have no rows for them. `dbStore.GetAuthorizedPermissions` runs:

```sql
SELECT DISTINCT rp.PERMISSION
FROM "ROLE_PERMISSION" rp
INNER JOIN "ROLE_ASSIGNMENT" ra ON rp.ROLE_ID = ra.ROLE_ID
WHERE ...
```

The `INNER JOIN` silently drops every assignment for a declarative role. The file-side `fileBasedStore.GetAuthorizedPermissions` only matches against the role YAML's static `assignments:` field, so it doesn't see the API-added row either. The composite merge of `∅ ∪ ∅` returns nothing → no scope downscoping → no role-derived scopes in the token.

Repro (with a declarative role `R` whose permissions live only in YAML, and entity `U` assigned via API):
```sql
SELECT * FROM ROLE_ASSIGNMENT WHERE ROLE_ID='R';   -- 1 row ✓
SELECT * FROM ROLE_PERMISSION WHERE ROLE_ID='R';   -- 0 rows
-- Existing query → 0 rows (the bug)
```

The previous refactor (`057b1ac0 Refactor role assignments to a separate service`) unblocked the write path for declarative-role assignments but did not update the read path to follow the resulting cross-store data layout.

### Approach

Bridge the split inside `compositeRoleStore.GetAuthorizedPermissions` rather than restructure where data lives. The composite store now resolves authorized permissions from three sources and merges them:

1. **DB store** — `dbStore.GetAuthorizedPermissions` (unchanged). Covers DB-managed roles.
2. **File store, static assignment path** — `fileStore.GetAuthorizedPermissions` (unchanged). Covers declarative roles whose YAML declares the entity/group inside `assignments:`.
3. **Cross-store path (new)** — `compositeRoleStore.crossStoreAuthorizedPermissions`. Reads the entity's role IDs from the DB, looks each up in the file store, and intersects the role's declared permissions with the requested set. DB-only roles are detected via `fileStore.IsRoleExist` and skipped — their permissions are already covered by source 1, so there is no double-counting.

Supporting changes on the store:
- New interface method `GetEntityRoleIDs(ctx, entityID, groupIDs) ([]string, error)` on `roleStoreInterface`.
- New SQL builder `buildEntityRoleIDsQuery` that returns `ra.ROLE_ID` directly out of `ROLE_ASSIGNMENT` without joining `ROLE`, so the call surfaces assignments to declarative roles whose `ROLE` row does not exist.
- DB implementation queries `ROLE_ASSIGNMENT` directly; file-based implementation returns an empty slice since assignments never live in files; composite delegates to the DB store.

No schema migration. No API surface change. The interface change is internal — both implementations live in this PR. All existing tests for the unchanged paths continue to pass; tests that touched `GetAuthorizedPermissions` were updated to mock the new method.

### Related Issues
- N/A

### Related PRs
- Follow-up to `057b1ac0 Refactor role assignments to a separate service` (which unblocked the assignment write path for declarative roles).

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization now consistently merges permissions from DB, file-declared, and mixed (file-defined but DB-assigned) roles, avoids duplicate resolution, and short-circuits empty requests.

* **Behavior**
  * File-backed role lookups explicitly report no dynamic assignments; corrupted declarative role data is surfaced as a benign, identifiable error.

* **Tests**
  * Added extensive tests covering cross-store resolution, error propagation, short-circuits, and role-ID lookup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->