### PR TITLE
Update Codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -29,7 +29,7 @@ codecov:
     # Without this, Codecov status checks can intermittently hang at
     # "Expected — Waiting for status to be reported" when CI signal is delayed.
     # See: https://about.codecov.io/blog/delay-notifications-for-flags-with-after_n_builds/
-    after_n_builds: 5
+    after_n_builds: 6
 
 flags:
   backend-unit:
@@ -44,14 +44,10 @@ flags:
     carryforward: false
     paths:
       - backend/
-  # backend-combined-sqlite:
-  #   carryforward: false
-  #   paths:
-  #     - backend/
-  # backend-combined-postgres:
-  #   carryforward: false
-  #   paths:
-  #     - backend/
+  backend-integration-redis:
+    carryforward: false
+    paths:
+      - backend/
   frontend-apps-console-unit:
     carryforward: false
     paths:
@@ -82,13 +78,26 @@ coverage:
         target: 60%
         threshold: 1%
         informational: true
-      # backend-combined:
-      #   flags:
-      #     - backend-combined-sqlite
-      #     - backend-combined-postgres
-      #   target: auto
-      #   threshold: 1%
-      #   informational: false
+      backend-combined:
+        flags:
+          - backend-unit
+          - backend-integration-sqlite
+          - backend-integration-postgres
+          - backend-integration-redis
+        target: auto
+        threshold: 1%
+        informational: false
+      combined:
+        flags:
+          - backend-unit
+          - backend-integration-sqlite
+          - backend-integration-postgres
+          - backend-integration-redis
+          - frontend-apps-console-unit
+          - frontend-apps-gate-unit
+        target: auto
+        threshold: 1%
+        informational: true
       frontend-apps-console-unit:
         flags:
           - frontend-apps-console-unit


### PR DESCRIPTION
### Purpose
This pull request updates the `codecov.yml` configuration to improve coverage reporting for backend and frontend tests. The main changes include adjusting the build aggregation settings, introducing new coverage flags, and updating coverage group definitions for more comprehensive reporting.

**Codecov build and flag configuration:**

* Increased `after_n_builds` from 5 to 6 to ensure Codecov waits for all expected CI builds before reporting status.
* Added a new `backend-integration-redis` flag for tracking Redis-related backend integration test coverage.

**Coverage group definitions:**

* Introduced a `backend-combined` coverage group that aggregates `backend-unit`, `backend-integration-sqlite`, `backend-integration-postgres`, and `backend-integration-redis` flags for more accurate backend coverage reporting.
* Added a new `combined` coverage group that includes both backend and frontend unit/integration test flags to provide an overall coverage metric.


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened code coverage reporting infrastructure by enforcing CI check requirements and consolidating exactly 6 coverage uploads before generating reports for improved accuracy and reliability.
  * Added comprehensive coverage tracking for newly implemented Redis backend integration tests to better monitor backend service testing metrics.
  * Reorganized coverage group definitions to provide more detailed aggregated metrics across the complete backend and frontend test suite landscape.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2811?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->