### PR TITLE
Improve ThunderID MCP server

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -110,6 +110,9 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	observabilitySvc = observability.Initialize()
 
+	// Initialize MCP server early so packages initializing below can register tools.
+	mcpServer := mcp.Initialize(mux, jwtService)
+
 	// List to collect exporters from each package
 	var exporters []declarativeresource.ResourceExporter
 
@@ -126,7 +129,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		logger.Fatal("Failed to initialize system authorization service", log.Error(err))
 	}
 
-	ouService, ouHierarchyResolver, ouExporter, err := ou.Initialize(mux, cacheManager, ouAuthzService)
+	ouService, ouHierarchyResolver, ouExporter, err := ou.Initialize(mux, mcpServer, cacheManager, ouAuthzService)
 	if err != nil {
 		logger.Fatal("Failed to initialize OrganizationUnitService", log.Error(err))
 	}
@@ -151,7 +154,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	// Initialize user type service
 	entityTypeService, entityTypeExporter, err := entitytype.Initialize(
-		mux, cacheManager, ouService, ouAuthzService, consentService)
+		mux, mcpServer, cacheManager, ouService, ouAuthzService, consentService)
 	if err != nil {
 		logger.Fatal("Failed to initialize EntityTypeService", log.Error(err))
 	}
@@ -218,9 +221,6 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	}
 	exporters = append(exporters, notificationExporter)
 
-	// Initialize MCP server
-	mcpServer := mcp.Initialize(mux, jwtService)
-
 	// Initialize passkey service
 	passkeyService := passkey.Initialize(entityService)
 
@@ -283,7 +283,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	}
 
 	// Initialize theme and layout services
-	themeMgtService, themeExporter, err := thememgt.Initialize(mux)
+	themeMgtService, themeExporter, err := thememgt.Initialize(mux, mcpServer)
 	if err != nil {
 		logger.Fatal("Failed to initialize ThemeMgtService", log.Error(err))
 	}

