### PR TITLE
Migrate frontend from @asgardeo/* to @thunderid/* SDKs

### DIFF
--- a/docs/plugins/shims/emotion-css.cjs
+++ b/docs/plugins/shims/emotion-css.cjs
@@ -1,0 +1,17 @@
+// SSR shim for @emotion/css — Emotion creates a DOM cache at module init
+// which fails in Node.js (document is not defined). This no-op shim is used
+// only during Docusaurus server-side rendering; the real package runs in the browser.
+function noop() { return ''; }
+function noopObj() { return {}; }
+
+module.exports = {
+  css: noop,
+  cx: noop,
+  injectGlobal: noop,
+  keyframes: noop,
+  hydrate: noop,
+  flush: noop,
+  merge: noop,
+  getRegisteredStyles: function() { return []; },
+  cache: { key: 'css', registered: {}, inserted: {}, sheet: { tags: [] } },
+};

--- a/docs/plugins/webpackPlugin.ts
+++ b/docs/plugins/webpackPlugin.ts
@@ -18,10 +18,12 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any */
 
+import path from 'path';
+
 export default function () {
   return {
     name: 'product-docs-webpack-plugin',
-    configureWebpack(config: any) {
+    configureWebpack(config: any, isServer: boolean) {
       // url-loader@4.x is incompatible with webpack@5.100+, causing:
       // "TypeError: Cannot read properties of undefined (reading 'date')"
       // Mutate existing rules in-place to replace url-loader with webpack 5
@@ -42,7 +44,7 @@ export default function () {
           }
         }
       }
-      return {
+      const baseConfig = {
         module: {
           rules: [
             {
@@ -54,6 +56,21 @@ export default function () {
           ],
         },
       };
+
+      // @emotion/css calls document.createElement at module init, which fails
+      // in Node.js SSR. Alias it to a no-op shim for the server build only.
+      if (isServer) {
+        return {
+          ...baseConfig,
+          resolve: {
+            alias: {
+              '@emotion/css': path.resolve(__dirname, 'shims/emotion-css.cjs'),
+            },
+          },
+        };
+      }
+
+      return baseConfig;
     },
   };
 }

--- a/frontend/apps/console/package.json
+++ b/frontend/apps/console/package.json
@@ -32,8 +32,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@asgardeo/react": "catalog:",
-    "@asgardeo/react-router": "catalog:",
+    "@thunderid/react": "workspace:^",
+    "@thunderid/react-router": "workspace:^",
     "@dnd-kit/abstract": "0.4.0",
     "@dnd-kit/collision": "0.4.0",
     "@dnd-kit/dom": "0.4.0",

--- a/frontend/apps/console/src/App.tsx
+++ b/frontend/apps/console/src/App.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {ProtectedRoute} from '@asgardeo/react-router';
+import {ProtectedRoute} from '@thunderid/react-router';
 import {ViewAgentTypePage} from '@thunderid/configure-agent-types';
 import {
   CreateOrganizationUnitPage,

--- a/frontend/apps/console/src/__tests__/App.test.tsx
+++ b/frontend/apps/console/src/__tests__/App.test.tsx
@@ -21,7 +21,7 @@ import {describe, it, expect, vi} from 'vitest';
 import App from '../App';
 
 // Mock the ProtectedRoute component
-vi.mock('@asgardeo/react-router', () => ({
+vi.mock('@thunderid/react-router', () => ({
   ProtectedRoute: ({children}: {children: React.ReactNode}) => <div data-testid="protected-route">{children}</div>,
 }));
 

--- a/frontend/apps/console/src/__tests__/AppWithDecorators.test.tsx
+++ b/frontend/apps/console/src/__tests__/AppWithDecorators.test.tsx
@@ -42,8 +42,8 @@ vi.mock('@thunderid/contexts', () => ({
   }),
 }));
 
-// Mock AsgardeoProvider
-interface MockAsgardeoProviderProps {
+// Mock ThunderIDProvider
+interface MockThunderIDProviderProps {
   children: ReactNode;
   baseUrl?: string | null;
   clientId?: string | null;
@@ -51,14 +51,14 @@ interface MockAsgardeoProviderProps {
   scopes?: string[];
 }
 
-vi.mock('@asgardeo/react', () => ({
-  AsgardeoProvider: ({
+vi.mock('@thunderid/react', () => ({
+  ThunderIDProvider: ({
     children,
     baseUrl = null,
     clientId = null,
     afterSignInUrl = null,
     scopes = undefined,
-  }: MockAsgardeoProviderProps) => (
+  }: MockThunderIDProviderProps) => (
     <div
       data-testid="asgardeo-provider"
       data-base-url={baseUrl}
@@ -123,7 +123,7 @@ describe('AppWithDecorators', () => {
     mockGetTrustedIssuerScopes.mockReturnValue([]);
   });
 
-  it('renders AsgardeoProvider with config values', () => {
+  it('renders ThunderIDProvider with config values', () => {
     mockGetTrustedIssuerClientId.mockReturnValue('test-client-id');
     mockGetTrustedIssuerUrl.mockReturnValue('https://test-server.example.com');
     mockGetClientUrl.mockReturnValue('https://test-client.example.com');

--- a/frontend/apps/console/src/components/GatePreview/GatePreview.tsx
+++ b/frontend/apps/console/src/components/GatePreview/GatePreview.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import type {EmbeddedFlowComponent} from '@asgardeo/react';
+import type {EmbeddedFlowComponent} from '@thunderid/react';
 import type {ColorSchemeOption, Stylesheet, Theme} from '@thunderid/design';
 import {Box, CircularProgress, Typography, useColorScheme} from '@wso2/oxygen-ui';
 import {useCallback, useLayoutEffect, useRef, useState, type JSX, type ReactNode} from 'react';

--- a/frontend/apps/console/src/components/GatePreview/IframeContent.tsx
+++ b/frontend/apps/console/src/components/GatePreview/IframeContent.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import type {EmbeddedFlowComponent} from '@asgardeo/react';
+import type {EmbeddedFlowComponent} from '@thunderid/react';
 import createCache from '@emotion/cache';
 import {CacheProvider} from '@emotion/react';
 import {

--- a/frontend/apps/console/src/components/GatePreview/mocks/buildPreviewMock.ts
+++ b/frontend/apps/console/src/components/GatePreview/mocks/buildPreviewMock.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import type {EmbeddedFlowComponent} from '@asgardeo/react';
+import type {EmbeddedFlowComponent} from '@thunderid/react';
 import {AuthenticatorTypes} from '@/features/integrations/models/authenticators';
 import type {IdentityProvider} from '@/features/integrations/models/identity-provider';
 import {IdentityProviderTypes} from '@/features/integrations/models/identity-provider';

--- a/frontend/apps/console/src/features/agents/api/__tests__/useCreateAgent.test.tsx
+++ b/frontend/apps/console/src/features/agents/api/__tests__/useCreateAgent.test.tsx
@@ -22,8 +22,8 @@ import AgentQueryKeys from '../../constants/agent-query-keys';
 import type {Agent, CreateAgentRequest} from '../../models/agent';
 import useCreateAgent from '../useCreateAgent';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useCreateAgent', () => {
@@ -89,9 +89,9 @@ describe('useCreateAgent', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {request: mockHttpRequest},
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://localhost:8090',

--- a/frontend/apps/console/src/features/agents/api/__tests__/useDeleteAgent.test.tsx
+++ b/frontend/apps/console/src/features/agents/api/__tests__/useDeleteAgent.test.tsx
@@ -21,8 +21,8 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import AgentQueryKeys from '../../constants/agent-query-keys';
 import useDeleteAgent from '../useDeleteAgent';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -34,7 +34,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useDeleteAgent', () => {
@@ -44,9 +44,9 @@ describe('useDeleteAgent', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {request: mockHttpRequest},
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://api.test.com',

--- a/frontend/apps/console/src/features/agents/api/__tests__/useGetAgent.test.tsx
+++ b/frontend/apps/console/src/features/agents/api/__tests__/useGetAgent.test.tsx
@@ -21,8 +21,8 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {Agent} from '../../models/agent';
 import useGetAgent from '../useGetAgent';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -33,7 +33,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useGetAgent', () => {
@@ -50,9 +50,9 @@ describe('useGetAgent', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {request: mockHttpRequest},
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://api.test.com',

--- a/frontend/apps/console/src/features/agents/api/__tests__/useGetAgents.test.tsx
+++ b/frontend/apps/console/src/features/agents/api/__tests__/useGetAgents.test.tsx
@@ -21,8 +21,8 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {AgentListResponse} from '../../models/agent';
 import useGetAgents from '../useGetAgents';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -33,7 +33,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useGetAgents', () => {
@@ -62,9 +62,9 @@ describe('useGetAgents', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {request: mockHttpRequest},
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://api.test.com',

--- a/frontend/apps/console/src/features/agents/api/__tests__/useRegenerateAgentSecret.test.tsx
+++ b/frontend/apps/console/src/features/agents/api/__tests__/useRegenerateAgentSecret.test.tsx
@@ -22,8 +22,8 @@ import AgentQueryKeys from '../../constants/agent-query-keys';
 import type {Agent} from '../../models/agent';
 import useRegenerateAgentSecret from '../useRegenerateAgentSecret';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useRegenerateAgentSecret', () => {
@@ -72,9 +72,9 @@ describe('useRegenerateAgentSecret', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {request: mockHttpRequest},
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://api.test.com',

--- a/frontend/apps/console/src/features/agents/api/__tests__/useUpdateAgent.test.tsx
+++ b/frontend/apps/console/src/features/agents/api/__tests__/useUpdateAgent.test.tsx
@@ -22,8 +22,8 @@ import AgentQueryKeys from '../../constants/agent-query-keys';
 import type {Agent, UpdateAgentRequest} from '../../models/agent';
 import useUpdateAgent from '../useUpdateAgent';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useUpdateAgent', () => {
@@ -58,9 +58,9 @@ describe('useUpdateAgent', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {request: mockHttpRequest},
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://api.test.com',

--- a/frontend/apps/console/src/features/agents/api/useCreateAgent.ts
+++ b/frontend/apps/console/src/features/agents/api/useCreateAgent.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {getErrorMessage} from '@thunderid/utils';
@@ -25,7 +25,7 @@ import AgentQueryKeys from '../constants/agent-query-keys';
 import type {Agent, CreateAgentRequest} from '../models/agent';
 
 export default function useCreateAgent(): UseMutationResult<Agent, Error, CreateAgentRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient = useQueryClient();
   const {t} = useTranslation('agents');

--- a/frontend/apps/console/src/features/agents/api/useDeleteAgent.ts
+++ b/frontend/apps/console/src/features/agents/api/useDeleteAgent.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {getErrorMessage} from '@thunderid/utils';
@@ -24,7 +24,7 @@ import {useTranslation} from 'react-i18next';
 import AgentQueryKeys from '../constants/agent-query-keys';
 
 export default function useDeleteAgent(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient = useQueryClient();
   const {t} = useTranslation('agents');

--- a/frontend/apps/console/src/features/agents/api/useGetAgent.ts
+++ b/frontend/apps/console/src/features/agents/api/useGetAgent.ts
@@ -16,14 +16,14 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import AgentQueryKeys from '../constants/agent-query-keys';
 import type {Agent} from '../models/agent';
 
 export default function useGetAgent(agentId: string): UseQueryResult<Agent> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<Agent>({

--- a/frontend/apps/console/src/features/agents/api/useGetAgents.ts
+++ b/frontend/apps/console/src/features/agents/api/useGetAgents.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import AgentQueryKeys from '../constants/agent-query-keys';
@@ -28,7 +28,7 @@ export interface UseGetAgentsParams {
 }
 
 export default function useGetAgents(params?: UseGetAgentsParams): UseQueryResult<AgentListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/apps/console/src/features/agents/api/useRegenerateAgentSecret.ts
+++ b/frontend/apps/console/src/features/agents/api/useRegenerateAgentSecret.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {getErrorMessage} from '@thunderid/utils';
@@ -51,7 +51,7 @@ export default function useRegenerateAgentSecret(): UseMutationResult<
   Error,
   RegenerateAgentSecretVariables
 > {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient = useQueryClient();
   const {t} = useTranslation('agents');

--- a/frontend/apps/console/src/features/agents/api/useUpdateAgent.ts
+++ b/frontend/apps/console/src/features/agents/api/useUpdateAgent.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {getErrorMessage} from '@thunderid/utils';
@@ -30,7 +30,7 @@ interface UpdateAgentParams {
 }
 
 export default function useUpdateAgent(): UseMutationResult<Agent, Error, UpdateAgentParams> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient = useQueryClient();
   const {t} = useTranslation('agents');

--- a/frontend/apps/console/src/features/agents/components/create-agent/ConfigureOwner.tsx
+++ b/frontend/apps/console/src/features/agents/components/create-agent/ConfigureOwner.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useGetUsers} from '@thunderid/configure-users';
 import {FormControl, FormLabel, MenuItem, Select, Stack, Typography} from '@wso2/oxygen-ui';
 import {useEffect, useMemo, type JSX} from 'react';
@@ -47,7 +47,7 @@ export default function ConfigureOwner({
   onReadyChange = undefined,
 }: ConfigureOwnerProps): JSX.Element {
   const {t} = useTranslation();
-  const asgardeoUser = useAsgardeo().user as {id?: string} | null | undefined;
+  const asgardeoUser = useThunderID().user as {id?: string} | null | undefined;
   const currentUserId = asgardeoUser?.id ?? null;
 
   const {data: usersData, isLoading: usersLoading} = useGetUsers({limit: 100, offset: 0});

--- a/frontend/apps/console/src/features/agents/components/create-agent/__tests__/ConfigureOwner.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/create-agent/__tests__/ConfigureOwner.test.tsx
@@ -26,8 +26,8 @@ const {mockAsgardeoUser, mockUseGetUsers} = vi.hoisted(() => ({
   mockUseGetUsers: vi.fn(),
 }));
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({user: mockAsgardeoUser}),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({user: mockAsgardeoUser}),
 }));
 
 vi.mock('@thunderid/configure-users', () => ({

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/OAuth2ConfigSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/OAuth2ConfigSection.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {SettingsCard} from '@thunderid/components';
 import {
   Box,
@@ -112,7 +112,7 @@ export default function OAuth2ConfigSection({
   onOAuth2ConfigChange = undefined,
 }: OAuth2ConfigSectionProps) {
   const {t} = useTranslation();
-  const {discovery} = useAsgardeo();
+  const {discovery} = useThunderID();
 
   if (!oauth2Config) return null;
 

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/OAuth2ConfigSection.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/OAuth2ConfigSection.test.tsx
@@ -27,8 +27,8 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     discovery: {
       wellKnown: {
         grant_types_supported: ['authorization_code', 'refresh_token', 'client_credentials'],

--- a/frontend/apps/console/src/features/agents/pages/AgentCreatePage.tsx
+++ b/frontend/apps/console/src/features/agents/pages/AgentCreatePage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useGetAgentType, useGetAgentTypes} from '@thunderid/configure-agent-types';
 import {useGetChildOrganizationUnits} from '@thunderid/configure-organization-units';
 import {ConfigureOrganizationUnit} from '@thunderid/configure-users';
@@ -66,7 +66,7 @@ export default function AgentCreatePage(): JSX.Element {
     isLoading: isChildOuLoading,
     error: childOuError,
   } = useGetChildOrganizationUnits(selectedSchema?.ouId, {limit: 1, offset: 0});
-  const user = useAsgardeo().user as {ouId?: string} | null | undefined;
+  const user = useThunderID().user as {ouId?: string} | null | undefined;
   const tokenOuId = user?.ouId ?? null;
   const isChildOuForbidden = (childOuError as {response?: {status?: number}} | null)?.response?.status === 403;
   const hasChildOUs = !isChildOuLoading && !childOuError && (childOuData?.totalResults ?? 0) > 0;

--- a/frontend/apps/console/src/features/agents/pages/__tests__/AgentCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/agents/pages/__tests__/AgentCreatePage.test.tsx
@@ -64,8 +64,8 @@ vi.mock('../../api/useCreateAgent', () => ({
   }),
 }));
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({user: {id: 'current-user', ouId: 'token-ou'}}),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({user: {id: 'current-user', ouId: 'token-ou'}}),
 }));
 
 vi.mock('../../contexts/AgentCreate/useAgentCreate', () => ({

--- a/frontend/apps/console/src/features/applications/api/__tests__/useCreateApplication.test.tsx
+++ b/frontend/apps/console/src/features/applications/api/__tests__/useCreateApplication.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import {waitFor, act, renderHook} from '@thunderid/test-utils';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
@@ -28,8 +28,8 @@ import useCreateApplication from '../useCreateApplication';
 // Import mocked modules
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -140,12 +140,12 @@ describe('useCreateApplication', () => {
     // Mock HTTP request function
     mockHttpRequest = vi.fn();
 
-    // Mock useAsgardeo hook
-    vi.mocked(useAsgardeo).mockReturnValue({
+    // Mock useThunderID hook
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     // Mock useConfig hook
     vi.mocked(useConfig).mockReturnValue({

--- a/frontend/apps/console/src/features/applications/api/__tests__/useDeleteApplication.test.tsx
+++ b/frontend/apps/console/src/features/applications/api/__tests__/useDeleteApplication.test.tsx
@@ -23,8 +23,8 @@ import type {ApplicationListResponse} from '../../models/responses';
 import useDeleteApplication from '../useDeleteApplication';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -36,7 +36,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useDeleteApplication', () => {
@@ -47,11 +47,11 @@ describe('useDeleteApplication', () => {
     mockHttpRequest = vi.fn();
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/applications/api/__tests__/useGetApplication.test.tsx
+++ b/frontend/apps/console/src/features/applications/api/__tests__/useGetApplication.test.tsx
@@ -23,8 +23,8 @@ import type {Application} from '../../models/application';
 import useGetApplication from '../useGetApplication';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useGetApplication', () => {
@@ -94,11 +94,11 @@ describe('useGetApplication', () => {
     mockHttpRequest = vi.fn();
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/applications/api/__tests__/useGetApplications.test.tsx
+++ b/frontend/apps/console/src/features/applications/api/__tests__/useGetApplications.test.tsx
@@ -23,8 +23,8 @@ import type {ApplicationListResponse} from '../../models/responses';
 import useGetApplications from '../useGetApplications';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useGetApplications', () => {
@@ -71,11 +71,11 @@ describe('useGetApplications', () => {
     mockHttpRequest = vi.fn();
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/applications/api/__tests__/useRegenerateClientSecret.test.tsx
+++ b/frontend/apps/console/src/features/applications/api/__tests__/useRegenerateClientSecret.test.tsx
@@ -23,8 +23,8 @@ import type {Application} from '../../models/application';
 import type {InboundAuthConfig} from '../../models/inbound-auth';
 import useRegenerateClientSecret from '../useRegenerateClientSecret';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useRegenerateClientSecret', () => {
@@ -95,11 +95,11 @@ describe('useRegenerateClientSecret', () => {
     mockHttpRequest = vi.fn();
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/applications/api/__tests__/useUpdateApplication.test.tsx
+++ b/frontend/apps/console/src/features/applications/api/__tests__/useUpdateApplication.test.tsx
@@ -24,8 +24,8 @@ import type {CreateApplicationRequest} from '../../models/requests';
 import useUpdateApplication from '../useUpdateApplication';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -37,7 +37,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useUpdateApplication', () => {
@@ -120,11 +120,11 @@ describe('useUpdateApplication', () => {
     mockHttpRequest = vi.fn();
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/applications/api/useCreateApplication.ts
+++ b/frontend/apps/console/src/features/applications/api/useCreateApplication.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {getErrorMessage} from '@thunderid/utils';
@@ -62,7 +62,7 @@ import type {CreateApplicationRequest} from '../models/requests';
  * @public
  */
 export default function useCreateApplication(): UseMutationResult<Application, Error, CreateApplicationRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('applications');

--- a/frontend/apps/console/src/features/applications/api/useDeleteApplication.ts
+++ b/frontend/apps/console/src/features/applications/api/useDeleteApplication.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {getErrorMessage} from '@thunderid/utils';
@@ -62,7 +62,7 @@ import ApplicationQueryKeys from '../constants/application-query-keys';
  * @public
  */
 export default function useDeleteApplication(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('applications');

--- a/frontend/apps/console/src/features/applications/api/useGetApplication.ts
+++ b/frontend/apps/console/src/features/applications/api/useGetApplication.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import ApplicationQueryKeys from '../constants/application-query-keys';
@@ -53,7 +53,7 @@ import type {Application} from '../models/application';
  * @public
  */
 export default function useGetApplication(applicationId: string): UseQueryResult<Application> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<Application>({

--- a/frontend/apps/console/src/features/applications/api/useGetApplications.ts
+++ b/frontend/apps/console/src/features/applications/api/useGetApplications.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import ApplicationQueryKeys from '../constants/application-query-keys';
@@ -71,7 +71,7 @@ export interface UseGetApplicationsParams {
  * @public
  */
 export default function useGetApplications(params?: UseGetApplicationsParams): UseQueryResult<ApplicationListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/apps/console/src/features/applications/api/useRegenerateClientSecret.ts
+++ b/frontend/apps/console/src/features/applications/api/useRegenerateClientSecret.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {getErrorMessage} from '@thunderid/utils';
@@ -137,7 +137,7 @@ export default function useRegenerateClientSecret(): UseMutationResult<
   Error,
   RegenerateSecretVariables
 > {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient = useQueryClient();
   const {t} = useTranslation('applications');

--- a/frontend/apps/console/src/features/applications/api/useUpdateApplication.ts
+++ b/frontend/apps/console/src/features/applications/api/useUpdateApplication.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {getErrorMessage} from '@thunderid/utils';
@@ -81,7 +81,7 @@ export interface UpdateApplicationVariables {
  * @public
  */
 export default function useUpdateApplication(): UseMutationResult<Application, Error, UpdateApplicationVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('applications');

--- a/frontend/apps/console/src/features/applications/components/create-application/Preview.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/Preview.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {BaseSignIn, ThemeProvider} from '@asgardeo/react';
+import {BaseSignIn, ThemeProvider} from '@thunderid/react';
 import {type Theme} from '@thunderid/design';
 import type {RecursivePartial} from '@thunderid/types';
 import {

--- a/frontend/apps/console/src/features/applications/components/create-application/__tests__/Preview.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/__tests__/Preview.test.tsx
@@ -25,8 +25,8 @@ import Preview, {type PreviewProps} from '../Preview';
 import {AuthenticatorTypes} from '@/features/integrations/models/authenticators';
 import {IdentityProviderTypes, type IdentityProvider} from '@/features/integrations/models/identity-provider';
 
-// Mock the @asgardeo/react module
-vi.mock('@asgardeo/react', () => ({
+// Mock the @thunderid/react module
+vi.mock('@thunderid/react', () => ({
   BaseSignIn: ({children}: {children: () => ReactNode}) => <div>{children()}</div>,
   ThemeProvider: ({children}: {children: ReactNode}) => <div>{children}</div>,
 }));

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/OAuth2ConfigSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/OAuth2ConfigSection.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {SettingsCard} from '@thunderid/components';
 import {
   Box,
@@ -148,7 +148,7 @@ export default function OAuth2ConfigSection({
   onOAuth2ConfigChange = undefined,
 }: OAuth2ConfigSectionProps) {
   const {t} = useTranslation();
-  const {discovery} = useAsgardeo();
+  const {discovery} = useThunderID();
 
   if (!oauth2Config) return null;
 

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {useConfig} from '@thunderid/contexts';
 import {useLogger} from '@thunderid/logger';
@@ -124,7 +124,7 @@ export default function EditTokenSettings({
 }: EditTokenSettingsProps) {
   const logger = useLogger('EditTokenSettings');
   const {t} = useTranslation();
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   const [userTypes, setUserTypes] = useState<ApiUserType[]>([]);

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettings.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettings.test.tsx
@@ -24,7 +24,7 @@ import EditTokenSettings from '../EditTokenSettings';
 
 // Stable mock references — must be created via vi.hoisted so they are available
 // inside the hoisted vi.mock factory functions below. Without stable references,
-// useAsgardeo/useConfig/useLogger return new object identities on every render,
+// useThunderID/useConfig/useLogger return new object identities on every render,
 // causing fetchSchemas' useEffect to re-fire every render → infinite loop → OOM.
 const {mockHttp, mockGetServerUrl, mockLogger} = vi.hoisted(() => {
   const hoistedMockHttp = {
@@ -115,10 +115,10 @@ vi.mock('../TokenValidationSection', () => ({
   },
 }));
 
-// Mock useAsgardeo — stable mockHttp reference prevents fetchSchemas effect from
+// Mock useThunderID — stable mockHttp reference prevents fetchSchemas effect from
 // re-firing on every render (http is in the effect's dependency array).
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: mockHttp,
   }),
 }));

--- a/frontend/apps/console/src/features/flows/api/__tests__/useCreateFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useCreateFlow.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import {renderHook, waitFor, act} from '@thunderid/test-utils';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
@@ -25,8 +25,8 @@ import {FlowType, FlowNodeType} from '../../models/flows';
 import type {CreateFlowRequest, FlowDefinitionResponse} from '../../models/responses';
 import useCreateFlow from '../useCreateFlow';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -67,9 +67,9 @@ describe('useCreateFlow', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {request: mockHttpRequest},
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://localhost:8090',

--- a/frontend/apps/console/src/features/flows/api/__tests__/useDeleteFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useDeleteFlow.test.tsx
@@ -16,15 +16,15 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import {renderHook, waitFor, act} from '@thunderid/test-utils';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import FlowQueryKeys from '../../constants/flow-query-keys';
 import useDeleteFlow from '../useDeleteFlow';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -41,9 +41,9 @@ describe('useDeleteFlow', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {request: mockHttpRequest},
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://localhost:8090',

--- a/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowById.test.tsx
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowById.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import {renderHook, waitFor} from '@thunderid/test-utils';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
@@ -25,8 +25,8 @@ import {FlowType, FlowNodeType} from '../../models/flows';
 import type {FlowDefinitionResponse} from '../../models/responses';
 import useGetFlowById from '../useGetFlowById';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -72,11 +72,11 @@ describe('useGetFlowById', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://localhost:8090',

--- a/frontend/apps/console/src/features/flows/api/__tests__/useGetFlows.test.tsx
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useGetFlows.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import {renderHook, waitFor} from '@thunderid/test-utils';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
@@ -25,8 +25,8 @@ import {FlowType} from '../../models/flows';
 import type {FlowListResponse} from '../../models/responses';
 import useGetFlows from '../useGetFlows';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -73,11 +73,11 @@ describe('useGetFlows', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://localhost:8090',

--- a/frontend/apps/console/src/features/flows/api/__tests__/useUpdateFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useUpdateFlow.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import {renderHook, waitFor, act} from '@thunderid/test-utils';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
@@ -25,8 +25,8 @@ import {FlowType, FlowNodeType} from '../../models/flows';
 import type {UpdateFlowRequest, FlowDefinitionResponse} from '../../models/responses';
 import useUpdateFlow from '../useUpdateFlow';
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -69,9 +69,9 @@ describe('useUpdateFlow', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {request: mockHttpRequest},
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://localhost:8090',

--- a/frontend/apps/console/src/features/flows/api/useCreateFlow.ts
+++ b/frontend/apps/console/src/features/flows/api/useCreateFlow.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import FlowQueryKeys from '../constants/flow-query-keys';
@@ -52,7 +52,7 @@ import type {CreateFlowRequest, FlowDefinitionResponse} from '../models/response
  * ```
  */
 export default function useCreateFlow(): UseMutationResult<FlowDefinitionResponse, Error, CreateFlowRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/apps/console/src/features/flows/api/useDeleteFlow.ts
+++ b/frontend/apps/console/src/features/flows/api/useDeleteFlow.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import FlowQueryKeys from '../constants/flow-query-keys';
@@ -57,7 +57,7 @@ import FlowQueryKeys from '../constants/flow-query-keys';
  * ```
  */
 export default function useDeleteFlow(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/apps/console/src/features/flows/api/useGetFlowById.ts
+++ b/frontend/apps/console/src/features/flows/api/useGetFlowById.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import FlowQueryKeys from '../constants/flow-query-keys';
@@ -48,7 +48,7 @@ export default function useGetFlowById(
   flowId: string | undefined,
   enabled = true,
 ): UseQueryResult<FlowDefinitionResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<FlowDefinitionResponse>({

--- a/frontend/apps/console/src/features/flows/api/useGetFlows.ts
+++ b/frontend/apps/console/src/features/flows/api/useGetFlows.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import FlowQueryKeys from '../constants/flow-query-keys';
@@ -104,7 +104,7 @@ export interface UseGetFlowsParams {
  * @public
  */
 export default function useGetFlows(params?: UseGetFlowsParams): UseQueryResult<FlowListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {flowType, limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/apps/console/src/features/flows/api/useUpdateFlow.ts
+++ b/frontend/apps/console/src/features/flows/api/useUpdateFlow.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import FlowQueryKeys from '../constants/flow-query-keys';
@@ -60,7 +60,7 @@ interface UpdateFlowVariables {
  * ```
  */
 export default function useUpdateFlow(): UseMutationResult<FlowDefinitionResponse, Error, UpdateFlowVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/apps/console/src/features/groups/api/__tests__/useAddGroupMembers.test.ts
+++ b/frontend/apps/console/src/features/groups/api/__tests__/useAddGroupMembers.test.ts
@@ -21,8 +21,8 @@ import {renderHook} from '@thunderid/test-utils';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/apps/console/src/features/groups/api/__tests__/useCreateGroup.test.ts
+++ b/frontend/apps/console/src/features/groups/api/__tests__/useCreateGroup.test.ts
@@ -23,8 +23,8 @@ import type {Group} from '../../models/group';
 import type {CreateGroupRequest} from '../../models/requests';
 
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/apps/console/src/features/groups/api/__tests__/useDeleteGroup.test.ts
+++ b/frontend/apps/console/src/features/groups/api/__tests__/useDeleteGroup.test.ts
@@ -21,8 +21,8 @@ import {renderHook} from '@thunderid/test-utils';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/apps/console/src/features/groups/api/__tests__/useGetGroup.test.ts
+++ b/frontend/apps/console/src/features/groups/api/__tests__/useGetGroup.test.ts
@@ -22,8 +22,8 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {Group} from '../../models/group';
 
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/apps/console/src/features/groups/api/__tests__/useGetGroupMembers.test.ts
+++ b/frontend/apps/console/src/features/groups/api/__tests__/useGetGroupMembers.test.ts
@@ -22,8 +22,8 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {MemberListResponse} from '../../models/group';
 
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/apps/console/src/features/groups/api/__tests__/useGetGroups.test.ts
+++ b/frontend/apps/console/src/features/groups/api/__tests__/useGetGroups.test.ts
@@ -22,8 +22,8 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {GroupListResponse} from '../../models/group';
 
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/apps/console/src/features/groups/api/__tests__/useRemoveGroupMembers.test.ts
+++ b/frontend/apps/console/src/features/groups/api/__tests__/useRemoveGroupMembers.test.ts
@@ -21,8 +21,8 @@ import {renderHook} from '@thunderid/test-utils';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/apps/console/src/features/groups/api/__tests__/useUpdateGroup.test.ts
+++ b/frontend/apps/console/src/features/groups/api/__tests__/useUpdateGroup.test.ts
@@ -22,8 +22,8 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {Group} from '../../models/group';
 
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/apps/console/src/features/groups/api/useAddGroupMembers.ts
+++ b/frontend/apps/console/src/features/groups/api/useAddGroupMembers.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -37,7 +37,7 @@ export interface AddGroupMembersVariables {
  * @returns TanStack Query mutation object for adding group members
  */
 export default function useAddGroupMembers(): UseMutationResult<void, Error, AddGroupMembersVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('groups');

--- a/frontend/apps/console/src/features/groups/api/useCreateGroup.ts
+++ b/frontend/apps/console/src/features/groups/api/useCreateGroup.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -30,7 +30,7 @@ import type {CreateGroupRequest} from '../models/requests';
  * @returns TanStack Query mutation object for creating groups
  */
 export default function useCreateGroup(): UseMutationResult<Group, Error, CreateGroupRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('groups');

--- a/frontend/apps/console/src/features/groups/api/useDeleteGroup.ts
+++ b/frontend/apps/console/src/features/groups/api/useDeleteGroup.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -28,7 +28,7 @@ import GroupQueryKeys from '../constants/group-query-keys';
  * @returns TanStack Query mutation object for deleting groups
  */
 export default function useDeleteGroup(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('groups');

--- a/frontend/apps/console/src/features/groups/api/useGetGroup.ts
+++ b/frontend/apps/console/src/features/groups/api/useGetGroup.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import GroupQueryKeys from '../constants/group-query-keys';
@@ -29,7 +29,7 @@ import type {Group} from '../models/group';
  * @returns TanStack Query result object containing group data
  */
 export default function useGetGroup(groupId: string): UseQueryResult<Group> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<Group>({

--- a/frontend/apps/console/src/features/groups/api/useGetGroupMembers.ts
+++ b/frontend/apps/console/src/features/groups/api/useGetGroupMembers.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import GroupQueryKeys from '../constants/group-query-keys';
@@ -34,7 +34,7 @@ export default function useGetGroupMembers(
   groupId: string | undefined,
   params?: GroupListParams,
 ): UseQueryResult<MemberListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/apps/console/src/features/groups/api/useGetGroups.ts
+++ b/frontend/apps/console/src/features/groups/api/useGetGroups.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import GroupQueryKeys from '../constants/group-query-keys';
@@ -30,7 +30,7 @@ import type {GroupListParams} from '../models/requests';
  * @returns TanStack Query result object containing groups list data
  */
 export default function useGetGroups(params?: GroupListParams): UseQueryResult<GroupListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/apps/console/src/features/groups/api/useRemoveGroupMembers.ts
+++ b/frontend/apps/console/src/features/groups/api/useRemoveGroupMembers.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -37,7 +37,7 @@ export interface RemoveGroupMembersVariables {
  * @returns TanStack Query mutation object for removing group members
  */
 export default function useRemoveGroupMembers(): UseMutationResult<void, Error, RemoveGroupMembersVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('groups');

--- a/frontend/apps/console/src/features/groups/api/useUpdateGroup.ts
+++ b/frontend/apps/console/src/features/groups/api/useUpdateGroup.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -38,7 +38,7 @@ export interface UpdateGroupVariables {
  * @returns TanStack Query mutation object for updating groups
  */
 export default function useUpdateGroup(): UseMutationResult<Group, Error, UpdateGroupVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('groups');

--- a/frontend/apps/console/src/features/home/pages/HomePage.tsx
+++ b/frontend/apps/console/src/features/home/pages/HomePage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {User} from '@asgardeo/react';
+import {User} from '@thunderid/react';
 import {Box, PageContent, Stack, Typography, useTheme} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';

--- a/frontend/apps/console/src/features/home/pages/__tests__/HomePage.test.tsx
+++ b/frontend/apps/console/src/features/home/pages/__tests__/HomePage.test.tsx
@@ -29,7 +29,7 @@ vi.mock('react-i18next', () => ({
 type UserData = {name?: string; email?: string} | null;
 let mockUser: UserData = null;
 
-vi.mock('@asgardeo/react', () => ({
+vi.mock('@thunderid/react', () => ({
   User: ({children}: {children: (user: UserData) => React.ReactNode}) => <>{children(mockUser)}</>,
 }));
 

--- a/frontend/apps/console/src/features/import-export/api/__tests__/useExportConfiguration.test.ts
+++ b/frontend/apps/console/src/features/import-export/api/__tests__/useExportConfiguration.test.ts
@@ -22,8 +22,8 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import type {ExportRequest, JSONExportResponse} from '../../models/export-configuration';
 
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/apps/console/src/features/import-export/api/__tests__/useImportConfiguration.test.ts
+++ b/frontend/apps/console/src/features/import-export/api/__tests__/useImportConfiguration.test.ts
@@ -22,8 +22,8 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import type {ImportRequest, ImportResponse} from '../../models/import-configuration';
 
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/apps/console/src/features/import-export/api/useExportConfiguration.ts
+++ b/frontend/apps/console/src/features/import-export/api/useExportConfiguration.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import type {ExportRequest, JSONExportResponse} from '../models/export-configuration';
@@ -63,7 +63,7 @@ import type {ExportRequest, JSONExportResponse} from '../models/export-configura
  * @public
  */
 export default function useExportConfiguration(): UseMutationResult<JSONExportResponse, Error, ExportRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useMutation<JSONExportResponse, Error, ExportRequest>({

--- a/frontend/apps/console/src/features/import-export/api/useImportConfiguration.ts
+++ b/frontend/apps/console/src/features/import-export/api/useImportConfiguration.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import type {ImportRequest, ImportResponse} from '../models/import-configuration';
@@ -29,7 +29,7 @@ import type {ImportRequest, ImportResponse} from '../models/import-configuration
  * @public
  */
 export default function useImportConfiguration(): UseMutationResult<ImportResponse, Error, ImportRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useMutation<ImportResponse, Error, ImportRequest>({

--- a/frontend/apps/console/src/features/integrations/api/__tests__/useIdentityProviders.test.tsx
+++ b/frontend/apps/console/src/features/integrations/api/__tests__/useIdentityProviders.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {QueryClient} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import {waitFor, act, renderHook} from '@thunderid/test-utils';
@@ -27,8 +27,8 @@ import type {IdentityProviderListResponse} from '../../models/responses';
 import useIdentityProviders from '../useIdentityProviders';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -66,11 +66,11 @@ describe('useIdentityProviders', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn().mockResolvedValue({data: mockIdentityProviders});
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'http://localhost:8090',

--- a/frontend/apps/console/src/features/integrations/api/useIdentityProviders.ts
+++ b/frontend/apps/console/src/features/integrations/api/useIdentityProviders.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import IntegrationQueryKeys from '../constants/query-keys';
@@ -46,7 +46,7 @@ import type {IdentityProviderListResponse} from '../models/responses';
  * ```
  */
 export default function useIdentityProviders(): UseQueryResult<IdentityProviderListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<IdentityProviderListResponse>({

--- a/frontend/apps/console/src/features/notification-senders/api/__tests__/useNotificationSenders.test.tsx
+++ b/frontend/apps/console/src/features/notification-senders/api/__tests__/useNotificationSenders.test.tsx
@@ -35,11 +35,11 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-// Mock useAsgardeo
+// Mock useThunderID
 const mockHttpRequest = vi.fn();
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/apps/console/src/features/notification-senders/api/useNotificationSenders.ts
+++ b/frontend/apps/console/src/features/notification-senders/api/useNotificationSenders.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import NotificationSenderQueryKeys from '../constants/query-keys';
@@ -46,7 +46,7 @@ import type {NotificationSenderListResponse} from '../models/notification-sender
  * ```
  */
 export default function useNotificationSenders(): UseQueryResult<NotificationSenderListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<NotificationSenderListResponse>({

--- a/frontend/apps/console/src/features/roles/api/__tests__/useAddRoleAssignments.test.tsx
+++ b/frontend/apps/console/src/features/roles/api/__tests__/useAddRoleAssignments.test.tsx
@@ -22,8 +22,8 @@ import RoleQueryKeys from '../../constants/role-query-keys';
 import useAddRoleAssignments from '../useAddRoleAssignments';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig, useToast} = await import('@thunderid/contexts');
 
 describe('useAddRoleAssignments', () => {
@@ -48,11 +48,11 @@ describe('useAddRoleAssignments', () => {
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
     mockShowToast = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/roles/api/__tests__/useCreateRole.test.tsx
+++ b/frontend/apps/console/src/features/roles/api/__tests__/useCreateRole.test.tsx
@@ -24,8 +24,8 @@ import type {Role} from '../../models/role';
 import useCreateRole from '../useCreateRole';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -37,7 +37,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig, useToast} = await import('@thunderid/contexts');
 
 describe('useCreateRole', () => {
@@ -64,11 +64,11 @@ describe('useCreateRole', () => {
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
     mockShowToast = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/roles/api/__tests__/useDeleteRole.test.tsx
+++ b/frontend/apps/console/src/features/roles/api/__tests__/useDeleteRole.test.tsx
@@ -22,8 +22,8 @@ import RoleQueryKeys from '../../constants/role-query-keys';
 import useDeleteRole from '../useDeleteRole';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig, useToast} = await import('@thunderid/contexts');
 
 describe('useDeleteRole', () => {
@@ -48,11 +48,11 @@ describe('useDeleteRole', () => {
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
     mockShowToast = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/roles/api/__tests__/useGetRole.test.tsx
+++ b/frontend/apps/console/src/features/roles/api/__tests__/useGetRole.test.tsx
@@ -23,8 +23,8 @@ import type {Role} from '../../models/role';
 import useGetRole from '../useGetRole';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useGetRole', () => {
@@ -59,11 +59,11 @@ describe('useGetRole', () => {
     mockHttpRequest = vi.fn();
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/roles/api/__tests__/useGetRoleAssignments.test.tsx
+++ b/frontend/apps/console/src/features/roles/api/__tests__/useGetRoleAssignments.test.tsx
@@ -23,8 +23,8 @@ import type {RoleAssignmentListResponse} from '../../models/role';
 import useGetRoleAssignments from '../useGetRoleAssignments';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useGetRoleAssignments', () => {
@@ -64,11 +64,11 @@ describe('useGetRoleAssignments', () => {
     mockHttpRequest = vi.fn();
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/roles/api/__tests__/useGetRoles.test.tsx
+++ b/frontend/apps/console/src/features/roles/api/__tests__/useGetRoles.test.tsx
@@ -23,8 +23,8 @@ import type {RoleListResponse} from '../../models/role';
 import useGetRoles from '../useGetRoles';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useGetRoles', () => {
@@ -66,11 +66,11 @@ describe('useGetRoles', () => {
     mockHttpRequest = vi.fn();
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/roles/api/__tests__/useRemoveRoleAssignments.test.tsx
+++ b/frontend/apps/console/src/features/roles/api/__tests__/useRemoveRoleAssignments.test.tsx
@@ -22,8 +22,8 @@ import RoleQueryKeys from '../../constants/role-query-keys';
 import useRemoveRoleAssignments from '../useRemoveRoleAssignments';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig, useToast} = await import('@thunderid/contexts');
 
 describe('useRemoveRoleAssignments', () => {
@@ -48,11 +48,11 @@ describe('useRemoveRoleAssignments', () => {
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
     mockShowToast = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/roles/api/__tests__/useUpdateRole.test.tsx
+++ b/frontend/apps/console/src/features/roles/api/__tests__/useUpdateRole.test.tsx
@@ -24,8 +24,8 @@ import type {Role} from '../../models/role';
 import useUpdateRole from '../useUpdateRole';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -37,7 +37,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig, useToast} = await import('@thunderid/contexts');
 
 describe('useUpdateRole', () => {
@@ -75,11 +75,11 @@ describe('useUpdateRole', () => {
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
     mockShowToast = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/roles/api/useAddRoleAssignments.ts
+++ b/frontend/apps/console/src/features/roles/api/useAddRoleAssignments.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -34,7 +34,7 @@ export interface AddRoleAssignmentsVariables {
  * @returns TanStack Query mutation object for adding role assignments
  */
 export default function useAddRoleAssignments(): UseMutationResult<void, Error, AddRoleAssignmentsVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('roles');

--- a/frontend/apps/console/src/features/roles/api/useCreateRole.ts
+++ b/frontend/apps/console/src/features/roles/api/useCreateRole.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -30,7 +30,7 @@ import type {Role} from '../models/role';
  * @returns TanStack Query mutation object for creating roles
  */
 export default function useCreateRole(): UseMutationResult<Role, Error, CreateRoleRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('roles');

--- a/frontend/apps/console/src/features/roles/api/useDeleteRole.ts
+++ b/frontend/apps/console/src/features/roles/api/useDeleteRole.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -28,7 +28,7 @@ import RoleQueryKeys from '../constants/role-query-keys';
  * @returns TanStack Query mutation object for deleting roles
  */
 export default function useDeleteRole(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('roles');

--- a/frontend/apps/console/src/features/roles/api/useGetRole.ts
+++ b/frontend/apps/console/src/features/roles/api/useGetRole.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import RoleQueryKeys from '../constants/role-query-keys';
@@ -29,7 +29,7 @@ import type {Role} from '../models/role';
  * @returns TanStack Query result object containing role data
  */
 export default function useGetRole(roleId: string): UseQueryResult<Role> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<Role>({

--- a/frontend/apps/console/src/features/roles/api/useGetRoleAssignments.ts
+++ b/frontend/apps/console/src/features/roles/api/useGetRoleAssignments.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import RoleQueryKeys from '../constants/role-query-keys';
@@ -38,7 +38,7 @@ export interface UseGetRoleAssignmentsParams extends RoleAssignmentListParams {
 export default function useGetRoleAssignments(
   params: UseGetRoleAssignmentsParams,
 ): UseQueryResult<RoleAssignmentListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {roleId, limit = 30, offset = 0, include, type, enabled = true} = params;
 

--- a/frontend/apps/console/src/features/roles/api/useGetRoles.ts
+++ b/frontend/apps/console/src/features/roles/api/useGetRoles.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import RoleQueryKeys from '../constants/role-query-keys';
@@ -30,7 +30,7 @@ import type {RoleListResponse} from '../models/role';
  * @returns TanStack Query result object containing roles list data
  */
 export default function useGetRoles(params?: RoleListParams): UseQueryResult<RoleListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/apps/console/src/features/roles/api/useRemoveRoleAssignments.ts
+++ b/frontend/apps/console/src/features/roles/api/useRemoveRoleAssignments.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -34,7 +34,7 @@ export interface RemoveRoleAssignmentsVariables {
  * @returns TanStack Query mutation object for removing role assignments
  */
 export default function useRemoveRoleAssignments(): UseMutationResult<void, Error, RemoveRoleAssignmentsVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('roles');

--- a/frontend/apps/console/src/features/roles/api/useUpdateRole.ts
+++ b/frontend/apps/console/src/features/roles/api/useUpdateRole.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -35,7 +35,7 @@ export interface UpdateRoleVariables {
  * @returns TanStack Query mutation object for updating roles
  */
 export default function useUpdateRole(): UseMutationResult<Role, Error, UpdateRoleVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('roles');

--- a/frontend/apps/console/src/features/user-types/api/__tests__/useCreateUserType.test.ts
+++ b/frontend/apps/console/src/features/user-types/api/__tests__/useCreateUserType.test.ts
@@ -22,13 +22,13 @@ import UserTypeQueryKeys from '../../constants/userTypeQueryKeys';
 import type {ApiUserType, CreateUserTypeRequest} from '../../types/user-types';
 import useCreateUserType from '../useCreateUserType';
 
-vi.mock('@asgardeo/react', () => ({useAsgardeo: vi.fn()}));
+vi.mock('@thunderid/react', () => ({useThunderID: vi.fn()}));
 vi.mock('@thunderid/contexts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@thunderid/contexts')>();
   return {...actual, useConfig: vi.fn()};
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useCreateUserType', () => {
@@ -62,11 +62,11 @@ describe('useCreateUserType', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://api.test.com',

--- a/frontend/apps/console/src/features/user-types/api/__tests__/useDeleteUserType.test.ts
+++ b/frontend/apps/console/src/features/user-types/api/__tests__/useDeleteUserType.test.ts
@@ -21,13 +21,13 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import UserTypeQueryKeys from '../../constants/userTypeQueryKeys';
 import useDeleteUserType from '../useDeleteUserType';
 
-vi.mock('@asgardeo/react', () => ({useAsgardeo: vi.fn()}));
+vi.mock('@thunderid/react', () => ({useThunderID: vi.fn()}));
 vi.mock('@thunderid/contexts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@thunderid/contexts')>();
   return {...actual, useConfig: vi.fn()};
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useDeleteUserType', () => {
@@ -38,11 +38,11 @@ describe('useDeleteUserType', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://api.test.com',

--- a/frontend/apps/console/src/features/user-types/api/__tests__/useGetUserType.test.ts
+++ b/frontend/apps/console/src/features/user-types/api/__tests__/useGetUserType.test.ts
@@ -23,8 +23,8 @@ import type {ApiUserType} from '../../types/user-types';
 import useGetUserType from '../useGetUserType';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useGetUserType', () => {
@@ -59,11 +59,11 @@ describe('useGetUserType', () => {
     mockHttpRequest = vi.fn();
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/user-types/api/__tests__/useGetUserTypes.test.ts
+++ b/frontend/apps/console/src/features/user-types/api/__tests__/useGetUserTypes.test.ts
@@ -23,8 +23,8 @@ import type {UserTypeListResponse} from '../../types/user-types';
 import useGetUserTypes from '../useGetUserTypes';
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: vi.fn(),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: vi.fn(),
 }));
 
 vi.mock('@thunderid/contexts', async (importOriginal) => {
@@ -35,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useGetUserTypes', () => {
@@ -57,11 +57,11 @@ describe('useGetUserTypes', () => {
     mockHttpRequest = vi.fn();
     mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: mockGetServerUrl,

--- a/frontend/apps/console/src/features/user-types/api/__tests__/useUpdateUserType.test.ts
+++ b/frontend/apps/console/src/features/user-types/api/__tests__/useUpdateUserType.test.ts
@@ -23,13 +23,13 @@ import type {ApiUserType, UpdateUserTypeRequest} from '../../types/user-types';
 import useUpdateUserType from '../useUpdateUserType';
 import type {UpdateUserTypeVariables} from '../useUpdateUserType';
 
-vi.mock('@asgardeo/react', () => ({useAsgardeo: vi.fn()}));
+vi.mock('@thunderid/react', () => ({useThunderID: vi.fn()}));
 vi.mock('@thunderid/contexts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@thunderid/contexts')>();
   return {...actual, useConfig: vi.fn()};
 });
 
-const {useAsgardeo} = await import('@asgardeo/react');
+const {useThunderID} = await import('@thunderid/react');
 const {useConfig} = await import('@thunderid/contexts');
 
 describe('useUpdateUserType', () => {
@@ -70,11 +70,11 @@ describe('useUpdateUserType', () => {
   beforeEach(() => {
     mockHttpRequest = vi.fn();
 
-    vi.mocked(useAsgardeo).mockReturnValue({
+    vi.mocked(useThunderID).mockReturnValue({
       http: {
         request: mockHttpRequest,
       },
-    } as unknown as ReturnType<typeof useAsgardeo>);
+    } as unknown as ReturnType<typeof useThunderID>);
 
     vi.mocked(useConfig).mockReturnValue({
       getServerUrl: () => 'https://api.test.com',

--- a/frontend/apps/console/src/features/user-types/api/useCreateUserType.ts
+++ b/frontend/apps/console/src/features/user-types/api/useCreateUserType.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -29,7 +29,7 @@ import type {ApiUserType, CreateUserTypeRequest} from '../types/user-types';
  * @returns TanStack Query mutation object for creating user types
  */
 export default function useCreateUserType(): UseMutationResult<ApiUserType, Error, CreateUserTypeRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('userTypes');

--- a/frontend/apps/console/src/features/user-types/api/useDeleteUserType.ts
+++ b/frontend/apps/console/src/features/user-types/api/useDeleteUserType.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -28,7 +28,7 @@ import UserTypeQueryKeys from '../constants/userTypeQueryKeys';
  * @returns TanStack Query mutation object for deleting user types
  */
 export default function useDeleteUserType(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('userTypes');

--- a/frontend/apps/console/src/features/user-types/api/useGetUserType.ts
+++ b/frontend/apps/console/src/features/user-types/api/useGetUserType.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import UserTypeQueryKeys from '../constants/userTypeQueryKeys';
@@ -29,7 +29,7 @@ import type {ApiUserType} from '../types/user-types';
  * @returns TanStack Query result object containing user type data, loading state, and error information
  */
 export default function useGetUserType(id?: string): UseQueryResult<ApiUserType> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<ApiUserType>({

--- a/frontend/apps/console/src/features/user-types/api/useGetUserTypes.ts
+++ b/frontend/apps/console/src/features/user-types/api/useGetUserTypes.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import UserTypeQueryKeys from '../constants/userTypeQueryKeys';
@@ -31,7 +31,7 @@ import type {UserTypeListParams, UserTypeListResponse} from '../types/user-types
  * @returns TanStack Query result object containing user types list data, loading state, and error information
  */
 export default function useGetUserTypes(params?: UserTypeListParams): UseQueryResult<UserTypeListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit, offset} = params ?? {};
 

--- a/frontend/apps/console/src/features/user-types/api/useUpdateUserType.ts
+++ b/frontend/apps/console/src/features/user-types/api/useUpdateUserType.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -43,7 +43,7 @@ export interface UpdateUserTypeVariables {
  * @returns TanStack Query mutation object for updating user types
  */
 export default function useUpdateUserType(): UseMutationResult<ApiUserType, Error, UpdateUserTypeVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('userTypes');

--- a/frontend/apps/console/src/features/welcome/components/WelcomeRedirect.tsx
+++ b/frontend/apps/console/src/features/welcome/components/WelcomeRedirect.tsx
@@ -16,14 +16,14 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import {useEffect, type JSX} from 'react';
 import {useLocation, useNavigate} from 'react-router';
 import getWelcomeDismissedStorageKey from '../utils/getWelcomeDismissedStorageKey';
 
 export default function WelcomeRedirect(): JSX.Element | null {
-  const {isSignedIn} = useAsgardeo();
+  const {isSignedIn} = useThunderID();
   const {config} = useConfig();
   const navigate = useNavigate();
   const location = useLocation();

--- a/frontend/apps/console/src/features/welcome/components/__tests__/WelcomeRedirect.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/WelcomeRedirect.test.tsx
@@ -27,8 +27,8 @@ const mockLocation = {
   pathname: '/dashboard',
 };
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     isSignedIn: mockIsSignedIn() as boolean,
   }),
 }));

--- a/frontend/apps/console/src/hocs/__tests__/withConfig.test.tsx
+++ b/frontend/apps/console/src/hocs/__tests__/withConfig.test.tsx
@@ -51,8 +51,8 @@ vi.mock('@thunderid/contexts', () => ({
   }),
 }));
 
-vi.mock('@asgardeo/react', () => ({
-  AsgardeoProvider: ({
+vi.mock('@thunderid/react', () => ({
+  ThunderIDProvider: ({
     children,
     /* eslint-disable react/require-default-props */
     baseUrl,
@@ -129,7 +129,7 @@ describe('withConfig (console)', () => {
     expect(screen.getByTestId('mock-child')).toBeInTheDocument();
   });
 
-  it('wraps with AsgardeoProvider', () => {
+  it('wraps with ThunderIDProvider', () => {
     mockGetClientId.mockReturnValue('client-id');
     mockGetServerUrl.mockReturnValue('https://server.example.com');
     mockGetClientUrl.mockReturnValue('https://client.example.com');
@@ -138,7 +138,7 @@ describe('withConfig (console)', () => {
     expect(screen.getByTestId('asgardeo-provider')).toBeInTheDocument();
   });
 
-  it('passes baseUrl from getTrustedIssuerUrl to AsgardeoProvider', () => {
+  it('passes baseUrl from getTrustedIssuerUrl to ThunderIDProvider', () => {
     mockGetTrustedIssuerUrl.mockReturnValue('https://custom-server.example.com');
     mockGetTrustedIssuerClientId.mockReturnValue('client-id');
     mockGetClientUrl.mockReturnValue('https://client.example.com');
@@ -147,7 +147,7 @@ describe('withConfig (console)', () => {
     expect(capturedProviderProps.baseUrl).toBe('https://custom-server.example.com');
   });
 
-  it('passes clientId from getTrustedIssuerClientId to AsgardeoProvider', () => {
+  it('passes clientId from getTrustedIssuerClientId to ThunderIDProvider', () => {
     mockGetTrustedIssuerClientId.mockReturnValue('custom-client-id');
     mockGetTrustedIssuerUrl.mockReturnValue('https://server.example.com');
     mockGetClientUrl.mockReturnValue('https://client.example.com');
@@ -156,7 +156,7 @@ describe('withConfig (console)', () => {
     expect(capturedProviderProps.clientId).toBe('custom-client-id');
   });
 
-  it('passes afterSignInUrl from useConfig to AsgardeoProvider', () => {
+  it('passes afterSignInUrl from useConfig to ThunderIDProvider', () => {
     mockGetClientUrl.mockReturnValue('https://custom-client.example.com');
     mockGetServerUrl.mockReturnValue('https://server.example.com');
     mockGetClientId.mockReturnValue('client-id');
@@ -228,7 +228,7 @@ describe('withConfig (console)', () => {
   // --- Trusted Issuer integration ---
 
   describe('trusted issuer', () => {
-    it('passes baseUrl from getTrustedIssuerUrl to AsgardeoProvider', () => {
+    it('passes baseUrl from getTrustedIssuerUrl to ThunderIDProvider', () => {
       mockGetTrustedIssuerUrl.mockReturnValue('http://localhost:8090');
       mockGetTrustedIssuerClientId.mockReturnValue('FEDERATED_CONSOLE');
       mockGetClientUrl.mockReturnValue('http://localhost:9443/console');
@@ -238,7 +238,7 @@ describe('withConfig (console)', () => {
       expect(capturedProviderProps.baseUrl).toBe('http://localhost:8090');
     });
 
-    it('passes clientId from getTrustedIssuerClientId to AsgardeoProvider', () => {
+    it('passes clientId from getTrustedIssuerClientId to ThunderIDProvider', () => {
       mockGetTrustedIssuerUrl.mockReturnValue('http://localhost:8090');
       mockGetTrustedIssuerClientId.mockReturnValue('FEDERATED_CONSOLE');
       mockGetClientUrl.mockReturnValue('http://localhost:9443/console');
@@ -248,7 +248,7 @@ describe('withConfig (console)', () => {
       expect(capturedProviderProps.clientId).toBe('FEDERATED_CONSOLE');
     });
 
-    it('passes scopes from getTrustedIssuerScopes to AsgardeoProvider', () => {
+    it('passes scopes from getTrustedIssuerScopes to ThunderIDProvider', () => {
       mockGetTrustedIssuerUrl.mockReturnValue('http://localhost:8090');
       mockGetTrustedIssuerClientId.mockReturnValue('FEDERATED_CONSOLE');
       mockGetTrustedIssuerScopes.mockReturnValue(['openid', 'profile', 'system']);

--- a/frontend/apps/console/src/hocs/withConfig.tsx
+++ b/frontend/apps/console/src/hocs/withConfig.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {AsgardeoProvider} from '@asgardeo/react';
+import {ThunderIDProvider} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import type {JSX, ComponentType} from 'react';
 
@@ -40,7 +40,7 @@ export default function withConfig<P extends object>(WrappedComponent: Component
     // product specific bootstrap calls that would otherwise 404 / be CORS-blocked
     // at the external authorization server: flow metadata (`{baseUrl}/flow/meta`)
     // and branding preferences. The user profile is already derived from ID token
-    // claims under the AsgardeoV2 platform, so no additional profile configuration
+    // claims under the ThunderID platform, so no additional profile configuration
     // is required.
     const genericOidc = isTrustedIssuerGenericOidc();
     const preferences = genericOidc
@@ -62,20 +62,19 @@ export default function withConfig<P extends object>(WrappedComponent: Component
     // requests and therefore CORS-safe against any compliant OIDC provider.
     //
     // The field is declared on the SDK's legacy auth client config and read at
-    // runtime (see @asgardeo/javascript DefaultConfig and requestAccessToken),
-    // but it is not surfaced on the v2 `AsgardeoProvider` prop type. The
+    // runtime (see @thunderid/browser DefaultConfig and requestAccessToken),
+    // but it is not surfaced on the v2 `ThunderIDProvider` prop type. The
     // provider spreads unknown props through to the underlying client via
     // `...rest`, so passing it here is the SDK-supported escape hatch.
     const genericOidcExtraProps: {sendCookiesInRequests?: boolean} = genericOidc ? {sendCookiesInRequests: false} : {};
 
     return (
-      <AsgardeoProvider
+      <ThunderIDProvider
         baseUrl={getTrustedIssuerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string)}
         clientId={getTrustedIssuerClientId() ?? (import.meta.env.VITE_ASGARDEO_CLIENT_ID as string)}
         afterSignInUrl={getClientUrl() ?? (import.meta.env.VITE_ASGARDEO_AFTER_SIGN_IN_URL as string)}
         scopes={getTrustedIssuerScopes().length > 0 ? getTrustedIssuerScopes() : undefined}
         signInOptions={signInOptions}
-        platform="AsgardeoV2"
         discovery={{
           wellKnown: {
             enabled: true,
@@ -85,7 +84,7 @@ export default function withConfig<P extends object>(WrappedComponent: Component
         {...genericOidcExtraProps}
       >
         <WrappedComponent {...props} />
-      </AsgardeoProvider>
+      </ThunderIDProvider>
     );
   };
 }

--- a/frontend/apps/console/src/i18n/I18nProvider.tsx
+++ b/frontend/apps/console/src/i18n/I18nProvider.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import {I18nQueryKeys} from '@thunderid/i18n';
@@ -68,7 +68,7 @@ export interface I18nProviderProps {
  */
 function I18nProvider({children}: I18nProviderProps): ReactElement {
   const {i18n} = useTranslation();
-  const {http} = useAsgardeo() as unknown as {
+  const {http} = useThunderID() as unknown as {
     http: {
       request: (config: {
         url: string;

--- a/frontend/apps/console/src/i18n/__tests__/I18nProvider.test.tsx
+++ b/frontend/apps/console/src/i18n/__tests__/I18nProvider.test.tsx
@@ -71,7 +71,7 @@ vi.mock('@thunderid/contexts', () => ({
   }),
 }));
 
-// Mock @asgardeo/react
+// Mock @thunderid/react
 const mockHttpRequest = vi.fn().mockResolvedValue({
   data: {
     language: 'en-US',
@@ -79,8 +79,8 @@ const mockHttpRequest = vi.fn().mockResolvedValue({
   },
 });
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/apps/console/src/layouts/DashboardLayout.tsx
+++ b/frontend/apps/console/src/layouts/DashboardLayout.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {SignOutButton, User, useAsgardeo} from '@asgardeo/react';
+import {SignOutButton, User, useThunderID} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import {useLogger} from '@thunderid/logger/react';
 import {
@@ -80,7 +80,7 @@ function ExportConfigButton(): ReactNode {
 }
 
 export default function DashboardLayout(): ReactNode {
-  const {signIn, clearSession, discovery} = useAsgardeo();
+  const {signIn, clearSession, discovery} = useThunderID();
   const {isTrustedIssuerGenericOidc, getTrustedIssuerClientId, getClientUrl} = useConfig();
   const {t} = useTranslation();
   const logger = useLogger();

--- a/frontend/apps/console/src/layouts/__tests__/DashboardLayout.test.tsx
+++ b/frontend/apps/console/src/layouts/__tests__/DashboardLayout.test.tsx
@@ -46,8 +46,8 @@ vi.mock('../../features/applications/api/useGetApplications', () => ({
 }));
 
 // Mock Asgardeo
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     signIn: mockSignIn,
     clearSession: mockClearSession,
     discovery: mockDiscovery,

--- a/frontend/apps/console/vite.config.ts
+++ b/frontend/apps/console/vite.config.ts
@@ -108,8 +108,8 @@ export default defineConfig({
     server: {
       deps: {
         inline: [
-          '@asgardeo/browser',
-          '@asgardeo/react',
+          '@thunderid/browser',
+          '@thunderid/react',
           '@wso2/oxygen-ui',
           '@wso2/oxygen-ui-icons-react',
           '@mui/x-data-grid',

--- a/frontend/apps/gate/package.json
+++ b/frontend/apps/gate/package.json
@@ -34,8 +34,8 @@
     "typecheck": "tsc -p tsconfig.app.json"
   },
   "dependencies": {
-    "@asgardeo/react": "catalog:",
-    "@asgardeo/react-router": "catalog:",
+    "@thunderid/react": "workspace:^",
+    "@thunderid/react-router": "workspace:^",
     "@fontsource-variable/inter": "5.2.8",
     "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "catalog:",

--- a/frontend/apps/gate/src/components/AcceptInvite/AcceptInviteBox.tsx
+++ b/frontend/apps/gate/src/components/AcceptInvite/AcceptInviteBox.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {AcceptInvite, useAsgardeo, type EmbeddedFlowComponent} from '@asgardeo/react';
+import {AcceptInvite, useThunderID, type EmbeddedFlowComponent} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import {useDesign, FlowComponentRenderer, AuthCardLayout} from '@thunderid/design';
 import {useLogger} from '@thunderid/logger/react';
@@ -29,7 +29,7 @@ import ROUTES from '../../constants/routes';
 
 export default function AcceptInviteBox(): JSX.Element {
   const navigate = useNavigate();
-  const {resolveFlowTemplateLiterals} = useAsgardeo();
+  const {resolveFlowTemplateLiterals} = useThunderID();
   const {t} = useTranslation();
   const {getServerUrl} = useConfig();
   const logger = useLogger('AcceptInviteBox');

--- a/frontend/apps/gate/src/components/AcceptInvite/__tests__/AcceptInviteBox.test.tsx
+++ b/frontend/apps/gate/src/components/AcceptInvite/__tests__/AcceptInviteBox.test.tsx
@@ -139,11 +139,11 @@ const mockUseAsgardeo = vi.fn().mockReturnValue({
   resolveFlowTemplateLiterals: (template: string) => template,
 });
 
-vi.mock('@asgardeo/react', async () => {
-  const actual = await vi.importActual('@asgardeo/react');
+vi.mock('@thunderid/react', async () => {
+  const actual = await vi.importActual('@thunderid/react');
   return {
     ...actual,
-    useAsgardeo: () => mockUseAsgardeo() as {resolveFlowTemplateLiterals: (t: string) => string; meta: unknown},
+    useThunderID: () => mockUseAsgardeo() as {resolveFlowTemplateLiterals: (t: string) => string; meta: unknown},
     AcceptInvite: ({
       children,
       onGoToSignIn = undefined,

--- a/frontend/apps/gate/src/components/Recovery/Recovery.tsx
+++ b/frontend/apps/gate/src/components/Recovery/Recovery.tsx
@@ -16,13 +16,13 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {AuthPageLayout} from '@thunderid/design';
 import type {JSX} from 'react';
 import RecoveryBox from './RecoveryBox';
 
 export default function Recovery(): JSX.Element {
-  const {isMetaLoading} = useAsgardeo();
+  const {isMetaLoading} = useThunderID();
 
   return (
     <AuthPageLayout isLoading={isMetaLoading} variant="Recovery">

--- a/frontend/apps/gate/src/components/Recovery/RecoveryBox.tsx
+++ b/frontend/apps/gate/src/components/Recovery/RecoveryBox.tsx
@@ -21,7 +21,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
-import {EmbeddedFlowEventType, Recovery, type EmbeddedFlowComponent} from '@asgardeo/react';
+import {EmbeddedFlowEventType, Recovery, type EmbeddedFlowComponent} from '@thunderid/react';
 import {FlowComponentRenderer, AuthCardLayout, useDesign} from '@thunderid/design';
 import {useTemplateLiteralResolver} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';

--- a/frontend/apps/gate/src/components/Recovery/__tests__/Recovery.test.tsx
+++ b/frontend/apps/gate/src/components/Recovery/__tests__/Recovery.test.tsx
@@ -25,14 +25,14 @@ vi.mock('../RecoveryBox', () => ({
   default: () => <div data-testid="recovery-box">RecoveryBox</div>,
 }));
 
-// Mock useAsgardeo hook
+// Mock useThunderID hook
 const mockUseAsgardeo = vi.fn();
-vi.mock('@asgardeo/react', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@asgardeo/react')>();
+vi.mock('@thunderid/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/react')>();
   return {
     ...actual,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    useAsgardeo: () => mockUseAsgardeo(),
+    useThunderID: () => mockUseAsgardeo(),
   };
 });
 

--- a/frontend/apps/gate/src/components/Recovery/__tests__/RecoveryBox.test.tsx
+++ b/frontend/apps/gate/src/components/Recovery/__tests__/RecoveryBox.test.tsx
@@ -99,8 +99,8 @@ let capturedOnFlowChange: ((response: unknown) => void) | undefined;
 let capturedOnError: ((error: Error) => void) | undefined;
 let capturedAfterRecoveryUrl: string | undefined;
 
-vi.mock('@asgardeo/react', async () => {
-  const actual = await vi.importActual('@asgardeo/react');
+vi.mock('@thunderid/react', async () => {
+  const actual = await vi.importActual('@thunderid/react');
   return {
     ...actual,
     Recovery: ({

--- a/frontend/apps/gate/src/components/SignIn/SignIn.tsx
+++ b/frontend/apps/gate/src/components/SignIn/SignIn.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useDesign, AuthPageLayout} from '@thunderid/design';
 import {ParticleBackground} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
@@ -24,7 +24,7 @@ import SignInBox from './SignInBox';
 import SignInSlogan from './SignInSlogan';
 
 export default function SignIn(): JSX.Element {
-  const {isMetaLoading} = useAsgardeo();
+  const {isMetaLoading} = useThunderID();
   const {isDesignEnabled, isLoading: isDesignLoading} = useDesign();
 
   const showSlogan = !isDesignLoading && !isDesignEnabled;

--- a/frontend/apps/gate/src/components/SignIn/SignInBox.tsx
+++ b/frontend/apps/gate/src/components/SignIn/SignInBox.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {EmbeddedFlowComponentType, SignIn, type EmbeddedFlowComponent} from '@asgardeo/react';
+import {EmbeddedFlowComponentType, SignIn, type EmbeddedFlowComponent} from '@thunderid/react';
 import {useDesign, FlowComponentRenderer, AuthCardLayout} from '@thunderid/design';
 import {useTemplateLiteralResolver} from '@thunderid/hooks';
 import {TemplateLiteralType} from '@thunderid/utils';

--- a/frontend/apps/gate/src/components/SignIn/__tests__/SignInBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignIn/__tests__/SignInBox.test.tsx
@@ -123,8 +123,8 @@ let mockSignInRenderProps: MockSignInRenderProps = createMockSignInRenderProps()
 
 let mockSignUpRenderProps: MockSignUpRenderProps = createMockSignUpRenderProps();
 
-vi.mock('@asgardeo/react', async () => {
-  const actual = await vi.importActual('@asgardeo/react');
+vi.mock('@thunderid/react', async () => {
+  const actual = await vi.importActual('@thunderid/react');
   return {
     ...actual,
     SignIn: ({children}: {children: (props: typeof mockSignInRenderProps) => React.ReactNode}) => (

--- a/frontend/apps/gate/src/components/SignUp/SignUp.tsx
+++ b/frontend/apps/gate/src/components/SignUp/SignUp.tsx
@@ -16,14 +16,14 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {AuthPageLayout, useDesign} from '@thunderid/design';
 import {ParticleBackground} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import SignUpBox from './SignUpBox';
 
 export default function SignUp(): JSX.Element {
-  const {isMetaLoading} = useAsgardeo();
+  const {isMetaLoading} = useThunderID();
   const {isDesignEnabled, isLoading: isDesignLoading} = useDesign();
 
   const showSlogan = !isDesignLoading && !isDesignEnabled;

--- a/frontend/apps/gate/src/components/SignUp/SignUpBox.tsx
+++ b/frontend/apps/gate/src/components/SignUp/SignUpBox.tsx
@@ -21,7 +21,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
-import {EmbeddedFlowEventType, SignUp, useAsgardeo, type EmbeddedFlowComponent} from '@asgardeo/react';
+import {EmbeddedFlowEventType, SignUp, useThunderID, type EmbeddedFlowComponent} from '@thunderid/react';
 import {FlowComponentRenderer, AuthCardLayout, useDesign} from '@thunderid/design';
 import {Box, Button, Alert, Typography, AlertTitle, CircularProgress} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
@@ -32,7 +32,7 @@ import ROUTES from '../../constants/routes';
 
 export default function SignUpBox(): JSX.Element {
   const navigate = useNavigate();
-  const {resolveFlowTemplateLiterals: resolve} = useAsgardeo();
+  const {resolveFlowTemplateLiterals: resolve} = useThunderID();
   const {t} = useTranslation();
   const {isDesignEnabled} = useDesign();
   const [flowError, setFlowError] = useState<string | null>(null);

--- a/frontend/apps/gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
@@ -99,8 +99,8 @@ const createMockSignUpRenderProps = (overrides: Partial<MockSignUpRenderProps> =
 let mockSignUpRenderProps: MockSignUpRenderProps = createMockSignUpRenderProps();
 let capturedOnFlowChange: ((response: unknown) => void) | undefined;
 
-vi.mock('@asgardeo/react', async () => {
-  const actual = await vi.importActual('@asgardeo/react');
+vi.mock('@thunderid/react', async () => {
+  const actual = await vi.importActual('@thunderid/react');
   return {
     ...actual,
     SignUp: ({

--- a/frontend/apps/gate/src/config/appRoutes.tsx
+++ b/frontend/apps/gate/src/config/appRoutes.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {CallbackRoute} from '@asgardeo/react-router';
+import {CallbackRoute} from '@thunderid/react-router';
 import {Navigate, type RouteProps} from 'react-router';
 import ROUTES from '../constants/routes';
 import DefaultLayout from '../layouts/DefaultLayout';

--- a/frontend/apps/gate/src/hocs/__tests__/withConfig.test.tsx
+++ b/frontend/apps/gate/src/hocs/__tests__/withConfig.test.tsx
@@ -20,7 +20,7 @@ import {render} from '@testing-library/react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import withConfig from '../withConfig';
 
-// Track the baseUrl passed to AsgardeoProvider
+// Track the baseUrl passed to ThunderIDProvider
 let capturedBaseUrl: string | undefined;
 
 function MockChild() {
@@ -28,9 +28,9 @@ function MockChild() {
 }
 const AppWithConfig = withConfig(MockChild);
 
-// Mock AsgardeoProvider to capture baseUrl
-vi.mock('@asgardeo/react', () => ({
-  AsgardeoProvider: ({children, baseUrl}: {children: React.ReactNode; baseUrl: string}) => {
+// Mock ThunderIDProvider to capture baseUrl
+vi.mock('@thunderid/react', () => ({
+  ThunderIDProvider: ({children, baseUrl}: {children: React.ReactNode; baseUrl: string}) => {
     capturedBaseUrl = baseUrl;
     return <div data-testid="asgardeo-provider">{children}</div>;
   },

--- a/frontend/apps/gate/src/hocs/__tests__/withDesign.test.tsx
+++ b/frontend/apps/gate/src/hocs/__tests__/withDesign.test.tsx
@@ -42,8 +42,8 @@ vi.mock('@thunderid/design', () => ({
 }));
 
 const mockUseAsgardeo = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: (): {meta?: {design?: unknown}} => mockUseAsgardeo() as {meta?: {design?: unknown}},
+vi.mock('@thunderid/react', () => ({
+  useThunderID: (): {meta?: {design?: unknown}} => mockUseAsgardeo() as {meta?: {design?: unknown}},
 }));
 
 function MockChild() {
@@ -74,7 +74,7 @@ describe('withDesign', () => {
     expect(screen.getByTestId('mock-child')).toBeInTheDocument();
   });
 
-  it('passes meta.design from useAsgardeo to DesignProvider', () => {
+  it('passes meta.design from useThunderID to DesignProvider', () => {
     const mockDesign = {theme: {colors: {primary: '#ff5700'}}, layout: {}};
     mockUseAsgardeo.mockReturnValue({meta: {design: mockDesign}});
 

--- a/frontend/apps/gate/src/hocs/__tests__/withI18n.test.tsx
+++ b/frontend/apps/gate/src/hocs/__tests__/withI18n.test.tsx
@@ -37,8 +37,8 @@ const mockEmit = vi.fn();
 const mockChangeLanguage = vi.fn().mockResolvedValue(undefined);
 const mockGetResourceBundle = vi.fn().mockReturnValue({});
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({meta: mockMeta}),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({meta: mockMeta}),
 }));
 
 vi.mock('react-i18next', () => ({

--- a/frontend/apps/gate/src/hocs/__tests__/withTheme.test.tsx
+++ b/frontend/apps/gate/src/hocs/__tests__/withTheme.test.tsx
@@ -64,8 +64,8 @@ let mockLanguageSwitcherProps: {
 
 const mockOnLanguageChange = vi.fn();
 
-// Mock LanguageSwitcher from @asgardeo/react
-vi.mock('@asgardeo/react', () => ({
+// Mock LanguageSwitcher from @thunderid/react
+vi.mock('@thunderid/react', () => ({
   LanguageSwitcher: ({
     children,
   }: {

--- a/frontend/apps/gate/src/hocs/withConfig.tsx
+++ b/frontend/apps/gate/src/hocs/withConfig.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {AsgardeoProvider} from '@asgardeo/react';
+import {ThunderIDProvider} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import type {JSX, ComponentType} from 'react';
 
@@ -26,13 +26,12 @@ export default function withConfig<P extends object>(WrappedComponent: Component
     const applicationId = new URL(window.location.href).searchParams.get('applicationId');
 
     return (
-      <AsgardeoProvider
+      <ThunderIDProvider
         baseUrl={getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string)}
         applicationId={applicationId!}
-        platform="AsgardeoV2"
       >
         <WrappedComponent {...props} />
-      </AsgardeoProvider>
+      </ThunderIDProvider>
     );
   };
 }

--- a/frontend/apps/gate/src/hocs/withDesign.tsx
+++ b/frontend/apps/gate/src/hocs/withDesign.tsx
@@ -16,13 +16,13 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {DesignProvider, type DesignResolveResponse} from '@thunderid/design';
 import type {JSX, ComponentType} from 'react';
 
 export default function withDesign<P extends object>(WrappedComponent: ComponentType<P>) {
   return function WithDesign(props: P): JSX.Element {
-    const {meta} = useAsgardeo();
+    const {meta} = useThunderID();
     return (
       <DesignProvider
         shouldResolveDesignInternally={false}

--- a/frontend/apps/gate/src/hocs/withI18n.tsx
+++ b/frontend/apps/gate/src/hocs/withI18n.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {I18nDefaultConstants} from '@thunderid/i18n';
 import enUS from '@thunderid/i18n/locales/en-US';
 import i18next from 'i18next';
@@ -46,7 +46,7 @@ await i18next.use(initReactI18next).init({
 
 export default function withI18n<P extends object>(WrappedComponent: ComponentType<P>) {
   return function WithI18n(props: P): JSX.Element {
-    const {meta} = useAsgardeo();
+    const {meta} = useThunderID();
     const {i18n} = useTranslation();
 
     useEffect(() => {

--- a/frontend/apps/gate/src/hocs/withTheme.tsx
+++ b/frontend/apps/gate/src/hocs/withTheme.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {LanguageSwitcher} from '@asgardeo/react';
+import {LanguageSwitcher} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
 import {useDesign, GoogleFontLoader, StylesheetInjector, DefaultTheme, type Theme} from '@thunderid/design';
 import {

--- a/frontend/apps/gate/vite.config.ts
+++ b/frontend/apps/gate/vite.config.ts
@@ -65,8 +65,8 @@ export default defineConfig({
     server: {
       deps: {
         inline: [
-          '@asgardeo/browser',
-          '@asgardeo/react',
+          '@thunderid/browser',
+          '@thunderid/react',
           '@wso2/oxygen-ui',
           '@wso2/oxygen-ui-icons-react',
           '@mui/x-data-grid',

--- a/frontend/packages/components/package.json
+++ b/frontend/packages/components/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@asgardeo/react": "catalog:",
+    "@thunderid/react": "workspace:^",
     "@wso2/oxygen-ui": "catalog:",
     "@wso2/oxygen-ui-icons-react": "catalog:",
     "@tanstack/react-query": "catalog:",

--- a/frontend/packages/configure-agent-types/package.json
+++ b/frontend/packages/configure-agent-types/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@asgardeo/react": "catalog:",
+    "@thunderid/react": "workspace:^",
     "@wso2/oxygen-ui": "catalog:",
     "@wso2/oxygen-ui-icons-react": "catalog:",
     "@tanstack/react-query": "catalog:",

--- a/frontend/packages/configure-agent-types/src/api/__tests__/useGetAgentType.test.tsx
+++ b/frontend/packages/configure-agent-types/src/api/__tests__/useGetAgentType.test.tsx
@@ -24,8 +24,8 @@ import useGetAgentType from '../useGetAgentType';
 const mockHttpRequest = vi.fn();
 const mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/packages/configure-agent-types/src/api/__tests__/useGetAgentTypes.test.tsx
+++ b/frontend/packages/configure-agent-types/src/api/__tests__/useGetAgentTypes.test.tsx
@@ -24,8 +24,8 @@ import useGetAgentTypes from '../useGetAgentTypes';
 const mockHttpRequest = vi.fn();
 const mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/packages/configure-agent-types/src/api/__tests__/useUpdateAgentType.test.tsx
+++ b/frontend/packages/configure-agent-types/src/api/__tests__/useUpdateAgentType.test.tsx
@@ -26,8 +26,8 @@ import useUpdateAgentType from '../useUpdateAgentType';
 const mockHttpRequest = vi.fn();
 const mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {request: mockHttpRequest},
   }),
 }));

--- a/frontend/packages/configure-agent-types/src/api/useGetAgentType.ts
+++ b/frontend/packages/configure-agent-types/src/api/useGetAgentType.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import AgentTypeQueryKeys from '../constants/agentTypeQueryKeys';
@@ -29,7 +29,7 @@ import type {ApiAgentType} from '../models/agent-type';
  * @returns TanStack Query result object containing agent type data, loading state, and error information
  */
 export default function useGetAgentType(id?: string): UseQueryResult<ApiAgentType> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<ApiAgentType>({

--- a/frontend/packages/configure-agent-types/src/api/useGetAgentTypes.ts
+++ b/frontend/packages/configure-agent-types/src/api/useGetAgentTypes.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import AgentTypeQueryKeys from '../constants/agentTypeQueryKeys';
@@ -32,7 +32,7 @@ import type {AgentTypeListResponse} from '../models/responses';
  * @returns TanStack Query result object containing agent types list data, loading state, and error information
  */
 export default function useGetAgentTypes(params?: AgentTypeListParams): UseQueryResult<AgentTypeListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit, offset} = params ?? {};
 

--- a/frontend/packages/configure-agent-types/src/api/useUpdateAgentType.ts
+++ b/frontend/packages/configure-agent-types/src/api/useUpdateAgentType.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -44,7 +44,7 @@ export interface UpdateAgentTypeVariables {
  * @returns TanStack Query mutation object for updating agent types
  */
 export default function useUpdateAgentType(): UseMutationResult<ApiAgentType, Error, UpdateAgentTypeVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('agentTypes');

--- a/frontend/packages/configure-organization-units/package.json
+++ b/frontend/packages/configure-organization-units/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@asgardeo/react": "catalog:",
+    "@thunderid/react": "workspace:^",
     "@hookform/resolvers": "catalog:",
     "@wso2/oxygen-ui": "catalog:",
     "@wso2/oxygen-ui-icons-react": "catalog:",

--- a/frontend/packages/configure-organization-units/src/api/__tests__/useCreateOrganizationUnit.test.ts
+++ b/frontend/packages/configure-organization-units/src/api/__tests__/useCreateOrganizationUnit.test.ts
@@ -22,10 +22,10 @@ import type {OrganizationUnit} from '../../models/organization-unit';
 import type {CreateOrganizationUnitRequest} from '../../models/requests';
 import useCreateOrganizationUnit from '../useCreateOrganizationUnit';
 
-// Mock useAsgardeo
+// Mock useThunderID
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-organization-units/src/api/__tests__/useDeleteOrganizationUnit.test.ts
+++ b/frontend/packages/configure-organization-units/src/api/__tests__/useDeleteOrganizationUnit.test.ts
@@ -20,10 +20,10 @@ import {waitFor, renderHook} from '@thunderid/test-utils';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import useDeleteOrganizationUnit from '../useDeleteOrganizationUnit';
 
-// Mock useAsgardeo
+// Mock useThunderID
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-organization-units/src/api/__tests__/useGetChildOrganizationUnits.test.ts
+++ b/frontend/packages/configure-organization-units/src/api/__tests__/useGetChildOrganizationUnits.test.ts
@@ -21,10 +21,10 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {OrganizationUnitListResponse} from '../../models/responses';
 import useGetChildOrganizationUnits from '../useGetChildOrganizationUnits';
 
-// Mock useAsgardeo
+// Mock useThunderID
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-organization-units/src/api/__tests__/useGetOrganizationUnit.test.ts
+++ b/frontend/packages/configure-organization-units/src/api/__tests__/useGetOrganizationUnit.test.ts
@@ -21,10 +21,10 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {OrganizationUnit} from '../../models/organization-unit';
 import useGetOrganizationUnit from '../useGetOrganizationUnit';
 
-// Mock useAsgardeo
+// Mock useThunderID
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-organization-units/src/api/__tests__/useGetOrganizationUnitGroups.test.ts
+++ b/frontend/packages/configure-organization-units/src/api/__tests__/useGetOrganizationUnitGroups.test.ts
@@ -21,10 +21,10 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {GroupListResponse} from '../../models/group';
 import useGetOrganizationUnitGroups from '../useGetOrganizationUnitGroups';
 
-// Mock useAsgardeo
+// Mock useThunderID
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-organization-units/src/api/__tests__/useGetOrganizationUnitUsers.test.ts
+++ b/frontend/packages/configure-organization-units/src/api/__tests__/useGetOrganizationUnitUsers.test.ts
@@ -21,11 +21,11 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {OrganizationUnitUserListResponse} from '../../models/responses';
 import useGetOrganizationUnitUsers from '../useGetOrganizationUnitUsers';
 
-// Mock useAsgardeo
+// Mock useThunderID
 const mockHttpRequest =
   vi.fn<(requestConfig: {method: string; url: string}) => Promise<{data: OrganizationUnitUserListResponse}>>();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-organization-units/src/api/__tests__/useGetOrganizationUnits.test.ts
+++ b/frontend/packages/configure-organization-units/src/api/__tests__/useGetOrganizationUnits.test.ts
@@ -22,10 +22,10 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {OrganizationUnitListResponse} from '../../models/responses';
 import useGetOrganizationUnits from '../useGetOrganizationUnits';
 
-// Mock useAsgardeo
+// Mock useThunderID
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-organization-units/src/api/__tests__/useUpdateOrganizationUnit.test.ts
+++ b/frontend/packages/configure-organization-units/src/api/__tests__/useUpdateOrganizationUnit.test.ts
@@ -22,10 +22,10 @@ import type {OrganizationUnit} from '../../models/organization-unit';
 import type {UpdateOrganizationUnitRequest} from '../../models/requests';
 import useUpdateOrganizationUnit from '../useUpdateOrganizationUnit';
 
-// Mock useAsgardeo
+// Mock useThunderID
 const mockHttpRequest = vi.fn();
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-organization-units/src/api/fetchChildOrganizationUnits.ts
+++ b/frontend/packages/configure-organization-units/src/api/fetchChildOrganizationUnits.ts
@@ -24,7 +24,7 @@ import type {OrganizationUnitListResponse} from '../models/responses';
  * This is a standalone API utility that can be used both by React Query hooks
  * and by imperative fetch calls (e.g. via queryClient.fetchQuery).
  *
- * @param http - The HTTP client from useAsgardeo
+ * @param http - The HTTP client from useThunderID
  * @param serverUrl - The base server URL
  * @param parentId - The ID of the parent organization unit
  * @param params - Pagination parameters

--- a/frontend/packages/configure-organization-units/src/api/fetchOrganizationUnits.ts
+++ b/frontend/packages/configure-organization-units/src/api/fetchOrganizationUnits.ts
@@ -24,7 +24,7 @@ import type {OrganizationUnitListResponse} from '../models/responses';
  * This is a standalone API utility that can be used both by React Query hooks
  * and by imperative fetch calls (e.g. via queryClient.fetchQuery).
  *
- * @param http - The HTTP client from useAsgardeo
+ * @param http - The HTTP client from useThunderID
  * @param serverUrl - The base server URL
  * @param params - Pagination parameters
  * @param params.limit - Maximum number of records to return

--- a/frontend/packages/configure-organization-units/src/api/useCreateOrganizationUnit.ts
+++ b/frontend/packages/configure-organization-units/src/api/useCreateOrganizationUnit.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -58,7 +58,7 @@ export default function useCreateOrganizationUnit(): UseMutationResult<
   Error,
   CreateOrganizationUnitRequest
 > {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('organizationUnits');

--- a/frontend/packages/configure-organization-units/src/api/useDeleteOrganizationUnit.ts
+++ b/frontend/packages/configure-organization-units/src/api/useDeleteOrganizationUnit.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -58,7 +58,7 @@ import OrganizationUnitQueryKeys from '../constants/organization-unit-query-keys
  * ```
  */
 export default function useDeleteOrganizationUnit(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('organizationUnits');

--- a/frontend/packages/configure-organization-units/src/api/useGetChildOrganizationUnits.ts
+++ b/frontend/packages/configure-organization-units/src/api/useGetChildOrganizationUnits.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import fetchChildOrganizationUnits from './fetchChildOrganizationUnits';
@@ -58,7 +58,7 @@ export default function useGetChildOrganizationUnits(
   parentId: string | undefined,
   params?: OrganizationUnitListParams,
 ): UseQueryResult<OrganizationUnitListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/packages/configure-organization-units/src/api/useGetOrganizationUnit.ts
+++ b/frontend/packages/configure-organization-units/src/api/useGetOrganizationUnit.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import OrganizationUnitQueryKeys from '../constants/organization-unit-query-keys';
@@ -48,7 +48,7 @@ export default function useGetOrganizationUnit(
   id: string | undefined,
   enabled = true,
 ): UseQueryResult<OrganizationUnit> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<OrganizationUnit>({

--- a/frontend/packages/configure-organization-units/src/api/useGetOrganizationUnitGroups.ts
+++ b/frontend/packages/configure-organization-units/src/api/useGetOrganizationUnitGroups.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import OrganizationUnitQueryKeys from '../constants/organization-unit-query-keys';
@@ -57,7 +57,7 @@ export default function useGetOrganizationUnitGroups(
   organizationUnitId: string | undefined,
   params?: OrganizationUnitListParams,
 ): UseQueryResult<GroupListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/packages/configure-organization-units/src/api/useGetOrganizationUnitUsers.ts
+++ b/frontend/packages/configure-organization-units/src/api/useGetOrganizationUnitUsers.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import type {ApiFilteringParams} from '@thunderid/types';
@@ -57,7 +57,7 @@ export default function useGetOrganizationUnitUsers(
   organizationUnitId: string | undefined,
   params?: ApiFilteringParams,
 ): UseQueryResult<OrganizationUnitUserListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/packages/configure-organization-units/src/api/useGetOrganizationUnits.ts
+++ b/frontend/packages/configure-organization-units/src/api/useGetOrganizationUnits.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import fetchOrganizationUnits from './fetchOrganizationUnits';
@@ -58,7 +58,7 @@ export default function useGetOrganizationUnits(
   params?: OrganizationUnitListParams,
   enabled = true,
 ): UseQueryResult<OrganizationUnitListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/packages/configure-organization-units/src/api/useUpdateOrganizationUnit.ts
+++ b/frontend/packages/configure-organization-units/src/api/useUpdateOrganizationUnit.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -66,7 +66,7 @@ export default function useUpdateOrganizationUnit(): UseMutationResult<
   Error,
   UpdateOrganizationUnitVariables
 > {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('organizationUnits');

--- a/frontend/packages/configure-organization-units/src/components/OrganizationUnitTreePicker.tsx
+++ b/frontend/packages/configure-organization-units/src/components/OrganizationUnitTreePicker.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQueryClient} from '@tanstack/react-query';
 import {ResourceAvatar} from '@thunderid/components';
 import {useConfig} from '@thunderid/contexts';
@@ -227,7 +227,7 @@ export default function OrganizationUnitTreePicker({
   const theme = useTheme();
   const {t} = useTranslation();
   const logger = useLogger('OrganizationUnitTreePicker');
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient = useQueryClient();
   const {data, isLoading} = useGetOrganizationUnits(undefined, !rootOuId);

--- a/frontend/packages/configure-organization-units/src/components/OrganizationUnitsTreeView.tsx
+++ b/frontend/packages/configure-organization-units/src/components/OrganizationUnitsTreeView.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQueryClient} from '@tanstack/react-query';
 import {ResourceAvatar} from '@thunderid/components';
 import {useConfig} from '@thunderid/contexts';
@@ -374,7 +374,7 @@ export default function OrganizationUnitsTreeView(): JSX.Element {
   const navigate = useNavigate();
   const {t} = useTranslation();
   const logger = useLogger('OrganizationUnitsTreeView');
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient = useQueryClient();
   const {data, isLoading, error} = useGetOrganizationUnits();

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitTreePicker.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitTreePicker.test.tsx
@@ -62,8 +62,8 @@ vi.mock('@/api/useGetChildOrganizationUnits', () => ({
 // Mock Asgardeo — stable reference to avoid useCallback churn
 const mockHttpRequest = vi.fn();
 const stableHttp = {request: mockHttpRequest};
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({http: stableHttp}),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({http: stableHttp}),
 }));
 
 // Mock config — stable reference to avoid useCallback churn

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitsTreeView.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitsTreeView.test.tsx
@@ -52,8 +52,8 @@ vi.mock('@/api/useGetOrganizationUnits', () => ({
 // Mock Asgardeo — stable reference to avoid useCallback churn
 const mockHttpRequest = vi.fn();
 const stableHttp = {request: mockHttpRequest};
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({http: stableHttp}),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({http: stableHttp}),
 }));
 
 // Mock useOrganizationUnit hook with React state for reactivity

--- a/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitsListPage.test.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitsListPage.test.tsx
@@ -66,8 +66,8 @@ vi.mock('@/api/useDeleteOrganizationUnit', () => ({
 
 // Mock Asgardeo — stable reference to avoid useCallback churn when tree view renders
 const stableHttp = {request: vi.fn()};
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({http: stableHttp}),
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({http: stableHttp}),
 }));
 
 // Mock useOrganizationUnit hook with React state for reactivity

--- a/frontend/packages/configure-translations/package.json
+++ b/frontend/packages/configure-translations/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@asgardeo/react": "catalog:",
+    "@thunderid/react": "workspace:^",
     "@monaco-editor/react": "catalog:",
     "@wso2/oxygen-ui": "catalog:",
     "@wso2/oxygen-ui-icons-react": "catalog:",

--- a/frontend/packages/configure-users/package.json
+++ b/frontend/packages/configure-users/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@asgardeo/react": "catalog:",
+    "@thunderid/react": "workspace:^",
     "@hookform/resolvers": "catalog:",
     "@wso2/oxygen-ui": "catalog:",
     "@wso2/oxygen-ui-icons-react": "catalog:",

--- a/frontend/packages/configure-users/src/api/__tests__/useCreateUser.test.ts
+++ b/frontend/packages/configure-users/src/api/__tests__/useCreateUser.test.ts
@@ -27,8 +27,8 @@ const mockHttpRequest = vi.fn();
 const mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-users/src/api/__tests__/useDeleteUser.test.ts
+++ b/frontend/packages/configure-users/src/api/__tests__/useDeleteUser.test.ts
@@ -25,8 +25,8 @@ const mockHttpRequest = vi.fn();
 const mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-users/src/api/__tests__/useGetUser.test.ts
+++ b/frontend/packages/configure-users/src/api/__tests__/useGetUser.test.ts
@@ -26,8 +26,8 @@ const mockHttpRequest = vi.fn();
 const mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-users/src/api/__tests__/useGetUserType.test.ts
+++ b/frontend/packages/configure-users/src/api/__tests__/useGetUserType.test.ts
@@ -26,8 +26,8 @@ const mockHttpRequest = vi.fn();
 const mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-users/src/api/__tests__/useGetUserTypes.test.ts
+++ b/frontend/packages/configure-users/src/api/__tests__/useGetUserTypes.test.ts
@@ -26,8 +26,8 @@ const mockHttpRequest = vi.fn();
 const mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-users/src/api/__tests__/useGetUsers.test.ts
+++ b/frontend/packages/configure-users/src/api/__tests__/useGetUsers.test.ts
@@ -26,8 +26,8 @@ const mockHttpRequest = vi.fn();
 const mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-users/src/api/__tests__/useUpdateUser.test.ts
+++ b/frontend/packages/configure-users/src/api/__tests__/useUpdateUser.test.ts
@@ -26,8 +26,8 @@ const mockHttpRequest = vi.fn();
 const mockGetServerUrl = vi.fn().mockReturnValue('https://api.test.com');
 
 // Mock the dependencies
-vi.mock('@asgardeo/react', () => ({
-  useAsgardeo: () => ({
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
     http: {
       request: mockHttpRequest,
     },

--- a/frontend/packages/configure-users/src/api/useCreateUser.ts
+++ b/frontend/packages/configure-users/src/api/useCreateUser.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import type {User} from '@thunderid/types';
@@ -30,7 +30,7 @@ import type {CreateUserRequest} from '../models/users';
  * @returns TanStack Query mutation object for creating users
  */
 export default function useCreateUser(): UseMutationResult<User, Error, CreateUserRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('users');

--- a/frontend/packages/configure-users/src/api/useDeleteUser.ts
+++ b/frontend/packages/configure-users/src/api/useDeleteUser.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useTranslation} from 'react-i18next';
@@ -28,7 +28,7 @@ import UserQueryKeys from '../constants/user-query-keys';
  * @returns TanStack Query mutation object for deleting users
  */
 export default function useDeleteUser(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('users');

--- a/frontend/packages/configure-users/src/api/useGetUser.ts
+++ b/frontend/packages/configure-users/src/api/useGetUser.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import type {User} from '@thunderid/types';
@@ -29,7 +29,7 @@ import UserQueryKeys from '../constants/user-query-keys';
  * @returns TanStack Query result object containing user data, loading state, and error information
  */
 export default function useGetUser(userId: string | undefined): UseQueryResult<User> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<User>({

--- a/frontend/packages/configure-users/src/api/useGetUserType.ts
+++ b/frontend/packages/configure-users/src/api/useGetUserType.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import UserQueryKeys from '../constants/user-query-keys';
@@ -29,7 +29,7 @@ import type {ApiUserType} from '../models/users';
  * @returns TanStack Query result object containing user type data, loading state, and error information
  */
 export default function useGetUserType(id?: string): UseQueryResult<ApiUserType> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<ApiUserType>({

--- a/frontend/packages/configure-users/src/api/useGetUserTypes.ts
+++ b/frontend/packages/configure-users/src/api/useGetUserTypes.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import UserQueryKeys from '../constants/user-query-keys';
@@ -29,7 +29,7 @@ import type {SchemaListParams, UserTypeListResponse} from '../models/users';
  * @returns TanStack Query result object containing user type list data, loading state, and error information
  */
 export default function useGetUserTypes(params?: SchemaListParams): UseQueryResult<UserTypeListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit, offset} = params ?? {};
 

--- a/frontend/packages/configure-users/src/api/useGetUsers.ts
+++ b/frontend/packages/configure-users/src/api/useGetUsers.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import type {ApiFilteringParams} from '@thunderid/types';
@@ -30,7 +30,7 @@ import type {UserListResponse} from '../models/users';
  * @returns TanStack Query result object containing user list data, loading state, and error information
  */
 export default function useGetUsers(params?: ApiFilteringParams): UseQueryResult<UserListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit, offset, filter} = params ?? {};
 

--- a/frontend/packages/configure-users/src/api/useUpdateUser.ts
+++ b/frontend/packages/configure-users/src/api/useUpdateUser.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig, useToast} from '@thunderid/contexts';
 import type {User} from '@thunderid/types';
@@ -38,7 +38,7 @@ export interface UpdateUserVariables {
  * @returns TanStack Query mutation object for updating users
  */
 export default function useUpdateUser(): UseMutationResult<User, Error, UpdateUserVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {t} = useTranslation('users');

--- a/frontend/packages/configure-users/src/pages/UserCreatePage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserCreatePage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useGetChildOrganizationUnits} from '@thunderid/configure-organization-units';
 import {useLogger} from '@thunderid/logger/react';
 import {
@@ -73,7 +73,7 @@ export default function UserCreatePage(): JSX.Element {
     limit: 1,
     offset: 0,
   });
-  const user = useAsgardeo().user as {ouId?: string} | null | undefined;
+  const user = useThunderID().user as {ouId?: string} | null | undefined;
   const tokenOuId = user?.ouId ?? null;
   const isChildOuForbidden = (childOuError as {response?: {status?: number}} | null)?.response?.status === 403;
   const isChildOuProbeFailed = !!childOuError && !isChildOuForbidden;

--- a/frontend/packages/configure-users/src/pages/UserInvitePage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserInvitePage.tsx
@@ -23,10 +23,10 @@ import {
   EmbeddedFlowComponentType,
   EmbeddedFlowEventType,
   InviteUser,
-  useAsgardeo,
+  useThunderID,
   type EmbeddedFlowComponent,
   type InviteUserRenderProps,
-} from '@asgardeo/react';
+} from '@thunderid/react';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {OrganizationUnitTreePicker} from '@thunderid/configure-organization-units';
 import {CopyableTextAdapter, type FlowComponent} from '@thunderid/design';
@@ -181,7 +181,7 @@ function InviteUserStepContent({
     resetFlow,
     isValid: propsIsValid,
   } = renderProps;
-  const {resolveFlowTemplateLiterals: rawResolve} = useAsgardeo();
+  const {resolveFlowTemplateLiterals: rawResolve} = useThunderID();
   const resolve = useCallback((text?: string) => (text ? rawResolve(text) : undefined), [rawResolve]);
   const {t} = useTranslation();
   const [activeActionId, setActiveActionId] = useState<string | null>(null);
@@ -774,7 +774,7 @@ function InviteUserFlowBridge({
   onOuStepDetected: () => void;
   onResetLocalState: () => void;
 }): JSX.Element {
-  const {resolveFlowTemplateLiterals: rawResolve} = useAsgardeo();
+  const {resolveFlowTemplateLiterals: rawResolve} = useThunderID();
   const resolve = useCallback((text?: string) => (text ? rawResolve(text) : undefined), [rawResolve]);
   const {t} = useTranslation();
   const components = renderProps.components as EmbeddedFlowComponent[] | undefined;

--- a/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
@@ -111,13 +111,13 @@ vi.mock('../../../organization-units/api/useGetChildOrganizationUnits', () => ({
   default: () => mockUseGetChildOrganizationUnits(),
 }));
 
-// Mock useAsgardeo
+// Mock useThunderID
 const mockUseAsgardeo = vi.fn();
-vi.mock('@asgardeo/react', async (importOriginal) => {
+vi.mock('@thunderid/react', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...(actual as object),
-    useAsgardeo: () => mockUseAsgardeo() as {user: {ouId?: string} | null | undefined},
+    useThunderID: () => mockUseAsgardeo() as {user: {ouId?: string} | null | undefined},
   };
 });
 

--- a/frontend/packages/configure-users/src/pages/__tests__/UserInvitePage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserInvitePage.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import type {EmbeddedFlowComponent} from '@asgardeo/react';
+import type {EmbeddedFlowComponent} from '@thunderid/react';
 import {render, screen, waitFor, userEvent} from '@thunderid/test-utils';
 import type {JSX} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
@@ -93,8 +93,8 @@ vi.mock('react-router', async () => ({
   useNavigate: () => mockNavigate,
 }));
 
-vi.mock('@asgardeo/react', async () => {
-  const actual = await vi.importActual<Record<string, unknown>>('@asgardeo/react');
+vi.mock('@thunderid/react', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@thunderid/react');
 
   return {
     ...actual,

--- a/frontend/packages/design/package.json
+++ b/frontend/packages/design/package.json
@@ -75,7 +75,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@asgardeo/react": "catalog:",
+    "@thunderid/react": "workspace:^",
     "@tanstack/react-query": "catalog:",
     "@thunderid/logger": "workspace:^",
     "@thunderid/contexts": "workspace:^",

--- a/frontend/packages/design/src/api/useCreateLayout.ts
+++ b/frontend/packages/design/src/api/useCreateLayout.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import DesignQueryKeys from '../constants/design-query-keys';
@@ -29,7 +29,7 @@ import type {LayoutResponse} from '../models/responses';
  * @returns TanStack Query mutation object for creating layout configurations
  */
 export default function useCreateLayout(): UseMutationResult<LayoutResponse, Error, CreateLayoutRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/packages/design/src/api/useCreateTheme.ts
+++ b/frontend/packages/design/src/api/useCreateTheme.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import DesignQueryKeys from '../constants/design-query-keys';
@@ -29,7 +29,7 @@ import type {ThemeResponse} from '../models/responses';
  * @returns TanStack Query mutation object for creating theme configurations
  */
 export default function useCreateTheme(): UseMutationResult<ThemeResponse, Error, CreateThemeRequest> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/packages/design/src/api/useDeleteLayout.ts
+++ b/frontend/packages/design/src/api/useDeleteLayout.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import DesignQueryKeys from '../constants/design-query-keys';
@@ -27,7 +27,7 @@ import DesignQueryKeys from '../constants/design-query-keys';
  * @returns TanStack Query mutation object for deleting layout configurations
  */
 export default function useDeleteLayout(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/packages/design/src/api/useDeleteTheme.ts
+++ b/frontend/packages/design/src/api/useDeleteTheme.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import DesignQueryKeys from '../constants/design-query-keys';
@@ -27,7 +27,7 @@ import DesignQueryKeys from '../constants/design-query-keys';
  * @returns TanStack Query mutation object for deleting theme configurations
  */
 export default function useDeleteTheme(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/packages/design/src/api/useGetLayout.ts
+++ b/frontend/packages/design/src/api/useGetLayout.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import DesignQueryKeys from '../constants/design-query-keys';
@@ -29,7 +29,7 @@ import type {LayoutResponse} from '../models/responses';
  * @returns TanStack Query result object with layout data
  */
 export default function useGetLayout(layoutId: string): UseQueryResult<LayoutResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<LayoutResponse>({

--- a/frontend/packages/design/src/api/useGetLayouts.ts
+++ b/frontend/packages/design/src/api/useGetLayouts.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import DesignQueryKeys from '../constants/design-query-keys';
@@ -36,7 +36,7 @@ interface UseGetLayoutsParams {
  * @returns TanStack Query result object with layout list data
  */
 export default function useGetLayouts(params?: UseGetLayoutsParams): UseQueryResult<LayoutListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/packages/design/src/api/useGetTheme.ts
+++ b/frontend/packages/design/src/api/useGetTheme.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import DesignQueryKeys from '../constants/design-query-keys';
@@ -29,7 +29,7 @@ import type {ThemeResponse} from '../models/responses';
  * @returns TanStack Query result object with theme data
  */
 export default function useGetTheme(themeId: string): UseQueryResult<ThemeResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<ThemeResponse>({

--- a/frontend/packages/design/src/api/useGetThemes.ts
+++ b/frontend/packages/design/src/api/useGetThemes.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import DesignQueryKeys from '../constants/design-query-keys';
@@ -36,7 +36,7 @@ interface UseGetThemesParams {
  * @returns TanStack Query result object with theme list data
  */
 export default function useGetThemes(params?: UseGetThemesParams): UseQueryResult<ThemeListResponse> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {limit = 30, offset = 0} = params ?? {};
 

--- a/frontend/packages/design/src/api/useUpdateLayout.ts
+++ b/frontend/packages/design/src/api/useUpdateLayout.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import DesignQueryKeys from '../constants/design-query-keys';
@@ -34,7 +34,7 @@ interface UpdateLayoutParams {
  * @returns TanStack Query mutation object for updating layout configurations
  */
 export default function useUpdateLayout(): UseMutationResult<LayoutResponse, Error, UpdateLayoutParams> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/packages/design/src/api/useUpdateTheme.ts
+++ b/frontend/packages/design/src/api/useUpdateTheme.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import DesignQueryKeys from '../constants/design-query-keys';
@@ -34,7 +34,7 @@ interface UpdateThemeParams {
  * @returns TanStack Query mutation object for updating theme configurations
  */
 export default function useUpdateTheme(): UseMutationResult<ThemeResponse, Error, UpdateThemeParams> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/packages/design/src/components/flow/FlowComponentRenderer.tsx
+++ b/frontend/packages/design/src/components/flow/FlowComponentRenderer.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {EmbeddedFlowComponentType, EmbeddedFlowEventType, type ConsentPurpose} from '@asgardeo/react';
+import {EmbeddedFlowComponentType, EmbeddedFlowEventType, type ConsentPurpose} from '@thunderid/react';
 import type {JSX} from 'react';
 import BlockAdapter from './adapters/BlockAdapter';
 import ConsentAdapter from './adapters/ConsentAdapter';

--- a/frontend/packages/design/src/components/flow/__tests__/FlowComponentRenderer.test.tsx
+++ b/frontend/packages/design/src/components/flow/__tests__/FlowComponentRenderer.test.tsx
@@ -17,7 +17,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import type {EmbeddedFlowComponent} from '@asgardeo/react';
+import type {EmbeddedFlowComponent} from '@thunderid/react';
 import {screen, cleanup} from '@testing-library/react';
 import {describe, it, expect, afterEach, vi} from 'vitest';
 import renderWithProviders from '../../../test/renderWithProviders';

--- a/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {EmbeddedFlowComponentType, EmbeddedFlowEventType, type EmbeddedFlowComponent} from '@asgardeo/react';
+import {EmbeddedFlowComponentType, EmbeddedFlowEventType, type EmbeddedFlowComponent} from '@thunderid/react';
 import {cn} from '@thunderid/utils';
 import {Box, Button} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';

--- a/frontend/packages/design/src/components/flow/adapters/ConsentAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/ConsentAdapter.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {Consent, ConsentCheckboxList, type ConsentPurpose, type ConsentRenderProps} from '@asgardeo/react';
+import {Consent, ConsentCheckboxList, type ConsentPurpose, type ConsentRenderProps} from '@thunderid/react';
 import {cn} from '@thunderid/utils';
 import {Box, Divider, FormControlLabel, Switch, Typography} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';

--- a/frontend/packages/design/src/components/flow/adapters/ImageAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/ImageAdapter.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {isEmojiUri, extractEmojiFromUri} from '@asgardeo/react';
+import {isEmojiUri, extractEmojiFromUri} from '@thunderid/react';
 import {cn} from '@thunderid/utils';
 import {Box} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';

--- a/frontend/packages/design/src/components/flow/adapters/StackAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/StackAdapter.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import type {EmbeddedFlowComponent} from '@asgardeo/react';
+import type {EmbeddedFlowComponent} from '@thunderid/react';
 import {cn} from '@thunderid/utils';
 import {Stack} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';

--- a/frontend/packages/design/src/components/flow/adapters/StandaloneTriggerAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/StandaloneTriggerAdapter.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {type EmbeddedFlowComponent} from '@asgardeo/react';
+import {type EmbeddedFlowComponent} from '@thunderid/react';
 import {cn} from '@thunderid/utils';
 import {Box, Button} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';

--- a/frontend/packages/design/src/components/flow/adapters/TimerAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/TimerAdapter.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {FlowTimer, type FlowTimerRenderProps} from '@asgardeo/react';
+import {FlowTimer, type FlowTimerRenderProps} from '@thunderid/react';
 import {cn} from '@thunderid/utils';
 import {Alert, Typography} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';

--- a/frontend/packages/design/src/models/flow.ts
+++ b/frontend/packages/design/src/models/flow.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import type {EmbeddedFlowComponent} from '@asgardeo/react';
+import type {EmbeddedFlowComponent} from '@thunderid/react';
 
 /**
  * Represents a normalized embedded flow component with all optional properties

--- a/frontend/packages/design/src/utils/mapEmbeddedFlowTextVariant.ts
+++ b/frontend/packages/design/src/utils/mapEmbeddedFlowTextVariant.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {EmbeddedFlowTextVariant} from '@asgardeo/react';
+import {EmbeddedFlowTextVariant} from '@thunderid/react';
 import type {TypographyVariant} from '@wso2/oxygen-ui';
 
 /**

--- a/frontend/packages/i18n/package.json
+++ b/frontend/packages/i18n/package.json
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@asgardeo/react": "catalog:",
+    "@thunderid/react": "workspace:^",
     "@tanstack/react-query": "catalog:",
     "@thunderid/contexts": "workspace:^",
     "i18next": "catalog:",

--- a/frontend/packages/i18n/src/api/useCreateTranslations.ts
+++ b/frontend/packages/i18n/src/api/useCreateTranslations.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import I18nQueryKeys from '../constants/i18n-query-keys';
@@ -53,7 +53,7 @@ export default function useCreateTranslations(): UseMutationResult<
   Error,
   CreateTranslationsVariables
 > {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/packages/i18n/src/api/useDeleteTranslations.ts
+++ b/frontend/packages/i18n/src/api/useDeleteTranslations.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import I18nQueryKeys from '../constants/i18n-query-keys';
@@ -50,7 +50,7 @@ import I18nQueryKeys from '../constants/i18n-query-keys';
  * ```
  */
 export default function useDeleteTranslations(): UseMutationResult<void, Error, string> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
 

--- a/frontend/packages/i18n/src/api/useGetLanguages.ts
+++ b/frontend/packages/i18n/src/api/useGetLanguages.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import I18nQueryKeys from '../constants/i18n-query-keys';
@@ -57,7 +57,7 @@ export interface UseGetLanguagesOptions {
  * ```
  */
 export default function useGetLanguages(options?: UseGetLanguagesOptions): UseQueryResult<LanguagesResponse, Error> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const {enabled = true} = options ?? {};
 

--- a/frontend/packages/i18n/src/api/useGetTranslations.ts
+++ b/frontend/packages/i18n/src/api/useGetTranslations.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import I18nQueryKeys from '../constants/i18n-query-keys';
@@ -74,7 +74,7 @@ export default function useGetTranslations({
   namespace,
   enabled = true,
 }: UseGetTranslationsOptions): UseQueryResult<TranslationsResponse, Error> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
 
   return useQuery<TranslationsResponse, Error>({

--- a/frontend/packages/i18n/src/api/useUpdateTranslation.ts
+++ b/frontend/packages/i18n/src/api/useUpdateTranslation.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useAsgardeo} from '@asgardeo/react';
+import {useThunderID} from '@thunderid/react';
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import I18nQueryKeys from '../constants/i18n-query-keys';
@@ -68,7 +68,7 @@ export interface UseUpdateTranslationOptions {
 export default function useUpdateTranslation(
   options?: UseUpdateTranslationOptions,
 ): UseMutationResult<TranslationResponse, Error, UpdateTranslationVariables> {
-  const {http} = useAsgardeo();
+  const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
   const {onMutationSuccess} = options ?? {};

--- a/frontend/packages/test-utils/src/setup.ts
+++ b/frontend/packages/test-utils/src/setup.ts
@@ -138,17 +138,17 @@ globalThis.ResizeObserver = class ResizeObserver {
   }
 } as unknown as typeof ResizeObserver;
 
-// Mock global for Node.js built-ins used by @asgardeo packages
+// Mock global for Node.js built-ins used by @thunderid packages
 if (typeof window !== 'undefined') {
   (window as unknown as {global: Window}).global = window;
 }
 
-// Mock @asgardeo/react to avoid buffer import issues in tests
-vi.mock('@asgardeo/react', async (importOriginal) => {
+// Mock @thunderid/react to avoid buffer import issues in tests
+vi.mock('@thunderid/react', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...(actual as object),
-    useAsgardeo: vi.fn(() => ({
+    useThunderID: vi.fn(() => ({
       http: {
         request: vi.fn(),
       },
@@ -160,7 +160,7 @@ vi.mock('@asgardeo/react', async (importOriginal) => {
       isAuthenticated: false,
       isLoading: false,
     })),
-    AsgardeoProvider: ({children}: {children: React.ReactNode}) => children,
+    ThunderIDProvider: ({children}: {children: React.ReactNode}) => children,
   };
 });
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "nx run-many --target=build --all --exclude=@thunderid/docs",
     "build:with-docs": "nx run-many --target=build --all",
     "build:apps": "nx run-many --target=build --projects=frontend/apps/*",
-    "build:packages": "nx run-many --target=build --projects=frontend/packages/*",
+    "build:packages": "nx run-many --target=build --projects=sdks/**,frontend/packages/*",
     "build:frontend": "nx run-many --target=build --projects=frontend/**",
     "build:sdks": "nx run-many --target=build --projects=sdks/**",
     "clean": "nx run-many --target=clean --all",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@asgardeo/react':
-      specifier: 0.25.2
-      version: 0.25.2
-    '@asgardeo/react-router':
-      specifier: 2.0.0
-      version: 2.0.0
     '@emotion/css':
       specifier: 11.13.5
       version: 11.13.5
@@ -320,12 +314,6 @@ importers:
 
   frontend/apps/console:
     dependencies:
-      '@asgardeo/react':
-        specifier: 'catalog:'
-        version: 0.25.2(@types/react@19.2.14)(react@19.2.3)
-      '@asgardeo/react-router':
-        specifier: 'catalog:'
-        version: 2.0.0(@asgardeo/react@0.25.2(@types/react@19.2.14)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@dnd-kit/abstract':
         specifier: 0.4.0
         version: 0.4.0
@@ -407,6 +395,12 @@ importers:
       '@thunderid/logger':
         specifier: workspace:^
         version: link:../../packages/logger
+      '@thunderid/react':
+        specifier: workspace:^
+        version: link:../../../sdks/react
+      '@thunderid/react-router':
+        specifier: workspace:^
+        version: link:../../../sdks/react-router
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -561,12 +555,6 @@ importers:
 
   frontend/apps/gate:
     dependencies:
-      '@asgardeo/react':
-        specifier: 'catalog:'
-        version: 0.25.2(@types/react@19.2.14)(react@19.2.3)
-      '@asgardeo/react-router':
-        specifier: 'catalog:'
-        version: 2.0.0(@asgardeo/react@0.25.2(@types/react@19.2.14)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@fontsource-variable/inter':
         specifier: 5.2.8
         version: 5.2.8
@@ -594,6 +582,12 @@ importers:
       '@thunderid/logger':
         specifier: workspace:^
         version: link:../../packages/logger
+      '@thunderid/react':
+        specifier: workspace:^
+        version: link:../../../sdks/react
+      '@thunderid/react-router':
+        specifier: workspace:^
+        version: link:../../../sdks/react-router
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -679,9 +673,6 @@ importers:
 
   frontend/packages/components:
     dependencies:
-      '@asgardeo/react':
-        specifier: 'catalog:'
-        version: 0.25.2(@types/react@19.2.14)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -700,6 +691,9 @@ importers:
       '@thunderid/logger':
         specifier: workspace:^
         version: link:../logger
+      '@thunderid/react':
+        specifier: workspace:^
+        version: link:../../../sdks/react
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../utils
@@ -773,9 +767,6 @@ importers:
 
   frontend/packages/configure-agent-types:
     dependencies:
-      '@asgardeo/react':
-        specifier: 'catalog:'
-        version: 0.25.2(@types/react@19.2.14)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -788,6 +779,9 @@ importers:
       '@thunderid/logger':
         specifier: workspace:^
         version: link:../logger
+      '@thunderid/react':
+        specifier: workspace:^
+        version: link:../../../sdks/react
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.10.1(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.10.1(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -861,9 +855,6 @@ importers:
 
   frontend/packages/configure-organization-units:
     dependencies:
-      '@asgardeo/react':
-        specifier: 'catalog:'
-        version: 0.25.2(@types/react@19.2.14)(react@19.2.3)
       '@hookform/resolvers':
         specifier: 'catalog:'
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.3))(zod@4.3.6)
@@ -888,6 +879,9 @@ importers:
       '@thunderid/logger':
         specifier: workspace:^
         version: link:../logger
+      '@thunderid/react':
+        specifier: workspace:^
+        version: link:../../../sdks/react
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../utils
@@ -970,9 +964,6 @@ importers:
 
   frontend/packages/configure-translations:
     dependencies:
-      '@asgardeo/react':
-        specifier: 'catalog:'
-        version: 0.25.2(@types/react@19.2.14)(react@19.2.3)
       '@monaco-editor/react':
         specifier: 'catalog:'
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -994,6 +985,9 @@ importers:
       '@thunderid/logger':
         specifier: workspace:^
         version: link:../logger
+      '@thunderid/react':
+        specifier: workspace:^
+        version: link:../../../sdks/react
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.10.1(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.10.1(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1064,9 +1058,6 @@ importers:
 
   frontend/packages/configure-users:
     dependencies:
-      '@asgardeo/react':
-        specifier: 'catalog:'
-        version: 0.25.2(@types/react@19.2.14)(react@19.2.3)
       '@hookform/resolvers':
         specifier: 'catalog:'
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.3))(zod@4.3.6)
@@ -1091,6 +1082,9 @@ importers:
       '@thunderid/logger':
         specifier: workspace:^
         version: link:../logger
+      '@thunderid/react':
+        specifier: workspace:^
+        version: link:../../../sdks/react
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.10.1(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.10.1(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1283,9 +1277,6 @@ importers:
 
   frontend/packages/design:
     dependencies:
-      '@asgardeo/react':
-        specifier: 'catalog:'
-        version: 0.25.2(@types/react@19.2.14)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
@@ -1295,6 +1286,9 @@ importers:
       '@thunderid/logger':
         specifier: workspace:^
         version: link:../logger
+      '@thunderid/react':
+        specifier: workspace:^
+        version: link:../../../sdks/react
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../utils
@@ -1532,15 +1526,15 @@ importers:
 
   frontend/packages/i18n:
     dependencies:
-      '@asgardeo/react':
-        specifier: 'catalog:'
-        version: 0.25.2(@types/react@19.2.14)(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.90.5(react@19.2.3)
       '@thunderid/contexts':
         specifier: workspace:^
         version: link:../contexts
+      '@thunderid/react':
+        specifier: workspace:^
+        version: link:../../../sdks/react
       i18next:
         specifier: 'catalog:'
         version: 25.6.0(typescript@5.9.3)
@@ -2131,19 +2125,22 @@ importers:
 
   sdks/react:
     dependencies:
-      '@thunderid/browser':
-        specifier: workspace:^
-        version: link:../browser
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-    devDependencies:
       '@emotion/css':
         specifier: 'catalog:'
         version: 11.13.5
       '@floating-ui/react':
         specifier: 'catalog:'
         version: 0.27.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@thunderid/browser':
+        specifier: workspace:^
+        version: link:../browser
+      dompurify:
+        specifier: 3.4.0
+        version: 3.4.0
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
+    devDependencies:
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2162,9 +2159,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
-      dompurify:
-        specifier: 3.4.0
-        version: 3.4.0
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.7.0)
@@ -2445,28 +2439,6 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
-
-  '@asgardeo/browser@0.7.7':
-    resolution: {integrity: sha512-MAS1FmsA42buDmsguoLOFQBV37hLXloi/bznvv2FYpjfQnKZ+JRNvSnzDtIbOOj2jGzSuUF9w4jA2m/X6HJZ4A==}
-
-  '@asgardeo/i18n@0.4.5':
-    resolution: {integrity: sha512-p1DVVI7lNu7KeDqhRNgAuSrHvVgCbbVXc04koyiiwjDx+sJaXychuC9pwVJ2PDUnIyEp3Xgdb3KqMq+Sx4e7xA==}
-
-  '@asgardeo/javascript@0.22.0':
-    resolution: {integrity: sha512-pEiePIbL+lzgNZxP6N0EgtMZn42gOswLtOTv5SlTb7CO2vs5CPQYP4B492BaZ3wgkbDsjbHw5n1RAk6VjCxR7g==}
-
-  '@asgardeo/react-router@2.0.0':
-    resolution: {integrity: sha512-RvHol3VgjV466y7RhpmPosER89Yz1prREvjWjhu95X9e4l761+3n8bRSQR5lpP1tasAVKtVH6RzWvWoPST7+Zg==}
-    peerDependencies:
-      '@asgardeo/react': '>=0.15.0'
-      react: '>=16.8.0'
-      react-router: '>=6.30.1'
-
-  '@asgardeo/react@0.25.2':
-    resolution: {integrity: sha512-11eQoxMKswrRDGWocJeDz+Ba8T6SuYFw7W+MoO8nSi3rvP/k5HrU6j7AlIN201JQnCUApAgaw6M0vHemLuyzfQ==}
-    peerDependencies:
-      '@types/react': '>=16.8.0'
-      react: '>=16.8.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -10393,14 +10365,8 @@ packages:
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
 
-  jose@5.10.0:
-    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
-
   jose@5.2.0:
     resolution: {integrity: sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==}
-
-  jose@6.0.11:
-    resolution: {integrity: sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==}
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
@@ -12457,11 +12423,6 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
-
-  react-dom@19.2.4:
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
-    peerDependencies:
-      react: ^19.2.4
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -14964,52 +14925,6 @@ snapshots:
       lru-cache: 11.3.6
 
   '@asamuzakjp/nwsapi@2.3.9': {}
-
-  '@asgardeo/browser@0.7.7':
-    dependencies:
-      '@asgardeo/javascript': 0.22.0
-      base64url: 3.0.1
-      buffer: 6.0.3
-      core-js: 3.42.0
-      crypto-browserify: 3.12.1
-      fast-sha256: 1.3.0
-      jose: 6.0.11
-      process: 0.11.10
-      randombytes: 2.1.0
-      stream-browserify: 3.0.0
-      tslib: 2.8.1
-
-  '@asgardeo/i18n@0.4.5':
-    dependencies:
-      tslib: 2.8.1
-
-  '@asgardeo/javascript@0.22.0':
-    dependencies:
-      '@asgardeo/i18n': 0.4.5
-      jose: 5.10.0
-      tslib: 2.8.1
-
-  '@asgardeo/react-router@2.0.0(@asgardeo/react@0.25.2(@types/react@19.2.14)(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@asgardeo/react': 0.25.2(@types/react@19.2.14)(react@19.2.3)
-      react: 19.2.3
-      react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      tslib: 2.8.1
-
-  '@asgardeo/react@0.25.2(@types/react@19.2.14)(react@19.2.3)':
-    dependencies:
-      '@asgardeo/browser': 0.7.7
-      '@asgardeo/i18n': 0.4.5
-      '@emotion/css': 11.13.5
-      '@floating-ui/react': 0.27.12(react-dom@19.2.4(react@19.2.3))(react@19.2.3)
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      dompurify: 3.4.0
-      react: 19.2.3
-      react-dom: 19.2.4(react@19.2.3)
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -17569,26 +17484,12 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      react: 19.2.3
-      react-dom: 19.2.4(react@19.2.3)
-
   '@floating-ui/react@0.27.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@floating-ui/utils': 0.2.11
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      tabbable: 6.4.0
-
-  '@floating-ui/react@0.27.12(react-dom@19.2.4(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.3))(react@19.2.3)
-      '@floating-ui/utils': 0.2.11
-      react: 19.2.3
-      react-dom: 19.2.4(react@19.2.3)
       tabbable: 6.4.0
 
   '@floating-ui/react@0.27.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
@@ -24912,11 +24813,7 @@ snapshots:
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
 
-  jose@5.10.0: {}
-
   jose@5.2.0: {}
-
-  jose@6.0.11: {}
 
   js-base64@3.7.8: {}
 
@@ -27637,11 +27534,6 @@ snapshots:
       strip-json-comments: 2.0.1
 
   react-dom@19.2.3(react@19.2.3):
-    dependencies:
-      react: 19.2.3
-      scheduler: 0.27.0
-
-  react-dom@19.2.4(react@19.2.3):
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,8 +20,6 @@ allowBuilds:
   vue-demi: false
 
 catalog:
-  '@asgardeo/react': 0.25.2
-  '@asgardeo/react-router': 2.0.0
   '@hookform/resolvers': 5.2.2
   '@monaco-editor/react': 4.7.0
   '@tanstack/react-query': 5.90.5

--- a/sdks/react-router/rolldown.config.js
+++ b/sdks/react-router/rolldown.config.js
@@ -21,7 +21,8 @@ import {rolldown} from 'rolldown';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
 
-const external = [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})];
+const externalPackages = [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})];
+const external = (id) => externalPackages.some((dep) => id === dep || id.startsWith(dep + '/'));
 
 const commonOptions = {
   external,

--- a/sdks/react/package.json
+++ b/sdks/react/package.json
@@ -52,9 +52,6 @@
     "eslint": "catalog:",
     "prettier": "catalog:",
     "react": "catalog:",
-    "@emotion/css": "catalog:",
-    "@floating-ui/react": "catalog:",
-    "dompurify": "catalog:",
     "react-dom": "catalog:",
     "rimraf": "catalog:",
     "rolldown": "catalog:",
@@ -67,7 +64,10 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
+    "@emotion/css": "catalog:",
+    "@floating-ui/react": "catalog:",
     "@thunderid/browser": "workspace:^",
+    "dompurify": "catalog:",
     "tslib": "catalog:"
   },
   "publishConfig": {

--- a/tests/e2e/utils/authentication/console-admin-auth-utils.ts
+++ b/tests/e2e/utils/authentication/console-admin-auth-utils.ts
@@ -167,7 +167,7 @@ export async function verifyAuthState(page: Page, debug: boolean = false): Promi
     return items;
   });
 
-  const isSessionActive = localStorage["asgardeo-session-active"] === "true";
+  const isSessionActive = localStorage["thunderid-session-active"] === "true";
   const hasSessionData = Object.keys(sessionStorage).some(key => key.includes("session_data-instance_0"));
 
   // Check if tokens exist and are not expired


### PR DESCRIPTION
### Purpose
The `@asgardeo/react` and `@asgardeo/react-router` packages have been moved into the monorepo as local workspace packages (`@thunderid/react` and `@thunderid/react-router` under `sdks/react` and `sdks/react-router`). This PR updates the entire frontend to reference the new local packages instead of the old external npm packages.

### Approach
- **`pnpm-workspace.yaml`** — replaced the external pinned catalog entries with `workspace:^` references so all consumers continue using `catalog:` shorthand while resolving to the local packages
- **9 `package.json` files** — renamed `@asgardeo/react`/`@asgardeo/react-router` in `dependencies` and `peerDependencies` across both apps and all shared packages
- **~208 `.ts`/`.tsx` source files** — bulk-renamed all import statements via `find`+`sed`
- **`vite.config.ts`** (console + gate) — updated `server.deps.inline` from `@asgardeo/browser` to `@thunderid/browser`

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided.
- [ ] Tests provided.
- [ ] Breaking changes.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.