### PR TITLE
Reduce setup script logs

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -82,9 +82,11 @@ if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
     $DEFAULT_OU_ID = $body.id
     if ($DEFAULT_OU_ID) {
         Log-Info "Default OU ID: $DEFAULT_OU_ID"
+        Log-Result-Success "Created default organization unit"
     }
     else {
         Log-Error "Could not extract OU ID from response"
+        Log-Result-Failure "Failed to create default organization unit"
         exit 1
     }
 }
@@ -98,20 +100,24 @@ elseif ($response.StatusCode -eq 409) {
         $DEFAULT_OU_ID = $body.id
         if ($DEFAULT_OU_ID) {
             Log-Success "Found OU ID: $DEFAULT_OU_ID"
+            Log-Result-Success "Created default organization unit"
         }
         else {
             Log-Error "Could not find OU ID in response"
+            Log-Result-Failure "Failed to create default organization unit"
             exit 1
         }
     }
     else {
         Log-Error "Failed to fetch organization unit by handle 'default' (HTTP $($response.StatusCode))"
+        Log-Result-Failure "Failed to create default organization unit"
         exit 1
     }
 }
 else {
     Log-Error "Failed to create organization unit (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
+    Log-Result-Failure "Failed to create default organization unit"
     exit 1
 }
 
@@ -197,8 +203,11 @@ elseif ($response.StatusCode -eq 409) {
 }
 else {
     Log-Error "Failed to create user type (HTTP $($response.StatusCode))"
+    Log-Result-Failure "Failed to create default user type (Person)"
     exit 1
 }
+
+Log-Result-Success "Created default user type (Person)"
 
 Write-Host ""
 
@@ -241,8 +250,11 @@ elseif ($response.StatusCode -eq 409) {
 }
 else {
     Log-Error "Failed to create agent type (HTTP $($response.StatusCode))"
+    Log-Result-Failure "Failed to create default agent type"
     exit 1
 }
+
+Log-Result-Success "Created default agent type"
 
 Write-Host ""
 
@@ -302,19 +314,24 @@ elseif ($response.StatusCode -eq 409) {
         }
         else {
             Log-Error "Could not find admin user in response"
+            Log-Result-Failure "Failed to create admin user"
             exit 1
         }
     }
     else {
         Log-Error "Failed to fetch users (HTTP $($response.StatusCode))"
+        Log-Result-Failure "Failed to create admin user"
         exit 1
     }
 }
 else {
     Log-Error "Failed to create admin user (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
+    Log-Result-Failure "Failed to create admin user"
     exit 1
 }
+
+Log-Result-Success "Created admin user"
 
 Write-Host ""
 
@@ -326,6 +343,7 @@ Log-Info "Creating system resource server..."
 
 if (-not $DEFAULT_OU_ID) {
     Log-Error "Default OU ID is not available. Cannot create resource server."
+    Log-Result-Failure "Failed to create system resource server"
     exit 1
 }
 
@@ -345,9 +363,11 @@ if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
     $SYSTEM_RS_ID = $body.id
     if ($SYSTEM_RS_ID) {
         Log-Info "System resource server ID: $SYSTEM_RS_ID"
+        Log-Result-Success "Created system resource server"
     }
     else {
         Log-Error "Could not extract resource server ID from response"
+        Log-Result-Failure "Failed to create system resource server"
         exit 1
     }
 }
@@ -367,22 +387,27 @@ elseif ($response.StatusCode -eq 409) {
             $existingIdentifier = if ($systemRS.identifier) { $systemRS.identifier } else { "" }
             if ($existingHandle -ne $SYSTEM_RS_HANDLE -or $existingIdentifier -ne $SYSTEM_RS_IDENTIFIER) {
                 Log-Error "Existing system resource server has mismatched configuration. Expected handle='${SYSTEM_RS_HANDLE}', identifier='${SYSTEM_RS_IDENTIFIER}' but found handle='${existingHandle}', identifier='${existingIdentifier}'. Manual migration required."
+                Log-Result-Failure "Failed to create system resource server"
                 exit 1
             }
+            Log-Result-Success "Created system resource server"
         }
         else {
             Log-Error "Could not find resource server ID in response"
+            Log-Result-Failure "Failed to create system resource server"
             exit 1
         }
     }
     else {
         Log-Error "Failed to fetch resource servers (HTTP $($response.StatusCode))"
+        Log-Result-Failure "Failed to create system resource server"
         exit 1
     }
 }
 else {
     Log-Error "Failed to create resource server (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
+    Log-Result-Failure "Failed to create system resource server"
     exit 1
 }
 
@@ -405,11 +430,16 @@ Write-Host ""
 #           └── Action handle "view"       → permission "system:usertype:view"
 # ============================================================================
 
+function System-Permissions-Failed {
+    Log-Result-Failure "Failed to create system permissions"
+    exit 1
+}
+
 Log-Info "Creating 'system' resource under the system resource server..."
 
 if (-not $SYSTEM_RS_ID) {
     Log-Error "System resource server ID is not available. Cannot create system resource."
-    exit 1
+    System-Permissions-Failed
 }
 
 $systemResourceData = @{
@@ -429,7 +459,7 @@ if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
     }
     else {
         Log-Error "Could not extract system resource ID from response"
-        exit 1
+        System-Permissions-Failed
     }
 }
 elseif ($response.StatusCode -eq 409) {
@@ -446,25 +476,25 @@ elseif ($response.StatusCode -eq 409) {
         }
         else {
             Log-Error "Could not find system resource in response"
-            exit 1
+            System-Permissions-Failed
         }
     }
     else {
         Log-Error "Failed to fetch resources (HTTP $($response.StatusCode))"
-        exit 1
+        System-Permissions-Failed
     }
 }
 else {
     Log-Error "Failed to create system resource (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
-    exit 1
+    System-Permissions-Failed
 }
 
 Log-Info "Creating 'ou' sub-resource under the 'system' resource..."
 
 if (-not $SYSTEM_RESOURCE_ID) {
     Log-Error "System resource ID is not available. Cannot create OU resource."
-    exit 1
+    System-Permissions-Failed
 }
 
 $ouResourceData = @{
@@ -485,7 +515,7 @@ if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
     }
     else {
         Log-Error "Could not extract OU resource ID from response"
-        exit 1
+        System-Permissions-Failed
     }
 }
 elseif ($response.StatusCode -eq 409) {
@@ -502,18 +532,18 @@ elseif ($response.StatusCode -eq 409) {
         }
         else {
             Log-Error "Could not find OU resource in response"
-            exit 1
+            System-Permissions-Failed
         }
     }
     else {
         Log-Error "Failed to fetch resources (HTTP $($response.StatusCode))"
-        exit 1
+        System-Permissions-Failed
     }
 }
 else {
     Log-Error "Failed to create OU resource (HTTP $($response.StatusCode))"
     Log-Error "Response: $($response.Body)"
-    exit 1
+    System-Permissions-Failed
 }
 
 Log-Info "Creating 'view' action under the 'ou' resource..."
@@ -535,14 +565,14 @@ elseif ($response.StatusCode -eq 409) {
 else {
     Log-Error "Failed to create OU view action (HTTP $($response.StatusCode))"
     Log-Error "Response: $($response.Body)"
-    exit 1
+    System-Permissions-Failed
 }
 
 Log-Info "Creating 'user' sub-resource under the 'system' resource..."
 
 if (-not $SYSTEM_RESOURCE_ID) {
     Log-Error "System resource ID is not available. Cannot create user resource."
-    exit 1
+    System-Permissions-Failed
 }
 
 $userResourceData = @{
@@ -563,7 +593,7 @@ if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
     }
     else {
         Log-Error "Could not extract user resource ID from response"
-        exit 1
+        System-Permissions-Failed
     }
 }
 elseif ($response.StatusCode -eq 409) {
@@ -580,18 +610,18 @@ elseif ($response.StatusCode -eq 409) {
         }
         else {
             Log-Error "Could not find user resource in response"
-            exit 1
+            System-Permissions-Failed
         }
     }
     else {
         Log-Error "Failed to fetch resources (HTTP $($response.StatusCode))"
-        exit 1
+        System-Permissions-Failed
     }
 }
 else {
     Log-Error "Failed to create user resource (HTTP $($response.StatusCode))"
     Log-Error "Response: $($response.Body)"
-    exit 1
+    System-Permissions-Failed
 }
 
 Log-Info "Creating 'view' action under the 'user' resource..."