--- a/backend/internal/application/tools.go
+++ b/backend/internal/application/tools.go
@@ -78,11 +78,16 @@ func registerMCPTools(server *mcp.Server, appService ApplicationServiceInterface
 
 Use get_application_templates to get pre-configured minimal templates for common app types (SPA, Mobile, Server, M2M).
 
-Prerequisites: Create flows first using create_flow if custom authentication/registration flows are needed.
+Prerequisites:
+- Create flows first using create_flow if custom authentication/registration flows are needed.
+- Use thunderid_list_themes to pick a theme and set themeId before creating the application
+  (skip for M2M — no login page).
 
 Behavior:
 - If auth_flow_id is omitted, the default authentication flow is used.
-- If user_attributes are omitted in token configs, defaults are applied.`,
+- If user_attributes are omitted in token configs, defaults are applied.
+- themeId (Go: InboundAuthProfile.ThemeID) controls the login page appearance. It is a top-level
+  field in the request body, not nested under inboundAuthProfile.`,
 		InputSchema: getCreateAppSchema(),
 		Annotations: &mcp.ToolAnnotations{
 			Title:          "Create Application",
@@ -115,8 +120,15 @@ Any field not provided will be reset to empty/default.`,
 
 Templates contain ONLY the required fields to create each app type. ` +
 			`Optional fields with service-layer defaults are omitted.
-` +
-			`Prompt the user for any missing required placeholders.`,
+
+Theme: SPA, Mobile, and Server templates include a themeId field that controls the ` +
+			`visual appearance of the ThunderID-hosted login page. ` +
+			`Call thunderid_list_themes first to see available themes, then replace the ` +
+			`<THEME_ID> placeholder with the ID of the desired theme. ` +
+			`Omit themeId to use the system default theme. ` +
+			`M2M templates do not include themeId — M2M apps have no login page.
+
+Prompt the user for any missing required placeholders.`,
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Application Templates",
 			ReadOnlyHint: true,
@@ -211,94 +223,112 @@ func (t *applicationTools) getApplicationTemplates(
 	ctx context.Context,
 	req *mcp.CallToolRequest,
 	_ any,
-) (*mcp.CallToolResult, map[string]interface{}, error) {
-	templates := map[string]interface{}{
-		"spa": map[string]interface{}{
-			"name": "<APP_NAME>",
-			"token": map[string]interface{}{
-				"user_attributes": model.DefaultUserAttributes,
+) (*mcp.CallToolResult, map[string]model.ApplicationDTO, error) {
+	templates := map[string]model.ApplicationDTO{
+		"spa": {
+			OUID: "<OU_ID>",
+			Name: "<APP_NAME>",
+			InboundAuthProfile: inboundmodel.InboundAuthProfile{
+				ThemeID: "<THEME_ID>",
 			},
-			"inbound_auth_config": []map[string]interface{}{
+			InboundAuthConfig: []inboundmodel.InboundAuthConfigWithSecret{
 				{
-					"type": "oauth2",
-					"config": map[string]interface{}{
-						"redirect_uris":              []string{"<REDIRECT_URI>"},
-						"grant_types":                []string{"authorization_code", "refresh_token"},
-						"token_endpoint_auth_method": "none",
-						"pkce_required":              true,
-						"public_client":              true,
-						"scopes":                     model.DefaultScopes,
-						"token": map[string]interface{}{
-							"access_token": map[string]interface{}{
-								"user_attributes": model.DefaultUserAttributes,
+					Type: inboundmodel.OAuthInboundAuthType,
+					OAuthConfig: &inboundmodel.OAuthConfigWithSecret{
+						RedirectURIs: []string{"<REDIRECT_URI>"},
+						GrantTypes: []oauth2const.GrantType{
+							oauth2const.GrantTypeAuthorizationCode,
+							oauth2const.GrantTypeRefreshToken,
+						},
+						TokenEndpointAuthMethod: oauth2const.TokenEndpointAuthMethodNone,
+						PKCERequired:            true,
+						PublicClient:            true,
+						Scopes:                  model.DefaultScopes,
+						Token: &inboundmodel.OAuthTokenConfig{
+							IDToken: &inboundmodel.IDTokenConfig{
+								UserAttributes: model.DefaultUserAttributes,
 							},
-							"id_token": map[string]interface{}{
-								"user_attributes": model.DefaultUserAttributes,
-							},
+						},
+						UserInfo: &inboundmodel.UserInfoConfig{
+							ResponseType:   inboundmodel.UserInfoResponseTypeJSON,
+							UserAttributes: model.DefaultUserAttributes,
 						},
 					},
 				},
 			},
 		},
-		"mobile": map[string]interface{}{
-			"name": "<APP_NAME>",
-			"token": map[string]interface{}{
-				"user_attributes": model.DefaultUserAttributes,
+		"mobile": {
+			OUID: "<OU_ID>",
+			Name: "<APP_NAME>",
+			InboundAuthProfile: inboundmodel.InboundAuthProfile{
+				ThemeID: "<THEME_ID>",
 			},
-			"inbound_auth_config": []map[string]interface{}{
+			InboundAuthConfig: []inboundmodel.InboundAuthConfigWithSecret{
 				{
-					"type": "oauth2",
-					"config": map[string]interface{}{
-						"redirect_uris":              []string{"<CUSTOM_SCHEME>://callback"},
-						"grant_types":                []string{"authorization_code", "refresh_token"},
-						"token_endpoint_auth_method": "none",
-						"pkce_required":              true,
-						"public_client":              true,
-						"scopes":                     model.DefaultScopes,
-						"token": map[string]interface{}{
-							"access_token": map[string]interface{}{
-								"user_attributes": model.DefaultUserAttributes,
+					Type: inboundmodel.OAuthInboundAuthType,
+					OAuthConfig: &inboundmodel.OAuthConfigWithSecret{
+						RedirectURIs: []string{"<CUSTOM_SCHEME>://callback"},
+						GrantTypes: []oauth2const.GrantType{
+							oauth2const.GrantTypeAuthorizationCode,
+							oauth2const.GrantTypeRefreshToken,
+						},
+						TokenEndpointAuthMethod: oauth2const.TokenEndpointAuthMethodNone,
+						PKCERequired:            true,
+						PublicClient:            true,
+						Scopes:                  model.DefaultScopes,
+						Token: &inboundmodel.OAuthTokenConfig{
+							IDToken: &inboundmodel.IDTokenConfig{
+								UserAttributes: model.DefaultUserAttributes,
 							},
-							"id_token": map[string]interface{}{
-								"user_attributes": model.DefaultUserAttributes,
-							},
+						},
+						UserInfo: &inboundmodel.UserInfoConfig{
+							ResponseType:   inboundmodel.UserInfoResponseTypeJSON,
+							UserAttributes: model.DefaultUserAttributes,
 						},
 					},
 				},
 			},
 		},
-		"server": map[string]interface{}{
-			"name": "<APP_NAME>",
-			"token": map[string]interface{}{
-				"user_attributes": model.DefaultUserAttributes,
+		"server": {
+			OUID: "<OU_ID>",
+			Name: "<APP_NAME>",
+			InboundAuthProfile: inboundmodel.InboundAuthProfile{
+				ThemeID: "<THEME_ID>",
 			},
-			"inbound_auth_config": []map[string]interface{}{
+			InboundAuthConfig: []inboundmodel.InboundAuthConfigWithSecret{
 				{
-					"type": "oauth2",
-					"config": map[string]interface{}{
-						"redirect_uris": []string{"<REDIRECT_URI>"},
-						"grant_types":   []string{"authorization_code", "refresh_token"},
-						"pkce_required": true,
-						"scopes":        model.DefaultScopes,
-						"token": map[string]interface{}{
-							"access_token": map[string]interface{}{
-								"user_attributes": model.DefaultUserAttributes,
+					Type: inboundmodel.OAuthInboundAuthType,
+					OAuthConfig: &inboundmodel.OAuthConfigWithSecret{
+						RedirectURIs: []string{"<REDIRECT_URI>"},
+						GrantTypes: []oauth2const.GrantType{
+							oauth2const.GrantTypeAuthorizationCode,
+							oauth2const.GrantTypeRefreshToken,
+						},
+						TokenEndpointAuthMethod: oauth2const.TokenEndpointAuthMethodClientSecretBasic,
+						PKCERequired:            true,
+						Scopes:                  model.DefaultScopes,
+						Token: &inboundmodel.OAuthTokenConfig{
+							IDToken: &inboundmodel.IDTokenConfig{
+								UserAttributes: model.DefaultUserAttributes,
 							},
-							"id_token": map[string]interface{}{
-								"user_attributes": model.DefaultUserAttributes,
-							},
+						},
+						UserInfo: &inboundmodel.UserInfoConfig{
+							ResponseType:   inboundmodel.UserInfoResponseTypeJSON,
+							UserAttributes: model.DefaultUserAttributes,
 						},
 					},
 				},
 			},
 		},
-		"m2m": map[string]interface{}{
-			"name": "<APP_NAME>",
-			"inbound_auth_config": []map[string]interface{}{
+		"m2m": {
+			OUID: "<OU_ID>",
+			Name: "<APP_NAME>",
+			InboundAuthConfig: []inboundmodel.InboundAuthConfigWithSecret{
 				{
-					"type": "oauth2",
-					"config": map[string]interface{}{
-						"grant_types": []string{"client_credentials"},
+					Type: inboundmodel.OAuthInboundAuthType,
+					OAuthConfig: &inboundmodel.OAuthConfigWithSecret{
+						GrantTypes:              []oauth2const.GrantType{oauth2const.GrantTypeClientCredentials},
+						TokenEndpointAuthMethod: oauth2const.TokenEndpointAuthMethodClientSecretBasic,
 					},
 				},
 			},

--- a/backend/internal/application/tools_test.go
+++ b/backend/internal/application/tools_test.go
@@ -361,9 +361,19 @@ func (suite *ApplicationToolsTestSuite) TestGetApplicationTemplates_Success() {
 	assert.Contains(suite.T(), output, "m2m")
 
 	// Verify SPA template structure
-	spaTemplate := output["spa"].(map[string]interface{})
-	assert.Equal(suite.T(), "<APP_NAME>", spaTemplate["name"])
-	assert.NotNil(suite.T(), spaTemplate["inbound_auth_config"])
+	spaTemplate := output["spa"]
+	assert.Equal(suite.T(), "<APP_NAME>", spaTemplate.Name)
+	assert.NotEmpty(suite.T(), spaTemplate.InboundAuthConfig)
+	assert.Equal(suite.T(), "<THEME_ID>", spaTemplate.InboundAuthProfile.ThemeID)
+
+	mobileTemplate := output["mobile"]
+	assert.Equal(suite.T(), "<THEME_ID>", mobileTemplate.InboundAuthProfile.ThemeID)
+
+	serverTemplate := output["server"]
+	assert.Equal(suite.T(), "<THEME_ID>", serverTemplate.InboundAuthProfile.ThemeID)
+
+	m2mTemplate := output["m2m"]
+	assert.Empty(suite.T(), m2mTemplate.InboundAuthProfile.ThemeID)
 
 	mockService.AssertExpectations(suite.T())
 }

--- a/backend/internal/authn/reactsdk/tool.go
+++ b/backend/internal/authn/reactsdk/tool.go
@@ -62,6 +62,7 @@ ThunderID supports two ways to integrate React authentication:
   API-Based Sample for implementation details.
 
 This guide covers both integration modes:
+
 - **Mode 1** (default): ThunderID-hosted login with redirect-based OAuth 2.0/OIDC.
 - **Mode 2**: Self-hosted app-native login using alternate API-driven patterns.
 
@@ -69,17 +70,18 @@ Mode 1 remains the recommended default path and uses the **ThunderID React SDK**
 for a minimal, declarative authentication flow.
 
 ## Project Context
+
 This project is a **React application** that integrates **ThunderID
 authentication** using the **ThunderID React SDK**, covering both
 ThunderID-hosted login (Mode 1) and app-native/self-hosted flows (Mode 2).
 
 The goal is to demonstrate a **minimal, declarative authentication flow** with minimal setup.
-
 This project intentionally avoids custom logic, hooks, and advanced configuration.
 
 ---
 
 ## SDK & Platform
+
 - **SDK**: @thunderid/react
 - **Authentication Mode**: ThunderID-hosted login (redirect-based)
 - **Base URL**: https://localhost:8090 (or ThunderID instance URL)
@@ -89,34 +91,46 @@ This project intentionally avoids custom logic, hooks, and advanced configuratio
 
 ## CRITICAL: Mode 1 Provider Configuration Rules (MUST FOLLOW EXACTLY)
 
-For **Mode 1 only**, ~ThunderIDProvider~ **MUST** be configured using **ONLY**
-the following two props.
+For **Mode 1 only**, ~ThunderIDProvider~ **MUST** be configured using the
+following props.
+
 Always create a NEW public SPA application with token endpoint method as none and use the
 client id. Use the application's URL as the redirect URL.
+
 Use the thunderid_get_application_templates tool to get the template and defaults(e.g. user attributes and scopes)
 before creating the application.
+
 No variations, no abstractions, no helper objects.
 
 **Mode 2 note:** Method 2 uses an alternate ~ThunderIDProvider~ shape with
 ~applicationId~ (instead of ~clientId~), as shown in the Mode 2 examples.
 
 ### ✅ REQUIRED Provider Configuration
+
 ~~~jsx
 import { ThunderIDProvider } from '@thunderid/react'
 
 <ThunderIDProvider
   clientId="<client-id>"
   baseUrl="https://localhost:8090"
+  afterSignOutUrl="<APP_HOMEPAGE_URL>"
 >
   <App />
 </ThunderIDProvider>
 ~~~
 
+**~afterSignOutUrl~ — set this to your app's homepage (e.g. ~http://localhost:5173~).**
+Without it, the user may be redirected to an unexpected page after signing out.
+Use ~window.location.origin~ or a hardcoded homepage URL. This should match the
+homepage of the deployed application in production.
+
 ### 🚨 FORBIDDEN Patterns
+
 **For Mode 1, NEVER** do any of the following:
+
 - ❌ ~const config = { ... }; <ThunderIDProvider {...config} />~
 - ❌ Extract props to variables
-- ❌ Add any other props beyond the two required ones
+- ❌ Add props other than ~clientId~, ~baseUrl~, and ~afterSignOutUrl~
 - ❌ Use different prop names or aliases
 
 ---
@@ -124,6 +138,7 @@ import { ThunderIDProvider } from '@thunderid/react'
 ## Application Structure
 
 ### Entry Point (main.jsx or index.jsx)
+
 ~~~jsx
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
@@ -136,6 +151,7 @@ createRoot(document.getElementById('root')).render(
     <ThunderIDProvider
       clientId="<client-id>"
       baseUrl="https://localhost:8090"
+      afterSignOutUrl={window.location.origin}
     >
       <App />
     </ThunderIDProvider>
@@ -152,6 +168,7 @@ createRoot(document.getElementById('root')).render(
 The SDK provides declarative components for handling auth states:
 
 #### 1. Sign In/Out Buttons
+
 ~~~jsx
 import { SignInButton, SignOutButton } from '@thunderid/react'
 
@@ -165,9 +182,41 @@ function Navigation() {
 }
 ~~~
 
-#### 2. Conditional Rendering Based on Auth State
+#### 2. Sign Up (Self-Registration)
+
+No custom React component is needed for signup. When self-registration is enabled, the ThunderID-hosted
+sign-in page automatically renders a **Sign Up** link.
+
+**Two conditions must both be met:**
+
+**1. The application must have registration enabled.**
+
+Use ~thunderid_update_application~ to set ~isRegistrationFlowEnabled~ and point it at a registration flow.
+Also add the user type name to ~allowedUserTypes~:
+
+~~~json
+{
+  "inboundAuthConfig": [{
+    "isRegistrationFlowEnabled": true,
+    "registrationFlowId": "<registration-flow-id>",
+    "allowedUserTypes": ["<user-type-name>"]
+  }]
+}
+~~~
+
+**2. The user type must have ~allowSelfRegistration~ enabled.**
+
+Use ~thunderid_list_user_types~ to find user types. The user type(s) listed in ~allowedUserTypes~ above
+must have ~allowSelfRegistration: true~. Without this, the sign-in page will not show the Sign Up link
+even if the application has registration enabled.
+
+Once both conditions are met, the hosted sign-in page shows the Sign Up link automatically —
+no changes to your React app are required.
+
+#### 3. Conditional Rendering Based on Auth State
+
 ~~~jsx
-import { SignedIn, SignedOut, Loading } from '@thunderid/react'
+import { SignedIn, SignedOut, Loading, SignInButton, SignOutButton } from '@thunderid/react'
 
 function App() {
   return (
@@ -190,7 +239,39 @@ function App() {
 }
 ~~~
 
-#### 3. Display User Information
+#### 4. Display User Information
+
+**Prerequisites — configure the application before using user attributes:**
+
+User attributes are only available in the React SDK if the application's inbound OAuth config explicitly
+includes them. Use the ~thunderid_update_application~ tool to set this on the application:
+
+~~~json
+{
+  "inboundAuthConfig": [{
+    "type": "oauth2",
+    "config": {
+      "token": {
+        "idToken": {
+          "userAttributes": ["email", "name", "given_name", "family_name", "picture"]
+        }
+      },
+      "userInfo": {
+        "responseType": "JSON",
+        "userAttributes": ["email", "name", "given_name", "family_name", "picture"]
+      }
+    }
+  }]
+}
+~~~
+
+The OAuth scopes requested at login must also cover the attributes you need (e.g. ~openid profile email~).
+Attributes not listed in ~userAttributes~ above will not appear in the ID token or the ~/oauth2/userinfo~
+response regardless of requested scopes.
+
+**How user data reaches the SDK:**
+- The ~User~ component (and ~useThunderID().user~) reads attributes from the **ID token** returned at login.
+- For the freshest data (e.g. after a profile update), call ~/oauth2/userinfo~ directly — it is always authoritative.
 
 **PREFERRED:** Use the ~User~ component from ~@thunderid/react~ with render props pattern:
 
@@ -267,6 +348,7 @@ function CustomComponent() {
 ## Route Protection
 
 ### Option 1: Using SDK Control Components
+
 ~~~jsx
 import { SignedIn, SignedOut } from '@thunderid/react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
@@ -292,6 +374,7 @@ function App() {
 ~~~
 
 ### Option 2: Using React Router Integration
+
 ~~~bash
 npm install @thunderid/react-router
 ~~~
@@ -310,6 +393,7 @@ import { ProtectedRoute } from '@thunderid/react-router'
 ~~~
 
 ### Option 3: Custom Implementation
+
 ~~~jsx
 import { useThunderID } from '@thunderid/react'
 import { Navigate } from 'react-router-dom'
@@ -334,6 +418,7 @@ function ProtectedRoute({ children }) {
 ## Accessing Protected APIs
 
 ### Using SDK Built-in HTTP Client (webWorker storage)
+
 ~~~jsx
 import { useThunderID } from '@thunderid/react'
 import { useEffect, useState } from 'react'
@@ -369,6 +454,7 @@ function UserData() {
 **Note:** The ~http~ module automatically attaches the access token to requests.
 
 ### Using Custom HTTP Client (sessionStorage/localStorage)
+
 ~~~jsx
 import { useThunderID } from '@thunderid/react'
 
@@ -407,6 +493,7 @@ createRoot(document.getElementById('root')).render(
     <ThunderIDProvider
       clientId="<client-id>"
       baseUrl="https://localhost:8090"
+      afterSignOutUrl={window.location.origin}
     >
       <App />
     </ThunderIDProvider>
@@ -416,8 +503,7 @@ createRoot(document.getElementById('root')).render(
 
 ~~~jsx
 // App.jsx
-import { SignedIn, SignedOut, SignInButton, SignOutButton, Loading } from '@thunderid/react'
-import User from './components/User'
+import { SignedIn, SignedOut, SignInButton, SignOutButton, Loading, User } from '@thunderid/react'
 
 function App() {
   return (
@@ -603,9 +689,351 @@ Both samples show how to build custom authentication UIs while leveraging Thunde
 
 ---
 
+## Migrating from Mode 1 to Mode 2
+
+Use this guide when switching an existing Mode 1 (redirect-based) integration to Mode 2 (app-native).
+
+### What changes
+
+| Area | Mode 1 | Mode 2 |
+|---|---|---|
+| Provider prop | ~clientId~ | ~applicationId~ |
+| Sign-in UI | ~<SignInButton />~ (redirect) | ~<SignIn />~ (inline app-native flow) |
+| Sign-out | ~<SignOutButton />~ | ~<SignOutButton />~ / ~signOut()~ |
+| App registration | Public SPA (token endpoint: none) | Standard application — use the Application ID (UUID) |
+
+### Step 1: Get your Application ID
+
+In Mode 2 the provider is configured with the application's UUID (~applicationId~), not a client ID string.
+
+Use ~thunderid_list_applications~ to find your application and copy its UUID. If you need a new application,
+use ~thunderid_create_application~ and note the returned UUID.
+
+### Step 2: Update the provider
+
+Replace ~clientId~ with ~applicationId~ in ~ThunderIDProvider~:
+
+~~~jsx
+// Before (Mode 1)
+<ThunderIDProvider
+  clientId="<client-id>"
+  baseUrl="https://localhost:8090"
+>
+
+// After (Mode 2)
+<ThunderIDProvider
+  applicationId="<application-uuid>"
+  baseUrl="https://localhost:8090"
+>
+~~~
+
+### Step 3: Update runtime/environment config
+
+If your app reads config from a file (e.g. ~runtime.json~) or environment variables, rename the key:
+
+~~~json
+// Before
+{ "clientId": "REACT_SDK_SAMPLE", "baseUrl": "https://localhost:8090" }
+
+// After
+{ "applicationId": "<application-uuid>", "baseUrl": "https://localhost:8090" }
+~~~
+
+Update the corresponding config loader (~config.ts~ or equivalent) to read ~applicationId~ instead of ~clientId~.
+
+### Step 4: Replace the sign-in component
+
+Replace ~<SignInButton />~ with the ~<SignIn />~ component. ~<SignIn />~ renders the app-native
+authentication UI inline — no browser redirect occurs and no separate sign-in page or route is needed.
+
+The ~<SignIn />~ component handles the entire auth flow (username/password fields, step-up prompts, etc.)
+within your app itself.
+
+~~~jsx
+// Before (Mode 1)
+import { SignedIn, SignedOut, SignInButton } from '@thunderid/react'
+
+function App() {
+  return (
+    <>
+      <SignedIn><Dashboard /></SignedIn>
+      <SignedOut><SignInButton /></SignedOut>
+    </>
+  )
+}
+
+// After (Mode 2)
+import { SignedIn, SignedOut, SignIn } from '@thunderid/react'
+
+function App() {
+  return (
+    <>
+      <SignedIn><Dashboard /></SignedIn>
+      <SignedOut><SignIn /></SignedOut>
+    </>
+  )
+}
+~~~
+
+If you previously had a dedicated sign-in route (e.g. ~<Route path="/signin" element={<SignInPage />} />~)
+just to host the ~<SignInButton />~, remove that route entirely and render ~<SignIn />~ directly in your
+main layout.
+
+### Step 5: Update sign-out
+
+In Mode 2, ~signOut()~ ends the session and the ~<SignIn />~ component re-renders automatically.
+
+~~~jsx
+// Mode 1
+import { SignOutButton } from '@thunderid/react'
+<SignOutButton>Sign Out</SignOutButton>
+
+// Mode 2
+import { SignOutButton } from '@thunderid/react'
+<SignOutButton>Sign Out</SignOutButton>
+
+// Or with the hook (Mode 2)
+const { signOut } = useThunderID()
+<button onClick={() => signOut()}>Sign Out</button>
+~~~
+
+If you were calling ~signIn()~ immediately after ~signOut()~ to return to the login screen, remove that
+call — ~<SignIn />~ handles re-rendering automatically when the user is signed out.
+
+### Step 6: Validation checks
+
+Update any startup validation that checks for ~clientId~ to check for ~applicationId~ instead.
+
+### Quick checklist
+
+- [ ] ~ThunderIDProvider~ uses ~applicationId~ (UUID), not ~clientId~
+- [ ] ~runtime.json~ / env vars updated to ~applicationId~
+- [ ] Config loader reads ~applicationId~
+- [ ] ~<SignInButton />~ replaced with ~<SignIn />~
+- [ ] Sign-out uses ~<SignOutButton>~ or ~signOut()~
+- [ ] No calls to ~signIn()~ after ~signOut()~
+
+---
+
+## Custom Signup Form
+
+### How it works
+
+The signup flow is server-driven. When the ~<SignUp>~ component mounts, it calls the ~/flow/execute~ API
+to initialize a ~REGISTRATION~ flow. The server responds with a list of **components** (fields, buttons,
+dividers, etc.) that describe what to render. On each form submission the same API is called again with
+the user's inputs until ~flowStatus === 'COMPLETE'~.
+
+### Provider setup for signup
+
+Wrap your app with ~ThunderIDProvider~. The minimum required config is ~baseUrl~ and ~clientId~.
+
+~~~tsx
+import { ThunderIDProvider } from '@thunderid/react';
+
+<ThunderIDProvider
+  baseUrl="https://localhost:8090"
+  clientId="your-client-id"
+  afterSignInUrl="http://localhost:3000"
+  afterSignOutUrl="http://localhost:3000"
+  scopes={['openid', 'profile', 'email']}
+>
+  <App />
+</ThunderIDProvider>
+~~~
+
+#### Do you need ~applicationId~?
+
+~applicationId~ is **optional but recommended**.
+
+| Scenario | Behavior without ~applicationId~ |
+|---|---|
+| Branding (colors, logo) | Falls back to org-level defaults |
+| Signup flow initialization | SDK reads ~applicationId~ from URL query param as fallback, otherwise omits it |
+| Flow meta / i18n | SDK uses org-level branding |
+
+If you set it in the provider, it propagates automatically to the signup flow:
+
+~~~tsx
+<ThunderIDProvider
+  baseUrl="https://localhost:8090"
+  clientId="your-client-id"
+  applicationId="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  // optional UUID
+>
+~~~
+
+Alternatively you can pass ~applicationId~ as a URL query param (~?applicationId=...~) and the SDK will
+pick it up automatically — useful when the signup page is shared across multiple apps.
+
+### Create the signup page/route
+
+Point users to a dedicated page that renders the ~<SignUp>~ component. Configure ~signUpUrl~ in the
+provider to that page:
+
+~~~tsx
+<ThunderIDProvider
+  ...
+  signUpUrl="http://localhost:3000/signup"
+>
+~~~
+
+### Render the signup form
+
+#### Option A — Pre-built UI (zero effort)
+
+~~~tsx
+import { SignUp } from '@thunderid/react';
+
+const SignUpPage = () => (
+  <SignUp
+    afterSignUpUrl="/welcome"
+    onComplete={(response) => console.log('Done', response)}
+    onError={(err) => console.error(err)}
+    size="medium"       // 'small' | 'medium' | 'large'
+    variant="outlined"  // 'elevated' | 'outlined' | 'flat'
+  />
+);
+~~~
+
+The component renders whatever fields the server sends (username, email, password, etc.) and handles all
+flow steps automatically.
+
+#### Option B — Custom UI with render props
+
+Pass a ~children~ function. The SDK still owns the flow state; you own the markup.
+
+~~~tsx
+import { SignUp } from '@thunderid/react';
+
+const SignUpPage = () => (
+  <SignUp
+    afterSignUpUrl="/welcome"
+    onError={(err) => console.error(err)}
+    onComplete={(response) => console.log('Signup complete', response)}
+  >
+    {({
+      components,        // server-driven component list for the current step
+      values,            // form field values — keyed by component.ref
+      fieldErrors,       // per-field validation errors
+      touched,           // whether a field has been blurred
+      isLoading,         // true while the flow API call is in-flight
+      messages,          // server error / info messages [{message, type}]
+      handleInputChange, // (fieldName, value) => void
+      handleSubmit,      // (component, values) => Promise<void> — pass the button component
+    }) => (
+      <div>
+        <h1>Create an Account</h1>
+
+        {/* Server messages (errors, warnings) */}
+        {messages.map((msg, i) => (
+          <p key={i} style={{ color: msg.type === 'error' ? 'red' : 'blue' }}>
+            {msg.message}
+          </p>
+        ))}
+
+        {/* Render text / email / password inputs */}
+        {components
+          .filter(c => ['TEXT_INPUT', 'EMAIL_INPUT', 'PASSWORD_INPUT'].includes(c.type))
+          .map(component => (
+            <div key={component.ref || component.id}>
+              <label>{component.label}</label>
+              <input
+                type={component.type === 'PASSWORD_INPUT' ? 'password' : 'text'}
+                value={values[component.ref] ?? ''}
+                onChange={e => handleInputChange(component.ref, e.target.value)}
+              />
+              {touched[component.ref] && fieldErrors[component.ref] && (
+                <span style={{ color: 'red' }}>{fieldErrors[component.ref]}</span>
+              )}
+            </div>
+          ))}
+
+        {/* Submit button */}
+        {components
+          .filter(c => c.type === 'BUTTON')
+          .map(component => (
+            <button
+              key={component.id}
+              onClick={() => handleSubmit(component, values)}
+              disabled={isLoading}
+            >
+              {isLoading ? 'Creating account...' : component.label ?? 'Sign Up'}
+            </button>
+          ))}
+      </div>
+    )}
+  </SignUp>
+);
+~~~
+
+### Handle completion
+
+~~~tsx
+<SignUp
+  afterSignUpUrl="/welcome"           // auto-redirect on success (default behavior)
+  shouldRedirectAfterSignUp={true}    // default: true
+  onComplete={(response) => {
+    // Called when flowStatus === 'COMPLETE'
+    // response.redirectUrl is set when an OAuth assertion was completed
+    console.log('Signup complete', response);
+  }}
+  onError={(err) => {
+    // Called on API errors or unrecoverable flow errors
+    console.error(err);
+  }}
+/>
+~~~
+
+If you need custom redirect logic (e.g. Next.js ~router.push~), set ~shouldRedirectAfterSignUp={false}~
+and handle it in ~onComplete~.
+
+### Render props reference
+
+| Prop | Type | Description |
+|---|---|---|
+| ~components~ | ~any[]~ | Server-driven component tree for the current flow step |
+| ~values~ | ~Record<string, string>~ | Form values keyed by ~component.ref~ |
+| ~fieldErrors~ | ~Record<string, string>~ | Per-field validation error messages |
+| ~touched~ | ~Record<string, boolean>~ | Whether the user has interacted with a field |
+| ~isLoading~ | ~boolean~ | Flow API call is in-flight |
+| ~isValid~ | ~boolean~ | All required fields pass validation |
+| ~messages~ | ~{message: string, type: string}[]~ | Server messages |
+| ~error~ | ~Error \| null~ | API-level error |
+| ~title~ | ~string~ | Flow step title (from server or i18n) |
+| ~subtitle~ | ~string~ | Flow step subtitle |
+| ~handleInputChange~ | ~(name, value) => void~ | Update a field value |
+| ~handleSubmit~ | ~(component, data?) => Promise<void>~ | Advance the flow; pass button and current ~values~ |
+| ~validateForm~ | ~() => {fieldErrors, isValid}~ | Manually trigger validation |
+
+### Key rules
+
+- **Use ~component.ref~ as the field key**, not ~component.id~. The SDK maps input names to ~ref~
+  when building the ~inputs~ payload sent to the server.
+- **Social / OAuth signup** (Google, GitHub, etc.) is handled automatically via a popup —
+  your render-prop UI does not need to handle ~type: 'REDIRECTION'~ responses.
+- **Passkey registration** is also handled automatically when
+  ~additionalData.passkeyCreationOptions~ is present in the flow response.
+- The flow can have **multiple steps** (e.g. email → OTP → password). The ~components~ array
+  updates after each successful submission — your UI re-renders the new step automatically.
+
+### Common ~component.type~ values
+
+| Type | Renders as |
+|---|---|
+| ~TEXT_INPUT~ | Plain text field |
+| ~EMAIL_INPUT~ | Email field |
+| ~PASSWORD_INPUT~ | Password field |
+| ~SELECT~ | Dropdown |
+| ~BUTTON~ | Submit / action button |
+| ~DIVIDER~ | Visual separator |
+| ~HEADING~ | Title/subtitle text |
+
+---
+
 ## Best Practices
 
 ### ✅ DO:
+
 - Use declarative components (~<SignedIn>~, ~<SignedOut>~, ~<Loading>~) for UI state
 - Use pre-built action components (~<SignInButton>~, ~<SignOutButton>~)
 - Keep the provider configuration minimal and explicit
@@ -613,6 +1041,7 @@ Both samples show how to build custom authentication UIs while leveraging Thunde
 - Handle loading and error states properly
 
 ### ❌ DON'T:
+
 - Don't create custom authentication logic unless absolutely necessary
 - Don't manipulate tokens manually
 - Don't store tokens in localStorage unless using the SDK's storage mechanism
@@ -624,6 +1053,7 @@ Both samples show how to build custom authentication UIs while leveraging Thunde
 ## Common Patterns
 
 ### Pattern 1: Simple Auth-Gated App
+
 ~~~jsx
 function App() {
   return (
@@ -640,6 +1070,7 @@ function App() {
 ~~~
 
 ### Pattern 2: Navigation Bar with Conditional Auth
+
 ~~~jsx
 function NavBar() {
   return (
@@ -658,6 +1089,7 @@ function NavBar() {
 ~~~
 
 ### Pattern 3: Loading State Handling
+
 ~~~jsx
 function App() {
   return (
@@ -679,20 +1111,25 @@ function App() {
 ## Troubleshooting
 
 ### Issue: Hook Error "useThunderID must be used within ThunderIDProvider"
+
 **Solution:** Ensure the component using ~useThunderID~ is a child of ~<ThunderIDProvider>~
 
 ### Issue: Infinite redirect loop
+
 **Solution:** Check that ~baseUrl~ and ~clientId~ are correct. Verify token validation settings.
 
 ### Issue: User object is null after sign in
+
 **Solution:** Ensure authentication has completed. Check for any errors in the console.
 
 ### Issue: CORS errors
+
 **Solution:** Configure CORS settings in ThunderID to allow your app's origin.
 
 ---
 
 ## References
+
 - [ThunderID React SDK Docs](/docs/next/sdks/react/overview)
 - [ThunderIDProvider Configuration](/docs/next/sdks/react/apis/contexts/thunderid-provider)
 - [SDK Components](/docs/next/sdks/react/apis/components/sign-in-button)
@@ -709,6 +1146,7 @@ import { ThunderIDProvider } from '@thunderid/react';
 <ThunderIDProvider
   clientId="<client-id>"
   baseUrl="https://localhost:8090"
+  afterSignOutUrl={window.location.origin}
 >
   <App />
 </ThunderIDProvider>

--- a/backend/internal/design/theme/mgt/init.go
+++ b/backend/internal/design/theme/mgt/init.go
@@ -21,13 +21,18 @@ package thememgt
 import (
 	"net/http"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
 )
 
 // Initialize initializes the theme management service and registers its routes.
-func Initialize(mux *http.ServeMux) (ThemeMgtServiceInterface, declarativeresource.ResourceExporter, error) {
+func Initialize(
+	mux *http.ServeMux,
+	mcpServer *mcp.Server,
+) (ThemeMgtServiceInterface, declarativeresource.ResourceExporter, error) {
 	// Step 1: Initialize store based on configuration
 	themeMgtStore, err := initializeStore()
 	if err != nil {
@@ -38,6 +43,10 @@ func Initialize(mux *http.ServeMux) (ThemeMgtServiceInterface, declarativeresour
 	themeMgtService := newThemeMgtService(themeMgtStore)
 	themeMgtHandler := newThemeMgtHandler(themeMgtService)
 	registerRoutes(mux, themeMgtHandler)
+
+	if mcpServer != nil {
+		registerMCPTools(mcpServer, themeMgtService)
+	}
 
 	exporter := newThemeExporter(themeMgtService)
 	return themeMgtService, exporter, nil

--- a/backend/internal/design/theme/mgt/tools.go
+++ b/backend/internal/design/theme/mgt/tools.go
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package thememgt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	"github.com/thunder-id/thunderid/internal/system/mcp/tool"
+)
+
+type themeTools struct {
+	themeMgtService ThemeMgtServiceInterface
+}
+
+// themeSummary is the MCP list-response item. It omits the raw theme JSON blob
+// so the output schema is derivable without json.RawMessage (which the schema
+// generator misidentifies as an array of bytes).
+type themeSummary struct {
+	ID          string `json:"id"`
+	Handle      string `json:"handle"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description,omitempty"`
+	IsReadOnly  bool   `json:"isReadOnly"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	UpdatedAt   string `json:"updatedAt,omitempty"`
+}
+
+// themeListMCPResponse is the MCP list tool output.
+type themeListMCPResponse struct {
+	TotalResults int            `json:"totalResults"`
+	Themes       []themeSummary `json:"themes"`
+}
+
+// themeDetailMCPResponse is the MCP get tool output. The Theme config field is
+// typed as map[string]interface{} so the schema generator emits {"type":"object"}
+// instead of the array-of-bytes schema that json.RawMessage would produce, or
+// the empty schema {} that interface{} would produce (both rejected by Claude).
+type themeDetailMCPResponse struct {
+	ID          string                 `json:"id"`
+	Handle      string                 `json:"handle"`
+	DisplayName string                 `json:"displayName"`
+	Description string                 `json:"description,omitempty"`
+	Theme       map[string]interface{} `json:"theme,omitempty"`
+	IsReadOnly  bool                   `json:"isReadOnly"`
+	CreatedAt   string                 `json:"createdAt,omitempty"`
+	UpdatedAt   string                 `json:"updatedAt,omitempty"`
+}
+
+// registerMCPTools registers all theme MCP tools with the server.
+func registerMCPTools(server *mcp.Server, themeMgtService ThemeMgtServiceInterface) {
+	tools := &themeTools{themeMgtService: themeMgtService}
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "thunderid_list_themes",
+		Description: `List all themes with summary information (ID, handle, display name). ` +
+			`Use thunderid_get_theme_by_id to retrieve full color and typography configuration for a specific theme.`,
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "List Themes",
+			ReadOnlyHint: true,
+		},
+	}, tools.listThemes)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_get_theme_by_id",
+		Description: `Retrieve full details of a theme by ID including color schemes and typography configuration.`,
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Theme by ID",
+			ReadOnlyHint: true,
+		},
+	}, tools.getThemeByID)
+}
+
+// listThemes handles the list_themes tool call.
+func (t *themeTools) listThemes(
+	_ context.Context,
+	_ *mcp.CallToolRequest,
+	_ any,
+) (*mcp.CallToolResult, *themeListMCPResponse, error) {
+	var summaries []themeSummary
+	var totalResults int
+	offset := 0
+
+	for {
+		resp, svcErr := t.themeMgtService.GetThemeList(serverconst.MaxPageSize, offset)
+		if svcErr != nil {
+			return nil, nil, fmt.Errorf("failed to list themes: %s", svcErr.ErrorDescription)
+		}
+		if offset == 0 {
+			totalResults = resp.TotalResults
+		}
+		for _, th := range resp.Themes {
+			summaries = append(summaries, themeSummary{
+				ID:          th.ID,
+				Handle:      th.Handle,
+				DisplayName: th.DisplayName,
+				Description: th.Description,
+				IsReadOnly:  th.IsReadOnly,
+				CreatedAt:   th.CreatedAt,
+				UpdatedAt:   th.UpdatedAt,
+			})
+		}
+		offset += len(resp.Themes)
+		if offset >= totalResults || len(resp.Themes) == 0 {
+			break
+		}
+	}
+
+	return nil, &themeListMCPResponse{
+		TotalResults: totalResults,
+		Themes:       summaries,
+	}, nil
+}
+
+// getThemeByID handles the get_theme_by_id tool call.
+func (t *themeTools) getThemeByID(
+	_ context.Context,
+	_ *mcp.CallToolRequest,
+	input tool.IDInput,
+) (*mcp.CallToolResult, *themeDetailMCPResponse, error) {
+	theme, svcErr := t.themeMgtService.GetTheme(input.ID)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf("failed to get theme: %s", svcErr.ErrorDescription)
+	}
+
+	detail := &themeDetailMCPResponse{
+		ID:          theme.ID,
+		Handle:      theme.Handle,
+		DisplayName: theme.DisplayName,
+		Description: theme.Description,
+		IsReadOnly:  theme.IsReadOnly,
+		CreatedAt:   theme.CreatedAt,
+		UpdatedAt:   theme.UpdatedAt,
+	}
+
+	if len(theme.Theme) > 0 {
+		var themeConfig map[string]interface{}
+		if err := json.Unmarshal(theme.Theme, &themeConfig); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse theme config: %w", err)
+		}
+		detail.Theme = themeConfig
+	}
+
+	return nil, detail, nil
+}

--- a/backend/internal/entitytype/init.go
+++ b/backend/internal/entitytype/init.go
@@ -21,6 +21,8 @@ package entitytype
 import (
 	"net/http"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/thunder-id/thunderid/internal/consent"
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/cache"
@@ -34,6 +36,7 @@ import (
 // Initialize initializes the entity type service and registers its routes.
 func Initialize(
 	mux *http.ServeMux,
+	mcpServer *mcp.Server,
 	cacheManager cache.CacheManagerInterface,
 	ouService oupkg.OrganizationUnitServiceInterface,
 	authzService sysauthz.SystemAuthorizationServiceInterface,
@@ -61,6 +64,10 @@ func Initialize(
 	agentTypeHandler := newEntityTypeHandler(entityTypeService, TypeCategoryAgent)
 	registerUserTypeRoutes(mux, userTypeHandler)
 	registerAgentTypeRoutes(mux, agentTypeHandler)
+
+	if mcpServer != nil {
+		registerMCPTools(mcpServer, entityTypeService)
+	}
 
 	exporter := newEntityTypeExporter(entityTypeService)
 	return entityTypeService, exporter, nil

--- a/backend/internal/entitytype/init_test.go
+++ b/backend/internal/entitytype/init_test.go
@@ -89,7 +89,7 @@ func (suite *InitTestSuite) TestInitialize() {
 	assert.NoError(suite.T(), err)
 
 	service, _, err := Initialize(
-		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	suite.NotNil(service)
@@ -113,7 +113,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_ListEndpoint() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodGet, "/user-types", nil)
@@ -141,7 +141,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CreateEndpoint() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodPost, "/user-types", nil)
@@ -177,7 +177,7 @@ func (suite *InitTestSuite) TestInitialize_DBTransactionerError() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.Error(suite.T(), err)
 	if err != nil {
 		assert.Contains(suite.T(), err.Error(), "failed to get config database client")
@@ -201,7 +201,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_GetByIDEndpoint() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodGet, "/user-types/test-id", nil)
@@ -229,7 +229,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_UpdateEndpoint() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodPut, "/user-types/test-id", nil)
@@ -257,7 +257,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_DeleteEndpoint() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodDelete, "/user-types/test-id", nil)
@@ -285,7 +285,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSPreflight() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodOptions, "/user-types", nil)
@@ -313,7 +313,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSPreflightByID() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodOptions, "/user-types/test-id", nil)
@@ -521,7 +521,7 @@ func TestInitialize_Standalone(t *testing.T) {
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
-	service, exporter, err := Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
+	service, exporter, err := Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
@@ -714,7 +714,7 @@ func TestInitialize_MutableMode(t *testing.T) {
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
-	service, exporter, err := Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
+	service, exporter, err := Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
@@ -757,7 +757,7 @@ func TestInitialize_StoreModes(t *testing.T) {
 				Maybe()
 			mockConsentService := mockConsentServiceWithDisabled(t)
 
-			service, exporter, err := Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
+			service, exporter, err := Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, service)
@@ -1148,7 +1148,7 @@ func TestInitialize_WithDeclarativeResourcesEnabled_InvalidYAML(t *testing.T) {
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
 	// Initialize should return an error due to invalid YAML
-	_, _, err = Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }
@@ -1208,7 +1208,7 @@ schema: |
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
 	// Initialize should return an error due to validation failure
-	_, _, err = Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }
@@ -1282,7 +1282,7 @@ schema: |
 		}).Once()
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
-	_, _, err = Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 
@@ -1342,7 +1342,7 @@ schema: |
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
 	// Initialize should return an error due to invalid JSON
-	_, _, err = Initialize(mux, cache.Initialize(), mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }

--- a/backend/internal/entitytype/tools.go
+++ b/backend/internal/entitytype/tools.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package entitytype
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+)
+
+type entityTypeTools struct {
+	entityTypeService EntityTypeServiceInterface
+}
+
+// entityTypeMCPItem is the MCP list-response item. HTTP pagination fields
+// (StartIndex, Count, Links) and the raw Schema blob are excluded.
+type entityTypeMCPItem struct {
+	ID                    string            `json:"id,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	OUID                  string            `json:"ouId"`
+	OUHandle              string            `json:"ouHandle,omitempty"`
+	AllowSelfRegistration bool              `json:"allowSelfRegistration"`
+	SystemAttributes      *SystemAttributes `json:"systemAttributes,omitempty"`
+	IsReadOnly            bool              `json:"isReadOnly"`
+}
+
+// entityTypeListMCPResponse is the MCP list tool output.
+type entityTypeListMCPResponse struct {
+	TotalResults int                 `json:"totalResults"`
+	Types        []entityTypeMCPItem `json:"types"`
+}
+
+// registerMCPTools registers all entity type MCP tools with the server.
+func registerMCPTools(server *mcp.Server, entityTypeService EntityTypeServiceInterface) {
+	tools := &entityTypeTools{entityTypeService: entityTypeService}
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_list_user_types",
+		Description: `List all user types.`,
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "List User Types",
+			ReadOnlyHint: true,
+		},
+	}, tools.listUserTypes)
+}
+
+// listUserTypes handles the list_user_types tool call.
+func (t *entityTypeTools) listUserTypes(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	_ any,
+) (*mcp.CallToolResult, *entityTypeListMCPResponse, error) {
+	resp, svcErr := t.entityTypeService.GetEntityTypeList(ctx, TypeCategoryUser, serverconst.MaxPageSize, 0, false)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf("failed to list user types: %s", svcErr.ErrorDescription)
+	}
+
+	items := make([]entityTypeMCPItem, len(resp.Types))
+	for i, et := range resp.Types {
+		items[i] = entityTypeMCPItem{
+			ID:                    et.ID,
+			Name:                  et.Name,
+			OUID:                  et.OUID,
+			OUHandle:              et.OUHandle,
+			AllowSelfRegistration: et.AllowSelfRegistration,
+			SystemAttributes:      et.SystemAttributes,
+			IsReadOnly:            et.IsReadOnly,
+		}
+	}
+
+	return nil, &entityTypeListMCPResponse{
+		TotalResults: resp.TotalResults,
+		Types:        items,
+	}, nil
+}

