### PR TITLE
Remove Asgardeo references from repo

### DIFF
--- a/.audit-ignore.json
+++ b/.audit-ignore.json
@@ -14,6 +14,6 @@
     { "id": "GHSA-w7fw-mjwx-w883", "package": "qs", "reason": "arrayLimit bypass (transitive via express, dev-only)" }
   ],
   "sample-apps": [
-    { "id": "GHSA-848j-6mx2-7j84", "package": "elliptic", "reason": "Risky crypto implementation (transitive via @asgardeo/react)" }
+    { "id": "GHSA-848j-6mx2-7j84", "package": "elliptic", "reason": "Risky crypto implementation (transitive via @thunderid/react)" }
   ]
 }

--- a/frontend/apps/console/src/__tests__/AppWithDecorators.test.tsx
+++ b/frontend/apps/console/src/__tests__/AppWithDecorators.test.tsx
@@ -60,7 +60,7 @@ vi.mock('@thunderid/react', () => ({
     scopes = undefined,
   }: MockThunderIDProviderProps) => (
     <div
-      data-testid="asgardeo-provider"
+      data-testid="thunderid-provider"
       data-base-url={baseUrl}
       data-client-id={clientId}
       data-after-sign-in-url={afterSignInUrl}
@@ -116,9 +116,9 @@ describe('AppWithDecorators', () => {
     Object.keys(mockConfig).forEach((key) => delete mockConfig[key]);
     mockConfig.brand = {favicon: {light: 'assets/images/favicon.ico', dark: 'assets/images/favicon-inverted.ico'}};
     // Set up default environment variables
-    import.meta.env.VITE_ASGARDEO_BASE_URL = 'https://default-base.example.com';
-    import.meta.env.VITE_ASGARDEO_CLIENT_ID = 'default-client-id';
-    import.meta.env.VITE_ASGARDEO_AFTER_SIGN_IN_URL = 'https://default-signin.example.com';
+    import.meta.env.VITE_THUNDER_BASE_URL = 'https://default-base.example.com';
+    import.meta.env.VITE_THUNDER_CLIENT_ID = 'default-client-id';
+    import.meta.env.VITE_THUNDER_AFTER_SIGN_IN_URL = 'https://default-signin.example.com';
     // Default to empty scopes
     mockGetTrustedIssuerScopes.mockReturnValue([]);
   });
@@ -130,7 +130,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-base-url', 'https://test-server.example.com');
     expect(provider).toHaveAttribute('data-client-id', 'test-client-id');
     expect(provider).toHaveAttribute('data-after-sign-in-url', 'https://test-client.example.com');
@@ -143,7 +143,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-base-url', 'https://default-base.example.com');
     expect(provider).toHaveAttribute('data-client-id', 'default-client-id');
     expect(provider).toHaveAttribute('data-after-sign-in-url', 'https://default-signin.example.com');
@@ -166,7 +166,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-base-url', 'https://config-server.example.com');
   });
 
@@ -177,7 +177,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-client-id', 'config-client-id');
   });
 
@@ -188,7 +188,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-after-sign-in-url', 'https://config-client.example.com');
   });
 
@@ -199,7 +199,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-base-url', 'https://default-base.example.com');
     expect(provider).toHaveAttribute('data-client-id', 'default-client-id');
     expect(provider).toHaveAttribute('data-after-sign-in-url', 'https://default-signin.example.com');
@@ -212,7 +212,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-base-url', 'https://config-server.example.com');
     expect(provider).toHaveAttribute('data-client-id', 'default-client-id');
     expect(provider).toHaveAttribute('data-after-sign-in-url', 'https://config-client.example.com');
@@ -225,7 +225,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-base-url', 'https://default-base.example.com');
     expect(provider).toHaveAttribute('data-client-id', 'config-client-id');
     expect(provider).toHaveAttribute('data-after-sign-in-url', 'https://default-signin.example.com');
@@ -239,7 +239,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-scopes', '["openid","profile","email","system"]');
   });
 
@@ -251,7 +251,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).not.toHaveAttribute('data-scopes');
   });
 
@@ -263,7 +263,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-scopes', '["openid","profile"]');
   });
 
@@ -275,7 +275,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-base-url', 'https://default-base.example.com');
     expect(provider).toHaveAttribute('data-client-id', 'default-client-id');
     expect(provider).toHaveAttribute('data-after-sign-in-url', 'https://default-signin.example.com');
@@ -292,7 +292,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     // Empty strings are truthy, so they will be passed through (not fallback to env vars)
     expect(provider).toHaveAttribute('data-base-url', '');
     expect(provider).toHaveAttribute('data-client-id', '');
