### PR TITLE
Add cache for entity credentials

### DIFF
--- a/backend/internal/entity/cache_backed_store.go
+++ b/backend/internal/entity/cache_backed_store.go
@@ -26,20 +26,36 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
 
+// defaultCacheableIdentifiers lists the filter keys eligible for single-key
+// IdentifyEntity cache lookups.
+var defaultCacheableIdentifiers = []string{"clientId"}
+
 // cacheBackedEntityStore wraps an entityStoreInterface with in-memory caching
 // for individual entity lookups by ID and identifier filter resolution.
 type cacheBackedEntityStore struct {
-	entityByIDCache cache.CacheInterface[*Entity]
-	store           entityStoreInterface
-	logger          *log.Logger
+	entityByIDCache                cache.CacheInterface[*Entity]
+	entityWithCredentialsByIDCache cache.CacheInterface[*entityWithCredentials]
+	entityIDByIdentifierCache      cache.CacheInterface[*string]
+	cacheableIdentifiers           map[string]bool
+	store                          entityStoreInterface
+	logger                         *log.Logger
 }
 
-// newCacheBackedEntityStore creates a cache-backed wrapper around the given store.
+// newCacheBackedEntityStore wraps a store with read-through caching.
 func newCacheBackedEntityStore(store entityStoreInterface,
-	entityByIDCache cache.CacheInterface[*Entity]) entityStoreInterface {
+	entityByIDCache cache.CacheInterface[*Entity],
+	entityWithCredentialsByIDCache cache.CacheInterface[*entityWithCredentials],
+	entityIDByIdentifierCache cache.CacheInterface[*string]) entityStoreInterface {
+	idSet := make(map[string]bool, len(defaultCacheableIdentifiers))
+	for _, id := range defaultCacheableIdentifiers {
+		idSet[id] = true
+	}
 	return &cacheBackedEntityStore{
-		entityByIDCache: entityByIDCache,
-		store:           store,
+		entityByIDCache:                entityByIDCache,
+		entityWithCredentialsByIDCache: entityWithCredentialsByIDCache,
+		entityIDByIdentifierCache:      entityIDByIdentifierCache,
+		cacheableIdentifiers:           idSet,
+		store:                          store,
 		logger: log.GetLogger().With(
 			log.String(log.LoggerKeyComponentName, "CacheBackedEntityStore")),
 	}
@@ -51,6 +67,7 @@ func (s *cacheBackedEntityStore) CreateEntity(ctx context.Context, entity Entity
 		return err
 	}
 	s.cacheEntityByID(ctx, &entity)
+	s.cacheEntityIDByIdentifiers(ctx, &entity)
 	return nil
 }
 