--- a/backend/internal/entitytype/tools_test.go
+++ b/backend/internal/entitytype/tools_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package entitytype
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	i18ncore "github.com/thunder-id/thunderid/internal/system/i18n/core"
+)
+
+type EntityTypeToolsTestSuite struct {
+	suite.Suite
+}
+
+func TestEntityTypeToolsTestSuite(t *testing.T) {
+	suite.Run(t, new(EntityTypeToolsTestSuite))
+}
+
+func (suite *EntityTypeToolsTestSuite) TestListUserTypes_Success() {
+	mockService := NewEntityTypeServiceInterfaceMock(suite.T())
+	tools := &entityTypeTools{entityTypeService: mockService}
+
+	expectedTypes := []EntityTypeListItem{
+		{
+			ID:                    "et1",
+			Name:                  "Employee",
+			OUID:                  "ou1",
+			OUHandle:              "engineering",
+			AllowSelfRegistration: false,
+			IsReadOnly:            false,
+		},
+		{
+			ID:                    "et2",
+			Name:                  "Customer",
+			OUID:                  "ou2",
+			OUHandle:              "sales",
+			AllowSelfRegistration: true,
+			IsReadOnly:            true,
+		},
+	}
+
+	mockService.On("GetEntityTypeList", mock.Anything, TypeCategoryUser, mock.Anything, mock.Anything, false).
+		Return(&EntityTypeListResponse{
+			TotalResults: 2,
+			Types:        expectedTypes,
+		}, nil)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.listUserTypes(ctx, req, nil)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), output)
+	assert.Equal(suite.T(), 2, output.TotalResults)
+	assert.Len(suite.T(), output.Types, 2)
+
+	item := output.Types[0]
+	assert.Equal(suite.T(), "et1", item.ID)
+	assert.Equal(suite.T(), "Employee", item.Name)
+	assert.Equal(suite.T(), "ou1", item.OUID)
+	assert.Equal(suite.T(), "engineering", item.OUHandle)
+	assert.False(suite.T(), item.AllowSelfRegistration)
+	assert.False(suite.T(), item.IsReadOnly)
+
+	item2 := output.Types[1]
+	assert.Equal(suite.T(), "et2", item2.ID)
+	assert.True(suite.T(), item2.AllowSelfRegistration)
+	assert.True(suite.T(), item2.IsReadOnly)
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *EntityTypeToolsTestSuite) TestListUserTypes_ServiceError() {
+	mockService := NewEntityTypeServiceInterfaceMock(suite.T())
+	tools := &entityTypeTools{entityTypeService: mockService}
+
+	mockService.On("GetEntityTypeList", mock.Anything, TypeCategoryUser, mock.Anything, mock.Anything, false).
+		Return(nil, &serviceerror.ServiceError{
+			ErrorDescription: i18ncore.I18nMessage{DefaultValue: "database error"},
+		})
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.listUserTypes(ctx, req, nil)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Nil(suite.T(), output)
+	assert.Contains(suite.T(), err.Error(), "failed to list user types")
+
+	mockService.AssertExpectations(suite.T())
+}

