### PR TITLE
Fix broken doc links on console welcome page

### DIFF
--- a/frontend/apps/console/src/features/welcome/pages/WelcomePage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/WelcomePage.tsx
@@ -71,11 +71,7 @@ export default function WelcomePage(): JSX.Element {
       label: t('common:welcome.walkthrough.getStartedDesigner'),
       description: t('common:welcome.walkthrough.getStartedDesignerDesc'),
       action: () =>
-        window.open(
-          'https://asgardeo.github.io/thunder/docs/next/guides/quick-start/quickstart',
-          '_blank',
-          'noopener,noreferrer',
-        ),
+        window.open('https://thunderid.dev/docs/next/guides/quick-start/quickstart', '_blank', 'noopener,noreferrer'),
     },
     {
       id: 'learn-fundamentals',
@@ -84,7 +80,7 @@ export default function WelcomePage(): JSX.Element {
       description: t('common:welcome.walkthrough.learnFundamentalsDesc'),
       action: () =>
         window.open(
-          'https://asgardeo.github.io/thunder/docs/next/guides/key-concepts/authentication/overview',
+          'https://thunderid.dev/docs/next/guides/key-concepts/authentication/overview',
           '_blank',
           'noopener,noreferrer',
         ),


### PR DESCRIPTION
### Purpose
The two walkthrough links on the console welcome page (`/console/welcome`) — **Get started** and **Learn the Fundamentals** — pointed to `asgardeo.github.io/thunder`, the old domain. Those URLs either 404 or go to the wrong place. The correct domain is `thunderid.dev`.

### Approach
Replaced the two hardcoded URLs in `WelcomePage.tsx`:

| Link | Old | New |
|------|-----|-----|
| Get started | `https://asgardeo.github.io/thunder/docs/next/guides/quick-start/quickstart` | `https://thunderid.dev/docs/next/guides/quick-start/quickstart` |
| Learn the Fundamentals | `https://asgardeo.github.io/thunder/docs/next/guides/key-concepts/authentication/overview` | `https://thunderid.dev/docs/next/guides/key-concepts/authentication/overview` |

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated welcome page documentation links to point users to the ThunderID quick-start guide and the ThunderID authentication overview, ensuring the walkthrough "get started (designer)" and "learn fundamentals" actions now open the new documentation resources. Session behavior, navigation, layout, and animations remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->