### PR TITLE
Change default resource server identifer to mcp url

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -54,7 +54,7 @@ Write-Host ""
 
 # System resource server configuration from environment variables.
 $SYSTEM_RS_HANDLE = if ($env:SYSTEM_RS_HANDLE) { $env:SYSTEM_RS_HANDLE } else { "" }
-$SYSTEM_RS_IDENTIFIER = if ($env:SYSTEM_RS_IDENTIFIER) { $env:SYSTEM_RS_IDENTIFIER } else { "system" }
+$SYSTEM_RS_IDENTIFIER = if ($env:SYSTEM_RS_IDENTIFIER) { $env:SYSTEM_RS_IDENTIFIER } else { "https://localhost:8090/mcp" }
 
 # Derive the system permission root based on the configured handle.
 if ($SYSTEM_RS_HANDLE) {

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -45,7 +45,7 @@ echo ""
 
 # System resource server configuration from environment variables.
 SYSTEM_RS_HANDLE="${SYSTEM_RS_HANDLE:-}"
-SYSTEM_RS_IDENTIFIER="${SYSTEM_RS_IDENTIFIER:-system}"
+SYSTEM_RS_IDENTIFIER="${SYSTEM_RS_IDENTIFIER:-https://localhost:8090/mcp}"
 
 # Derive the system permission root based on the configured handle.
 if [[ -n "$SYSTEM_RS_HANDLE" ]]; then


### PR DESCRIPTION
### Purpose
Change default resource server identifer to mcp url.

When connecting to Thunder MCP server, thunder needs to authorize with a resource server with identifier "https://localhost:8090/mcp". 
Currently we don't have protocol specific MCP servers

### Approach
This pull request updates the default value for the `SYSTEM_RS_IDENTIFIER` environment variable in both the PowerShell and Bash server bootstrap scripts. The new default is now a URL pointing to `https://localhost:8090/mcp` instead of the previous value `"system"`.

Configuration changes:

* Changed the default value of `SYSTEM_RS_IDENTIFIER` from `"system"` to `"https://localhost:8090/mcp"` in the PowerShell bootstrap script (`backend/cmd/server/bootstrap/01-default-resources.ps1`).
* Changed the default value of `SYSTEM_RS_IDENTIFIER` from `"system"` to `"https://localhost:8090/mcp"` in the Bash bootstrap script (`backend/cmd/server/bootstrap/01-default-resources.sh`).

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default system resource server identifier configuration from a simple handle to a URL format during system initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->