### PR TITLE
Add agent id sample application

### DIFF
--- a/samples/apps/agent-id-sample/.gitignore
+++ b/samples/apps/agent-id-sample/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.env
+dist
+*.sqlite
+*.sqlite-*

--- a/samples/apps/agent-id-sample/README.md
+++ b/samples/apps/agent-id-sample/README.md
@@ -1,0 +1,122 @@
+# Agent Identity Sample (Wayfinder)
+
+End-to-end sample of an AI agent that holds its own Thunder-managed identity.
+
+The agent uses **its own access token (client_credentials grant)** for browsing tools and switches to a **user-context token via OAuth 2.0 authorization-code + PKCE** when a tool needs the user's consent (booking, cancellation, viewing the user's own data).
+
+The sample is a travel booking app called Wayfinder. A chat widget in the UI talks to a LangChain agent that calls REST tools through an MCP server.
+
+## What This Demonstrates
+
+- A Thunder **agent** acting as an autonomous principal — distinct from a Thunder user.
+- The agent's **machine-to-machine (M2M) token** used for read-only browsing tools (search flights, search hotels, etc.).
+- An **on-behalf-of (OBO)** flow triggered from inside a chat session: the agent asks for the user's consent in a popup, the user picks which booking permissions to grant, and the issued user-context token only carries the approved subset.
+- A REST API that **verifies the JWT** and **enforces scopes per route** (`booking:read`, `booking:create`, `booking:cancel`).
+
+## Project Structure
+
+```text
+agent-id-sample/
+├── frontend/   React + Vite UI. Hosts the chat widget and the
+│               /agent-callback route used by the consent popup.
+├── api/        Node REST API backed by SQLite. Validates JWTs
+│               and enforces scopes on booking routes.
+├── mcp/        Streamable-HTTP MCP server that wraps the REST API.
+├── ai-agent/   WebSocket chat agent (LangChain + Claude).
+└── README.md
+```
+
+Each subdirectory has its own README with the environment variables it reads and a `npm start` command.
+
+## Prerequisites
+
+- Node.js 20+
+- A running Thunder backend on `https://localhost:8090` (self-signed cert is fine).
+- An Anthropic API key from [console.anthropic.com](https://console.anthropic.com).
+
+## Thunder Setup
+
+Before running the sample, create the following entities in Thunder. You can use the Console UI or the management APIs.
+
+### 1. Resource server with permissions
+
+Create a resource server **`booking-api`** (identifier `booking-api`) with a resource handle `booking` and three actions:
+
+| Action handle | Resulting permission |
+| ------------- | -------------------- |
+| `read`        | `booking:read`       |
+| `create`      | `booking:create`     |
+| `cancel`      | `booking:cancel`     |
+
+### 2. Demo user
+
+Create a user (e.g. username `john.doe`, password `john.doe`) under the default OU. This will be the resource owner who consents in the popup.
+
+### 3. Role granting the booking permissions
+
+Create a role (e.g. **Wayfinder Admin**) that grants the three `booking:read`, `booking:create`, `booking:cancel` permissions on the `booking-api` resource server. Assign the role to the demo user.
+
+### 4. Wayfinder web application
+
+Create an OAuth application **`WAYFINDER`** with redirect URI `http://localhost:5173` and assign it any user authentication flow (the default sign-in flow works). This is what the frontend uses for user sign-in.
+
+### 5. Agent + agent authentication flow
+
+Create an **agent authentication flow** with the following node sequence and register it for the agent below:
+
+```
+start → prompt_credentials → basic_auth → authorization_check → auth_assert → end
+```
+
+The `authorization_check` node uses the **AuthorizationExecutor**; the rest are standard.
+
+Create an **agent** named **`WAYFINDER-CHAT-AGENT`** with:
+
+- Redirect URI: `http://localhost:5173/agent-callback`
+- Allowed grants: `authorization_code` (for OBO) and `client_credentials` (for M2M)
+- `accessToken.userAttributes`: `given_name`, `family_name`, `email`, `groups`
+- The agent authentication flow created above
+
+Thunder prints the agent's **client secret only once** at creation. Capture it for `ai-agent/.env`.
+
+## Configure the Sample
+
+`api/`, `ai-agent/`, and `frontend/` each ship with a `.env.example` listing only the variables you actually need to set. In each of those folders, copy it to `.env` and fill the placeholders. The `mcp/` server has no required configuration.
+
+The two placeholder values you must replace are in `ai-agent/.env`:
+
+- `AGENT_SECRET=` — the agent client secret captured at agent creation.
+- `ANTHROPIC_API_KEY=` — your Anthropic API key.
+
+Everything else in the examples is local-dev defaults that match the run instructions below.
+
+## Run
+
+In four terminals:
+
+```bash
+cd api      && npm install && npm run seed && npm start   # http://localhost:8787
+cd mcp      && npm install && npm start                   # http://localhost:8000/mcp
+cd ai-agent && npm install && npm start                   # ws://localhost:8790/chat
+cd frontend && npm install && npm run dev                 # http://localhost:5173
+```
+
+`npm run seed` initializes the local SQLite database with sample flights, hotels, and trips. Run it once on first setup.
+
+## Try It
+
+Open `http://localhost:5173`, open the chat widget, and try:
+
+```
+What flights are there from Colombo to Singapore?
+```
+
+These browsing tools use the agent's M2M token — no popup, no user sign-in.
+
+Then:
+
+```
+Book flight 2
+```
+
+The agent will pause and ask for your permission. A popup opens, you sign in as the demo user, you pick which booking permissions to grant in the consent screen, and the booking succeeds (or returns 403 if you denied `booking:create`).

--- a/samples/apps/agent-id-sample/README.md
+++ b/samples/apps/agent-id-sample/README.md
@@ -12,6 +12,7 @@ The sample is a travel booking app called Wayfinder. A chat widget in the UI tal
 - The agent's **machine-to-machine (M2M) token** used for read-only browsing tools (search flights, search hotels, etc.).
 - An **on-behalf-of (OBO)** flow triggered from inside a chat session: the agent asks for the user's consent in a popup, the user picks which booking permissions to grant, and the issued user-context token only carries the approved subset.
 - A REST API that **verifies the JWT** and **enforces scopes per route** (`booking:read`, `booking:create`, `booking:cancel`).
+- An in-app **Agent Portal** page (`/agent-portal`) where a signed-in admin can list, create, and delete agents and assign Thunder roles to them — calling Thunder's admin APIs directly from the browser with the user's `system`-scoped access token.
 
 ## Project Structure
 
@@ -38,7 +39,7 @@ Each subdirectory has its own README with the environment variables it reads and
 
 Before running the sample, create the following entities in Thunder. You can use the Console UI or the management APIs.
 
-### 1. Resource server with permissions
+### 1. Resource Server With Permissions
 
 Create a resource server **`booking-api`** (identifier `booking-api`) with a resource handle `booking` and three actions:
 
@@ -48,19 +49,21 @@ Create a resource server **`booking-api`** (identifier `booking-api`) with a res
 | `create`      | `booking:create`     |
 | `cancel`      | `booking:cancel`     |
 
-### 2. Demo user
+### 2. Demo User
 
 Create a user (e.g. username `john.doe`, password `john.doe`) under the default OU. This will be the resource owner who consents in the popup.
 
-### 3. Role granting the booking permissions
+### 3. Roles Granting the Demo User Permissions
 
 Create a role (e.g. **Wayfinder Admin**) that grants the three `booking:read`, `booking:create`, `booking:cancel` permissions on the `booking-api` resource server. Assign the role to the demo user.
 
-### 4. Wayfinder web application
+Also assign the demo user the built-in **Administrator** role (or any role that grants the `system` permission on the `system` resource server). This is what lets the in-app Agent Portal page call Thunder's admin APIs. Without it, sign-in still works but the Agent Portal will see authorization errors when listing or creating agents.
 
-Create an OAuth application **`WAYFINDER`** with redirect URI `http://localhost:5173` and assign it any user authentication flow (the default sign-in flow works). This is what the frontend uses for user sign-in.
+### 4. Wayfinder Web Application
 
-### 5. Agent + agent authentication flow
+Create an OAuth application **`WAYFINDER`** with redirect URI `http://localhost:5173`. Assign it an authentication flow that runs the **AuthorizationExecutor** so the user's role permissions are evaluated into the access token (the same flow shape as the agent flow below works). This is what the frontend uses for user sign-in.
+
+### 5. Agent and Agent Authentication Flow
 
 Create an **agent authentication flow** with the following node sequence and register it for the agent below:
 
@@ -88,7 +91,7 @@ The two placeholder values you must replace are in `ai-agent/.env`:
 - `AGENT_SECRET=` — the agent client secret captured at agent creation.
 - `ANTHROPIC_API_KEY=` — your Anthropic API key.
 
-Everything else in the examples is local-dev defaults that match the run instructions below.
+Everything else in the examples is local development defaults that match the run instructions below.
 
 ## Run
 
@@ -120,3 +123,5 @@ Book flight 2
 ```
 
 The agent will pause and ask for your permission. A popup opens, you sign in as the demo user, you pick which booking permissions to grant in the consent screen, and the booking succeeds (or returns 403 if you denied `booking:create`).
+
+To exercise the **Agent Portal**, sign in to the Wayfinder web app itself (using the same demo user, who now has the `system` permission) and open the account menu → **Agent Portal**. From there you can create more agents, delete them, and assign roles to them — all calling Thunder's admin APIs with the user's access token.

--- a/samples/apps/agent-id-sample/ai-agent/.env.example
+++ b/samples/apps/agent-id-sample/ai-agent/.env.example
@@ -1,0 +1,14 @@
+# Thunder base URL.
+THUNDER_BASE_URL=https://localhost:8090
+
+# OAuth client ID and secret of the agent created in Thunder.
+# Thunder shows the secret once at agent creation — capture it then.
+AGENT_ID=WAYFINDER-CHAT-AGENT
+AGENT_SECRET=replace-with-the-secret-thunder-printed
+
+# Redirect URI used for the on-behalf-of (user-context) authorization-code flow.
+# Must match the redirect URI registered on the agent in Thunder.
+AGENT_REDIRECT_URI=http://localhost:5173/agent-callback
+
+# Anthropic API key — https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/samples/apps/agent-id-sample/ai-agent/README.md
+++ b/samples/apps/agent-id-sample/ai-agent/README.md
@@ -1,0 +1,17 @@
+# AI Agent
+
+WebSocket chat agent that authenticates against Thunder with its own identity and switches to a user-context token via authorization-code + PKCE when a tool needs user consent.
+
+See the parent README for end-to-end setup. Configure with `.env.example` in this folder.
+
+## Run
+
+```bash
+npm install
+npm start
+```
+
+Endpoints:
+
+- Chat:   `ws://localhost:8790/chat`
+- Health: `http://localhost:8790/health`

--- a/samples/apps/agent-id-sample/ai-agent/agent.ts
+++ b/samples/apps/agent-id-sample/ai-agent/agent.ts
@@ -1,0 +1,859 @@
+/*
+Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { createServer } from "node:http";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import type { Duplex } from "node:stream";
+
+import { ChatAnthropic } from "@langchain/anthropic";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+import dotenv from "dotenv";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+dotenv.config({
+    path: resolve(__dirname, ".env"),
+});
+
+// Local-dev TLS bypass: Thunder ships with a self-signed cert on localhost,
+// so fetch() and the Asgardeo JS SDK would otherwise refuse to talk to it.
+// We disable Node's TLS verification ONLY when the configured base URL points
+// at localhost / 127.0.0.1 to keep production builds safe.
+const __thunderBaseUrl = process.env.THUNDER_BASE_URL || "";
+if (/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/.test(__thunderBaseUrl)) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    console.warn("[ai-agent] Local Thunder detected — NODE_TLS_REJECT_UNAUTHORIZED set to 0. Do not use this build in production.");
+}
+
+const agentConfig = {
+    agentID: process.env.AGENT_ID || "",
+    agentSecret: process.env.AGENT_SECRET || "",
+};
+
+const model = new ChatAnthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY || "",
+    model: process.env.MODEL_NAME || "claude-sonnet-4-6",
+});
+
+// LangChain @langchain/anthropic 0.3.x has special "send only when explicitly
+// set" handling for sonnet-4-5 / haiku-4-5 / opus-4-1, but not for sonnet-4-6.
+// For models outside that list it sends top_p:-1 and top_k:-1 as defaults,
+// which the Anthropic API rejects ("top_p cannot be set to -1", and
+// "temperature and top_p cannot both be specified"). Mutating these to
+// `undefined` makes JSON.stringify omit them from the request body so only
+// the model's own default temperature (1) is sent.
+(model as unknown as { topP: number | undefined }).topP = undefined;
+(model as unknown as { topK: number | undefined }).topK = undefined;
+
+// System prompt for the chat agent. Kept short and focused on formatting so
+// answers render cleanly inside a narrow chat widget. Tables and complex
+// markdown render as raw text in the widget today.
+const SYSTEM_PROMPT = `You are the Wayfinder Chat Agent, a travel assistant for the Wayfinder Travel app.
+
+Use the available tools to answer travel questions and manage the user's bookings.
+
+Output formatting — this is critical. The chat UI is plain text. It renders raw newlines but does NOT render markdown tables, headings, bold, italics, or HTML.
+
+Strict rules:
+- Never output markdown tables, pipes ("|"), or column separators.
+- Never output markdown headings ("#", "##").
+- Never output bold ("**...**") or italics ("*...*").
+- One fact per line. Use plain text "Label: Value" lines.
+- For multiple items (e.g. a list of flights), separate each item with a BLANK LINE between them so they don't visually merge.
+- Use a single short emoji at the very start of a section header line if helpful, never inside data lines.
+- Be concise. Skip recaps of the user's question and trailing pleasantries unless asked.
+
+Example of how to render a list of flights — copy this style exactly. ALWAYS include the flight ID on every flight so the user can refer to it later (e.g. "book flight-cmb-sin-01"):
+
+Available flights from Colombo to Singapore
+
+Flight 1 — Meridian Airways
+- ID: flight-cmb-sin-03
+- Departure: 01:10
+- Arrival: 09:20
+- Duration: 5h 40m
+- Stops: 1
+- Price: USD 276
+
+Flight 2 — Serendib Air
+- ID: flight-cmb-sin-01
+- Departure: 08:45
+- Arrival: 15:05
+- Duration: 3h 50m
+- Stops: 0 (non-stop)
+- Price: USD 314
+
+When the user says "book flight 1" or "book the cheapest one" after a listing, look up the flight ID from the previous turn's tool result and call create_booking with that ID — do not ask the user for the ID again.
+
+Example of a good single booking summary:
+
+Booking WF-76855E8F (confirmed)
+- Route: Colombo → Singapore
+- Airline: Meridian Airways
+- Departure: 01:10
+- Arrival: 09:20
+- Duration: 5h 40m
+- Stops: 1
+- Price: USD 276
+- Travelers: 1
+
+When you need information you can call the tools. When a tool requires the user's permission to act on their behalf, the system handles that automatically — do not mention it in the chat.`;
+
+// ---------------------------------------------------------------------------
+// On-behalf-of (OBO) configuration
+// ---------------------------------------------------------------------------
+// When the agent calls a tool that mutates user data (booking, cancellation),
+// it cannot use its own client-credentials token — it needs a token that
+// represents the signed-in user. We obtain one with a standard OAuth 2.0
+// authorization-code flow with PKCE, triggered inside the chat session.
+//
+// The agent sends `need_user_consent` to the chat widget, which opens a popup
+// at THUNDER_BASE_URL/oauth2/authorize. After the user signs in, the popup
+// posts the auth code back to the agent via the WebSocket, which exchanges it
+// at THUNDER_BASE_URL/oauth2/token for a user-context access token.
+
+const THUNDER_BASE_URL = process.env.THUNDER_BASE_URL || "";
+const AGENT_REDIRECT_URI = process.env.AGENT_REDIRECT_URI || "http://localhost:5173/agent-callback";
+const MCP_SERVER_URL = process.env.MCP_SERVER_URL || "http://localhost:8000/mcp";
+
+// Tools that require a user-context access token. For these, the agent will
+// initiate the consent flow if it doesn't already have a user token cached
+// for the current chat session.
+const USER_CONTEXT_TOOLS = new Set<string>([
+    "create_booking",
+    "cancel_booking",
+    "delete_all_bookings",
+    "get_flight_bookings",
+    "get_profile",
+]);
+
+// Scope to request for each user-context tool. Booking tools share one OBO popup
+// requesting all three permissions; the user picks which to grant in the consent
+// screen and the issued token carries only the approved subset. Per-route API
+// checks (booking:create/read/cancel) then decide whether each tool call succeeds.
+const ALL_BOOKING_SCOPES = "booking:read booking:create booking:cancel";
+const USER_CONTEXT_SCOPES: Record<string, string> = {
+    create_booking: ALL_BOOKING_SCOPES,
+    cancel_booking: ALL_BOOKING_SCOPES,
+    delete_all_bookings: ALL_BOOKING_SCOPES,
+    get_flight_bookings: ALL_BOOKING_SCOPES,
+    get_profile: "profile email",
+};
+
+const USER_CONSENT_TIMEOUT_MS = 120_000;
+
+type UserToken = {
+    accessToken: string;
+    expiresAt: number;
+};
+
+type PendingConsent = {
+    resolve: (data: { type: string; code?: string; state?: string; error?: string; error_description?: string }) => void;
+    reject: (err: Error) => void;
+    verifier: string;
+    state: string;
+    timeoutHandle: ReturnType<typeof setTimeout>;
+};
+
+type SessionState = {
+    socket: Duplex;
+    isClosed: boolean;
+    userToken?: UserToken;
+    userToolsByName?: Map<string, MCPLikeTool>;
+    pendingConsents: Map<string, PendingConsent>;
+    // Accumulated conversation history for this WebSocket session. We feed
+    // the full thread (including prior tool calls and assistant replies) into
+    // each invoke() so the agent remembers what it just said. Without this
+    // every turn starts from a blank slate.
+    chatMessages: unknown[];
+};
+
+type MCPLikeTool = {
+    name: string;
+    description?: string;
+    schema?: unknown;
+    invoke: (input: unknown, config?: unknown) => Promise<unknown>;
+};
+
+function base64UrlEncode(input: Buffer): string {
+    return input.toString("base64").replace(/=+$/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function generatePkceVerifier(): string {
+    return base64UrlEncode(randomBytes(32));
+}
+
+function pkceChallengeFromVerifier(verifier: string): string {
+    return base64UrlEncode(createHash("sha256").update(verifier).digest());
+}
+
+function buildAuthorizeUrl(state: string, codeChallenge: string, scope: string): string {
+    const params = new URLSearchParams({
+        response_type: "code",
+        client_id: agentConfig.agentID,
+        redirect_uri: AGENT_REDIRECT_URI,
+        scope,
+        state,
+        code_challenge: codeChallenge,
+        code_challenge_method: "S256",
+    });
+
+    return `${THUNDER_BASE_URL}/oauth2/authorize?${params.toString()}`;
+}
+
+async function exchangeCodeForUserToken(code: string, codeVerifier: string): Promise<UserToken> {
+    const body = new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: AGENT_REDIRECT_URI,
+        client_id: agentConfig.agentID,
+        code_verifier: codeVerifier,
+    });
+
+    const basicAuth = Buffer.from(`${agentConfig.agentID}:${agentConfig.agentSecret}`).toString("base64");
+
+    const response = await fetch(`${THUNDER_BASE_URL}/oauth2/token`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Authorization: `Basic ${basicAuth}`,
+            Accept: "application/json",
+        },
+        body,
+    });
+
+    const text = await response.text();
+
+    if (!response.ok) {
+        throw new Error(`Token exchange failed (${response.status}): ${text}`);
+    }
+
+    let payload: { access_token?: string; expires_in?: number };
+    try {
+        payload = JSON.parse(text);
+    } catch {
+        throw new Error(`Token exchange returned non-JSON response: ${text}`);
+    }
+
+    if (!payload.access_token) {
+        throw new Error(`Token exchange response missing access_token: ${text}`);
+    }
+
+    try {
+        const claims = JSON.parse(Buffer.from(payload.access_token.split(".")[1], "base64url").toString("utf8"));
+        console.log("[obo] user token claims:", JSON.stringify({
+            sub: claims.sub,
+            authorized_permissions: claims.authorized_permissions,
+            scope: claims.scope,
+            aud: claims.aud,
+        }));
+    } catch (decodeErr) {
+        console.warn("[obo] failed to decode access token for logging", decodeErr);
+    }
+
+    return {
+        accessToken: payload.access_token,
+        expiresAt: Date.now() + (payload.expires_in ?? 3600) * 1000,
+    };
+}
+
+async function requestUserConsent(session: SessionState, scope: string): Promise<void> {
+    const requestId = randomUUID();
+    const state = randomUUID();
+    const verifier = generatePkceVerifier();
+    const challenge = pkceChallengeFromVerifier(verifier);
+    const authorizeUrl = buildAuthorizeUrl(state, challenge, scope);
+
+    const ok = sendJson(session.socket, {
+        type: "need_user_consent",
+        authorize_url: authorizeUrl,
+        state,
+        request_id: requestId,
+        scope,
+    });
+
+    if (!ok) {
+        throw new Error("WebSocket is closed; cannot request user consent");
+    }
+
+    const response = await new Promise<{ type: string; code?: string; state?: string; error?: string; error_description?: string }>(
+        (resolve, reject) => {
+            const timeoutHandle = setTimeout(() => {
+                if (session.pendingConsents.delete(requestId)) {
+                    reject(new Error("User did not respond to the consent prompt in time."));
+                }
+            }, USER_CONSENT_TIMEOUT_MS);
+
+            session.pendingConsents.set(requestId, { resolve, reject, verifier, state, timeoutHandle });
+        },
+    );
+
+    if (response.type === "user_consent_error" || response.error) {
+        throw new Error(`User declined consent: ${response.error || "unknown"}`);
+    }
+
+    if (response.type !== "user_code" || !response.code) {
+        throw new Error("Received an unexpected consent response from the client.");
+    }
+
+    if (response.state && response.state !== state) {
+        throw new Error("Consent response state did not match. Aborting.");
+    }
+
+    const userToken = await exchangeCodeForUserToken(response.code, verifier);
+    session.userToken = userToken;
+    // Force the user-context MCP tools cache to be rebuilt with the new token.
+    session.userToolsByName = undefined;
+}
+
+async function getUserContextTool(session: SessionState, toolName: string): Promise<MCPLikeTool> {
+    if (!session.userToken) {
+        throw new Error("No user token available");
+    }
+
+    if (!session.userToolsByName) {
+        const userClient = new MultiServerMCPClient({
+            travel: {
+                transport: "http",
+                url: MCP_SERVER_URL,
+                headers: {
+                    Authorization: `Bearer ${session.userToken.accessToken}`,
+                },
+            },
+        });
+
+        const userTools = (await userClient.getTools()) as unknown as MCPLikeTool[];
+        session.userToolsByName = new Map(userTools.map((t) => [t.name, t]));
+    }
+
+    const userTool = session.userToolsByName.get(toolName);
+    if (!userTool) {
+        throw new Error(`User-context tool not found on MCP server: ${toolName}`);
+    }
+
+    return userTool;
+}
+
+function wrapToolForSession(originalTool: MCPLikeTool, session: SessionState): MCPLikeTool {
+    if (!USER_CONTEXT_TOOLS.has(originalTool.name)) {
+        return originalTool;
+    }
+
+    const wrapped: MCPLikeTool = Object.create(Object.getPrototypeOf(originalTool) as object | null);
+    Object.assign(wrapped, originalTool);
+
+    wrapped.invoke = async (input: unknown, config?: unknown) => {
+        if (!session.userToken || session.userToken.expiresAt <= Date.now() + 5_000) {
+            const scope = USER_CONTEXT_SCOPES[originalTool.name] || "booking";
+            console.log(`[obo] ${originalTool.name} → requesting user consent (scope=${scope})`);
+            await requestUserConsent(session, scope);
+            console.log(`[obo] ${originalTool.name} → user token acquired`);
+        } else {
+            console.log(`[obo] ${originalTool.name} → reusing cached user token`);
+        }
+        const userTool = await getUserContextTool(session, originalTool.name);
+        return userTool.invoke(input, config);
+    };
+
+    return wrapped;
+}
+
+type ChatMessage = {
+    role: "user" | "assistant" | "system";
+    content: string;
+};
+
+type ChatRequest = {
+    message?: unknown;
+    messages?: unknown;
+};
+
+type WebSocketFrame = {
+    opcode: number;
+    payload: Buffer<ArrayBufferLike>;
+};
+
+const WEB_SOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+function parseChatRequest(payload: string): ChatMessage[] {
+
+    try {
+        const request = JSON.parse(payload) as ChatRequest;
+
+        if (typeof request.message === "string" && request.message.trim()) {
+            return [{ role: "user", content: request.message }];
+        }
+
+        if (Array.isArray(request.messages)) {
+            const messages = request.messages.filter((message): message is ChatMessage => {
+                if (typeof message !== "object" || message === null) {
+                    return false;
+                }
+
+                const candidate = message as Partial<ChatMessage>;
+
+                return (
+                    typeof candidate.content === "string" &&
+                    ["user", "assistant", "system"].includes(candidate.role || "")
+                );
+            });
+
+            if (messages.length > 0) {
+                return messages;
+            }
+        }
+    } catch {
+        if (payload.trim()) {
+            return [{ role: "user", content: payload }];
+        }
+    }
+
+    throw new Error("Send a non-empty text message or JSON payload with a `message` field.");
+}
+
+function getResponseContent(content: unknown): string {
+    if (typeof content === "string") {
+        return content;
+    }
+
+    return JSON.stringify(content);
+}
+
+function createWebSocketAcceptKey(key: string): string {
+    return createHash("sha1")
+        .update(`${key}${WEB_SOCKET_GUID}`)
+        .digest("base64");
+}
+
+function encodeWebSocketFrame(payload: string, opcode = 0x1): Buffer {
+    const payloadBuffer = Buffer.from(payload);
+    const payloadLength = payloadBuffer.length;
+
+    if (payloadLength <= 125) {
+        return Buffer.concat([
+            Buffer.from([0x80 | opcode, payloadLength]),
+            payloadBuffer,
+        ]);
+    }
+
+    if (payloadLength <= 65535) {
+        const header = Buffer.alloc(4);
+        header[0] = 0x80 | opcode;
+        header[1] = 126;
+        header.writeUInt16BE(payloadLength, 2);
+
+        return Buffer.concat([header, payloadBuffer]);
+    }
+
+    const header = Buffer.alloc(10);
+    header[0] = 0x80 | opcode;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(payloadLength), 2);
+
+    return Buffer.concat([header, payloadBuffer]);
+}
+
+function parseWebSocketFrame(
+    buffer: Buffer<ArrayBufferLike>
+): { frame: WebSocketFrame; remaining: Buffer<ArrayBufferLike> } | null {
+    if (buffer.length < 2) {
+        return null;
+    }
+
+    const opcode = buffer[0] & 0x0f;
+    const isMasked = (buffer[1] & 0x80) === 0x80;
+    let payloadLength = buffer[1] & 0x7f;
+    let offset = 2;
+
+    if (payloadLength === 126) {
+        if (buffer.length < offset + 2) {
+            return null;
+        }
+
+        payloadLength = buffer.readUInt16BE(offset);
+        offset += 2;
+    } else if (payloadLength === 127) {
+        if (buffer.length < offset + 8) {
+            return null;
+        }
+
+        const extendedPayloadLength = buffer.readBigUInt64BE(offset);
+
+        if (extendedPayloadLength > BigInt(Number.MAX_SAFE_INTEGER)) {
+            throw new Error("WebSocket message is too large.");
+        }
+
+        payloadLength = Number(extendedPayloadLength);
+        offset += 8;
+    }
+
+    const maskOffset = offset;
+
+    if (isMasked) {
+        offset += 4;
+    }
+
+    if (buffer.length < offset + payloadLength) {
+        return null;
+    }
+
+    const payload = Buffer.from(buffer.subarray(offset, offset + payloadLength));
+
+    if (isMasked) {
+        const mask = buffer.subarray(maskOffset, maskOffset + 4);
+
+        for (let index = 0; index < payload.length; index += 1) {
+            payload[index] = payload[index] ^ mask[index % 4];
+        }
+    }
+
+    return {
+        frame: { opcode, payload },
+        remaining: buffer.subarray(offset + payloadLength),
+    };
+}
+
+function isSocketWritable(socket: Duplex) {
+    return !socket.destroyed && !socket.writableEnded;
+}
+
+function writeFrame(socket: Duplex, frame: Buffer) {
+    if (!isSocketWritable(socket)) {
+        return false;
+    }
+
+    try {
+        socket.write(frame);
+
+        return true;
+    } catch (error) {
+        console.warn("Unable to write WebSocket frame:", error instanceof Error ? error.message : error);
+
+        return false;
+    }
+}
+
+function sendJson(socket: Duplex, payload: Record<string, unknown>) {
+    return writeFrame(socket, encodeWebSocketFrame(JSON.stringify(payload)));
+}
+
+function closeWebSocket(socket: Duplex) {
+    if (isSocketWritable(socket)) {
+        try {
+            socket.end(encodeWebSocketFrame("", 0x8));
+        } catch {
+            socket.destroy();
+        }
+    }
+}
+
+async function getAgentTokenViaClientCredentials(): Promise<string> {
+    const body = new URLSearchParams({ grant_type: "client_credentials" });
+    const basicAuth = Buffer.from(`${agentConfig.agentID}:${agentConfig.agentSecret}`).toString("base64");
+
+    const response = await fetch(`${THUNDER_BASE_URL}/oauth2/token`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Authorization: `Basic ${basicAuth}`,
+            Accept: "application/json",
+        },
+        body,
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+        throw new Error(`Agent token request failed (${response.status}): ${text}`);
+    }
+
+    let payload: { access_token?: string };
+    try {
+        payload = JSON.parse(text);
+    } catch {
+        throw new Error(`Agent token endpoint returned non-JSON: ${text}`);
+    }
+    if (!payload.access_token) {
+        throw new Error(`Agent token response missing access_token: ${text}`);
+    }
+    return payload.access_token;
+}
+
+async function createAgent() {
+    console.log("##########################################################################################################");
+    console.log("##      This is an Agent Authentication Flow sample application for authenticating AI agents            ##");
+    console.log("##                         using Asgardeo and LangChain framework                                       ##");
+    console.log("##########################################################################################################");
+
+    // Call Thunder's /oauth2/token directly with the client_credentials grant.
+    // We don't use AsgardeoJavaScriptClient.getAgentToken here because the V1
+    // (legacy) Asgardeo flow expects an /oauth2/flow/embedded endpoint that
+    // Thunder doesn't expose; calling /oauth2/token directly is the same wire
+    // protocol and works for both platforms.
+    const agentAccessToken = await getAgentTokenViaClientCredentials();
+
+    const client = new MultiServerMCPClient({
+        travel: {
+            transport: "http",
+            url: MCP_SERVER_URL,
+            headers: {
+                Authorization: `Bearer ${agentAccessToken}`,
+            },
+        },
+    });
+
+    // Base tools use the agent's autonomous token. They are shared across
+    // sessions for non-user-context calls. For user-context tools we will
+    // wrap each tool per-session so it can trigger the OAuth code flow and
+    // route the call through a separate MCP client that uses the user token.
+    const baseTools = (await client.getTools()) as unknown as MCPLikeTool[];
+
+    return { baseTools, client };
+}
+
+async function runAgentServer() {
+    const { baseTools, client } = await createAgent();
+    const port = Number(process.env.PORT || process.env.AGENT_PORT || 8790);
+    const host = process.env.HOST || "localhost";
+
+    const server = createServer((request, response) => {
+        if (request.url === "/health") {
+            response.writeHead(200, { "Content-Type": "application/json" });
+            response.end(JSON.stringify({ status: "ok" }));
+
+            return;
+        }
+
+        response.writeHead(404, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ error: "Not found" }));
+    });
+
+    const handleConnection = (socket: Duplex) => {
+        const session: SessionState = {
+            socket,
+            isClosed: false,
+            pendingConsents: new Map(),
+            chatMessages: [],
+        };
+
+        // Lazily-built ReAct agent for this WebSocket session. The agent wraps
+        // user-context tools so that they trigger the OAuth code flow + token
+        // exchange transparently from inside the agent's tool-call loop.
+        let sessionAgent: ReturnType<typeof createReactAgent> | null = null;
+        const getSessionAgent = () => {
+            if (!sessionAgent) {
+                const wrapped = baseTools.map((t) => wrapToolForSession(t, session));
+                sessionAgent = createReactAgent({
+                    llm: model,
+                    tools: wrapped as unknown as Parameters<typeof createReactAgent>[0]["tools"],
+                    prompt: SYSTEM_PROMPT,
+                });
+            }
+            return sessionAgent;
+        };
+
+        const cleanupPendingConsents = (reason: string) => {
+            for (const pending of session.pendingConsents.values()) {
+                clearTimeout(pending.timeoutHandle);
+                pending.reject(new Error(reason));
+            }
+            session.pendingConsents.clear();
+        };
+
+        socket.on("close", () => {
+            session.isClosed = true;
+            cleanupPendingConsents("WebSocket closed before consent completed.");
+        });
+
+        socket.on("end", () => {
+            session.isClosed = true;
+            cleanupPendingConsents("WebSocket ended before consent completed.");
+        });
+
+        socket.on("error", (error) => {
+            session.isClosed = true;
+            console.warn("WebSocket client disconnected:", error.message);
+            cleanupPendingConsents(`WebSocket error: ${error.message}`);
+        });
+
+        sendJson(socket, {
+            type: "ready",
+            message: "Connected to the Asgardeo AI agent.",
+        });
+
+        let queue = Promise.resolve();
+        let buffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+
+        socket.on("data", (data) => {
+            buffer = Buffer.concat([buffer, data]);
+
+            try {
+                let parsed = parseWebSocketFrame(buffer);
+
+                while (parsed) {
+                    buffer = parsed.remaining;
+
+                    if (parsed.frame.opcode === 0x8) {
+                        closeWebSocket(socket);
+
+                        return;
+                    }
+
+                    if (parsed.frame.opcode === 0x9) {
+                        writeFrame(socket, encodeWebSocketFrame(parsed.frame.payload.toString(), 0xA));
+                    }
+
+                    if (parsed.frame.opcode === 0x1) {
+                        const payload = parsed.frame.payload.toString("utf8");
+
+                        // Intercept consent responses BEFORE the per-message queue,
+                        // because the queue may be blocked on the chat message that
+                        // requested this consent in the first place.
+                        let preParsed: { type?: unknown; request_id?: unknown } | undefined;
+                        try {
+                            preParsed = JSON.parse(payload) as { type?: unknown; request_id?: unknown };
+                        } catch {
+                            preParsed = undefined;
+                        }
+
+                        if (preParsed && (preParsed.type === "user_code" || preParsed.type === "user_consent_error")) {
+                            const requestId = typeof preParsed.request_id === "string" ? preParsed.request_id : "";
+                            const pending = session.pendingConsents.get(requestId);
+                            if (pending) {
+                                clearTimeout(pending.timeoutHandle);
+                                session.pendingConsents.delete(requestId);
+                                pending.resolve(preParsed as { type: string; code?: string; state?: string; error?: string });
+                            }
+                            parsed = parseWebSocketFrame(buffer);
+                            continue;
+                        }
+
+                        queue = queue.then(async () => {
+                            if (session.isClosed) {
+                                return;
+                            }
+
+                            const newMessages = parseChatRequest(payload);
+
+                            if (!sendJson(socket, { type: "processing" })) {
+                                session.isClosed = true;
+                                return;
+                            }
+
+                            // Append the new user turn to the session's running thread.
+                            // The agent.invoke() call receives the FULL history so it can
+                            // refer back to its own earlier replies (e.g. resolve "flight 1"
+                            // to a flight ID it listed two turns ago).
+                            session.chatMessages = [...session.chatMessages, ...newMessages];
+
+                            const agent = getSessionAgent();
+                            const result = await agent.invoke({ messages: session.chatMessages });
+                            // Persist the updated thread (now includes any new tool calls and
+                            // the assistant reply) back to session state.
+                            session.chatMessages = result.messages;
+                            const finalResponse = result.messages[result.messages.length - 1];
+
+                            if (session.isClosed) {
+                                return;
+                            }
+
+                            sendJson(socket, {
+                                type: "response",
+                                message: getResponseContent(finalResponse.content),
+                            });
+                        }).catch((error: unknown) => {
+                            if (session.isClosed) {
+                                return;
+                            }
+
+                            console.error("Error handling chat message:", error);
+                            sendJson(socket, {
+                                type: "error",
+                                message: error instanceof Error ? error.message : "Failed to process chat message.",
+                            });
+                        });
+                    }
+
+                    parsed = parseWebSocketFrame(buffer);
+                }
+            } catch (error) {
+                console.error("Error parsing WebSocket frame:", error);
+                sendJson(socket, {
+                    type: "error",
+                    message: error instanceof Error ? error.message : "Invalid WebSocket message.",
+                });
+                closeWebSocket(socket);
+            }
+        });
+    };
+
+    server.on("upgrade", (request, socket, head) => {
+        socket.on("error", (error) => {
+            console.warn("WebSocket upgrade socket error:", error.message);
+        });
+
+        try {
+            const url = new URL(request.url || "", `http://${request.headers.host || host}`);
+            const key = request.headers["sec-websocket-key"];
+
+            if (url.pathname !== "/chat" || typeof key !== "string") {
+                if (!socket.destroyed && !socket.writableEnded) {
+                    socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
+                }
+                socket.destroy();
+
+                return;
+            }
+
+            writeFrame(socket, Buffer.from([
+                "HTTP/1.1 101 Switching Protocols",
+                "Upgrade: websocket",
+                "Connection: Upgrade",
+                `Sec-WebSocket-Accept: ${createWebSocketAcceptKey(key)}`,
+                "",
+                "",
+            ].join("\r\n")));
+
+            if (head.length > 0) {
+                socket.unshift(head);
+            }
+
+            handleConnection(socket);
+        } catch (error) {
+            console.error("Error upgrading WebSocket connection:", error);
+            socket.destroy();
+        }
+    });
+
+    server.listen(port, host, () => {
+        console.log(`AI agent WebSocket server is running at ws://${host}:${port}/chat`);
+        console.log(`Health check is available at http://${host}:${port}/health`);
+    });
+
+    const shutdown = async () => {
+        console.log("Shutting down AI agent server...");
+        server.close();
+        await client.close();
+        process.exit(0);
+    };
+
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+}
+
+runAgentServer().catch(console.error);

--- a/samples/apps/agent-id-sample/ai-agent/package-lock.json
+++ b/samples/apps/agent-id-sample/ai-agent/package-lock.json
@@ -1,0 +1,2136 @@
+{
+  "name": "ai-agent",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-agent",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@asgardeo/javascript": "^0.9.0",
+        "@langchain/anthropic": "^1.3.0",
+        "@langchain/langgraph": "^1.3.0",
+        "@langchain/mcp-adapters": "^1.1.0",
+        "dotenv": "^16.5.0",
+        "tsx": "^4.19.4"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.19"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@asgardeo/i18n": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@asgardeo/i18n/-/i18n-0.4.4.tgz",
+      "integrity": "sha512-ZbaMDgN3TBg1B8+76xWXnsTwnqrsSSuy4vf6Cqrf/i7ecAqykHmaEtzY5A+piI3F4V4kPWMdU+hs1N3JYOC8FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@asgardeo/javascript": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@asgardeo/javascript/-/javascript-0.9.2.tgz",
+      "integrity": "sha512-jwyWKwRkQJprVWVoPqKr+WdFGD6tMJFLzr4P6X7PaSJAcTk2PbwJobjW5A1h2MHf3dpETfntpmnx7SRkNFUrig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@asgardeo/i18n": "0.4.4",
+        "jose": "^5.2.0",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@langchain/anthropic": {
+      "version": "1.3.29",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.3.29.tgz",
+      "integrity": "sha512-ep1qBIcV07bajsg3fDqMd39rYwoRLOEK/6lk+MCxlm1YB5SRoKKJAZANrblQ/4RYhZJnxf95c6BSQu8VoNbVAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.45"
+      }
+    },
+    "node_modules/@langchain/core": {
+      "version": "1.1.46",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.46.tgz",
+      "integrity": "sha512-i8rDC83BpItxChCw4Lf+6tAr+k+OUcbirc5ZkrhI9ywYWmvxegUljLGOGYvtJNTbEAIFkhYIODPE5QRqyjF6sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.0.tgz",
+      "integrity": "sha512-QvhTjiyqFPz81A+y6LHs223w6DTjv5+882DT4mup72bd72rRhNjTYo5fhes5um0swnKArvY/arc7KeFInfHHWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.0.2",
+        "@langchain/langgraph-sdk": "~1.9.0",
+        "@langchain/protocol": "^0.0.15",
+        "@standard-schema/spec": "1.1.0",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.44",
+        "zod": "^3.25.32 || ^4.2.0",
+        "zod-to-json-schema": "^3.x"
+      },
+      "peerDependenciesMeta": {
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
+      "integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.44"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.2.tgz",
+      "integrity": "sha512-1kDPjR0VH/39q2h8k0Sxi35KxOvEQPModVCepxGLlRkbZmuWUH+zfICuJd3rmD1ByeOKQBZEaB7Y+VCYmSMt1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/core": "^1.1.44",
+        "@langchain/protocol": "^0.0.15",
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1",
+        "uuid": "^13.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/mcp-adapters": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@langchain/mcp-adapters/-/mcp-adapters-1.1.3.tgz",
+      "integrity": "sha512-OPHIQNkTUJjnRj1pr+cp2nguMBZeF3Q1pVT1hCbgU7BrHgV7lov99wbU8po8Cm4zZzmeRtVO/T9X1SrDD1ogtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "debug": "^4.4.3",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20.10.0"
+      },
+      "optionalDependencies": {
+        "extended-eventsource": "^1.7.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.0",
+        "@langchain/langgraph": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": false
+        },
+        "@langchain/langgraph": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@langchain/protocol": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
+      "integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extended-eventsource": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extended-eventsource/-/extended-eventsource-1.7.0.tgz",
+      "integrity": "sha512-s8rtvZuYcKBpzytHb5g95cHbZ1J99WeMnV18oKc5wKoxkHzlzpPc/bNAm7Da2Db0BDw0CAu1z3LpH+7UsyzIpw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/langsmith": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.1.tgz",
+      "integrity": "sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "6.6.2"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
+      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/samples/apps/agent-id-sample/ai-agent/package.json
+++ b/samples/apps/agent-id-sample/ai-agent/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ai-agent",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "tsx agent.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "@asgardeo/javascript": "^0.9.0",
+    "@langchain/anthropic": "^1.3.0",
+    "@langchain/langgraph": "^1.3.0",
+    "@langchain/mcp-adapters": "^1.1.0",
+    "dotenv": "^16.5.0",
+    "tsx": "^4.19.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.19"
+  }
+}

--- a/samples/apps/agent-id-sample/ai-agent/tsconfig.json
+++ b/samples/apps/agent-id-sample/ai-agent/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}

--- a/samples/apps/agent-id-sample/api/.env.example
+++ b/samples/apps/agent-id-sample/api/.env.example
@@ -1,0 +1,8 @@
+# Enable JWT validation and per-route scope enforcement.
+API_REQUIRE_AUTH=true
+
+# Thunder base URL — used for JWKS fetch and as the default issuer.
+THUNDER_BASE_URL=https://localhost:8090
+
+# Identifier of the resource server in Thunder that owns the booking permissions.
+THUNDER_AUDIENCE=booking-api

--- a/samples/apps/agent-id-sample/api/README.md
+++ b/samples/apps/agent-id-sample/api/README.md
@@ -1,0 +1,31 @@
+# Wayfinder Travel API
+
+REST API for the Wayfinder Travel app. Verifies Thunder-issued JWTs and enforces scopes per route.
+
+Configure with `.env.example` in this folder.
+
+## Run
+
+```bash
+npm install
+npm run seed
+npm start
+```
+
+The API runs on `http://localhost:8787`.
+
+## Endpoints
+
+| Method | Route                       | Required scope     | Notes                                  |
+| ------ | --------------------------- | ------------------ | -------------------------------------- |
+| GET    | `/health`                   | —                  |                                        |
+| GET    | `/api/flights`              | —                  | `?from=Colombo&to=Singapore`           |
+| GET    | `/api/hotels`               | —                  | `?location=Singapore`                  |
+| GET    | `/api/trips`                | —                  |                                        |
+| GET    | `/api/locations`            | —                  | `?category=flights`                    |
+| POST   | `/api/bookings`             | `booking:create`   |                                        |
+| GET    | `/api/bookings/flights`     | `booking:read`     |                                        |
+| DELETE | `/api/bookings/flights`     | `booking:cancel`   |                                        |
+| GET    | `/api/me`                   | —                  | Requires a valid JWT but no scope.     |
+
+OpenAPI documentation is available in `openapi.yaml`.

--- a/samples/apps/agent-id-sample/api/openapi.yaml
+++ b/samples/apps/agent-id-sample/api/openapi.yaml
@@ -1,0 +1,574 @@
+openapi: 3.0.3
+info:
+  title: Wayfinder Travel API
+  version: 0.1.0
+  description: REST API for the Wayfinder Travel sample application.
+servers:
+  - url: http://localhost:8787
+    description: Local development server
+tags:
+  - name: Health
+  - name: Flights
+  - name: Hotels
+  - name: Trips
+  - name: Locations
+  - name: Bookings
+  - name: User
+paths:
+  /health:
+    get:
+      tags:
+        - Health
+      summary: Check API health
+      responses:
+        "200":
+          description: API is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+  /api/flights:
+    get:
+      tags:
+        - Flights
+      summary: Search flights
+      parameters:
+        - name: from
+          in: query
+          required: false
+          schema:
+            type: string
+          example: Colombo
+        - name: to
+          in: query
+          required: false
+          schema:
+            type: string
+          example: Singapore
+        - name: cabin
+          in: query
+          required: false
+          schema:
+            type: string
+          example: Economy
+      responses:
+        "200":
+          description: Matching flights
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Flight"
+  /api/hotels:
+    get:
+      tags:
+        - Hotels
+      summary: Search hotels
+      parameters:
+        - name: location
+          in: query
+          required: false
+          schema:
+            type: string
+          example: Singapore
+        - name: maxNightlyRate
+          in: query
+          required: false
+          schema:
+            type: number
+          example: 150
+      responses:
+        "200":
+          description: Matching hotels
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Hotel"
+  /api/trips:
+    get:
+      tags:
+        - Trips
+      summary: List saved sample trips
+      parameters:
+        - name: destination
+          in: query
+          required: false
+          schema:
+            type: string
+          example: Singapore
+      responses:
+        "200":
+          description: Saved trips
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Trip"
+  /api/locations:
+    get:
+      tags:
+        - Locations
+      summary: List searchable locations
+      parameters:
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - flights
+              - hotels
+              - trips
+          example: flights
+      responses:
+        "200":
+          description: Available locations for search dropdowns
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Location"
+  /api/bookings:
+    post:
+      tags:
+        - Bookings
+      summary: Create a booking
+      description: Requires an Asgardeo bearer token when `API_REQUIRE_AUTH=true`.
+      security:
+        - AsgardeoBearerAuth: []
+        - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateBookingRequest"
+            examples:
+              flightBooking:
+                summary: Flight booking
+                value:
+                  type: flight
+                  itemId: flight-cmb-sin-01
+                  travelers: 2
+      responses:
+        "201":
+          description: Booking created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Booking"
+        "400":
+          description: Invalid booking request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Token is missing the required scope
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/bookings/flights:
+    get:
+      tags:
+        - Bookings
+      summary: List booked flights for the current user
+      description: Requires an Asgardeo bearer token when `API_REQUIRE_AUTH=true`.
+      security:
+        - AsgardeoBearerAuth: []
+        - {}
+      responses:
+        "200":
+          description: Current user's booked flights
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/BookedFlight"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Token is missing the required scope
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      tags:
+        - Bookings
+      summary: Delete all booked flights for the current user
+      description: Requires an Asgardeo bearer token when `API_REQUIRE_AUTH=true`.
+      security:
+        - AsgardeoBearerAuth: []
+        - {}
+      responses:
+        "200":
+          description: Deletion summary
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      deleted:
+                        type: integer
+                      username:
+                        type: string
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Token is missing the required scope
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/me:
+    get:
+      tags:
+        - User
+      summary: Get current user profile
+      description: Requires an Asgardeo bearer token when `API_REQUIRE_AUTH=true`.
+      security:
+        - AsgardeoBearerAuth: []
+        - {}
+      responses:
+        "200":
+          description: Current user profile
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: "#/components/schemas/User"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  securitySchemes:
+    AsgardeoBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Asgardeo access token.
+  schemas:
+    Flight:
+      type: object
+      required:
+        - id
+        - from
+        - to
+        - airline
+        - departureTime
+        - arrivalTime
+        - duration
+        - stops
+        - price
+        - currency
+        - cabin
+        - dates
+        - tags
+      properties:
+        id:
+          type: string
+          example: flight-cmb-sin-01
+        from:
+          type: string
+          example: Colombo
+        to:
+          type: string
+          example: Singapore
+        airline:
+          type: string
+          example: Serendib Air
+        departureTime:
+          type: string
+          example: "08:45"
+        arrivalTime:
+          type: string
+          example: "15:05"
+        duration:
+          type: string
+          example: 3h 50m
+        stops:
+          type: integer
+          example: 0
+        price:
+          type: number
+          example: 314
+        currency:
+          type: string
+          example: USD
+        cabin:
+          type: string
+          example: Economy
+        dates:
+          type: string
+          example: Jun 12 - Jun 18
+        tags:
+          type: array
+          items:
+            type: string
+          example:
+            - Best value
+            - Nonstop
+    Hotel:
+      type: object
+      required:
+        - id
+        - name
+        - location
+        - nightlyRate
+        - currency
+        - rating
+        - amenities
+      properties:
+        id:
+          type: string
+          example: hotel-harborlight-suites
+        name:
+          type: string
+          example: Harborlight Suites
+        location:
+          type: string
+          example: Singapore Marina
+        nightlyRate:
+          type: number
+          example: 142
+        currency:
+          type: string
+          example: USD
+        rating:
+          type: number
+          example: 9.1
+        amenities:
+          type: array
+          items:
+            type: string
+          example:
+            - Breakfast
+            - Pool
+            - Airport shuttle
+    Trip:
+      type: object
+      required:
+        - id
+        - title
+        - destination
+        - flightId
+        - hotelId
+        - status
+        - totalEstimate
+        - currency
+      properties:
+        id:
+          type: string
+          example: trip-singapore-week
+        title:
+          type: string
+          example: Singapore city week
+        destination:
+          type: string
+          example: Singapore
+        flightId:
+          type: string
+          example: flight-cmb-sin-01
+        hotelId:
+          type: string
+          example: hotel-harborlight-suites
+        status:
+          type: string
+          example: planning
+        totalEstimate:
+          type: number
+          example: 1166
+        currency:
+          type: string
+          example: USD
+    CreateBookingRequest:
+      type: object
+      required:
+        - type
+        - itemId
+      properties:
+        type:
+          type: string
+          enum:
+            - flight
+            - hotel
+            - trip
+          example: flight
+        itemId:
+          type: string
+          example: flight-cmb-sin-01
+        travelers:
+          type: integer
+          minimum: 1
+          default: 1
+          example: 2
+    Location:
+      type: object
+      required:
+        - name
+        - type
+      properties:
+        name:
+          type: string
+          example: Singapore
+        type:
+          type: string
+          example: city
+    Booking:
+      type: object
+      required:
+        - id
+        - userId
+        - username
+        - type
+        - itemId
+        - travelers
+        - status
+        - createdAt
+      properties:
+        id:
+          type: string
+          example: booking-2cd80f0a-17b8-4d2f-a436-44595fa0aa44
+        userId:
+          type: string
+          example: local-demo-user
+        username:
+          type: string
+          example: local.traveler
+        type:
+          type: string
+          example: flight
+        itemId:
+          type: string
+          example: flight-cmb-sin-01
+        travelers:
+          type: integer
+          example: 2
+        status:
+          type: string
+          example: confirmed
+        createdAt:
+          type: string
+          format: date-time
+    BookedFlight:
+      type: object
+      required:
+        - id
+        - username
+        - travelers
+        - status
+        - createdAt
+        - flight
+      properties:
+        id:
+          type: string
+          example: booking-2cd80f0a-17b8-4d2f-a436-44595fa0aa44
+        username:
+          type: string
+          example: local.traveler
+        travelers:
+          type: integer
+          example: 2
+        status:
+          type: string
+          example: confirmed
+        createdAt:
+          type: string
+          format: date-time
+        flight:
+          $ref: "#/components/schemas/Flight"
+    User:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          example: local-demo-user
+        username:
+          type: string
+          example: local.traveler
+        email:
+          type: string
+          format: email
+          example: local.traveler@example.com
+        givenName:
+          type: string
+          example: Local
+        familyName:
+          type: string
+          example: Traveler
+        rawClaims:
+          type: object
+          additionalProperties: true
+    Error:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          example: Missing bearer token

--- a/samples/apps/agent-id-sample/api/package-lock.json
+++ b/samples/apps/agent-id-sample/api/package-lock.json
@@ -1,0 +1,480 @@
+{
+  "name": "wayfinder-travel-api",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wayfinder-travel-api",
+      "version": "0.1.0",
+      "dependencies": {
+        "better-sqlite3": "^11.10.0",
+        "dotenv": "^16.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/samples/apps/agent-id-sample/api/package.json
+++ b/samples/apps/agent-id-sample/api/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "wayfinder-travel-api",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch src/server.js",
+    "seed": "node scripts/seed.js",
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.10.0",
+    "dotenv": "^16.5.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/samples/apps/agent-id-sample/api/scripts/seed.js
+++ b/samples/apps/agent-id-sample/api/scripts/seed.js
@@ -1,0 +1,467 @@
+import Database from "better-sqlite3";
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const apiRoot = resolve(__dirname, "..");
+const dbPath = resolve(apiRoot, "wayfinder.sqlite");
+
+const flights = [
+  {
+    id: "flight-cmb-sin-01",
+    from: "Colombo",
+    to: "Singapore",
+    airline: "Serendib Air",
+    departure_time: "08:45",
+    arrival_time: "15:05",
+    duration: "3h 50m",
+    stops: 0,
+    price: 314,
+    currency: "USD",
+    cabin: "Economy",
+    dates: "Jun 12 - Jun 18",
+    tags: JSON.stringify(["Best value", "Nonstop"])
+  },
+  {
+    id: "flight-sfo-tyo-01",
+    from: "San Francisco",
+    to: "Tokyo",
+    airline: "Pacifica",
+    departure_time: "11:20",
+    arrival_time: "15:35",
+    duration: "11h 15m",
+    stops: 0,
+    price: 782,
+    currency: "USD",
+    cabin: "Economy",
+    dates: "Jul 04 - Jul 16",
+    tags: JSON.stringify(["Nonstop", "Popular"])
+  },
+  {
+    id: "flight-lon-lis-01",
+    from: "London",
+    to: "Lisbon",
+    airline: "Northline",
+    departure_time: "17:10",
+    arrival_time: "20:05",
+    duration: "2h 55m",
+    stops: 0,
+    price: 168,
+    currency: "USD",
+    cabin: "Economy",
+    dates: "Aug 21 - Aug 27",
+    tags: JSON.stringify(["Weekend"])
+  },
+  {
+    id: "flight-cmb-dxb-01",
+    from: "Colombo",
+    to: "Dubai",
+    airline: "Ceylon Wings",
+    departure_time: "21:15",
+    arrival_time: "00:25",
+    duration: "4h 40m",
+    stops: 0,
+    price: 289,
+    currency: "USD",
+    cabin: "Economy",
+    dates: "Jun 20 - Jun 26",
+    tags: JSON.stringify(["Evening"])
+  },
+  {
+    id: "flight-cmb-sin-02",
+    from: "Colombo",
+    to: "Singapore",
+    airline: "IslandJet",
+    departure_time: "13:30",
+    arrival_time: "19:50",
+    duration: "3h 50m",
+    stops: 0,
+    price: 342,
+    currency: "USD",
+    cabin: "Economy",
+    dates: "Jun 12 - Jun 18",
+    tags: JSON.stringify(["Flexible ticket", "Carry-on included"])
+  },
+  {
+    id: "flight-cmb-sin-03",
+    from: "Colombo",
+    to: "Singapore",
+    airline: "Meridian Airways",
+    departure_time: "01:10",
+    arrival_time: "09:20",
+    duration: "5h 40m",
+    stops: 1,
+    price: 276,
+    currency: "USD",
+    cabin: "Economy",
+    dates: "Jun 12 - Jun 18",
+    tags: JSON.stringify(["Lowest price", "1 stop"])
+  },
+  {
+    id: "flight-cmb-tyo-01",
+    from: "Colombo",
+    to: "Tokyo",
+    airline: "Serendib Air",
+    departure_time: "07:25",
+    arrival_time: "22:10",
+    duration: "11h 15m",
+    stops: 1,
+    price: 598,
+    currency: "USD",
+    cabin: "Economy",
+    dates: "Jul 04 - Jul 16",
+    tags: JSON.stringify(["Good connection", "Meal included"])
+  },
+  {
+    id: "flight-dxb-lon-01",
+    from: "Dubai",
+    to: "London",
+    airline: "Gulfline",
+    departure_time: "09:40",
+    arrival_time: "14:35",
+    duration: "7h 55m",
+    stops: 0,
+    price: 431,
+    currency: "USD",
+    cabin: "Economy",
+    dates: "Sep 02 - Sep 09",
+    tags: JSON.stringify(["Nonstop", "Morning"])
+  },
+  {
+    id: "flight-sin-syd-01",
+    from: "Singapore",
+    to: "Sydney",
+    airline: "Pacifica",
+    departure_time: "20:15",
+    arrival_time: "06:05",
+    duration: "7h 50m",
+    stops: 0,
+    price: 502,
+    currency: "USD",
+    cabin: "Economy",
+    dates: "Oct 10 - Oct 18",
+    tags: JSON.stringify(["Overnight", "Nonstop"])
+  }
+];
+
+const hotels = [
+  {
+    id: "hotel-harborlight-suites",
+    name: "Harborlight Suites",
+    location: "Singapore Marina",
+    nightly_rate: 142,
+    currency: "USD",
+    rating: 9.1,
+    amenities: JSON.stringify(["Breakfast", "Pool", "Airport shuttle"])
+  },
+  {
+    id: "hotel-saffron-yard",
+    name: "The Saffron Yard",
+    location: "Lisbon Old Town",
+    nightly_rate: 119,
+    currency: "USD",
+    rating: 8.8,
+    amenities: JSON.stringify(["Boutique rooms", "Rooftop bar", "Late checkout"])
+  },
+  {
+    id: "hotel-north-pier-rooms",
+    name: "North Pier Rooms",
+    location: "Tokyo Bay",
+    nightly_rate: 173,
+    currency: "USD",
+    rating: 9.4,
+    amenities: JSON.stringify(["Bay view", "Onsen access", "Workspace"])
+  },
+  {
+    id: "hotel-cinnamon-court",
+    name: "Cinnamon Court",
+    location: "Colombo Fort",
+    nightly_rate: 96,
+    currency: "USD",
+    rating: 8.9,
+    amenities: JSON.stringify(["Central location", "Breakfast", "Gym"])
+  },
+  {
+    id: "hotel-garden-quay",
+    name: "Garden Quay Hotel",
+    location: "Singapore Riverside",
+    nightly_rate: 128,
+    currency: "USD",
+    rating: 8.7,
+    amenities: JSON.stringify(["River view", "Metro nearby", "Breakfast"])
+  },
+  {
+    id: "hotel-orchid-house",
+    name: "Orchid House",
+    location: "Singapore Orchard",
+    nightly_rate: 156,
+    currency: "USD",
+    rating: 9.0,
+    amenities: JSON.stringify(["Family rooms", "Pool", "Shopping district"])
+  },
+  {
+    id: "hotel-shibuya-harbor",
+    name: "Shibuya Harbor",
+    location: "Tokyo Shibuya",
+    nightly_rate: 188,
+    currency: "USD",
+    rating: 9.2,
+    amenities: JSON.stringify(["Train access", "Compact suites", "Late checkout"])
+  },
+  {
+    id: "hotel-dubai-creek-lofts",
+    name: "Dubai Creek Lofts",
+    location: "Dubai Creek",
+    nightly_rate: 135,
+    currency: "USD",
+    rating: 8.6,
+    amenities: JSON.stringify(["Creek view", "Airport transfer", "Pool"])
+  },
+  {
+    id: "hotel-kings-cross-nest",
+    name: "Kings Cross Nest",
+    location: "London Kings Cross",
+    nightly_rate: 161,
+    currency: "USD",
+    rating: 8.5,
+    amenities: JSON.stringify(["Station nearby", "Breakfast", "Workspace"])
+  },
+  {
+    id: "hotel-darling-harbor-stay",
+    name: "Darling Harbor Stay",
+    location: "Sydney Darling Harbour",
+    nightly_rate: 149,
+    currency: "USD",
+    rating: 8.9,
+    amenities: JSON.stringify(["Harbor access", "Kitchenette", "Laundry"])
+  }
+];
+
+const trips = [
+  {
+    id: "trip-singapore-week",
+    title: "Singapore city week",
+    destination: "Singapore",
+    flight_id: "flight-cmb-sin-01",
+    hotel_id: "hotel-harborlight-suites",
+    status: "planning",
+    total_estimate: 1166,
+    currency: "USD"
+  },
+  {
+    id: "trip-lisbon-weekend",
+    title: "Lisbon weekend",
+    destination: "Lisbon",
+    flight_id: "flight-lon-lis-01",
+    hotel_id: "hotel-saffron-yard",
+    status: "saved",
+    total_estimate: 525,
+    currency: "USD"
+  },
+  {
+    id: "trip-tokyo-first-timer",
+    title: "Tokyo first-timer route",
+    destination: "Tokyo",
+    flight_id: "flight-cmb-tyo-01",
+    hotel_id: "hotel-shibuya-harbor",
+    status: "planning",
+    total_estimate: 1540,
+    currency: "USD"
+  },
+  {
+    id: "trip-singapore-family",
+    title: "Singapore family break",
+    destination: "Singapore",
+    flight_id: "flight-cmb-sin-02",
+    hotel_id: "hotel-orchid-house",
+    status: "saved",
+    total_estimate: 1278,
+    currency: "USD"
+  },
+  {
+    id: "trip-dubai-stopover",
+    title: "Dubai stopover",
+    destination: "Dubai",
+    flight_id: "flight-cmb-dxb-01",
+    hotel_id: "hotel-dubai-creek-lofts",
+    status: "planning",
+    total_estimate: 694,
+    currency: "USD"
+  },
+  {
+    id: "trip-london-week",
+    title: "London rail-and-city week",
+    destination: "London",
+    flight_id: "flight-dxb-lon-01",
+    hotel_id: "hotel-kings-cross-nest",
+    status: "saved",
+    total_estimate: 1558,
+    currency: "USD"
+  }
+];
+
+if (!existsSync(apiRoot)) {
+  mkdirSync(apiRoot, { recursive: true });
+}
+
+const db = new Database(dbPath);
+
+db.pragma("journal_mode = WAL");
+db.pragma("foreign_keys = ON");
+
+db.exec(`
+  DROP TABLE IF EXISTS bookings;
+  DROP TABLE IF EXISTS trips;
+  DROP TABLE IF EXISTS hotels;
+  DROP TABLE IF EXISTS flights;
+
+  CREATE TABLE flights (
+    id TEXT PRIMARY KEY,
+    from_city TEXT NOT NULL,
+    to_city TEXT NOT NULL,
+    airline TEXT NOT NULL,
+    departure_time TEXT NOT NULL,
+    arrival_time TEXT NOT NULL,
+    duration TEXT NOT NULL,
+    stops INTEGER NOT NULL,
+    price REAL NOT NULL,
+    currency TEXT NOT NULL,
+    cabin TEXT NOT NULL,
+    dates TEXT NOT NULL,
+    tags TEXT NOT NULL
+  );
+
+  CREATE TABLE hotels (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    location TEXT NOT NULL,
+    nightly_rate REAL NOT NULL,
+    currency TEXT NOT NULL,
+    rating REAL NOT NULL,
+    amenities TEXT NOT NULL
+  );
+
+  CREATE TABLE trips (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    destination TEXT NOT NULL,
+    flight_id TEXT NOT NULL,
+    hotel_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    total_estimate REAL NOT NULL,
+    currency TEXT NOT NULL,
+    FOREIGN KEY (flight_id) REFERENCES flights(id),
+    FOREIGN KEY (hotel_id) REFERENCES hotels(id)
+  );
+
+  CREATE TABLE bookings (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    username TEXT NOT NULL,
+    type TEXT NOT NULL,
+    item_id TEXT NOT NULL,
+    travelers INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL
+  );
+`);
+
+const insertFlight = db.prepare(`
+  INSERT INTO flights (
+    id,
+    from_city,
+    to_city,
+    airline,
+    departure_time,
+    arrival_time,
+    duration,
+    stops,
+    price,
+    currency,
+    cabin,
+    dates,
+    tags
+  ) VALUES (
+    @id,
+    @from,
+    @to,
+    @airline,
+    @departure_time,
+    @arrival_time,
+    @duration,
+    @stops,
+    @price,
+    @currency,
+    @cabin,
+    @dates,
+    @tags
+  )
+`);
+
+const insertHotel = db.prepare(`
+  INSERT INTO hotels (
+    id,
+    name,
+    location,
+    nightly_rate,
+    currency,
+    rating,
+    amenities
+  ) VALUES (
+    @id,
+    @name,
+    @location,
+    @nightly_rate,
+    @currency,
+    @rating,
+    @amenities
+  )
+`);
+
+const insertTrip = db.prepare(`
+  INSERT INTO trips (
+    id,
+    title,
+    destination,
+    flight_id,
+    hotel_id,
+    status,
+    total_estimate,
+    currency
+  ) VALUES (
+    @id,
+    @title,
+    @destination,
+    @flight_id,
+    @hotel_id,
+    @status,
+    @total_estimate,
+    @currency
+  )
+`);
+
+const seed = db.transaction(() => {
+  for (const flight of flights) {
+    insertFlight.run(flight);
+  }
+
+  for (const hotel of hotels) {
+    insertHotel.run(hotel);
+  }
+
+  for (const trip of trips) {
+    insertTrip.run(trip);
+  }
+});
+
+try {
+  seed();
+} catch (error) {
+  console.error(`Failed to seed SQLite database at ${dbPath}: ${error.message}`);
+  process.exitCode = 1;
+} finally {
+  db.close();
+}
+
+console.log(`Seeded SQLite database at ${dbPath}`);

--- a/samples/apps/agent-id-sample/api/src/auth.js
+++ b/samples/apps/agent-id-sample/api/src/auth.js
@@ -1,0 +1,164 @@
+import { createPublicKey, createVerify } from "node:crypto";
+
+const textDecoder = new TextDecoder();
+let jwksCache = null;
+
+function base64UrlToBuffer(value) {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+
+  return Buffer.from(padded, "base64");
+}
+
+function parseJwt(token) {
+  const parts = token.split(".");
+
+  if (parts.length !== 3) {
+    throw new Error("Invalid token format");
+  }
+
+  const header = JSON.parse(textDecoder.decode(base64UrlToBuffer(parts[0])));
+  const payload = JSON.parse(textDecoder.decode(base64UrlToBuffer(parts[1])));
+
+  return {
+    header,
+    payload,
+    signingInput: `${parts[0]}.${parts[1]}`,
+    signature: base64UrlToBuffer(parts[2])
+  };
+}
+
+function getIssuer() {
+  if (process.env.THUNDER_ISSUER) {
+    return process.env.THUNDER_ISSUER;
+  }
+
+  return `${process.env.THUNDER_BASE_URL}/oauth2/token`;
+}
+
+async function getJwks() {
+  if (jwksCache) {
+    return jwksCache;
+  }
+
+  if (!process.env.THUNDER_BASE_URL) {
+    throw new Error("THUNDER_BASE_URL is required when API_REQUIRE_AUTH=true");
+  }
+
+  const response = await fetch(`${process.env.THUNDER_BASE_URL}/oauth2/jwks`);
+
+  if (!response.ok) {
+    throw new Error("Unable to load Asgardeo JWKS");
+  }
+
+  jwksCache = await response.json();
+
+  return jwksCache;
+}
+
+function verifySignature(token, jwk) {
+  const key = createPublicKey({
+    key: jwk,
+    format: "jwk"
+  });
+  const verifier = createVerify("RSA-SHA256");
+
+  verifier.update(token.signingInput);
+  verifier.end();
+
+  return verifier.verify(key, token.signature);
+}
+
+function validateClaims(payload) {
+  const now = Math.floor(Date.now() / 1000);
+  const issuer = getIssuer();
+  const audience = process.env.THUNDER_AUDIENCE;
+
+  if (payload.iss !== issuer) {
+    throw new Error("Invalid token issuer");
+  }
+
+  if (payload.exp && payload.exp < now) {
+    throw new Error("Token has expired");
+  }
+
+  if (payload.nbf && payload.nbf > now) {
+    throw new Error("Token is not active yet");
+  }
+
+  if (audience) {
+    const tokenAudience = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+
+    if (!tokenAudience.includes(audience)) {
+      throw new Error("Invalid token audience");
+    }
+  }
+}
+
+export async function getAuthenticatedUser(request) {
+  const authHeader = request.headers.authorization || "";
+  const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+  if (!token) {
+    throw new Error("Missing bearer token");
+  }
+
+  const parsedToken = parseJwt(token);
+
+  if (parsedToken.header.alg !== "RS256") {
+    throw new Error("Unsupported token algorithm");
+  }
+
+  const jwks = await getJwks();
+  const jwk = jwks.keys?.find((key) => key.kid === parsedToken.header.kid);
+
+  if (!jwk) {
+    throw new Error("Signing key not found");
+  }
+
+  if (!verifySignature(parsedToken, jwk)) {
+    throw new Error("Invalid token signature");
+  }
+
+  validateClaims(parsedToken.payload);
+
+  const scopes = typeof parsedToken.payload.scope === "string"
+    ? parsedToken.payload.scope.split(" ").filter(Boolean)
+    : [];
+
+  return {
+    id: parsedToken.payload.sub,
+    username: parsedToken.payload.username || parsedToken.payload.preferred_username,
+    email: parsedToken.payload.email,
+    givenName: parsedToken.payload.given_name,
+    familyName: parsedToken.payload.family_name,
+    scopes,
+    rawClaims: parsedToken.payload
+  };
+}
+
+export async function resolveUser(request) {
+  if (process.env.API_REQUIRE_AUTH !== "true") {
+    return {
+      id: "local-demo-user",
+      username: "local.traveler",
+      email: "local.traveler@example.com",
+      givenName: "Local",
+      familyName: "Traveler",
+      scopes: ["booking:read", "booking:create", "booking:cancel"]
+    };
+  }
+
+  return getAuthenticatedUser(request);
+}
+
+export function requireScope(user, scope) {
+  const scopes = user?.scopes || [];
+
+  if (!scopes.includes(scope)) {
+    const error = new Error(`Missing required scope: ${scope}`);
+
+    error.statusCode = 403;
+    throw error;
+  }
+}

--- a/samples/apps/agent-id-sample/api/src/db.js
+++ b/samples/apps/agent-id-sample/api/src/db.js
@@ -1,0 +1,354 @@
+import Database from "better-sqlite3";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultDbPath = resolve(__dirname, "..", "wayfinder.sqlite");
+const dbPath = process.env.SQLITE_DB_PATH || defaultDbPath;
+
+let db;
+
+function ensureSchema(database) {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS bookings (
+      id TEXT PRIMARY KEY,
+      booking_reference TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      username TEXT NOT NULL,
+      type TEXT NOT NULL,
+      item_id TEXT NOT NULL,
+      travelers INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
+
+  const bookingColumns = database.prepare("PRAGMA table_info(bookings)").all();
+  const hasBookingReference = bookingColumns.some((column) => column.name === "booking_reference");
+
+  if (!hasBookingReference) {
+    database.exec("ALTER TABLE bookings ADD COLUMN booking_reference TEXT;");
+  }
+
+  const bookingsWithoutReference = database
+    .prepare("SELECT id FROM bookings WHERE booking_reference IS NULL OR booking_reference = ''")
+    .all();
+
+  const updateBookingReference = database.prepare(
+    "UPDATE bookings SET booking_reference = @bookingReference WHERE id = @id"
+  );
+
+  for (const booking of bookingsWithoutReference) {
+    const source = String(booking.id || "").replace(/^booking-/i, "").replace(/[^a-z0-9]/gi, "");
+    const bookingReference = `WF-${source.toUpperCase().padEnd(8, "0").slice(0, 8)}`;
+
+    updateBookingReference.run({
+      id: booking.id,
+      bookingReference
+    });
+  }
+}
+
+function getDatabase() {
+  if (!existsSync(dbPath)) {
+    throw new Error("SQLite database not found. Run `npm run seed` from the api directory.");
+  }
+
+  if (!db) {
+    db = new Database(dbPath);
+    ensureSchema(db);
+  }
+
+  return db;
+}
+
+function parseJsonArray(value) {
+  try {
+    return JSON.parse(value || "[]");
+  } catch {
+    return [];
+  }
+}
+
+function mapFlight(row) {
+  return {
+    id: row.id,
+    from: row.from_city,
+    to: row.to_city,
+    airline: row.airline,
+    departureTime: row.departure_time,
+    arrivalTime: row.arrival_time,
+    duration: row.duration,
+    stops: row.stops,
+    price: row.price,
+    currency: row.currency,
+    cabin: row.cabin,
+    dates: row.dates,
+    tags: parseJsonArray(row.tags)
+  };
+}
+
+function mapHotel(row) {
+  return {
+    id: row.id,
+    name: row.name,
+    location: row.location,
+    nightlyRate: row.nightly_rate,
+    currency: row.currency,
+    rating: row.rating,
+    amenities: parseJsonArray(row.amenities)
+  };
+}
+
+function mapTrip(row) {
+  return {
+    id: row.id,
+    title: row.title,
+    destination: row.destination,
+    flightId: row.flight_id,
+    hotelId: row.hotel_id,
+    status: row.status,
+    totalEstimate: row.total_estimate,
+    currency: row.currency
+  };
+}
+
+export function findFlights({ from, to, cabin }) {
+  const conditions = [];
+  const params = {};
+
+  if (from) {
+    conditions.push("LOWER(from_city) LIKE LOWER(@from)");
+    params.from = `%${from}%`;
+  }
+
+  if (to) {
+    conditions.push("LOWER(to_city) LIKE LOWER(@to)");
+    params.to = `%${to}%`;
+  }
+
+  if (cabin) {
+    conditions.push("LOWER(cabin) LIKE LOWER(@cabin)");
+    params.cabin = `%${cabin}%`;
+  }
+
+  const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+  const rows = getDatabase()
+    .prepare(`SELECT * FROM flights ${whereClause} ORDER BY price ASC`)
+    .all(params);
+
+  return rows.map(mapFlight);
+}
+
+export function findFlightById(id) {
+  const row = getDatabase()
+    .prepare("SELECT * FROM flights WHERE id = @id")
+    .get({ id });
+
+  return row ? mapFlight(row) : null;
+}
+
+export function findHotels({ location, maxNightlyRate }) {
+  const conditions = [];
+  const params = {};
+
+  if (location) {
+    conditions.push("LOWER(location) LIKE LOWER(@location)");
+    params.location = `%${location}%`;
+  }
+
+  if (maxNightlyRate !== undefined && maxNightlyRate !== null && !Number.isNaN(maxNightlyRate)) {
+    conditions.push("nightly_rate <= @maxNightlyRate");
+    params.maxNightlyRate = maxNightlyRate;
+  }
+
+  const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+  const rows = getDatabase()
+    .prepare(`SELECT * FROM hotels ${whereClause} ORDER BY rating DESC`)
+    .all(params);
+
+  return rows.map(mapHotel);
+}
+
+export function listTrips({ destination } = {}) {
+  const conditions = [];
+  const params = {};
+
+  if (destination) {
+    conditions.push("LOWER(destination) LIKE LOWER(@destination)");
+    params.destination = `%${destination}%`;
+  }
+
+  const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+  const rows = getDatabase()
+    .prepare(`SELECT * FROM trips ${whereClause} ORDER BY total_estimate ASC`)
+    .all(params);
+
+  return rows.map(mapTrip);
+}
+
+export function listLocations({ category } = {}) {
+  let query = `
+    SELECT from_city AS name, 'city' AS type FROM flights
+    UNION
+    SELECT to_city AS name, 'city' AS type FROM flights
+  `;
+
+  if (category === "hotels") {
+    query = `
+      SELECT location AS name, 'area' AS type FROM hotels
+    `;
+  }
+
+  if (category === "trips") {
+    query = `
+      SELECT destination AS name, 'destination' AS type FROM trips
+    `;
+  }
+
+  const rows = getDatabase()
+    .prepare(`SELECT DISTINCT name, type FROM (${query}) ORDER BY name ASC`)
+    .all();
+
+  return rows;
+}
+
+export function createBookingRecord({
+  id,
+  bookingReference,
+  user,
+  type,
+  itemId,
+  travelers,
+  status,
+  createdAt
+}) {
+  const username = user.username || user.email || user.id;
+
+  getDatabase()
+    .prepare(
+      `
+        INSERT INTO bookings (
+          id,
+          booking_reference,
+          user_id,
+          username,
+          type,
+          item_id,
+          travelers,
+          status,
+          created_at
+        ) VALUES (
+          @id,
+          @bookingReference,
+          @userId,
+          @username,
+          @type,
+          @itemId,
+          @travelers,
+          @status,
+          @createdAt
+        )
+      `
+    )
+    .run({
+      id,
+      bookingReference,
+      userId: user.id,
+      username,
+      type,
+      itemId,
+      travelers,
+      status,
+      createdAt
+    });
+
+  return {
+    id,
+    bookingReference,
+    userId: user.id,
+    username,
+    type,
+    itemId,
+    travelers,
+    status,
+    createdAt
+  };
+}
+
+export function findDuplicateBooking({ username, type, itemId }) {
+  if (type !== "flight") {
+    return getDatabase()
+      .prepare(
+        `
+          SELECT id
+          FROM bookings
+          WHERE username = @username
+            AND type = @type
+            AND item_id = @itemId
+          LIMIT 1
+        `
+      )
+      .get({ username, type, itemId });
+  }
+
+  return getDatabase()
+    .prepare(
+      `
+        SELECT bookings.id
+        FROM bookings
+        INNER JOIN flights booked_flight ON bookings.item_id = booked_flight.id
+        INNER JOIN flights requested_flight ON requested_flight.id = @itemId
+        WHERE bookings.username = @username
+          AND bookings.type = 'flight'
+          AND booked_flight.from_city = requested_flight.from_city
+          AND booked_flight.to_city = requested_flight.to_city
+          AND booked_flight.departure_time = requested_flight.departure_time
+          AND booked_flight.arrival_time = requested_flight.arrival_time
+          AND booked_flight.dates = requested_flight.dates
+        LIMIT 1
+      `
+    )
+    .get({ username, itemId });
+}
+
+export function listBookedFlights(username) {
+  const rows = getDatabase()
+    .prepare(
+      `
+        SELECT
+          bookings.id AS booking_id,
+          bookings.booking_reference,
+          bookings.username,
+          bookings.travelers,
+          bookings.status,
+          bookings.created_at,
+          flights.*
+        FROM bookings
+        INNER JOIN flights ON bookings.item_id = flights.id
+        WHERE bookings.type = 'flight'
+          AND bookings.username = @username
+        ORDER BY bookings.created_at DESC
+      `
+    )
+    .all({ username });
+
+  return rows.map((row) => ({
+    id: row.booking_id,
+    bookingReference: row.booking_reference,
+    username: row.username,
+    travelers: row.travelers,
+    status: row.status,
+    createdAt: row.created_at,
+    flight: mapFlight(row)
+  }));
+}
+
+export function deleteBookingsForUser(username) {
+  const result = getDatabase()
+    .prepare(`DELETE FROM bookings WHERE username = @username`)
+    .run({ username });
+
+  return { deleted: result.changes };
+}

--- a/samples/apps/agent-id-sample/api/src/server.js
+++ b/samples/apps/agent-id-sample/api/src/server.js
@@ -1,0 +1,247 @@
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+import { URL } from "node:url";
+import "dotenv/config";
+
+// Local-dev TLS bypass: Thunder ships with a self-signed cert on localhost,
+// so the JWKS fetch in auth.js would otherwise fail with UNABLE_TO_VERIFY_LEAF_SIGNATURE.
+// We disable Node's TLS verification ONLY when the configured issuer base URL
+// points at localhost / 127.0.0.1.
+const __thunderBaseUrl = process.env.THUNDER_BASE_URL || "";
+if (/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/.test(__thunderBaseUrl)) {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+  console.warn("[api] Local Thunder detected — NODE_TLS_REJECT_UNAUTHORIZED set to 0. Do not use this build in production.");
+}
+
+import { resolveUser, requireScope } from "./auth.js";
+import {
+  createBookingRecord,
+  deleteBookingsForUser,
+  findDuplicateBooking,
+  findFlightById,
+  findFlights,
+  findHotels,
+  listBookedFlights,
+  listLocations,
+  listTrips
+} from "./db.js";
+
+const port = Number(process.env.PORT || 8787);
+const frontendOrigin = process.env.FRONTEND_ORIGIN || "http://localhost:5173";
+
+function sendJson(response, statusCode, body) {
+  response.writeHead(statusCode, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": frontendOrigin,
+    "Access-Control-Allow-Methods": "GET,POST,DELETE,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type,Authorization"
+  });
+  response.end(JSON.stringify(body));
+}
+
+async function readJsonBody(request) {
+  const chunks = [];
+
+  for await (const chunk of request) {
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch (error) {
+    const badJsonError = new Error("Request body is not valid JSON.");
+    badJsonError.statusCode = 400;
+    throw badJsonError;
+  }
+}
+
+function searchFlights(params) {
+  return findFlights({
+    from: params.get("from"),
+    to: params.get("to"),
+    cabin: params.get("cabin")
+  });
+}
+
+function searchHotels(params) {
+  return findHotels({
+    location: params.get("location"),
+    maxNightlyRate: Number(params.get("maxNightlyRate") || 0)
+  });
+}
+
+function generateBookingReference() {
+  return `WF-${randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
+}
+
+async function handleBooking(request) {
+  const user = await resolveUser(request);
+
+  requireScope(user, "booking:create");
+
+  const body = await readJsonBody(request);
+  const itemType = body.type;
+  const itemId = body.itemId;
+  const requestedTravelers = body.travelers ?? 1;
+  const travelers = Number(requestedTravelers);
+  const username = user.username || user.email || user.id;
+
+  if (!["flight", "hotel", "trip"].includes(itemType)) {
+    return {
+      statusCode: 400,
+      body: { error: "type must be one of: flight, hotel, trip" }
+    };
+  }
+
+  if (!itemId) {
+    return {
+      statusCode: 400,
+      body: { error: "itemId is required" }
+    };
+  }
+
+  if (!Number.isInteger(travelers) || travelers < 1) {
+    return {
+      statusCode: 400,
+      body: { error: "travelers must be a positive integer" }
+    };
+  }
+
+  const duplicateBooking = findDuplicateBooking({
+    username,
+    type: itemType,
+    itemId
+  });
+
+  if (duplicateBooking) {
+    return {
+      statusCode: 409,
+      body: { error: "This booking already exists." }
+    };
+  }
+
+  const booking = createBookingRecord({
+    id: `booking-${randomUUID()}`,
+    bookingReference: generateBookingReference(),
+    user,
+    type: itemType,
+    itemId,
+    travelers,
+    status: "confirmed",
+    createdAt: new Date().toISOString()
+  });
+
+  return {
+    statusCode: 201,
+    body: booking
+  };
+}
+
+async function route(request, response) {
+  const url = new URL(request.url, `http://${request.headers.host}`);
+
+  if (request.method === "OPTIONS") {
+    return sendJson(response, 204, {});
+  }
+
+  try {
+    if (request.method === "GET" && url.pathname === "/health") {
+      return sendJson(response, 200, { status: "ok" });
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/flights") {
+      return sendJson(response, 200, {
+        data: searchFlights(url.searchParams)
+      });
+    }
+
+    if (request.method === "GET" && url.pathname.startsWith("/api/flights/")) {
+      const flightId = decodeURIComponent(url.pathname.replace("/api/flights/", ""));
+      const flight = findFlightById(flightId);
+
+      if (!flight) {
+        return sendJson(response, 404, { error: "Flight not found" });
+      }
+
+      return sendJson(response, 200, {
+        data: flight
+      });
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/hotels") {
+      return sendJson(response, 200, {
+        data: searchHotels(url.searchParams)
+      });
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/locations") {
+      return sendJson(response, 200, {
+        data: listLocations({
+          category: url.searchParams.get("category")
+        })
+      });
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/trips") {
+      return sendJson(response, 200, {
+        data: listTrips({
+          destination: url.searchParams.get("destination")
+        })
+      });
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/me") {
+      const user = await resolveUser(request);
+
+      return sendJson(response, 200, { data: user });
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/bookings/flights") {
+      const user = await resolveUser(request);
+
+      requireScope(user, "booking:read");
+
+      const username = user.username || user.email || user.id;
+
+      return sendJson(response, 200, {
+        data: listBookedFlights(username)
+      });
+    }
+
+    if (request.method === "POST" && url.pathname === "/api/bookings") {
+      const result = await handleBooking(request);
+
+      return sendJson(response, result.statusCode, result.body);
+    }
+
+    if (request.method === "DELETE" && url.pathname === "/api/bookings/flights") {
+      const user = await resolveUser(request);
+
+      requireScope(user, "booking:cancel");
+
+      const username = user.username || user.email || user.id;
+      const result = deleteBookingsForUser(username);
+
+      return sendJson(response, 200, {
+        data: { deleted: result.deleted, username }
+      });
+    }
+
+    return sendJson(response, 404, { error: "Route not found" });
+  } catch (error) {
+    const statusCode = error.statusCode
+      || (error.message.toLowerCase().includes("token") ? 401 : 500);
+
+    return sendJson(response, statusCode, {
+      error: error.message
+    });
+  }
+}
+
+createServer(route).listen(port, () => {
+  console.log(`Wayfinder Travel API listening on http://localhost:${port}`);
+});

--- a/samples/apps/agent-id-sample/frontend/.env.example
+++ b/samples/apps/agent-id-sample/frontend/.env.example
@@ -1,0 +1,4 @@
+# Thunder OAuth client used for user sign-in in the Wayfinder web app.
+# This is the WAYFINDER application — separate from the chat agent's client.
+VITE_THUNDER_CLIENT_ID=WAYFINDER
+VITE_THUNDER_BASE_URL=https://localhost:8090

--- a/samples/apps/agent-id-sample/frontend/README.md
+++ b/samples/apps/agent-id-sample/frontend/README.md
@@ -1,0 +1,31 @@
+# Wayfinder Travel (Frontend)
+
+Vite + React UI for the agent identity sample. Two things matter here:
+
+1. **User sign-in** via the Asgardeo JavaScript SDK pointed at Thunder. Uses Thunder's `WAYFINDER` application (a separate OAuth client from the chat agent).
+2. **Chat widget** that talks to the agent over WebSocket. The widget also hosts the `/agent-callback` route that captures the auth code from the OBO popup and forwards it back to the agent.
+
+Configure with `.env.example` in this folder.
+
+## Run
+
+```bash
+npm install
+npm run dev
+```
+
+The app opens on `http://localhost:5173/`.
+
+## Routes
+
+| Route              | Purpose                                                                 |
+| ------------------ | ----------------------------------------------------------------------- |
+| `/`                | Travel UI + chat widget.                                                |
+| `/agent-callback`  | Lands the OBO auth code and posts it back to the chat widget.           |
+
+## Build
+
+```bash
+npm run build
+npm run preview
+```

--- a/samples/apps/agent-id-sample/frontend/index.html
+++ b/samples/apps/agent-id-sample/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wayfinder Travel</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/samples/apps/agent-id-sample/frontend/package-lock.json
+++ b/samples/apps/agent-id-sample/frontend/package-lock.json
@@ -1,0 +1,3283 @@
+{
+  "name": "asgardeo-b2c-sample-app",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "asgardeo-b2c-sample-app",
+      "version": "0.1.0",
+      "dependencies": {
+        "@asgardeo/react": "^0.23.6",
+        "@vitejs/plugin-react": "^4.4.1",
+        "lucide-react": "^0.511.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.3",
+        "vite": "^6.3.5"
+      }
+    },
+    "node_modules/@asgardeo/browser": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@asgardeo/browser/-/browser-0.7.2.tgz",
+      "integrity": "sha512-n9J153vQ0WehoSHZeMI/rBYgA/EAKnZiKSlik3+UPgmE+ZW/4TIPqcp/hLHGaF1nP1yz/d80nJpwDPYwcylKqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@asgardeo/javascript": "0.19.1",
+        "base64url": "3.0.1",
+        "buffer": "6.0.3",
+        "core-js": "3.42.0",
+        "crypto-browserify": "3.12.1",
+        "fast-sha256": "1.3.0",
+        "jose": "6.0.11",
+        "process": "0.11.10",
+        "randombytes": "2.1.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@asgardeo/i18n": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@asgardeo/i18n/-/i18n-0.4.5.tgz",
+      "integrity": "sha512-p1DVVI7lNu7KeDqhRNgAuSrHvVgCbbVXc04koyiiwjDx+sJaXychuC9pwVJ2PDUnIyEp3Xgdb3KqMq+Sx4e7xA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@asgardeo/javascript": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@asgardeo/javascript/-/javascript-0.19.1.tgz",
+      "integrity": "sha512-HWthqx9aIPqwA0fAUbqmN9+oy9UCunYkSnRFRYr+I8m5iTkvRl7A+nY5J37ohhUIYWZ2Phhj/SLPR13z57x7hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@asgardeo/i18n": "0.4.5",
+        "jose": "^5.2.0",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@asgardeo/javascript/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@asgardeo/react": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/@asgardeo/react/-/react-0.23.6.tgz",
+      "integrity": "sha512-LmeJOR54Duwdi6KHkF2c7zugj5mEqmfDSJRsrlhKbks8Jeglgjn5/VAH8QKxtssoSKuSDJYGct4tSq2uU7kC3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@asgardeo/browser": "0.7.2",
+        "@asgardeo/i18n": "0.4.5",
+        "@emotion/css": "11.13.5",
+        "@floating-ui/react": "0.27.12",
+        "@types/react-dom": "19.2.3",
+        "dompurify": "3.3.1",
+        "react-dom": "19.2.4",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@asgardeo/react/node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.12.tgz",
+      "integrity": "sha512-kKlWNrpIQxF1B/a2MZvE0/uyKby4960yjO91W7nVyNKmmfNi62xU9HCjL1M1eWzx/LFj/VPSwJVbwQk9Pq/68A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.3",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
+      "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.2.2",
+        "browserify-rsa": "^4.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.6.1",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.9",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.42.0.tgz",
+      "integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.352",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
+      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
+      "license": "ISC"
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
+      "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.511.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.511.0.tgz",
+      "integrity": "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "license": "MIT"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "pbkdf2": "^3.1.5",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
+      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-browserify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/samples/apps/agent-id-sample/frontend/package.json
+++ b/samples/apps/agent-id-sample/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "asgardeo-b2c-sample-app",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0"
+  },
+  "dependencies": {
+    "@asgardeo/react": "^0.23.6",
+    "@vitejs/plugin-react": "^4.4.1",
+    "lucide-react": "^0.511.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.3",
+    "vite": "^6.3.5"
+  }
+}

--- a/samples/apps/agent-id-sample/frontend/src/App.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useAsgardeo } from "@asgardeo/react";
 import {
+  Bot,
   ChevronDown,
   CircleUserRound,
   LogOut,
@@ -12,6 +13,7 @@ import {
 } from "lucide-react";
 import { Link, Navigate, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
 import { getLocations } from "./api";
+import { AgentPortalPage } from "./pages/AgentPortalPage";
 import { BookingDetailsPageWithAuth } from "./pages/BookingDetailsPageWithAuth";
 import { BookingsPageWithAuth } from "./pages/BookingsPageWithAuth";
 import { BookingsUnavailable } from "./pages/BookingsUnavailable";
@@ -142,6 +144,10 @@ function LiveAuthHeader() {
             <Link className="account-menu-item" to="/bookings" role="menuitem">
               <CircleUserRound size={18} />
               <span>My Bookings</span>
+            </Link>
+            <Link className="account-menu-item" to="/agent-portal" role="menuitem">
+              <Bot size={18} />
+              <span>Agent Portal</span>
             </Link>
             <button
               className="account-menu-item"
@@ -807,6 +813,10 @@ function AppRoutes({ authReady, criteria, locations, onSearch }) {
       <Route
         path="/bookings"
         element={authReady ? <BookingsPageWithAuth /> : <BookingsUnavailable />}
+      />
+      <Route
+        path="/agent-portal"
+        element={authReady ? <AgentPortalPage /> : <BookingsUnavailable />}
       />
       <Route path="/agent-callback" element={<AgentCallbackRoute />} />
       <Route

--- a/samples/apps/agent-id-sample/frontend/src/App.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/App.jsx
@@ -1,0 +1,919 @@
+import { useEffect, useRef, useState } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import {
+  ChevronDown,
+  CircleUserRound,
+  LogOut,
+  MessageCircle,
+  Plane,
+  Send,
+  ShieldCheck,
+  X
+} from "lucide-react";
+import { Link, Navigate, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
+import { getLocations } from "./api";
+import { BookingDetailsPageWithAuth } from "./pages/BookingDetailsPageWithAuth";
+import { BookingsPageWithAuth } from "./pages/BookingsPageWithAuth";
+import { BookingsUnavailable } from "./pages/BookingsUnavailable";
+import { FlightDetailsPage } from "./pages/FlightDetailsPage";
+import { HomePage, SignedInHomePage } from "./pages/HomePage";
+import { PaymentPageWithAuth } from "./pages/PaymentPageWithAuth";
+import { ResultsPage, ResultsPageWithAuth } from "./pages/ResultsPage";
+import { buildResultsPath, readCriteria } from "./utils/routes";
+
+const AGENT_CHAT_URL = import.meta.env.VITE_AGENT_CHAT_URL || "ws://localhost:8790/chat";
+const THUNDER_BASE_URL = import.meta.env.VITE_THUNDER_BASE_URL || "";
+const ASGARDEO_ORG_NAME = getAsgardeoOrgName();
+const SIGN_UP_URL = ASGARDEO_ORG_NAME
+  ? `https://accounts.asgardeo.io/t/${encodeURIComponent(ASGARDEO_ORG_NAME)}/accounts/register`
+  : "https://accounts.asgardeo.io/accounts/register";
+
+function getAsgardeoOrgName() {
+  const configuredOrgName = import.meta.env.VITE_THUNDER_ORG_NAME?.trim();
+
+  if (configuredOrgName) {
+    return configuredOrgName;
+  }
+
+  if (!THUNDER_BASE_URL) {
+    return "";
+  }
+
+  try {
+    const pathParts = new URL(THUNDER_BASE_URL).pathname.split("/").filter(Boolean);
+    const tenantIndex = pathParts.indexOf("t");
+
+    return tenantIndex >= 0 ? pathParts[tenantIndex + 1] || "" : "";
+  } catch {
+    return "";
+  }
+}
+
+function createChatMessage(role, content) {
+  return {
+    id: `${role}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    role,
+    content
+  };
+}
+
+function AuthenticatedHeader({ authReady }) {
+  if (!authReady) {
+    return <SignedOutHeader disabled />;
+  }
+
+  return <LiveAuthHeader />;
+}
+
+function PrimaryNav({ authReady }) {
+  if (!authReady) {
+    return <PublicPrimaryNav />;
+  }
+
+  return <LivePrimaryNav />;
+}
+
+function PublicPrimaryNav() {
+  return (
+    <nav className="header-nav" aria-label="Primary navigation">
+      <a href="/flights#search">Search</a>
+      <a href="/flights#deals">Deals</a>
+      <a href="/flights#faq">FAQ</a>
+    </nav>
+  );
+}
+
+function LivePrimaryNav() {
+  const { isSignedIn } = useAsgardeo();
+
+  if (isSignedIn) {
+    return <span aria-hidden="true" />;
+  }
+
+  return <PublicPrimaryNav />;
+}
+
+function LiveAuthHeader() {
+  const { isSignedIn, isLoading, signIn, signOut, user } = useAsgardeo();
+  const [isAccountMenuOpen, setIsAccountMenuOpen] = useState(false);
+  const accountMenuRef = useRef(null);
+  const firstName = user?.name?.givenName || "";
+  const lastName = user?.name?.familyName || "";
+  const fullName = `${firstName} ${lastName}`.trim();
+  const email = user?.email || user?.mail || user?.username || user?.userName || "";
+  const displayName = fullName || email || user?.sub || "Traveler";
+
+  useEffect(() => {
+    function handlePointerDown(event) {
+      if (accountMenuRef.current && !accountMenuRef.current.contains(event.target)) {
+        setIsAccountMenuOpen(false);
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, []);
+
+  if (isSignedIn) {
+    return (
+      <div className="auth-cluster account-menu-wrap" ref={accountMenuRef}>
+        <button
+          className="user-chip"
+          type="button"
+          aria-expanded={isAccountMenuOpen}
+          aria-haspopup="menu"
+          onClick={() => setIsAccountMenuOpen((current) => !current)}
+        >
+          <CircleUserRound className="user-chip-avatar" size={28} />
+          <span className="user-chip-text">
+            <span className="user-chip-name">{displayName}</span>
+            {fullName && email && <span className="user-chip-email">{email}</span>}
+          </span>
+          <ChevronDown
+            className={`user-chip-chevron ${isAccountMenuOpen ? "user-chip-chevron--open" : ""}`}
+            size={18}
+          />
+        </button>
+        {isAccountMenuOpen && (
+          <div className="account-menu" role="menu">
+            <Link className="account-menu-item" to="/bookings" role="menuitem">
+              <CircleUserRound size={18} />
+              <span>My Bookings</span>
+            </Link>
+            <button
+              className="account-menu-item"
+              type="button"
+              role="menuitem"
+              onClick={() => signOut()}
+            >
+              <LogOut size={18} />
+              <span>Sign Out</span>
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="auth-cluster">
+      <button
+        className="text-button"
+        type="button"
+        disabled={isLoading}
+        onClick={() => signIn({ acr_values: "urn:thunder:auth:user" })}
+      >
+        Sign in
+      </button>
+      <a className="primary-small" href={SIGN_UP_URL}>
+        Sign up
+      </a>
+    </div>
+  );
+}
+
+function SignedOutHeader({ disabled }) {
+  return (
+    <div className="auth-cluster">
+      <button className="text-button" type="button" disabled={disabled}>
+        Sign in
+      </button>
+      <button className="primary-small" type="button" disabled={disabled}>
+        Sign up
+      </button>
+    </div>
+  );
+}
+
+function FooterLinks({ authReady }) {
+  if (!authReady) {
+    return <PublicFooterLinks />;
+  }
+
+  return <LiveFooterLinks />;
+}
+
+function PublicFooterLinks() {
+  return (
+    <nav className="footer-links" aria-label="Footer navigation">
+      <a href="/flights#search">Search</a>
+      <a href="/flights#deals">Deals</a>
+      <a href="/flights#faq">FAQ</a>
+    </nav>
+  );
+}
+
+function LiveFooterLinks() {
+  const { isSignedIn } = useAsgardeo();
+
+  if (isSignedIn) {
+    return null;
+  }
+
+  return <PublicFooterLinks />;
+}
+
+function SiteFooter({ authReady }) {
+  return (
+    <footer className="site-footer">
+      <div>
+        <Link className="brand footer-brand" to="/flights" aria-label="Wayfinder Travel home">
+          <span className="brand-mark">
+            <Plane size={22} />
+          </span>
+          <span>Wayfinder</span>
+        </Link>
+        <p>Modern travel booking flows, secured with Asgardeo.</p>
+      </div>
+      <FooterLinks authReady={authReady} />
+    </footer>
+  );
+}
+
+// Opens an OAuth authorize URL in a popup, waits for the /agent-callback page
+// to post the auth code back via window.postMessage, then forwards the code
+// over the WebSocket so the ai-agent can exchange it for a user-context token.
+function handleNeedUserConsent(payload, socket) {
+  const authorizeUrl = payload.authorize_url;
+  const expectedState = payload.state;
+  const requestId = payload.request_id;
+
+  if (!authorizeUrl || !requestId) {
+    return;
+  }
+
+  const popup = window.open(
+    authorizeUrl,
+    "wayfinder-agent-consent",
+    "width=520,height=720,popup=yes"
+  );
+
+  if (!popup) {
+    socket.send(JSON.stringify({
+      type: "user_consent_error",
+      request_id: requestId,
+      error: "popup_blocked"
+    }));
+    return;
+  }
+
+  let settled = false;
+
+  const onMessage = (event) => {
+    if (event.origin !== window.location.origin) return;
+    const data = event.data;
+    if (!data || data.type !== "wayfinder-agent-oauth") return;
+    if (expectedState && data.state !== expectedState) return;
+    settled = true;
+    window.removeEventListener("message", onMessage);
+    window.clearInterval(closedPoll);
+    if (data.error) {
+      socket.send(JSON.stringify({
+        type: "user_consent_error",
+        request_id: requestId,
+        error: data.error,
+        error_description: data.errorDescription
+      }));
+    } else if (data.code) {
+      socket.send(JSON.stringify({
+        type: "user_code",
+        request_id: requestId,
+        code: data.code,
+        state: data.state
+      }));
+    }
+  };
+
+  window.addEventListener("message", onMessage);
+
+  // If the user closes the popup before completing the flow, signal cancel.
+  const closedPoll = window.setInterval(() => {
+    if (popup.closed && !settled) {
+      window.removeEventListener("message", onMessage);
+      window.clearInterval(closedPoll);
+      socket.send(JSON.stringify({
+        type: "user_consent_error",
+        request_id: requestId,
+        error: "popup_closed"
+      }));
+    }
+  }, 500);
+}
+
+// In-chat prompt that asks the user to confirm BEFORE the OAuth popup opens.
+// Clicking "Authorize" inside this bubble is what actually triggers
+// handleNeedUserConsent. Because the click is a direct user gesture, browsers
+// honour the popup window features and render a real popup (not a tab).
+function ConsentRequestBubble({ message, onUpdate, socket }) {
+  const status = message.status || "pending";
+
+  function handleAuthorize() {
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      onUpdate({ status: "error", errorReason: "Connection to assistant lost" });
+      return;
+    }
+    onUpdate({ status: "awaiting" });
+    handleNeedUserConsent(message.consent, socket);
+  }
+
+  function handleCancel() {
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({
+        type: "user_consent_error",
+        request_id: message.consent.request_id,
+        error: "user_cancelled"
+      }));
+    }
+    onUpdate({ status: "cancelled" });
+  }
+
+  return (
+    <div className="chat-message chat-message--assistant chat-message--consent">
+      <p style={{ margin: 0 }}>{message.content}</p>
+      {message.consent?.scope && (
+        <p style={{ margin: "6px 0 0", fontSize: "12px", color: "#666" }}>
+          Scope requested: <code>{message.consent.scope}</code>
+        </p>
+      )}
+      <div style={{ display: "flex", gap: 8, marginTop: 10 }}>
+        {status === "pending" && (
+          <>
+            <button
+              type="button"
+              onClick={handleAuthorize}
+              style={{
+                flex: "0 0 auto",
+                whiteSpace: "nowrap",
+                background: "#1f6feb",
+                color: "white",
+                border: "none",
+                borderRadius: 6,
+                padding: "8px 16px",
+                cursor: "pointer",
+                fontWeight: 600
+              }}
+            >
+              Authorize
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              style={{
+                flex: "0 0 auto",
+                whiteSpace: "nowrap",
+                background: "transparent",
+                border: "1px solid #ccc",
+                borderRadius: 6,
+                padding: "8px 16px",
+                cursor: "pointer"
+              }}
+            >
+              Not now
+            </button>
+          </>
+        )}
+        {status === "awaiting" && (
+          <p style={{ margin: 0, fontStyle: "italic", color: "#666" }}>
+            Waiting for sign in…
+          </p>
+        )}
+        {status === "cancelled" && (
+          <p style={{ margin: 0, fontStyle: "italic", color: "#888" }}>
+            Cancelled.
+          </p>
+        )}
+        {status === "error" && (
+          <p style={{ margin: 0, color: "#c00" }}>
+            {message.errorReason || "Could not start authorization."}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ChatWidget() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [connectionStatus, setConnectionStatus] = useState("disconnected");
+  const [messages, setMessages] = useState([
+    createChatMessage("assistant", "Hi, I can help with travel questions and booking details.")
+  ]);
+  const [draft, setDraft] = useState("");
+  const [isProcessing, setIsProcessing] = useState(false);
+  const socketRef = useRef(null);
+  const reconnectTimerRef = useRef(null);
+  const messagesEndRef = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsProcessing(false);
+      setConnectionStatus("disconnected");
+      return undefined;
+    }
+
+    let isCurrent = true;
+    let retryDelay = 700;
+
+    function connect() {
+      if (!isCurrent) {
+        return;
+      }
+
+      setConnectionStatus("connecting");
+      const socket = new WebSocket(AGENT_CHAT_URL);
+      socketRef.current = socket;
+
+      socket.addEventListener("open", () => {
+        if (!isCurrent) {
+          return;
+        }
+
+        retryDelay = 700;
+        setConnectionStatus("connected");
+      });
+
+      socket.addEventListener("message", (event) => {
+        if (!isCurrent) {
+          return;
+        }
+
+        let payload;
+
+        try {
+          payload = JSON.parse(event.data);
+        } catch {
+          payload = { type: "message", message: event.data };
+        }
+
+        if (payload.type === "message" || payload.type === "response") {
+          setMessages((current) => [
+            ...current,
+            createChatMessage("assistant", payload.message || "")
+          ]);
+          setIsProcessing(false);
+        } else if (payload.type === "error") {
+          setMessages((current) => [
+            ...current,
+            createChatMessage("assistant", payload.message || "I could not process that request.")
+          ]);
+          setIsProcessing(false);
+        } else if (payload.type === "need_user_consent") {
+          // Don't auto-open the popup. Browsers demote window.open() to a
+          // background tab when it's not triggered by a user gesture, which
+          // is why the OAuth screen previously opened in a full tab. Instead,
+          // render an in-chat prompt with an "Authorize" button. The user's
+          // click is a direct gesture, so window.open will produce a real
+          // popup window.
+          setMessages((current) => [
+            ...current,
+            {
+              id: `consent-${payload.request_id}`,
+              role: "assistant",
+              kind: "consent_request",
+              content: `This action needs your permission. Sign in to authorize the assistant to act on your behalf.`,
+              consent: {
+                authorize_url: payload.authorize_url,
+                state: payload.state,
+                request_id: payload.request_id,
+                scope: payload.scope
+              },
+              status: "pending"
+            }
+          ]);
+          // The agent is now waiting for the user — turn off the "typing" dots.
+          setIsProcessing(false);
+        }
+      });
+
+      socket.addEventListener("close", () => {
+        if (!isCurrent) {
+          return;
+        }
+
+        setConnectionStatus("disconnected");
+        socketRef.current = null;
+        reconnectTimerRef.current = window.setTimeout(connect, retryDelay);
+        retryDelay = Math.min(retryDelay * 1.6, 4000);
+      });
+
+      socket.addEventListener("error", () => {
+        if (!isCurrent) {
+          return;
+        }
+
+        setConnectionStatus("disconnected");
+      });
+    }
+
+    connect();
+
+    return () => {
+      isCurrent = false;
+      window.clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+
+      if (socketRef.current) {
+        socketRef.current.close();
+        socketRef.current = null;
+      }
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      messagesEndRef.current?.scrollIntoView({ block: "end", behavior: "smooth" });
+    }
+  }, [isOpen, messages]);
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const message = draft.trim();
+
+    if (!message || isProcessing) {
+      return;
+    }
+
+    setMessages((current) => [...current, createChatMessage("user", message)]);
+    setDraft("");
+    setIsProcessing(true);
+
+    if (socketRef.current?.readyState === WebSocket.OPEN) {
+      socketRef.current.send(JSON.stringify({ message }));
+      return;
+    }
+
+    setMessages((current) => [
+      ...current,
+      createChatMessage("assistant", "The travel assistant is reconnecting. Try again in a moment.")
+    ]);
+    setIsProcessing(false);
+  }
+
+  return (
+    <div className="chat-widget">
+      {isOpen && (
+        <section className="chat-panel" aria-label="AI travel assistant">
+          <header className="chat-header">
+            <div>
+              <span className="chat-kicker">AI assistant</span>
+              <h2>Wayfinder concierge</h2>
+            </div>
+            <div className="chat-header-actions">
+              <span className={`chat-status chat-status--${connectionStatus}`}>
+                {connectionStatus}
+              </span>
+              <button
+                className="chat-icon-button"
+                type="button"
+                aria-label="Close AI chat"
+                onClick={() => setIsOpen(false)}
+              >
+                <X size={18} />
+              </button>
+            </div>
+          </header>
+          <div className="chat-messages" role="log" aria-live="polite">
+            {messages.map((message) => {
+              if (message.kind === "consent_request") {
+                return (
+                  <ConsentRequestBubble
+                    key={message.id}
+                    message={message}
+                    onUpdate={(patch) => {
+                      setMessages((current) =>
+                        current.map((m) => (m.id === message.id ? { ...m, ...patch } : m))
+                      );
+                    }}
+                    socket={socketRef.current}
+                  />
+                );
+              }
+              return (
+                <div className={`chat-message chat-message--${message.role}`} key={message.id}>
+                  {message.content}
+                </div>
+              );
+            })}
+            {isProcessing && (
+              <div className="chat-message chat-message--assistant chat-message--typing">
+                Thinking...
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+          <form className="chat-composer" onSubmit={handleSubmit}>
+            <label className="chat-input-label">
+              <span>Ask the travel assistant</span>
+              <input
+                value={draft}
+                placeholder="Ask about flights or bookings"
+                onChange={(event) => setDraft(event.target.value)}
+              />
+            </label>
+            <button
+              className="chat-send-button"
+              type="submit"
+              disabled={!draft.trim() || isProcessing}
+              aria-label="Send message"
+            >
+              <Send size={18} />
+            </button>
+          </form>
+        </section>
+      )}
+
+      <button
+        className="chat-launcher"
+        type="button"
+        aria-label={isOpen ? "Close AI chat" : "Open AI chat"}
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        {isOpen ? <X size={22} /> : <MessageCircle size={24} />}
+      </button>
+    </div>
+  );
+}
+
+function FlightDetailsRoute({ criteria }) {
+  const { flightId = "" } = useParams();
+
+  return <FlightDetailsPage criteria={criteria} flightId={flightId} />;
+}
+
+function PaymentRoute({ criteria }) {
+  const { flightId = "" } = useParams();
+
+  return <PaymentPageWithAuth criteria={criteria} flightId={flightId} />;
+}
+
+function BookingDetailsRoute() {
+  const { bookingId = "" } = useParams();
+
+  return <BookingDetailsPageWithAuth bookingId={bookingId} />;
+}
+
+function LandingRoute({ authReady, category, locations, onSearch }) {
+  if (authReady) {
+    return <SignedInHomePage category={category} locations={locations} onSearch={onSearch} />;
+  }
+
+  return <HomePage category={category} locations={locations} onSearch={onSearch} />;
+}
+
+function HomeRedirect() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has("code") || params.has("error")) {
+    return null;
+  }
+  return <Navigate to="/flights" replace />;
+}
+
+// Receives the OAuth authorization code from Thunder after the chat agent has
+// triggered an authorization-code flow in a popup. Posts the code (and state)
+// back to the opener window (the chat widget) and closes itself.
+function AgentCallbackRoute() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const state = params.get("state");
+    const error = params.get("error");
+    const errorDescription = params.get("error_description");
+    if (window.opener) {
+      window.opener.postMessage(
+        {
+          type: "wayfinder-agent-oauth",
+          code: code || null,
+          state: state || null,
+          error: error || null,
+          errorDescription: errorDescription || null
+        },
+        window.location.origin
+      );
+    }
+    // Give the parent a moment to receive the message before tearing the popup down.
+    const timer = window.setTimeout(() => window.close(), 100);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return (
+    <main style={{
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      minHeight: "100vh",
+      fontFamily: "sans-serif",
+      color: "#555"
+    }}>
+      <p>Connecting your account to the assistant…</p>
+    </main>
+  );
+}
+
+// Deep-link entry point for agent sign-in. Triggers an OAuth authorize with
+// acr_values=urn:thunder:auth:agent so the gate renders the Agent ID/Secret
+// form directly instead of the standard user credentials screen. Used by the
+// wayfinder-agent-demo skill and any bookmarkable "Sign in as Agent" link.
+function AgentSignInRoute() {
+  const { isSignedIn, signIn } = useAsgardeo();
+  const navigate = useNavigate();
+  const triggered = useRef(false);
+
+  useEffect(() => {
+    if (isSignedIn) {
+      navigate("/flights", { replace: true });
+      return;
+    }
+    if (triggered.current) {
+      return;
+    }
+    triggered.current = true;
+    signIn({ acr_values: "urn:thunder:auth:agent" });
+  }, [isSignedIn, signIn, navigate]);
+
+  return (
+    <main style={{
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      minHeight: "60vh",
+      color: "#555"
+    }}>
+      <p>Redirecting to agent sign in…</p>
+    </main>
+  );
+}
+
+function AppRoutes({ authReady, criteria, locations, onSearch }) {
+  return (
+    <Routes>
+      <Route path="/" element={<HomeRedirect />} />
+      <Route
+        path="/flights"
+        element={
+          <LandingRoute
+            authReady={authReady}
+            category="flights"
+            locations={locations}
+            onSearch={onSearch}
+          />
+        }
+      />
+      <Route
+        path="/hotels"
+        element={
+          <LandingRoute
+            authReady={authReady}
+            category="hotels"
+            locations={locations}
+            onSearch={onSearch}
+          />
+        }
+      />
+      <Route
+        path="/trips"
+        element={
+          <LandingRoute
+            authReady={authReady}
+            category="trips"
+            locations={locations}
+            onSearch={onSearch}
+          />
+        }
+      />
+      <Route
+        path="/results"
+        element={
+          authReady ? (
+            <ResultsPageWithAuth criteria={criteria} locations={locations} onSearch={onSearch} />
+          ) : (
+            <ResultsPage criteria={criteria} locations={locations} onSearch={onSearch} />
+          )
+        }
+      />
+      <Route path="/flights/:flightId" element={<FlightDetailsRoute criteria={criteria} />} />
+      <Route
+        path="/payment/flight/:flightId"
+        element={authReady ? <PaymentRoute criteria={criteria} /> : <BookingsUnavailable />}
+      />
+      <Route
+        path="/bookings/:bookingId"
+        element={authReady ? <BookingDetailsRoute /> : <BookingsUnavailable />}
+      />
+      <Route
+        path="/bookings"
+        element={authReady ? <BookingsPageWithAuth /> : <BookingsUnavailable />}
+      />
+      <Route path="/agent-callback" element={<AgentCallbackRoute />} />
+      <Route
+        path="/signin-as-agent"
+        element={authReady ? <AgentSignInRoute /> : <BookingsUnavailable />}
+      />
+      <Route path="*" element={<Navigate to="/flights" replace />} />
+    </Routes>
+  );
+}
+
+function App({ authReady }) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [locations, setLocations] = useState({
+    flights: [],
+    hotels: [],
+    trips: []
+  });
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    async function loadLocations() {
+      try {
+        const [flightLocations, hotelLocations, tripLocations] = await Promise.all([
+          getLocations({ category: "flights" }),
+          getLocations({ category: "hotels" }),
+          getLocations({ category: "trips" })
+        ]);
+
+        if (isCurrent) {
+          setLocations({
+            flights: flightLocations,
+            hotels: hotelLocations,
+            trips: tripLocations
+          });
+        }
+      } catch {
+        if (isCurrent) {
+          setLocations({
+            flights: [
+              { name: "Colombo", type: "city" },
+              { name: "Singapore", type: "city" },
+              { name: "Tokyo", type: "city" },
+              { name: "London", type: "city" },
+              { name: "Dubai", type: "city" }
+            ],
+            hotels: [
+              { name: "Singapore Marina", type: "area" },
+              { name: "Tokyo Shibuya", type: "area" },
+              { name: "London Kings Cross", type: "area" }
+            ],
+            trips: [
+              { name: "Singapore", type: "destination" },
+              { name: "Tokyo", type: "destination" },
+              { name: "Dubai", type: "destination" }
+            ]
+          });
+        }
+      }
+    }
+
+    loadLocations();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, []);
+
+  function handleSearch(searchParams) {
+    navigate(buildResultsPath(searchParams));
+  }
+
+  const criteria = readCriteria(location.search);
+
+  return (
+    <div className="app-shell">
+      <header className="site-header">
+        <Link className="brand" to="/flights" aria-label="Wayfinder Travel home">
+          <span className="brand-mark">
+            <Plane size={22} />
+          </span>
+          <span>Wayfinder</span>
+        </Link>
+        <PrimaryNav authReady={authReady} />
+        <AuthenticatedHeader authReady={authReady} />
+      </header>
+
+      {!authReady && (
+        <div className="setup-banner" role="status">
+          <ShieldCheck size={18} />
+          Add `VITE_THUNDER_CLIENT_ID` and `VITE_THUNDER_BASE_URL` to enable live
+          Asgardeo sign in, sign up, and sign out.
+        </div>
+      )}
+
+      <AppRoutes
+        authReady={authReady}
+        criteria={criteria}
+        locations={locations}
+        onSearch={handleSearch}
+      />
+      <ChatWidget />
+      <SiteFooter authReady={authReady} />
+    </div>
+  );
+}
+
+export default App;

--- a/samples/apps/agent-id-sample/frontend/src/api.js
+++ b/samples/apps/agent-id-sample/frontend/src/api.js
@@ -1,0 +1,103 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8787";
+
+async function requestJson(path, options = {}) {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers
+    },
+    ...options
+  });
+
+  const body = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new Error(body.error || "API request failed");
+  }
+
+  return body;
+}
+
+export async function getFlights(searchParams = {}) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+
+  const query = params.toString();
+  const response = await requestJson(`/api/flights${query ? `?${query}` : ""}`);
+
+  return response.data;
+}
+
+export async function getFlight(flightId) {
+  const response = await requestJson(`/api/flights/${encodeURIComponent(flightId)}`);
+
+  return response.data;
+}
+
+export async function getHotels(searchParams = {}) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+
+  const query = params.toString();
+  const response = await requestJson(`/api/hotels${query ? `?${query}` : ""}`);
+
+  return response.data;
+}
+
+export async function getTrips(searchParams = {}) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+
+  const query = params.toString();
+  const response = await requestJson(`/api/trips${query ? `?${query}` : ""}`);
+
+  return response.data;
+}
+
+export async function getLocations(searchParams = {}) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+
+  const query = params.toString();
+  const response = await requestJson(`/api/locations${query ? `?${query}` : ""}`);
+
+  return response.data;
+}
+
+export async function createBooking(booking, accessToken) {
+  const response = await requestJson("/api/bookings", {
+    method: "POST",
+    headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+    body: JSON.stringify(booking)
+  });
+
+  return response;
+}
+
+export async function getBookedFlights(accessToken) {
+  const response = await requestJson("/api/bookings/flights", {
+    headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {}
+  });
+
+  return response.data;
+}

--- a/samples/apps/agent-id-sample/frontend/src/api/thunder.js
+++ b/samples/apps/agent-id-sample/frontend/src/api/thunder.js
@@ -1,0 +1,153 @@
+// Client for Thunder admin REST APIs (agents, roles, organization units).
+// Calls go directly from the browser to the Thunder server using the access
+// token issued at sign-in. The token must carry the appropriate `system:*`
+// scopes — see SCOPES in src/main.jsx.
+
+const THUNDER_BASE_URL =
+  import.meta.env.VITE_THUNDER_BASE_URL ||
+  import.meta.env.VITE_THUNDER_BASE_URL ||
+  "https://localhost:8090";
+
+async function thunderRequest(path, accessToken, options = {}) {
+  const headers = {
+    Accept: "application/json",
+    ...(options.body ? { "Content-Type": "application/json" } : {}),
+    ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    ...options.headers
+  };
+  const response = await fetch(`${THUNDER_BASE_URL}${path}`, { ...options, headers });
+  const text = await response.text();
+  const body = text ? safeJson(text) : null;
+  if (!response.ok) {
+    const message =
+      (body && (body.description || body.message || body.error)) ||
+      `Thunder request failed (${response.status})`;
+    const error = new Error(message);
+    error.status = response.status;
+    error.body = body;
+    throw error;
+  }
+  return body;
+}
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+export async function getDefaultOrganizationUnit(accessToken, handle = "default") {
+  const data = await thunderRequest(
+    `/organization-units/tree/${encodeURIComponent(handle)}`,
+    accessToken
+  );
+  return data;
+}
+
+export async function listAgents(accessToken, { limit = 50, offset = 0 } = {}) {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  const data = await thunderRequest(`/agents?${params.toString()}`, accessToken);
+  return data;
+}
+
+export async function getAgent(accessToken, agentId) {
+  return thunderRequest(`/agents/${encodeURIComponent(agentId)}`, accessToken);
+}
+
+export async function listRoles(accessToken, { limit = 100, offset = 0 } = {}) {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  const data = await thunderRequest(`/roles?${params.toString()}`, accessToken);
+  return data;
+}
+
+export async function getRoleAssignments(accessToken, roleId, { type = "agent" } = {}) {
+  const params = new URLSearchParams({ type, include: "display", limit: "100" });
+  return thunderRequest(
+    `/roles/${encodeURIComponent(roleId)}/assignments?${params.toString()}`,
+    accessToken
+  );
+}
+
+// Creates an agent with an OAuth2 inbound auth profile that supports the
+// client_credentials grant. The returned object includes the freshly issued
+// clientSecret in inboundAuthConfig[0].config.clientSecret — display it to the
+// admin immediately because Thunder will not return it on subsequent reads.
+export async function createAgent(accessToken, { name, description, ouId }) {
+  const safeName = name.trim();
+  const clientId = `WAYFINDER-AGENT-${safeName
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40) || "AGENT"}-${Date.now().toString(36)}`;
+
+  const payload = {
+    name: safeName,
+    description: description?.trim() || undefined,
+    type: "default",
+    ouId,
+    inboundAuthConfig: [
+      {
+        type: "oauth2",
+        config: {
+          clientId,
+          grantTypes: ["client_credentials"],
+          tokenEndpointAuthMethod: "client_secret_basic",
+          publicClient: false,
+          pkceRequired: false,
+          token: {
+            accessToken: {
+              validityPeriod: 3600
+            }
+          }
+        }
+      }
+    ]
+  };
+
+  return thunderRequest(`/agents`, accessToken, {
+    method: "POST",
+    body: JSON.stringify(payload)
+  });
+}
+
+export async function deleteAgent(accessToken, agentId) {
+  return thunderRequest(`/agents/${encodeURIComponent(agentId)}`, accessToken, {
+    method: "DELETE"
+  });
+}
+
+export async function addAgentRoleAssignment(accessToken, roleId, agentId) {
+  return thunderRequest(
+    `/roles/${encodeURIComponent(roleId)}/assignments/add`,
+    accessToken,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        assignments: [{ id: agentId, type: "agent" }]
+      })
+    }
+  );
+}
+
+export async function removeAgentRoleAssignment(accessToken, roleId, agentId) {
+  return thunderRequest(
+    `/roles/${encodeURIComponent(roleId)}/assignments/remove`,
+    accessToken,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        assignments: [{ id: agentId, type: "agent" }]
+      })
+    }
+  );
+}
+
+export function extractAgentOAuthCreds(agentResponse) {
+  const oauth = agentResponse?.inboundAuthConfig?.find((c) => c.type === "oauth2");
+  return {
+    clientId: oauth?.config?.clientId || "",
+    clientSecret: oauth?.config?.clientSecret || ""
+  };
+}

--- a/samples/apps/agent-id-sample/frontend/src/components/SearchPanel.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/components/SearchPanel.jsx
@@ -1,0 +1,472 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  CalendarDays,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Hotel,
+  MapPin,
+  Minus,
+  Plane,
+  Plus,
+  Search,
+  Sparkles,
+  UsersRound
+} from "lucide-react";
+
+const categoryPaths = {
+  flights: "/flights",
+  hotels: "/hotels",
+  trips: "/trips"
+};
+
+function LocationField({
+  icon,
+  label,
+  name,
+  defaultValue,
+  locations,
+  placeholder,
+  isOpen,
+  onOpen,
+  onClose
+}) {
+  const [value, setValue] = useState(defaultValue || "");
+  const normalizedValue = value.trim().toLowerCase();
+  const filteredLocations = locations
+    .filter((location) => location.name.toLowerCase().includes(normalizedValue))
+    .slice(0, 8);
+
+  useEffect(() => {
+    setValue(defaultValue || "");
+  }, [defaultValue]);
+
+  function selectLocation(locationName) {
+    setValue(locationName);
+    onClose();
+  }
+
+  return (
+    <label className="field field--wide location-field">
+      <span>{label}</span>
+      <div className="field-control">
+        {icon}
+        <input
+          autoComplete="off"
+          name={name}
+          value={value}
+          placeholder={placeholder}
+          aria-label={label}
+          onChange={(event) => {
+            setValue(event.target.value);
+            onOpen();
+          }}
+          onClick={onOpen}
+          onFocus={onOpen}
+        />
+      </div>
+      {isOpen && filteredLocations.length > 0 && (
+        <div className="location-menu" role="listbox">
+          {filteredLocations.map((location) => (
+            <button
+              className="location-option"
+              key={`${location.type}-${location.name}`}
+              type="button"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => selectLocation(location.name)}
+            >
+              <MapPin size={16} />
+              <span>{location.name}</span>
+              <small>{location.type}</small>
+              {location.name === value && <Check size={16} />}
+            </button>
+          ))}
+        </div>
+      )}
+    </label>
+  );
+}
+
+const monthFormatter = new Intl.DateTimeFormat("en", { month: "long" });
+const shortDateFormatter = new Intl.DateTimeFormat("en", { month: "short", day: "numeric" });
+
+function addMonths(date, months) {
+  return new Date(date.getFullYear(), date.getMonth() + months, 1);
+}
+
+function dateKey(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function formatDateRange(startDate, endDate) {
+  if (!startDate || !endDate) {
+    return "Select dates";
+  }
+
+  return `${shortDateFormatter.format(startDate)} - ${shortDateFormatter.format(endDate)}`;
+}
+
+function buildCalendarDays(monthDate) {
+  const year = monthDate.getFullYear();
+  const month = monthDate.getMonth();
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const leadingDays = (firstDay.getDay() + 6) % 7;
+  const days = [];
+
+  for (let index = 0; index < leadingDays; index += 1) {
+    days.push(null);
+  }
+
+  for (let day = 1; day <= lastDay.getDate(); day += 1) {
+    days.push(new Date(year, month, day));
+  }
+
+  return days;
+}
+
+function DateField({ defaultValue, isOpen, onOpen, onClose }) {
+  const [visibleMonth, setVisibleMonth] = useState(new Date(2026, 4, 1));
+  const [startDate, setStartDate] = useState(new Date(2026, 5, 12));
+  const [endDate, setEndDate] = useState(new Date(2026, 5, 18));
+  const displayValue = formatDateRange(startDate, endDate) || defaultValue;
+
+  function selectDate(date) {
+    if (!startDate || (startDate && endDate) || date < startDate) {
+      setStartDate(date);
+      setEndDate(null);
+      return;
+    }
+
+    setEndDate(date);
+  }
+
+  function renderMonth(monthDate) {
+    const days = buildCalendarDays(monthDate);
+
+    return (
+      <div className="calendar-month">
+        <h3>{monthFormatter.format(monthDate)}</h3>
+        <div className="calendar-weekdays">
+          {["M", "T", "W", "T", "F", "S", "S"].map((day, index) => (
+            <span key={`${day}-${index}`}>{day}</span>
+          ))}
+        </div>
+        <div className="calendar-grid">
+          {days.map((date, index) => {
+            if (!date) {
+              return <span className="calendar-empty" key={`empty-${index}`} />;
+            }
+
+            const isStart = startDate && dateKey(date) === dateKey(startDate);
+            const isEnd = endDate && dateKey(date) === dateKey(endDate);
+            const isInRange = startDate && endDate && date > startDate && date < endDate;
+
+            return (
+              <button
+                className={`calendar-day ${isStart || isEnd ? "calendar-day--selected" : ""} ${
+                  isInRange ? "calendar-day--range" : ""
+                }`}
+                key={dateKey(date)}
+                type="button"
+                onClick={() => selectDate(date)}
+              >
+                {date.getDate()}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <label className="field date-field">
+      <span>Dates</span>
+      <div className="field-control">
+        <CalendarDays size={18} />
+        <input
+          name="dates"
+          readOnly
+          value={displayValue}
+          aria-label="Travel dates"
+          onFocus={onOpen}
+          onClick={onOpen}
+        />
+      </div>
+      {isOpen && (
+        <div className="date-menu">
+          <div className="calendar-wrap">
+            <button
+              className="calendar-nav"
+              type="button"
+              onClick={() => setVisibleMonth(addMonths(visibleMonth, -1))}
+              aria-label="Previous month"
+            >
+              <ChevronLeft size={26} />
+            </button>
+            {renderMonth(visibleMonth)}
+            {renderMonth(addMonths(visibleMonth, 1))}
+            <button
+              className="calendar-nav"
+              type="button"
+              onClick={() => setVisibleMonth(addMonths(visibleMonth, 1))}
+              aria-label="Next month"
+            >
+              <ChevronRight size={26} />
+            </button>
+          </div>
+          <div className="date-menu-footer">
+            <button className="apply-button" type="button" onClick={onClose}>
+              Apply
+            </button>
+          </div>
+        </div>
+      )}
+    </label>
+  );
+}
+
+function TravelersField({ defaultValue, isOpen, onOpen, onClose }) {
+  const [adults, setAdults] = useState(2);
+  const [children, setChildren] = useState(0);
+  const displayValue =
+    `${adults} adult${adults === 1 ? "" : "s"}${children > 0 ? `, ${children} child${children === 1 ? "" : "ren"}` : ""}` ||
+    defaultValue;
+
+  function changeAdults(change) {
+    setAdults((current) => Math.max(1, current + change));
+  }
+
+  function changeChildren(change) {
+    setChildren((current) => Math.max(0, current + change));
+  }
+
+  return (
+    <label className="field travelers-field">
+      <span>Travelers</span>
+      <div className="field-control">
+        <UsersRound size={18} />
+        <input
+          name="travelers"
+          readOnly
+          value={displayValue}
+          aria-label="Travelers"
+          onFocus={onOpen}
+          onClick={onOpen}
+        />
+      </div>
+      {isOpen && (
+        <div className="travelers-menu">
+          <div className="traveler-row">
+            <div>
+              <strong>Adults</strong>
+              <span>Aged 18+</span>
+            </div>
+            <div className="stepper">
+              <button type="button" disabled={adults <= 1} onClick={() => changeAdults(-1)}>
+                <Minus size={20} />
+              </button>
+              <strong>{adults}</strong>
+              <button type="button" onClick={() => changeAdults(1)}>
+                <Plus size={22} />
+              </button>
+            </div>
+          </div>
+          <div className="traveler-row">
+            <div>
+              <strong>Children</strong>
+              <span>Aged 0 to 17</span>
+            </div>
+            <div className="stepper">
+              <button type="button" disabled={children <= 0} onClick={() => changeChildren(-1)}>
+                <Minus size={20} />
+              </button>
+              <strong>{children}</strong>
+              <button type="button" onClick={() => changeChildren(1)}>
+                <Plus size={22} />
+              </button>
+            </div>
+          </div>
+          <p>
+            Your age at time of travel must be valid for the age category booked.
+            Airlines have restrictions on under 18s travelling alone.
+          </p>
+          <p>
+            Age limits and policies for travelling with children may vary so please check
+            with the airline before booking.
+          </p>
+          <button className="apply-button apply-button--full" type="button" onClick={onClose}>
+            Apply
+          </button>
+        </div>
+      )}
+    </label>
+  );
+}
+
+export function SearchPanel({
+  compact = false,
+  defaultCategory = "flights",
+  initialCriteria,
+  locations,
+  navigateOnCategoryChange = true,
+  onSearch
+}) {
+  const navigate = useNavigate();
+  const [category, setCategory] = useState(initialCriteria?.category || defaultCategory);
+  const [tripType, setTripType] = useState(initialCriteria?.tripType || "round-trip");
+  const [openDropdown, setOpenDropdown] = useState(null);
+  const panelRef = useRef(null);
+
+  useEffect(() => {
+    setCategory(initialCriteria?.category || defaultCategory);
+    setTripType(initialCriteria?.tripType || "round-trip");
+  }, [defaultCategory, initialCriteria?.category, initialCriteria?.tripType]);
+
+  useEffect(() => {
+    function handlePointerDown(event) {
+      if (panelRef.current && !panelRef.current.contains(event.target)) {
+        setOpenDropdown(null);
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, []);
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+
+    onSearch({
+      category,
+      tripType: category === "flights" ? tripType : "",
+      from: formData.get("from"),
+      to: formData.get("to"),
+      dates: formData.get("dates"),
+      travelers: formData.get("travelers")
+    });
+  }
+
+  function selectCategory(nextCategory) {
+    setCategory(nextCategory);
+    setOpenDropdown(null);
+
+    if (navigateOnCategoryChange) {
+      navigate(categoryPaths[nextCategory]);
+    }
+  }
+
+  const isHotelSearch = category === "hotels";
+  const destinationPlaceholder = isHotelSearch ? "Choose area" : "Choose destination";
+
+  return (
+    <section
+      className={`search-panel ${compact ? "search-panel--compact" : ""}`}
+      ref={panelRef}
+      aria-label="Search travel"
+    >
+      <div className="tabs" aria-label="Booking type">
+        <button
+          className={`tab ${category === "flights" ? "tab--active" : ""}`}
+          type="button"
+          onClick={() => selectCategory("flights")}
+        >
+          <Plane size={18} />
+          Flights
+        </button>
+        <button
+          className={`tab ${category === "hotels" ? "tab--active" : ""}`}
+          type="button"
+          onClick={() => selectCategory("hotels")}
+        >
+          <Hotel size={18} />
+          Hotels
+        </button>
+        <button
+          className={`tab ${category === "trips" ? "tab--active" : ""}`}
+          type="button"
+          onClick={() => selectCategory("trips")}
+        >
+          <Sparkles size={18} />
+          Trips
+        </button>
+      </div>
+
+      {category === "flights" && (
+        <div className="trip-type">
+          <button
+            className={`pill ${tripType === "round-trip" ? "pill--selected" : ""}`}
+            type="button"
+            onClick={() => setTripType("round-trip")}
+          >
+            Round trip
+          </button>
+          <button
+            className={`pill ${tripType === "one-way" ? "pill--selected" : ""}`}
+            type="button"
+            onClick={() => setTripType("one-way")}
+          >
+            One way
+          </button>
+          <button
+            className={`pill ${tripType === "multi-city" ? "pill--selected" : ""}`}
+            type="button"
+            onClick={() => setTripType("multi-city")}
+          >
+            Multi-city
+          </button>
+        </div>
+      )}
+
+      <form className={`search-grid search-grid--${category}`} onSubmit={handleSubmit}>
+        {!isHotelSearch && (
+          <LocationField
+            defaultValue={initialCriteria?.from || "Colombo"}
+            icon={<MapPin size={18} />}
+            isOpen={openDropdown === "from"}
+            label="From"
+            locations={locations[category] || []}
+            name="from"
+            onClose={() => setOpenDropdown(null)}
+            onOpen={() => setOpenDropdown("from")}
+            placeholder="Choose origin"
+          />
+        )}
+        <LocationField
+          defaultValue={initialCriteria?.to || "Singapore"}
+          icon={isHotelSearch ? <MapPin size={18} /> : <Plane size={18} />}
+          isOpen={openDropdown === "to"}
+          label={isHotelSearch ? "Destination" : "To"}
+          locations={locations[category] || []}
+          name="to"
+          onClose={() => setOpenDropdown(null)}
+          onOpen={() => setOpenDropdown("to")}
+          placeholder={destinationPlaceholder}
+        />
+        <DateField
+          defaultValue={initialCriteria?.dates}
+          isOpen={openDropdown === "dates"}
+          onClose={() => setOpenDropdown(null)}
+          onOpen={() => setOpenDropdown("dates")}
+        />
+        <TravelersField
+          defaultValue={initialCriteria?.travelers}
+          isOpen={openDropdown === "travelers"}
+          onClose={() => setOpenDropdown(null)}
+          onOpen={() => setOpenDropdown("travelers")}
+        />
+        <button className="search-button" type="submit">
+          <Search size={20} />
+          Search
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/samples/apps/agent-id-sample/frontend/src/main.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/main.jsx
@@ -1,0 +1,49 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { AsgardeoProvider } from "@asgardeo/react";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App.jsx";
+import "./styles.css";
+
+const clientId = import.meta.env.VITE_THUNDER_CLIENT_ID;
+const baseUrl = import.meta.env.VITE_THUNDER_BASE_URL;
+const asgardeoReady = Boolean(clientId && baseUrl);
+
+// Scopes requested at sign-in. The trailing `system:*` scopes power the in-app
+// Agent Portal: when an admin user signs in, the issued access token carries
+// the system permissions needed to call Thunder's /agents and /roles APIs
+// directly from the browser. Non-admin users will simply have these scopes
+// stripped from the issued token.
+const SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "ou",
+  "system",
+  "system:user",
+  "system:group",
+  "system:ou:view",
+  "system:usertype:view"
+];
+
+createRoot(document.getElementById("root")).render(
+  <StrictMode>
+    <BrowserRouter>
+      {asgardeoReady ? (
+        <AsgardeoProvider
+          clientId={clientId}
+          baseUrl={baseUrl}
+          platform="AsgardeoV2"
+          afterSignInUrl={window.location.origin}
+          afterSignOutUrl={window.location.origin}
+          scopes={SCOPES}
+          discovery={{ wellKnown: { enabled: true } }}
+        >
+          <App authReady />
+        </AsgardeoProvider>
+      ) : (
+        <App authReady={false} />
+      )}
+    </BrowserRouter>
+  </StrictMode>
+);

--- a/samples/apps/agent-id-sample/frontend/src/pages/AgentPortalPage.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/AgentPortalPage.jsx
@@ -1,0 +1,536 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import { Bot, Copy, Plus, RefreshCw, Trash2, X } from "lucide-react";
+import {
+  addAgentRoleAssignment,
+  createAgent,
+  deleteAgent,
+  extractAgentOAuthCreds,
+  getDefaultOrganizationUnit,
+  listAgents,
+  listRoles
+} from "../api/thunder";
+
+const DEFAULT_OU_HANDLE =
+  import.meta.env.VITE_THUNDER_DEFAULT_OU_HANDLE || "default";
+
+export function AgentPortalPage() {
+  const { isSignedIn, isLoading: authLoading, signIn, getAccessToken } = useAsgardeo();
+
+  if (authLoading) {
+    return (
+      <main className="bookings-page">
+        <p className="empty-state management-message">Loading…</p>
+      </main>
+    );
+  }
+
+  if (!isSignedIn) {
+    return (
+      <main className="bookings-page">
+        <section className="management-empty">
+          <div>
+            <p className="eyebrow">Agent Portal</p>
+            <h1>Sign in to manage agents.</h1>
+            <p>Admins can create agents and assign Thunder roles to them.</p>
+          </div>
+          <button
+            className="dashboard-action dashboard-action--secondary"
+            type="button"
+            onClick={() => signIn({ acr_values: "urn:thunder:auth:user" })}
+          >
+            Sign in
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  return <AgentPortal getAccessToken={getAccessToken} />;
+}
+
+function AgentPortal({ getAccessToken }) {
+  const getAccessTokenRef = useRef(getAccessToken);
+  useEffect(() => {
+    getAccessTokenRef.current = getAccessToken;
+  }, [getAccessToken]);
+
+  const [agents, setAgents] = useState([]);
+  const [roles, setRoles] = useState([]);
+  const [ou, setOu] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [showCreate, setShowCreate] = useState(false);
+  const [createdCreds, setCreatedCreds] = useState(null);
+
+  const loadAll = useCallback(async () => {
+    setIsLoading(true);
+    setError("");
+    try {
+      const accessToken = await getAccessTokenRef.current();
+      const [agentsResp, rolesResp, ouResp] = await Promise.all([
+        listAgents(accessToken),
+        listRoles(accessToken),
+        getDefaultOrganizationUnit(accessToken, DEFAULT_OU_HANDLE)
+      ]);
+      setAgents(agentsResp?.agents || []);
+      setRoles(rolesResp?.roles || []);
+      setOu(ouResp || null);
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAll();
+  }, [loadAll]);
+
+  async function handleCreate({ name, description, selectedRoleIds }) {
+    setError("");
+    if (!ou?.id) {
+      setError("Default organization unit not loaded yet.");
+      return null;
+    }
+    const accessToken = await getAccessTokenRef.current();
+    const created = await createAgent(accessToken, {
+      name,
+      description,
+      ouId: ou.id
+    });
+
+    for (const roleId of selectedRoleIds) {
+      try {
+        await addAgentRoleAssignment(accessToken, roleId, created.id);
+      } catch (assignErr) {
+        setError(`Agent created but role assignment failed: ${formatError(assignErr)}`);
+      }
+    }
+
+    const creds = extractAgentOAuthCreds(created);
+    setCreatedCreds({
+      agentName: created.name,
+      clientId: creds.clientId,
+      clientSecret: creds.clientSecret
+    });
+    setShowCreate(false);
+    await loadAll();
+    return created;
+  }
+
+  async function handleDelete(agentId) {
+    if (!window.confirm("Delete this agent? Its OAuth client will stop working immediately.")) {
+      return;
+    }
+    setError("");
+    try {
+      const accessToken = await getAccessTokenRef.current();
+      await deleteAgent(accessToken, agentId);
+      await loadAll();
+    } catch (err) {
+      setError(formatError(err));
+    }
+  }
+
+  return (
+    <main className="bookings-page">
+      <section className="management-header">
+        <div>
+          <p className="eyebrow">Agent Portal</p>
+          <h1>Agents</h1>
+          <p style={{ marginTop: 4, color: "#666" }}>
+            Provision agent identities with roles to perform actions on Wayfinder.
+            The agent can then sign in via the &ldquo;Log in as Agent&rdquo; path
+            using the credentials shown here.
+          </p>
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button
+            className="dashboard-action dashboard-action--secondary"
+            type="button"
+            onClick={() => loadAll()}
+            disabled={isLoading}
+          >
+            <RefreshCw size={16} /> Refresh
+          </button>
+          <button
+            className="dashboard-action"
+            type="button"
+            onClick={() => setShowCreate(true)}
+            disabled={!ou?.id}
+          >
+            <Plus size={16} /> Create agent
+          </button>
+        </div>
+      </section>
+
+      {error && (
+        <div className="api-status api-status--error" role="status">
+          {error}
+        </div>
+      )}
+
+      {createdCreds && (
+        <CredentialsCallout creds={createdCreds} onDismiss={() => setCreatedCreds(null)} />
+      )}
+
+      <section
+        className="management-panel"
+        aria-label="Agents"
+        style={{ minHeight: 0 }}
+      >
+        {isLoading && <p className="empty-state management-message">Loading agents…</p>}
+        {!isLoading && agents.length === 0 && (
+          <div className="management-empty-state">
+            <h2>No agents yet</h2>
+            <p>Create your first agent to mint credentials for it.</p>
+          </div>
+        )}
+        {!isLoading && agents.length > 0 && (
+          <AgentTable agents={agents} onDelete={handleDelete} />
+        )}
+      </section>
+
+      {showCreate && (
+        <CreateAgentModal
+          roles={roles}
+          ou={ou}
+          onCancel={() => setShowCreate(false)}
+          onCreate={handleCreate}
+        />
+      )}
+    </main>
+  );
+}
+
+function AgentTable({ agents, onDelete }) {
+  return (
+    <>
+      <div className="booking-table-heading" aria-hidden="true">
+        <span>Name</span>
+        <span>Agent ID</span>
+        <span>Description</span>
+        <span></span>
+      </div>
+      {agents.map((agent) => (
+        <div className="booking-row" key={agent.id} role="row">
+          <div className="booking-route">
+            <Bot size={16} style={{ marginBottom: 4 }} />
+            <strong>{agent.name}</strong>
+            <small>{agent.type || "default"}</small>
+          </div>
+          <div className="booking-cell">
+            <strong style={{ wordBreak: "break-all" }}>{agent.clientId || "—"}</strong>
+            <span>Sign-in identifier</span>
+          </div>
+          <div className="booking-cell">
+            <span>{agent.description || "—"}</span>
+          </div>
+          <div className="booking-price" style={{ alignItems: "flex-end" }}>
+            <button
+              className="dashboard-action dashboard-action--secondary"
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                onDelete(agent.id);
+              }}
+              title="Delete agent"
+            >
+              <Trash2 size={16} />
+            </button>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+const HIDDEN_ROLE_NAMES = new Set(["administrator"]);
+
+function CreateAgentModal({ roles, ou, onCancel, onCreate }) {
+  const assignableRoles = useMemo(
+    () => roles.filter((role) => !HIDDEN_ROLE_NAMES.has((role.name || "").trim().toLowerCase())),
+    [roles]
+  );
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [selectedRoles, setSelectedRoles] = useState(() => new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [localError, setLocalError] = useState("");
+
+  function toggleRole(roleId) {
+    setSelectedRoles((prev) => {
+      const next = new Set(prev);
+      if (next.has(roleId)) {
+        next.delete(roleId);
+      } else {
+        next.add(roleId);
+      }
+      return next;
+    });
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    setLocalError("");
+    if (!name.trim()) {
+      setLocalError("Name is required.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await onCreate({
+        name,
+        description,
+        selectedRoleIds: Array.from(selectedRoles)
+      });
+    } catch (err) {
+      setLocalError(formatError(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div style={modalBackdrop} onClick={onCancel}>
+      <div style={modalCard} onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <h2 style={{ margin: 0 }}>Create agent</h2>
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Close"
+            style={iconButton}
+          >
+            <X size={18} />
+          </button>
+        </div>
+        <p style={{ color: "#666", marginTop: 4 }}>
+          Agent will be created in OU{" "}
+          <code>{ou?.handle || "default"}</code>.
+        </p>
+        <form onSubmit={handleSubmit} style={{ display: "grid", gap: 12, marginTop: 8 }}>
+          <label style={fieldLabel}>
+            Name
+            <input
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. trip-research-bot"
+              style={fieldInput}
+            />
+          </label>
+          <label style={fieldLabel}>
+            Description
+            <input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What is this agent for?"
+              style={fieldInput}
+            />
+          </label>
+          <fieldset style={{ border: "1px solid #e2e2e2", borderRadius: 8, padding: 12 }}>
+            <legend style={{ fontSize: 13, color: "#444", padding: "0 6px" }}>
+              Roles ({assignableRoles.length} available)
+            </legend>
+            {assignableRoles.length === 0 && (
+              <p style={{ margin: 0, color: "#888" }}>No roles available.</p>
+            )}
+            <div style={{ maxHeight: 200, overflowY: "auto", display: "grid", gap: 4 }}>
+              {assignableRoles.map((role) => (
+                <label
+                  key={role.id}
+                  style={{
+                    display: "flex",
+                    gap: 8,
+                    alignItems: "flex-start",
+                    padding: "4px 0"
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedRoles.has(role.id)}
+                    onChange={() => toggleRole(role.id)}
+                  />
+                  <span>
+                    <strong>{role.name}</strong>
+                    {role.description && (
+                      <span style={{ color: "#666", display: "block", fontSize: 12 }}>
+                        {role.description}
+                      </span>
+                    )}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+          {localError && (
+            <div className="api-status api-status--error" role="status">
+              {localError}
+            </div>
+          )}
+          <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+            <button
+              type="button"
+              className="dashboard-action dashboard-action--secondary"
+              onClick={onCancel}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="dashboard-action"
+              disabled={submitting}
+            >
+              {submitting ? "Creating…" : "Create agent"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function CredentialsCallout({ creds, onDismiss }) {
+  return (
+    <section
+      style={{
+        background: "#0f172a",
+        color: "white",
+        padding: 16,
+        borderRadius: 12,
+        marginBottom: 16
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h2 style={{ margin: 0, fontSize: 18 }}>
+          Credentials for {creds.agentName}
+        </h2>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss credentials"
+          style={{ ...iconButton, color: "white" }}
+        >
+          <X size={18} />
+        </button>
+      </div>
+      <p style={{ margin: "4px 0 12px", color: "#cbd5e1" }}>
+        Copy these now — the agent secret will not be shown again.
+      </p>
+      <CredField label="Agent ID" value={creds.clientId} />
+      <CredField label="Agent Secret" value={creds.clientSecret} mono secret />
+    </section>
+  );
+}
+
+function CredField({ label, value, mono, secret }) {
+  const [copied, setCopied] = useState(false);
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(value || "");
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  }
+  return (
+    <div style={{ display: "grid", gap: 4, marginBottom: 8 }}>
+      <span style={{ fontSize: 12, color: "#94a3b8" }}>{label}</span>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          background: "#1e293b",
+          padding: "8px 10px",
+          borderRadius: 6
+        }}
+      >
+        <code
+          style={{
+            flex: 1,
+            wordBreak: "break-all",
+            fontFamily: mono ? "monospace" : undefined,
+            fontSize: 13,
+            color: secret ? "#fde68a" : "white"
+          }}
+        >
+          {value || "—"}
+        </code>
+        <button
+          type="button"
+          onClick={copy}
+          aria-label={`Copy ${label}`}
+          style={{
+            background: "transparent",
+            color: copied ? "#86efac" : "white",
+            border: "1px solid #334155",
+            borderRadius: 6,
+            padding: "4px 8px",
+            cursor: "pointer",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4
+          }}
+        >
+          <Copy size={14} />
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function formatError(err) {
+  if (!err) return "Unknown error";
+  if (err.status === 401 || err.status === 403) {
+    return `${err.message} — make sure you are signed in as an admin user with the 'system' scope.`;
+  }
+  return err.message || String(err);
+}
+
+const modalBackdrop = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(15, 23, 42, 0.55)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 50
+};
+
+const modalCard = {
+  background: "white",
+  borderRadius: 12,
+  padding: 20,
+  width: "min(540px, 92vw)",
+  maxHeight: "85vh",
+  overflowY: "auto",
+  boxShadow: "0 24px 60px rgba(0,0,0,0.25)"
+};
+
+const fieldLabel = {
+  display: "grid",
+  gap: 4,
+  fontSize: 13,
+  color: "#374151"
+};
+
+const fieldInput = {
+  padding: "8px 10px",
+  borderRadius: 6,
+  border: "1px solid #d1d5db",
+  fontSize: 14
+};
+
+const iconButton = {
+  background: "transparent",
+  border: "none",
+  cursor: "pointer",
+  padding: 4,
+  color: "inherit"
+};

--- a/samples/apps/agent-id-sample/frontend/src/pages/BookingDetailsPageWithAuth.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/BookingDetailsPageWithAuth.jsx
@@ -1,0 +1,208 @@
+import { useEffect, useRef, useState } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import { Link } from "react-router-dom";
+import { ChevronLeft, Plane, ShieldCheck } from "lucide-react";
+import { getBookedFlights } from "../api";
+import { formatPrice, getBookingReference } from "../utils/bookings";
+
+const walletCredentialOffer = import.meta.env.VITE_WALLET_CREDENTIAL_OFFER || "";
+
+export function BookingDetailsPageWithAuth({ bookingId }) {
+  const { getAccessToken, isSignedIn, signIn, user } = useAsgardeo();
+  const [booking, setBooking] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const userKey = user?.sub || user?.username || user?.userName || user?.email || "signed-in";
+  const getAccessTokenRef = useRef(getAccessToken);
+
+  useEffect(() => {
+    getAccessTokenRef.current = getAccessToken;
+  }, [getAccessToken]);
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    async function loadBooking() {
+      if (!isSignedIn) {
+        return;
+      }
+
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const accessToken = getAccessTokenRef.current ? await getAccessTokenRef.current() : null;
+        const bookings = await getBookedFlights(accessToken);
+        const selectedBooking = bookings.find((item) => String(item.id) === String(bookingId));
+
+        if (isCurrent) {
+          setBooking(selectedBooking || null);
+          setError(selectedBooking ? "" : "Booking not found.");
+        }
+      } catch (requestError) {
+        if (isCurrent) {
+          setError(requestError.message);
+        }
+      } finally {
+        if (isCurrent) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadBooking();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [bookingId, isSignedIn, userKey]);
+
+  if (!isSignedIn) {
+    return (
+      <main className="bookings-page">
+        <section className="management-empty">
+          <div>
+            <p className="eyebrow">Booking details</p>
+            <h1>Sign in to view this booking.</h1>
+            <p>Booking details are available after authentication.</p>
+          </div>
+          <button className="dashboard-action dashboard-action--secondary" type="button" onClick={() => signIn({ acr_values: "urn:thunder:auth:user" })}>
+            Sign in
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="bookings-page">
+      <section className="management-header">
+        <div>
+          <Link className="back-link" to="/bookings">
+            <ChevronLeft size={18} />
+            Back to bookings
+          </Link>
+          <h1>{booking ? `${booking.flight.from} to ${booking.flight.to}` : "Booking"}</h1>
+          <p>{booking ? `Reference ${getBookingReference(booking)}` : "Loading booking information"}</p>
+        </div>
+      </section>
+
+      {error && (
+        <div className="api-status api-status--error" role="status">
+          {error}
+        </div>
+      )}
+
+      {isLoading && <p className="empty-state management-message">Loading booking details...</p>}
+
+      {!isLoading && booking && (
+        <section className="booking-detail-panel booking-confirmed-panel" aria-label="Booking information">
+          <div className="booking-flight-widget">
+            <div className="booking-flight-main">
+              <div className="booking-detail-topline">
+                <span className="booking-status">{booking.status}</span>
+                <strong>{booking.flight.airline}</strong>
+              </div>
+              <div className="itinerary-route">
+                <div>
+                  <span>{booking.flight.departureTime}</span>
+                  <strong>{booking.flight.from}</strong>
+                </div>
+                <div className="itinerary-line">
+                  <Plane size={20} />
+                </div>
+                <div>
+                  <span>{booking.flight.arrivalTime}</span>
+                  <strong>{booking.flight.to}</strong>
+                </div>
+              </div>
+              <div className="itinerary-meta">
+                <span>{booking.flight.duration}</span>
+                <span>{booking.flight.stops === 0 ? "Nonstop" : `${booking.flight.stops} stop`}</span>
+                <span>{booking.flight.cabin}</span>
+              </div>
+            </div>
+            <aside className="wallet-qr-panel" aria-label="Wallet QR code">
+              <span>Add to wallet</span>
+              <div className="wallet-qr-frame">
+                <img
+                  alt="QR code for adding this booking to a wallet"
+                  src={`https://api.qrserver.com/v1/create-qr-code/?size=180x180&data=${encodeURIComponent(walletCredentialOffer)}`}
+                />
+              </div>
+              <p>Scan with a compatible wallet app.</p>
+            </aside>
+          </div>
+
+          <div className="booking-detail-sections booking-confirmed-sections">
+            <section>
+              <h2>Trip details</h2>
+              <dl>
+                <div>
+                  <dt>Travel dates</dt>
+                  <dd>{booking.flight.dates}</dd>
+                </div>
+                <div>
+                  <dt>Travelers</dt>
+                  <dd>
+                    {booking.travelers} traveler{booking.travelers === 1 ? "" : "s"}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Duration</dt>
+                  <dd>{booking.flight.duration}</dd>
+                </div>
+              </dl>
+            </section>
+            <section>
+              <h2>Booking details</h2>
+              <dl>
+                <div>
+                  <dt>Reference</dt>
+                  <dd>{getBookingReference(booking)}</dd>
+                </div>
+                <div>
+                  <dt>Booked on</dt>
+                  <dd>{new Date(booking.createdAt).toLocaleDateString()}</dd>
+                </div>
+                <div>
+                  <dt>Status</dt>
+                  <dd>{booking.status}</dd>
+                </div>
+              </dl>
+            </section>
+            <section>
+              <h2>Payment</h2>
+              <dl>
+                <div>
+                  <dt>Total paid</dt>
+                  <dd>{formatPrice(booking.flight.currency, booking.flight.price)}</dd>
+                </div>
+                <div>
+                  <dt>Fare type</dt>
+                  <dd>{booking.flight.cabin}</dd>
+                </div>
+              </dl>
+            </section>
+          </div>
+
+          <section className="travel-insurance-section" aria-label="Travel insurance offer">
+            <div className="travel-insurance-icon" aria-hidden="true">
+              <ShieldCheck size={26} />
+            </div>
+            <div>
+              <span>Travel protection</span>
+              <h2>Add travel insurance before you fly.</h2>
+              <p>
+                Cover unexpected delays, medical emergencies, and baggage issues for this trip.
+              </p>
+            </div>
+            <button className="travel-insurance-button" type="button">
+              Buy insurance
+            </button>
+          </section>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/samples/apps/agent-id-sample/frontend/src/pages/BookingsPageWithAuth.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/BookingsPageWithAuth.jsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import { Link } from "react-router-dom";
+import { getBookedFlights } from "../api";
+import { formatPrice, getBookingReference } from "../utils/bookings";
+
+export function BookingsPageWithAuth() {
+  const { getAccessToken, isSignedIn, signIn, user } = useAsgardeo();
+  const [bookings, setBookings] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const userKey = user?.sub || user?.username || user?.userName || user?.email || "signed-in";
+  const getAccessTokenRef = useRef(getAccessToken);
+
+  useEffect(() => {
+    getAccessTokenRef.current = getAccessToken;
+  }, [getAccessToken]);
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    async function loadBookings() {
+      if (!isSignedIn) {
+        return;
+      }
+
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const accessToken = getAccessTokenRef.current ? await getAccessTokenRef.current() : null;
+        const data = await getBookedFlights(accessToken);
+
+        if (isCurrent) {
+          setBookings(data);
+        }
+      } catch (requestError) {
+        if (isCurrent) {
+          setError(requestError.message);
+        }
+      } finally {
+        if (isCurrent) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadBookings();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [isSignedIn, userKey]);
+
+  if (!isSignedIn) {
+    return (
+      <main className="bookings-page">
+        <section className="management-empty">
+          <div>
+            <p className="eyebrow">Bookings</p>
+            <h1>Sign in to manage your bookings.</h1>
+            <p>View confirmed trips, booking status, passenger count, and flight details.</p>
+          </div>
+          <button className="dashboard-action dashboard-action--secondary" type="button" onClick={() => signIn({ acr_values: "urn:thunder:auth:user" })}>
+            Sign in
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="bookings-page">
+      <section className="management-header">
+        <div>
+          <p className="eyebrow">Management</p>
+          <h1>Bookings</h1>
+        </div>
+      </section>
+
+      {error && (
+        <div className="api-status api-status--error" role="status">
+          {error}
+        </div>
+      )}
+
+      <section className="management-panel" aria-label="Booked flights">
+        {isLoading && <p className="empty-state management-message">Loading booked flights...</p>}
+        {!isLoading && bookings.length === 0 && (
+          <div className="management-empty-state">
+            <h2>No bookings yet</h2>
+            <p>Your confirmed flights will appear here after booking.</p>
+            <Link className="dashboard-action dashboard-action--secondary" to="/flights#search">
+              Start searching
+            </Link>
+          </div>
+        )}
+        {!isLoading &&
+          bookings.length > 0 && (
+            <div className="booking-table-heading" aria-hidden="true">
+              <span>Route</span>
+              <span>Reference</span>
+              <span>Schedule</span>
+              <span>Travelers</span>
+              <span>Total</span>
+            </div>
+          )}
+        {!isLoading &&
+          bookings.length > 0 &&
+          bookings.map((booking) => (
+            <Link className="booking-row" to={`/bookings/${booking.id}`} key={booking.id}>
+              <div className="booking-route">
+                <span className="booking-status">{booking.status}</span>
+                <strong>{booking.flight.from} to {booking.flight.to}</strong>
+                <small>Booked {new Date(booking.createdAt).toLocaleDateString()}</small>
+              </div>
+              <div className="booking-cell">
+                <strong>{getBookingReference(booking)}</strong>
+                <span>Booking reference</span>
+              </div>
+              <div className="booking-cell">
+                <strong>{booking.flight.departureTime} - {booking.flight.arrivalTime}</strong>
+                <span>{booking.flight.duration} · {booking.flight.dates}</span>
+              </div>
+              <div className="booking-cell">
+                <strong>
+                  {booking.travelers} traveler{booking.travelers === 1 ? "" : "s"}
+                </strong>
+                <span>{booking.flight.cabin}</span>
+              </div>
+              <div className="booking-price">
+                <strong>{formatPrice(booking.flight.currency, booking.flight.price)}</strong>
+              </div>
+            </Link>
+          ))}
+      </section>
+    </main>
+  );
+}

--- a/samples/apps/agent-id-sample/frontend/src/pages/BookingsUnavailable.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/BookingsUnavailable.jsx
@@ -1,0 +1,13 @@
+export function BookingsUnavailable() {
+  return (
+    <main className="bookings-page">
+      <section className="management-empty">
+        <div>
+          <p className="eyebrow">Bookings</p>
+          <h1>Configure Asgardeo to manage bookings.</h1>
+          <p>Live booking management is available after the Asgardeo client settings are added.</p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/samples/apps/agent-id-sample/frontend/src/pages/FlightDetailsPage.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/FlightDetailsPage.jsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { ChevronLeft, Plane } from "lucide-react";
+import { getFlight } from "../api";
+import { formatPrice } from "../utils/bookings";
+import { buildFlightPaymentPath } from "../utils/routes";
+
+export function FlightDetailsPage({ criteria, flightId }) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [flight, setFlight] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    async function loadFlight() {
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const data = await getFlight(flightId);
+
+        if (isCurrent) {
+          setFlight(data);
+        }
+      } catch (requestError) {
+        if (isCurrent) {
+          setError(requestError.message);
+        }
+      } finally {
+        if (isCurrent) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadFlight();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [flightId]);
+
+  return (
+    <main className="bookings-page">
+      <section className="management-header">
+        <div>
+          <Link className="back-link" to={`/results${location.search}`}>
+            <ChevronLeft size={18} />
+            Back to results
+          </Link>
+          <p className="eyebrow">Flight details</p>
+          <h1>{flight ? `${flight.from} to ${flight.to}` : "Flight details"}</h1>
+          <p>{flight ? `${flight.airline} · ${flight.dates}` : "Review your selected flight"}</p>
+        </div>
+      </section>
+
+      {error && (
+        <div className="api-status api-status--error" role="status">
+          {error}
+        </div>
+      )}
+
+      {isLoading && <p className="empty-state management-message">Loading flight details...</p>}
+
+      {!isLoading && flight && (
+        <section className="booking-detail-panel flight-review-panel" aria-label="Flight information">
+          <div className="flight-review-layout">
+            <div className="flight-review-main">
+              <div className="booking-itinerary-card">
+                <div className="booking-detail-topline">
+                  <span className="booking-status">Selected</span>
+                  <strong>{flight.airline}</strong>
+                </div>
+                <div className="itinerary-route">
+                  <div>
+                    <span>{flight.departureTime}</span>
+                    <strong>{flight.from}</strong>
+                  </div>
+                  <div className="itinerary-line">
+                    <Plane size={20} />
+                  </div>
+                  <div>
+                    <span>{flight.arrivalTime}</span>
+                    <strong>{flight.to}</strong>
+                  </div>
+                </div>
+                <div className="itinerary-meta">
+                  <span>{flight.duration}</span>
+                  <span>{flight.stops === 0 ? "Nonstop" : `${flight.stops} stop`}</span>
+                  <span>{flight.cabin}</span>
+                  <span>{criteria.travelers || "1 Adult, Economy"}</span>
+                </div>
+              </div>
+
+              <div className="booking-detail-sections flight-review-sections">
+                <section>
+                  <h2>Schedule</h2>
+                  <dl>
+                    <div>
+                      <dt>Travel dates</dt>
+                      <dd>{flight.dates}</dd>
+                    </div>
+                    <div>
+                      <dt>Duration</dt>
+                      <dd>{flight.duration}</dd>
+                    </div>
+                  </dl>
+                </section>
+                <section>
+                  <h2>Fare</h2>
+                  <dl>
+                    <div>
+                      <dt>Cabin</dt>
+                      <dd>{flight.cabin}</dd>
+                    </div>
+                    <div>
+                      <dt>Stops</dt>
+                      <dd>{flight.stops === 0 ? "Nonstop" : `${flight.stops} stop`}</dd>
+                    </div>
+                  </dl>
+                </section>
+              </div>
+            </div>
+
+            <aside className="booking-receipt-card flight-review-summary" aria-label="Flight price">
+              <div className="flight-review-summary-content">
+                <span>Total</span>
+                <strong>{formatPrice(flight.currency, flight.price)}</strong>
+                <p>Includes taxes and charges.</p>
+                <dl>
+                  <div>
+                    <dt>Airline</dt>
+                    <dd>{flight.airline}</dd>
+                  </div>
+                  <div>
+                    <dt>Travelers</dt>
+                    <dd>{criteria.travelers || "1 Adult, Economy"}</dd>
+                  </div>
+                </dl>
+              </div>
+              <button
+                className="wallet-button flight-review-confirm"
+                type="button"
+                onClick={() => navigate(buildFlightPaymentPath(flight.id, criteria))}
+              >
+                Confirm
+              </button>
+            </aside>
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/samples/apps/agent-id-sample/frontend/src/pages/HomePage.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/HomePage.jsx
@@ -1,0 +1,383 @@
+import { useAsgardeo } from "@asgardeo/react";
+import {
+  ArrowRight,
+  Clock3,
+  Hotel,
+  LifeBuoy,
+  Plane,
+  Search,
+  ShieldCheck,
+  Sparkles,
+  Star
+} from "lucide-react";
+import { SearchPanel } from "../components/SearchPanel";
+
+const pageDetails = {
+  flights: {
+    heroHeading: "Find flights for wherever you are headed.",
+    heroCopy:
+      "Compare flexible fares, departure times, and routes while keeping bookings connected to a secure account experience.",
+    freshPicksHeading: "Flight ideas for your next window of free time.",
+    whyTitle: "A cleaner path from route search to booking.",
+    whyCopy:
+      "Keep the practical pieces close together: route ideas, dates, traveler counts, and authenticated bookings.",
+    highlights: [
+      {
+        icon: <Sparkles size={22} />,
+        title: "Flexible fares",
+        copy: "Compare routes, cabins, and timings from one calm workspace."
+      },
+      {
+        icon: <ShieldCheck size={22} />,
+        title: "Protected bookings",
+        copy: "Keep booked trips connected to secure Asgardeo sign-in."
+      },
+      {
+        icon: <Clock3 size={22} />,
+        title: "Fast comparisons",
+        copy: "Filter practical options for routes, dates, and travelers."
+      }
+    ],
+    deals: [
+      {
+        className: "deal-card--mint",
+        icon: <Plane size={22} />,
+        route: "Colombo to Singapore",
+        title: "Nonstop city break with smart baggage picks",
+        price: "$420",
+        meta: "Jun 12 - Jun 18"
+      },
+      {
+        className: "deal-card--coral",
+        icon: <Plane size={22} />,
+        route: "Colombo to Tokyo",
+        title: "Evening departure with a comfortable connection",
+        price: "$610",
+        meta: "Economy round trip"
+      },
+      {
+        className: "deal-card--gold",
+        icon: <Plane size={22} />,
+        route: "Colombo to Dubai",
+        title: "Short-haul escape with flexible return dates",
+        price: "$380",
+        meta: "Best value this week"
+      }
+    ]
+  },
+  hotels: {
+    heroHeading: "Find stays that fit the way you travel.",
+    heroCopy:
+      "Compare areas, nightly rates, and useful amenities before choosing the stay that keeps your trip simple.",
+    freshPicksHeading: "Stay ideas close to food, rail, and plans.",
+    whyTitle: "A cleaner path from area search to reservation.",
+    whyCopy:
+      "Keep destinations, dates, guest counts, and stay preferences in one focused search flow.",
+    highlights: [
+      {
+        icon: <Hotel size={22} />,
+        title: "Area-first search",
+        copy: "Start from the neighborhood or district that fits the trip."
+      },
+      {
+        icon: <Star size={22} />,
+        title: "Useful amenities",
+        copy: "Compare the details that matter for repeatable travel decisions."
+      },
+      {
+        icon: <Clock3 size={22} />,
+        title: "Quick scanning",
+        copy: "Nightly rates and dates stay easy to compare."
+      }
+    ],
+    deals: [
+      {
+        className: "deal-card--mint",
+        icon: <Hotel size={22} />,
+        route: "Singapore Marina",
+        title: "Waterfront stays close to transit and evening plans",
+        price: "$210",
+        meta: "Average nightly rate"
+      },
+      {
+        className: "deal-card--coral",
+        icon: <Hotel size={22} />,
+        route: "Tokyo Shibuya",
+        title: "Walkable rooms near food, rail, and late-night plans",
+        price: "$186",
+        meta: "Guest favorite area"
+      },
+      {
+        className: "deal-card--gold",
+        icon: <Hotel size={22} />,
+        route: "London Kings Cross",
+        title: "Rail-friendly stays for a compact city visit",
+        price: "$240",
+        meta: "Central location"
+      }
+    ]
+  },
+  trips: {
+    heroHeading: "Find trip ideas when the destination is still forming.",
+    heroCopy:
+      "Explore city plans, estimated budgets, and flexible destination ideas before turning curiosity into a booking.",
+    freshPicksHeading: "Trip ideas with enough structure to start.",
+    whyTitle: "A cleaner path from inspiration to itinerary.",
+    whyCopy:
+      "Keep destinations, estimates, and plan types together so comparing possible trips feels lighter.",
+    highlights: [
+      {
+        icon: <Sparkles size={22} />,
+        title: "Curated ideas",
+        copy: "Compare ready-to-shape city plans before you commit."
+      },
+      {
+        icon: <Star size={22} />,
+        title: "Budget signals",
+        copy: "Estimated trip totals keep options grounded."
+      },
+      {
+        icon: <LifeBuoy size={22} />,
+        title: "Flexible planning",
+        copy: "Move from inspiration to search without switching tools."
+      }
+    ],
+    deals: [
+      {
+        className: "deal-card--mint",
+        icon: <Sparkles size={22} />,
+        route: "Singapore highlights",
+        title: "A food, gardens, and skyline plan for a long weekend",
+        price: "$620",
+        meta: "Estimated trip total"
+      },
+      {
+        className: "deal-card--coral",
+        icon: <Sparkles size={22} />,
+        route: "Tokyo first-timer",
+        title: "A practical city plan with rail-friendly neighborhoods",
+        price: "$920",
+        meta: "Five-day estimate"
+      },
+      {
+        className: "deal-card--gold",
+        icon: <Sparkles size={22} />,
+        route: "Dubai highlights",
+        title: "A polished three-day plan with room to wander",
+        price: "$780",
+        meta: "Estimated trip total"
+      }
+    ]
+  }
+};
+
+export function HomePage({
+  category = "flights",
+  hideHeroSupport = false,
+  heroHeading,
+  locations,
+  onSearch,
+  showSearch = false
+}) {
+  const details = pageDetails[category] || pageDetails.flights;
+  const isGreetingHero = hideHeroSupport;
+
+  const faqs = [
+    {
+      question: "How does Skyscanner work?",
+      answer: "We’re a flight, car hire and hotel search engine. We scan all the top airlines and travel providers across the net, so you can compare flight fares and other travel costs in one place. Once you’ve found the best flight, car hire or hotel, you book directly with the provider."
+    },
+    {
+      question: "How can I find the cheapest flight using Skyscanner?",
+      answer: "Finding flights is easy here – over 100 million savvy travellers come to us each month to find cheap flight tickets, hotels and car hire. Here are a few simple tips on how to get the most out of your flight search. Save money and time. Whether it's the fastest flight or the smartest stay, you can pick your preferred flight provider or hotel based on real traveller ratings, and book instantly. Search Everywhere. Go anywhere. Fancy a trip but don’t mind where? Or perhaps you want to discover somewhere new. Search ‘Everywhere’ for the best budget airfare anywhere on any given day. Find the cheapest time to fly. If you have a destination in mind and want to find the cheapest flight, choose ‘Cheapest month’ when you search. Then find flights on the cheapest day."
+    },
+    {
+      question: "Where should I book a flight to right now?",
+      answer: "If you're looking for inspiration for your next trip, search Everywhere to find a cheap flight ticket anywhere."
+    },
+    {
+      question: "Do I book my flight with Skyscanner?",
+      answer: "We’re a search engine, so after you’ve found the best flight ticket you’ll book directly with the airline or travel provider on their site. This will give you the opportunity to add any loyalty information you would like and select your preferred flight options, such as seating."
+    },
+    {
+      question: "What happens after I have booked my flight?",
+      answer: "Your flight booking confirmation email and all the other info you'll need will come from the airline or provider you booked with. If you have any follow-up questions about your booking, or want to change or cancel your flight, you’d need to get in touch with them."
+    },
+    {
+      question: "Does Skyscanner do hotels too?",
+      answer: "Yes. You can use the same magic that powers flight search to find your perfect stay anywhere."
+    },
+    {
+      question: "What about car hire?",
+      answer: "You can also use Skyscanner to search for and compare cheap car hire in seconds, then pick up your wheels from the airport as soon as you touch down."
+    },
+    {
+      question: "What’s a Price Alert?",
+      answer: "If you set up a Price Alert, we’ll watch the price of plane tickets for you, and let you know via email or push notification via the app if they rise or fall."
+    }
+  ];
+
+  return (
+    <main>
+      <section className={`hero ${isGreetingHero ? "hero--greeting" : ""}`} id="search">
+        <div className="hero-copy">
+          <h1>{heroHeading || details.heroHeading}</h1>
+          {!hideHeroSupport && (
+            <>
+              <p>{details.heroCopy}</p>
+              <div className="hero-actions" aria-label="Popular planning links">
+                <a className="secondary-button" href="#deals">
+                  <Sparkles size={18} />
+                  See ideas
+                </a>
+                <a className="link-button" href="#faq">
+                  FAQ
+                  <ArrowRight size={18} />
+                </a>
+              </div>
+            </>
+          )}
+        </div>
+        {showSearch && (
+          <SearchPanel
+            compact
+            defaultCategory={category}
+            locations={locations}
+            onSearch={onSearch}
+          />
+        )}
+      </section>
+
+      <section className="insight-strip" aria-label="Wayfinder highlights">
+        {details.highlights.map((item) => (
+          <div key={item.title}>
+            {item.icon}
+            <span>
+              <strong>{item.title}</strong>
+              <small>{item.copy}</small>
+            </span>
+          </div>
+        ))}
+      </section>
+
+      <section className="content-band" id="deals">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">Fresh picks</p>
+            <h2>{details.freshPicksHeading}</h2>
+          </div>
+          <a className="link-button" href="#search">
+            Start searching
+            <ArrowRight size={18} />
+          </a>
+        </div>
+        <div className="deal-grid">
+          {details.deals.map((deal) => (
+            <article className={`deal-card ${deal.className}`} key={deal.title}>
+              <div className="deal-icon">{deal.icon}</div>
+              <p>{deal.route}</p>
+              <h3>{deal.title}</h3>
+              <span>{deal.meta}</span>
+              <strong>{deal.price}</strong>
+              <button className="card-action" type="button" onClick={() => window.location.hash = "search"}>
+                Explore
+              </button>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="two-column content-band">
+        <div>
+          <p className="eyebrow">Why Wayfinder</p>
+          <h2>{details.whyTitle}</h2>
+          <p className="section-copy">{details.whyCopy}</p>
+          <a className="secondary-button" href="#search">
+            <Search size={18} />
+            Plan a route
+          </a>
+        </div>
+        <div className="stay-list">
+          <article className="stay-card">
+            <div>
+              <h3>Secure account journey</h3>
+              <p>Sign in, sign up, and booking actions sit naturally in the flow.</p>
+            </div>
+            <div className="stay-meta">
+              <span>
+                <ShieldCheck size={18} />
+              </span>
+              <strong>Asgardeo</strong>
+            </div>
+          </article>
+          <article className="stay-card">
+            <div>
+              <h3>Human-friendly choices</h3>
+              <p>Flights, hotels, and trip ideas are grouped for repeat comparison.</p>
+            </div>
+            <div className="stay-meta">
+              <span>
+                <Star size={18} />
+              </span>
+              <strong>Curated</strong>
+            </div>
+          </article>
+          <article className="stay-card">
+            <div>
+              <h3>Support-ready setup</h3>
+              <p>Fallback sample data keeps the front end useful while APIs connect.</p>
+            </div>
+            <div className="stay-meta">
+              <span>
+                <LifeBuoy size={18} />
+              </span>
+              <strong>Resilient</strong>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section className="faq-section" id="faq">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">FAQ</p>
+            <h2>Answers before takeoff.</h2>
+          </div>
+        </div>
+        <div className="faq-grid">
+          {faqs.map((faq) => (
+            <details className="faq-item" key={faq.question}>
+              <summary>{faq.question}</summary>
+              <p>{faq.answer}</p>
+            </details>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export function SignedInHomePage({ category = "flights", locations, onSearch }) {
+  const { isSignedIn, user } = useAsgardeo();
+
+  if (!isSignedIn) {
+    return <HomePage category={category} locations={locations} onSearch={onSearch} />;
+  }
+
+  const firstName = user?.name?.givenName || "";
+  const lastName = user?.name?.familyName || "";
+  const fullName = `${firstName} ${lastName}`.trim();
+  const email = user?.email || user?.mail || user?.username || user?.userName || "";
+  const greetingName = firstName || fullName || email || "Traveler";
+
+  return (
+    <HomePage
+      hideHeroSupport
+      category={category}
+      heroHeading={`Welcome back, ${greetingName}.`}
+      locations={locations}
+      onSearch={onSearch}
+      showSearch
+    />
+  );
+}

--- a/samples/apps/agent-id-sample/frontend/src/pages/PaymentPageWithAuth.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/PaymentPageWithAuth.jsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import { Link, useNavigate } from "react-router-dom";
+import { ChevronLeft, CreditCard } from "lucide-react";
+import { createBooking, getBookedFlights, getFlight } from "../api";
+import { formatPrice, isSameFlight } from "../utils/bookings";
+import { buildFlightDetailsPath } from "../utils/routes";
+
+export function PaymentPageWithAuth({ criteria, flightId }) {
+  const navigate = useNavigate();
+  const { getAccessToken, isSignedIn, signIn, user } = useAsgardeo();
+  const [flight, setFlight] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [paymentState, setPaymentState] = useState("idle");
+  const [error, setError] = useState("");
+  const userKey = user?.sub || user?.username || user?.userName || user?.email || "signed-in";
+  const getAccessTokenRef = useRef(getAccessToken);
+
+  useEffect(() => {
+    getAccessTokenRef.current = getAccessToken;
+  }, [getAccessToken]);
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    async function loadFlight() {
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const data = await getFlight(flightId);
+
+        if (isCurrent) {
+          setFlight(data);
+        }
+      } catch (requestError) {
+        if (isCurrent) {
+          setError(requestError.message);
+        }
+      } finally {
+        if (isCurrent) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadFlight();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [flightId, userKey]);
+
+  async function handlePayment() {
+    if (!flight) {
+      return;
+    }
+
+    setPaymentState("paying");
+    setError("");
+
+    try {
+      const accessToken = getAccessTokenRef.current ? await getAccessTokenRef.current() : null;
+      const booking = await createBooking({
+        type: "flight",
+        itemId: flight.id,
+        travelers: Number.parseInt(criteria.travelers, 10) || 1
+      }, accessToken);
+
+      navigate(`/bookings/${encodeURIComponent(booking.id)}`);
+    } catch (requestError) {
+      try {
+        if (requestError.message.includes("already exists")) {
+          const accessToken = getAccessTokenRef.current ? await getAccessTokenRef.current() : null;
+          const bookings = await getBookedFlights(accessToken);
+          const existingBooking = bookings.find((booking) => isSameFlight(flight, booking.flight));
+
+          if (existingBooking) {
+            navigate(`/bookings/${encodeURIComponent(existingBooking.id)}`);
+            return;
+          }
+        }
+      } catch {
+        // Keep the original payment error visible.
+      }
+
+      setPaymentState("idle");
+      setError(requestError.message);
+    }
+  }
+
+  if (!isSignedIn) {
+    return (
+      <main className="bookings-page">
+        <section className="management-empty">
+          <div>
+            <p className="eyebrow">Payment</p>
+            <h1>Sign in to complete payment.</h1>
+            <p>Your flight will be booked only after payment is completed.</p>
+          </div>
+          <button className="dashboard-action dashboard-action--secondary" type="button" onClick={() => signIn({ acr_values: "urn:thunder:auth:user" })}>
+            Sign in
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="bookings-page">
+      <section className="management-header">
+        <div>
+          <Link className="back-link" to={buildFlightDetailsPath(flightId, criteria)}>
+            <ChevronLeft size={18} />
+            Back to flight
+          </Link>
+          <p className="eyebrow">Payment</p>
+          <h1>Complete payment</h1>
+          <p>{flight ? `${flight.from} to ${flight.to} · ${flight.airline}` : "Preparing checkout"}</p>
+        </div>
+      </section>
+
+      {error && (
+        <div className="api-status api-status--error" role="status">
+          {error}
+        </div>
+      )}
+
+      {isLoading && <p className="empty-state management-message">Loading payment details...</p>}
+
+      {!isLoading && flight && (
+        <section className="payment-panel" aria-label="Payment details">
+          <div className="payment-form-card">
+            <div className="booking-detail-topline">
+              <span className="booking-status">Secure payment</span>
+              <CreditCard size={22} />
+            </div>
+            <label className="payment-field">
+              <span>Card number</span>
+              <input readOnly value="4242 4242 4242 4242" aria-label="Card number" />
+            </label>
+            <div className="payment-field-grid">
+              <label className="payment-field">
+                <span>Expiry</span>
+                <input readOnly value="12 / 30" aria-label="Expiry" />
+              </label>
+              <label className="payment-field">
+                <span>CVC</span>
+                <input readOnly value="123" aria-label="CVC" />
+              </label>
+            </div>
+            <button
+              className="search-button standalone-button"
+              type="button"
+              disabled={paymentState === "paying"}
+              onClick={handlePayment}
+            >
+              {paymentState === "paying" ? "Processing..." : "Pay and confirm booking"}
+            </button>
+          </div>
+
+          <aside className="booking-receipt-card" aria-label="Payment summary">
+            <span>Total due</span>
+            <strong>{formatPrice(flight.currency, flight.price)}</strong>
+            <p>{criteria.travelers || "1 Adult, Economy"} · {flight.dates}</p>
+          </aside>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/samples/apps/agent-id-sample/frontend/src/pages/ResultsPage.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/ResultsPage.jsx
@@ -1,0 +1,261 @@
+import { useEffect, useState } from "react";
+import { useAsgardeo } from "@asgardeo/react";
+import { useNavigate } from "react-router-dom";
+import { SearchPanel } from "../components/SearchPanel";
+import {
+  createBooking,
+  getBookedFlights,
+  getFlights,
+  getHotels,
+  getTrips
+} from "../api";
+import { formatPrice, isSameFlight } from "../utils/bookings";
+import { buildFlightDetailsPath } from "../utils/routes";
+
+function BookingButton({ bookingState, children, onClick }) {
+  const isBooking = bookingState === "booking";
+  const isConfirmed = bookingState === "confirmed";
+
+  return (
+    <button
+      className={`card-action ${isConfirmed ? "card-action--confirmed" : ""}`}
+      type="button"
+      disabled={isBooking || isConfirmed}
+      onClick={onClick}
+    >
+      {isBooking ? "Booking..." : isConfirmed ? "Booked" : children}
+    </button>
+  );
+}
+
+function ResultCard({ bookingState, category, item, onBook, onSelectFlight }) {
+  if (category === "hotels") {
+    return (
+      <article className="result-card">
+        <div>
+          <p className="result-label">Hotel · Rating {item.rating}</p>
+          <h2>{item.name}</h2>
+          <p>{item.location}</p>
+          <div className="result-tags">
+            {item.amenities?.map((amenity) => (
+              <span key={amenity}>{amenity}</span>
+            ))}
+          </div>
+        </div>
+        <div className="result-side">
+          <strong>{formatPrice(item.currency, item.nightlyRate)}</strong>
+          <span>per night</span>
+          <BookingButton bookingState={bookingState} onClick={() => onBook("hotel", item.id)}>
+            Reserve
+          </BookingButton>
+        </div>
+      </article>
+    );
+  }
+
+  if (category === "trips") {
+    return (
+      <article className="result-card">
+        <div>
+          <p className="result-label">Trip · {item.status}</p>
+          <h2>{item.title}</h2>
+          <p>{item.destination}</p>
+        </div>
+        <div className="result-side">
+          <strong>{formatPrice(item.currency, item.totalEstimate)}</strong>
+          <span>estimate</span>
+          <BookingButton bookingState={bookingState} onClick={() => onBook("trip", item.id)}>
+            Book trip
+          </BookingButton>
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article className="result-card">
+      <div>
+        <p className="result-label">
+          {item.airline} · {item.stops === 0 ? "Nonstop" : `${item.stops} stop`}
+        </p>
+        <h2>{item.from} to {item.to}</h2>
+        <p>
+          {item.departureTime} - {item.arrivalTime} · {item.duration} · {item.dates}
+        </p>
+        <div className="result-tags">
+          {item.tags?.map((tag) => (
+            <span key={tag}>{tag}</span>
+          ))}
+        </div>
+      </div>
+      <div className="result-side">
+        <strong>{formatPrice(item.currency, item.price)}</strong>
+        <span>{item.cabin}</span>
+        <BookingButton bookingState={bookingState} onClick={() => onSelectFlight(item.id)}>
+          Book flight
+        </BookingButton>
+      </div>
+    </article>
+  );
+}
+
+export function ResultsPage({ criteria, getAccessToken, locations, onSearch }) {
+  const navigate = useNavigate();
+  const [results, setResults] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [bookingStates, setBookingStates] = useState({});
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    async function loadResults() {
+      setIsLoading(true);
+      setError("");
+      setBookingStates({});
+
+      try {
+        let data;
+
+        if (criteria.category === "hotels") {
+          data = await getHotels({ location: criteria.to });
+        } else if (criteria.category === "trips") {
+          data = await getTrips({ destination: criteria.to });
+        } else {
+          data = await getFlights({
+            from: criteria.from,
+            to: criteria.to
+          });
+        }
+
+        if (isCurrent) {
+          setResults(data);
+
+          if (criteria.category === "flights" && getAccessToken) {
+            try {
+              const accessToken = await getAccessToken();
+              const bookedFlights = await getBookedFlights(accessToken);
+              const nextBookingStates = {};
+
+              for (const result of data) {
+                if (bookedFlights.some((booking) => isSameFlight(result, booking.flight))) {
+                  nextBookingStates[result.id] = "confirmed";
+                }
+              }
+
+              if (isCurrent) {
+                setBookingStates(nextBookingStates);
+              }
+            } catch {
+              // Results should remain usable even if existing bookings cannot be checked.
+            }
+          }
+        }
+      } catch (requestError) {
+        if (isCurrent) {
+          setError(requestError.message);
+        }
+      } finally {
+        if (isCurrent) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadResults();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [criteria, getAccessToken]);
+
+  async function handleBooking(type, itemId) {
+    setError("");
+    setBookingStates((current) => ({
+      ...current,
+      [itemId]: "booking"
+    }));
+
+    try {
+      const accessToken = getAccessToken ? await getAccessToken() : null;
+
+      await createBooking({
+        type,
+        itemId,
+        travelers: Number.parseInt(criteria.travelers, 10) || 1
+      }, accessToken);
+
+      setBookingStates((current) => ({
+        ...current,
+        [itemId]: "confirmed"
+      }));
+    } catch (requestError) {
+      setBookingStates((current) => ({
+        ...current,
+        [itemId]: requestError.message.includes("already exists") ? "confirmed" : "idle"
+      }));
+      setError(requestError.message);
+    }
+  }
+
+  function handleFlightSelection(itemId) {
+    navigate(buildFlightDetailsPath(itemId, criteria));
+  }
+
+  const title =
+    criteria.category === "hotels"
+      ? `Hotels in ${criteria.to || "your destination"}`
+      : criteria.category === "trips"
+        ? `Trips to ${criteria.to || "your destination"}`
+        : `${criteria.from || "Anywhere"} to ${criteria.to || "anywhere"}`;
+
+  return (
+    <main>
+      <section className="results-hero">
+        <div>
+          <p className="eyebrow">Search results</p>
+          <h1>{title}</h1>
+          <p>
+            {criteria.dates || "Flexible dates"} · {criteria.travelers || "Any travelers"}
+          </p>
+        </div>
+        <SearchPanel
+          initialCriteria={criteria}
+          key={`${criteria.category}-${criteria.from}-${criteria.to}-${criteria.dates}-${criteria.travelers}`}
+          locations={locations}
+          onSearch={onSearch}
+        />
+      </section>
+
+      {error && (
+        <div className="api-status api-status--error" role="status">
+          {error}
+        </div>
+      )}
+
+      <section className="results-section" aria-label="Search results">
+        {isLoading && <p className="empty-state">Loading results...</p>}
+        {!isLoading && results.length === 0 && (
+          <p className="empty-state">No results matched this search.</p>
+        )}
+        {!isLoading &&
+          results.map((item) => (
+            <ResultCard
+              category={criteria.category}
+              item={item}
+              key={item.id}
+              bookingState={bookingStates[item.id] || "idle"}
+              onBook={handleBooking}
+              onSelectFlight={handleFlightSelection}
+            />
+          ))}
+      </section>
+    </main>
+  );
+}
+
+export function ResultsPageWithAuth(props) {
+  const { getAccessToken } = useAsgardeo();
+
+  return <ResultsPage {...props} getAccessToken={getAccessToken} />;
+}

--- a/samples/apps/agent-id-sample/frontend/src/styles.css
+++ b/samples/apps/agent-id-sample/frontend/src/styles.css
@@ -1,0 +1,2712 @@
+:root {
+  color: #111827;
+  background: #ffffff;
+  font-family:
+    Aptos, "Avenir Next", "SF Pro Text", "Helvetica Neue", ui-sans-serif,
+    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  font-weight: 400;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-shell {
+  min-height: 100vh;
+  background: #ffffff;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: center;
+  padding: 18px clamp(20px, 5vw, 72px);
+  background: rgba(255, 255, 255, 0.94);
+  border-bottom: 1px solid rgba(17, 24, 39, 0.1);
+  backdrop-filter: blur(18px);
+}
+
+.brand,
+.auth-cluster,
+.header-nav,
+.primary-small,
+.tabs,
+.trip-type,
+.field-control,
+.insight-strip div,
+.section-heading,
+.link-button,
+.secondary-button,
+.planner-actions,
+.filter-button,
+.icon-text-button,
+.user-chip {
+  display: flex;
+  align-items: center;
+}
+
+.brand {
+  gap: 10px;
+  font-weight: 600;
+  font-size: 1.08rem;
+}
+
+.header-nav {
+  gap: 8px;
+  justify-content: center;
+}
+
+.header-nav a,
+.header-link {
+  color: #2563eb;
+  font-weight: 700;
+}
+
+.header-nav a {
+  min-height: 38px;
+  padding: 9px 12px;
+  border-radius: 8px;
+}
+
+.header-nav a:hover {
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.brand-mark {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  color: #ffffff;
+  background: #2563eb;
+  border-radius: 8px;
+}
+
+.auth-cluster {
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.text-button,
+.primary-small,
+.icon-text-button,
+.search-button,
+.secondary-button,
+.link-button,
+.filter-button {
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.text-button {
+  padding: 0 12px;
+  color: #263136;
+  background: transparent;
+}
+
+.primary-small {
+  padding: 0 18px;
+  color: #151e24;
+  background: #ffd166;
+  box-shadow: 0 12px 26px rgba(255, 177, 66, 0.25);
+}
+
+.icon-text-button,
+.user-chip,
+.account-menu-item {
+  gap: 8px;
+}
+
+.icon-text-button {
+  padding: 0 14px;
+  color: #ffffff;
+  background: #263136;
+}
+
+.user-chip {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 2px;
+  column-gap: 9px;
+  align-items: center;
+  justify-items: start;
+  max-width: 300px;
+  min-height: 48px;
+  padding: 7px 12px;
+  overflow: hidden;
+  color: #1e3a8a;
+  background: #ffffff;
+  border: 0;
+  border-radius: 8px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.user-chip-avatar,
+.user-chip-chevron {
+  flex: 0 0 auto;
+  color: #2563eb;
+}
+
+.user-chip-avatar {
+  display: block;
+}
+
+.user-chip-chevron {
+  transition: transform 160ms ease;
+}
+
+.user-chip-chevron--open {
+  transform: rotate(180deg);
+}
+
+.user-chip-text {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.user-chip span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-chip-name {
+  max-width: 100%;
+  color: #111827;
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+.user-chip-email {
+  max-width: 100%;
+  color: #5b6574;
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+
+.account-menu-wrap {
+  position: relative;
+}
+
+.account-menu {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  z-index: 1100;
+  display: grid;
+  gap: 6px;
+  width: 220px;
+  padding: 8px;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.14);
+  border-radius: 8px;
+  box-shadow: 0 20px 50px rgba(17, 24, 39, 0.18);
+}
+
+.account-menu-item {
+  display: flex;
+  align-items: center;
+  min-height: 42px;
+  padding: 0 10px;
+  color: #111827;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  font-weight: 700;
+  text-align: left;
+}
+
+.account-menu-item:hover {
+  color: #ffffff;
+  background: #2563eb;
+}
+
+.setup-banner {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin: 18px clamp(20px, 5vw, 72px) 0;
+  padding: 12px 14px;
+  color: #5b3a08;
+  background: #ffe8b7;
+  border: 1px solid #e6b95d;
+  border-radius: 8px;
+  font-weight: 500;
+}
+
+.api-status {
+  margin: 0 clamp(20px, 5vw, 72px) 24px;
+  padding: 12px 14px;
+  color: #1e3a8a;
+  background: #ffffff;
+  border: 1px solid #2563eb;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.api-status--error {
+  color: #652419;
+  background: #ffe4dd;
+  border-color: #efab9c;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(460px, 1.1fr);
+  gap: clamp(28px, 5vw, 72px);
+  align-items: center;
+  margin: 20px clamp(20px, 5vw, 72px) 0;
+  padding: clamp(42px, 6vw, 78px) clamp(20px, 5vw, 54px) 32px;
+  background: #eaf3ff;
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  border-radius: 8px;
+}
+
+.hero-copy {
+  max-width: 640px;
+}
+
+.hero--greeting {
+  grid-template-columns: 1fr;
+}
+
+.hero--greeting .hero-copy {
+  max-width: none;
+}
+
+.hero--greeting h1 {
+  white-space: nowrap;
+}
+
+.hero .search-panel--compact {
+  grid-column: 1 / -1;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1,
+h2,
+h3,
+strong {
+  font-weight: 650;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(2.1rem, 4vw, 3.7rem);
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+.hero-copy p:last-child {
+  max-width: 560px;
+  margin-bottom: 0;
+  color: #5f6b7a;
+  font-size: 1.13rem;
+  line-height: 1.7;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.search-panel {
+  position: relative;
+  z-index: 20;
+  padding: 18px;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+  box-shadow: 0 28px 80px rgba(17, 24, 39, 0.14);
+}
+
+.search-panel--compact {
+  padding: 12px;
+  background: #061a33;
+  border: 0;
+  box-shadow: none;
+}
+
+.search-panel--compact .tabs {
+  width: fit-content;
+  margin-bottom: 12px;
+  padding: 4px;
+  background: #0f2744;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.search-panel--compact .tab {
+  flex: 0 0 auto;
+  min-height: 40px;
+  padding: 0 16px;
+  color: #dbeafe;
+  font-size: 0.94rem;
+}
+
+.search-panel--compact .tab--active {
+  color: #061a33;
+  background: #ffffff;
+}
+
+.search-panel--compact .trip-type {
+  width: fit-content;
+  margin: 0 0 12px;
+  padding: 3px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+}
+
+.search-panel--compact .pill {
+  min-height: 28px;
+  padding: 0 10px;
+  color: #bfd4f4;
+  background: transparent;
+  border-color: transparent;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.search-panel--compact .pill--selected {
+  color: #ffffff;
+  background: rgba(37, 99, 235, 0.72);
+  border-color: transparent;
+}
+
+.tabs {
+  gap: 8px;
+  padding: 6px;
+  background: #111827;
+  border-radius: 8px;
+}
+
+.tab,
+.pill {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  color: #53666a;
+  background: transparent;
+  font-weight: 600;
+}
+
+.tab {
+  flex: 1;
+}
+
+.tab--active {
+  color: #111827;
+  background: #f59e0b;
+  box-shadow: none;
+}
+
+.tabs .tab {
+  color: #ffffff;
+}
+
+.tabs .tab--active {
+  color: #111827;
+}
+
+.trip-type {
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 18px 0;
+}
+
+.pill {
+  padding: 0 14px;
+  border: 1px solid rgba(24, 33, 37, 0.12);
+}
+
+.pill--selected {
+  color: #ffffff;
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.search-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.search-panel--compact .search-grid {
+  gap: 4px;
+}
+
+.search-panel--compact .search-grid--flights {
+  grid-template-columns:
+    minmax(160px, 1fr)
+    minmax(160px, 1fr)
+    minmax(150px, 0.85fr)
+    minmax(190px, 1fr)
+    minmax(118px, auto);
+}
+
+.search-panel--compact .search-grid--hotels,
+.search-panel--compact .search-grid--trips {
+  grid-template-columns:
+    minmax(0, 1.35fr)
+    minmax(0, 0.8fr)
+    minmax(0, 1fr)
+    minmax(112px, auto);
+}
+
+.field {
+  position: relative;
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  padding: 14px;
+  background: #ffffff;
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+}
+
+.search-panel--compact .field {
+  gap: 5px;
+  min-height: 72px;
+  padding: 12px 16px;
+  border-color: transparent;
+  border-radius: 0;
+}
+
+.search-panel--compact .search-grid > .field:first-child {
+  border-radius: 8px 0 0 8px;
+}
+
+.field span {
+  color: #647276;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.field-control {
+  gap: 8px;
+}
+
+.field svg {
+  flex: 0 0 auto;
+  color: #2563eb;
+}
+
+.field input {
+  min-width: 0;
+  width: 100%;
+  color: #172225;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  font-weight: 700;
+}
+
+.location-field {
+  z-index: 90;
+}
+
+.location-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  left: 0;
+  z-index: 80;
+  display: grid;
+  gap: 4px;
+  max-height: 280px;
+  padding: 8px;
+  overflow-y: auto;
+  background: #ffffff;
+  border: 1px solid #d9e2de;
+  border-radius: 8px;
+  box-shadow: 0 18px 44px rgba(24, 33, 37, 0.16);
+}
+
+.location-option {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  gap: 8px;
+  align-items: center;
+  min-height: 42px;
+  padding: 0 10px;
+  color: #172225;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  text-align: left;
+}
+
+.location-option:hover {
+  color: #ffffff;
+  background: #2563eb;
+}
+
+.location-option:hover span,
+.location-option:hover small,
+.location-option:hover svg {
+  color: #ffffff;
+}
+
+.location-option span {
+  overflow: hidden;
+  color: #172225;
+  font-size: 0.95rem;
+  text-overflow: ellipsis;
+  text-transform: none;
+  white-space: nowrap;
+}
+
+.location-option small {
+  color: #66767a;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.date-field,
+.travelers-field {
+  z-index: 80;
+}
+
+.date-menu,
+.travelers-menu {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  z-index: 70;
+  background: #ffffff;
+  border: 1px solid #d9e2de;
+  border-radius: 8px;
+  box-shadow: 0 18px 48px rgba(24, 33, 37, 0.18);
+}
+
+.date-menu {
+  right: 0;
+  width: min(700px, calc(100vw - 32px));
+  padding: 14px 16px 0;
+}
+
+.calendar-wrap {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) minmax(0, 1fr) 32px;
+  gap: 12px;
+  align-items: start;
+}
+
+.calendar-nav {
+  display: grid;
+  min-height: 34px;
+  margin-top: 48px;
+  place-items: center;
+  color: #172225;
+  background: transparent;
+  border: 0;
+}
+
+.calendar-month h3 {
+  margin-bottom: 14px;
+  font-size: 1.2rem;
+  text-align: center;
+}
+
+.calendar-weekdays,
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.calendar-weekdays {
+  margin-bottom: 8px;
+}
+
+.calendar-weekdays span {
+  display: grid;
+  min-height: 28px;
+  place-items: center;
+  color: #182125;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.calendar-day,
+.calendar-empty {
+  display: grid;
+  min-height: 34px;
+  place-items: center;
+}
+
+.calendar-day {
+  color: #111719;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.calendar-day--range {
+  background: #f59e0b;
+}
+
+.calendar-day--selected {
+  color: #ffffff;
+  background: #2563eb;
+  border-radius: 999px;
+}
+
+.date-menu-footer {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  justify-content: flex-end;
+  margin: 14px -16px 0;
+  padding: 12px 16px;
+  border-top: 1px solid #d9e2de;
+}
+
+.date-menu-footer span {
+  color: #172225;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.apply-button {
+  min-height: 42px;
+  padding: 0 18px;
+  color: #ffffff;
+  background: #2563eb;
+  border: 0;
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.travelers-menu {
+  right: 0;
+  width: min(360px, calc(100vw - 32px));
+  padding: 18px;
+}
+
+.traveler-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: center;
+  margin-bottom: 18px;
+}
+
+.traveler-row strong {
+  display: block;
+  color: #172225;
+  font-size: 1rem;
+}
+
+.traveler-row span,
+.travelers-menu p {
+  color: #667079;
+  font-weight: 600;
+}
+
+.traveler-row span {
+  font-size: 0.9rem;
+}
+
+.stepper {
+  display: grid;
+  grid-template-columns: 42px 32px 42px;
+  gap: 8px;
+  align-items: center;
+}
+
+.stepper button {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  color: #172225;
+  background: #dce2e8;
+  border: 0;
+  border-radius: 8px;
+}
+
+.stepper strong {
+  text-align: center;
+}
+
+.travelers-menu p {
+  margin-bottom: 14px;
+  line-height: 1.45;
+  font-size: 0.9rem;
+}
+
+.apply-button--full {
+  width: 100%;
+}
+
+.date-menu svg,
+.travelers-menu svg {
+  color: currentColor;
+}
+
+.search-button {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  min-height: 56px;
+  color: #ffffff;
+  background: #2563eb;
+}
+
+.search-panel--compact .search-button {
+  grid-column: auto;
+  gap: 8px;
+  min-width: 112px;
+  min-height: 72px;
+  padding: 0 18px;
+  border-radius: 0 8px 8px 0;
+  font-size: 0.98rem;
+  white-space: nowrap;
+}
+
+.results-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 0.75fr) minmax(460px, 1fr);
+  gap: clamp(24px, 4vw, 58px);
+  align-items: start;
+  padding: 42px clamp(20px, 5vw, 72px) 28px;
+}
+
+.results-hero h1 {
+  margin-bottom: 14px;
+  font-size: clamp(2rem, 3.6vw, 3.3rem);
+}
+
+.results-hero p:last-child {
+  color: #516166;
+  font-weight: 600;
+}
+
+.results-section {
+  display: grid;
+  gap: 14px;
+  padding: 0 clamp(20px, 5vw, 72px) 56px;
+}
+
+.bookings-page {
+  min-height: calc(100vh - 180px);
+  padding-bottom: 64px;
+  background: #f3f4f6;
+}
+
+.bookings-heading,
+.bookings-empty {
+  padding: 54px clamp(20px, 5vw, 72px) 28px;
+}
+
+.bookings-heading h1,
+.bookings-empty h1 {
+  margin-bottom: 12px;
+  font-size: clamp(2rem, 3.6vw, 3.3rem);
+}
+
+.bookings-heading p:last-child,
+.bookings-empty p:last-child {
+  color: #516166;
+  font-weight: 600;
+}
+
+.management-header,
+.management-empty {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 34px clamp(20px, 5vw, 72px) 22px;
+  background: #ffffff;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.1);
+}
+
+.management-header h1,
+.management-empty h1 {
+  margin-bottom: 8px;
+  font-size: clamp(1.5rem, 2.2vw, 2rem);
+  line-height: 1.1;
+}
+
+.management-header p:last-child,
+.management-empty p:last-child {
+  margin: 0;
+  color: #5b6574;
+  font-weight: 600;
+}
+
+.back-link {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 18px;
+  color: #2563eb;
+  font-weight: 700;
+}
+
+.management-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  padding: 22px clamp(20px, 5vw, 72px);
+}
+
+.management-summary article {
+  min-height: 96px;
+  padding: 18px;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+}
+
+.management-summary span {
+  display: block;
+  margin-bottom: 8px;
+  color: #5b6574;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.management-summary strong {
+  color: #111827;
+  font-size: 1.8rem;
+}
+
+.management-panel {
+  margin: 22px clamp(20px, 5vw, 72px) 0;
+  min-height: 260px;
+  overflow: hidden;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+}
+
+.management-panel-header {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.1);
+}
+
+.management-panel-header h2,
+.management-empty-state h2 {
+  margin-bottom: 6px;
+  font-size: 1.25rem;
+  line-height: 1.2;
+}
+
+.management-panel-header p,
+.management-empty-state p {
+  margin: 0;
+  color: #5b6574;
+  font-weight: 500;
+}
+
+.management-message {
+  padding: 20px;
+}
+
+.management-empty-state {
+  display: grid;
+  min-height: 240px;
+  place-items: center;
+  align-content: center;
+  justify-items: center;
+  padding: 34px 20px;
+  text-align: center;
+}
+
+.management-empty-state p {
+  margin-bottom: 18px;
+}
+
+.booking-table-heading,
+.booking-row {
+  display: grid;
+  grid-template-columns: minmax(210px, 1.1fr) minmax(140px, 0.7fr) minmax(180px, 0.95fr) minmax(130px, 0.7fr) minmax(120px, auto);
+  gap: 18px;
+  align-items: center;
+}
+
+.booking-table-heading {
+  padding: 12px 20px;
+  color: #5b6574;
+  background: #f9fafb;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.1);
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.booking-row {
+  padding: 18px 20px;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+}
+
+.booking-row:hover {
+  background: #f9fafb;
+}
+
+.booking-row:last-child {
+  border-bottom: 0;
+}
+
+.booking-route,
+.booking-cell,
+.booking-price {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.booking-route strong,
+.booking-cell strong,
+.booking-price strong {
+  color: #111827;
+}
+
+.booking-route small,
+.booking-cell span {
+  overflow: hidden;
+  color: #5b6574;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.booking-cell strong {
+  overflow-wrap: anywhere;
+}
+
+.booking-status {
+  width: fit-content;
+  padding: 5px 8px;
+  color: #ffffff;
+  background: #2563eb;
+  border-radius: 8px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.booking-price {
+  justify-items: end;
+}
+
+.booking-price strong {
+  font-size: 1.2rem;
+}
+
+.booking-detail-panel {
+  margin: 22px clamp(20px, 5vw, 72px) 0;
+  display: grid;
+  gap: 18px;
+}
+
+.booking-detail-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.34fr);
+  gap: 18px;
+  align-items: stretch;
+}
+
+.flight-review-panel {
+  width: min(1180px, calc(100% - 40px));
+  max-width: 1180px;
+  margin: 22px auto 0;
+}
+
+.flight-review-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.36fr);
+  gap: 18px;
+  align-items: stretch;
+}
+
+.flight-review-main {
+  display: grid;
+  gap: 18px;
+}
+
+.booking-confirmed-panel {
+  width: min(1180px, calc(100% - 40px));
+  max-width: 1180px;
+  margin: 22px auto 0;
+}
+
+.booking-flight-widget {
+  --booking-route-code-size: clamp(1.7rem, 4vw, 3rem);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(200px, 260px);
+  overflow: hidden;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+  box-shadow: 0 18px 48px rgba(17, 24, 39, 0.08);
+}
+
+.booking-flight-main {
+  padding: 24px;
+}
+
+.booking-flight-widget .booking-detail-topline {
+  margin-bottom: 30px;
+}
+
+.booking-flight-widget .itinerary-route {
+  grid-template-columns: minmax(0, 1fr) minmax(92px, 0.35fr) minmax(0, 1fr);
+  align-items: end;
+}
+
+.booking-flight-widget .itinerary-route > div:not(.itinerary-line) {
+  display: grid;
+  gap: 8px;
+}
+
+.booking-flight-widget .itinerary-route > div:first-child span {
+  grid-column: auto;
+  grid-row: auto;
+}
+
+.booking-flight-widget .itinerary-route > div:first-child strong {
+  grid-column: auto;
+  grid-row: auto;
+}
+
+.booking-flight-widget .itinerary-line {
+  grid-column: auto;
+  grid-row: auto;
+  align-self: end;
+  min-height: var(--booking-route-code-size);
+  height: var(--booking-route-code-size);
+  transform: none;
+}
+
+.booking-flight-widget .itinerary-route > div:last-child span {
+  grid-column: auto;
+  grid-row: auto;
+}
+
+.booking-flight-widget .itinerary-route > div:last-child strong {
+  grid-column: auto;
+  grid-row: auto;
+}
+
+.wallet-qr-panel {
+  display: grid;
+  gap: 12px;
+  align-content: center;
+  justify-items: center;
+  padding: 22px;
+  color: #ffffff;
+  background: #111827;
+  border-left: 1px dashed rgba(255, 255, 255, 0.34);
+  text-align: center;
+}
+
+.wallet-qr-panel span {
+  color: #fbbf24;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.wallet-qr-panel p {
+  max-width: 180px;
+  margin: 0;
+  color: #d1d5db;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.45;
+}
+
+.wallet-qr-frame {
+  display: grid;
+  width: min(180px, 100%);
+  aspect-ratio: 1;
+  place-items: center;
+  background: #ffffff;
+  border: 8px solid #f9fafb;
+  border-radius: 8px;
+}
+
+.wallet-qr-frame img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.booking-itinerary-card,
+.booking-receipt-card,
+.booking-detail-sections section {
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+}
+
+.booking-itinerary-card {
+  padding: 24px;
+}
+
+.booking-detail-topline {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 28px;
+}
+
+.booking-detail-topline > strong {
+  color: #111827;
+}
+
+.itinerary-route {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(120px, 0.45fr) minmax(0, 1fr);
+  gap: 18px;
+  align-items: center;
+}
+
+.itinerary-route > div:not(.itinerary-line) {
+  display: grid;
+  gap: 8px;
+}
+
+.itinerary-route span,
+.booking-receipt-card span,
+.booking-detail-sections dt {
+  color: #5b6574;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.itinerary-route strong {
+  color: #111827;
+  font-size: clamp(1.7rem, 4vw, 3rem);
+  line-height: 1;
+}
+
+.itinerary-line {
+  position: relative;
+  display: grid;
+  min-height: 46px;
+  place-items: center;
+  color: #2563eb;
+}
+
+.itinerary-line::before {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  left: 0;
+  height: 2px;
+  background: #2563eb;
+  content: "";
+  transform: translateY(-50%);
+}
+
+.itinerary-line svg {
+  position: relative;
+  z-index: 1;
+  padding: 4px;
+  background: #ffffff;
+}
+
+@media (min-width: 901px) {
+  .itinerary-route {
+    grid-template-rows: auto auto;
+    row-gap: 8px;
+  }
+
+  .itinerary-route > div:not(.itinerary-line) {
+    display: contents;
+  }
+
+  .itinerary-route > div:first-child span {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .itinerary-route > div:first-child strong {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .itinerary-line {
+    grid-column: 2;
+    grid-row: 2;
+    align-self: center;
+  }
+
+  .itinerary-route > div:last-child span {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .itinerary-route > div:last-child strong {
+    grid-column: 3;
+    grid-row: 2;
+  }
+}
+
+.itinerary-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 28px;
+}
+
+.itinerary-meta span {
+  padding: 8px 10px;
+  color: #111827;
+  background: #f3f4f6;
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.booking-receipt-card {
+  display: grid;
+  align-content: center;
+  gap: 10px;
+  padding: 24px;
+  color: #ffffff;
+  background: #111827;
+}
+
+.flight-review-summary {
+  min-height: 100%;
+  align-content: stretch;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 24px;
+}
+
+.flight-review-summary-content {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+}
+
+.flight-review-summary dl {
+  display: grid;
+  gap: 12px;
+  margin: 18px 0 0;
+  padding-top: 18px;
+  border-top: 1px solid rgba(255, 255, 255, 0.16);
+}
+
+.flight-review-summary dl div {
+  display: grid;
+  gap: 4px;
+}
+
+.flight-review-summary dt {
+  color: #fbbf24;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.flight-review-summary dd {
+  margin: 0;
+  color: #ffffff;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.booking-receipt-card span {
+  color: #fbbf24;
+}
+
+.booking-receipt-card strong {
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1;
+}
+
+.booking-receipt-card p {
+  margin: 0;
+  color: #d1d5db;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.wallet-button {
+  width: fit-content;
+  min-height: 42px;
+  margin-top: 12px;
+  padding: 0 14px;
+  color: #111827;
+  background: #fbbf24;
+  border: 0;
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.flight-review-confirm {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 50px;
+  margin-top: auto;
+}
+
+.booking-detail-sections {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.booking-confirmed-sections {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.booking-detail-sections section {
+  padding: 22px;
+}
+
+.booking-detail-sections h2 {
+  margin-bottom: 18px;
+  font-size: 1.25rem;
+}
+
+.booking-detail-sections dl {
+  display: grid;
+  gap: 16px;
+  margin: 0;
+}
+
+.booking-detail-sections dl div {
+  display: flex;
+  gap: 16px;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-bottom: 14px;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+}
+
+.booking-detail-sections dl div:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.booking-detail-sections dd {
+  margin: 0;
+  color: #111827;
+  font-weight: 700;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.travel-insurance-section {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: center;
+  padding: 22px;
+  color: #111827;
+  background: #f9fafb;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+}
+
+.travel-insurance-icon {
+  display: grid;
+  width: 54px;
+  height: 54px;
+  place-items: center;
+  color: #ffffff;
+  background: #2563eb;
+  border-radius: 8px;
+}
+
+.travel-insurance-section span {
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.travel-insurance-section h2 {
+  margin: 4px 0 6px;
+  font-size: 1.25rem;
+}
+
+.travel-insurance-section p {
+  max-width: 620px;
+  margin: 0;
+  color: #5b6574;
+  font-weight: 600;
+  line-height: 1.45;
+}
+
+.travel-insurance-button {
+  min-height: 44px;
+  padding: 0 16px;
+  color: #111827;
+  background: #fbbf24;
+  border: 0;
+  border-radius: 8px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.payment-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.36fr);
+  gap: 18px;
+  margin: 22px clamp(20px, 5vw, 72px) 0;
+  align-items: start;
+}
+
+.payment-form-card {
+  display: grid;
+  gap: 16px;
+  padding: 24px;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+}
+
+.payment-field,
+.payment-field-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.payment-field-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.payment-field span {
+  color: #5b6574;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.payment-field input {
+  min-height: 48px;
+  padding: 0 12px;
+  color: #111827;
+  background: #f9fafb;
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  border-radius: 8px;
+  outline: 0;
+  font-weight: 700;
+}
+
+.standalone-button {
+  width: auto;
+  padding: 0 22px;
+}
+
+.result-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 22px;
+  align-items: center;
+  padding: 20px;
+  background: #ffffff;
+  border: 1px solid rgba(24, 33, 37, 0.1);
+  border-radius: 8px;
+  box-shadow: 0 16px 44px rgba(24, 33, 37, 0.08);
+}
+
+.result-card h2 {
+  margin-bottom: 8px;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+}
+
+.result-card p {
+  margin-bottom: 0;
+  color: #66767a;
+  font-weight: 500;
+}
+
+.result-label {
+  margin-bottom: 8px;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.result-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.result-tags span {
+  padding: 7px 10px;
+  color: #1e3a8a;
+  background: #ffffff;
+  border: 1px solid #2563eb;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.result-side {
+  display: grid;
+  gap: 8px;
+  justify-items: end;
+  min-width: 150px;
+}
+
+.result-side strong {
+  font-size: 1.9rem;
+}
+
+.result-side span {
+  color: #66767a;
+  font-weight: 600;
+}
+
+.insight-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  padding: 0 clamp(20px, 5vw, 72px) 52px;
+}
+
+.insight-strip div {
+  gap: 14px;
+  min-height: 118px;
+  padding: 18px;
+  color: #1f2937;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+  font-weight: 700;
+  box-shadow: 0 18px 50px rgba(17, 24, 39, 0.06);
+}
+
+.insight-strip svg {
+  flex: 0 0 auto;
+  color: #f59e0b;
+}
+
+.insight-strip span {
+  display: grid;
+  gap: 6px;
+}
+
+.insight-strip small {
+  color: #667085;
+  font-size: 0.92rem;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.content-band,
+.planner-panel {
+  padding: 44px clamp(20px, 5vw, 72px);
+}
+
+.section-heading {
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 22px;
+}
+
+h2 {
+  margin-bottom: 0;
+  max-width: 820px;
+  font-size: clamp(1.65rem, 3vw, 2.45rem);
+  line-height: 1.1;
+}
+
+.link-button {
+  gap: 8px;
+  padding: 0 14px;
+  color: #2563eb;
+  background: transparent;
+}
+
+.deal-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.empty-state {
+  margin: 0;
+  color: #66767a;
+  font-weight: 600;
+}
+
+.empty-state--light {
+  color: #d7e2e1;
+}
+
+.deal-card,
+.stay-card {
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+}
+
+.deal-card {
+  min-height: 260px;
+  padding: 22px;
+}
+
+.deal-card--mint {
+  border-top: 6px solid #2563eb;
+}
+
+.deal-card--coral {
+  border-top: 6px solid #fb7185;
+}
+
+.deal-card--gold {
+  border-top: 6px solid #f59e0b;
+}
+
+.deal-icon {
+  display: grid;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 24px;
+  place-items: center;
+  color: #ffffff;
+  background: #111827;
+  border-radius: 8px;
+}
+
+.deal-card p,
+.deal-card span,
+.section-copy,
+.stay-card p {
+  color: #66767a;
+}
+
+.deal-card p {
+  margin-bottom: 10px;
+  font-weight: 700;
+}
+
+.deal-card h3 {
+  min-height: 58px;
+  margin-bottom: 18px;
+  font-size: 1.45rem;
+  line-height: 1.1;
+}
+
+.deal-card span {
+  display: block;
+  margin-bottom: 18px;
+  font-weight: 500;
+}
+
+.deal-card strong {
+  display: block;
+  margin-bottom: 18px;
+  font-size: 2rem;
+}
+
+.card-action,
+.inline-action {
+  border: 0;
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.card-action {
+  min-height: 42px;
+  padding: 0 14px;
+  color: #ffffff;
+  background: #2563eb;
+}
+
+.card-action--confirmed {
+  background: #203235;
+}
+
+.inline-action {
+  margin-top: 12px;
+  min-height: 34px;
+  padding: 0 12px;
+  color: #1e3a8a;
+  background: #ffffff;
+  border: 1px solid #2563eb;
+}
+
+.two-column {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(360px, 1fr);
+  gap: clamp(24px, 5vw, 70px);
+  align-items: start;
+  background: #111827;
+  color: #ffffff;
+}
+
+.two-column .eyebrow {
+  color: #fbbf24;
+}
+
+.section-copy {
+  max-width: 560px;
+  margin: 18px 0 24px;
+  color: #c5d1d2;
+  line-height: 1.7;
+}
+
+.secondary-button {
+  gap: 8px;
+  padding: 0 18px;
+  color: #111827;
+  background: #fbbf24;
+}
+
+.stay-list {
+  display: grid;
+  gap: 12px;
+}
+
+.stay-card {
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  padding: 18px;
+  color: #182125;
+}
+
+.stay-card h3 {
+  margin-bottom: 6px;
+}
+
+.stay-card p {
+  margin-bottom: 0;
+  font-weight: 500;
+}
+
+.stay-meta {
+  display: grid;
+  gap: 8px;
+  justify-items: end;
+  white-space: nowrap;
+}
+
+.stay-meta span {
+  display: grid;
+  min-width: 42px;
+  min-height: 32px;
+  place-items: center;
+  color: #ffffff;
+  background: #2563eb;
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.faq-section {
+  padding: 54px clamp(20px, 5vw, 72px) 72px;
+}
+
+.faq-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.faq-item {
+  min-height: 118px;
+  padding: 18px 20px;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+  box-shadow: 0 18px 42px rgba(17, 24, 39, 0.06);
+}
+
+.faq-item summary {
+  color: #111827;
+  cursor: pointer;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.faq-item summary::marker {
+  color: #f59e0b;
+}
+
+.faq-item p {
+  margin: 14px 0 0;
+  color: #667085;
+  font-weight: 500;
+  line-height: 1.55;
+}
+
+.dashboard-home {
+  padding-bottom: 64px;
+}
+
+.dashboard-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: end;
+  padding: 54px clamp(20px, 5vw, 72px) 28px;
+  background: #ffffff;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.1);
+}
+
+.dashboard-hero h1 {
+  max-width: 760px;
+  margin-bottom: 12px;
+  font-size: clamp(2rem, 3.8vw, 3.2rem);
+}
+
+.dashboard-hero p:last-child {
+  max-width: 620px;
+  margin: 0;
+  color: #5b6574;
+  font-size: 1.08rem;
+  font-weight: 500;
+  line-height: 1.6;
+}
+
+.dashboard-profile {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  min-width: 280px;
+  padding: 16px;
+  color: #111827;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 16px 36px rgba(17, 24, 39, 0.08);
+}
+
+.dashboard-profile svg {
+  color: #2563eb;
+}
+
+.dashboard-profile div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.dashboard-profile strong,
+.dashboard-profile span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-profile span {
+  color: #5b6574;
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  padding: 24px clamp(20px, 5vw, 72px);
+  background: #f3f4f6;
+}
+
+.dashboard-card {
+  min-height: 240px;
+  padding: 22px;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 8px;
+}
+
+.dashboard-card--primary {
+  color: #ffffff;
+  background: #111827;
+}
+
+.dashboard-card span {
+  display: block;
+  margin-bottom: 14px;
+  color: #2563eb;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.dashboard-card--primary span {
+  color: #fbbf24;
+}
+
+.dashboard-card h2 {
+  margin-bottom: 12px;
+  font-size: clamp(1.3rem, 2.4vw, 1.7rem);
+  line-height: 1.15;
+}
+
+.dashboard-card p {
+  margin-bottom: 20px;
+  color: #5b6574;
+  font-weight: 500;
+  line-height: 1.55;
+}
+
+.dashboard-card--primary p {
+  color: #d1d5db;
+}
+
+.dashboard-action,
+.dashboard-status {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 42px;
+  padding: 0 14px;
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.dashboard-action {
+  color: #111827;
+  background: #fbbf24;
+}
+
+.dashboard-action--secondary,
+.dashboard-status {
+  color: #ffffff;
+  background: #2563eb;
+}
+
+.dashboard-search-section {
+  padding: 36px clamp(20px, 5vw, 72px) 0;
+}
+
+.dashboard-search-section .search-panel {
+  max-width: none;
+}
+
+.site-footer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 28px;
+  align-items: center;
+  min-height: 180px;
+  padding: 34px clamp(20px, 5vw, 72px);
+  color: #d9edf0;
+  background: #111827;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.footer-brand {
+  width: fit-content;
+  margin-bottom: 12px;
+  color: #ffffff;
+}
+
+.site-footer p {
+  max-width: 420px;
+  margin: 0;
+  color: #adc4ca;
+  font-weight: 500;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.footer-links a {
+  min-height: 38px;
+  padding: 9px 12px;
+  color: #d9edf0;
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.footer-links a:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.planner-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 0.7fr) minmax(320px, 1fr);
+  gap: 28px;
+  align-items: center;
+}
+
+.planner-actions {
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.filter-button {
+  gap: 8px;
+  padding: 0 14px;
+  color: #243438;
+  background: #ffffff;
+  border: 1px solid rgba(24, 33, 37, 0.12);
+}
+
+.chat-widget {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 1300;
+  display: grid;
+  justify-items: end;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.chat-panel,
+.chat-launcher {
+  pointer-events: auto;
+}
+
+.chat-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  width: min(380px, calc(100vw - 32px));
+  height: min(560px, calc(100vh - 118px));
+  overflow: hidden;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.14);
+  border-radius: 8px;
+  box-shadow: 0 24px 70px rgba(17, 24, 39, 0.24);
+}
+
+.chat-header {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  color: #ffffff;
+  background: #111827;
+}
+
+.chat-kicker {
+  display: block;
+  margin-bottom: 4px;
+  color: #fbbf24;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.chat-header h2 {
+  margin: 0;
+  font-size: 1.08rem;
+}
+
+.chat-header-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.chat-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 9px;
+  color: #d1d5db;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.chat-status--connected {
+  color: #bbf7d0;
+}
+
+.chat-status--connecting {
+  color: #fde68a;
+}
+
+.chat-status--disconnected {
+  color: #fecaca;
+}
+
+.chat-icon-button,
+.chat-launcher,
+.chat-send-button {
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+}
+
+.chat-icon-button {
+  width: 32px;
+  height: 32px;
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.chat-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  overflow-y: auto;
+  background: #f3f4f6;
+}
+
+.chat-message {
+  max-width: 86%;
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 0.94rem;
+  font-weight: 500;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  /* Preserve newlines from the assistant's text so plain-text bullet lists
+     render on multiple lines instead of being collapsed onto one row. */
+  white-space: pre-wrap;
+}
+
+.chat-message--assistant {
+  align-self: flex-start;
+  color: #111827;
+  background: #ffffff;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+}
+
+.chat-message--user {
+  align-self: flex-end;
+  color: #ffffff;
+  background: #2563eb;
+}
+
+.chat-message--error {
+  align-self: flex-start;
+  color: #652419;
+  background: #ffe4dd;
+  border: 1px solid #efab9c;
+}
+
+.chat-message--typing {
+  color: #5b6574;
+  font-style: italic;
+}
+
+.chat-composer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 44px;
+  gap: 10px;
+  padding: 12px;
+  background: #ffffff;
+  border-top: 1px solid rgba(17, 24, 39, 0.1);
+}
+
+.chat-input-label {
+  display: grid;
+  gap: 0;
+}
+
+.chat-input-label span {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.chat-input-label input {
+  width: 100%;
+  min-height: 44px;
+  padding: 0 12px;
+  color: #111827;
+  background: #f9fafb;
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  border-radius: 8px;
+  outline: 0;
+  font-weight: 600;
+}
+
+.chat-input-label input:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
+}
+
+.chat-send-button {
+  width: 44px;
+  height: 44px;
+  color: #ffffff;
+  background: #2563eb;
+}
+
+.chat-launcher {
+  width: 58px;
+  height: 58px;
+  color: #ffffff;
+  background: #2563eb;
+  box-shadow: 0 18px 42px rgba(37, 99, 235, 0.32);
+}
+
+@media (max-width: 900px) {
+  .hero,
+  .results-hero,
+  .two-column,
+  .planner-panel,
+  .dashboard-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .insight-strip,
+  .deal-grid,
+  .faq-grid,
+  .dashboard-grid,
+  .management-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .management-header,
+  .management-empty {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .booking-table-heading {
+    display: none;
+  }
+
+  .booking-row {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+
+  .booking-price {
+    justify-items: start;
+  }
+
+  .booking-detail-main,
+  .booking-detail-sections,
+  .flight-review-layout,
+  .itinerary-route,
+  .payment-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .booking-flight-widget {
+    --booking-route-code-size: clamp(1.35rem, 4vw, 2.2rem);
+    grid-template-columns: minmax(0, 1fr) minmax(150px, 180px);
+  }
+
+  .booking-flight-widget .itinerary-route {
+    grid-template-columns: minmax(0, 1fr) minmax(44px, 0.28fr) minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .booking-flight-widget .itinerary-line {
+    min-height: var(--booking-route-code-size);
+    height: var(--booking-route-code-size);
+    justify-items: center;
+  }
+
+  .booking-flight-widget .itinerary-line::before {
+    display: block;
+  }
+
+  .booking-flight-widget .itinerary-route strong {
+    font-size: clamp(1.35rem, 4vw, 2.2rem);
+  }
+
+  .wallet-qr-panel {
+    padding: 16px;
+  }
+
+  .wallet-qr-frame {
+    width: min(138px, 100%);
+  }
+
+  .flight-review-summary {
+    min-height: auto;
+  }
+
+  .itinerary-line {
+    min-height: 34px;
+    justify-items: start;
+  }
+
+  .itinerary-line::before {
+    display: none;
+  }
+
+  .booking-flight-widget .itinerary-line {
+    justify-items: center;
+    transform: none;
+  }
+
+  .booking-flight-widget .itinerary-line::before {
+    display: block;
+  }
+
+  .planner-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 620px) {
+  .site-header {
+    grid-template-columns: auto 1fr;
+    gap: 14px;
+    padding: 14px 16px;
+  }
+
+  .header-nav {
+    display: none;
+  }
+
+  .header-link {
+    display: none;
+  }
+
+  .brand span:last-child,
+  .user-chip-email {
+    display: none;
+  }
+
+  .user-chip {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    max-width: 170px;
+    min-height: 38px;
+    padding: 0 10px;
+  }
+
+  .auth-cluster {
+    gap: 6px;
+  }
+
+  .text-button,
+  .primary-small,
+  .icon-text-button {
+    min-height: 38px;
+    padding: 0 10px;
+  }
+
+  .setup-banner,
+  .hero,
+  .content-band,
+  .planner-panel {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .hero {
+    padding: 30px 16px 24px;
+  }
+
+  .results-hero {
+    padding: 30px 16px 20px;
+  }
+
+  h1 {
+    font-size: 2.72rem;
+  }
+
+  .search-panel {
+    padding: 12px;
+  }
+
+  .tabs,
+  .trip-type {
+    align-items: stretch;
+  }
+
+  .tab,
+  .pill {
+    flex: 1 1 100%;
+  }
+
+  .search-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .search-panel--compact .search-grid,
+  .search-panel--compact .search-grid--flights,
+  .search-panel--compact .search-grid--hotels,
+  .search-panel--compact .search-grid--trips {
+    grid-template-columns: 1fr;
+  }
+
+  .search-panel--compact .search-grid--hotels,
+  .search-panel--compact .search-grid--trips {
+    grid-template-columns: minmax(0, 1.25fr) minmax(0, 0.82fr) minmax(0, 0.95fr) minmax(88px, auto);
+  }
+
+  .search-panel--compact .field,
+  .search-panel--compact .search-grid > .field:first-child,
+  .search-panel--compact .search-button {
+    min-height: 58px;
+    border-radius: 8px;
+  }
+
+  .search-panel--compact .search-button {
+    min-width: 88px;
+    padding: 0 10px;
+  }
+
+  .results-section {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .result-card {
+    grid-template-columns: 1fr;
+  }
+
+  .result-side {
+    justify-items: start;
+  }
+
+  .date-menu,
+  .travelers-menu {
+    right: auto;
+    left: 0;
+    width: calc(100vw - 32px);
+  }
+
+  .date-menu {
+    padding: 12px 12px 0;
+  }
+
+  .calendar-wrap {
+    grid-template-columns: 30px minmax(0, 1fr) 30px;
+    gap: 8px;
+  }
+
+  .calendar-wrap .calendar-month:nth-of-type(2) {
+    display: none;
+  }
+
+  .calendar-nav {
+    margin-top: 42px;
+  }
+
+  .date-menu-footer {
+    margin-right: -12px;
+    margin-left: -12px;
+    padding: 10px 12px;
+  }
+
+  .travelers-menu {
+    padding: 16px;
+  }
+
+  .traveler-row {
+    gap: 14px;
+  }
+
+  .stepper {
+    grid-template-columns: 44px 32px 44px;
+  }
+
+  .stepper button {
+    width: 44px;
+    height: 44px;
+  }
+
+  .insight-strip,
+  .content-band,
+  .planner-panel,
+  .faq-section {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .stay-card {
+    flex-direction: column;
+  }
+
+  .stay-meta {
+    justify-items: start;
+  }
+
+  .dashboard-hero,
+  .dashboard-grid,
+  .dashboard-search-section,
+  .management-header,
+  .management-empty,
+  .management-summary {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .management-panel {
+    margin-right: 16px;
+    margin-left: 16px;
+  }
+
+  .booking-detail-panel {
+    margin-right: 16px;
+    margin-left: 16px;
+  }
+
+  .booking-flight-widget {
+    --booking-route-code-size: clamp(1.05rem, 6vw, 1.45rem);
+    grid-template-columns: minmax(0, 1fr) 116px;
+  }
+
+  .booking-flight-main {
+    padding: 16px;
+  }
+
+  .booking-flight-widget .booking-detail-topline {
+    align-items: flex-start;
+    flex-direction: column;
+    margin-bottom: 20px;
+  }
+
+  .booking-flight-widget .itinerary-route {
+    grid-template-columns: minmax(0, 1fr) minmax(30px, 0.24fr) minmax(0, 1fr);
+    gap: 6px;
+  }
+
+  .booking-flight-widget .itinerary-line {
+    min-height: var(--booking-route-code-size);
+    height: var(--booking-route-code-size);
+    transform: none;
+  }
+
+  .booking-flight-widget .itinerary-route span {
+    font-size: 0.7rem;
+  }
+
+  .booking-flight-widget .itinerary-route strong {
+    font-size: clamp(1.05rem, 6vw, 1.45rem);
+  }
+
+  .booking-flight-widget .itinerary-meta {
+    gap: 6px;
+    margin-top: 18px;
+  }
+
+  .booking-flight-widget .itinerary-meta span {
+    padding: 6px 7px;
+    font-size: 0.72rem;
+  }
+
+  .wallet-qr-panel {
+    padding: 10px;
+  }
+
+  .wallet-qr-frame {
+    width: 88px;
+    border-width: 5px;
+  }
+
+  .wallet-qr-panel p {
+    display: none;
+  }
+
+  .travel-insurance-section {
+    grid-template-columns: 1fr;
+    justify-items: start;
+  }
+
+  .payment-panel {
+    margin-right: 16px;
+    margin-left: 16px;
+  }
+
+  .payment-field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-widget {
+    right: 16px;
+    bottom: 16px;
+  }
+
+  .chat-panel {
+    height: min(520px, calc(100vh - 96px));
+  }
+
+  .dashboard-profile {
+    min-width: 0;
+  }
+
+  .site-footer {
+    grid-template-columns: 1fr;
+    min-height: 220px;
+    padding: 32px 16px;
+  }
+
+  .footer-links {
+    justify-content: flex-start;
+  }
+}

--- a/samples/apps/agent-id-sample/frontend/src/utils/bookings.js
+++ b/samples/apps/agent-id-sample/frontend/src/utils/bookings.js
@@ -1,0 +1,25 @@
+export function formatPrice(currency, amount) {
+  return `${currency === "USD" ? "$" : `${currency} `}${amount}`;
+}
+
+function formatBookingReference(bookingId) {
+  const source = String(bookingId || "").replace(/^booking-/i, "");
+  const letters = source.replace(/[^a-z]/gi, "").toUpperCase().padEnd(4, "WXYZ");
+  const numbers = source.replace(/\D/g, "").padEnd(6, "202600");
+
+  return `${letters.slice(0, 4)}-${numbers.slice(0, 6)}`;
+}
+
+export function getBookingReference(booking) {
+  return booking?.bookingReference || formatBookingReference(booking?.id);
+}
+
+export function isSameFlight(firstFlight, secondFlight) {
+  return (
+    firstFlight?.from === secondFlight?.from &&
+    firstFlight?.to === secondFlight?.to &&
+    firstFlight?.departureTime === secondFlight?.departureTime &&
+    firstFlight?.arrivalTime === secondFlight?.arrivalTime &&
+    firstFlight?.dates === secondFlight?.dates
+  );
+}

--- a/samples/apps/agent-id-sample/frontend/src/utils/routes.js
+++ b/samples/apps/agent-id-sample/frontend/src/utils/routes.js
@@ -1,0 +1,52 @@
+export function readCriteria(search) {
+  const params = new URLSearchParams(search);
+
+  return {
+    category: params.get("category") || "flights",
+    tripType: params.get("tripType") || "round-trip",
+    from: params.get("from") || "",
+    to: params.get("to") || "",
+    dates: params.get("dates") || "",
+    travelers: params.get("travelers") || ""
+  };
+}
+
+export function buildResultsPath(criteria) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(criteria)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+
+  return `/results?${params.toString()}`;
+}
+
+export function buildFlightDetailsPath(flightId, criteria = {}) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(criteria)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+
+  const query = params.toString();
+
+  return `/flights/${encodeURIComponent(flightId)}${query ? `?${query}` : ""}`;
+}
+
+export function buildFlightPaymentPath(flightId, criteria = {}) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(criteria)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+
+  const query = params.toString();
+
+  return `/payment/flight/${encodeURIComponent(flightId)}${query ? `?${query}` : ""}`;
+}

--- a/samples/apps/agent-id-sample/frontend/vite.config.js
+++ b/samples/apps/agent-id-sample/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});

--- a/samples/apps/agent-id-sample/mcp/README.md
+++ b/samples/apps/agent-id-sample/mcp/README.md
@@ -1,0 +1,28 @@
+# Travel MCP Server
+
+Streamable-HTTP MCP server that wraps the Wayfinder Travel REST API and forwards the incoming `Authorization` header unchanged. No configuration required for local development.
+
+## Tools
+
+- `search_flights` — `GET /api/flights`
+- `search_hotels` — `GET /api/hotels`
+- `get_trips` — `GET /api/trips`
+- `get_locations` — `GET /api/locations`
+- `create_booking` — `POST /api/bookings` (requires `booking:create`)
+- `get_flight_bookings` — `GET /api/bookings/flights` (requires `booking:read`)
+- `delete_all_bookings` — `DELETE /api/bookings/flights` (requires `booking:cancel`)
+- `get_profile` — `GET /api/me`
+
+Scope enforcement happens at the REST API, not here.
+
+## Run
+
+```bash
+npm install
+npm start
+```
+
+Endpoints:
+
+- MCP:    `http://localhost:8000/mcp`
+- Health: `http://localhost:8000/health`

--- a/samples/apps/agent-id-sample/mcp/package-lock.json
+++ b/samples/apps/agent-id-sample/mcp/package-lock.json
@@ -1,0 +1,1671 @@
+{
+  "name": "travel-mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "travel-mcp-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.4",
+        "tsx": "^4.19.4",
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.19"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/samples/apps/agent-id-sample/mcp/package.json
+++ b/samples/apps/agent-id-sample/mcp/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "travel-mcp-server",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "server.ts",
+  "scripts": {
+    "start": "tsx server.ts",
+    "dev": "tsx watch server.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.4",
+    "tsx": "^4.19.4",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.19"
+  }
+}

--- a/samples/apps/agent-id-sample/mcp/server.ts
+++ b/samples/apps/agent-id-sample/mcp/server.ts
@@ -1,0 +1,271 @@
+/*
+Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { z } from "zod";
+
+const apiBaseUrl = process.env.API_BASE_URL || "http://localhost:8787";
+const port = Number(process.env.PORT || process.env.MCP_PORT || 8000);
+const host = process.env.HOST || "localhost";
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+function getAuthorizationHeader(request: IncomingMessage): string | undefined {
+    const authorization = request.headers.authorization;
+
+    return Array.isArray(authorization) ? authorization[0] : authorization;
+}
+
+function createApiClient(authorization?: string) {
+    async function requestApi(path: string, options: RequestInit = {}): Promise<JsonValue> {
+        const headers = new Headers(options.headers);
+
+        headers.set("Accept", "application/json");
+
+        if (options.body && !headers.has("Content-Type")) {
+            headers.set("Content-Type", "application/json");
+        }
+
+        if (authorization) {
+            headers.set("Authorization", authorization);
+        }
+
+        const response = await fetch(`${apiBaseUrl}${path}`, {
+            ...options,
+            headers,
+        });
+
+        const contentType = response.headers.get("content-type") || "";
+        const body = contentType.includes("application/json")
+            ? await response.json()
+            : await response.text();
+
+        if (!response.ok) {
+            throw new Error(`API request failed with ${response.status}: ${JSON.stringify(body)}`);
+        }
+
+        return body as JsonValue;
+    }
+
+    return {
+        get: (path: string) => requestApi(path),
+        post: (path: string, body: JsonValue) => requestApi(path, {
+            method: "POST",
+            body: JSON.stringify(body),
+        }),
+        delete: (path: string) => requestApi(path, { method: "DELETE" }),
+    };
+}
+
+function toToolContent(data: JsonValue) {
+    return {
+        content: [
+            {
+                type: "text" as const,
+                text: typeof data === "string" ? data : JSON.stringify(data, null, 2),
+            },
+        ],
+    };
+}
+
+function createTravelMcpServer(authorization?: string) {
+    const api = createApiClient(authorization);
+    const server = new McpServer({
+        name: "wayfinder-travel-api",
+        version: "1.0.0",
+    });
+
+    server.tool(
+        "search_flights",
+        "Search available flights from the travel API.",
+        {
+            from: z.string().optional().describe("Departure location, for example Colombo."),
+            to: z.string().optional().describe("Arrival location, for example Singapore."),
+        },
+        async ({ from, to }) => {
+            const params = new URLSearchParams();
+
+            if (from) {
+                params.set("from", from);
+            }
+
+            if (to) {
+                params.set("to", to);
+            }
+
+            const query = params.toString();
+
+            return toToolContent(await api.get(`/api/flights${query ? `?${query}` : ""}`));
+        },
+    );
+
+    server.tool(
+        "search_hotels",
+        "Search available hotels from the travel API.",
+        {
+            location: z.string().optional().describe("Hotel location, for example Singapore."),
+        },
+        async ({ location }) => {
+            const params = new URLSearchParams();
+
+            if (location) {
+                params.set("location", location);
+            }
+
+            const query = params.toString();
+
+            return toToolContent(await api.get(`/api/hotels${query ? `?${query}` : ""}`));
+        },
+    );
+
+    server.tool(
+        "get_trips",
+        "Get saved trip ideas from the travel API.",
+        {},
+        async () => toToolContent(await api.get("/api/trips")),
+    );
+
+    server.tool(
+        "get_locations",
+        "Get available travel locations from the travel API.",
+        {
+            category: z.enum(["flights", "hotels", "trips"]).optional().describe("Optional location category."),
+        },
+        async ({ category }) => {
+            const query = category ? `?${new URLSearchParams({ category }).toString()}` : "";
+
+            return toToolContent(await api.get(`/api/locations${query}`));
+        },
+    );
+
+    server.tool(
+        "create_booking",
+        "Create a sample booking in the travel API.",
+        {
+            type: z.enum(["flight", "hotel", "trip"]).describe("Booking type."),
+            itemId: z.string().describe("Flight or hotel item ID to book."),
+            travelers: z.number().int().optional().describe("Number of travelers."),
+        },
+        async ({ type, itemId, travelers }) => toToolContent(await api.post("/api/bookings", {
+            type,
+            itemId,
+            travelers: travelers ?? 1,
+        })),
+    );
+
+    server.tool(
+        "get_flight_bookings",
+        "Get flight bookings for the current authenticated user.",
+        {},
+        async () => toToolContent(await api.get("/api/bookings/flights")),
+    );
+
+    server.tool(
+        "delete_all_bookings",
+        "Delete ALL flight bookings for the current authenticated user. Use this to reset the user's bookings (e.g. when the user explicitly says 'clear all my bookings' or 'reset my bookings'). Destructive — only call when explicitly requested.",
+        {},
+        async () => toToolContent(await api.delete("/api/bookings/flights")),
+    );
+
+    server.tool(
+        "get_profile",
+        "Get the current authenticated user's profile from the travel API.",
+        {},
+        async () => toToolContent(await api.get("/api/me")),
+    );
+
+    return server;
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+    const chunks: Buffer[] = [];
+
+    for await (const chunk of request) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+
+    if (chunks.length === 0) {
+        return undefined;
+    }
+
+    const body = Buffer.concat(chunks).toString("utf8");
+
+    return body ? JSON.parse(body) : undefined;
+}
+
+function sendJson(response: ServerResponse, statusCode: number, body: JsonValue) {
+    response.writeHead(statusCode, { "Content-Type": "application/json" });
+    response.end(JSON.stringify(body));
+}
+
+const httpServer = createServer(async (request, response) => {
+    if (request.url === "/health") {
+        sendJson(response, 200, { status: "ok" });
+
+        return;
+    }
+
+    if (request.url !== "/mcp") {
+        sendJson(response, 404, { error: "Not found" });
+
+        return;
+    }
+
+    if (request.method !== "POST") {
+        sendJson(response, 405, { error: "Method not allowed" });
+
+        return;
+    }
+
+    let body: unknown;
+    try {
+        body = await readJsonBody(request);
+    } catch (error) {
+        sendJson(response, 400, {
+            error: error instanceof Error ? `Malformed JSON body: ${error.message}` : "Malformed JSON body",
+        });
+        return;
+    }
+
+    try {
+        const server = createTravelMcpServer(getAuthorizationHeader(request));
+        const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+        });
+
+        response.on("close", () => {
+            transport.close();
+        });
+
+        await server.connect(transport);
+        await transport.handleRequest(request, response, body);
+    } catch (error) {
+        console.error("Error handling MCP request:", error);
+
+        if (!response.headersSent) {
+            sendJson(response, 500, {
+                error: error instanceof Error ? error.message : "Failed to handle MCP request.",
+            });
+        }
+    }
+});
+
+httpServer.listen(port, host, () => {
+    console.log(`Travel MCP server is running at http://${host}:${port}/mcp`);
+    console.log(`Health check is available at http://${host}:${port}/health`);
+});

--- a/samples/apps/agent-id-sample/mcp/tsconfig.json
+++ b/samples/apps/agent-id-sample/mcp/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
End-to-end demo of an AI agent that holds its own Thunder-managed identity. Uses a client-credentials (M2M) token for browsing tools and switches to a user-context token via OAuth 2.0 authorization-code + PKCE when a tool needs the user's consent.

### What's included
- **api/** — Node REST API for Wayfinder Travel, validates JWTs and enforces scopes per route (`booking:read`, `booking:create`, `booking:cancel`).
- **mcp/** — Streamable-HTTP MCP server wrapping the REST API.
- **ai-agent/** — WebSocket chat agent (LangChain ReAct + Claude) with M2M for browsing tools and per-session OBO for user-context tools.
- **frontend/** — React/Vite UI with chat widget, OBO popup handling, and an in-app **Agent Portal** page for managing agents and role assignments from the browser.

### Setup
See [README.md](samples/apps/agent-id-sample/README.md) — Thunder setup (resource server, demo user, roles, agent + flow) is self-contained and doesn't depend on the bootstrap script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Complete Agent Identity sample: WebSocket AI chat with in-chat consent and agent↔user auth switching
  * Full frontend: search, results, details, payment/booking flows, bookings management, QR credential panel, Agent Portal for agent lifecycle
  * REST API (OpenAPI) and MCP server with seeded travel data; sample env configs and startup scripts
  * New responsive styles and UI components for the app

* **Documentation**
  * Comprehensive READMEs and .env examples for end-to-end local setup and demos

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->