### PR TITLE
Switch to `npm` Trusted Publishing for JavaScript ecosystem SDKs

### DIFF
--- a/.github/actions/release-sdk/npm/action.yml
+++ b/.github/actions/release-sdk/npm/action.yml
@@ -16,9 +16,6 @@ inputs:
   bump-type:
     description: 'Semver bump type: major, minor, or patch'
     required: true
-  npm-token:
-    description: 'NPM authentication token'
-    required: true
   git-user-name:
     description: 'Git committer name'
     required: false
@@ -95,6 +92,4 @@ runs:
       shell: bash
       run: |
         cd sdks/${{ inputs.sdk }}
-        pnpm publish --no-git-checks --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
+        pnpm publish --no-git-checks --access public --provenance

--- a/.github/workflows/release-sdks.yml
+++ b/.github/workflows/release-sdks.yml
@@ -80,6 +80,8 @@ on:
 
 permissions:
   contents: write
+  # IMPORTANT: DO NOT REMOVE. `id-token` is required for OIDC publishing.
+  id-token: write
 
 env:
   RELEASE_GIT_USER_NAME: "thunderid-automation-bot"
@@ -104,7 +106,6 @@ jobs:
         with:
           sdk: javascript
           bump-type: ${{ github.event.inputs.bump_type }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}
@@ -127,7 +128,6 @@ jobs:
         with:
           sdk: browser
           bump-type: ${{ github.event.inputs.bump_type }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}
@@ -149,7 +149,6 @@ jobs:
         with:
           sdk: node
           bump-type: ${{ github.event.inputs.bump_type }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}
@@ -172,7 +171,6 @@ jobs:
         with:
           sdk: express
           bump-type: ${{ github.event.inputs.bump_type }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}
@@ -194,7 +192,6 @@ jobs:
         with:
           sdk: react
           bump-type: ${{ github.event.inputs.bump_type }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}
@@ -216,7 +213,6 @@ jobs:
         with:
           sdk: vue
           bump-type: ${{ github.event.inputs.bump_type }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}
@@ -239,7 +235,6 @@ jobs:
         with:
           sdk: react-router
           bump-type: ${{ github.event.inputs.bump_type }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}
@@ -261,7 +256,6 @@ jobs:
         with:
           sdk: tanstack-router
           bump-type: ${{ github.event.inputs.bump_type }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}
@@ -283,7 +277,6 @@ jobs:
         with:
           sdk: nextjs
           bump-type: ${{ github.event.inputs.bump_type }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}
@@ -305,7 +298,6 @@ jobs:
         with:
           sdk: nuxt
           bump-type: ${{ github.event.inputs.bump_type }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request updates the SDK release workflow to improve security and simplify configuration by switching from using an NPM token to GitHub's OIDC (OpenID Connect) authentication for publishing packages. The changes remove the need to pass the NPM token explicitly and update permissions and publishing commands accordingly.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

**Authentication and Security Improvements:**

* Added `id-token: write` permission to the workflow to enable OIDC-based publishing, which is required for secure authentication with the npm registry.
* Removed the `npm-token` input from the workflow and action configuration, as it is no longer needed with OIDC authentication. [[1]](diffhunk://#diff-e303a7573bd7c546f98e3b81a60c68bd93ea39424a134d1a4388061051dac8b9L19-L21) [[2]](diffhunk://#diff-58c2117164d893dedb30f78fc5422b96c72986668113bcaef7bb9509c124fdb2L107) [[3]](diffhunk://#diff-58c2117164d893dedb30f78fc5422b96c72986668113bcaef7bb9509c124fdb2L130) [[4]](diffhunk://#diff-58c2117164d893dedb30f78fc5422b96c72986668113bcaef7bb9509c124fdb2L152) [[5]](diffhunk://#diff-58c2117164d893dedb30f78fc5422b96c72986668113bcaef7bb9509c124fdb2L175) [[6]](diffhunk://#diff-58c2117164d893dedb30f78fc5422b96c72986668113bcaef7bb9509c124fdb2L197) [[7]](diffhunk://#diff-58c2117164d893dedb30f78fc5422b96c72986668113bcaef7bb9509c124fdb2L219) [[8]](diffhunk://#diff-58c2117164d893dedb30f78fc5422b96c72986668113bcaef7bb9509c124fdb2L242) [[9]](diffhunk://#diff-58c2117164d893dedb30f78fc5422b96c72986668113bcaef7bb9509c124fdb2L264) [[10]](diffhunk://#diff-58c2117164d893dedb30f78fc5422b96c72986668113bcaef7bb9509c124fdb2L286) [[11]](diffhunk://#diff-58c2117164d893dedb30f78fc5422b96c72986668113bcaef7bb9509c124fdb2L308)

**Publishing Command Updates:**

* Updated the `pnpm publish` command to use the `--provenance` flag and removed the explicit `NODE_AUTH_TOKEN` environment variable, aligning with OIDC authentication best practices.


### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/2759

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK release process with enhanced authentication mechanisms for improved security and reliability during package publication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->