@@ -308,7 +308,7 @@ describe('AppWithDecorators', () => {
 
     render(<AppWithDecorators />);
 
-    const provider = screen.getByTestId('asgardeo-provider');
+    const provider = screen.getByTestId('thunderid-provider');
     expect(provider).toHaveAttribute('data-base-url', 'https://server.test');
     expect(provider).toHaveAttribute('data-client-id', 'client-123');
     expect(provider).toHaveAttribute('data-after-sign-in-url', 'https://client.test');

--- a/frontend/apps/console/src/features/agents/components/create-agent/ConfigureOwner.tsx
+++ b/frontend/apps/console/src/features/agents/components/create-agent/ConfigureOwner.tsx
@@ -47,8 +47,8 @@ export default function ConfigureOwner({
   onReadyChange = undefined,
 }: ConfigureOwnerProps): JSX.Element {
   const {t} = useTranslation();
-  const asgardeoUser = useThunderID().user as {id?: string} | null | undefined;
-  const currentUserId = asgardeoUser?.id ?? null;
+  const currentUser = useThunderID().user as {id?: string} | null | undefined;
+  const currentUserId = currentUser?.id ?? null;
 
   const {data: usersData, isLoading: usersLoading} = useGetUsers({limit: 100, offset: 0});
 

--- a/frontend/apps/console/src/features/agents/components/create-agent/__tests__/ConfigureOwner.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/create-agent/__tests__/ConfigureOwner.test.tsx
@@ -21,13 +21,13 @@ import {render, screen, within, waitFor} from '@thunderid/test-utils';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import ConfigureOwner, {type ConfigureOwnerProps} from '../ConfigureOwner';
 
-const {mockAsgardeoUser, mockUseGetUsers} = vi.hoisted(() => ({
-  mockAsgardeoUser: {id: 'current-user-id'},
+const {mockCurrentUser, mockUseGetUsers} = vi.hoisted(() => ({
+  mockCurrentUser: {id: 'current-user-id'},
   mockUseGetUsers: vi.fn(),
 }));
 
 vi.mock('@thunderid/react', () => ({
-  useThunderID: () => ({user: mockAsgardeoUser}),
+  useThunderID: () => ({user: mockCurrentUser}),
 }));
 
 vi.mock('@thunderid/configure-users', () => ({

--- a/frontend/apps/console/src/hocs/__tests__/withConfig.test.tsx
+++ b/frontend/apps/console/src/hocs/__tests__/withConfig.test.tsx
@@ -84,7 +84,7 @@ vi.mock('@thunderid/react', () => ({
     };
     return (
       <div
-        data-testid="asgardeo-provider"
+        data-testid="thunderid-provider"
         data-base-url={baseUrl}
         data-client-id={clientId}
         data-after-sign-in-url={afterSignInUrl}
@@ -101,9 +101,9 @@ describe('withConfig (console)', () => {
     vi.clearAllMocks();
     capturedProviderProps = {};
     Object.keys(mockConfig).forEach((key) => delete mockConfig[key]);
-    import.meta.env.VITE_ASGARDEO_BASE_URL = 'https://env-base.example.com';
-    import.meta.env.VITE_ASGARDEO_CLIENT_ID = 'env-client-id';
-    import.meta.env.VITE_ASGARDEO_AFTER_SIGN_IN_URL = 'https://env-signin.example.com';
+    import.meta.env.VITE_THUNDER_BASE_URL = 'https://env-base.example.com';
+    import.meta.env.VITE_THUNDER_CLIENT_ID = 'env-client-id';
+    import.meta.env.VITE_THUNDER_AFTER_SIGN_IN_URL = 'https://env-signin.example.com';
     mockGetScopes.mockReturnValue([]);
     mockGetTrustedIssuerUrl.mockReturnValue('https://server.example.com');
     mockGetTrustedIssuerClientId.mockReturnValue('client-id');
@@ -135,7 +135,7 @@ describe('withConfig (console)', () => {
     mockGetClientUrl.mockReturnValue('https://client.example.com');
 
     render(<WithConfigComponent />);
-    expect(screen.getByTestId('asgardeo-provider')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-provider')).toBeInTheDocument();
   });
 
   it('passes baseUrl from getTrustedIssuerUrl to ThunderIDProvider', () => {
@@ -165,7 +165,7 @@ describe('withConfig (console)', () => {
     expect(capturedProviderProps.afterSignInUrl).toBe('https://custom-client.example.com');
   });
 
-  it('falls back to env VITE_ASGARDEO_BASE_URL when getTrustedIssuerUrl returns null', () => {
+  it('falls back to env VITE_THUNDER_BASE_URL when getTrustedIssuerUrl returns null', () => {
     mockGetTrustedIssuerUrl.mockReturnValue(null);
     mockGetTrustedIssuerClientId.mockReturnValue('client-id');
     mockGetClientUrl.mockReturnValue('https://client.example.com');
@@ -174,7 +174,7 @@ describe('withConfig (console)', () => {
     expect(capturedProviderProps.baseUrl).toBe('https://env-base.example.com');
   });
 
-  it('falls back to env VITE_ASGARDEO_CLIENT_ID when getTrustedIssuerClientId returns null', () => {
+  it('falls back to env VITE_THUNDER_CLIENT_ID when getTrustedIssuerClientId returns null', () => {
     mockGetTrustedIssuerClientId.mockReturnValue(null);
     mockGetTrustedIssuerUrl.mockReturnValue('https://server.example.com');
     mockGetClientUrl.mockReturnValue('https://client.example.com');
@@ -183,7 +183,7 @@ describe('withConfig (console)', () => {
     expect(capturedProviderProps.clientId).toBe('env-client-id');
   });
 
-  it('falls back to env VITE_ASGARDEO_AFTER_SIGN_IN_URL when getClientUrl returns null', () => {
+  it('falls back to env VITE_THUNDER_AFTER_SIGN_IN_URL when getClientUrl returns null', () => {
     mockGetClientUrl.mockReturnValue(null);
     mockGetServerUrl.mockReturnValue('https://server.example.com');
     mockGetClientId.mockReturnValue('client-id');
@@ -302,7 +302,7 @@ describe('withConfig (console)', () => {
       expect(capturedProviderProps.preferences).toBeUndefined();
     });
 
-    it('disables Asgardeo vendor-specific bootstrap calls for generic OIDC trusted issuers', () => {
+    it('disables ThunderID vendor-specific bootstrap calls for generic OIDC trusted issuers', () => {
       mockConfig.trusted_issuer = {hostname: 'tenant.auth0.com', port: 443, http_only: false, type: 'generic'};
       mockIsTrustedIssuerGenericOidc.mockReturnValue(true);
       mockGetServerUrl.mockReturnValue('https://tenant.example.com:9443');

--- a/frontend/apps/console/src/hocs/withConfig.tsx
+++ b/frontend/apps/console/src/hocs/withConfig.tsx
@@ -55,7 +55,7 @@ export default function withConfig<P extends object>(WrappedComponent: Component
     // Generic OIDC authorization servers typically respond to the `/oauth/token`
     // endpoint with `access-control-allow-credentials:
     // false`, so a credentialed fetch from the browser is blocked by CORS and the
-    // SDK never sees the issued token. The Asgardeo SDK defaults
+    // SDK never sees the issued token. The ThunderID SDK defaults
     // `sendCookiesInRequests` to `true`, which makes it issue the token request
     // with `credentials: 'include'`. Forcing it to `false` switches the request
     // to `credentials: 'same-origin'`, which is uncredentialed for cross-origin
@@ -70,9 +70,9 @@ export default function withConfig<P extends object>(WrappedComponent: Component
 
     return (
       <ThunderIDProvider
-        baseUrl={getTrustedIssuerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string)}
-        clientId={getTrustedIssuerClientId() ?? (import.meta.env.VITE_ASGARDEO_CLIENT_ID as string)}
-        afterSignInUrl={getClientUrl() ?? (import.meta.env.VITE_ASGARDEO_AFTER_SIGN_IN_URL as string)}
+        baseUrl={getTrustedIssuerUrl() ?? (import.meta.env.VITE_THUNDER_BASE_URL as string)}
+        clientId={getTrustedIssuerClientId() ?? (import.meta.env.VITE_THUNDER_CLIENT_ID as string)}
+        afterSignInUrl={getClientUrl() ?? (import.meta.env.VITE_THUNDER_AFTER_SIGN_IN_URL as string)}
         scopes={getTrustedIssuerScopes().length > 0 ? getTrustedIssuerScopes() : undefined}
         signInOptions={signInOptions}
         discovery={{

--- a/frontend/apps/console/src/layouts/__tests__/DashboardLayout.test.tsx
+++ b/frontend/apps/console/src/layouts/__tests__/DashboardLayout.test.tsx
@@ -45,7 +45,7 @@ vi.mock('../../features/applications/api/useGetApplications', () => ({
   default: (params: unknown) => mockUseGetApplications(params),
 }));
 
-// Mock Asgardeo
+// Mock ThunderID
 vi.mock('@thunderid/react', () => ({
   useThunderID: () => ({
     signIn: mockSignIn,

--- a/frontend/apps/gate/src/components/AcceptInvite/AcceptInviteBox.tsx
+++ b/frontend/apps/gate/src/components/AcceptInvite/AcceptInviteBox.tsx
@@ -37,7 +37,7 @@ export default function AcceptInviteBox(): JSX.Element {
   const {isDesignEnabled} = useDesign();
   const [flowError, setFlowError] = useState<string | null>(null);
 
-  const baseUrl = getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string);
+  const baseUrl = getServerUrl() ?? (import.meta.env.VITE_THUNDER_BASE_URL as string);
 
   const handleGoToSignIn = () => {
     const result = navigate(ROUTES.AUTH.SIGN_IN);

--- a/frontend/apps/gate/src/components/AcceptInvite/__tests__/AcceptInviteBox.test.tsx
+++ b/frontend/apps/gate/src/components/AcceptInvite/__tests__/AcceptInviteBox.test.tsx
@@ -79,9 +79,10 @@ vi.mock('@thunderid/hooks', () => ({
 }));
 
 // Mock useConfig
+const mockGetServerUrl = vi.fn().mockReturnValue('https://api.example.com');
 vi.mock('@thunderid/contexts', () => ({
   useConfig: () => ({
-    getServerUrl: () => 'https://api.example.com',
+    getServerUrl: mockGetServerUrl,
   }),
 }));
 
@@ -91,7 +92,7 @@ vi.mock('react-router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-// Mock Asgardeo AcceptInvite component
+// Mock ThunderID AcceptInvite component
 const mockHandleSubmit = vi.fn().mockResolvedValue(undefined);
 const mockHandleInputChange = vi.fn();
 
@@ -135,7 +136,9 @@ let mockAcceptInviteRenderProps: MockAcceptInviteRenderProps = createMockAcceptI
 let capturedOnGoToSignIn: (() => void) | undefined;
 let capturedOnComplete: (() => void) | undefined;
 let capturedOnError: ((error: Error) => void) | undefined;
-const mockUseAsgardeo = vi.fn().mockReturnValue({
+let capturedOnFlowChange: ((response: {failureReason?: string}) => void) | undefined;
+let capturedBaseUrl: string | undefined;
+const mockUseThunderID = vi.fn().mockReturnValue({
   resolveFlowTemplateLiterals: (template: string) => template,
 });
 
@@ -143,22 +146,28 @@ vi.mock('@thunderid/react', async () => {
   const actual = await vi.importActual('@thunderid/react');
   return {
     ...actual,
-    useThunderID: () => mockUseAsgardeo() as {resolveFlowTemplateLiterals: (t: string) => string; meta: unknown},
+    useThunderID: () => mockUseThunderID() as {resolveFlowTemplateLiterals: (t: string) => string; meta: unknown},
     AcceptInvite: ({
       children,
+      baseUrl = undefined,
       onGoToSignIn = undefined,
       onComplete = undefined,
       onError = undefined,
+      onFlowChange = undefined,
     }: {
       children: (props: typeof mockAcceptInviteRenderProps) => React.ReactNode;
+      baseUrl?: string;
       onGoToSignIn?: () => void;
       onComplete?: () => void;
       onError?: (error: Error) => void;
+      onFlowChange?: (response: {failureReason?: string}) => void;
     }) => {
+      capturedBaseUrl = baseUrl;
       capturedOnGoToSignIn = onGoToSignIn;
       capturedOnComplete = onComplete;
       capturedOnError = onError;
-      return <div data-testid="asgardeo-accept-invite">{children(mockAcceptInviteRenderProps)}</div>;
+      capturedOnFlowChange = onFlowChange;
+      return <div data-testid="thunderid-accept-invite">{children(mockAcceptInviteRenderProps)}</div>;
     },
     EmbeddedFlowComponentType: {
       Text: 'TEXT',
@@ -177,12 +186,13 @@ vi.mock('@thunderid/react', async () => {
 describe('AcceptInviteBox', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseAsgardeo.mockReturnValue({
+    mockUseThunderID.mockReturnValue({
       resolveFlowTemplateLiterals: (template: string) => template,
     });
     mockUseDesign.mockReturnValue({
       isDesignEnabled: false,
     });
+    mockGetServerUrl.mockReturnValue('https://api.example.com');
     mockAcceptInviteRenderProps = createMockAcceptInviteRenderProps();
   });
 
@@ -214,7 +224,7 @@ describe('AcceptInviteBox', () => {
       components: [],
     });
     render(<AcceptInviteBox />);
-    expect(screen.getByTestId('asgardeo-accept-invite')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-accept-invite')).toBeInTheDocument();
   });
 
   it('renders without error when sdk has not produced a branch yet', () => {
@@ -226,7 +236,7 @@ describe('AcceptInviteBox', () => {
       isTokenInvalid: false,
     });
     render(<AcceptInviteBox />);
-    expect(screen.getByTestId('asgardeo-accept-invite')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-accept-invite')).toBeInTheDocument();
   });
 
   it('does not pass onComplete to AcceptInvite', () => {
@@ -511,7 +521,7 @@ describe('AcceptInviteBox', () => {
       components: [{id: 'block', type: 'BLOCK', components: []}],
     });
     render(<AcceptInviteBox />);
-    expect(screen.getByTestId('asgardeo-accept-invite')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-accept-invite')).toBeInTheDocument();
   });
 
   it('shows validation error for SELECT component', () => {
@@ -1396,12 +1406,12 @@ describe('AcceptInviteBox', () => {
 
   it('renders branded logo with alt fallback', () => {
     render(<AcceptInviteBox />);
-    expect(screen.getByTestId('asgardeo-accept-invite')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-accept-invite')).toBeInTheDocument();
   });
 
   it('renders branded logo with custom alt, height, and width', () => {
     render(<AcceptInviteBox />);
-    expect(screen.getByTestId('asgardeo-accept-invite')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-accept-invite')).toBeInTheDocument();
   });
 
   it('renders block without components property', () => {
@@ -1414,6 +1424,57 @@ describe('AcceptInviteBox', () => {
       ],
     });
     render(<AcceptInviteBox />);
-    expect(screen.getByTestId('asgardeo-accept-invite')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-accept-invite')).toBeInTheDocument();
+  });
+
+  it('passes getServerUrl result as baseUrl when non-null', () => {
+    render(<AcceptInviteBox />);
+    expect(capturedBaseUrl).toBe('https://api.example.com');
+  });
+
+  it('falls back to VITE_THUNDER_BASE_URL as baseUrl when getServerUrl returns null', () => {
+    mockGetServerUrl.mockReturnValue(null);
+    render(<AcceptInviteBox />);
+    expect(capturedBaseUrl).toBe(import.meta.env.VITE_THUNDER_BASE_URL as string);
+  });
+
+  it('shows flowError when onFlowChange is called with a failureReason', async () => {
+    mockAcceptInviteRenderProps = createMockAcceptInviteRenderProps({
+      components: [{id: 'block', type: 'BLOCK', components: []}],
+    });
+    render(<AcceptInviteBox />);
+
+    expect(capturedOnFlowChange).toBeDefined();
+    capturedOnFlowChange?.({failureReason: 'Flow failed due to policy'});
+
+    expect(await screen.findByText('Flow failed due to policy')).toBeInTheDocument();
+  });
+
+  it('clears flowError when onFlowChange is called without failureReason', async () => {
+    mockAcceptInviteRenderProps = createMockAcceptInviteRenderProps({
+      components: [{id: 'block', type: 'BLOCK', components: []}],
+    });
+    render(<AcceptInviteBox />);
+
+    capturedOnFlowChange?.({failureReason: 'Initial error'});
+    expect(await screen.findByText('Initial error')).toBeInTheDocument();
+
+    capturedOnFlowChange?.({});
+    await waitFor(() => {
+      expect(screen.queryByText('Initial error')).not.toBeInTheDocument();
+    });
+  });
+
+  it('prefers flowError over error.message in the alert', async () => {
+    mockAcceptInviteRenderProps = createMockAcceptInviteRenderProps({
+      error: {message: 'SDK error'},
+      components: [{id: 'block', type: 'BLOCK', components: []}],
+    });
+    render(<AcceptInviteBox />);
+
+    capturedOnFlowChange?.({failureReason: 'Flow error'});
+
+    expect(await screen.findByText('Flow error')).toBeInTheDocument();
+    expect(screen.queryByText('SDK error')).not.toBeInTheDocument();
   });
 });

--- a/frontend/apps/gate/src/components/Recovery/__tests__/Recovery.test.tsx
+++ b/frontend/apps/gate/src/components/Recovery/__tests__/Recovery.test.tsx
@@ -26,13 +26,13 @@ vi.mock('../RecoveryBox', () => ({
 }));
 
 // Mock useThunderID hook
-const mockUseAsgardeo = vi.fn();
+const mockUseThunderID = vi.fn();
 vi.mock('@thunderid/react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@thunderid/react')>();
   return {
     ...actual,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    useThunderID: () => mockUseAsgardeo(),
+    useThunderID: () => mockUseThunderID(),
   };
 });
 
@@ -48,7 +48,7 @@ vi.mock('@thunderid/design', async (importOriginal) => {
 describe('Recovery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseAsgardeo.mockReturnValue({
+    mockUseThunderID.mockReturnValue({
       isMetaLoading: false,
     });
   });
@@ -69,7 +69,7 @@ describe('Recovery', () => {
   });
 
   it('renders when isMetaLoading is true', () => {
-    mockUseAsgardeo.mockReturnValue({
+    mockUseThunderID.mockReturnValue({
       isMetaLoading: true,
     });
     render(<Recovery />);

--- a/frontend/apps/gate/src/components/Recovery/__tests__/RecoveryBox.test.tsx
+++ b/frontend/apps/gate/src/components/Recovery/__tests__/RecoveryBox.test.tsx
@@ -117,7 +117,7 @@ vi.mock('@thunderid/react', async () => {
       capturedOnFlowChange = onFlowChange;
       capturedOnError = onError;
       capturedAfterRecoveryUrl = afterRecoveryUrl;
-      return <div data-testid="asgardeo-recovery">{children(mockRecoveryRenderProps)}</div>;
+      return <div data-testid="thunderid-recovery">{children(mockRecoveryRenderProps)}</div>;
     },
     EmbeddedFlowEventType: {
       Submit: 'SUBMIT',
@@ -148,9 +148,9 @@ describe('RecoveryBox', () => {
     expect(container).toBeInTheDocument();
   });
 
-  it('renders the asgardeo Recovery component', () => {
+  it('renders the ThunderID Recovery component', () => {
     render(<RecoveryBox />);
-    expect(screen.getByTestId('asgardeo-recovery')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-recovery')).toBeInTheDocument();
   });
 
   it('renders AuthCardLayout', () => {
@@ -279,7 +279,7 @@ describe('RecoveryBox', () => {
       isLoading: false,
     });
     render(<RecoveryBox />);
-    expect(screen.getByTestId('asgardeo-recovery')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-recovery')).toBeInTheDocument();
   });
 
   it('uses fallback index keys when components have undefined id', () => {

--- a/frontend/apps/gate/src/components/SignIn/__tests__/SignInBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignIn/__tests__/SignInBox.test.tsx
@@ -71,7 +71,7 @@ vi.mock('react-router', () => ({
   useSearchParams: () => [mockSearchParams, vi.fn()],
 }));
 
-// Mock Asgardeo SignIn and SignUp components
+// Mock ThunderID SignIn and SignUp components
 const mockOnSubmit = vi.fn().mockResolvedValue(undefined);
 
 // Mock component type for testing embedded flow components
@@ -128,10 +128,10 @@ vi.mock('@thunderid/react', async () => {
   return {
     ...actual,
     SignIn: ({children}: {children: (props: typeof mockSignInRenderProps) => React.ReactNode}) => (
-      <div data-testid="asgardeo-signin">{children(mockSignInRenderProps)}</div>
+      <div data-testid="thunderid-signin">{children(mockSignInRenderProps)}</div>
     ),
     SignUp: ({children}: {children: (props: typeof mockSignUpRenderProps) => React.ReactNode}) => (
-      <div data-testid="asgardeo-signup">{children(mockSignUpRenderProps)}</div>
+      <div data-testid="thunderid-signup">{children(mockSignUpRenderProps)}</div>
     ),
     EmbeddedFlowComponentType: {
       Text: 'TEXT',
@@ -170,7 +170,7 @@ describe('SignInBox', () => {
     });
     render(<SignInBox />);
     // CircularProgress should be shown
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
   it('shows loading spinner when not initialized', () => {
@@ -178,7 +178,7 @@ describe('SignInBox', () => {
       isInitialized: false,
     });
     render(<SignInBox />);
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
   it('shows error alert when error is present', () => {
@@ -544,7 +544,7 @@ describe('SignInBox', () => {
       isDesignEnabled: true,
     });
     render(<SignInBox />);
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
   it('shows loading when no components are available', () => {
@@ -555,7 +555,7 @@ describe('SignInBox', () => {
     });
     render(<SignInBox />);
     // Shows loading when no components
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
   it('handles OTP input changes and auto-focus', async () => {
@@ -1233,7 +1233,7 @@ describe('SignInBox', () => {
     });
     render(<SignInBox />);
     // Should show default error description
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
   it('handles form submission with password field', async () => {
@@ -1719,17 +1719,17 @@ describe('SignInBox', () => {
 
   it('renders branded logo with alt fallback when alt is not provided', () => {
     render(<SignInBox />);
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
   it('renders branded logo with custom alt, height, and width', () => {
     render(<SignInBox />);
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
   it('renders without brandingTheme palette (uses theme fallback)', () => {
     render(<SignInBox />);
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
   it('renders text field with resolve fallback for placeholder', () => {
@@ -1965,7 +1965,7 @@ describe('SignInBox', () => {
     });
     render(<SignInBox />);
     // Should still render without crashing
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
   it('renders block with empty components array', () => {
@@ -1979,7 +1979,7 @@ describe('SignInBox', () => {
       ],
     });
     render(<SignInBox />);
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
   it('renders block without components property', () => {
@@ -1993,6 +1993,6 @@ describe('SignInBox', () => {
       ],
     });
     render(<SignInBox />);
-    expect(screen.getByTestId('asgardeo-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
@@ -68,7 +68,7 @@ vi.mock('react-router', () => ({
   useSearchParams: () => [new URLSearchParams(), vi.fn()],
 }));
 
-// Mock Asgardeo SignUp component
+// Mock ThunderID SignUp component
 const mockHandleSubmit = vi.fn().mockResolvedValue(undefined);
 const mockHandleInputChange = vi.fn();
 
@@ -111,7 +111,7 @@ vi.mock('@thunderid/react', async () => {
       onFlowChange?: (response: unknown) => void;
     }) => {
       capturedOnFlowChange = onFlowChange;
-      return <div data-testid="asgardeo-signup">{children(mockSignUpRenderProps)}</div>;
+      return <div data-testid="thunderid-signup">{children(mockSignUpRenderProps)}</div>;
     },
     EmbeddedFlowComponentType: {
       Text: 'TEXT',
@@ -147,7 +147,7 @@ describe('SignUpBox', () => {
       components: null as unknown as unknown[],
     });
     render(<SignUpBox />);
-    expect(screen.getByTestId('asgardeo-signup')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signup')).toBeInTheDocument();
   });
 
   it('shows error alert when error is present', () => {
@@ -631,7 +631,7 @@ describe('SignUpBox', () => {
       components: [{id: 'block', type: 'BLOCK', components: []}],
     });
     render(<SignUpBox />);
-    expect(screen.getByTestId('asgardeo-signup')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signup')).toBeInTheDocument();
   });
 
   it('handles TRIGGER action within form block', async () => {
@@ -1773,12 +1773,12 @@ describe('SignUpBox', () => {
 
   it('renders branded logo with alt fallback', () => {
     render(<SignUpBox />);
-    expect(screen.getByTestId('asgardeo-signup')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signup')).toBeInTheDocument();
   });
 
   it('renders branded logo with custom alt, height, and width', () => {
     render(<SignUpBox />);
-    expect(screen.getByTestId('asgardeo-signup')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signup')).toBeInTheDocument();
   });
 
   it('renders block without components property', () => {
@@ -1791,7 +1791,7 @@ describe('SignUpBox', () => {
       ],
     });
     render(<SignUpBox />);
-    expect(screen.getByTestId('asgardeo-signup')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signup')).toBeInTheDocument();
   });
 
   it('renders social login trigger with missing label and image', () => {
@@ -1811,6 +1811,6 @@ describe('SignUpBox', () => {
       ],
     });
     render(<SignUpBox />);
-    expect(screen.getByTestId('asgardeo-signup')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderid-signup')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/gate/src/hocs/__tests__/withConfig.test.tsx
+++ b/frontend/apps/gate/src/hocs/__tests__/withConfig.test.tsx
@@ -32,7 +32,7 @@ const AppWithConfig = withConfig(MockChild);
 vi.mock('@thunderid/react', () => ({
   ThunderIDProvider: ({children, baseUrl}: {children: React.ReactNode; baseUrl: string}) => {
     capturedBaseUrl = baseUrl;
-    return <div data-testid="asgardeo-provider">{children}</div>;
+    return <div data-testid="thunderid-provider">{children}</div>;
   },
 }));
 
@@ -49,7 +49,7 @@ describe('AppWithConfig', () => {
     vi.clearAllMocks();
     capturedBaseUrl = undefined;
     // Set up default environment variable for fallback tests
-    import.meta.env.VITE_ASGARDEO_BASE_URL = 'https://env-fallback-url.example.com';
+    import.meta.env.VITE_THUNDER_BASE_URL = 'https://env-fallback-url.example.com';
   });
 
   it('renders without crashing', () => {
@@ -70,13 +70,13 @@ describe('AppWithConfig', () => {
     expect(capturedBaseUrl).toBe('https://custom-server.com');
   });
 
-  it('falls back to VITE_ASGARDEO_BASE_URL when getServerUrl returns undefined', () => {
+  it('falls back to VITE_THUNDER_BASE_URL when getServerUrl returns undefined', () => {
     mockGetServerUrl.mockReturnValue(undefined);
     render(<AppWithConfig />);
     expect(capturedBaseUrl).toBe('https://env-fallback-url.example.com');
   });
 
-  it('falls back to VITE_ASGARDEO_BASE_URL when getServerUrl returns null', () => {
+  it('falls back to VITE_THUNDER_BASE_URL when getServerUrl returns null', () => {
     mockGetServerUrl.mockReturnValue(null);
     render(<AppWithConfig />);
     expect(capturedBaseUrl).toBe('https://env-fallback-url.example.com');

--- a/frontend/apps/gate/src/hocs/__tests__/withDesign.test.tsx
+++ b/frontend/apps/gate/src/hocs/__tests__/withDesign.test.tsx
@@ -41,9 +41,9 @@ vi.mock('@thunderid/design', () => ({
   },
 }));
 
-const mockUseAsgardeo = vi.fn();
+const mockUseThunderID = vi.fn();
 vi.mock('@thunderid/react', () => ({
-  useThunderID: (): {meta?: {design?: unknown}} => mockUseAsgardeo() as {meta?: {design?: unknown}},
+  useThunderID: (): {meta?: {design?: unknown}} => mockUseThunderID() as {meta?: {design?: unknown}},
 }));
 
 function MockChild() {
@@ -56,7 +56,7 @@ describe('withDesign', () => {
     vi.clearAllMocks();
     capturedDesignProp = undefined;
     capturedShouldResolveDesignInternally = undefined;
-    mockUseAsgardeo.mockReturnValue({meta: undefined});
+    mockUseThunderID.mockReturnValue({meta: undefined});
   });
 
   it('renders without crashing', () => {
@@ -76,21 +76,21 @@ describe('withDesign', () => {
 
   it('passes meta.design from useThunderID to DesignProvider', () => {
     const mockDesign = {theme: {colors: {primary: '#ff5700'}}, layout: {}};
-    mockUseAsgardeo.mockReturnValue({meta: {design: mockDesign}});
+    mockUseThunderID.mockReturnValue({meta: {design: mockDesign}});
 
     render(<WithDesignComponent />);
     expect(capturedDesignProp).toEqual(mockDesign);
   });
 
   it('passes undefined to DesignProvider when meta is undefined', () => {
-    mockUseAsgardeo.mockReturnValue({meta: undefined});
+    mockUseThunderID.mockReturnValue({meta: undefined});
 
     render(<WithDesignComponent />);
     expect(capturedDesignProp).toBeUndefined();
   });
 
   it('passes undefined to DesignProvider when meta.design is undefined', () => {
-    mockUseAsgardeo.mockReturnValue({meta: {design: undefined}});
+    mockUseThunderID.mockReturnValue({meta: {design: undefined}});
 
     render(<WithDesignComponent />);
     expect(capturedDesignProp).toBeUndefined();

--- a/frontend/apps/gate/src/hocs/withConfig.tsx
+++ b/frontend/apps/gate/src/hocs/withConfig.tsx
@@ -27,7 +27,7 @@ export default function withConfig<P extends object>(WrappedComponent: Component
 
     return (
       <ThunderIDProvider
-        baseUrl={getServerUrl() ?? (import.meta.env.VITE_ASGARDEO_BASE_URL as string)}
+        baseUrl={getServerUrl() ?? (import.meta.env.VITE_THUNDER_BASE_URL as string)}
         applicationId={applicationId!}
       >
         <WrappedComponent {...props} />

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/thunder-id/thunderid"
   },
   "keywords": [
-    "asgardeo",
     "thunderid",
     "frontend",
     "workspace",

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitTreePicker.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitTreePicker.test.tsx
@@ -59,7 +59,7 @@ vi.mock('@/api/useGetChildOrganizationUnits', () => ({
     },
 }));
 
-// Mock Asgardeo — stable reference to avoid useCallback churn
+// Mock ThunderID — stable reference to avoid useCallback churn
 const mockHttpRequest = vi.fn();
 const stableHttp = {request: mockHttpRequest};
 vi.mock('@thunderid/react', () => ({

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitsTreeView.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitsTreeView.test.tsx
@@ -49,7 +49,7 @@ vi.mock('@/api/useGetOrganizationUnits', () => ({
     },
 }));
 
-// Mock Asgardeo — stable reference to avoid useCallback churn
+// Mock ThunderID — stable reference to avoid useCallback churn
 const mockHttpRequest = vi.fn();
 const stableHttp = {request: mockHttpRequest};
 vi.mock('@thunderid/react', () => ({

--- a/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitsListPage.test.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitsListPage.test.tsx
@@ -64,7 +64,7 @@ vi.mock('@/api/useDeleteOrganizationUnit', () => ({
   }),
 }));
 
-// Mock Asgardeo — stable reference to avoid useCallback churn when tree view renders
+// Mock ThunderID — stable reference to avoid useCallback churn when tree view renders
 const stableHttp = {request: vi.fn()};
 vi.mock('@thunderid/react', () => ({
   useThunderID: () => ({http: stableHttp}),

--- a/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
@@ -112,12 +112,12 @@ vi.mock('../../../organization-units/api/useGetChildOrganizationUnits', () => ({
 }));
 
 // Mock useThunderID
-const mockUseAsgardeo = vi.fn();
+const mockUseThunderID = vi.fn();
 vi.mock('@thunderid/react', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...(actual as object),
-    useThunderID: () => mockUseAsgardeo() as {user: {ouId?: string} | null | undefined},
+    useThunderID: () => mockUseThunderID() as {user: {ouId?: string} | null | undefined},
   };
 });
 
@@ -331,7 +331,7 @@ describe('UserCreatePage', () => {
       error: null,
     });
     // Default: user object has no ouId
-    mockUseAsgardeo.mockReturnValue({
+    mockUseThunderID.mockReturnValue({
       user: {ouId: undefined},
     });
   });

--- a/frontend/packages/contexts/src/Config/types.ts
+++ b/frontend/packages/contexts/src/Config/types.ts
@@ -65,7 +65,7 @@ export interface ClientConfig {
 
   /**
    * Unique identifier for the client application, used for authentication
-   * and authorization with identity providers like Asgardeo.
+   * and authorization with identity providers like ThunderID.
    * @example "CONSOLE", "my-app-client-id"
    */
   client_id: string;

--- a/frontend/packages/design/src/components/GoogleFontLoader.tsx
+++ b/frontend/packages/design/src/components/GoogleFontLoader.tsx
@@ -20,8 +20,8 @@ import {useConfig} from '@thunderid/contexts';
 import {useEffect} from 'react';
 import {SYSTEM_FONTS} from '../constants/fonts';
 
-/** CSS variable set by the Asgardeo SDK when design data includes a custom font. */
-const ASGARDEO_FONT_CSS_VAR = '--asgardeo-typography-fontFamily';
+/** CSS variable set by the ThunderID SDK when design data includes a custom font. */
+const THUNDERID_FONT_CSS_VAR = '--thunderid-typography-fontFamily';
 
 /** MUI class selectors that set their own font-family via CSS-in-JS. */
 const MUI_FONT_SELECTORS = [
@@ -38,7 +38,7 @@ const MUI_FONT_SELECTORS = [
 
 export interface GoogleFontLoaderProps {
   /** Optional explicit font family. When omitted the component references the
-   *  Asgardeo CSS variable so the browser resolves it automatically. */
+   *  ThunderID CSS variable so the browser resolves it automatically. */
   fontFamily?: string;
   /** Optional document to inject elements into (defaults to `window.document`). */
   targetDocument?: Document;
@@ -49,10 +49,10 @@ export interface GoogleFontLoaderProps {
  * theme specifies a custom font family.
  *
  * It performs two tasks:
- * 1. Injects a CSS override referencing `var(--asgardeo-typography-fontFamily)`
+ * 1. Injects a CSS override referencing `var(--thunderid-typography-fontFamily)`
  *    so MUI components use the design font instead of the theme default.
  *    By using the CSS variable directly (rather than reading its value in JS),
- *    there are no timing issues with the Asgardeo SDK setting it.
+ *    there are no timing issues with the ThunderID SDK setting it.
  * 2. Watches for the CSS variable to be set, then loads the Google Font if needed.
  */
 export default function GoogleFontLoader({
@@ -75,9 +75,9 @@ export default function GoogleFontLoader({
       // Explicit font: use the value directly.
       style.textContent = `${MUI_FONT_SELECTORS} { font-family: ${fontFamilyProp}, sans-serif !important; }`;
     } else {
-      // No explicit font: reference the Asgardeo CSS variable so the browser
+      // No explicit font: reference the ThunderID CSS variable so the browser
       // resolves it whenever the SDK sets it — no race condition.
-      style.textContent = `${MUI_FONT_SELECTORS} { font-family: var(${ASGARDEO_FONT_CSS_VAR}), sans-serif !important; }`;
+      style.textContent = `${MUI_FONT_SELECTORS} { font-family: var(${THUNDERID_FONT_CSS_VAR}), sans-serif !important; }`;
     }
 
     doc.getElementById(fontOverrideId)?.remove();
@@ -95,13 +95,13 @@ export default function GoogleFontLoader({
       return loadGoogleFont(fontLinkId, fontFamilyProp, targetDocument);
     }
 
-    // Poll briefly for the Asgardeo CSS variable to be set, then load the font.
+    // Poll briefly for the ThunderID CSS variable to be set, then load the font.
     const doc = targetDocument ?? document;
     let cancelled = false;
     let cleanup: (() => void) | undefined;
 
     const tryLoad = (): boolean => {
-      const value = getComputedStyle(doc.documentElement).getPropertyValue(ASGARDEO_FONT_CSS_VAR).trim();
+      const value = getComputedStyle(doc.documentElement).getPropertyValue(THUNDERID_FONT_CSS_VAR).trim();
       if (value) {
         cleanup = loadGoogleFont(fontLinkId, value, targetDocument);
         return true;

--- a/frontend/packages/design/src/contexts/Design/DesignProvider.tsx
+++ b/frontend/packages/design/src/contexts/Design/DesignProvider.tsx
@@ -32,7 +32,7 @@ import type {DesignResolveResponse} from '../../models/responses';
 export type DesignProviderProps = PropsWithChildren<{
   /**
    * Optional pre-resolved design to use directly, skipping the internal
-   * resolve API call. Useful when the host SDK (e.g. Asgardeo) already
+   * resolve API call. Useful when the host SDK (e.g. ThunderID) already
    * provides design data via its metadata (e.g. `meta.design`).
    */
   design?: DesignResolveResponse;
@@ -44,7 +44,7 @@ export type DesignProviderProps = PropsWithChildren<{
   shouldResolveDesignInternally?: boolean;
 
   /**
-   * Signals that an external source (e.g. Asgardeo meta) is still loading.
+   * Signals that an external source (e.g. ThunderID meta) is still loading.
    * When true, isLoading is reported as true so consumers can defer rendering
    * until the design data has actually arrived.
    */

--- a/package.json
+++ b/package.json
@@ -6,16 +6,15 @@
   "author": "WSO2",
   "license": "Apache-2.0",
   "type": "module",
-  "homepage": "https://github.com/asgardeo/thunder/tree/main",
+  "homepage": "https://github.com/thunder-id/thunderid/tree/main",
   "bugs": {
-    "url": "https://github.com/asgardeo/thunder/issues"
+    "url": "https://github.com/thunder-id/thunderid/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/asgardeo/thunder"
+    "url": "https://github.com/thunder-id/thunderid"
   },
   "keywords": [
-    "asgardeo",
     "thunderid",
     "workspace",
     "wso2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1861,10 +1861,10 @@ importers:
     dependencies:
       '@thunderid/react':
         specifier: 0.0.5
-        version: 0.0.5(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.0.5(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 0.0.1-alpha.10
-        version: 0.0.1-alpha.10(171fa4cc23748d7be851a5fb7f819281)
+        version: 0.0.1-alpha.10(6fb253412db1176a6ec158a6cfaa2e46)
       jwt-decode:
         specifier: 4.0.0
         version: 4.0.0
@@ -1882,11 +1882,11 @@ importers:
         specifier: 20.19.24
         version: 20.19.24
       '@types/react':
-        specifier: 19.2.7
-        version: 19.2.7
+        specifier: 19.2.14
+        version: 19.2.14
       '@types/react-dom':
         specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.7)
+        version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-basic-ssl':
         specifier: 2.1.0
         version: 2.1.0(rolldown-vite@7.1.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@20.19.24)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.47.1)(yaml@2.8.3))
@@ -16241,17 +16241,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@base-ui-components/utils@0.1.2(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@floating-ui/utils': 0.2.11
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      reselect: 5.1.1
-      use-sync-external-store: 1.6.0(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.7
-
   '@blazediff/core@1.9.1': {}
 
   '@bomb.sh/tab@0.0.15(cac@6.7.14)(citty@0.2.2)':
@@ -17437,7 +17426,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@19.2.3)':
     dependencies:
-      '@types/react': 19.2.7
+      '@types/react': 19.2.14
       react: 19.2.3
 
   '@docusaurus/theme-classic@3.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)':
@@ -17787,22 +17776,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.3)
-      '@emotion/utils': 1.4.2
-      '@emotion/weak-memoize': 0.4.0
-      hoist-non-react-statics: 3.3.2
-      react: 19.2.3
-    optionalDependencies:
-      '@types/react': 19.2.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@emotion/serialize@1.3.3':
     dependencies:
       '@emotion/hash': 0.9.2
@@ -17840,21 +17813,6 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.14
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.3)
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.3)
-      '@emotion/utils': 1.4.2
-      react: 19.2.3
-    optionalDependencies:
-      '@types/react': 19.2.7
     transitivePeerDependencies:
       - supports-color
 
@@ -18951,27 +18909,6 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3)
       '@types/react': 19.2.14
 
-  '@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/core-downloads-tracker': 7.3.11
-      '@mui/system': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
-      '@mui/types': 7.4.12(@types/react@19.2.7)
-      '@mui/utils': 7.3.11(@types/react@19.2.7)(react@19.2.3)
-      '@popperjs/core': 2.11.8
-      '@types/react-transition-group': 4.4.12(@types/react@19.2.7)
-      clsx: 2.1.1
-      csstype: 3.2.3
-      prop-types: 15.8.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-is: 19.2.6
-      react-transition-group: 4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
-      '@types/react': 19.2.7
-
   '@mui/private-theming@7.3.11(@types/react@19.2.14)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -19015,19 +18952,6 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.3)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3)
-
-  '@mui/styled-engine@7.3.10(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      '@emotion/sheet': 1.4.0
-      csstype: 3.2.3
-      prop-types: 15.8.1
-      react: 19.2.3
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
 
   '@mui/system@7.1.0(@emotion/react@11.11.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.11.0(@emotion/react@11.11.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
@@ -19076,22 +19000,6 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.3)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3)
       '@types/react': 19.2.14
-
-  '@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/private-theming': 7.3.11(@types/react@19.2.7)(react@19.2.3)
-      '@mui/styled-engine': 7.3.10(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
-      '@mui/types': 7.4.12(@types/react@19.2.7)
-      '@mui/utils': 7.3.11(@types/react@19.2.7)(react@19.2.3)
-      clsx: 2.1.1
-      csstype: 3.2.3
-      prop-types: 15.8.1
-      react: 19.2.3
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
-      '@types/react': 19.2.7
 
   '@mui/types@7.4.12(@types/react@19.2.14)':
     dependencies:
@@ -19191,28 +19099,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-charts@8.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@mui/system': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
-      '@mui/utils': 7.3.11(@types/react@19.2.7)(react@19.2.3)
-      '@mui/x-charts-vendor': 8.14.0
-      '@mui/x-internal-gestures': 0.3.3
-      '@mui/x-internals': 8.14.0(@types/react@19.2.7)(react@19.2.3)
-      bezier-easing: 2.1.0
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      reselect: 5.1.1
-      use-sync-external-store: 1.6.0(react@19.2.3)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@mui/x-data-grid@8.16.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -19229,25 +19115,6 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.3)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@mui/x-data-grid@8.16.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@mui/system': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
-      '@mui/utils': 7.3.11(@types/react@19.2.7)(react@19.2.3)
-      '@mui/x-internals': 8.16.0(@types/react@19.2.7)(react@19.2.3)
-      '@mui/x-virtualizer': 0.2.6(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      use-sync-external-store: 1.6.0(react@19.2.3)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -19272,27 +19139,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-date-pickers@8.16.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(date-fns@4.1.0)(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@mui/system': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
-      '@mui/utils': 7.3.11(@types/react@19.2.7)(react@19.2.3)
-      '@mui/x-internals': 8.16.0(@types/react@19.2.7)(react@19.2.3)
-      '@types/react-transition-group': 4.4.12(@types/react@19.2.7)
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-transition-group: 4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
-      date-fns: 4.1.0
-      dayjs: 1.11.18
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@mui/x-internal-gestures@0.3.3':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -19307,30 +19153,10 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-internals@8.14.0(@types/react@19.2.7)(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/utils': 7.3.11(@types/react@19.2.7)(react@19.2.3)
-      react: 19.2.3
-      reselect: 5.1.1
-      use-sync-external-store: 1.6.0(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@mui/x-internals@8.16.0(@types/react@19.2.14)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@mui/utils': 7.3.11(@types/react@19.2.14)(react@19.2.3)
-      react: 19.2.3
-      reselect: 5.1.1
-      use-sync-external-store: 1.6.0(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@mui/x-internals@8.16.0(@types/react@19.2.7)(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/utils': 7.3.11(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       reselect: 5.1.1
       use-sync-external-store: 1.6.0(react@19.2.3)
@@ -19357,41 +19183,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-tree-view@8.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@base-ui-components/utils': 0.1.2(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@mui/system': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
-      '@mui/utils': 7.3.11(@types/react@19.2.7)(react@19.2.3)
-      '@mui/x-internals': 8.14.0(@types/react@19.2.7)(react@19.2.3)
-      '@types/react-transition-group': 4.4.12(@types/react@19.2.7)
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-transition-group: 4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@mui/x-virtualizer@0.2.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@mui/utils': 7.3.11(@types/react@19.2.14)(react@19.2.3)
       '@mui/x-internals': 8.16.0(@types/react@19.2.14)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@mui/x-virtualizer@0.2.6(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/utils': 7.3.11(@types/react@19.2.7)(react@19.2.3)
-      '@mui/x-internals': 8.16.0(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
@@ -21167,10 +20963,10 @@ snapshots:
       jose: 5.2.0
       tslib: 2.8.1
 
-  '@thunderid/react@0.0.5(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@thunderid/react@0.0.5(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@thunderid/browser': 0.0.5
-      '@types/react': 19.2.7
+      '@types/react': 19.2.14
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       tslib: 2.8.1
@@ -22420,16 +22216,16 @@ snapshots:
       lucide-react: 0.545.0(react@19.2.3)
       react: 19.2.3
 
-  '@wso2/oxygen-ui@0.0.1-alpha.10(171fa4cc23748d7be851a5fb7f819281)':
+  '@wso2/oxygen-ui@0.0.1-alpha.10(6fb253412db1176a6ec158a6cfaa2e46)':
     dependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.3)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.3)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3)
       '@fontsource-variable/inter': 5.2.8
-      '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@mui/x-charts': 8.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@mui/x-data-grid': 8.16.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@mui/x-date-pickers': 8.16.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(date-fns@4.1.0)(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@mui/x-tree-view': 8.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@mui/material': 7.3.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@mui/x-charts': 8.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@mui/x-data-grid': 8.16.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@mui/x-date-pickers': 8.16.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(date-fns@4.1.0)(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@mui/x-tree-view': 8.14.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@mui/material@7.3.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui-icons-react': 0.0.1-alpha.10(lucide-react@0.545.0(react@19.2.3))(react@19.2.3)
       date-fns: 4.1.0
       react: 19.2.3

--- a/samples/apps/agent-id-sample/ai-agent/agent.ts
+++ b/samples/apps/agent-id-sample/ai-agent/agent.ts
@@ -34,7 +34,7 @@ dotenv.config({
 });
 
 // Local-dev TLS bypass: Thunder ships with a self-signed cert on localhost,
-// so fetch() and the Asgardeo JS SDK would otherwise refuse to talk to it.
+// so fetch() and the ThunderID JS SDK would otherwise refuse to talk to it.
 // We disable Node's TLS verification ONLY when the configured base URL points
 // at localhost / 127.0.0.1 to keep production builds safe.
 const __thunderBaseUrl = process.env.THUNDER_BASE_URL || "";
@@ -623,14 +623,10 @@ async function getAgentTokenViaClientCredentials(): Promise<string> {
 async function createAgent() {
     console.log("##########################################################################################################");
     console.log("##      This is an Agent Authentication Flow sample application for authenticating AI agents            ##");
-    console.log("##                         using Asgardeo and LangChain framework                                       ##");
+    console.log("##                         using ThunderID and LangChain framework                                      ##");
     console.log("##########################################################################################################");
 
     // Call Thunder's /oauth2/token directly with the client_credentials grant.
-    // We don't use AsgardeoJavaScriptClient.getAgentToken here because the V1
-    // (legacy) Asgardeo flow expects an /oauth2/flow/embedded endpoint that
-    // Thunder doesn't expose; calling /oauth2/token directly is the same wire
-    // protocol and works for both platforms.
     const agentAccessToken = await getAgentTokenViaClientCredentials();
 
     const client = new MultiServerMCPClient({
@@ -719,7 +715,7 @@ async function runAgentServer() {
 
         sendJson(socket, {
             type: "ready",
-            message: "Connected to the Asgardeo AI agent.",
+            message: "Connected to the ThunderID AI agent.",
         });
 
         let queue = Promise.resolve();

--- a/samples/apps/agent-id-sample/ai-agent/package-lock.json
+++ b/samples/apps/agent-id-sample/ai-agent/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@asgardeo/javascript": "^0.9.0",
         "@langchain/anthropic": "^1.3.0",
         "@langchain/google-genai": "^2.1.0",
         "@langchain/langgraph": "^1.3.0",
         "@langchain/mcp-adapters": "^1.1.0",
+        "@thunderid/javascript": "0.0.5",
         "dotenv": "^16.5.0",
         "tsx": "^4.19.4"
       },
@@ -39,26 +39,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@asgardeo/i18n": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@asgardeo/i18n/-/i18n-0.4.4.tgz",
-      "integrity": "sha512-ZbaMDgN3TBg1B8+76xWXnsTwnqrsSSuy4vf6Cqrf/i7ecAqykHmaEtzY5A+piI3F4V4kPWMdU+hs1N3JYOC8FQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "2.8.1"
-      }
-    },
-    "node_modules/@asgardeo/javascript": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@asgardeo/javascript/-/javascript-0.9.2.tgz",
-      "integrity": "sha512-jwyWKwRkQJprVWVoPqKr+WdFGD6tMJFLzr4P6X7PaSJAcTk2PbwJobjW5A1h2MHf3dpETfntpmnx7SRkNFUrig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@asgardeo/i18n": "0.4.4",
-        "jose": "^5.2.0",
-        "tslib": "2.8.1"
       }
     },
     "node_modules/@babel/runtime": {
@@ -776,6 +756,25 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@thunderid/javascript": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@thunderid/javascript/-/javascript-0.0.5.tgz",
+      "integrity": "sha512-lMjbHCsNgYWclUiPlN3CA6vjKSyjIBIxVGSnuJwiC9eVakVsWmRuxkO8KX6AWlA4SRHgpGLMnD4ZE5lpM+gi9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "5.2.0",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@thunderid/javascript/node_modules/jose": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
+      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1490,15 +1489,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
     },
     "node_modules/js-tiktoken": {
       "version": "1.0.21",

--- a/samples/apps/agent-id-sample/ai-agent/package.json
+++ b/samples/apps/agent-id-sample/ai-agent/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@asgardeo/javascript": "^0.9.0",
+    "@thunderid/javascript": "0.0.5",
     "@langchain/anthropic": "^1.3.0",
     "@langchain/google-genai": "^2.1.0",
     "@langchain/langgraph": "^1.3.0",

--- a/samples/apps/agent-id-sample/api/openapi.yaml
+++ b/samples/apps/agent-id-sample/api/openapi.yaml
@@ -162,9 +162,9 @@ paths:
       tags:
         - Bookings
       summary: Create a booking
-      description: Requires an Asgardeo bearer token when `API_REQUIRE_AUTH=true`.
+      description: Requires a ThunderID bearer token when `API_REQUIRE_AUTH=true`.
       security:
-        - AsgardeoBearerAuth: []
+        - ThunderIDBearerAuth: []
         - {}
       requestBody:
         required: true
@@ -209,9 +209,9 @@ paths:
       tags:
         - Bookings
       summary: List booked flights for the current user
-      description: Requires an Asgardeo bearer token when `API_REQUIRE_AUTH=true`.
+      description: Requires a ThunderID bearer token when `API_REQUIRE_AUTH=true`.
       security:
-        - AsgardeoBearerAuth: []
+        - ThunderIDBearerAuth: []
         - {}
       responses:
         "200":
@@ -243,9 +243,9 @@ paths:
       tags:
         - Bookings
       summary: Delete all booked flights for the current user
-      description: Requires an Asgardeo bearer token when `API_REQUIRE_AUTH=true`.
+      description: Requires a ThunderID bearer token when `API_REQUIRE_AUTH=true`.
       security:
-        - AsgardeoBearerAuth: []
+        - ThunderIDBearerAuth: []
         - {}
       responses:
         "200":
@@ -281,9 +281,9 @@ paths:
       tags:
         - User
       summary: Get current user profile
-      description: Requires an Asgardeo bearer token when `API_REQUIRE_AUTH=true`.
+      description: Requires a ThunderID bearer token when `API_REQUIRE_AUTH=true`.
       security:
-        - AsgardeoBearerAuth: []
+        - ThunderIDBearerAuth: []
         - {}
       responses:
         "200":
@@ -305,11 +305,11 @@ paths:
                 $ref: "#/components/schemas/Error"
 components:
   securitySchemes:
-    AsgardeoBearerAuth:
+    ThunderIDBearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: Asgardeo access token.
+      description: ThunderID access token.
   schemas:
     Flight:
       type: object

--- a/samples/apps/agent-id-sample/api/src/auth.js
+++ b/samples/apps/agent-id-sample/api/src/auth.js
@@ -48,7 +48,7 @@ async function getJwks() {
   const response = await fetch(`${process.env.THUNDER_BASE_URL}/oauth2/jwks`);
 
   if (!response.ok) {
-    throw new Error("Unable to load Asgardeo JWKS");
+    throw new Error("Unable to load ThunderID JWKS");
   }
 
   jwksCache = await response.json();

--- a/samples/apps/agent-id-sample/frontend/package.json
+++ b/samples/apps/agent-id-sample/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "asgardeo-b2c-sample-app",
+  "name": "thunderid-agent-id-sample",
   "private": true,
   "version": "0.1.0",
   "type": "module",
@@ -9,7 +9,7 @@
     "preview": "vite preview --host 0.0.0.0"
   },
   "dependencies": {
-    "@asgardeo/react": "^0.23.6",
+    "@thunderid/react": "0.0.5",
     "@vitejs/plugin-react": "^4.4.1",
     "lucide-react": "^0.511.0",
     "react": "^19.1.0",

--- a/samples/apps/agent-id-sample/frontend/src/App.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useAsgardeo } from "@asgardeo/react";
+import { useThunderID } from "@thunderid/react";
 import {
   Bot,
   ChevronDown,
@@ -25,31 +25,6 @@ import { buildResultsPath, readCriteria } from "./utils/routes";
 
 const AGENT_CHAT_URL = import.meta.env.VITE_AGENT_CHAT_URL || "ws://localhost:8790/chat";
 const THUNDER_BASE_URL = import.meta.env.VITE_THUNDER_BASE_URL || "";
-const ASGARDEO_ORG_NAME = getAsgardeoOrgName();
-const SIGN_UP_URL = ASGARDEO_ORG_NAME
-  ? `https://accounts.asgardeo.io/t/${encodeURIComponent(ASGARDEO_ORG_NAME)}/accounts/register`
-  : "https://accounts.asgardeo.io/accounts/register";
-
-function getAsgardeoOrgName() {
-  const configuredOrgName = import.meta.env.VITE_THUNDER_ORG_NAME?.trim();
-
-  if (configuredOrgName) {
-    return configuredOrgName;
-  }
-
-  if (!THUNDER_BASE_URL) {
-    return "";
-  }
-
-  try {
-    const pathParts = new URL(THUNDER_BASE_URL).pathname.split("/").filter(Boolean);
-    const tenantIndex = pathParts.indexOf("t");
-
-    return tenantIndex >= 0 ? pathParts[tenantIndex + 1] || "" : "";
-  } catch {
-    return "";
-  }
-}
 
 function createChatMessage(role, content) {
   return {
@@ -86,7 +61,7 @@ function PublicPrimaryNav() {
 }
 
 function LivePrimaryNav() {
-  const { isSignedIn } = useAsgardeo();
+  const { isSignedIn } = useThunderID();
 
   if (isSignedIn) {
     return <span aria-hidden="true" />;
@@ -96,7 +71,7 @@ function LivePrimaryNav() {
 }
 
 function LiveAuthHeader() {
-  const { isSignedIn, isLoading, signIn, signOut, user } = useAsgardeo();
+  const { isSignedIn, isLoading, signIn, signOut, signUpUrl, user } = useThunderID();
   const [isAccountMenuOpen, setIsAccountMenuOpen] = useState(false);
   const accountMenuRef = useRef(null);
   const firstName = user?.name?.givenName || "";
@@ -174,9 +149,11 @@ function LiveAuthHeader() {
       >
         Sign in
       </button>
-      <a className="primary-small" href={SIGN_UP_URL}>
-        Sign up
-      </a>
+      {signUpUrl && (
+        <a className="primary-small" href={signUpUrl}>
+          Sign up
+        </a>
+      )}
     </div>
   );
 }
@@ -213,7 +190,7 @@ function PublicFooterLinks() {
 }
 
 function LiveFooterLinks() {
-  const { isSignedIn } = useAsgardeo();
+  const { isSignedIn } = useThunderID();
 
   if (isSignedIn) {
     return null;
@@ -232,7 +209,7 @@ function SiteFooter({ authReady }) {
           </span>
           <span>Wayfinder</span>
         </Link>
-        <p>Modern travel booking flows, secured with Asgardeo.</p>
+        <p>Modern travel booking flows, secured with ThunderID.</p>
       </div>
       <FooterLinks authReady={authReady} />
     </footer>
@@ -725,7 +702,7 @@ function AgentCallbackRoute() {
 // form directly instead of the standard user credentials screen. Used by the
 // wayfinder-agent-demo skill and any bookmarkable "Sign in as Agent" link.
 function AgentSignInRoute() {
-  const { isSignedIn, signIn } = useAsgardeo();
+  const { isSignedIn, signIn } = useThunderID();
   const navigate = useNavigate();
   const triggered = useRef(false);
 
@@ -910,7 +887,7 @@ function App({ authReady }) {
         <div className="setup-banner" role="status">
           <ShieldCheck size={18} />
           Add `VITE_THUNDER_CLIENT_ID` and `VITE_THUNDER_BASE_URL` to enable live
-          Asgardeo sign in, sign up, and sign out.
+          ThunderID sign in, sign up, and sign out.
         </div>
       )}
 

--- a/samples/apps/agent-id-sample/frontend/src/main.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/main.jsx
@@ -1,13 +1,13 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { AsgardeoProvider } from "@asgardeo/react";
+import { ThunderIDProvider } from "@thunderid/react";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App.jsx";
 import "./styles.css";
 
 const clientId = import.meta.env.VITE_THUNDER_CLIENT_ID;
 const baseUrl = import.meta.env.VITE_THUNDER_BASE_URL;
-const asgardeoReady = Boolean(clientId && baseUrl);
+const thunderidReady = Boolean(clientId && baseUrl);
 
 // Scopes requested at sign-in. The trailing `system:*` scopes power the in-app
 // Agent Portal: when an admin user signs in, the issued access token carries
@@ -29,18 +29,17 @@ const SCOPES = [
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <BrowserRouter>
-      {asgardeoReady ? (
-        <AsgardeoProvider
+      {thunderidReady ? (
+        <ThunderIDProvider
           clientId={clientId}
           baseUrl={baseUrl}
-          platform="AsgardeoV2"
           afterSignInUrl={window.location.origin}
           afterSignOutUrl={window.location.origin}
           scopes={SCOPES}
           discovery={{ wellKnown: { enabled: true } }}
         >
           <App authReady />
-        </AsgardeoProvider>
+        </ThunderIDProvider>
       ) : (
         <App authReady={false} />
       )}

--- a/samples/apps/agent-id-sample/frontend/src/pages/AgentPortalPage.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/AgentPortalPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAsgardeo } from "@asgardeo/react";
+import { useThunderID } from "@thunderid/react";
 import { Bot, Copy, Plus, RefreshCw, Trash2, X } from "lucide-react";
 import {
   addAgentRoleAssignment,
@@ -15,7 +15,7 @@ const DEFAULT_OU_HANDLE =
   import.meta.env.VITE_THUNDER_DEFAULT_OU_HANDLE || "default";
 
 export function AgentPortalPage() {
-  const { isSignedIn, isLoading: authLoading, signIn, getAccessToken } = useAsgardeo();
+  const { isSignedIn, isLoading: authLoading, signIn, getAccessToken } = useThunderID();
 
   if (authLoading) {
     return (

--- a/samples/apps/agent-id-sample/frontend/src/pages/BookingDetailsPageWithAuth.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/BookingDetailsPageWithAuth.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useAsgardeo } from "@asgardeo/react";
+import { useThunderID } from "@thunderid/react";
 import { Link } from "react-router-dom";
 import { ChevronLeft, Plane, ShieldCheck } from "lucide-react";
 import { getBookedFlights } from "../api";
@@ -8,7 +8,7 @@ import { formatPrice, getBookingReference } from "../utils/bookings";
 const walletCredentialOffer = import.meta.env.VITE_WALLET_CREDENTIAL_OFFER || "";
 
 export function BookingDetailsPageWithAuth({ bookingId }) {
-  const { getAccessToken, isSignedIn, signIn, user } = useAsgardeo();
+  const { getAccessToken, isSignedIn, signIn, user } = useThunderID();
   const [booking, setBooking] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");

--- a/samples/apps/agent-id-sample/frontend/src/pages/BookingsPageWithAuth.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/BookingsPageWithAuth.jsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from "react";
-import { useAsgardeo } from "@asgardeo/react";
+import { useThunderID } from "@thunderid/react";
 import { Link } from "react-router-dom";
 import { getBookedFlights } from "../api";
 import { formatPrice, getBookingReference } from "../utils/bookings";
 
 export function BookingsPageWithAuth() {
-  const { getAccessToken, isSignedIn, signIn, user } = useAsgardeo();
+  const { getAccessToken, isSignedIn, signIn, user } = useThunderID();
   const [bookings, setBookings] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");

--- a/samples/apps/agent-id-sample/frontend/src/pages/BookingsUnavailable.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/BookingsUnavailable.jsx
@@ -4,8 +4,8 @@ export function BookingsUnavailable() {
       <section className="management-empty">
         <div>
           <p className="eyebrow">Bookings</p>
-          <h1>Configure Asgardeo to manage bookings.</h1>
-          <p>Live booking management is available after the Asgardeo client settings are added.</p>
+          <h1>Configure ThunderID to manage bookings.</h1>
+          <p>Live booking management is available after the ThunderID client settings are added.</p>
         </div>
       </section>
     </main>

--- a/samples/apps/agent-id-sample/frontend/src/pages/HomePage.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/HomePage.jsx
@@ -1,4 +1,4 @@
-import { useAsgardeo } from "@asgardeo/react";
+import { useThunderID } from "@thunderid/react";
 import {
   ArrowRight,
   Clock3,
@@ -30,7 +30,7 @@ const pageDetails = {
       {
         icon: <ShieldCheck size={22} />,
         title: "Protected bookings",
-        copy: "Keep booked trips connected to secure Asgardeo sign-in."
+        copy: "Keep booked trips connected to secure ThunderID sign-in."
       },
       {
         icon: <Clock3 size={22} />,
@@ -307,7 +307,7 @@ export function HomePage({
               <span>
                 <ShieldCheck size={18} />
               </span>
-              <strong>Asgardeo</strong>
+              <strong>ThunderID</strong>
             </div>
           </article>
           <article className="stay-card">
@@ -358,7 +358,7 @@ export function HomePage({
 }
 
 export function SignedInHomePage({ category = "flights", locations, onSearch }) {
-  const { isSignedIn, user } = useAsgardeo();
+  const { isSignedIn, user } = useThunderID();
 
   if (!isSignedIn) {
     return <HomePage category={category} locations={locations} onSearch={onSearch} />;

--- a/samples/apps/agent-id-sample/frontend/src/pages/PaymentPageWithAuth.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/PaymentPageWithAuth.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useAsgardeo } from "@asgardeo/react";
+import { useThunderID } from "@thunderid/react";
 import { Link, useNavigate } from "react-router-dom";
 import { ChevronLeft, CreditCard } from "lucide-react";
 import { createBooking, getBookedFlights, getFlight } from "../api";
@@ -8,7 +8,7 @@ import { buildFlightDetailsPath } from "../utils/routes";
 
 export function PaymentPageWithAuth({ criteria, flightId }) {
   const navigate = useNavigate();
-  const { getAccessToken, isSignedIn, signIn, user } = useAsgardeo();
+  const { getAccessToken, isSignedIn, signIn, user } = useThunderID();
   const [flight, setFlight] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [paymentState, setPaymentState] = useState("idle");

--- a/samples/apps/agent-id-sample/frontend/src/pages/ResultsPage.jsx
+++ b/samples/apps/agent-id-sample/frontend/src/pages/ResultsPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useAsgardeo } from "@asgardeo/react";
+import { useThunderID } from "@thunderid/react";
 import { useNavigate } from "react-router-dom";
 import { SearchPanel } from "../components/SearchPanel";
 import {
@@ -255,7 +255,7 @@ export function ResultsPage({ criteria, getAccessToken, locations, onSearch }) {
 }
 
 export function ResultsPageWithAuth(props) {
-  const { getAccessToken } = useAsgardeo();
+  const { getAccessToken } = useThunderID();
 
   return <ResultsPage {...props} getAccessToken={getAccessToken} />;
 }

--- a/samples/apps/react-sdk-sample/package.json
+++ b/samples/apps/react-sdk-sample/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@eslint/js": "9.39.0",
     "@types/node": "20.19.24",
-    "@types/react": "19.2.7",
+    "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-basic-ssl": "2.1.0",
     "@vitejs/plugin-react": "5.1.0",


### PR DESCRIPTION
### Purpose
Remove leftover Asgardeo branding and package references from the repo, completing the migration to the ThunderID identity.

### Approach

**Package metadata**
- Update root `package.json` `homepage`, `bugs`, and `repository` URLs from `asgardeo/thunder` → `thunder-id/thunderid`
- Remove `"asgardeo"` keyword from root and `frontend/package.json`

**`agent-id-sample` — frontend**
- Replace `@asgardeo/react ^0.23.6` with `@thunderid/react 0.0.5` in `package.json`
- Rename app from `asgardeo-b2c-sample-app` → `thunderid-agent-id-sample`
- Replace `AsgardeoProvider` + `platform="AsgardeoV2"` with `ThunderIDProvider`
- Replace `useAsgardeo` with `useThunderID` across all page components
- Drop hard-coded `accounts.asgardeo.io` sign-up URL construction; use `signUpUrl` from the `useThunderID` hook instead
- Update user-visible strings and comments

**`agent-id-sample` — ai-agent**
- Replace `@asgardeo/javascript ^0.9.0` with `@thunderid/javascript 0.0.5` in `package.json`
- Update comments and log strings

**`AcceptInviteBox` — test coverage**
- Make `getServerUrl` overridable per test via `vi.fn()`
- Capture `baseUrl` and `onFlowChange` props in the `AcceptInvite` mock
- Add tests for the `baseUrl` fallback to `VITE_THUNDER_BASE_URL` when `getServerUrl` returns `null`
- Add tests for `onFlowChange` setting and clearing `flowError`, and `flowError` taking priority over `error.message`

**Not changed (intentional)**
- Postman collection for Asgardeo as a federated IDP — valid supported use case
- Go IDP test fixtures using `api.asgardeo.io` URLs — generic OAuth test data
- SDK backward-compat utilities for Asgardeo URL patterns

### Related Issues
- N/A

### Related PRs
- #2783 — frontend migration (merged)
- #2805 — react-sdk-sample migration (merged)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided.
- [x] Tests provided.
- [ ] Breaking changes.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/).
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.