### PR TITLE
Fix start.sh syntax error when invoked with sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -153,7 +153,11 @@ setup_declarative_resources() {
                     # JSON array — expand into KEY_0, KEY_1, ...
                     idx=0
                     _json_tmp=$(mktemp)
-                    python3 -c "import json,sys; [print(x) for x in json.loads(sys.argv[1])]" "$value" 2>/dev/null > "$_json_tmp"
+                    if ! python3 -c "import json,sys; [print(x) for x in json.loads(sys.argv[1])]" "$value" > "$_json_tmp" 2>&1; then
+                        echo "Error: failed to parse JSON array for key '$key': $(cat "$_json_tmp")" >&2
+                        rm -f "$_json_tmp"
+                        exit 1
+                    fi
                     while IFS= read -r elem; do
                         export "${key}_${idx}=${elem}"
                         ((idx++))

--- a/start.sh
+++ b/start.sh
@@ -152,10 +152,13 @@ setup_declarative_resources() {
                 if [[ "$value" == \[* ]]; then
                     # JSON array — expand into KEY_0, KEY_1, ...
                     idx=0
+                    _json_tmp=$(mktemp)
+                    python3 -c "import json,sys; [print(x) for x in json.loads(sys.argv[1])]" "$value" 2>/dev/null > "$_json_tmp"
                     while IFS= read -r elem; do
                         export "${key}_${idx}=${elem}"
                         ((idx++))
-                    done < <(python3 -c "import json,sys; [print(x) for x in json.loads(sys.argv[1])]" "$value" 2>/dev/null)
+                    done < "$_json_tmp"
+                    rm -f "$_json_tmp"
                 else
                     export "${key}=${value}"
                 fi


### PR DESCRIPTION
### Purpose
`start.sh` fails with `syntax error near unexpected token '<'` at line 158 when invoked as `sh start.sh`. This is a regression from commit 722f574b (\"Support running thunder with exported resources\").

The `--env` flag's JSON array parsing used `< <(python3 ...)` — process substitution, which is bash-only syntax. When `sh`/`dash` is used as the interpreter (bypassing the `#!/bin/bash` shebang), parsing fails at that line.

### Approach
Replace the process substitution with a `mktemp` temp file, which is POSIX-compatible and behaves identically in both `sh` and `bash`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided.
- [ ] Tests provided.
- [ ] Breaking changes.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the setup script’s handling of JSON array values in environment configuration so arrays are parsed via a stable file-based process and expanded into individually indexed environment variables for consistent initialization.
  * Added explicit parse-failure detection with a clear error message before exporting values to prevent partial or invalid exports during setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->