@@ -613,14 +643,14 @@ elseif ($response.StatusCode -eq 409) {
 else {
     Log-Error "Failed to create user view action (HTTP $($response.StatusCode))"
     Log-Error "Response: $($response.Body)"
-    exit 1
+    System-Permissions-Failed
 }
 
 Log-Info "Creating 'usertype' sub-resource under the 'system' resource..."
 
 if (-not $SYSTEM_RESOURCE_ID) {
     Log-Error "System resource ID is not available. Cannot create user type resource."
-    exit 1
+    System-Permissions-Failed
 }
 
 $userTypeResourceData = @{
@@ -641,7 +671,7 @@ if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
     }
     else {
         Log-Error "Could not extract user type resource ID from response"
-        exit 1
+        System-Permissions-Failed
     }
 }
 elseif ($response.StatusCode -eq 409) {
@@ -658,18 +688,18 @@ elseif ($response.StatusCode -eq 409) {
         }
         else {
             Log-Error "Could not find user type resource in response"
-            exit 1
+            System-Permissions-Failed
         }
     }
     else {
         Log-Error "Failed to fetch resources (HTTP $($response.StatusCode))"
-        exit 1
+        System-Permissions-Failed
     }
 }
 else {
     Log-Error "Failed to create user type resource (HTTP $($response.StatusCode))"
     Log-Error "Response: $($response.Body)"
-    exit 1
+    System-Permissions-Failed
 }
 
 Log-Info "Creating 'view' action under the 'usertype' resource..."
@@ -691,7 +721,7 @@ elseif ($response.StatusCode -eq 409) {
 else {
     Log-Error "Failed to create user type view action (HTTP $($response.StatusCode))"
     Log-Error "Response: $($response.Body)"
-    exit 1
+    System-Permissions-Failed
 }
 
 Write-Host ""
@@ -700,7 +730,7 @@ Log-Info "Creating 'group' sub-resource under the 'system' resource..."
 
 if (-not $SYSTEM_RESOURCE_ID) {
     Log-Error "System resource ID is not available. Cannot create group resource."
-    exit 1
+    System-Permissions-Failed
 }
 
 $groupResourceData = @{
@@ -721,7 +751,7 @@ if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
     }
     else {
         Log-Error "Could not extract group resource ID from response"
-        exit 1
+        System-Permissions-Failed
     }
 }
 elseif ($response.StatusCode -eq 409) {
@@ -738,18 +768,18 @@ elseif ($response.StatusCode -eq 409) {
         }
         else {
             Log-Error "Could not find group resource in response"
-            exit 1
+            System-Permissions-Failed
         }
     }
     else {
         Log-Error "Failed to fetch resources (HTTP $($response.StatusCode))"
-        exit 1
+        System-Permissions-Failed
     }
 }
 else {
     Log-Error "Failed to create group resource (HTTP $($response.StatusCode))"
     Log-Error "Response: $($response.Body)"
-    exit 1
+    System-Permissions-Failed
 }
 
 Log-Info "Creating 'view' action under the 'group' resource..."
@@ -771,8 +801,10 @@ elseif ($response.StatusCode -eq 409) {
 else {
     Log-Error "Failed to create group view action (HTTP $($response.StatusCode))"
     Log-Error "Response: $($response.Body)"
-    exit 1
+    System-Permissions-Failed
 }
+
+Log-Result-Success "Created system permissions"
 
 Write-Host ""
 
@@ -784,11 +816,13 @@ Log-Info "Creating administrator group..."
 
 if (-not $DEFAULT_OU_ID) {
     Log-Error "Default OU ID is not available. Cannot create administrator group."
+    Log-Result-Failure "Failed to create Administrators group"
     exit 1
 }
 
 if (-not $ADMIN_USER_ID) {
     Log-Error "Admin user ID is not available. Cannot create administrator group with user membership."
+    Log-Result-Failure "Failed to create Administrators group"
     exit 1
 }
 
@@ -812,9 +846,11 @@ if ($response.StatusCode -eq 201 -or $response.StatusCode -eq 200) {
     $ADMIN_GROUP_ID = $body.id
     if ($ADMIN_GROUP_ID) {
         Log-Info "Administrator group ID: $ADMIN_GROUP_ID"
+        Log-Result-Success "Created Administrators group"
     }
     else {
         Log-Error "Could not extract administrator group ID from response"
+        Log-Result-Failure "Failed to create Administrators group"
         exit 1
     }
 }
@@ -829,20 +865,24 @@ elseif ($response.StatusCode -eq 409) {
         if ($adminGroup) {
             $ADMIN_GROUP_ID = $adminGroup.id
             Log-Success "Found administrator group ID: $ADMIN_GROUP_ID"
+            Log-Result-Success "Created Administrators group"
         }
         else {
             Log-Error "Could not find administrator group in response"
+            Log-Result-Failure "Failed to create Administrators group"
             exit 1
         }
     }
     else {
         Log-Error "Failed to fetch groups under default OU (HTTP $($response.StatusCode))"
+        Log-Result-Failure "Failed to create Administrators group"
         exit 1
     }
 }
 else {
     Log-Error "Failed to create administrator group (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
+    Log-Result-Failure "Failed to create Administrators group"
     exit 1
 }
 
@@ -856,16 +896,19 @@ Log-Info "Creating admin role with '$SYSTEM_PERMISSION' permission..."
 
 if (-not $ADMIN_GROUP_ID) {
     Log-Error "Administrator group ID is not available. Cannot create role."
+    Log-Result-Failure "Failed to create Administrator role"
     exit 1
 }
 
 if (-not $DEFAULT_OU_ID) {
     Log-Error "Default OU ID is not available. Cannot create role."
+    Log-Result-Failure "Failed to create Administrator role"
     exit 1
 }
 
 if (-not $SYSTEM_RS_ID) {
     Log-Error "System resource server ID is not available. Cannot create role."
+    Log-Result-Failure "Failed to create Administrator role"
     exit 1
 }
 
