### PR TITLE
Rename BEM blocks to use 'thunderid' prefix across all primitive components in vue sdk

### DIFF
--- a/sdks/vue/src/components/presentation/create-organization/CreateOrganization.css.ts
+++ b/sdks/vue/src/components/presentation/create-organization/CreateOrganization.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the CreateOrganization presentation component.
  *
- * BEM block: `.thunder-create-organization`
+ * BEM block: `.thunderid-create-organization`
  *
  * The root element is a Card, whose padding is intentionally kept
  * as this is a full form panel.
@@ -36,7 +36,7 @@ const CREATE_ORGANIZATION_CSS = `
    CreateOrganization
    ============================================================ */
 
-.thunder-create-organization {
+.thunderid-create-organization {
   display: flex;
   flex-direction: column;
   gap: calc(var(--thunder-spacing-unit) * 1.75);
@@ -46,20 +46,20 @@ const CREATE_ORGANIZATION_CSS = `
 
 /* Title & description --------------------------------------- */
 
-.thunder-create-organization__description {
+.thunderid-create-organization__description {
   margin-top: calc(var(--thunder-spacing-unit) * -0.75);
   color: var(--thunder-color-text-secondary);
 }
 
 /* Input ----------------------------------------------------- */
 
-.thunder-create-organization__input {
+.thunderid-create-organization__input {
   width: 100%;
 }
 
 /* Submit ---------------------------------------------------- */
 
-.thunder-create-organization__submit {
+.thunderid-create-organization__submit {
   align-self: flex-start;
 }
 `;

--- a/sdks/vue/src/components/presentation/language-switcher/LanguageSwitcher.css.ts
+++ b/sdks/vue/src/components/presentation/language-switcher/LanguageSwitcher.css.ts
@@ -19,9 +19,9 @@
 /**
  * Styles for the LanguageSwitcher presentation component.
  *
- * BEM block: `.thunder-language-switcher`
+ * BEM block: `.thunderid-language-switcher`
  *
- * The root element is a Card (`.thunder-card`). We override its default
+ * The root element is a Card (`.thunderid-card`). We override its default
  * padding to 0 so the trigger button fills the surface edge-to-edge,
  * and apply `position: relative` to anchor the absolute dropdown.
  * The Card's border-radius and shadow are intentionally kept.
@@ -39,7 +39,7 @@ const LANGUAGE_SWITCHER_CSS = `
    ============================================================ */
 
 /* Override Card's default padding so the trigger fills the surface */
-.thunder-language-switcher.thunder-card {
+.thunderid-language-switcher.thunderid-card {
   padding: 0;
   position: relative;
   display: inline-block;
@@ -47,7 +47,7 @@ const LANGUAGE_SWITCHER_CSS = `
 
 /* Trigger ---------------------------------------------------- */
 
-.thunder-language-switcher__trigger {
+.thunderid-language-switcher__trigger {
   display: inline-flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 0.5);
@@ -64,23 +64,23 @@ const LANGUAGE_SWITCHER_CSS = `
   box-sizing: border-box;
 }
 
-.thunder-language-switcher__trigger:hover {
+.thunderid-language-switcher__trigger:hover {
   background-color: var(--thunder-color-action-hover);
 }
 
-.thunder-language-switcher__trigger:focus-visible {
+.thunderid-language-switcher__trigger:focus-visible {
   outline: none;
   box-shadow: inset 0 0 0 var(--thunder-focus-ring-width) var(--thunder-focus-ring-color);
   border-radius: var(--thunder-dropdown-borderRadius);
 }
 
-.thunder-language-switcher__trigger-label {
+.thunderid-language-switcher__trigger-label {
   flex: 0 0 auto;
 }
 
 /* Dropdown --------------------------------------------------- */
 
-.thunder-language-switcher__dropdown {
+.thunderid-language-switcher__dropdown {
   position: absolute;
   top: calc(100% + calc(var(--thunder-spacing-unit) * 0.5));
   right: 0;
@@ -98,7 +98,7 @@ const LANGUAGE_SWITCHER_CSS = `
 
 /* Items ----------------------------------------------------- */
 
-.thunder-language-switcher__item {
+.thunderid-language-switcher__item {
   display: flex;
   align-items: center;
   width: 100%;
@@ -114,17 +114,17 @@ const LANGUAGE_SWITCHER_CSS = `
   box-sizing: border-box;
 }
 
-.thunder-language-switcher__item:hover {
+.thunderid-language-switcher__item:hover {
   background-color: var(--thunder-color-action-hover);
 }
 
-.thunder-language-switcher__item--active {
+.thunderid-language-switcher__item--active {
   background-color: var(--thunder-color-action-selected);
   color: var(--thunder-color-primary-main);
   font-weight: var(--thunder-typography-fontWeight-medium);
 }
 
-.thunder-language-switcher__item--active:hover {
+.thunderid-language-switcher__item--active:hover {
   background-color: var(--thunder-color-action-focus);
 }
 `;

--- a/sdks/vue/src/components/presentation/organization-list/OrganizationList.css.ts
+++ b/sdks/vue/src/components/presentation/organization-list/OrganizationList.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the OrganizationList presentation component.
  *
- * BEM block: `.thunder-organization-list`
+ * BEM block: `.thunderid-organization-list`
  *
  * The root element is a plain `div`. There is no Card wrapper here,
  * so this file provides the full layout including border and spacing.
@@ -34,7 +34,7 @@ const ORGANIZATION_LIST_CSS = `
    OrganizationList
    ============================================================ */
 
-.thunder-organization-list {
+.thunderid-organization-list {
   display: flex;
   flex-direction: column;
   gap: calc(var(--thunder-spacing-unit) * 0.5);
@@ -43,8 +43,8 @@ const ORGANIZATION_LIST_CSS = `
 
 /* Loading / Empty ------------------------------------------- */
 
-.thunder-organization-list__loading,
-.thunder-organization-list__empty {
+.thunderid-organization-list__loading,
+.thunderid-organization-list__empty {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -54,7 +54,7 @@ const ORGANIZATION_LIST_CSS = `
 
 /* Items ----------------------------------------------------- */
 
-.thunder-organization-list__item {
+.thunderid-organization-list__item {
   display: flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 1.25);
@@ -75,12 +75,12 @@ const ORGANIZATION_LIST_CSS = `
   box-sizing: border-box;
 }
 
-.thunder-organization-list__item:hover {
+.thunderid-organization-list__item:hover {
   background-color: var(--thunder-color-primary-light);
   border-color: var(--thunder-color-primary-main);
 }
 
-.thunder-organization-list__item:focus-visible {
+.thunderid-organization-list__item:focus-visible {
   outline: none;
   box-shadow: 0 0 0 var(--thunder-focus-ring-width) var(--thunder-focus-ring-color);
 }

--- a/sdks/vue/src/components/presentation/organization-profile/OrganizationProfile.css.ts
+++ b/sdks/vue/src/components/presentation/organization-profile/OrganizationProfile.css.ts
@@ -19,14 +19,14 @@
 /**
  * Styles for the OrganizationProfile presentation component.
  *
- * BEM block: `.thunder-organization-profile`
+ * BEM block: `.thunderid-organization-profile`
  */
 const ORGANIZATION_PROFILE_CSS = `
 /* ============================================================
    OrganizationProfile
    ============================================================ */
 
-.thunder-organization-profile {
+.thunderid-organization-profile {
   display: flex;
   flex-direction: column;
   min-width: 320px;
@@ -36,22 +36,22 @@ const ORGANIZATION_PROFILE_CSS = `
 
 /* Header: title + divider ------------------------------------ */
 
-.thunder-organization-profile__header {
+.thunderid-organization-profile__header {
   padding: calc(var(--thunder-spacing-unit) * 2) calc(var(--thunder-spacing-unit) * 2.5);
   padding-bottom: calc(var(--thunder-spacing-unit) * 1.5);
 }
 
-.thunder-organization-profile__title {
+.thunderid-organization-profile__title {
   margin: 0;
 }
 
-.thunder-organization-profile__header-divider {
+.thunderid-organization-profile__header-divider {
   margin: 0;
 }
 
 /* Identity: avatar + org name + handle ----------------------- */
 
-.thunder-organization-profile__identity {
+.thunderid-organization-profile__identity {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -59,7 +59,7 @@ const ORGANIZATION_PROFILE_CSS = `
   gap: calc(var(--thunder-spacing-unit) * 0.5);
 }
 
-.thunder-organization-profile__avatar {
+.thunderid-organization-profile__avatar {
   width: var(--thunder-avatar-size);
   height: var(--thunder-avatar-size);
   border-radius: 50%;
@@ -70,7 +70,7 @@ const ORGANIZATION_PROFILE_CSS = `
   margin-bottom: calc(var(--thunder-spacing-unit) * 0.375);
 }
 
-.thunder-organization-profile__avatar-initials {
+.thunderid-organization-profile__avatar-initials {
   color: #ffffff;
   font-size: var(--thunder-avatar-fontSize);
   font-weight: 600;
@@ -80,28 +80,28 @@ const ORGANIZATION_PROFILE_CSS = `
   user-select: none;
 }
 
-.thunder-organization-profile__org-name {
+.thunderid-organization-profile__org-name {
   margin: 0;
   text-align: center;
 }
 
-.thunder-organization-profile__org-handle {
+.thunderid-organization-profile__org-handle {
   color: var(--thunder-color-text-secondary);
   text-align: center;
 }
 
-.thunder-organization-profile__identity-divider {
+.thunderid-organization-profile__identity-divider {
   margin: 0;
 }
 
 /* Fields ---------------------------------------------------- */
 
-.thunder-organization-profile__fields {
+.thunderid-organization-profile__fields {
   display: flex;
   flex-direction: column;
 }
 
-.thunder-organization-profile__field {
+.thunderid-organization-profile__field {
   display: grid;
   grid-template-columns: 36% 64%;
   align-items: center;
@@ -111,28 +111,28 @@ const ORGANIZATION_PROFILE_CSS = `
   transition: background-color var(--thunder-transition-fast);
 }
 
-.thunder-organization-profile__field:hover {
+.thunderid-organization-profile__field:hover {
   background-color: var(--thunder-color-action-hover);
 }
 
-.thunder-organization-profile__field + .thunder-organization-profile__field {
+.thunderid-organization-profile__field + .thunderid-organization-profile__field {
   border-top: 1px solid var(--thunder-color-border);
 }
 
-.thunder-organization-profile__field-label-col {
+.thunderid-organization-profile__field-label-col {
   /* label column */
 }
 
-.thunder-organization-profile__field-label {
+.thunderid-organization-profile__field-label {
   color: var(--thunder-color-text-secondary);
   font-size: var(--thunder-typography-fontSize-sm);
 }
 
-.thunder-organization-profile__field-value-col {
+.thunderid-organization-profile__field-value-col {
   /* value column */
 }
 
-.thunder-organization-profile__field-display {
+.thunderid-organization-profile__field-display {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -140,21 +140,21 @@ const ORGANIZATION_PROFILE_CSS = `
   min-height: 1.5rem;
 }
 
-.thunder-organization-profile__field-value {
+.thunderid-organization-profile__field-value {
   color: var(--thunder-color-text-primary);
   word-break: break-word;
   flex: 1;
   font-size: var(--thunder-typography-fontSize-sm);
 }
 
-.thunder-organization-profile__field-value--id {
+.thunderid-organization-profile__field-value--id {
   font-size: calc(var(--thunder-typography-fontSize-sm) * 0.9);
   color: var(--thunder-color-text-secondary);
   font-family: monospace;
   word-break: break-all;
 }
 
-.thunder-organization-profile__field-placeholder {
+.thunderid-organization-profile__field-placeholder {
   color: var(--thunder-color-primary-main);
   font-style: italic;
   font-size: var(--thunder-typography-fontSize-sm);
@@ -167,7 +167,7 @@ const ORGANIZATION_PROFILE_CSS = `
 
 /* Edit button (pencil icon) --------------------------------- */
 
-.thunder-organization-profile__field-edit-btn {
+.thunderid-organization-profile__field-edit-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -186,16 +186,16 @@ const ORGANIZATION_PROFILE_CSS = `
   line-height: 0;
 }
 
-.thunder-organization-profile__field:hover .thunder-organization-profile__field-edit-btn {
+.thunderid-organization-profile__field:hover .thunderid-organization-profile__field-edit-btn {
   opacity: 1;
 }
 
-.thunder-organization-profile__field-edit-btn:hover {
+.thunderid-organization-profile__field-edit-btn:hover {
   color: var(--thunder-color-primary-main);
   background-color: var(--thunder-color-primary-light);
 }
 
-.thunder-organization-profile__field-edit-btn:focus-visible {
+.thunderid-organization-profile__field-edit-btn:focus-visible {
   opacity: 1;
   outline: none;
   box-shadow: 0 0 0 var(--thunder-focus-ring-width) var(--thunder-focus-ring-color);
@@ -203,13 +203,13 @@ const ORGANIZATION_PROFILE_CSS = `
 
 /* Edit mode ------------------------------------------------- */
 
-.thunder-organization-profile__field-edit {
+.thunderid-organization-profile__field-edit {
   display: flex;
   flex-direction: column;
   gap: calc(var(--thunder-spacing-unit) * 0.75);
 }
 
-.thunder-organization-profile__field-edit-actions {
+.thunderid-organization-profile__field-edit-actions {
   display: flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 0.75);

--- a/sdks/vue/src/components/presentation/organization-switcher/OrganizationSwitcher.css.ts
+++ b/sdks/vue/src/components/presentation/organization-switcher/OrganizationSwitcher.css.ts
@@ -19,9 +19,9 @@
 /**
  * Styles for the OrganizationSwitcher presentation component.
  *
- * BEM block: `.thunder-organization-switcher`
+ * BEM block: `.thunderid-organization-switcher`
  *
- * The root element is a Card (`.thunder-card`), so we override its
+ * The root element is a Card (`.thunderid-card`), so we override its
  * default padding to let the trigger button fill the surface edge-to-edge,
  * and apply `position: relative` to anchor the absolute dropdown.
  *
@@ -42,7 +42,7 @@ const ORGANIZATION_SWITCHER_CSS = `
    ============================================================ */
 
 /* Override Card's default padding so the trigger button fills the surface */
-.thunder-organization-switcher.thunder-card {
+.thunderid-organization-switcher.thunderid-card {
   padding: 0;
   position: relative;
   display: inline-block;
@@ -51,7 +51,7 @@ const ORGANIZATION_SWITCHER_CSS = `
 
 /* Trigger ---------------------------------------------------- */
 
-.thunder-organization-switcher__trigger {
+.thunderid-organization-switcher__trigger {
   display: flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 0.75);
@@ -69,17 +69,17 @@ const ORGANIZATION_SWITCHER_CSS = `
   box-sizing: border-box;
 }
 
-.thunder-organization-switcher__trigger:hover {
+.thunderid-organization-switcher__trigger:hover {
   background-color: var(--thunder-color-action-hover);
 }
 
-.thunder-organization-switcher__trigger:focus-visible {
+.thunderid-organization-switcher__trigger:focus-visible {
   outline: none;
   box-shadow: inset 0 0 0 var(--thunder-focus-ring-width) var(--thunder-focus-ring-color);
   border-radius: var(--thunder-dropdown-borderRadius);
 }
 
-.thunder-organization-switcher__trigger-label {
+.thunderid-organization-switcher__trigger-label {
   flex: 1;
   text-align: left;
   overflow: hidden;
@@ -89,7 +89,7 @@ const ORGANIZATION_SWITCHER_CSS = `
 
 /* Dropdown --------------------------------------------------- */
 
-.thunder-organization-switcher__dropdown {
+.thunderid-organization-switcher__dropdown {
   position: absolute;
   top: calc(100% + calc(var(--thunder-spacing-unit) * 0.5));
   left: 0;
@@ -108,8 +108,8 @@ const ORGANIZATION_SWITCHER_CSS = `
 
 /* Loading / Empty states ------------------------------------ */
 
-.thunder-organization-switcher__loading,
-.thunder-organization-switcher__empty {
+.thunderid-organization-switcher__loading,
+.thunderid-organization-switcher__empty {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -119,7 +119,7 @@ const ORGANIZATION_SWITCHER_CSS = `
 
 /* Items ----------------------------------------------------- */
 
-.thunder-organization-switcher__item {
+.thunderid-organization-switcher__item {
   display: flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 0.75);
@@ -136,17 +136,17 @@ const ORGANIZATION_SWITCHER_CSS = `
   box-sizing: border-box;
 }
 
-.thunder-organization-switcher__item:hover {
+.thunderid-organization-switcher__item:hover {
   background-color: var(--thunder-color-action-hover);
 }
 
-.thunder-organization-switcher__item--active {
+.thunderid-organization-switcher__item--active {
   background-color: var(--thunder-color-action-selected);
   color: var(--thunder-color-primary-main);
   font-weight: var(--thunder-typography-fontWeight-medium);
 }
 
-.thunder-organization-switcher__item--active:hover {
+.thunderid-organization-switcher__item--active:hover {
   background-color: var(--thunder-color-action-focus);
 }
 `;

--- a/sdks/vue/src/components/presentation/user-dropdown/UserDropdown.css.ts
+++ b/sdks/vue/src/components/presentation/user-dropdown/UserDropdown.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the UserDropdown presentation component.
  *
- * BEM block: `.thunder-user-dropdown`
+ * BEM block: `.thunderid-user-dropdown`
  *
  * Trigger modifiers:
  *   __trigger--open               – ring + border while menu is visible
@@ -47,7 +47,7 @@ const USER_DROPDOWN_CSS = `
    UserDropdown
    ============================================================ */
 
-.thunder-user-dropdown {
+.thunderid-user-dropdown {
   position: relative;
   display: inline-block;
   font-family: var(--thunder-typography-fontFamily);
@@ -55,7 +55,7 @@ const USER_DROPDOWN_CSS = `
 
 /* ── Trigger ─────────────────────────────────────────────────── */
 
-.thunder-user-dropdown__trigger {
+.thunderid-user-dropdown__trigger {
   display: inline-flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 0.5);
@@ -72,23 +72,23 @@ const USER_DROPDOWN_CSS = `
   outline: none;
 }
 
-.thunder-user-dropdown__trigger:hover {
+.thunderid-user-dropdown__trigger:hover {
   border-color: var(--thunder-color-primary-main);
 }
 
-.thunder-user-dropdown__trigger--open {
+.thunderid-user-dropdown__trigger--open {
   border-color: var(--thunder-color-primary-main);
   box-shadow: 0 0 0 3px var(--thunder-focus-ring-color);
 }
 
-.thunder-user-dropdown__trigger:focus-visible {
+.thunderid-user-dropdown__trigger:focus-visible {
   border-color: var(--thunder-color-primary-main);
   box-shadow: 0 0 0 var(--thunder-focus-ring-width) var(--thunder-focus-ring-color);
 }
 
 /* ── Trigger avatar ──────────────────────────────────────────── */
 
-.thunder-user-dropdown__avatar {
+.thunderid-user-dropdown__avatar {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -105,14 +105,14 @@ const USER_DROPDOWN_CSS = `
 }
 
 /* sm — 28 px */
-.thunder-user-dropdown__avatar--sm {
+.thunderid-user-dropdown__avatar--sm {
   width: 28px;
   height: 28px;
   font-size: var(--thunder-typography-fontSize-xs);
 }
 
 /* lg — 38 px */
-.thunder-user-dropdown__avatar--lg {
+.thunderid-user-dropdown__avatar--lg {
   width: 38px;
   height: 38px;
   font-size: var(--thunder-typography-fontSize-md);
@@ -120,7 +120,7 @@ const USER_DROPDOWN_CSS = `
 
 /* ── Chevron ─────────────────────────────────────────────────── */
 
-.thunder-user-dropdown__chevron {
+.thunderid-user-dropdown__chevron {
   display: inline-flex;
   align-items: center;
   color: var(--thunder-color-text-secondary);
@@ -128,13 +128,13 @@ const USER_DROPDOWN_CSS = `
   padding-right: calc(var(--thunder-spacing-unit) * 0.25);
 }
 
-.thunder-user-dropdown__trigger--open .thunder-user-dropdown__chevron {
+.thunderid-user-dropdown__trigger--open .thunderid-user-dropdown__chevron {
   transform: rotate(180deg);
 }
 
 /* ── Dropdown menu ───────────────────────────────────────────── */
 
-.thunder-user-dropdown__menu {
+.thunderid-user-dropdown__menu {
   position: absolute;
   top: calc(100% + calc(var(--thunder-spacing-unit) * 0.75));
   right: 0;
@@ -152,51 +152,51 @@ const USER_DROPDOWN_CSS = `
 
 /* Alignment */
 
-.thunder-user-dropdown__menu--align-left {
+.thunderid-user-dropdown__menu--align-left {
   right: auto;
   left: 0;
 }
 
 /* Size: sm */
 
-.thunder-user-dropdown__menu--size-sm {
+.thunderid-user-dropdown__menu--size-sm {
   min-width: 180px;
 }
 
-.thunder-user-dropdown__menu--size-sm .thunder-user-dropdown__menu-header {
+.thunderid-user-dropdown__menu--size-sm .thunderid-user-dropdown__menu-header {
   padding: calc(var(--thunder-spacing-unit) * 1.25) calc(var(--thunder-spacing-unit) * 1.5);
   gap: calc(var(--thunder-spacing-unit) * 1);
 }
 
-.thunder-user-dropdown__menu--size-sm .thunder-user-dropdown__menu-header-avatar {
+.thunderid-user-dropdown__menu--size-sm .thunderid-user-dropdown__menu-header-avatar {
   width: 30px;
   height: 30px;
   font-size: var(--thunder-typography-fontSize-sm);
 }
 
-.thunder-user-dropdown__menu--size-sm .thunder-user-dropdown__item {
+.thunderid-user-dropdown__menu--size-sm .thunderid-user-dropdown__item {
   padding: calc(var(--thunder-spacing-unit) * 0.75) calc(var(--thunder-spacing-unit) * 1.5);
   font-size: var(--thunder-typography-fontSize-xs);
 }
 
 /* Size: lg */
 
-.thunder-user-dropdown__menu--size-lg {
+.thunderid-user-dropdown__menu--size-lg {
   min-width: 280px;
 }
 
-.thunder-user-dropdown__menu--size-lg .thunder-user-dropdown__menu-header {
+.thunderid-user-dropdown__menu--size-lg .thunderid-user-dropdown__menu-header {
   padding: calc(var(--thunder-spacing-unit) * 2) calc(var(--thunder-spacing-unit) * 2);
   gap: calc(var(--thunder-spacing-unit) * 1.5);
 }
 
-.thunder-user-dropdown__menu--size-lg .thunder-user-dropdown__menu-header-avatar {
+.thunderid-user-dropdown__menu--size-lg .thunderid-user-dropdown__menu-header-avatar {
   width: 42px;
   height: 42px;
   font-size: var(--thunder-typography-fontSize-lg);
 }
 
-.thunder-user-dropdown__menu--size-lg .thunder-user-dropdown__item {
+.thunderid-user-dropdown__menu--size-lg .thunderid-user-dropdown__item {
   padding: calc(var(--thunder-spacing-unit) * 1.25) calc(var(--thunder-spacing-unit) * 2);
   font-size: var(--thunder-typography-fontSize-md);
 }
@@ -214,14 +214,14 @@ const USER_DROPDOWN_CSS = `
 
 /* ── Menu header (user identity) ─────────────────────────────── */
 
-.thunder-user-dropdown__menu-header {
+.thunderid-user-dropdown__menu-header {
   display: flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 1.25);
   padding: calc(var(--thunder-spacing-unit) * 1.5) calc(var(--thunder-spacing-unit) * 1.75);
 }
 
-.thunder-user-dropdown__menu-header-avatar {
+.thunderid-user-dropdown__menu-header-avatar {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -236,14 +236,14 @@ const USER_DROPDOWN_CSS = `
   user-select: none;
 }
 
-.thunder-user-dropdown__menu-header-info {
+.thunderid-user-dropdown__menu-header-info {
   display: flex;
   flex-direction: column;
   gap: 2px;
   min-width: 0;
 }
 
-.thunder-user-dropdown__menu-header-name {
+.thunderid-user-dropdown__menu-header-name {
   font-size: var(--thunder-typography-fontSize-sm);
   font-weight: var(--thunder-typography-fontWeight-semibold);
   color: var(--thunder-color-text-primary);
@@ -253,7 +253,7 @@ const USER_DROPDOWN_CSS = `
   line-height: var(--thunder-typography-lineHeight-tight);
 }
 
-.thunder-user-dropdown__menu-header-subtitle {
+.thunderid-user-dropdown__menu-header-subtitle {
   font-size: var(--thunder-typography-fontSize-xs);
   color: var(--thunder-color-text-secondary);
   white-space: nowrap;
@@ -264,7 +264,7 @@ const USER_DROPDOWN_CSS = `
 
 /* ── Menu divider ────────────────────────────────────────────── */
 
-.thunder-user-dropdown__menu-divider {
+.thunderid-user-dropdown__menu-divider {
   height: 1px;
   background-color: var(--thunder-color-border);
   margin: calc(var(--thunder-spacing-unit) * 0.5) 0;
@@ -273,7 +273,7 @@ const USER_DROPDOWN_CSS = `
 
 /* ── Menu items ──────────────────────────────────────────────── */
 
-.thunder-user-dropdown__item {
+.thunderid-user-dropdown__item {
   display: flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 1);
@@ -290,28 +290,28 @@ const USER_DROPDOWN_CSS = `
   box-sizing: border-box;
 }
 
-.thunder-user-dropdown__item:hover {
+.thunderid-user-dropdown__item:hover {
   background-color: var(--thunder-color-action-hover);
 }
 
-.thunder-user-dropdown__item:focus-visible {
+.thunderid-user-dropdown__item:focus-visible {
   outline: none;
   background-color: var(--thunder-color-action-focus);
 }
 
 /* Danger variant (sign-out) */
 
-.thunder-user-dropdown__item--danger {
+.thunderid-user-dropdown__item--danger {
   color: var(--thunder-color-error-main);
 }
 
-.thunder-user-dropdown__item--danger:hover {
+.thunderid-user-dropdown__item--danger:hover {
   background-color: var(--thunder-color-error-light);
 }
 
 /* ── Modal overlay ───────────────────────────────────────────── */
 
-.thunder-user-dropdown__modal-overlay {
+.thunderid-user-dropdown__modal-overlay {
   position: fixed;
   inset: 0;
   background-color: rgba(0, 0, 0, 0.45);
@@ -330,7 +330,7 @@ const USER_DROPDOWN_CSS = `
 
 /* ── Modal content ───────────────────────────────────────────── */
 
-.thunder-user-dropdown__modal-content {
+.thunderid-user-dropdown__modal-content {
   background: var(--thunder-color-background-surface);
   border-radius: var(--thunder-border-radius-large);
   box-shadow: var(--thunder-shadow-large);
@@ -355,7 +355,7 @@ const USER_DROPDOWN_CSS = `
 
 /* ── Modal close button ──────────────────────────────────────── */
 
-.thunder-user-dropdown__modal-close {
+.thunderid-user-dropdown__modal-close {
   position: absolute;
   top: calc(var(--thunder-spacing-unit) * 1.25);
   right: calc(var(--thunder-spacing-unit) * 1.25);
@@ -375,12 +375,12 @@ const USER_DROPDOWN_CSS = `
   line-height: 0;
 }
 
-.thunder-user-dropdown__modal-close:hover {
+.thunderid-user-dropdown__modal-close:hover {
   color: var(--thunder-color-text-primary);
   background-color: var(--thunder-color-action-hover);
 }
 
-.thunder-user-dropdown__modal-close:focus-visible {
+.thunderid-user-dropdown__modal-close:focus-visible {
   outline: none;
   box-shadow: 0 0 0 var(--thunder-focus-ring-width) var(--thunder-focus-ring-color);
 }

--- a/sdks/vue/src/components/presentation/user-profile/UserProfile.css.ts
+++ b/sdks/vue/src/components/presentation/user-profile/UserProfile.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the UserProfile presentation component.
  *
- * BEM block: `.thunder-user-profile`
+ * BEM block: `.thunderid-user-profile`
  *
  * Modifiers:
  *   --compact   – reduced field padding for modal / dropdown embedding
@@ -35,7 +35,7 @@ const USER_PROFILE_CSS = `
    UserProfile  (modern redesign)
    ============================================================ */
 
-.thunder-user-profile {
+.thunderid-user-profile {
   display: flex;
   flex-direction: column;
   min-width: 320px;
@@ -45,7 +45,7 @@ const USER_PROFILE_CSS = `
 
 /* ── Header ─────────────────────────────────────────────────── */
 
-.thunder-user-profile__header {
+.thunderid-user-profile__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -53,7 +53,7 @@ const USER_PROFILE_CSS = `
     calc(var(--thunder-spacing-unit) * 1.75);
 }
 
-.thunder-user-profile__title {
+.thunderid-user-profile__title {
   margin: 0;
   font-size: var(--thunder-typography-fontSize-md);
   font-weight: var(--thunder-typography-fontWeight-semibold);
@@ -61,13 +61,13 @@ const USER_PROFILE_CSS = `
   letter-spacing: var(--thunder-typography-letterSpacing-tight);
 }
 
-.thunder-user-profile__header-divider {
+.thunderid-user-profile__header-divider {
   margin: 0;
 }
 
 /* ── Hero (avatar + name + subtitle) ────────────────────────── */
 
-.thunder-user-profile__hero {
+.thunderid-user-profile__hero {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -82,7 +82,7 @@ const USER_PROFILE_CSS = `
   border-bottom: 1px solid var(--thunder-color-border);
 }
 
-.thunder-user-profile__avatar-wrapper {
+.thunderid-user-profile__avatar-wrapper {
   position: relative;
   border-radius: 50%;
   padding: 3px;
@@ -94,7 +94,7 @@ const USER_PROFILE_CSS = `
   box-shadow: 0 4px 14px rgba(75, 110, 245, 0.28);
 }
 
-.thunder-user-profile__avatar {
+.thunderid-user-profile__avatar {
   width: var(--thunder-avatar-size, 72px);
   height: var(--thunder-avatar-size, 72px);
   border-radius: 50%;
@@ -107,34 +107,34 @@ const USER_PROFILE_CSS = `
 
 /* Avatar size variants */
 
-.thunder-user-profile__avatar--sm {
+.thunderid-user-profile__avatar--sm {
   width: 48px;
   height: 48px;
 }
 
-.thunder-user-profile__avatar--sm .thunder-user-profile__avatar-initials {
+.thunderid-user-profile__avatar--sm .thunderid-user-profile__avatar-initials {
   font-size: 1rem;
 }
 
-.thunder-user-profile__avatar--md {
+.thunderid-user-profile__avatar--md {
   width: 64px;
   height: 64px;
 }
 
-.thunder-user-profile__avatar--md .thunder-user-profile__avatar-initials {
+.thunderid-user-profile__avatar--md .thunderid-user-profile__avatar-initials {
   font-size: 1.25rem;
 }
 
-.thunder-user-profile__avatar--lg {
+.thunderid-user-profile__avatar--lg {
   width: 80px;
   height: 80px;
 }
 
-.thunder-user-profile__avatar--lg .thunder-user-profile__avatar-initials {
+.thunderid-user-profile__avatar--lg .thunderid-user-profile__avatar-initials {
   font-size: 1.625rem;
 }
 
-.thunder-user-profile__avatar-initials {
+.thunderid-user-profile__avatar-initials {
   color: #ffffff;
   font-weight: var(--thunder-typography-fontWeight-semibold);
   line-height: 1;
@@ -143,7 +143,7 @@ const USER_PROFILE_CSS = `
   user-select: none;
 }
 
-.thunder-user-profile__hero-info {
+.thunderid-user-profile__hero-info {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -151,7 +151,7 @@ const USER_PROFILE_CSS = `
   text-align: center;
 }
 
-.thunder-user-profile__hero-name {
+.thunderid-user-profile__hero-name {
   font-size: var(--thunder-typography-fontSize-lg);
   font-weight: var(--thunder-typography-fontWeight-semibold);
   color: var(--thunder-color-text-primary);
@@ -159,7 +159,7 @@ const USER_PROFILE_CSS = `
   letter-spacing: var(--thunder-typography-letterSpacing-tight);
 }
 
-.thunder-user-profile__hero-subtitle {
+.thunderid-user-profile__hero-subtitle {
   font-size: var(--thunder-typography-fontSize-sm);
   color: var(--thunder-color-text-secondary);
   line-height: var(--thunder-typography-lineHeight-normal);
@@ -167,12 +167,12 @@ const USER_PROFILE_CSS = `
 
 /* ── Alerts & loading ────────────────────────────────────────── */
 
-.thunder-user-profile__error {
+.thunderid-user-profile__error {
   margin: calc(var(--thunder-spacing-unit) * 1.5) calc(var(--thunder-spacing-unit) * 2.5)
     calc(var(--thunder-spacing-unit) * 0.5);
 }
 
-.thunder-user-profile__loading {
+.thunderid-user-profile__loading {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -181,12 +181,12 @@ const USER_PROFILE_CSS = `
 
 /* ── Fields ──────────────────────────────────────────────────── */
 
-.thunder-user-profile__fields {
+.thunderid-user-profile__fields {
   display: flex;
   flex-direction: column;
 }
 
-.thunder-user-profile__field {
+.thunderid-user-profile__field {
   display: grid;
   grid-template-columns: 38% 62%;
   align-items: start;
@@ -196,22 +196,22 @@ const USER_PROFILE_CSS = `
   transition: background-color var(--thunder-transition-fast);
 }
 
-.thunder-user-profile__field:hover {
+.thunderid-user-profile__field:hover {
   background-color: var(--thunder-color-action-hover);
 }
 
-.thunder-user-profile__field + .thunder-user-profile__field {
+.thunderid-user-profile__field + .thunderid-user-profile__field {
   border-top: 1px solid var(--thunder-color-border);
 }
 
-.thunder-user-profile__field-label {
+.thunderid-user-profile__field-label {
   color: var(--thunder-color-text-secondary);
   font-size: var(--thunder-typography-fontSize-sm);
   font-weight: var(--thunder-typography-fontWeight-medium);
   padding-top: 2px;
 }
 
-.thunder-user-profile__field-display {
+.thunderid-user-profile__field-display {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -219,14 +219,14 @@ const USER_PROFILE_CSS = `
   min-height: 1.5rem;
 }
 
-.thunder-user-profile__field-value {
+.thunderid-user-profile__field-value {
   color: var(--thunder-color-text-primary);
   word-break: break-word;
   flex: 1;
   font-size: var(--thunder-typography-fontSize-sm);
 }
 
-.thunder-user-profile__field-placeholder {
+.thunderid-user-profile__field-placeholder {
   color: var(--thunder-color-primary-main);
   font-size: var(--thunder-typography-fontSize-sm);
   font-style: italic;
@@ -239,13 +239,13 @@ const USER_PROFILE_CSS = `
   transition: opacity var(--thunder-transition-fast);
 }
 
-.thunder-user-profile__field-placeholder:hover {
+.thunderid-user-profile__field-placeholder:hover {
   opacity: 1;
 }
 
 /* ── Edit button (pencil) ────────────────────────────────────── */
 
-.thunder-user-profile__field-edit-btn {
+.thunderid-user-profile__field-edit-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -264,16 +264,16 @@ const USER_PROFILE_CSS = `
   line-height: 0;
 }
 
-.thunder-user-profile__field:hover .thunder-user-profile__field-edit-btn {
+.thunderid-user-profile__field:hover .thunderid-user-profile__field-edit-btn {
   opacity: 1;
 }
 
-.thunder-user-profile__field-edit-btn:hover {
+.thunderid-user-profile__field-edit-btn:hover {
   color: var(--thunder-color-primary-main);
   background-color: var(--thunder-color-primary-light);
 }
 
-.thunder-user-profile__field-edit-btn:focus-visible {
+.thunderid-user-profile__field-edit-btn:focus-visible {
   opacity: 1;
   outline: none;
   box-shadow: 0 0 0 var(--thunder-focus-ring-width) var(--thunder-focus-ring-color);
@@ -281,14 +281,14 @@ const USER_PROFILE_CSS = `
 
 /* ── Edit mode ───────────────────────────────────────────────── */
 
-.thunder-user-profile__field-edit {
+.thunderid-user-profile__field-edit {
   display: flex;
   flex-direction: column;
   gap: calc(var(--thunder-spacing-unit) * 0.75);
   padding: calc(var(--thunder-spacing-unit) * 0.25) 0;
 }
 
-.thunder-user-profile__field-edit-actions {
+.thunderid-user-profile__field-edit-actions {
   display: flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 0.75);
@@ -296,31 +296,31 @@ const USER_PROFILE_CSS = `
 
 /* ── Footer slot ─────────────────────────────────────────────── */
 
-.thunder-user-profile__footer {
+.thunderid-user-profile__footer {
   padding: calc(var(--thunder-spacing-unit) * 1.5) calc(var(--thunder-spacing-unit) * 2.5);
   border-top: 1px solid var(--thunder-color-border);
 }
 
 /* ── Compact modifier ────────────────────────────────────────── */
 
-.thunder-user-profile--compact .thunder-user-profile__hero {
+.thunderid-user-profile--compact .thunderid-user-profile__hero {
   padding: calc(var(--thunder-spacing-unit) * 2) calc(var(--thunder-spacing-unit) * 2);
 }
 
-.thunder-user-profile--compact .thunder-user-profile__avatar--lg {
+.thunderid-user-profile--compact .thunderid-user-profile__avatar--lg {
   width: 56px;
   height: 56px;
 }
 
-.thunder-user-profile--compact .thunder-user-profile__avatar--lg .thunder-user-profile__avatar-initials {
+.thunderid-user-profile--compact .thunderid-user-profile__avatar--lg .thunderid-user-profile__avatar-initials {
   font-size: 1.125rem;
 }
 
-.thunder-user-profile--compact .thunder-user-profile__field {
+.thunderid-user-profile--compact .thunderid-user-profile__field {
   padding: calc(var(--thunder-spacing-unit) * 1) calc(var(--thunder-spacing-unit) * 2);
 }
 
-.thunder-user-profile--compact .thunder-user-profile__hero-name {
+.thunderid-user-profile--compact .thunderid-user-profile__hero-name {
   font-size: var(--thunder-typography-fontSize-md);
 }
 `;

--- a/sdks/vue/src/components/primitives/Alert/Alert.css.ts
+++ b/sdks/vue/src/components/primitives/Alert/Alert.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the Alert primitive component.
  *
- * BEM block: `.thunder-alert`
+ * BEM block: `.thunderid-alert`
  *
  * Modifiers:
  *   Severity: --info | --success | --warning | --error
@@ -32,7 +32,7 @@ const ALERT_CSS = `
    Alert
    ============================================================ */
 
-.thunder-alert {
+.thunderid-alert {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -47,35 +47,35 @@ const ALERT_CSS = `
   line-height: var(--thunder-typography-lineHeight-normal);
 }
 
-.thunder-alert__content {
+.thunderid-alert__content {
   flex: 1;
 }
 
-.thunder-alert--info {
+.thunderid-alert--info {
   background-color: var(--thunder-color-info-light);
   border-color: var(--thunder-color-info-main);
   color: var(--thunder-color-info-contrastText);
 }
 
-.thunder-alert--success {
+.thunderid-alert--success {
   background-color: var(--thunder-color-success-light);
   border-color: var(--thunder-color-success-main);
   color: var(--thunder-color-success-contrastText);
 }
 
-.thunder-alert--warning {
+.thunderid-alert--warning {
   background-color: var(--thunder-color-warning-light);
   border-color: var(--thunder-color-warning-main);
   color: var(--thunder-color-warning-contrastText);
 }
 
-.thunder-alert--error {
+.thunderid-alert--error {
   background-color: var(--thunder-color-error-light);
   border-color: var(--thunder-color-error-main);
   color: var(--thunder-color-error-contrastText);
 }
 
-.thunder-alert__dismiss {
+.thunderid-alert__dismiss {
   background: none;
   border: none;
   cursor: pointer;
@@ -88,7 +88,7 @@ const ALERT_CSS = `
   flex-shrink: 0;
   transition: opacity var(--thunder-transition-fast), background-color var(--thunder-transition-fast);
 }
-.thunder-alert__dismiss:hover {
+.thunderid-alert__dismiss:hover {
   opacity: 1;
   background-color: var(--thunder-color-action-hover);
 }

--- a/sdks/vue/src/components/primitives/Button/Button.css.ts
+++ b/sdks/vue/src/components/primitives/Button/Button.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the Button primitive component.
  *
- * BEM block: `.thunder-button`
+ * BEM block: `.thunderid-button`
  *
  * Modifiers:
  *   Variant:  --solid | --outline | --ghost | --text
@@ -38,7 +38,7 @@ const BUTTON_CSS = `
    Button
    ============================================================ */
 
-.thunder-button {
+.thunderid-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -68,26 +68,26 @@ const BUTTON_CSS = `
   user-select: none;
 }
 
-.thunder-button:focus-visible {
+.thunderid-button:focus-visible {
   outline: none;
   box-shadow: 0 0 0 var(--thunder-focus-ring-width) var(--thunder-focus-ring-color);
 }
 
 /* -- Sizes -- */
 
-.thunder-button--small {
+.thunderid-button--small {
   padding: 0 var(--thunder-button-sm-paddingX);
   font-size: var(--thunder-button-sm-fontSize);
   height: var(--thunder-button-sm-height);
 }
 
-.thunder-button--medium {
+.thunderid-button--medium {
   padding: 0 var(--thunder-button-md-paddingX);
   font-size: var(--thunder-button-md-fontSize);
   height: var(--thunder-button-md-height);
 }
 
-.thunder-button--large {
+.thunderid-button--large {
   padding: 0 var(--thunder-button-lg-paddingX);
   font-size: var(--thunder-button-lg-fontSize);
   height: var(--thunder-button-lg-height);
@@ -95,12 +95,12 @@ const BUTTON_CSS = `
 
 /* -- Modifiers -- */
 
-.thunder-button--full-width {
+.thunderid-button--full-width {
   width: 100%;
 }
 
-.thunder-button--loading,
-.thunder-button:disabled {
+.thunderid-button--loading,
+.thunderid-button:disabled {
   cursor: not-allowed;
   opacity: 0.55;
   pointer-events: none;
@@ -108,172 +108,172 @@ const BUTTON_CSS = `
 
 /* -- Solid variants -- */
 
-.thunder-button--solid.thunder-button--primary {
+.thunderid-button--solid.thunderid-button--primary {
   background-color: var(--thunder-color-primary-main);
   color: var(--thunder-color-primary-contrastText);
   border-color: var(--thunder-color-primary-main);
 }
-.thunder-button--solid.thunder-button--primary:hover:not(:disabled) {
+.thunderid-button--solid.thunderid-button--primary:hover:not(:disabled) {
   background-color: var(--thunder-color-primary-dark);
   border-color: var(--thunder-color-primary-dark);
 }
-.thunder-button--solid.thunder-button--primary:active:not(:disabled) {
+.thunderid-button--solid.thunderid-button--primary:active:not(:disabled) {
   transform: scale(0.98);
 }
 
-.thunder-button--solid.thunder-button--secondary {
+.thunderid-button--solid.thunderid-button--secondary {
   background-color: var(--thunder-color-secondary-light);
   color: var(--thunder-color-secondary-main);
   border-color: var(--thunder-color-border);
 }
-.thunder-button--solid.thunder-button--secondary:hover:not(:disabled) {
+.thunderid-button--solid.thunderid-button--secondary:hover:not(:disabled) {
   background-color: var(--thunder-color-border);
   border-color: var(--thunder-color-border);
 }
-.thunder-button--solid.thunder-button--secondary:active:not(:disabled) {
+.thunderid-button--solid.thunderid-button--secondary:active:not(:disabled) {
   transform: scale(0.98);
 }
 
-.thunder-button--solid.thunder-button--danger {
+.thunderid-button--solid.thunderid-button--danger {
   background-color: var(--thunder-color-error-main);
   color: #ffffff;
   border-color: var(--thunder-color-error-main);
 }
-.thunder-button--solid.thunder-button--danger:hover:not(:disabled) {
+.thunderid-button--solid.thunderid-button--danger:hover:not(:disabled) {
   filter: brightness(0.92);
 }
-.thunder-button--solid.thunder-button--danger:active:not(:disabled) {
+.thunderid-button--solid.thunderid-button--danger:active:not(:disabled) {
   transform: scale(0.98);
 }
 
 /* -- Outline variants -- */
 
-.thunder-button--outline.thunder-button--primary {
+.thunderid-button--outline.thunderid-button--primary {
   background-color: transparent;
   color: var(--thunder-color-primary-main);
   border-color: var(--thunder-color-primary-main);
 }
-.thunder-button--outline.thunder-button--primary:hover:not(:disabled) {
+.thunderid-button--outline.thunderid-button--primary:hover:not(:disabled) {
   background-color: var(--thunder-color-primary-light);
 }
-.thunder-button--outline.thunder-button--primary:active:not(:disabled) {
+.thunderid-button--outline.thunderid-button--primary:active:not(:disabled) {
   transform: scale(0.98);
 }
 
-.thunder-button--outline.thunder-button--secondary {
+.thunderid-button--outline.thunderid-button--secondary {
   background-color: transparent;
   color: var(--thunder-color-secondary-main);
   border-color: var(--thunder-color-border);
 }
-.thunder-button--outline.thunder-button--secondary:hover:not(:disabled) {
+.thunderid-button--outline.thunderid-button--secondary:hover:not(:disabled) {
   background-color: var(--thunder-color-secondary-light);
   border-color: var(--thunder-color-secondary-main);
 }
-.thunder-button--outline.thunder-button--secondary:active:not(:disabled) {
+.thunderid-button--outline.thunderid-button--secondary:active:not(:disabled) {
   transform: scale(0.98);
 }
 
-.thunder-button--outline.thunder-button--danger {
+.thunderid-button--outline.thunderid-button--danger {
   background-color: transparent;
   color: var(--thunder-color-error-main);
   border-color: var(--thunder-color-error-main);
 }
-.thunder-button--outline.thunder-button--danger:hover:not(:disabled) {
+.thunderid-button--outline.thunderid-button--danger:hover:not(:disabled) {
   background-color: var(--thunder-color-error-light);
 }
-.thunder-button--outline.thunder-button--danger:active:not(:disabled) {
+.thunderid-button--outline.thunderid-button--danger:active:not(:disabled) {
   transform: scale(0.98);
 }
 
 /* -- Ghost variants -- */
 
-.thunder-button--ghost.thunder-button--primary {
+.thunderid-button--ghost.thunderid-button--primary {
   background-color: transparent;
   color: var(--thunder-color-primary-main);
   border-color: transparent;
 }
-.thunder-button--ghost.thunder-button--primary:hover:not(:disabled) {
+.thunderid-button--ghost.thunderid-button--primary:hover:not(:disabled) {
   background-color: var(--thunder-color-primary-light);
   border-color: transparent;
 }
 
-.thunder-button--ghost.thunder-button--secondary {
+.thunderid-button--ghost.thunderid-button--secondary {
   background-color: transparent;
   color: var(--thunder-color-secondary-main);
   border-color: transparent;
 }
-.thunder-button--ghost.thunder-button--secondary:hover:not(:disabled) {
+.thunderid-button--ghost.thunderid-button--secondary:hover:not(:disabled) {
   background-color: var(--thunder-color-action-hover);
   border-color: transparent;
 }
 
-.thunder-button--ghost.thunder-button--danger {
+.thunderid-button--ghost.thunderid-button--danger {
   background-color: transparent;
   color: var(--thunder-color-error-main);
   border-color: transparent;
 }
-.thunder-button--ghost.thunder-button--danger:hover:not(:disabled) {
+.thunderid-button--ghost.thunderid-button--danger:hover:not(:disabled) {
   background-color: var(--thunder-color-error-light);
   border-color: transparent;
 }
 
 /* -- Text variants -- */
 
-.thunder-button--text {
+.thunderid-button--text {
   border-color: transparent;
   background-color: transparent;
   padding-left: calc(var(--thunder-spacing-unit) * 0.25);
   padding-right: calc(var(--thunder-spacing-unit) * 0.25);
 }
 
-.thunder-button--text.thunder-button--primary {
+.thunderid-button--text.thunderid-button--primary {
   color: var(--thunder-color-primary-main);
 }
-.thunder-button--text.thunder-button--primary:hover:not(:disabled) {
+.thunderid-button--text.thunderid-button--primary:hover:not(:disabled) {
   color: var(--thunder-color-primary-dark);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.thunder-button--text.thunder-button--secondary {
+.thunderid-button--text.thunderid-button--secondary {
   color: var(--thunder-color-secondary-main);
 }
-.thunder-button--text.thunder-button--secondary:hover:not(:disabled) {
+.thunderid-button--text.thunderid-button--secondary:hover:not(:disabled) {
   color: var(--thunder-color-text-primary);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.thunder-button--text.thunder-button--danger {
+.thunderid-button--text.thunderid-button--danger {
   color: var(--thunder-color-error-main);
 }
-.thunder-button--text.thunder-button--danger:hover:not(:disabled) {
+.thunderid-button--text.thunderid-button--danger:hover:not(:disabled) {
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 /* -- Inner elements -- */
 
-.thunder-button__start-icon,
-.thunder-button__end-icon {
+.thunderid-button__start-icon,
+.thunderid-button__end-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
   line-height: 0;
 }
-.thunder-button--small .thunder-button__start-icon svg,
-.thunder-button--small .thunder-button__end-icon svg {
+.thunderid-button--small .thunderid-button__start-icon svg,
+.thunderid-button--small .thunderid-button__end-icon svg {
   width: 14px;
   height: 14px;
 }
 
-.thunder-button__content {
+.thunderid-button__content {
   display: inline-flex;
   align-items: center;
 }
 
-.thunder-button__spinner {
+.thunderid-button__spinner {
   display: inline-block;
   width: 1em;
   height: 1em;

--- a/sdks/vue/src/components/primitives/Card/Card.css.ts
+++ b/sdks/vue/src/components/primitives/Card/Card.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the Card primitive component.
  *
- * BEM block: `.thunder-card`
+ * BEM block: `.thunderid-card`
  *
  * Modifiers:
  *   --elevated  – medium drop shadow
@@ -31,7 +31,7 @@ const CARD_CSS = `
    Card
    ============================================================ */
 
-.thunder-card {
+.thunderid-card {
   background-color: var(--thunder-color-background-surface);
   border-radius: var(--thunder-card-borderRadius);
   padding: var(--thunder-card-padding);
@@ -39,15 +39,15 @@ const CARD_CSS = `
   transition: box-shadow var(--thunder-transition-normal);
 }
 
-.thunder-card--elevated {
+.thunderid-card--elevated {
   box-shadow: var(--thunder-card-shadow);
 }
 
-.thunder-card--outlined {
+.thunderid-card--outlined {
   border: 1px solid var(--thunder-card-borderColor);
 }
 
-/* .thunder-card--flat: no shadow or border */
+/* .thunderid-card--flat: no shadow or border */
 `;
 
 export default CARD_CSS;

--- a/sdks/vue/src/components/primitives/Checkbox/Checkbox.css.ts
+++ b/sdks/vue/src/components/primitives/Checkbox/Checkbox.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the Checkbox primitive component.
  *
- * BEM block: `.thunder-checkbox`
+ * BEM block: `.thunderid-checkbox`
  *
  * Modifiers:
  *   --error  – shows validation error state
@@ -32,14 +32,14 @@ const CHECKBOX_CSS = `
    Checkbox
    ============================================================ */
 
-.thunder-checkbox {
+.thunderid-checkbox {
   display: flex;
   flex-direction: column;
   gap: calc(var(--thunder-spacing-unit) * 0.5);
   font-family: var(--thunder-typography-fontFamily);
 }
 
-.thunder-checkbox__wrapper {
+.thunderid-checkbox__wrapper {
   display: inline-flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 0.75);
@@ -47,7 +47,7 @@ const CHECKBOX_CSS = `
   user-select: none;
 }
 
-.thunder-checkbox__input {
+.thunderid-checkbox__input {
   width: var(--thunder-checkbox-size);
   height: var(--thunder-checkbox-size);
   cursor: pointer;
@@ -55,22 +55,22 @@ const CHECKBOX_CSS = `
   flex-shrink: 0;
   border-radius: var(--thunder-border-radius-xs);
 }
-.thunder-checkbox__input:focus-visible {
+.thunderid-checkbox__input:focus-visible {
   outline: none;
   box-shadow: 0 0 0 var(--thunder-focus-ring-width) var(--thunder-focus-ring-color);
 }
-.thunder-checkbox__input:disabled {
+.thunderid-checkbox__input:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
-.thunder-checkbox__label {
+.thunderid-checkbox__label {
   font-size: var(--thunder-typography-fontSize-md);
   color: var(--thunder-color-text-primary);
   line-height: var(--thunder-typography-lineHeight-normal);
 }
 
-.thunder-checkbox__error {
+.thunderid-checkbox__error {
   font-size: var(--thunder-typography-fontSize-xs);
   color: var(--thunder-color-error-contrastText);
   line-height: var(--thunder-typography-lineHeight-normal);

--- a/sdks/vue/src/components/primitives/DatePicker/DatePicker.css.ts
+++ b/sdks/vue/src/components/primitives/DatePicker/DatePicker.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the DatePicker primitive component.
  *
- * BEM block: `.thunder-date-picker`
+ * BEM block: `.thunderid-date-picker`
  *
  * Modifiers:
  *   --error  – shows validation error state
@@ -32,7 +32,7 @@ const DATE_PICKER_CSS = `
    DatePicker
    ============================================================ */
 
-.thunder-date-picker {
+.thunderid-date-picker {
   display: flex;
   flex-direction: column;
   gap: calc(var(--thunder-spacing-unit) * 0.5);
@@ -41,7 +41,7 @@ const DATE_PICKER_CSS = `
   box-sizing: border-box;
 }
 
-.thunder-date-picker__label {
+.thunderid-date-picker__label {
   font-size: var(--thunder-typography-fontSize-sm);
   font-weight: var(--thunder-typography-fontWeight-medium);
   color: var(--thunder-color-text-primary);
@@ -49,12 +49,12 @@ const DATE_PICKER_CSS = `
   line-height: var(--thunder-typography-lineHeight-normal);
 }
 
-.thunder-date-picker__required {
+.thunderid-date-picker__required {
   color: var(--thunder-color-error-main);
   margin-left: 2px;
 }
 
-.thunder-date-picker__input {
+.thunderid-date-picker__input {
   width: 100%;
   height: var(--thunder-input-height);
   padding: 0 var(--thunder-input-paddingX);
@@ -71,23 +71,23 @@ const DATE_PICKER_CSS = `
   outline: none;
   cursor: pointer;
 }
-.thunder-date-picker__input:focus {
+.thunderid-date-picker__input:focus {
   border-color: var(--thunder-input-focusBorderColor);
   box-shadow: var(--thunder-input-focusRing);
 }
-.thunder-date-picker--error .thunder-date-picker__input {
+.thunderid-date-picker--error .thunderid-date-picker__input {
   border-color: var(--thunder-color-error-main);
 }
-.thunder-date-picker--error .thunder-date-picker__input:focus {
+.thunderid-date-picker--error .thunderid-date-picker__input:focus {
   box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
 }
-.thunder-date-picker__input:disabled {
+.thunderid-date-picker__input:disabled {
   background-color: var(--thunder-color-background-disabled);
   color: var(--thunder-color-action-disabled);
   cursor: not-allowed;
 }
 
-.thunder-date-picker__error {
+.thunderid-date-picker__error {
   font-size: var(--thunder-typography-fontSize-xs);
   color: var(--thunder-color-error-contrastText);
   line-height: var(--thunder-typography-lineHeight-normal);

--- a/sdks/vue/src/components/primitives/Divider/Divider.css.ts
+++ b/sdks/vue/src/components/primitives/Divider/Divider.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the Divider primitive component.
  *
- * BEM block: `.thunder-divider`
+ * BEM block: `.thunderid-divider`
  *
  * Modifiers:
  *   --horizontal   – full-width horizontal rule
@@ -34,18 +34,18 @@ const DIVIDER_CSS = `
    Divider
    ============================================================ */
 
-.thunder-divider {
+.thunderid-divider {
   box-sizing: border-box;
 }
 
-.thunder-divider--horizontal {
+.thunderid-divider--horizontal {
   width: 100%;
   border: none;
   border-top: 1px solid var(--thunder-color-border);
   margin: calc(var(--thunder-spacing-unit) * 1) 0;
 }
 
-.thunder-divider--vertical {
+.thunderid-divider--vertical {
   display: inline-block;
   width: 1px;
   height: 100%;
@@ -56,7 +56,7 @@ const DIVIDER_CSS = `
   align-self: stretch;
 }
 
-.thunder-divider--with-content {
+.thunderid-divider--with-content {
   display: flex;
   align-items: center;
   gap: calc(var(--thunder-spacing-unit) * 1);
@@ -64,13 +64,13 @@ const DIVIDER_CSS = `
   margin: calc(var(--thunder-spacing-unit) * 1) 0;
 }
 
-.thunder-divider__line {
+.thunderid-divider__line {
   flex: 1;
   height: 1px;
   background-color: var(--thunder-color-border);
 }
 
-.thunder-divider__content {
+.thunderid-divider__content {
   flex-shrink: 0;
   font-size: var(--thunder-typography-fontSize-xs);
   color: var(--thunder-color-text-secondary);

--- a/sdks/vue/src/components/primitives/Logo/Logo.css.ts
+++ b/sdks/vue/src/components/primitives/Logo/Logo.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the Logo primitive component.
  *
- * BEM block: `.thunder-logo`
+ * BEM block: `.thunderid-logo`
  *
  * Elements:
  *   __image
@@ -29,18 +29,18 @@ const LOGO_CSS = `
    Logo
    ============================================================ */
 
-.thunder-logo {
+.thunderid-logo {
   display: inline-flex;
   align-items: center;
   text-decoration: none;
   transition: opacity var(--thunder-transition-fast);
 }
 
-.thunder-logo:hover {
+.thunderid-logo:hover {
   opacity: 0.85;
 }
 
-.thunder-logo__image {
+.thunderid-logo__image {
   display: block;
   max-height: 100%;
   width: auto;

--- a/sdks/vue/src/components/primitives/OtpField/OtpField.css.ts
+++ b/sdks/vue/src/components/primitives/OtpField/OtpField.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the OtpField primitive component.
  *
- * BEM block: `.thunder-otp-field`
+ * BEM block: `.thunderid-otp-field`
  *
  * Elements:
  *   __label | __required | __inputs | __digit | __error
@@ -29,14 +29,14 @@ const OTP_FIELD_CSS = `
    OtpField
    ============================================================ */
 
-.thunder-otp-field {
+.thunderid-otp-field {
   display: flex;
   flex-direction: column;
   gap: calc(var(--thunder-spacing-unit) * 0.75);
   font-family: var(--thunder-typography-fontFamily);
 }
 
-.thunder-otp-field__label {
+.thunderid-otp-field__label {
   font-size: var(--thunder-typography-fontSize-sm);
   font-weight: var(--thunder-typography-fontWeight-medium);
   color: var(--thunder-color-text-primary);
@@ -44,17 +44,17 @@ const OTP_FIELD_CSS = `
   line-height: var(--thunder-typography-lineHeight-normal);
 }
 
-.thunder-otp-field__required {
+.thunderid-otp-field__required {
   color: var(--thunder-color-error-main);
   margin-left: 2px;
 }
 
-.thunder-otp-field__inputs {
+.thunderid-otp-field__inputs {
   display: flex;
   gap: calc(var(--thunder-spacing-unit) * 0.75);
 }
 
-.thunder-otp-field__digit {
+.thunderid-otp-field__digit {
   width: var(--thunder-input-height);
   height: var(--thunder-input-height);
   text-align: center;
@@ -71,17 +71,17 @@ const OTP_FIELD_CSS = `
     border-color var(--thunder-transition-fast),
     box-shadow var(--thunder-transition-fast);
 }
-.thunder-otp-field__digit:focus {
+.thunderid-otp-field__digit:focus {
   border-color: var(--thunder-input-focusBorderColor);
   box-shadow: var(--thunder-input-focusRing);
 }
-.thunder-otp-field__digit:disabled {
+.thunderid-otp-field__digit:disabled {
   background-color: var(--thunder-color-background-disabled);
   color: var(--thunder-color-action-disabled);
   cursor: not-allowed;
 }
 
-.thunder-otp-field__error {
+.thunderid-otp-field__error {
   font-size: var(--thunder-typography-fontSize-xs);
   color: var(--thunder-color-error-contrastText);
   line-height: var(--thunder-typography-lineHeight-normal);

--- a/sdks/vue/src/components/primitives/PasswordField/PasswordField.css.ts
+++ b/sdks/vue/src/components/primitives/PasswordField/PasswordField.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the PasswordField primitive component.
  *
- * BEM block: `.thunder-password-field`
+ * BEM block: `.thunderid-password-field`
  *
  * Modifiers:
  *   --error  – shows validation error state
@@ -32,7 +32,7 @@ const PASSWORD_FIELD_CSS = `
    PasswordField
    ============================================================ */
 
-.thunder-password-field {
+.thunderid-password-field {
   display: flex;
   flex-direction: column;
   gap: calc(var(--thunder-spacing-unit) * 0.5);
@@ -41,7 +41,7 @@ const PASSWORD_FIELD_CSS = `
   box-sizing: border-box;
 }
 
-.thunder-password-field__label {
+.thunderid-password-field__label {
   font-size: var(--thunder-typography-fontSize-sm);
   font-weight: var(--thunder-typography-fontWeight-medium);
   color: var(--thunder-color-text-primary);
@@ -49,12 +49,12 @@ const PASSWORD_FIELD_CSS = `
   line-height: var(--thunder-typography-lineHeight-normal);
 }
 
-.thunder-password-field__required {
+.thunderid-password-field__required {
   color: var(--thunder-color-error-main);
   margin-left: 2px;
 }
 
-.thunder-password-field__wrapper {
+.thunderid-password-field__wrapper {
   display: flex;
   align-items: center;
   height: var(--thunder-input-height);
@@ -67,18 +67,18 @@ const PASSWORD_FIELD_CSS = `
   overflow: hidden;
   box-sizing: border-box;
 }
-.thunder-password-field__wrapper:focus-within {
+.thunderid-password-field__wrapper:focus-within {
   border-color: var(--thunder-input-focusBorderColor);
   box-shadow: var(--thunder-input-focusRing);
 }
-.thunder-password-field--error .thunder-password-field__wrapper {
+.thunderid-password-field--error .thunderid-password-field__wrapper {
   border-color: var(--thunder-color-error-main);
 }
-.thunder-password-field--error .thunder-password-field__wrapper:focus-within {
+.thunderid-password-field--error .thunderid-password-field__wrapper:focus-within {
   box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
 }
 
-.thunder-password-field__input {
+.thunderid-password-field__input {
   flex: 1;
   padding: 0 var(--thunder-input-paddingX);
   border: none;
@@ -92,14 +92,14 @@ const PASSWORD_FIELD_CSS = `
   box-sizing: border-box;
   min-width: 0;
 }
-.thunder-password-field__input::placeholder {
+.thunderid-password-field__input::placeholder {
   color: var(--thunder-color-text-secondary);
 }
-.thunder-password-field__input:disabled {
+.thunderid-password-field__input:disabled {
   cursor: not-allowed;
 }
 
-.thunder-password-field__toggle {
+.thunderid-password-field__toggle {
   background: none;
   border: none;
   cursor: pointer;
@@ -113,11 +113,11 @@ const PASSWORD_FIELD_CSS = `
   height: 100%;
   transition: color var(--thunder-transition-fast);
 }
-.thunder-password-field__toggle:hover {
+.thunderid-password-field__toggle:hover {
   color: var(--thunder-color-text-primary);
 }
 
-.thunder-password-field__error {
+.thunderid-password-field__error {
   font-size: var(--thunder-typography-fontSize-xs);
   color: var(--thunder-color-error-contrastText);
   line-height: var(--thunder-typography-lineHeight-normal);

--- a/sdks/vue/src/components/primitives/Select/Select.css.ts
+++ b/sdks/vue/src/components/primitives/Select/Select.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the Select primitive component.
  *
- * BEM block: `.thunder-select`
+ * BEM block: `.thunderid-select`
  *
  * Modifiers:
  *   --error  – shows validation error state
@@ -32,7 +32,7 @@ const SELECT_CSS = `
    Select
    ============================================================ */
 
-.thunder-select {
+.thunderid-select {
   display: flex;
   flex-direction: column;
   gap: calc(var(--thunder-spacing-unit) * 0.5);
@@ -41,7 +41,7 @@ const SELECT_CSS = `
   box-sizing: border-box;
 }
 
-.thunder-select__label {
+.thunderid-select__label {
   font-size: var(--thunder-typography-fontSize-sm);
   font-weight: var(--thunder-typography-fontWeight-medium);
   color: var(--thunder-color-text-primary);
@@ -49,12 +49,12 @@ const SELECT_CSS = `
   line-height: var(--thunder-typography-lineHeight-normal);
 }
 
-.thunder-select__required {
+.thunderid-select__required {
   color: var(--thunder-color-error-main);
   margin-left: 2px;
 }
 
-.thunder-select__input {
+.thunderid-select__input {
   width: 100%;
   height: var(--thunder-input-height);
   padding: 0 calc(var(--thunder-spacing-unit) * 4) 0 var(--thunder-input-paddingX);
@@ -77,30 +77,30 @@ const SELECT_CSS = `
   outline: none;
   line-height: var(--thunder-typography-lineHeight-normal);
 }
-.thunder-select__input:focus {
+.thunderid-select__input:focus {
   border-color: var(--thunder-input-focusBorderColor);
   box-shadow: var(--thunder-input-focusRing);
 }
-.thunder-select__input:disabled {
+.thunderid-select__input:disabled {
   background-color: var(--thunder-color-background-disabled);
   color: var(--thunder-color-action-disabled);
   cursor: not-allowed;
 }
 
-.thunder-select--error .thunder-select__input {
+.thunderid-select--error .thunderid-select__input {
   border-color: var(--thunder-color-error-main);
 }
-.thunder-select--error .thunder-select__input:focus {
+.thunderid-select--error .thunderid-select__input:focus {
   box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
 }
 
-.thunder-select__error {
+.thunderid-select__error {
   font-size: var(--thunder-typography-fontSize-xs);
   color: var(--thunder-color-error-contrastText);
   line-height: var(--thunder-typography-lineHeight-normal);
 }
 
-.thunder-select__helper {
+.thunderid-select__helper {
   font-size: var(--thunder-typography-fontSize-xs);
   color: var(--thunder-color-text-secondary);
   line-height: var(--thunder-typography-lineHeight-normal);

--- a/sdks/vue/src/components/primitives/Spinner/Spinner.css.ts
+++ b/sdks/vue/src/components/primitives/Spinner/Spinner.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the Spinner primitive component.
  *
- * BEM block: `.thunder-spinner`
+ * BEM block: `.thunderid-spinner`
  *
  * Modifiers:
  *   Size: --small | --medium | --large
@@ -35,35 +35,35 @@ const SPINNER_CSS = `
    Spinner
    ============================================================ */
 
-.thunder-spinner {
+.thunderid-spinner {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   color: var(--thunder-color-primary-main);
 }
 
-.thunder-spinner--small {
+.thunderid-spinner--small {
   width: calc(var(--thunder-spacing-unit) * 2);
   height: calc(var(--thunder-spacing-unit) * 2);
 }
 
-.thunder-spinner--medium {
+.thunderid-spinner--medium {
   width: calc(var(--thunder-spacing-unit) * 2.5);
   height: calc(var(--thunder-spacing-unit) * 2.5);
 }
 
-.thunder-spinner--large {
+.thunderid-spinner--large {
   width: calc(var(--thunder-spacing-unit) * 3.5);
   height: calc(var(--thunder-spacing-unit) * 3.5);
 }
 
-.thunder-spinner__svg {
+.thunderid-spinner__svg {
   width: 100%;
   height: 100%;
   animation: thunder-spin 1.4s linear infinite;
 }
 
-.thunder-spinner__circle {
+.thunderid-spinner__circle {
   stroke-dasharray: 80, 200;
   stroke-dashoffset: 0;
   animation: thunder-spinner-dash 1.4s ease-in-out infinite;

--- a/sdks/vue/src/components/primitives/TextField/TextField.css.ts
+++ b/sdks/vue/src/components/primitives/TextField/TextField.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the TextField primitive component.
  *
- * BEM block: `.thunder-text-field`
+ * BEM block: `.thunderid-text-field`
  *
  * Modifiers:
  *   --error  – shows validation error state
@@ -32,7 +32,7 @@ const TEXT_FIELD_CSS = `
    TextField
    ============================================================ */
 
-.thunder-text-field {
+.thunderid-text-field {
   display: flex;
   flex-direction: column;
   gap: calc(var(--thunder-spacing-unit) * 0.5);
@@ -41,7 +41,7 @@ const TEXT_FIELD_CSS = `
   box-sizing: border-box;
 }
 
-.thunder-text-field__label {
+.thunderid-text-field__label {
   font-size: var(--thunder-typography-fontSize-sm);
   font-weight: var(--thunder-typography-fontWeight-medium);
   color: var(--thunder-color-text-primary);
@@ -49,12 +49,12 @@ const TEXT_FIELD_CSS = `
   line-height: var(--thunder-typography-lineHeight-normal);
 }
 
-.thunder-text-field__required {
+.thunderid-text-field__required {
   color: var(--thunder-color-error-main);
   margin-left: 2px;
 }
 
-.thunder-text-field__input {
+.thunderid-text-field__input {
   width: 100%;
   height: var(--thunder-input-height);
   padding: 0 var(--thunder-input-paddingX);
@@ -70,33 +70,33 @@ const TEXT_FIELD_CSS = `
     box-shadow var(--thunder-transition-fast);
   outline: none;
 }
-.thunder-text-field__input:focus {
+.thunderid-text-field__input:focus {
   border-color: var(--thunder-input-focusBorderColor);
   box-shadow: var(--thunder-input-focusRing);
 }
-.thunder-text-field__input::placeholder {
+.thunderid-text-field__input::placeholder {
   color: var(--thunder-color-text-secondary);
 }
-.thunder-text-field__input:disabled {
+.thunderid-text-field__input:disabled {
   background-color: var(--thunder-color-background-disabled);
   color: var(--thunder-color-action-disabled);
   cursor: not-allowed;
 }
 
-.thunder-text-field--error .thunder-text-field__input {
+.thunderid-text-field--error .thunderid-text-field__input {
   border-color: var(--thunder-color-error-main);
 }
-.thunder-text-field--error .thunder-text-field__input:focus {
+.thunderid-text-field--error .thunderid-text-field__input:focus {
   box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
 }
 
-.thunder-text-field__error {
+.thunderid-text-field__error {
   font-size: var(--thunder-typography-fontSize-xs);
   color: var(--thunder-color-error-contrastText);
   line-height: var(--thunder-typography-lineHeight-normal);
 }
 
-.thunder-text-field__helper {
+.thunderid-text-field__helper {
   font-size: var(--thunder-typography-fontSize-xs);
   color: var(--thunder-color-text-secondary);
   line-height: var(--thunder-typography-lineHeight-normal);

--- a/sdks/vue/src/components/primitives/Typography/Typography.css.ts
+++ b/sdks/vue/src/components/primitives/Typography/Typography.css.ts
@@ -19,7 +19,7 @@
 /**
  * Styles for the Typography primitive component.
  *
- * BEM block: `.thunder-typography`
+ * BEM block: `.thunderid-typography`
  *
  * Modifiers (variant):
  *   --h1 | --h2 | --h3 | --h4 | --h5 | --h6
@@ -32,7 +32,7 @@ const TYPOGRAPHY_CSS = `
    Typography
    ============================================================ */
 
-.thunder-typography {
+.thunderid-typography {
   font-family: var(--thunder-typography-fontFamily);
   color: var(--thunder-color-text-primary);
   margin: 0;
@@ -41,74 +41,74 @@ const TYPOGRAPHY_CSS = `
   -moz-osx-font-smoothing: grayscale;
 }
 
-.thunder-typography--h1 {
+.thunderid-typography--h1 {
   font-size: var(--thunder-typography-fontSize-3xl);
   font-weight: var(--thunder-typography-fontWeight-bold);
   line-height: var(--thunder-typography-lineHeight-tight);
   letter-spacing: var(--thunder-typography-letterSpacing-tight);
 }
 
-.thunder-typography--h2 {
+.thunderid-typography--h2 {
   font-size: var(--thunder-typography-fontSize-2xl);
   font-weight: var(--thunder-typography-fontWeight-bold);
   line-height: var(--thunder-typography-lineHeight-tight);
   letter-spacing: var(--thunder-typography-letterSpacing-tight);
 }
 
-.thunder-typography--h3 {
+.thunderid-typography--h3 {
   font-size: var(--thunder-typography-fontSize-xl);
   font-weight: var(--thunder-typography-fontWeight-semibold);
   line-height: var(--thunder-typography-lineHeight-tight);
 }
 
-.thunder-typography--h4 {
+.thunderid-typography--h4 {
   font-size: var(--thunder-typography-fontSize-lg);
   font-weight: var(--thunder-typography-fontWeight-semibold);
 }
 
-.thunder-typography--h5 {
+.thunderid-typography--h5 {
   font-size: var(--thunder-typography-fontSize-md);
   font-weight: var(--thunder-typography-fontWeight-semibold);
 }
 
-.thunder-typography--h6 {
+.thunderid-typography--h6 {
   font-size: var(--thunder-typography-fontSize-sm);
   font-weight: var(--thunder-typography-fontWeight-semibold);
   text-transform: uppercase;
   letter-spacing: var(--thunder-typography-letterSpacing-wide);
 }
 
-.thunder-typography--subtitle1 {
+.thunderid-typography--subtitle1 {
   font-size: var(--thunder-typography-fontSize-lg);
   font-weight: var(--thunder-typography-fontWeight-medium);
 }
 
-.thunder-typography--subtitle2 {
+.thunderid-typography--subtitle2 {
   font-size: var(--thunder-typography-fontSize-md);
   font-weight: var(--thunder-typography-fontWeight-medium);
   color: var(--thunder-color-text-secondary);
 }
 
-.thunder-typography--body1 {
+.thunderid-typography--body1 {
   font-size: var(--thunder-typography-fontSize-md);
   font-weight: var(--thunder-typography-fontWeight-normal);
   line-height: var(--thunder-typography-lineHeight-relaxed);
 }
 
-.thunder-typography--body2 {
+.thunderid-typography--body2 {
   font-size: var(--thunder-typography-fontSize-sm);
   font-weight: var(--thunder-typography-fontWeight-normal);
   line-height: var(--thunder-typography-lineHeight-relaxed);
   color: var(--thunder-color-text-secondary);
 }
 
-.thunder-typography--caption {
+.thunderid-typography--caption {
   font-size: var(--thunder-typography-fontSize-xs);
   font-weight: var(--thunder-typography-fontWeight-normal);
   color: var(--thunder-color-text-secondary);
 }
 
-.thunder-typography--overline {
+.thunderid-typography--overline {
   font-size: var(--thunder-typography-fontSize-xs);
   font-weight: var(--thunder-typography-fontWeight-medium);
   text-transform: uppercase;


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request standardizes the BEM (Block Element Modifier) CSS naming convention across several Vue presentation components by updating the block prefix from `.thunder-` to `.thunderid-`. This change affects all related class names and documentation comments, ensuring consistency and alignment with the new naming scheme throughout the codebase.

**BEM Block Prefix Update:**

* Updated all BEM block and element class names from `.thunder-` to `.thunderid-` in the following presentation components' stylesheets:
  - `CreateOrganization.css.ts` [[1]](diffhunk://#diff-28a42618e3e9c3affb39cdd16d5ac392f54306623e59408710a64fd7ef19ef31L22-R22) [[2]](diffhunk://#diff-28a42618e3e9c3affb39cdd16d5ac392f54306623e59408710a64fd7ef19ef31L39-R39) [[3]](diffhunk://#diff-28a42618e3e9c3affb39cdd16d5ac392f54306623e59408710a64fd7ef19ef31L49-R62)
  - `LanguageSwitcher.css.ts` [[1]](diffhunk://#diff-498ae1266f971d115c5ec54553d3e459271a55d0abac5e6121f372a474bcb6eaL22-R24) [[2]](diffhunk://#diff-498ae1266f971d115c5ec54553d3e459271a55d0abac5e6121f372a474bcb6eaL42-R50) [[3]](diffhunk://#diff-498ae1266f971d115c5ec54553d3e459271a55d0abac5e6121f372a474bcb6eaL67-R83) [[4]](diffhunk://#diff-498ae1266f971d115c5ec54553d3e459271a55d0abac5e6121f372a474bcb6eaL101-R101) [[5]](diffhunk://#diff-498ae1266f971d115c5ec54553d3e459271a55d0abac5e6121f372a474bcb6eaL117-R127)
  - `OrganizationList.css.ts` [[1]](diffhunk://#diff-a9a090c525570d5cc0d4f74e9f578a6ba43852b8d20aefdce3766c2429ec2dbfL22-R22) [[2]](diffhunk://#diff-a9a090c525570d5cc0d4f74e9f578a6ba43852b8d20aefdce3766c2429ec2dbfL37-R37) [[3]](diffhunk://#diff-a9a090c525570d5cc0d4f74e9f578a6ba43852b8d20aefdce3766c2429ec2dbfL46-R47) [[4]](diffhunk://#diff-a9a090c525570d5cc0d4f74e9f578a6ba43852b8d20aefdce3766c2429ec2dbfL57-R57) [[5]](diffhunk://#diff-a9a090c525570d5cc0d4f74e9f578a6ba43852b8d20aefdce3766c2429ec2dbfL78-R83)
  - `OrganizationProfile.css.ts` [[1]](diffhunk://#diff-fed7df36b62d9992cce84cf8f2436656743e776a7538941e863f1397f17b7922L22-R29) [[2]](diffhunk://#diff-fed7df36b62d9992cce84cf8f2436656743e776a7538941e863f1397f17b7922L39-R62) [[3]](diffhunk://#diff-fed7df36b62d9992cce84cf8f2436656743e776a7538941e863f1397f17b7922L73-R73) [[4]](diffhunk://#diff-fed7df36b62d9992cce84cf8f2436656743e776a7538941e863f1397f17b7922L83-R104) [[5]](diffhunk://#diff-fed7df36b62d9992cce84cf8f2436656743e776a7538941e863f1397f17b7922L114-R157) [[6]](diffhunk://#diff-fed7df36b62d9992cce84cf8f2436656743e776a7538941e863f1397f17b7922L170-R170) [[7]](diffhunk://#diff-fed7df36b62d9992cce84cf8f2436656743e776a7538941e863f1397f17b7922L189-R212)
  - `OrganizationSwitcher.css.ts` [[1]](diffhunk://#diff-fe150a77465d2d74b16ea5e338dc42a10854c64dc9c252ac38d2447c1e5ccd64L22-R24) [[2]](diffhunk://#diff-fe150a77465d2d74b16ea5e338dc42a10854c64dc9c252ac38d2447c1e5ccd64L45-R45) [[3]](diffhunk://#diff-fe150a77465d2d74b16ea5e338dc42a10854c64dc9c252ac38d2447c1e5ccd64L54-R54) [[4]](diffhunk://#diff-fe150a77465d2d74b16ea5e338dc42a10854c64dc9c252ac38d2447c1e5ccd64L72-R82) [[5]](diffhunk://#diff-fe150a77465d2d74b16ea5e338dc42a10854c64dc9c252ac38d2447c1e5ccd64L92-R92) [[6]](diffhunk://#diff-fe150a77465d2d74b16ea5e338dc42a10854c64dc9c252ac38d2447c1e5ccd64L111-R112) [[7]](diffhunk://#diff-fe150a77465d2d74b16ea5e338dc42a10854c64dc9c252ac38d2447c1e5ccd64L122-R122)

**Documentation Consistency:**

* Updated documentation comments in each CSS file to reference the new `.thunderid-` BEM block prefix, ensuring clarity for future maintainers. [[1]](diffhunk://#diff-28a42618e3e9c3affb39cdd16d5ac392f54306623e59408710a64fd7ef19ef31L22-R22) [[2]](diffhunk://#diff-498ae1266f971d115c5ec54553d3e459271a55d0abac5e6121f372a474bcb6eaL22-R24) [[3]](diffhunk://#diff-a9a090c525570d5cc0d4f74e9f578a6ba43852b8d20aefdce3766c2429ec2dbfL22-R22) [[4]](diffhunk://#diff-fed7df36b62d9992cce84cf8f2436656743e776a7538941e863f1397f17b7922L22-R29) [[5]](diffhunk://#diff-fe150a77465d2d74b16ea5e338dc42a10854c64dc9c252ac38d2447c1e5ccd64L22-R24)

These changes are purely related to naming and documentation, with no impact on component logic or styling behavior.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated CSS styling identifiers across Vue SDK components to use a new namespace. No changes to functionality, behavior, or visual appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->