--- a/backend/internal/ou/init.go
+++ b/backend/internal/ou/init.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/thunder-id/thunderid/internal/system/cache"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
@@ -34,7 +36,9 @@ import (
 // It returns the service, a hierarchy resolver (for injection into the authz service to
 // avoid an import cycle), and the declarative resource exporter.
 func Initialize(
-	mux *http.ServeMux, cacheManager cache.CacheManagerInterface,
+	mux *http.ServeMux,
+	mcpServer *mcp.Server,
+	cacheManager cache.CacheManagerInterface,
 	authzService sysauthz.SystemAuthorizationServiceInterface,
 ) (ConfigurableOUService, sysauthz.OUHierarchyResolver, declarativeresource.ResourceExporter, error) {
 	ouStore, transactioner, err := initializeStore(cacheManager)
@@ -46,6 +50,10 @@ func Initialize(
 
 	ouHandler := newOrganizationUnitHandler(ouService)
 	registerRoutes(mux, ouHandler)
+
+	if mcpServer != nil {
+		registerMCPTools(mcpServer, ouService)
+	}
 
 	// Create the hierarchy resolver backed directly by the store (no authz checks) so
 	// the authz service can traverse the OU tree without recursive authorization calls.

--- a/backend/internal/ou/init_test.go
+++ b/backend/internal/ou/init_test.go
@@ -69,7 +69,7 @@ func (suite *InitTestSuite) TestInitialize_WithDeclarativeResourcesDisabled() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, resolver, exporter, err := Initialize(mux, nil, nil)
+	service, resolver, exporter, err := Initialize(mux, nil, nil, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
@@ -90,7 +90,7 @@ func (suite *InitTestSuite) TestInitialize_WithDeclarativeResourcesEnabled() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, resolver, exporter, err := Initialize(mux, nil, nil)
+	service, resolver, exporter, err := Initialize(mux, nil, nil, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
@@ -111,7 +111,7 @@ func (suite *InitTestSuite) TestInitialize_FileBasedStoreCreation() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, resolver, exporter, err := Initialize(mux, nil, nil)
+	service, resolver, exporter, err := Initialize(mux, nil, nil, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
@@ -132,7 +132,7 @@ func (suite *InitTestSuite) TestInitialize_DatabaseStoreCreation() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, resolver, exporter, err := Initialize(mux, nil, nil)
+	service, resolver, exporter, err := Initialize(mux, nil, nil, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
@@ -149,7 +149,7 @@ func (suite *InitTestSuite) TestInitialize_RoutesRegistered() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, resolver, exporter, err := Initialize(mux, nil, nil)
+	service, resolver, exporter, err := Initialize(mux, nil, nil, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
@@ -170,7 +170,7 @@ func (suite *InitTestSuite) TestInitialize_ExporterInterfaceCompliance() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, resolver, exporter, err := Initialize(mux, nil, nil)
+	service, resolver, exporter, err := Initialize(mux, nil, nil, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
@@ -198,7 +198,7 @@ func (suite *InitTestSuite) TestInitialize_ServiceInterfaceCompliance() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, resolver, exporter, err := Initialize(mux, nil, nil)
+	service, resolver, exporter, err := Initialize(mux, nil, nil, nil)
 
 	// Assert
 	assert.NoError(suite.T(), err)
@@ -215,14 +215,14 @@ func (suite *InitTestSuite) TestInitialize_MultipleInitializations() {
 	runtime.Config.DeclarativeResources.Enabled = false
 
 	mux1 := http.NewServeMux()
-	service1, resolver1, exporter1, err1 := Initialize(mux1, nil, nil)
+	service1, resolver1, exporter1, err1 := Initialize(mux1, nil, nil, nil)
 	assert.NoError(suite.T(), err1)
 	assert.NotNil(suite.T(), service1)
 	assert.NotNil(suite.T(), resolver1)
 	assert.NotNil(suite.T(), exporter1)
 
 	mux2 := http.NewServeMux()
-	service2, resolver2, exporter2, err2 := Initialize(mux2, nil, nil)
+	service2, resolver2, exporter2, err2 := Initialize(mux2, nil, nil, nil)
 	assert.NoError(suite.T(), err2)
 	assert.NotNil(suite.T(), service2)
 	assert.NotNil(suite.T(), resolver2)

--- a/backend/internal/ou/tools.go
+++ b/backend/internal/ou/tools.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ou
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+)
+
+type ouTools struct {
+	ouService OrganizationUnitServiceInterface
+}
+
+// ouMCPItem is the MCP list-response item. HTTP pagination fields
+// (StartIndex, Count, Links) are excluded, and time.Time fields are
+// serialized as strings to produce a stable JSON schema.
+type ouMCPItem struct {
+	ID          string `json:"id"`
+	Handle      string `json:"handle"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	LogoURL     string `json:"logoUrl,omitempty"`
+	IsReadOnly  bool   `json:"isReadOnly"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	UpdatedAt   string `json:"updatedAt,omitempty"`
+}
+
+// ouListMCPResponse is the MCP list tool output.
+type ouListMCPResponse struct {
+	TotalResults      int         `json:"totalResults"`
+	OrganizationUnits []ouMCPItem `json:"organizationUnits"`
+}
+
+// registerMCPTools registers all OU MCP tools with the server.
+func registerMCPTools(server *mcp.Server, ouService OrganizationUnitServiceInterface) {
+	tools := &ouTools{ouService: ouService}
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_list_organization_units",
+		Description: `List all organization units.`,
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "List Organization Units",
+			ReadOnlyHint: true,
+		},
+	}, tools.listOrganizationUnits)
+}
+
+// listOrganizationUnits handles the list_organization_units tool call.
+func (t *ouTools) listOrganizationUnits(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	_ any,
+) (*mcp.CallToolResult, *ouListMCPResponse, error) {
+	resp, svcErr := t.ouService.GetOrganizationUnitList(ctx, serverconst.MaxPageSize, 0, nil)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf("failed to list organization units: %s", svcErr.ErrorDescription)
+	}
+
+	items := make([]ouMCPItem, len(resp.OrganizationUnits))
+	for i, ou := range resp.OrganizationUnits {
+		items[i] = ouMCPItem{
+			ID:          ou.ID,
+			Handle:      ou.Handle,
+			Name:        ou.Name,
+			Description: ou.Description,
+			LogoURL:     ou.LogoURL,
+			IsReadOnly:  ou.IsReadOnly,
+			CreatedAt:   ou.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			UpdatedAt:   ou.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		}
+	}
+
+	return nil, &ouListMCPResponse{
+		TotalResults:      resp.TotalResults,
+		OrganizationUnits: items,
+	}, nil
+}

--- a/backend/internal/ou/tools_test.go
+++ b/backend/internal/ou/tools_test.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ou
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	i18ncore "github.com/thunder-id/thunderid/internal/system/i18n/core"
+)
+
+type OUToolsTestSuite struct {
+	suite.Suite
+}
+
+func TestOUToolsTestSuite(t *testing.T) {
+	suite.Run(t, new(OUToolsTestSuite))
+}
+
+func (suite *OUToolsTestSuite) TestListOrganizationUnits_Success() {
+	mockService := NewOrganizationUnitServiceInterfaceMock(suite.T())
+	tools := &ouTools{ouService: mockService}
+
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expectedOUs := []OrganizationUnitBasic{
+		{
+			ID:          "ou1",
+			Handle:      "engineering",
+			Name:        "Engineering",
+			Description: "Engineering OU",
+			LogoURL:     "https://example.com/logo.png",
+			IsReadOnly:  false,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+		{
+			ID:         "ou2",
+			Handle:     "marketing",
+			Name:       "Marketing",
+			IsReadOnly: true,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+	}
+
+	mockService.On("GetOrganizationUnitList", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(&OrganizationUnitListResponse{
+			TotalResults:      2,
+			OrganizationUnits: expectedOUs,
+		}, nil)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.listOrganizationUnits(ctx, req, nil)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), output)
+	assert.Equal(suite.T(), 2, output.TotalResults)
+	assert.Len(suite.T(), output.OrganizationUnits, 2)
+
+	item := output.OrganizationUnits[0]
+	assert.Equal(suite.T(), "ou1", item.ID)
+	assert.Equal(suite.T(), "engineering", item.Handle)
+	assert.Equal(suite.T(), "Engineering", item.Name)
+	assert.Equal(suite.T(), "Engineering OU", item.Description)
+	assert.Equal(suite.T(), "https://example.com/logo.png", item.LogoURL)
+	assert.False(suite.T(), item.IsReadOnly)
+	assert.Equal(suite.T(), "2026-01-01T00:00:00Z", item.CreatedAt)
+	assert.Equal(suite.T(), "2026-01-01T00:00:00Z", item.UpdatedAt)
+
+	item2 := output.OrganizationUnits[1]
+	assert.Equal(suite.T(), "ou2", item2.ID)
+	assert.True(suite.T(), item2.IsReadOnly)
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *OUToolsTestSuite) TestListOrganizationUnits_Error() {
+	mockService := NewOrganizationUnitServiceInterfaceMock(suite.T())
+	tools := &ouTools{ouService: mockService}
+
+	mockService.On("GetOrganizationUnitList", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, &serviceerror.ServiceError{
+			ErrorDescription: i18ncore.I18nMessage{DefaultValue: "database error"},
+		})
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.listOrganizationUnits(ctx, req, nil)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Nil(suite.T(), output)
+	assert.Contains(suite.T(), err.Error(), "failed to list organization units")
+
+	mockService.AssertExpectations(suite.T())
+}


### PR DESCRIPTION
### Purpose
Improve ThunderID MCP server

### Approach
This pull request introduces MCP (Model Context Protocol) tool support for theme management and entity type services, and refactors service initialization to enable tool registration during startup. It also improves the application template MCP tools to support theme selection and provides more structured output. The most important changes are grouped below:

### MCP Tool Integration

* Added `registerMCPTools` to `thememgt` and `entitytype` packages, registering MCP tools for listing and retrieving themes and entity types. This enables external systems to discover and interact with these resources via MCP. (`backend/internal/design/theme/mgt/tools.go` [[1]](diffhunk://#diff-854723dd209a6586f9ef4101205705a5e53db3c51d4ec016366c00898aefbc51R1-R153) `backend/internal/entitytype/init.go` [[2]](diffhunk://#diff-86449f7f73dac729a9b401954bfa62ca9f4247e0b5f26c2d16aed32fc9f22cc1R68-R71)
* Refactored service initialization in `servicemanager.go` to initialize the MCP server early and pass it to downstream services, allowing them to register their MCP tools during startup. (`backend/cmd/server/servicemanager.go` [[1]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216R113-R115) [[2]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L129-R132) [[3]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L154-R157) [[4]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L286-R286) [[5]](diffhunk://#diff-36914807f52c25f79a7d09a3a5cca10a8adb6df10e3df582e89ea4c713143216L221-L223)

### Theme Management Improvements

* Updated the theme management service initialization to accept and use an MCP server reference for tool registration. (`backend/internal/design/theme/mgt/init.go` [[1]](diffhunk://#diff-7282131a3c859c9675e11cd990e6b4af730a01f6ead9cc5ad2dc71ae3e0ffc2bR24-R32) [[2]](diffhunk://#diff-7282131a3c859c9675e11cd990e6b4af730a01f6ead9cc5ad2dc71ae3e0ffc2bR44-R47)
* Implemented two MCP tools: `thunderid_list_themes` (lists all themes with summary info) and `thunderid_get_theme_by_id` (retrieves full theme details including color and typography config). (`backend/internal/design/theme/mgt/tools.go` [backend/internal/design/theme/mgt/tools.goR1-R153](diffhunk://#diff-854723dd209a6586f9ef4101205705a5e53db3c51d4ec016366c00898aefbc51R1-R153))

### Application Template Tool Enhancements

* Updated the `getApplicationTemplates` MCP tool to include theme selection guidance in the description and add a `themeId` field to SPA, Mobile, and Server templates. M2M templates do not include `themeId`. (`backend/internal/application/tools.go` [[1]](diffhunk://#diff-0dce7f9f481cd90f115e5867a97c396c7555af7c30850f6320b79c394b3068e2L81-R88) [[2]](diffhunk://#diff-0dce7f9f481cd90f115e5867a97c396c7555af7c30850f6320b79c394b3068e2L118-R129)
* Refactored the template output to use strongly-typed `ApplicationDTO` structs instead of generic maps, improving schema accuracy and downstream usage. (`backend/internal/application/tools.go` [[1]](diffhunk://#diff-0dce7f9f481cd90f115e5867a97c396c7555af7c30850f6320b79c394b3068e2L214-R320) `backend/internal/application/tools_test.go` [[2]](diffhunk://#diff-8480a385e2d0736309e205584cec7871e9a35e0cea379866759851ff164f9a6fL364-R366)

### Entity Type Service Enhancements

* Modified entity type service initialization to accept and use an MCP server reference for registering MCP tools. (`backend/internal/entitytype/init.go` [[1]](diffhunk://#diff-86449f7f73dac729a9b401954bfa62ca9f4247e0b5f26c2d16aed32fc9f22cc1R24-R25) [[2]](diffhunk://#diff-86449f7f73dac729a9b401954bfa62ca9f4247e0b5f26c2d16aed32fc9f22cc1R39)

These changes collectively improve extensibility, schema correctness, and developer experience for MCP-based integrations.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP-accessible tools for listing themes, user types, and organization units; application templates now expose typed SPA/Mobile/Server/M2M templates with explicit themeId behavior.

* **Documentation**
  * Expanded React SDK guide (Mode 1→2 migration, hosted signup flow, route protection, examples) and enhanced application creation docs (auth flow defaults, token/user-attribute behavior, themeId usage).

* **Tests**
  * Added and updated tests covering templates and new management tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->