@@ -903,8 +946,11 @@ elseif ($response.StatusCode -eq 409) {
 else {
     Log-Error "Failed to create admin role (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
+    Log-Result-Failure "Failed to create Administrator role"
     exit 1
 }
+
+Log-Result-Success "Created Administrator role"
 
 Write-Host ""
 
@@ -1315,6 +1361,20 @@ else {
     Log-Warning "Application flows directory not found at $APPS_FLOWS_DIR"
 }
 
+if ($flowCount -gt 0) {
+    $flowFailures = $flowCount - $flowSuccess - $flowSkipped
+    if ($flowFailures -eq 0) {
+        Log-Result-Success "Created default flows"
+    }
+    else {
+        Log-Result-Failure "Failed to create default flows (flowCount=$flowCount, flowSuccess=$flowSuccess, flowSkipped=$flowSkipped, failures=$flowFailures)"
+        exit 1
+    }
+}
+else {
+    Log-Result-Success "Created default flows"
+}
+
 Write-Host ""
 
 # ============================================================================
@@ -1338,11 +1398,13 @@ if ($APP_FLOW_IDS.ContainsKey("console")) {
 if (-not $CONSOLE_AUTH_FLOW_ID) {
     Log-Error "Console authentication flow ID not found, cannot create Console application"
     Log-Error "Make sure flows/apps/console/auth_flow_console.json exists"
+    Log-Result-Failure "Failed to create Console application"
     exit 1
 }
 if (-not $CONSOLE_REG_FLOW_ID) {
     Log-Error "Console registration flow ID not found, cannot create Console application"
     Log-Error "Make sure flows/apps/console/registration_flow_console.json exists"
+    Log-Result-Failure "Failed to create Console application"
     exit 1
 }
 if (-not $CONSOLE_RECOVERY_FLOW_ID) {
@@ -1427,8 +1489,11 @@ elseif ($response.StatusCode -eq 400 -and ($response.Body -match "Application al
 else {
     Log-Error "Failed to create Console application (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
+    Log-Result-Failure "Failed to create Console application"
     exit 1
 }
+
+Log-Result-Success "Created Console application"
 
 Write-Host ""
 
@@ -1497,12 +1562,14 @@ else {
                 else {
                     Log-Error "Failed to update theme '$themeName' (HTTP $($response.StatusCode))"
                     Write-Host "Response: $($response.Body)"
+                    Log-Result-Failure "Failed to create themes"
                     exit 1
                 }
             }
             else {
                 Log-Error "Failed to create theme '$themeName' (HTTP $($response.StatusCode))"
                 Write-Host "Response: $($response.Body)"
+                Log-Result-Failure "Failed to create themes"
                 exit 1
             }
         }
@@ -1514,6 +1581,8 @@ else {
         Log-Warning "No theme files found in $themesDir"
     }
 }
+
+Log-Result-Success "Created themes"
 
 Write-Host ""
 
@@ -1556,6 +1625,7 @@ else {
             else {
                 Log-Error "Failed to seed translations for '$language' (HTTP $($response.StatusCode))"
                 Write-Host "Response: $($response.Body)"
+                Log-Result-Failure "Failed to seed i18n translations"
                 exit 1
             }
         }
@@ -1568,6 +1638,8 @@ else {
     }
 }
 
+Log-Result-Success "Seeded i18n translations"
+
 Write-Host ""
 
 # ============================================================================
@@ -1575,9 +1647,5 @@ Write-Host ""
 # ============================================================================
 
 Log-Success "Default resources setup completed successfully!"
-Write-Host ""
-Log-Info "👤 Admin credentials:"
-Log-Info "   Username: admin"
-Log-Info "   Password: admin"
-Log-Info "   Role: Administrator ($SYSTEM_PERMISSION permission via Administrators group)"
+Log-Result-Success "Created default resources"
 Write-Host ""

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -75,8 +75,10 @@ if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
     DEFAULT_OU_ID=$(echo "$BODY" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
     if [[ -n "$DEFAULT_OU_ID" ]]; then
         log_info "Default OU ID: $DEFAULT_OU_ID"
+        log_result_success "Created default organization unit"
     else
         log_error "Could not extract OU ID from response"
+        log_result_failure "Failed to create default organization unit"
         exit 1
     fi
 elif [[ "$HTTP_CODE" == "409" ]]; then
@@ -90,17 +92,21 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
         DEFAULT_OU_ID=$(echo "$BODY" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
         if [[ -n "$DEFAULT_OU_ID" ]]; then
             log_success "Found OU ID: $DEFAULT_OU_ID"
+            log_result_success "Created default organization unit"
         else
             log_error "Could not find OU ID in response"
+            log_result_failure "Failed to create default organization unit"
             exit 1
         fi
     else
         log_error "Failed to fetch organization unit by handle 'default' (HTTP $HTTP_CODE)"
+        log_result_failure "Failed to create default organization unit"
         exit 1
     fi
 else
     log_error "Failed to create organization unit (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
+    log_result_failure "Failed to create default organization unit"
     exit 1
 fi
 
@@ -184,8 +190,10 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
     log_warning "User type already exists, skipping"
 else
     log_error "Failed to create user type (HTTP $HTTP_CODE)"
+    log_result_failure "Failed to create default user type (Person)"
     exit 1
 fi
+log_result_success "Created default user type (Person)"
 
 echo ""
 
@@ -226,8 +234,10 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
     log_warning "Agent type already exists, skipping"
 else
     log_error "Failed to create agent type (HTTP $HTTP_CODE)"
+    log_result_failure "Failed to create default agent type"
     exit 1
 fi
+log_result_success "Created default agent type"
 
 echo ""
 
@@ -289,17 +299,21 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
             log_success "Found admin user ID: $ADMIN_USER_ID"
         else
             log_error "Could not find admin user in response"
+            log_result_failure "Failed to create admin user"
             exit 1
         fi
     else
         log_error "Failed to fetch users (HTTP $HTTP_CODE)"
+        log_result_failure "Failed to create admin user"
         exit 1
     fi
 else
     log_error "Failed to create admin user (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
+    log_result_failure "Failed to create admin user"
     exit 1
 fi
+log_result_success "Created admin user"
 
 echo ""
 
@@ -311,6 +325,7 @@ log_info "Creating system resource server..."
 
 if [[ -z "$DEFAULT_OU_ID" ]]; then
     log_error "Default OU ID is not available. Cannot create resource server."
+    log_result_failure "Failed to create system resource server"
     exit 1
 fi
 
@@ -330,8 +345,10 @@ if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
     SYSTEM_RS_ID=$(echo "$BODY" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
     if [[ -n "$SYSTEM_RS_ID" ]]; then
         log_info "System resource server ID: $SYSTEM_RS_ID"
+        log_result_success "Created system resource server"
     else
         log_error "Could not extract resource server ID from response"
+        log_result_failure "Failed to create system resource server"
         exit 1
     fi
 elif [[ "$HTTP_CODE" == "409" ]]; then
@@ -356,19 +373,24 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
             EXISTING_IDENTIFIER=$(echo "$SYSTEM_LINE" | grep -o '"identifier":"[^"]*"' | head -1 | cut -d'"' -f4)
             if [[ "$EXISTING_HANDLE" != "$SYSTEM_RS_HANDLE" ]] || [[ "$EXISTING_IDENTIFIER" != "$SYSTEM_RS_IDENTIFIER" ]]; then
                 log_error "Existing system resource server has mismatched configuration. Expected handle='${SYSTEM_RS_HANDLE}', identifier='${SYSTEM_RS_IDENTIFIER}' but found handle='${EXISTING_HANDLE}', identifier='${EXISTING_IDENTIFIER}'. Manual migration required."
+                log_result_failure "Failed to create system resource server"
                 exit 1
             fi
+            log_result_success "Created system resource server"
         else
             log_error "Could not find resource server ID in response"
+            log_result_failure "Failed to create system resource server"
             exit 1
         fi
     else
         log_error "Failed to fetch resource servers (HTTP $HTTP_CODE)"
+        log_result_failure "Failed to create system resource server"
         exit 1
     fi
 else
     log_error "Failed to create resource server (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
+    log_result_failure "Failed to create system resource server"
     exit 1
 fi
 
@@ -391,11 +413,16 @@ echo ""
 #           └── Action handle "view"       → permission "system:usertype:view"
 # ============================================================================
 
+system_permissions_failed() {
+    log_result_failure "Failed to create system permissions"
+    exit 1
+}
+
 log_info "Creating 'system' resource under the system resource server..."
 
 if [[ -z "$SYSTEM_RS_ID" ]]; then
     log_error "System resource server ID is not available. Cannot create system resource."
-    exit 1
+    system_permissions_failed
 fi
 
 RESPONSE=$(api_call POST "/resource-servers/${SYSTEM_RS_ID}/resources" '{
@@ -414,7 +441,7 @@ if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
         log_info "System resource ID: $SYSTEM_RESOURCE_ID"
     else
         log_error "Could not extract system resource ID from response"
-        exit 1
+        system_permissions_failed
     fi
 elif [[ "$HTTP_CODE" == "409" ]]; then
     log_warning "System resource already exists, retrieving ID..."
@@ -428,16 +455,16 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
             log_success "Found system resource ID: $SYSTEM_RESOURCE_ID"
         else
             log_error "Could not find system resource in response"
-            exit 1
+            system_permissions_failed
         fi
     else
         log_error "Failed to fetch resources (HTTP $HTTP_CODE)"
-        exit 1
+        system_permissions_failed
     fi
 else
     log_error "Failed to create system resource (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
-    exit 1
+    system_permissions_failed
 fi
 
 log_info "Creating 'ou' sub-resource under the 'system' resource..."
@@ -459,7 +486,7 @@ if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
         log_info "OU resource ID: $OU_RESOURCE_ID"
     else
         log_error "Could not extract OU resource ID from response"
-        exit 1
+        system_permissions_failed
     fi
 elif [[ "$HTTP_CODE" == "409" ]]; then
     log_warning "OU resource already exists, retrieving ID..."
@@ -473,16 +500,16 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
             log_success "Found OU resource ID: $OU_RESOURCE_ID"
         else
             log_error "Could not find OU resource in response"
-            exit 1
+            system_permissions_failed
         fi
     else
         log_error "Failed to fetch resources (HTTP $HTTP_CODE)"
-        exit 1
+        system_permissions_failed
     fi
 else
     log_error "Failed to create OU resource (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
-    exit 1
+    system_permissions_failed
 fi
 
 log_info "Creating 'view' action under the 'ou' resource..."
@@ -503,7 +530,7 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
 else
     log_error "Failed to create OU view action (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
-    exit 1
+    system_permissions_failed
 fi
 
 log_info "Creating 'user' sub-resource under the 'system' resource..."
@@ -525,7 +552,7 @@ if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
         log_info "User resource ID: $USER_RESOURCE_ID"
     else
         log_error "Could not extract user resource ID from response"
-        exit 1
+        system_permissions_failed
     fi
 elif [[ "$HTTP_CODE" == "409" ]]; then
     log_warning "User resource already exists, retrieving ID..."
@@ -539,16 +566,16 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
             log_success "Found user resource ID: $USER_RESOURCE_ID"
         else
             log_error "Could not find user resource in response"
-            exit 1
+            system_permissions_failed
         fi
     else
         log_error "Failed to fetch resources (HTTP $HTTP_CODE)"
-        exit 1
+        system_permissions_failed
     fi
 else
     log_error "Failed to create user resource (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
-    exit 1
+    system_permissions_failed
 fi
 
 log_info "Creating 'view' action under the 'user' resource..."
@@ -569,7 +596,7 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
 else
     log_error "Failed to create user view action (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
-    exit 1
+    system_permissions_failed
 fi
 
 log_info "Creating 'usertype' sub-resource under the 'system' resource..."
@@ -591,7 +618,7 @@ if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
         log_info "User type resource ID: $USER_TYPE_RESOURCE_ID"
     else
         log_error "Could not extract user type resource ID from response"
-        exit 1
+        system_permissions_failed
     fi
 elif [[ "$HTTP_CODE" == "409" ]]; then
     log_warning "User type resource already exists, retrieving ID..."
@@ -605,16 +632,16 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
             log_success "Found user type resource ID: $USER_TYPE_RESOURCE_ID"
         else
             log_error "Could not find user type resource in response"
-            exit 1
+            system_permissions_failed
         fi
     else
         log_error "Failed to fetch resources (HTTP $HTTP_CODE)"
-        exit 1
+        system_permissions_failed
     fi
 else
     log_error "Failed to create user type resource (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
-    exit 1
+    system_permissions_failed
 fi
 
 log_info "Creating 'view' action under the 'usertype' resource..."
@@ -635,7 +662,7 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
 else
     log_error "Failed to create user type view action (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
-    exit 1
+    system_permissions_failed
 fi
 
 echo ""
@@ -659,7 +686,7 @@ if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
         log_info "Group resource ID: $GROUP_RESOURCE_ID"
     else
         log_error "Could not extract group resource ID from response"
-        exit 1
+        system_permissions_failed
     fi
 elif [[ "$HTTP_CODE" == "409" ]]; then
     log_warning "Group resource already exists, retrieving ID..."
@@ -673,16 +700,16 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
             log_success "Found group resource ID: $GROUP_RESOURCE_ID"
         else
             log_error "Could not find group resource in response"
-            exit 1
+            system_permissions_failed
         fi
     else
         log_error "Failed to fetch resources (HTTP $HTTP_CODE)"
-        exit 1
+        system_permissions_failed
     fi
 else
     log_error "Failed to create group resource (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
-    exit 1
+    system_permissions_failed
 fi
 
 log_info "Creating 'view' action under the 'group' resource..."
@@ -703,8 +730,9 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
 else
     log_error "Failed to create group view action (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
-    exit 1
+    system_permissions_failed
 fi
+log_result_success "Created system permissions"
 
 echo ""
 
@@ -716,11 +744,13 @@ log_info "Creating administrator group..."
 
 if [[ -z "$DEFAULT_OU_ID" ]]; then
     log_error "Default OU ID is not available. Cannot create administrator group."
+    log_result_failure "Failed to create Administrators group"
     exit 1
 fi
 
 if [[ -z "$ADMIN_USER_ID" ]]; then
     log_error "Admin user ID is not available. Cannot create administrator group with user membership."
+    log_result_failure "Failed to create Administrators group"
     exit 1
 fi
 
@@ -744,8 +774,10 @@ if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
     ADMIN_GROUP_ID=$(echo "$BODY" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
     if [[ -n "$ADMIN_GROUP_ID" ]]; then
         log_info "Administrator group ID: $ADMIN_GROUP_ID"
+        log_result_success "Created Administrators group"
     else
         log_error "Could not extract administrator group ID from response"
+        log_result_failure "Failed to create Administrators group"
         exit 1
     fi
 elif [[ "$HTTP_CODE" == "409" ]]; then
@@ -758,17 +790,21 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
         ADMIN_GROUP_ID=$(echo "$BODY" | sed 's/},{/}\n{/g' | grep '"name":"Administrators"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
         if [[ -n "$ADMIN_GROUP_ID" ]]; then
             log_success "Found administrator group ID: $ADMIN_GROUP_ID"
+            log_result_success "Created Administrators group"
         else
             log_error "Could not find administrator group in response"
+            log_result_failure "Failed to create Administrators group"
             exit 1
         fi
     else
         log_error "Failed to fetch groups under default OU (HTTP $HTTP_CODE)"
+        log_result_failure "Failed to create Administrators group"
         exit 1
     fi
 else
     log_error "Failed to create administrator group (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
+    log_result_failure "Failed to create Administrators group"
     exit 1
 fi
 
@@ -782,16 +818,19 @@ log_info "Creating admin role with '${SYSTEM_PERMISSION}' permission..."
 
 if [[ -z "$ADMIN_GROUP_ID" ]]; then
     log_error "Administrator group ID is not available. Cannot create role."
+    log_result_failure "Failed to create Administrator role"
     exit 1
 fi
 
 if [[ -z "$DEFAULT_OU_ID" ]]; then
     log_error "Default OU ID is not available. Cannot create role."
+    log_result_failure "Failed to create Administrator role"
     exit 1
 fi
 
 if [[ -z "$SYSTEM_RS_ID" ]]; then
     log_error "System resource server ID is not available. Cannot create role."
+    log_result_failure "Failed to create Administrator role"
     exit 1
 fi
 
@@ -827,8 +866,10 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
 else
     log_error "Failed to create admin role (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
+    log_result_failure "Failed to create Administrator role"
     exit 1
 fi
+log_result_success "Created Administrator role"
 
 echo ""
 
@@ -1277,6 +1318,8 @@ else
     log_warning "Application flows directory not found at $APPS_FLOWS_DIR"
 fi
 
+log_result_success "Created default flows"
+
 echo ""
 
 # ============================================================================
@@ -1294,10 +1337,12 @@ log_debug "Extracted flow IDs: auth=$CONSOLE_AUTH_FLOW_ID, reg=$CONSOLE_REG_FLOW
 # Validate that flow IDs are available
 if [[ -z "$CONSOLE_AUTH_FLOW_ID" ]]; then
     log_error "Console authentication flow ID not found, cannot create CONSOLE application"
+    log_result_failure "Failed to create Console application"
     exit 1
 fi
 if [[ -z "$CONSOLE_REG_FLOW_ID" ]]; then
     log_error "Console registration flow ID not found, cannot create CONSOLE application"
+    log_result_failure "Failed to create Console application"
     exit 1
 fi
 if [[ -z "$CONSOLE_RECOVERY_FLOW_ID" ]]; then
@@ -1385,8 +1430,10 @@ elif [[ "$HTTP_CODE" == "400" ]] && [[ "$BODY" =~ (Application already exists|AP
 else
     log_error "Failed to create CONSOLE application (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
+    log_result_failure "Failed to create Console application"
     exit 1
 fi
+log_result_success "Created Console application"
 
 echo ""
 
@@ -1471,6 +1518,7 @@ else
         log_warning "No theme files found in ${THEMES_DIR}"
     fi
 fi
+log_result_success "Created themes"
 
 echo ""
 
@@ -1518,6 +1566,7 @@ else
             else
                 log_error "Failed to seed translations for '${LANGUAGE}' (HTTP $HTTP_CODE)"
                 log_error "Response: $BODY"
+                log_result_failure "Failed to seed i18n translations"
                 exit 1
             fi
         done
@@ -1528,6 +1577,7 @@ else
         log_warning "No i18n translation files found in ${I18N_DIR}"
     fi
 fi
+log_result_success "Seeded i18n translations"
 
 echo ""
 

--- a/backend/cmd/server/bootstrap/02-sample-resources.ps1
+++ b/backend/cmd/server/bootstrap/02-sample-resources.ps1
@@ -79,21 +79,25 @@ elseif ($response.StatusCode -eq 409) {
     else {
         Log-Error "Failed to fetch organization unit by handle '$customerOuHandle' (HTTP $($response.StatusCode))"
         Write-Host "Response: $($response.Body)"
+        Log-Result-Failure "Failed to create Customers organization unit"
         exit 1
     }
 }
 else {
     Log-Error "Failed to create Customers organization unit (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
+    Log-Result-Failure "Failed to create Customers organization unit"
     exit 1
 }
 
 if (-not $CUSTOMER_OU_ID) {
     Log-Error "Could not determine Customers organization unit ID"
+    Log-Result-Failure "Failed to create Customers organization unit"
     exit 1
 }
 
 Log-Info "Customers OU ID: $CUSTOMER_OU_ID"
+Log-Result-Success "Created Customers organization unit"
 
 Write-Host ""
 
@@ -164,8 +168,11 @@ elseif ($response.StatusCode -eq 409) {
 else {
     Log-Error "Failed to create Customer user type (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
+    Log-Result-Failure "Failed to create Customer user type"
     exit 1
 }
+
+Log-Result-Success "Created Customer user type"
 
 Write-Host ""
 
@@ -242,8 +249,11 @@ elseif ($response.StatusCode -eq 400 -and ($response.Body -match "Application al
 else {
     Log-Error "Failed to create Sample App (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
+    Log-Result-Failure "Failed to create Sample App"
     exit 1
 }
+
+Log-Result-Success "Created Sample App"
 
 Write-Host ""
 
@@ -324,8 +334,11 @@ elseif ($response.StatusCode -eq 400 -and ($response.Body -match "Application al
 else {
     Log-Error "Failed to create React SDK Sample App (HTTP $($response.StatusCode))"
     Write-Host "Response: $($response.Body)"
+    Log-Result-Failure "Failed to create React SDK Sample App"
     exit 1
 }
+
+Log-Result-Success "Created React SDK Sample App"
 
 Write-Host ""
 
@@ -334,4 +347,5 @@ Write-Host ""
 # ============================================================================
 
 Log-Success "Sample resources setup completed successfully!"
+Log-Result-Success "Created sample resources"
 Write-Host ""

--- a/backend/cmd/server/bootstrap/02-sample-resources.sh
+++ b/backend/cmd/server/bootstrap/02-sample-resources.sh
@@ -70,15 +70,18 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
 else
     log_error "Failed to create Customers organization unit (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
+  log_result_failure "Failed to create Customers organization unit"
     exit 1
 fi
 
 if [[ -z "$CUSTOMER_OU_ID" ]]; then
     log_error "Could not determine Customers organization unit ID"
+  log_result_failure "Failed to create Customers organization unit"
     exit 1
 fi
 
 log_info "Customers OU ID: $CUSTOMER_OU_ID"
+log_result_success "Created Customers organization unit"
 
 echo ""
 
@@ -149,8 +152,10 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
     log_warning "Customer user type already exists, skipping"
 else
     log_error "Failed to create Customer user type (HTTP $HTTP_CODE)"
+  log_result_failure "Failed to create Customer user type"
     exit 1
 fi
+log_result_success "Created Customer user type"
 
 echo ""
 
@@ -224,8 +229,10 @@ elif [[ "$HTTP_CODE" == "400" ]] && [[ "$BODY" =~ (Application already exists|AP
 else
     log_error "Failed to create Sample App (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
+  log_result_failure "Failed to create Sample App"
     exit 1
 fi
+log_result_success "Created Sample App"
 
 echo ""
 
@@ -303,8 +310,10 @@ elif [[ "$HTTP_CODE" == "400" ]] && [[ "$BODY" =~ (Application already exists|AP
 else
     log_error "Failed to create React SDK Sample App (HTTP $HTTP_CODE)"
     echo "Response: $BODY"
+  log_result_failure "Failed to create React SDK Sample App"
     exit 1
 fi
+log_result_success "Created React SDK Sample App"
 
 echo ""
 

--- a/backend/cmd/server/bootstrap/common.ps1
+++ b/backend/cmd/server/bootstrap/common.ps1
@@ -21,6 +21,14 @@
 # Dot-source this file at the beginning of each bootstrap script
 
 $PRODUCT_NAME = "ThunderID"
+$QUIET_MODE = if ($env:SETUP_SILENT_MODE -eq "true") { $true } else { $false }
+$RESULT_COLOR_ENABLED = $false
+
+# Check if FD3 (like in bash) is available - PowerShell doesn't have file descriptors,
+# so we'll simulate by checking if we're in a TTY context
+if ([Environment]::UserInteractive -and -not [Console]::IsInputRedirected) {
+    $RESULT_COLOR_ENABLED = $true
+}
 
 # Configure TLS to use modern protocols (required for HTTPS requests on Windows)
 try {
@@ -33,28 +41,60 @@ try {
 # Logging Functions
 function Log-Info {
     param([string]$Message)
-    Write-Host "[INFO] $Message" -ForegroundColor Blue
+    if (-not $QUIET_MODE) {
+        Write-Host "[INFO] $Message" -ForegroundColor Blue
+    }
 }
 
 function Log-Success {
     param([string]$Message)
-    Write-Host "[SUCCESS] ✓ $Message" -ForegroundColor Green
+    if (-not $QUIET_MODE) {
+        Write-Host "[SUCCESS] ✓ $Message" -ForegroundColor Green
+    }
 }
 
 function Log-Warning {
     param([string]$Message)
-    Write-Host "[WARNING] ⚠ $Message" -ForegroundColor Yellow
+    if (-not $QUIET_MODE) {
+        Write-Host "[WARNING] ⚠ $Message" -ForegroundColor Yellow
+    }
 }
 
 function Log-Error {
     param([string]$Message)
-    Write-Host "[ERROR] ✗ $Message" -ForegroundColor Red
+    if (-not $QUIET_MODE) {
+        Write-Host "[ERROR] ✗ $Message" -ForegroundColor Red
+    }
 }
 
 function Log-Debug {
     param([string]$Message)
-    if ($env:DEBUG -eq "true") {
+    if ($env:DEBUG -eq "true" -and -not $QUIET_MODE) {
         Write-Host "[DEBUG] $Message" -ForegroundColor Cyan
+    }
+}
+
+function Log-Result-Success {
+    param([string]$Message)
+    if ($QUIET_MODE) {
+        if ($RESULT_COLOR_ENABLED) {
+            [Console]::WriteLine("      $($PSStyle.Foreground.Green)✓$($PSStyle.Reset) $Message")
+        }
+        else {
+            [Console]::WriteLine("      ✓ $Message")
+        }
+    }
+}
+
+function Log-Result-Failure {
+    param([string]$Message)
+    if ($QUIET_MODE) {
+        if ($RESULT_COLOR_ENABLED) {
+            [Console]::WriteLine("      $($PSStyle.Foreground.Red)✗$($PSStyle.Reset) $Message")
+        }
+        else {
+            [Console]::WriteLine("      ✗ $Message")
+        }
     }
 }
 

--- a/backend/cmd/server/bootstrap/common.sh
+++ b/backend/cmd/server/bootstrap/common.sh
@@ -21,6 +21,12 @@
 # Source this file at the beginning of each bootstrap script
 
 PRODUCT_NAME="ThunderID"
+QUIET_MODE="${SETUP_SILENT_MODE:-false}"
+RESULT_COLOR_ENABLED=false
+
+if [ -t 3 ] && [ -z "${NO_COLOR:-}" ]; then
+    RESULT_COLOR_ENABLED=true
+fi
 
 # Color codes
 RED='\033[0;31m'
@@ -32,24 +38,52 @@ NC='\033[0m'
 
 # Logging Functions
 log_info() {
-    echo -e "${BLUE}[INFO]${NC} $1" >&2
+    if [[ "$QUIET_MODE" != "true" ]]; then
+        echo -e "${BLUE}[INFO]${NC} $1" >&2
+    fi
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} ✓ $1" >&2
+    if [[ "$QUIET_MODE" != "true" ]]; then
+        echo -e "${GREEN}[SUCCESS]${NC} ✓ $1" >&2
+    fi
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${NC} ⚠ $1" >&2
+    if [[ "$QUIET_MODE" != "true" ]]; then
+        echo -e "${YELLOW}[WARNING]${NC} ⚠ $1" >&2
+    fi
 }
 
 log_error() {
-    echo -e "${RED}[ERROR]${NC} ✗ $1" >&2
+    if [[ "$QUIET_MODE" != "true" ]]; then
+        echo -e "${RED}[ERROR]${NC} ✗ $1" >&2
+    fi
 }
 
 log_debug() {
-    if [ "${DEBUG:-false}" = "true" ]; then
+    if [ "${DEBUG:-false}" = "true" ] && [[ "$QUIET_MODE" != "true" ]]; then
         echo -e "${CYAN}[DEBUG]${NC} $1" >&2
+    fi
+}
+
+log_result_success() {
+    if [[ "$QUIET_MODE" == "true" ]]; then
+        if [[ "$RESULT_COLOR_ENABLED" == "true" ]]; then
+            echo -e "      ${GREEN}✓${NC} $1" >&3
+        else
+            echo "      ✓ $1" >&3
+        fi
+    fi
+}
+
+log_result_failure() {
+    if [[ "$QUIET_MODE" == "true" ]]; then
+        if [[ "$RESULT_COLOR_ENABLED" == "true" ]]; then
+            echo -e "      ${RED}✗${NC} $1" >&3
+        else
+            echo "      ✗ $1" >&3
+        fi
     fi
 }
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -50,6 +50,8 @@ $ErrorActionPreference = 'Stop'
 # Default settings
 $DEBUG_PORT = if ($env:DEBUG_PORT) { [int]$env:DEBUG_PORT } else { 2345 }
 $DEBUG_MODE = if ($env:DEBUG_MODE -eq "true") { $true } else { $false }
+$VERBOSE_MODE = $false
+$SILENT_MODE = $true
 $BOOTSTRAP_FAIL_FAST = if ($env:BOOTSTRAP_FAIL_FAST -eq "false") { $false } else { $true }
 $BOOTSTRAP_SKIP_PATTERN = if ($env:BOOTSTRAP_SKIP_PATTERN) { $env:BOOTSTRAP_SKIP_PATTERN } else { "" }
 $BOOTSTRAP_ONLY_PATTERN = if ($env:BOOTSTRAP_ONLY_PATTERN) { $env:BOOTSTRAP_ONLY_PATTERN } else { "" }
@@ -62,16 +64,25 @@ $WITH_CONSENT = if ($env:WITH_CONSENT -eq 'false') { $false } else { $true }
 
 function Log-Info {
     param([string]$Message)
+    if (-not $VERBOSE_MODE) {
+        return
+    }
     Write-Host "[INFO] $Message" -ForegroundColor Blue
 }
 
 function Log-Success {
     param([string]$Message)
+    if (-not $VERBOSE_MODE) {
+        return
+    }
     Write-Host "[SUCCESS] [OK] $Message" -ForegroundColor Green
 }
 
 function Log-Warning {
     param([string]$Message)
+    if (-not $VERBOSE_MODE) {
+        return
+    }
     Write-Host "[WARNING] ! $Message" -ForegroundColor Yellow
 }
 
@@ -82,7 +93,7 @@ function Log-Error {
 
 function Log-Debug {
     param([string]$Message)
-    if ($env:DEBUG -eq "true") {
+    if ($env:DEBUG -eq "true" -and $VERBOSE_MODE) {
         Write-Host "[DEBUG] $Message" -ForegroundColor Cyan
     }
 }
@@ -213,6 +224,7 @@ function Show-Help {
     Write-Host "Usage: .\setup.ps1 [options]"
     Write-Host ""
     Write-Host "Options:"
+    Write-Host "  --verbose                Enable detailed setup output"
     Write-Host "  --debug                  Enable debug mode with remote debugging"
     Write-Host "  --debug-port PORT        Set debug port (default: 2345)"
     Write-Host "  --without-consent        Disable the bundled consent server"
@@ -235,6 +247,12 @@ function Show-Help {
 $i = 0
 while ($i -lt $args.Count) {
     switch ($args[$i]) {
+        '--verbose' {
+            $VERBOSE_MODE = $true
+            $SILENT_MODE = $false
+            $i++
+            break
+        }
         '--debug' {
             $DEBUG_MODE = $true
             $i++
@@ -393,17 +411,14 @@ Write-Host "========================================="
 Write-Host "   $PRODUCT_NAME Setup"
 Write-Host "========================================="
 Write-Host ""
-Write-Host "Server URL: $BASE_URL" -ForegroundColor Blue
-Write-Host "Public URL: $PUBLIC_URL" -ForegroundColor Blue
-if ($DEBUG_MODE) {
-    Write-Host "Debug: Enabled (port $DEBUG_PORT)" -ForegroundColor Blue
+if ($VERBOSE_MODE) {
+    Write-Host "Server URL: $BASE_URL" -ForegroundColor Blue
+    Write-Host "Public URL: $PUBLIC_URL" -ForegroundColor Blue
+    if ($DEBUG_MODE) {
+        Write-Host "Debug: Enabled (port $DEBUG_PORT)" -ForegroundColor Blue
+    }
+    Write-Host ""
 }
-Write-Host ""
-
-# Log PowerShell version for debugging
-Log-Debug "PowerShell Version: $($PSVersionTable.PSVersion)"
-Log-Debug "PowerShell Edition: $($PSVersionTable.PSEdition)"
-Log-Debug "OS: $($PSVersionTable.OS)"
 Log-Debug "Platform: $($PSVersionTable.Platform)"
 
 # ============================================================================
@@ -467,8 +482,10 @@ if ($DEBUG_MODE -and -not (Get-Command dlv -ErrorAction SilentlyContinue)) {
 # Start the Server with Security Disabled
 # ============================================================================
 
-Write-Host "[WARN] Starting temporary server with security disabled..." -ForegroundColor Yellow
-Write-Host ""
+if ($VERBOSE_MODE) {
+    Write-Host "[WARN] Starting temporary server with security disabled..." -ForegroundColor Yellow
+    Write-Host ""
+}
 
 # Export environment variable to skip security
 $hadSkipSecurity = Test-Path Env:SKIP_SECURITY
@@ -489,12 +506,18 @@ if (-not $serverExecPath) {
 # Start Consent Server (if enabled)
 $consentProc = $null
 $consentDir = Join-Path $scriptDir 'consent'
+$serverStdOutLog = $null
+$serverStdErrLog = $null
+$consentStdOutLog = $null
+$consentStdErrLog = $null
 if ($WITH_CONSENT) {
     if (-not (Test-Path $consentDir)) {
         Log-Error "Consent server is enabled but consent directory not found: $consentDir"
         exit 1
     }
-    Write-Host "[INFO] Starting Consent Server..." -ForegroundColor Cyan
+    if ($VERBOSE_MODE) {
+        Write-Host "[INFO] Starting Consent Server..." -ForegroundColor Cyan
+    }
     $consentPort = if ($env:CONSENT_SERVER_PORT) { $env:CONSENT_SERVER_PORT } else { "9090" }
     $consentBinary = @(
         (Join-Path $consentDir 'consent-server.exe'),
@@ -504,7 +527,19 @@ if ($WITH_CONSENT) {
         Log-Error "Consent server is enabled but consent-server binary not found in: $consentDir"
         exit 1
     }
-    $consentProc = Start-Process -FilePath $consentBinary -WorkingDirectory $consentDir -NoNewWindow -PassThru
+    $consentProcessArgs = @{
+        FilePath = $consentBinary
+        WorkingDirectory = $consentDir
+        NoNewWindow = $true
+        PassThru = $true
+    }
+    if ($SILENT_MODE) {
+        $consentStdOutLog = [System.IO.Path]::GetTempFileName()
+        $consentStdErrLog = [System.IO.Path]::GetTempFileName()
+        $consentProcessArgs["RedirectStandardOutput"] = $consentStdOutLog
+        $consentProcessArgs["RedirectStandardError"] = $consentStdErrLog
+    }
+    $consentProc = Start-Process @consentProcessArgs
     $consentTimeout = 30
     $consentElapsed = 0
     while ($consentElapsed -lt $consentTimeout) {
@@ -515,7 +550,9 @@ if ($WITH_CONSENT) {
         try {
             $resp = Invoke-WebRequest -Uri "http://localhost:${consentPort}/health/readiness" -UseBasicParsing -ErrorAction Stop
             if ($resp.StatusCode -eq 200) {
-                Write-Host "[INFO] Consent server is ready" -ForegroundColor Cyan
+                if ($VERBOSE_MODE) {
+                    Write-Host "[INFO] Consent server is ready" -ForegroundColor Cyan
+                }
                 break
             }
         } catch { }
@@ -530,6 +567,18 @@ if ($WITH_CONSENT) {
 
 $proc = $null
 try {
+    $serverProcessArgs = @{
+        WorkingDirectory = $scriptDir
+        NoNewWindow = $true
+        PassThru = $true
+    }
+    if ($SILENT_MODE) {
+        $serverStdOutLog = [System.IO.Path]::GetTempFileName()
+        $serverStdErrLog = [System.IO.Path]::GetTempFileName()
+        $serverProcessArgs["RedirectStandardOutput"] = $serverStdOutLog
+        $serverProcessArgs["RedirectStandardError"] = $serverStdErrLog
+    }
+
     if ($DEBUG_MODE) {
         $dlvArgs = @(
             'exec'
@@ -540,18 +589,23 @@ try {
             '--continue'
             $serverExecPath
         )
-        $proc = Start-Process -FilePath dlv -ArgumentList $dlvArgs -WorkingDirectory $scriptDir -NoNewWindow -PassThru
+        $serverProcessArgs["FilePath"] = "dlv"
+        $serverProcessArgs["ArgumentList"] = $dlvArgs
+        $proc = Start-Process @serverProcessArgs
     }
     else {
-        $proc = Start-Process -FilePath $serverExecPath -WorkingDirectory $scriptDir -NoNewWindow -PassThru
+        $serverProcessArgs["FilePath"] = $serverExecPath
+        $proc = Start-Process @serverProcessArgs
     }
 
     $SERVER_PID = $proc.Id
 
     # Cleanup function
     $cleanup = {
-        Write-Host ""
-        Write-Host "[STOP] Stopping temporary server..." -ForegroundColor Cyan
+        if ($VERBOSE_MODE) {
+            Write-Host ""
+            Write-Host "[STOP] Stopping temporary server..." -ForegroundColor Cyan
+        }
         if ($proc -and -not $proc.HasExited) {
             try {
                 Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
@@ -571,8 +625,10 @@ try {
     # Wait for Server to be Ready
     # ============================================================================
 
-    Write-Host "[WAIT] Waiting for server to be ready..." -ForegroundColor Blue
-    Write-Host "   Server URL: $BASE_URL" -ForegroundColor Blue
+    if ($VERBOSE_MODE) {
+        Write-Host "[WAIT] Waiting for server to be ready..." -ForegroundColor Blue
+        Write-Host "   Server URL: $BASE_URL" -ForegroundColor Blue
+    }
 
     $TIMEOUT = 60
     $ELAPSED = 0
@@ -592,10 +648,12 @@ try {
         Log-Debug "Request completed in $([math]::Round($requestDuration.TotalSeconds, 2))s with status: $statusCode"
 
         if ($statusCode -eq "200") {
-            Write-Host ""
-            Write-Host "[OK] Server is ready" -ForegroundColor Green
-            Log-Debug "Health check response: $body"
-            Write-Host ""
+            if ($VERBOSE_MODE) {
+                Write-Host ""
+                Write-Host "[OK] Server is ready" -ForegroundColor Green
+                Log-Debug "Health check response: $body"
+                Write-Host ""
+            }
             break
         }
         else {
@@ -635,6 +693,9 @@ try {
     # ============================================================================
     # Run Bootstrap Scripts
     # ============================================================================
+
+    # Export environment variable for bootstrap scripts
+    $env:SETUP_SILENT_MODE = if ($SILENT_MODE) { "true" } else { "false" }
 
     # Check if bootstrap directory exists
     if (-not (Test-Path $BOOTSTRAP_DIR)) {
@@ -687,6 +748,17 @@ try {
             foreach ($bootstrapScript in $sortedScripts) {
                 $scriptName = $bootstrapScript.Name
 
+                if ($SILENT_MODE) {
+                    if ($scriptName -eq "01-default-resources.ps1" -or $scriptName -eq "01-default-resources.sh") {
+                        Write-Host ""
+                        Write-Host "  Default resources"
+                    }
+                    elseif ($scriptName -eq "02-sample-resources.ps1" -or $scriptName -eq "02-sample-resources.sh") {
+                        Write-Host ""
+                        Write-Host "  Sample resources"
+                    }
+                }
+
                 # Skip if matches skip pattern
                 if ($BOOTSTRAP_SKIP_PATTERN -and ($scriptName -match $BOOTSTRAP_SKIP_PATTERN)) {
                     Log-Info "[SKIP] Skipping $scriptName (matches skip pattern regex: $BOOTSTRAP_SKIP_PATTERN)"
@@ -708,7 +780,12 @@ try {
                 $startTime = Get-Date
 
                 try {
-                    & $bootstrapScript.FullName
+                    if ($SILENT_MODE) {
+                        & $bootstrapScript.FullName *> $null
+                    }
+                    else {
+                        & $bootstrapScript.FullName
+                    }
                     $exitCode = $LASTEXITCODE
 
                     $endTime = Get-Date
@@ -777,22 +854,40 @@ try {
     # ============================================================================
 
     Write-Host ""
-    Write-Host "========================================="
-    Write-Host "[OK] Setup completed successfully!" -ForegroundColor Green
-    Write-Host "========================================="
     Write-Host ""
-    Write-Host "[INFO] Next steps:"
-    Write-Host "   1. Start the server: .\start.ps1" -ForegroundColor Cyan
-    Write-Host "   2. Access $PRODUCT_NAME at: $BASE_URL" -ForegroundColor Cyan
-    Write-Host "   3. Login with admin credentials:"
-    Write-Host "      Username: admin" -ForegroundColor Cyan
-    Write-Host "      Password: admin" -ForegroundColor Cyan
-    Write-Host ""
+    if ($SILENT_MODE) {
+        Write-Host "========================================="
+        Write-Host "✅ Setup completed successfully!"
+        Write-Host "========================================="
+        Write-Host ""
+        Write-Host "Admin credentials:"
+        Write-Host "  URL:      ${PUBLIC_URL}/console"
+        Write-Host "  Username: admin"
+        Write-Host "  Password: admin"
+        Write-Host ""
+        Write-Host "Run .\start.ps1 to start ${PRODUCT_NAME}."
+        Write-Host ""
+    }
+    else {
+        Write-Host "========================================="
+        Write-Host "[OK] Setup completed successfully!" -ForegroundColor Green
+        Write-Host "========================================="
+        Write-Host ""
+        Write-Host "[INFO] Next steps:"
+        Write-Host "   1. Start the server: .\start.ps1" -ForegroundColor Cyan
+        Write-Host "   2. Access $PRODUCT_NAME at: $BASE_URL" -ForegroundColor Cyan
+        Write-Host "   3. Login with admin credentials:"
+        Write-Host "      Username: admin" -ForegroundColor Cyan
+        Write-Host "      Password: admin" -ForegroundColor Cyan
+        Write-Host ""
+    }
 }
 finally {
     # Cleanup
-    Write-Host ""
-    Write-Host "[STOP] Stopping temporary server..." -ForegroundColor Cyan
+    if ($VERBOSE_MODE) {
+        Write-Host ""
+        Write-Host "[STOP] Stopping temporary server..." -ForegroundColor Cyan
+    }
     if ($proc -and -not $proc.HasExited) {
         try {
             Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
@@ -802,6 +897,12 @@ finally {
         try {
             Stop-Process -Id $consentProc.Id -Force -ErrorAction SilentlyContinue
         } catch { }
+    }
+
+    foreach ($tempLog in @($serverStdOutLog, $serverStdErrLog, $consentStdOutLog, $consentStdErrLog)) {
+        if ($tempLog -and (Test-Path $tempLog)) {
+            Remove-Item $tempLog -Force -ErrorAction SilentlyContinue
+        }
     }
 
     # Restore SKIP_SECURITY to its previous state

--- a/setup.sh
+++ b/setup.sh
@@ -43,6 +43,8 @@ PRODUCT_NAME_LOWERCASE="$(echo "$PRODUCT_NAME" | tr '[:upper:]' '[:lower:]')"
 BINARY_NAME="${PRODUCT_NAME_LOWERCASE}"
 DEBUG_PORT=${DEBUG_PORT:-2345}
 DEBUG_MODE=${DEBUG_MODE:-false}
+VERBOSE_MODE=${VERBOSE_MODE:-false}
+SILENT_MODE=true
 BOOTSTRAP_FAIL_FAST=${BOOTSTRAP_FAIL_FAST:-true}
 BOOTSTRAP_SKIP_PATTERN="${BOOTSTRAP_SKIP_PATTERN:-}"
 BOOTSTRAP_ONLY_PATTERN="${BOOTSTRAP_ONLY_PATTERN:-}"
@@ -62,15 +64,21 @@ NC='\033[0m'
 # ============================================================================
 
 log_info() {
-    echo -e "${BLUE}[INFO]${NC} $1"
+    if [ "$VERBOSE_MODE" = "true" ]; then
+        echo -e "${BLUE}[INFO]${NC} $1"
+    fi
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} ✓ $1"
+    if [ "$VERBOSE_MODE" = "true" ]; then
+        echo -e "${GREEN}[SUCCESS]${NC} ✓ $1"
+    fi
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${NC} ⚠ $1"
+    if [ "$VERBOSE_MODE" = "true" ]; then
+        echo -e "${YELLOW}[WARNING]${NC} ⚠ $1"
+    fi
 }
 
 log_error() {
@@ -78,7 +86,7 @@ log_error() {
 }
 
 log_debug() {
-    if [ "${DEBUG:-false}" = "true" ]; then
+    if [ "${DEBUG:-false}" = "true" ] && [ "$VERBOSE_MODE" = "true" ]; then
         echo -e "${CYAN}[DEBUG]${NC} $1"
     fi
 }
@@ -119,6 +127,7 @@ print_help() {
     echo "Usage: $0 [options]"
     echo ""
     echo "Options:"
+    echo "  --verbose                Enable detailed setup output"
     echo "  --debug                  Enable debug mode with remote debugging"
     echo "  --debug-port PORT        Set debug port (default: 2345)"
     echo "  --without-consent        Disable the bundled consent server"
@@ -142,6 +151,11 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --debug)
             DEBUG_MODE=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE_MODE=true
+            SILENT_MODE=false
             shift
             ;;
         --debug-port)
@@ -249,12 +263,14 @@ echo "========================================="
 echo "   ${PRODUCT_NAME} Setup"
 echo "========================================="
 echo ""
-echo -e "${BLUE}Server URL:${NC} $BASE_URL"
-echo -e "${BLUE}Public URL:${NC} $PUBLIC_URL"
-if [ "$DEBUG_MODE" = "true" ]; then
-    echo -e "${BLUE}Debug:${NC} Enabled (port $DEBUG_PORT)"
+if [ "$VERBOSE_MODE" = "true" ]; then
+    echo -e "${BLUE}Server URL:${NC} $BASE_URL"
+    echo -e "${BLUE}Public URL:${NC} $PUBLIC_URL"
+    if [ "$DEBUG_MODE" = "true" ]; then
+        echo -e "${BLUE}Debug:${NC} Enabled (port $DEBUG_PORT)"
+    fi
+    echo ""
 fi
-echo ""
 
 # ============================================================================
 # Check for Port Conflicts
@@ -302,8 +318,10 @@ SERVER_PID=""
 
 # Cleanup function
 cleanup() {
-    echo ""
-    echo -e "${CYAN}🛑 Stopping temporary server...${NC}"
+    if [ "$VERBOSE_MODE" = "true" ]; then
+        echo ""
+        echo -e "${CYAN}🛑 Stopping temporary server...${NC}"
+    fi
     if [ -n "$SERVER_PID" ]; then
         kill $SERVER_PID 2>/dev/null || true
         wait $SERVER_PID 2>/dev/null || true
@@ -322,8 +340,12 @@ if [ "$WITH_CONSENT" = "true" ]; then
         log_error "Consent server is enabled but consent/start.sh is missing or not executable"
         exit 1
     fi
-    echo -e "${CYAN}Starting Consent Server...${NC}"
-    (cd "$(dirname "$0")/consent" && ./start.sh) &
+    if [ "$VERBOSE_MODE" = "true" ]; then
+        echo -e "${CYAN}Starting Consent Server...${NC}"
+        (cd "$(dirname "$0")/consent" && ./start.sh) &
+    else
+        (cd "$(dirname "$0")/consent" && ./start.sh >/dev/null 2>&1) &
+    fi
     CONSENT_PID=$!
     CONSENT_TIMEOUT=30
     CONSENT_ELAPSED=0
@@ -333,7 +355,9 @@ if [ "$WITH_CONSENT" = "true" ]; then
             exit 1
         fi
         if curl -s -f "http://localhost:${CONSENT_SERVER_PORT}/health/readiness" > /dev/null 2>&1; then
-            echo -e "${GREEN}✓ Consent server is ready${NC}"
+            if [ "$VERBOSE_MODE" = "true" ]; then
+                echo -e "${GREEN}✓ Consent server is ready${NC}"
+            fi
             break
         fi
         sleep 1
@@ -349,17 +373,27 @@ fi
 # Start the Server with Security Disabled
 # ============================================================================
 
-echo -e "${YELLOW}⚠️  Starting temporary server with security disabled...${NC}"
-echo ""
+if [ "$VERBOSE_MODE" = "true" ]; then
+    echo -e "${YELLOW}⚠️  Starting temporary server with security disabled...${NC}"
+    echo ""
+fi
 
 # Export environment variable to skip security
 export SKIP_SECURITY=true
 
 if [ "$DEBUG_MODE" = "true" ]; then
-    dlv exec --listen=:$DEBUG_PORT --headless=true --api-version=2 --accept-multiclient --continue ./${BINARY_NAME} &
+    if [ "$VERBOSE_MODE" = "true" ]; then
+        dlv exec --listen=:$DEBUG_PORT --headless=true --api-version=2 --accept-multiclient --continue ./${BINARY_NAME} &
+    else
+        dlv exec --listen=:$DEBUG_PORT --headless=true --api-version=2 --accept-multiclient --continue ./${BINARY_NAME} >/dev/null 2>&1 &
+    fi
     SERVER_PID=$!
 else
-    ./${BINARY_NAME} &
+    if [ "$VERBOSE_MODE" = "true" ]; then
+        ./${BINARY_NAME} &
+    else
+        ./${BINARY_NAME} >/dev/null 2>&1 &
+    fi
     SERVER_PID=$!
 fi
 
@@ -367,20 +401,26 @@ fi
 # Wait for Server to be Ready
 # ============================================================================
 
-echo -e "${BLUE}⏳ Waiting for server to be ready...${NC}"
+if [ "$VERBOSE_MODE" = "true" ]; then
+    echo -e "${BLUE}⏳ Waiting for server to be ready...${NC}"
+fi
 TIMEOUT=60
 ELAPSED=0
 RETRY_DELAY=2
 
 while [ $ELAPSED -lt $TIMEOUT ]; do
     if curl -k -s "${BASE_URL}/health/readiness" > /dev/null 2>&1; then
-        echo -e "${GREEN}✓ Server is ready${NC}"
-        echo ""
+        if [ "$VERBOSE_MODE" = "true" ]; then
+            echo -e "${GREEN}✓ Server is ready${NC}"
+            echo ""
+        fi
         break
     fi
     sleep $RETRY_DELAY
     ELAPSED=$((ELAPSED + RETRY_DELAY))
-    printf "."
+    if [ "$VERBOSE_MODE" = "true" ]; then
+        printf "."
+    fi
 done
 
 if [ $ELAPSED -ge $TIMEOUT ]; then
@@ -399,6 +439,12 @@ export API_BASE="${BASE_URL}"
 export PUBLIC_URL="${PUBLIC_URL}"
 export SYSTEM_RS_HANDLE="${SYSTEM_RS_HANDLE}"
 export SYSTEM_RS_IDENTIFIER="${SYSTEM_RS_IDENTIFIER}"
+export SETUP_SILENT_MODE="${SILENT_MODE}"
+
+# FD3 always points to the real terminal stdout.
+# Quiet-mode result markers write to FD3 so they reach the terminal even
+# when FD1 (normal stdout) is suppressed inside the bootstrap subshell.
+exec 3>&1
 
 # Check if bootstrap directory exists
 if [ ! -d "$BOOTSTRAP_DIR" ]; then
@@ -446,6 +492,16 @@ else
         for script in "${SORTED_SCRIPTS[@]}"; do
             script_name=$(basename "$script")
 
+            if [ "$SILENT_MODE" = "true" ]; then
+                if [ "$script_name" = "01-default-resources.sh" ]; then
+                    echo ""
+                    echo "  Default resources"
+                elif [ "$script_name" = "02-sample-resources.sh" ]; then
+                    echo ""
+                    echo "  Sample resources"
+                fi
+            fi
+
             # Skip if matches skip pattern
             if [ -n "$BOOTSTRAP_SKIP_PATTERN" ] && [[ "$script_name" =~ $BOOTSTRAP_SKIP_PATTERN ]]; then
                 log_info "⊘ Skipping $script_name (matches skip pattern)"
@@ -482,6 +538,11 @@ else
             set +e  # Temporarily disable exit on error to catch errors
             (
                 set -e  # Re-enable in subshell to catch script errors
+                # In quiet mode suppress all ordinary stdout so only explicit
+                # FD3 writes (log_result_success/failure) reach the terminal.
+                if [ "$SILENT_MODE" = "true" ]; then
+                    exec 1>/dev/null
+                fi
                 source "$script"
             )
             EXIT_CODE=$?
@@ -494,12 +555,23 @@ else
                 log_success "$script_name completed (${DURATION}s)"
                 SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
             else
-                log_error "$script_name failed with exit code $EXIT_CODE (${DURATION}s)"
+                if [ "$VERBOSE_MODE" = "true" ]; then
+                    log_error "$script_name failed with exit code $EXIT_CODE (${DURATION}s)"
+                fi
                 FAILED_COUNT=$((FAILED_COUNT + 1))
 
                 # Check if we should fail fast
                 if [ "$BOOTSTRAP_FAIL_FAST" = "true" ]; then
-                    log_error "Stopping bootstrap (BOOTSTRAP_FAIL_FAST=true)"
+                    if [ "$VERBOSE_MODE" = "true" ]; then
+                        log_error "Stopping bootstrap (BOOTSTRAP_FAIL_FAST=true)"
+                    fi
+                    if [ "$SILENT_MODE" = "true" ]; then
+                        echo ""
+                        echo "========================================="
+                        echo "❌ Setup failed."
+                        echo "========================================="
+                        echo ""
+                    fi
                     exit 1
                 fi
             fi
@@ -515,7 +587,7 @@ else
         log_info "Executed: $SCRIPT_COUNT"
         log_success "Successful: $SUCCESS_COUNT"
 
-        if [ $FAILED_COUNT -gt 0 ]; then
+        if [ $FAILED_COUNT -gt 0 ] && [ "$VERBOSE_MODE" = "true" ]; then
             log_error "Failed: $FAILED_COUNT"
         fi
 
@@ -539,10 +611,25 @@ fi
 # ============================================================================
 
 echo ""
-echo "========================================="
-echo -e "${GREEN}✅ Setup completed successfully!${NC}"
-echo "========================================="
 echo ""
+if [ "$SILENT_MODE" = "true" ]; then
+    echo "========================================="
+    echo "✅ Setup completed successfully!"
+    echo "========================================="
+    echo ""
+    echo "Admin credentials:"
+    echo "  URL:      ${PUBLIC_URL}/console"
+    echo "  Username: admin"
+    echo "  Password: admin"
+    echo ""
+    echo "Run ./start.sh to start ${PRODUCT_NAME}."
+    echo ""
+else
+    echo "========================================="
+    echo -e "${GREEN}✅ Setup completed successfully!${NC}"
+    echo "========================================="
+    echo ""
+fi
 
 # Cleanup will be called automatically via trap
 exit 0


### PR DESCRIPTION
### Purpose

Make the local setup scripts run in silent mode by default, producing compact progress output instead of verbose logs. A --verbose flag is added to opt into the full detailed output when needed.

Before: Running [setup.sh](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [setup.ps1](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) would print every HTTP request, response body, and internal log message during bootstrap — making it hard to track overall progress.

After: By default, only milestone checkpoints are shown (e.g. ✓ Created admin user, ✗ Failed to create system resource server). Pass --verbose to restore the original detailed output.

Sample Output :

```
=========================================
   ThunderID Setup
=========================================




  Default resources
      ✓ Created default organization unit
      ✓ Created default user type (Person)
      ✓ Created default agent type
      ✓ Created admin user
      ✓ Created system resource server
      ✓ Created system permissions
      ✓ Created Administrators group
      ✓ Created Administrator role
      ✓ Created default flows
      ✓ Created Console application
      ✓ Created themes
      ✓ Seeded i18n translations


  Sample resources
      ✓ Created Customers organization unit
      ✓ Created Customer user type
      ✓ Created Sample App
      ✓ Created React SDK Sample App




=========================================
✅ Setup completed successfully!
=========================================

Admin credentials:
  URL:      https://localhost:8090/console
  Username: admin
  Password: admin

Run ./start.sh to start ThunderID.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --verbose flag and a silent/quiet mode for setup to control detailed vs minimal output.
  * Bootstrap now emits consistent success/failure status markers, with optional colorized symbols when supported.

* **Behavior Changes**
  * Final setup summary varies by verbosity (silent mode shows condensed admin info; verbose shows next steps).
  * Failure and termination reporting during bootstrap is standardized for clearer terminal output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->