@@ -71,60 +88,68 @@ func (s *cacheBackedEntityStore) GetEntity(ctx context.Context, id string) (Enti
 
 func (s *cacheBackedEntityStore) GetEntityWithCredentials(ctx context.Context,
 	id string) (*entityWithCredentials, error) {
-	return s.store.GetEntityWithCredentials(ctx, id)
+	cacheKey := cache.CacheKey{Key: id}
+	if cached, ok := s.entityWithCredentialsByIDCache.Get(ctx, cacheKey); ok {
+		return cached, nil
+	}
+
+	result, err := s.store.GetEntityWithCredentials(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	s.cacheEntityWithCredentialsByID(ctx, result)
+	return result, nil
 }
 
 func (s *cacheBackedEntityStore) UpdateEntity(ctx context.Context, entity *Entity) error {
+	s.invalidateIdentifierCache(ctx, entity.ID)
+	s.invalidateEntityByID(ctx, entity.ID)
+
 	if err := s.store.UpdateEntity(ctx, entity); err != nil {
 		return err
 	}
 
-	s.invalidateEntityByID(ctx, entity.ID)
 	s.cacheEntityByID(ctx, entity)
+	s.cacheEntityIDByIdentifiers(ctx, entity)
 	return nil
 }
 
 func (s *cacheBackedEntityStore) UpdateAttributes(ctx context.Context,
 	entityID string, attributes json.RawMessage) error {
-	if err := s.store.UpdateAttributes(ctx, entityID, attributes); err != nil {
-		return err
-	}
-
+	s.invalidateIdentifierCache(ctx, entityID)
 	s.invalidateEntityByID(ctx, entityID)
-	return nil
+
+	return s.store.UpdateAttributes(ctx, entityID, attributes)
 }
 
 func (s *cacheBackedEntityStore) UpdateSystemAttributes(ctx context.Context,
 	entityID string, attrs json.RawMessage) error {
-	if err := s.store.UpdateSystemAttributes(ctx, entityID, attrs); err != nil {
-		return err
-	}
-
+	s.invalidateIdentifierCache(ctx, entityID)
 	s.invalidateEntityByID(ctx, entityID)
-	return nil
+
+	return s.store.UpdateSystemAttributes(ctx, entityID, attrs)
 }
 
 func (s *cacheBackedEntityStore) UpdateCredentials(ctx context.Context,
 	entityID string, creds json.RawMessage) error {
-	if err := s.store.UpdateCredentials(ctx, entityID, creds); err != nil {
-		return err
-	}
-
 	s.invalidateEntityByID(ctx, entityID)
-	return nil
+
+	return s.store.UpdateCredentials(ctx, entityID, creds)
 }
 
 func (s *cacheBackedEntityStore) UpdateSystemCredentials(ctx context.Context,
 	entityID string, creds json.RawMessage) error {
-	if err := s.store.UpdateSystemCredentials(ctx, entityID, creds); err != nil {
-		return err
-	}
-
 	s.invalidateEntityByID(ctx, entityID)
-	return nil
+
+	return s.store.UpdateSystemCredentials(ctx, entityID, creds)
 }
 
 func (s *cacheBackedEntityStore) DeleteEntity(ctx context.Context, id string) error {
+	// Invalidate identifier cache before the store delete so the store fallback
+	// can still fetch the entity if the by-ID cache is cold.
+	s.invalidateIdentifierCache(ctx, id)
+
 	if err := s.store.DeleteEntity(ctx, id); err != nil {
 		return err
 	}
@@ -135,12 +160,32 @@ func (s *cacheBackedEntityStore) DeleteEntity(ctx context.Context, id string) er
 
 func (s *cacheBackedEntityStore) IdentifyEntity(ctx context.Context,
 	filters map[string]interface{}) (*string, error) {
-	entityID, err := s.store.IdentifyEntity(ctx, filters)
-	if err != nil || entityID == nil {
-		return entityID, err
+	if len(filters) == 1 {
+		for filterKey, filterVal := range filters {
+			val, ok := filterVal.(string)
+			if !ok || val == "" || !s.cacheableIdentifiers[filterKey] {
+				return s.store.IdentifyEntity(ctx, filters)
+			}
+			compositeKey := identifierCacheKey(filterKey, val)
+			if cached, hit := s.entityIDByIdentifierCache.Get(ctx, compositeKey); hit {
+				return cached, nil
+			}
+
+			entityID, err := s.store.IdentifyEntity(ctx, filters)
+			if err != nil || entityID == nil {
+				return entityID, err
+			}
+
+			if err := s.entityIDByIdentifierCache.Set(ctx,
+				compositeKey, entityID); err != nil {
+				s.logger.Error("Failed to cache entity ID by identifier",
+					log.String("key", filterKey), log.String("value", val), log.Error(err))
+			}
+			return entityID, nil
+		}
 	}
 
-	return entityID, nil
+	return s.store.IdentifyEntity(ctx, filters)
 }
 
 // Pass-through methods.
@@ -215,6 +260,82 @@ func (s *cacheBackedEntityStore) LoadIndexedAttributes(attributes []string) erro
 
 // --- Cache helpers ---
 
+func identifierCacheKey(filterKey, filterValue string) cache.CacheKey {
+	return cache.CacheKey{Key: filterKey + ":" + filterValue}
+}
+
+// parseEntityAttributes unmarshals the entity's SystemAttributes and Attributes
+// into a single merged map. SystemAttributes take precedence on key collisions.
+func (s *cacheBackedEntityStore) parseEntityAttributes(entity *Entity) map[string]interface{} {
+	if entity == nil {
+		return nil
+	}
+	merged := make(map[string]interface{})
+	for _, raw := range []json.RawMessage{entity.Attributes, entity.SystemAttributes} {
+		if len(raw) == 0 {
+			continue
+		}
+		var attrs map[string]interface{}
+		if err := json.Unmarshal(raw, &attrs); err != nil {
+			s.logger.Warn("Failed to unmarshal entity attributes for cache key resolution",
+				log.String("entityID", entity.ID), log.Error(err))
+			continue
+		}
+		for k, v := range attrs {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+
+func (s *cacheBackedEntityStore) cacheEntityIDByIdentifiers(ctx context.Context, entity *Entity) {
+	if entity == nil || entity.ID == "" {
+		return
+	}
+	attrs := s.parseEntityAttributes(entity)
+	for key := range s.cacheableIdentifiers {
+		val, _ := attrs[key].(string)
+		if val == "" {
+			continue
+		}
+		if err := s.entityIDByIdentifierCache.Set(ctx,
+			identifierCacheKey(key, val), &entity.ID); err != nil {
+			s.logger.Error("Failed to cache entity ID by identifier",
+				log.String("key", key), log.String("value", val), log.Error(err))
+		}
+	}
+}
+
+func (s *cacheBackedEntityStore) invalidateIdentifierCache(ctx context.Context, entityID string) {
+	if entityID == "" || len(s.cacheableIdentifiers) == 0 {
+		return
+	}
+	var entity *Entity
+	if cached, ok := s.entityByIDCache.Get(ctx, cache.CacheKey{Key: entityID}); ok && cached != nil {
+		entity = cached
+	} else {
+		fetched, err := s.store.GetEntity(ctx, entityID)
+		if err != nil {
+			s.logger.Error("Failed to fetch entity for identifier cache invalidation",
+				log.String("entityID", entityID), log.Error(err))
+			return
+		}
+		entity = &fetched
+	}
+	attrs := s.parseEntityAttributes(entity)
+	for key := range s.cacheableIdentifiers {
+		val, _ := attrs[key].(string)
+		if val == "" {
+			continue
+		}
+		if err := s.entityIDByIdentifierCache.Delete(ctx,
+			identifierCacheKey(key, val)); err != nil {
+			s.logger.Error("Failed to invalidate identifier cache",
+				log.String("key", key), log.String("value", val), log.Error(err))
+		}
+	}
+}
+
 func (s *cacheBackedEntityStore) cacheEntityByID(ctx context.Context, entity *Entity) {
 	if entity == nil || entity.ID == "" {
 		return
@@ -225,12 +346,28 @@ func (s *cacheBackedEntityStore) cacheEntityByID(ctx context.Context, entity *En
 	}
 }
 
+func (s *cacheBackedEntityStore) cacheEntityWithCredentialsByID(ctx context.Context,
+	ewc *entityWithCredentials) {
+	if ewc == nil || ewc.Entity == nil || ewc.Entity.ID == "" {
+		return
+	}
+	if err := s.entityWithCredentialsByIDCache.Set(ctx,
+		cache.CacheKey{Key: ewc.Entity.ID}, ewc); err != nil {
+		s.logger.Error("Failed to cache entity with credentials by ID",
+			log.String("entityID", ewc.Entity.ID), log.Error(err))
+	}
+}
+
 func (s *cacheBackedEntityStore) invalidateEntityByID(ctx context.Context, entityID string) {
 	if entityID == "" {
 		return
 	}
 	if err := s.entityByIDCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
 		s.logger.Error("Failed to invalidate entity cache by ID",
+			log.String("entityID", entityID), log.Error(err))
+	}
+	if err := s.entityWithCredentialsByIDCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
+		s.logger.Error("Failed to invalidate entity with credentials cache by ID",
 			log.String("entityID", entityID), log.Error(err))
 	}
 }

--- a/backend/internal/entity/cache_backed_store_test.go
+++ b/backend/internal/entity/cache_backed_store_test.go
@@ -35,10 +35,14 @@ import (
 // CacheBackedEntityStoreTestSuite tests the cacheBackedEntityStore.
 type CacheBackedEntityStoreTestSuite struct {
 	suite.Suite
-	mockStore       *entityStoreInterfaceMock
-	entityByIDCache *cachemock.CacheInterfaceMock[*Entity]
-	cachedStore     *cacheBackedEntityStore
-	entityByIDData  map[string]*Entity
+	mockStore                      *entityStoreInterfaceMock
+	entityByIDCache                *cachemock.CacheInterfaceMock[*Entity]
+	entityWithCredentialsByIDCache *cachemock.CacheInterfaceMock[*entityWithCredentials]
+	entityIDByIdentifierCache      *cachemock.CacheInterfaceMock[*string]
+	cachedStore                    *cacheBackedEntityStore
+	entityByIDData                 map[string]*Entity
+	entityWithCredsByIDData        map[string]*entityWithCredentials
+	entityIDByIdentifierData       map[string]*string
 }
 
 func TestCacheBackedEntityStoreTestSuite(t *testing.T) {
@@ -48,16 +52,27 @@ func TestCacheBackedEntityStoreTestSuite(t *testing.T) {
 func (s *CacheBackedEntityStoreTestSuite) SetupTest() {
 	s.mockStore = newEntityStoreInterfaceMock(s.T())
 	s.entityByIDData = make(map[string]*Entity)
+	s.entityWithCredsByIDData = make(map[string]*entityWithCredentials)
+	s.entityIDByIdentifierData = make(map[string]*string)
 
 	s.entityByIDCache = cachemock.NewCacheInterfaceMock[*Entity](s.T())
+	s.entityWithCredentialsByIDCache = cachemock.NewCacheInterfaceMock[*entityWithCredentials](s.T())
+	s.entityIDByIdentifierCache = cachemock.NewCacheInterfaceMock[*string](s.T())
 
 	setupEntityCacheMock(s.entityByIDCache, s.entityByIDData)
+	setupEntityCacheMock(s.entityWithCredentialsByIDCache, s.entityWithCredsByIDData)
+	setupEntityCacheMock(s.entityIDByIdentifierCache, s.entityIDByIdentifierData)
 
 	s.entityByIDCache.EXPECT().IsEnabled().Return(true).Maybe()
+	s.entityWithCredentialsByIDCache.EXPECT().IsEnabled().Return(true).Maybe()
+	s.entityIDByIdentifierCache.EXPECT().IsEnabled().Return(true).Maybe()
 
 	s.cachedStore = &cacheBackedEntityStore{
-		entityByIDCache: s.entityByIDCache,
-		store:           s.mockStore,
+		entityByIDCache:                s.entityByIDCache,
+		entityWithCredentialsByIDCache: s.entityWithCredentialsByIDCache,
+		entityIDByIdentifierCache:      s.entityIDByIdentifierCache,
+		cacheableIdentifiers:           map[string]bool{"clientId": true},
+		store:                          s.mockStore,
 		logger: log.GetLogger().With(
 			log.String(log.LoggerKeyComponentName, "CacheBackedEntityStore")),
 	}
@@ -151,6 +166,57 @@ func (s *CacheBackedEntityStoreTestSuite) TestGetEntity_StoreError() {
 	s.False(ok)
 }
 
+// GetEntityWithCredentials tests
+
+func (s *CacheBackedEntityStoreTestSuite) TestGetEntityWithCredentials_CacheHit() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	ewc := &entityWithCredentials{
+		Entity:            &entity,
+		SchemaCredentials: json.RawMessage(`{"password":"hashed"}`),
+		SystemCredentials: json.RawMessage(`{"secret":"val"}`),
+	}
+	s.entityWithCredsByIDData[entity.ID] = ewc
+
+	result, err := s.cachedStore.GetEntityWithCredentials(context.Background(), entity.ID)
+	s.Nil(err)
+	s.Equal(entity.ID, result.Entity.ID)
+	s.Equal(ewc.SchemaCredentials, result.SchemaCredentials)
+	s.mockStore.AssertNotCalled(s.T(), "GetEntityWithCredentials")
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestGetEntityWithCredentials_CacheMiss() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	ewc := &entityWithCredentials{
+		Entity:            &entity,
+		SchemaCredentials: json.RawMessage(`{"password":"hashed"}`),
+		SystemCredentials: json.RawMessage(`{"secret":"val"}`),
+	}
+	s.mockStore.On("GetEntityWithCredentials", mock.Anything, entity.ID).Return(ewc, nil).Once()
+
+	result, err := s.cachedStore.GetEntityWithCredentials(context.Background(), entity.ID)
+	s.Nil(err)
+	s.Equal(entity.ID, result.Entity.ID)
+	s.mockStore.AssertExpectations(s.T())
+
+	cached, ok := s.entityWithCredentialsByIDCache.Get(context.Background(),
+		cache.CacheKey{Key: entity.ID})
+	s.True(ok)
+	s.Equal(entity.ID, cached.Entity.ID)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestGetEntityWithCredentials_StoreError() {
+	storeErr := errors.New("db error")
+	s.mockStore.On("GetEntityWithCredentials", mock.Anything, "bad-id").
+		Return(nil, storeErr).Once()
+
+	_, err := s.cachedStore.GetEntityWithCredentials(context.Background(), "bad-id")
+	s.Equal(storeErr, err)
+
+	_, ok := s.entityWithCredentialsByIDCache.Get(context.Background(),
+		cache.CacheKey{Key: "bad-id"})
+	s.False(ok)
+}
+
 // IdentifyEntity tests
 
 func (s *CacheBackedEntityStoreTestSuite) TestIdentifyEntity_CallsStore() {
@@ -191,6 +257,118 @@ func (s *CacheBackedEntityStoreTestSuite) TestUpdateSystemAttributes_Invalidates
 
 	_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
 	s.False(ok)
+}
+
+// GetEntityWithCredentials cache helper edge cases
+
+func (s *CacheBackedEntityStoreTestSuite) TestGetEntityWithCredentials_NilResult_DoesNotCache() {
+	s.mockStore.On("GetEntityWithCredentials", mock.Anything, "nil-entity").
+		Return(&entityWithCredentials{}, nil).Once()
+
+	result, err := s.cachedStore.GetEntityWithCredentials(context.Background(), "nil-entity")
+	s.Nil(err)
+	s.NotNil(result)
+	s.mockStore.AssertExpectations(s.T())
+
+	// Result has nil Entity, so it should not be cached.
+	_, ok := s.entityWithCredentialsByIDCache.Get(context.Background(),
+		cache.CacheKey{Key: "nil-entity"})
+	s.False(ok)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestGetEntityWithCredentials_CacheSetError() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	ewc := &entityWithCredentials{
+		Entity:            &entity,
+		SchemaCredentials: json.RawMessage(`{"password":"hashed"}`),
+	}
+
+	failingCredsCache := cachemock.NewCacheInterfaceMock[*entityWithCredentials](s.T())
+	failingCredsCache.EXPECT().Get(mock.Anything, mock.Anything).
+		Return(nil, false).Once()
+	failingCredsCache.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("cache set error")).Once()
+	failingCredsCache.EXPECT().Delete(mock.Anything, mock.Anything).Return(nil).Maybe()
+	failingCredsCache.EXPECT().GetName().Return("failingCredsCache").Maybe()
+	failingCredsCache.EXPECT().CleanupExpired().Maybe()
+
+	store := &cacheBackedEntityStore{
+		entityByIDCache:                s.entityByIDCache,
+		entityWithCredentialsByIDCache: failingCredsCache,
+		entityIDByIdentifierCache:      s.entityIDByIdentifierCache,
+		cacheableIdentifiers:           map[string]bool{"clientId": true},
+		store:                          s.mockStore,
+		logger: log.GetLogger().With(
+			log.String(log.LoggerKeyComponentName, "CacheBackedEntityStore")),
+	}
+
+	s.mockStore.On("GetEntityWithCredentials", mock.Anything, entity.ID).Return(ewc, nil).Once()
+
+	result, err := store.GetEntityWithCredentials(context.Background(), entity.ID)
+	s.Nil(err)
+	s.Equal(entity.ID, result.Entity.ID)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestInvalidateEntityByID_CredsDeleteError() {
+	failingCredsCache := cachemock.NewCacheInterfaceMock[*entityWithCredentials](s.T())
+	failingCredsCache.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, false).Maybe()
+	failingCredsCache.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	failingCredsCache.EXPECT().Delete(mock.Anything, mock.Anything).
+		Return(errors.New("cache delete error")).Once()
+	failingCredsCache.EXPECT().GetName().Return("failingCredsCache").Maybe()
+	failingCredsCache.EXPECT().CleanupExpired().Maybe()
+
+	store := &cacheBackedEntityStore{
+		entityByIDCache:                s.entityByIDCache,
+		entityWithCredentialsByIDCache: failingCredsCache,
+		entityIDByIdentifierCache:      s.entityIDByIdentifierCache,
+		cacheableIdentifiers:           map[string]bool{"clientId": true},
+		store:                          s.mockStore,
+		logger: log.GetLogger().With(
+			log.String(log.LoggerKeyComponentName, "CacheBackedEntityStore")),
+	}
+
+	entity := s.makeEntity(testEntityID, "client-1")
+	s.entityByIDData[entity.ID] = &entity
+	s.mockStore.On("DeleteEntity", mock.Anything, entity.ID).Return(nil).Once()
+
+	// Should not propagate the cache delete error.
+	err := store.DeleteEntity(context.Background(), entity.ID)
+	s.Nil(err)
+}
+
+// UpdateCredentials / UpdateSystemCredentials tests
+
+func (s *CacheBackedEntityStoreTestSuite) TestUpdateCredentials_InvalidatesBothCaches() {
+	tests := []struct {
+		name       string
+		storeFn    string
+		updateFunc func(ctx context.Context, entityID string, creds json.RawMessage) error
+	}{
+		{"UpdateCredentials", "UpdateCredentials", s.cachedStore.UpdateCredentials},
+		{"UpdateSystemCredentials", "UpdateSystemCredentials", s.cachedStore.UpdateSystemCredentials},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			entity := s.makeEntity(testEntityID, "client-1")
+			s.entityByIDData[entity.ID] = &entity
+			s.entityWithCredsByIDData[entity.ID] = &entityWithCredentials{Entity: &entity}
+
+			newCreds := json.RawMessage(`{"key":"new"}`)
+			s.mockStore.On(tc.storeFn, mock.Anything, entity.ID, newCreds).Return(nil).Once()
+
+			err := tc.updateFunc(context.Background(), entity.ID, newCreds)
+			s.Nil(err)
+			s.mockStore.AssertExpectations(s.T())
+
+			_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+			s.False(ok)
+			_, ok = s.entityWithCredentialsByIDCache.Get(context.Background(),
+				cache.CacheKey{Key: entity.ID})
+			s.False(ok)
+		})
+	}
 }
 
 // DeleteEntity tests
@@ -238,6 +416,11 @@ func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_CachesEntityByID() {
 	cached, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
 	s.True(ok)
 	s.Equal(entity.ID, cached.ID)
+
+	cachedID, ok := s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:client-1"})
+	s.True(ok)
+	s.Equal(entity.ID, *cachedID)
 }
 
 func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_StoreError_DoesNotCache() {
@@ -250,6 +433,10 @@ func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_StoreError_DoesNotCac
 	s.Equal(storeErr, err)
 
 	_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.False(ok)
+
+	_, ok = s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:client-1"})
 	s.False(ok)
 }
 
@@ -269,4 +456,235 @@ func (s *CacheBackedEntityStoreTestSuite) TestUpdateEntity_InvalidatesAndRecache
 	cached, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
 	s.True(ok)
 	s.Equal(entity.ID, cached.ID)
+}
+
+// IdentifyEntity cache tests
+
+func (s *CacheBackedEntityStoreTestSuite) TestIdentifyEntity_CacheHit_CacheableIdentifier() {
+	entityID := testEntityID
+	s.entityIDByIdentifierData["clientId:client-1"] = &entityID
+
+	result, err := s.cachedStore.IdentifyEntity(context.Background(),
+		map[string]interface{}{"clientId": "client-1"})
+	s.Nil(err)
+	s.Equal(entityID, *result)
+	s.mockStore.AssertNotCalled(s.T(), "IdentifyEntity")
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestIdentifyEntity_CacheMiss_CacheableIdentifier_PopulatesCache() {
+	entityID := testEntityID
+	filters := map[string]interface{}{"clientId": "client-1"}
+	s.mockStore.On("IdentifyEntity", mock.Anything, filters).Return(&entityID, nil).Once()
+
+	result, err := s.cachedStore.IdentifyEntity(context.Background(), filters)
+	s.Nil(err)
+	s.Equal(entityID, *result)
+	s.mockStore.AssertExpectations(s.T())
+
+	cachedID, ok := s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:client-1"})
+	s.True(ok)
+	s.Equal(entityID, *cachedID)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestIdentifyEntity_MultipleFilters_BypassesCache() {
+	entityID := testEntityID
+	s.entityIDByIdentifierData["clientId:client-1"] = &entityID
+
+	filters := map[string]interface{}{"clientId": "client-1", "name": "app"}
+	s.mockStore.On("IdentifyEntity", mock.Anything, filters).Return(&entityID, nil).Once()
+
+	result, err := s.cachedStore.IdentifyEntity(context.Background(), filters)
+	s.Nil(err)
+	s.Equal(entityID, *result)
+	s.mockStore.AssertExpectations(s.T())
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestIdentifyEntity_NonCacheableFilter_BypassesCache() {
+	entityID := testEntityID
+	filters := map[string]interface{}{"email": "user@example.com"}
+	s.mockStore.On("IdentifyEntity", mock.Anything, filters).Return(&entityID, nil).Once()
+
+	result, err := s.cachedStore.IdentifyEntity(context.Background(), filters)
+	s.Nil(err)
+	s.Equal(entityID, *result)
+	s.mockStore.AssertExpectations(s.T())
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestIdentifyEntity_StoreError_DoesNotPopulateCache() {
+	filters := map[string]interface{}{"clientId": "bad-client"}
+	storeErr := errors.New("not found")
+	s.mockStore.On("IdentifyEntity", mock.Anything, filters).Return(nil, storeErr).Once()
+
+	result, err := s.cachedStore.IdentifyEntity(context.Background(), filters)
+	s.Equal(storeErr, err)
+	s.Nil(result)
+
+	_, ok := s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:bad-client"})
+	s.False(ok)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestIdentifyEntity_StoreReturnsNil_DoesNotPopulateCache() {
+	filters := map[string]interface{}{"clientId": "unknown"}
+	s.mockStore.On("IdentifyEntity", mock.Anything, filters).
+		Return((*string)(nil), nil).Once()
+
+	result, err := s.cachedStore.IdentifyEntity(context.Background(), filters)
+	s.Nil(err)
+	s.Nil(result)
+
+	_, ok := s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:unknown"})
+	s.False(ok)
+}
+
+// Identifier cache invalidation tests
+
+func (s *CacheBackedEntityStoreTestSuite) TestDeleteEntity_InvalidatesIdentifierCache() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	s.entityByIDData[entity.ID] = &entity
+	entityID := entity.ID
+	s.entityIDByIdentifierData["clientId:client-1"] = &entityID
+
+	s.mockStore.On("DeleteEntity", mock.Anything, entity.ID).Return(nil).Once()
+
+	err := s.cachedStore.DeleteEntity(context.Background(), entity.ID)
+	s.Nil(err)
+	s.mockStore.AssertExpectations(s.T())
+
+	_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.False(ok)
+
+	_, ok = s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:client-1"})
+	s.False(ok)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestUpdateEntity_InvalidatesAndRewarmsIdentifierCache() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	s.entityByIDData[entity.ID] = &entity
+	entityID := entity.ID
+	s.entityIDByIdentifierData["clientId:client-1"] = &entityID
+
+	s.mockStore.On("UpdateEntity", mock.Anything, &entity).Return(nil).Once()
+
+	err := s.cachedStore.UpdateEntity(context.Background(), &entity)
+	s.Nil(err)
+	s.mockStore.AssertExpectations(s.T())
+
+	cachedID, ok := s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:client-1"})
+	s.True(ok)
+	s.Equal(entity.ID, *cachedID)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestUpdateSystemAttributes_InvalidatesIdentifierCache() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	s.entityByIDData[entity.ID] = &entity
+	entityID := entity.ID
+	s.entityIDByIdentifierData["clientId:client-1"] = &entityID
+
+	newSysAttrs, _ := json.Marshal(map[string]interface{}{"clientId": "new-client"})
+	s.mockStore.On("UpdateSystemAttributes", mock.Anything, entity.ID,
+		json.RawMessage(newSysAttrs)).Return(nil).Once()
+
+	err := s.cachedStore.UpdateSystemAttributes(context.Background(), entity.ID, newSysAttrs)
+	s.Nil(err)
+	s.mockStore.AssertExpectations(s.T())
+
+	_, ok := s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:client-1"})
+	s.False(ok)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestDeleteEntity_InvalidatesIdentifierCache_CacheMiss() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	entityID := entity.ID
+	s.entityIDByIdentifierData["clientId:client-1"] = &entityID
+
+	// Entity is NOT in entityByIDCache — invalidateIdentifierCache must fall back to the store.
+	s.mockStore.On("DeleteEntity", mock.Anything, entity.ID).Return(nil).Once()
+	s.mockStore.On("GetEntity", mock.Anything, entity.ID).Return(entity, nil).Once()
+
+	err := s.cachedStore.DeleteEntity(context.Background(), entity.ID)
+	s.Nil(err)
+	s.mockStore.AssertExpectations(s.T())
+
+	_, ok := s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:client-1"})
+	s.False(ok)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestUpdateEntity_InvalidatesIdentifierCache_CacheMiss() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	entityID := entity.ID
+	s.entityIDByIdentifierData["clientId:client-1"] = &entityID
+
+	// Entity is NOT in entityByIDCache — invalidateIdentifierCache must fall back to the store
+	// BEFORE the update, so it reads the old attributes.
+	s.mockStore.On("GetEntity", mock.Anything, entity.ID).Return(entity, nil).Once()
+	s.mockStore.On("UpdateEntity", mock.Anything, &entity).Return(nil).Once()
+
+	err := s.cachedStore.UpdateEntity(context.Background(), &entity)
+	s.Nil(err)
+	s.mockStore.AssertExpectations(s.T())
+
+	_, ok := s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:client-1"})
+	// Old key is evicted, then re-warmed with the (unchanged) entity.
+	s.True(ok)
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestUpdateAttributeMethods_InvalidateIdentifierCache_CacheMiss() {
+	tests := []struct {
+		name       string
+		storeFn    string
+		updateFunc func(ctx context.Context, entityID string, attrs json.RawMessage) error
+	}{
+		{"UpdateAttributes", "UpdateAttributes", s.cachedStore.UpdateAttributes},
+		{"UpdateSystemAttributes", "UpdateSystemAttributes", s.cachedStore.UpdateSystemAttributes},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			entity := s.makeEntity(testEntityID, "client-1")
+			entityID := entity.ID
+			s.entityIDByIdentifierData["clientId:client-1"] = &entityID
+
+			// Entity is NOT in entityByIDCache — store fallback happens before the update.
+			s.mockStore.On("GetEntity", mock.Anything, entity.ID).Return(entity, nil).Once()
+			newAttrs, _ := json.Marshal(map[string]interface{}{"clientId": "new-client"})
+			s.mockStore.On(tc.storeFn, mock.Anything, entity.ID,
+				json.RawMessage(newAttrs)).Return(nil).Once()
+
+			err := tc.updateFunc(context.Background(), entity.ID, newAttrs)
+			s.Nil(err)
+			s.mockStore.AssertExpectations(s.T())
+
+			// Old identifier key should be evicted.
+			_, ok := s.entityIDByIdentifierCache.Get(context.Background(),
+				cache.CacheKey{Key: "clientId:client-1"})
+			s.False(ok)
+		})
+	}
+}
+
+func (s *CacheBackedEntityStoreTestSuite) TestUpdateCredentials_DoesNotInvalidateIdentifierCache() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	s.entityByIDData[entity.ID] = &entity
+	entityID := entity.ID
+	s.entityIDByIdentifierData["clientId:client-1"] = &entityID
+
+	newCreds := json.RawMessage(`{"key":"new"}`)
+	s.mockStore.On("UpdateCredentials", mock.Anything, entity.ID, newCreds).Return(nil).Once()
+
+	err := s.cachedStore.UpdateCredentials(context.Background(), entity.ID, newCreds)
+	s.Nil(err)
+	s.mockStore.AssertExpectations(s.T())
+
+	cachedID, ok := s.entityIDByIdentifierCache.Get(context.Background(),
+		cache.CacheKey{Key: "clientId:client-1"})
+	s.True(ok)
+	s.Equal(entity.ID, *cachedID)
 }

--- a/backend/internal/entity/init.go
+++ b/backend/internal/entity/init.go
@@ -54,6 +54,11 @@ func initializeStore(cacheManager cache.CacheManagerInterface) (
 		return nil, nil, err
 	}
 	entityByIDCache := cache.GetCache[*Entity](cacheManager, "EntityByIDCache")
-	cacheBackedEntityStore := newCacheBackedEntityStore(dbStore, entityByIDCache)
+	entityWithCredsByIDCache := cache.GetCache[*entityWithCredentials](cacheManager,
+		"EntityWithCredentialsByIDCache")
+	entityIDByIdentifierCache := cache.GetCache[*string](cacheManager,
+		"EntityIDByIdentifierCache")
+	cacheBackedEntityStore := newCacheBackedEntityStore(dbStore, entityByIDCache,
+		entityWithCredsByIDCache, entityIDByIdentifierCache)
 	return newEntityCompositeStore(fileStore, cacheBackedEntityStore), transactioner, nil
 }


### PR DESCRIPTION
### Purpose

This pull request enhances the caching layer for the entity store by introducing new cache mechanisms for entities with credentials and for mapping client IDs to entity IDs. It also refines cache invalidation logic and adds comprehensive tests to ensure correct caching behavior and error handling.

### Approach

**Caching improvements:**

- Added a new cache (`entityWithCredentialsByIDCache`) to store entities along with their credentials, optimizing repeated lookups for credentialed entities. The `GetEntityWithCredentials` method now checks this cache before querying the underlying store and caches results after a miss. [[1]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R33-R47) [[2]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277L74-R107) [[3]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R315-R326) [[4]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R335-R338)
- Introduced a cache (`entityIDByClientIDCache`) to quickly resolve entity IDs from client IDs, including logic to extract and cache the mapping during entity creation and updates, and to consult the cache in `IdentifyEntity`. [[1]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R33-R47) [[2]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R60-R62) [[3]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R157-R182) [[4]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R256-R304)

**Cache invalidation and helpers:**

- Refined cache invalidation to ensure that updates or deletions to entities also invalidate both the new credentialed entity cache and the client ID cache, preventing stale data. [[1]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277L74-R107) [[2]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R127) [[3]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R157-R182) [[4]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R256-R304) [[5]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R335-R338)
- Added helper functions for extracting client IDs from entities and for handling cache set/delete operations, with appropriate error logging. [[1]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R256-R304) [[2]](diffhunk://#diff-d2e42cf48e4cc60e4b4373ad34736a12bdb474cb3170da7a14112a3d5d592277R315-R326)

**Testing enhancements:**

- Expanded the test suite to cover the new caches, including hit/miss scenarios, error handling for cache set/delete failures, and edge cases (such as nil results or entities). [[1]](diffhunk://#diff-fcf3ab5fe993b9f93441602b92dcbc9403c4de1b5f9e037f64a9cb86406801f1R40-R45) [[2]](diffhunk://#diff-fcf3ab5fe993b9f93441602b92dcbc9403c4de1b5f9e037f64a9cb86406801f1R55-R73) [[3]](diffhunk://#diff-fcf3ab5fe993b9f93441602b92dcbc9403c4de1b5f9e037f64a9cb86406801f1R168-R218) [[4]](diffhunk://#diff-fcf3ab5fe993b9f93441602b92dcbc9403c4de1b5f9e037f64a9cb86406801f1R261-R370)
- Updated tests to check that client ID mappings are cached or not cached appropriately after entity creation or store errors. [[1]](diffhunk://#diff-fcf3ab5fe993b9f93441602b92dcbc9403c4de1b5f9e037f64a9cb86406801f1R416-R420) [[2]](diffhunk://#diff-fcf3ab5fe993b9f93441602b92dcbc9403c4de1b5f9e037f64a9cb86406801f1R434-R437)

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2806

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added credential-aware per-entity caching and a client-ID→entity-ID mapping to reduce redundant lookups and improve lookup performance.
* **Bug Fixes**
  * Extended cache invalidation to keep client-ID and credential entries consistent across create, update, attribute changes and delete operations.
* **Tests**
  * Added tests for credential cache hits/misses, client-ID caching behavior, invalidation paths, and error edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->