### PR TITLE
Introduce `ExpressJS` integration to ThunderID

### DIFF
--- a/frontend/apps/console/src/features/applications/components/create-application/ShowClientSecret.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/ShowClientSecret.tsx
@@ -29,6 +29,10 @@ export interface ShowClientSecretProps {
    */
   appName: string;
   /**
+   * The client ID of the created application
+   */
+  clientId?: string;
+  /**
    * The client secret that needs to be saved
    */
   clientSecret: string;
@@ -48,16 +52,24 @@ export interface ShowClientSecretProps {
  */
 export default function ShowClientSecret({
   appName,
+  clientId = '',
   clientSecret,
   onCopySecret = () => null,
   onContinue,
 }: ShowClientSecretProps): JSX.Element {
   const {t} = useTranslation();
   const [showSecret, setShowSecret] = useState(false);
+  const {copy: copyClientId} = useCopyToClipboard({
+    resetDelay: 2000,
+  }) as {copied: boolean; copy: (text: string) => Promise<void>};
   const {copied, copy} = useCopyToClipboard({
     resetDelay: 2000,
     onCopy: onCopySecret,
   }) as {copied: boolean; copy: (text: string) => Promise<void>};
+
+  const handleClientIdCopy = async (): Promise<void> => {
+    await copyClientId(clientId);
+  };
 
   const handleCopy = async (): Promise<void> => {
     await copy(clientSecret);
@@ -112,6 +124,42 @@ export default function ShowClientSecret({
             <Typography variant="body1">{appName}</Typography>
           </Box>
 
+          {clientId && (
+            <>
+              <Divider />
+
+              <Box>
+                <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 1}}>
+                  {t('applications:clientSecret.clientIdLabel')}
+                </Typography>
+                <TextField
+                  fullWidth
+                  data-testid="application-client-id-value"
+                  value={clientId}
+                  InputProps={{
+                    readOnly: true,
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          aria-label={`${t('common:actions.copy')} ${t('applications:clientSecret.clientIdLabel')}`}
+                          onClick={() => {
+                            handleClientIdCopy().catch(() => {
+                              // Error already handled in handleClientIdCopy
+                            });
+                          }}
+                          edge="end"
+                          size="small"
+                        >
+                          <Copy size={16} />
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+              </Box>
+            </>
+          )}
+
           <Divider />
 
           <Box>
@@ -127,10 +175,16 @@ export default function ShowClientSecret({
                 readOnly: true,
                 endAdornment: (
                   <InputAdornment position="end">
-                    <IconButton onClick={handleToggleVisibility} edge="end" size="small">
+                    <IconButton
+                      aria-label={t('applications:regenerateSecret.success.toggleVisibility')}
+                      onClick={handleToggleVisibility}
+                      edge="end"
+                      size="small"
+                    >
                       {showSecret ? <EyeOff size={16} /> : <Eye size={16} />}
                     </IconButton>
                     <IconButton
+                      aria-label={`${t('common:actions.copy')} ${t('applications:clientSecret.clientSecretLabel')}`}
                       onClick={() => {
                         handleCopy().catch(() => {
                           // Error already handled in handleCopy

--- a/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureStack.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureStack.test.tsx
@@ -295,6 +295,7 @@ describe('ConfigureStack', () => {
       onReadyChange: vi.fn(),
     });
 
+    expect(screen.getByText('applications:onboarding.configure.stack.technology.express.title')).toBeInTheDocument();
     expect(screen.getByText('applications:onboarding.configure.stack.technology.react.title')).toBeInTheDocument();
     expect(screen.getByText('applications:onboarding.configure.stack.technology.nextjs.title')).toBeInTheDocument();
   });

--- a/frontend/apps/console/src/features/applications/components/create-application/__tests__/ShowClientSecret.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/__tests__/ShowClientSecret.test.tsx
@@ -35,6 +35,7 @@ describe('ShowClientSecret', () => {
 
   const defaultProps: ShowClientSecretProps = {
     appName: 'Test Application',
+    clientId: 'test_client_id_12345',
     clientSecret: 'test_secret_12345',
     onCopySecret: mockOnCopySecret,
     onContinue: mockOnContinue,
@@ -73,6 +74,15 @@ describe('ShowClientSecret', () => {
       expect(screen.getByText('Test Application')).toBeInTheDocument();
     });
 
+    it('should render the client ID field', () => {
+      renderComponent();
+
+      expect(screen.getByText('Client ID')).toBeInTheDocument();
+      const input = screen.getByDisplayValue('test_client_id_12345');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('readonly');
+    });
+
     it('should render the client secret field', () => {
       renderComponent();
 
@@ -106,13 +116,7 @@ describe('ShowClientSecret', () => {
       const input = screen.getByDisplayValue('test_secret_12345');
       expect(input).toHaveAttribute('type', 'password');
 
-      // Get all icon buttons - the first one in the input should be the visibility toggle
-      const allButtons = screen.getAllByRole('button');
-      // Filter to get only icon buttons (small buttons without text content)
-      const iconButtons = allButtons.filter((btn) => btn.querySelector('svg'));
-      // The first icon button should be the visibility toggle
-      const visibilityButton = iconButtons[0];
-      expect(visibilityButton).toBeInTheDocument();
+      const visibilityButton = screen.getByRole('button', {name: 'Toggle secret visibility'});
 
       await user.click(visibilityButton);
 
@@ -132,17 +136,25 @@ describe('ShowClientSecret', () => {
       const user = userEvent.setup();
       renderComponent();
 
-      // Get all icon buttons - the second one in the input should be the copy button
-      const allButtons = screen.getAllByRole('button');
-      const iconButtons = allButtons.filter((btn) => btn.querySelector('svg'));
-      // The second icon button should be the copy button (first is visibility toggle)
-      const copyButton = iconButtons[1];
-      expect(copyButton).toBeInTheDocument();
+      const copyButton = screen.getByRole('button', {name: 'Copy Client Secret'});
 
       await user.click(copyButton);
 
       await waitFor(() => {
         expect(mockCopy).toHaveBeenCalledWith('test_secret_12345');
+      });
+    });
+
+    it('should call copy function when copy client ID button is clicked', async () => {
+      const user = userEvent.setup();
+      renderComponent();
+
+      const copyButton = screen.getByRole('button', {name: 'Copy Client ID'});
+
+      await user.click(copyButton);
+
+      await waitFor(() => {
+        expect(mockCopy).toHaveBeenCalledWith('test_client_id_12345');
       });
     });
 
@@ -184,10 +196,12 @@ describe('ShowClientSecret', () => {
     it('should call onCopySecret callback through useCopyToClipboard', () => {
       renderComponent();
 
-      // Get the config passed to useCopyToClipboard
-      const hookCall = vi.mocked(useCopyToClipboard).mock.calls[0][0];
-      expect(hookCall).toHaveProperty('onCopy', mockOnCopySecret);
-      expect(hookCall).toHaveProperty('resetDelay', 2000);
+      const hookCalls = vi.mocked(useCopyToClipboard).mock.calls.map((call) => call[0]);
+      const secretHookCall = hookCalls.find((call) => call?.onCopy === mockOnCopySecret);
+
+      expect(secretHookCall).toBeDefined();
+      expect(secretHookCall).toHaveProperty('onCopy', mockOnCopySecret);
+      expect(secretHookCall).toHaveProperty('resetDelay', 2000);
     });
   });
 
@@ -215,6 +229,12 @@ describe('ShowClientSecret', () => {
 
       const input = screen.getByDisplayValue('different_secret_abc');
       expect(input).toBeInTheDocument();
+    });
+
+    it('should not render the client ID field when not provided', () => {
+      renderComponent({clientId: ''});
+
+      expect(screen.queryByText('Client ID')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/apps/console/src/features/applications/config/TechnologyBasedApplicationTemplateMetadata.tsx
+++ b/frontend/apps/console/src/features/applications/config/TechnologyBasedApplicationTemplateMetadata.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import ExpressTemplate from '../data/application-templates/technology-based/express.json';
 import NextJSTemplate from '../data/application-templates/technology-based/nextjs.json';
 import ReactTemplate from '../data/application-templates/technology-based/react.json';
 import type {ApplicationTemplate, ApplicationTemplateMetadata} from '../models/application-templates';
@@ -47,6 +48,18 @@ const TechnologyBasedApplicationTemplateMetadata: ApplicationTemplateMetadata<Te
     titleKey: 'applications:onboarding.configure.stack.technology.react.title',
     descriptionKey: 'applications:onboarding.configure.stack.technology.react.description',
     template: ReactTemplate as ApplicationTemplate,
+  },
+  {
+    value: TechnologyApplicationTemplate.EXPRESS,
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 16 16" fill="none">
+        <rect width="16" height="16" rx="4" fill="#111827" />
+        <path d="M4.25 5.25h7.5v1h-6.25v1.75h5.75v1h-5.75v1.75h6.25v1h-7.5v-6.5Z" fill="#fff" />
+      </svg>
+    ),
+    titleKey: 'applications:onboarding.configure.stack.technology.express.title',
+    descriptionKey: 'applications:onboarding.configure.stack.technology.express.description',
+    template: ExpressTemplate as ApplicationTemplate,
   },
   {
     value: TechnologyApplicationTemplate.NEXTJS,

--- a/frontend/apps/console/src/features/applications/config/__tests__/TechnologyBasedApplicationTemplateMetadata.test.tsx
+++ b/frontend/apps/console/src/features/applications/config/__tests__/TechnologyBasedApplicationTemplateMetadata.test.tsx
@@ -27,8 +27,8 @@ describe('TechnologyBasedApplicationTemplateMetadata', () => {
       expect(Array.isArray(TechnologyBasedApplicationTemplateMetadata)).toBe(true);
     });
 
-    it('should have at least 2 technology templates', () => {
-      expect(TechnologyBasedApplicationTemplateMetadata.length).toBeGreaterThanOrEqual(2);
+    it('should have at least 3 technology templates', () => {
+      expect(TechnologyBasedApplicationTemplateMetadata.length).toBeGreaterThanOrEqual(3);
     });
 
     it('should have all required properties for each template', () => {
@@ -39,6 +39,42 @@ describe('TechnologyBasedApplicationTemplateMetadata', () => {
         expect(metadata).toHaveProperty('descriptionKey');
         expect(metadata).toHaveProperty('template');
       });
+    });
+  });
+
+  describe('Express Technology', () => {
+    const expressMetadata = TechnologyBasedApplicationTemplateMetadata.find(
+      (m) => m.value === TechnologyApplicationTemplate.EXPRESS,
+    );
+
+    it('should exist', () => {
+      expect(expressMetadata).toBeDefined();
+    });
+
+    it('should have correct value', () => {
+      expect(expressMetadata?.value).toBe(TechnologyApplicationTemplate.EXPRESS);
+    });
+
+    it('should have icon component', () => {
+      expect(expressMetadata?.icon).toBeDefined();
+      const {container} = render(<div>{expressMetadata?.icon}</div>);
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('should have correct i18n keys', () => {
+      expect(expressMetadata?.titleKey).toBe('applications:onboarding.configure.stack.technology.express.title');
+      expect(expressMetadata?.descriptionKey).toBe(
+        'applications:onboarding.configure.stack.technology.express.description',
+      );
+    });
+
+    it('should have a template', () => {
+      expect(expressMetadata?.template).toBeDefined();
+      expect(expressMetadata?.template).toHaveProperty(['defaults', 'name']);
+    });
+
+    it('should not be disabled', () => {
+      expect(expressMetadata?.disabled).not.toBe(true);
     });
   });
 
@@ -140,6 +176,7 @@ describe('TechnologyBasedApplicationTemplateMetadata', () => {
 
     it('should have at least React and Next.js templates', () => {
       const configuredValues = TechnologyBasedApplicationTemplateMetadata.map((m) => m.value);
+      expect(configuredValues).toContain(TechnologyApplicationTemplate.EXPRESS);
       expect(configuredValues).toContain(TechnologyApplicationTemplate.REACT);
       expect(configuredValues).toContain(TechnologyApplicationTemplate.NEXTJS);
     });

--- a/frontend/apps/console/src/features/applications/data/application-templates/technology-based/express.json
+++ b/frontend/apps/console/src/features/applications/data/application-templates/technology-based/express.json
@@ -1,0 +1,107 @@
+{
+  "id": "express",
+  "displayName": "Express.js",
+  "description": "Server-side Node.js application built with Express.js",
+  "defaults": {
+    "name": "Express.js Application",
+    "inboundAuthConfig": [
+      {
+        "type": "oauth2",
+        "config": {
+          "grantTypes": ["authorization_code", "refresh_token"],
+          "responseTypes": ["code"],
+          "redirectUris": ["http://localhost:3000/login"],
+          "pkceRequired": false,
+          "tokenEndpointAuthMethod": "client_secret_basic",
+          "publicClient": false
+        }
+      }
+    ],
+    "allowedUserTypes": []
+  },
+  "fieldConstraints": {
+    "oauth2": {
+      "publicClient": {
+        "readOnly": true,
+        "value": false
+      },
+      "tokenEndpointAuthMethod": {
+        "readOnly": true,
+        "value": "client_secret_basic"
+      }
+    }
+  },
+  "integrationGuides": {
+    "INBUILT": {
+      "llm_prompt": {
+        "id": "llm-prompt",
+        "title": "Integrate with a Coding Agent Prompt",
+        "description": "Use AI to generate integration code for your Express.js application",
+        "type": "llm",
+        "icon": "sparkles",
+        "content": "# Integrate {{productName}} Authentication in an Express.js Application (Inbuilt Mode)\n\n## Context\nI have an Express.js application and I want to integrate {{productName}} authentication using the ThunderID Express SDK with {{productName}}-hosted sign-in pages.\n\n## Requirements\n- Use `@thunderid/express` in a Node.js + Express application\n- Use `cookie-parser` and `express.json()` middleware\n- Configure ThunderID middleware with `baseUrl`, `clientId`, `clientSecret`, `afterSignInUrl`, and `afterSignOutUrl`\n- Implement `/login` with `handleSignIn()` and `/logout` with `handleSignOut()`\n- Protect a route (`/protected`) using `protect((res) => res.redirect('/login'))`\n- Add a `/me` route that returns the authenticated user profile as JSON\n- Keep the code minimal, production-lean, and fully runnable\n\n## Configuration\n- **Client ID**: {{clientId}}\n- **Client Secret**: `<your-client-secret>`\n- **Base URL**: https://localhost:8090 (or your {{productName}} instance URL)\n- **App URL**: http://localhost:3000\n- **Login Callback Route**: `/login`\n- **Logout Callback Route**: `/logout`\n- **SDK**: @thunderid/express\n\n## Important Rules\n- Use CommonJS syntax (`require`) in `index.js`\n- Use these SDK imports exactly: `thunderID`, `handleSignIn`, `handleSignOut`, `protect`\n- Ensure redirect URL alignment: the app callback URL must be `http://localhost:3000/login`, and the post-logout redirect URL must be `http://localhost:3000/logout`\n- Do not invent unsupported SDK APIs or custom wrappers\n- Keep route names and behavior exactly as specified\n\n## Implementation Steps\n1. Create a new project and install `express` and `cookie-parser`\n2. Install `@thunderid/express`\n3. Add `index.js` with ThunderID middleware and auth routes\n4. Add `/protected` and `/me` routes with `protect()`\n5. Start the server with `node index.js`\n6. Validate the flow by opening `/protected`, then `/me`\n\nPlease provide:\n- The exact terminal commands\n- A complete `index.js` file\n- A short verification checklist for sign-in, sign-out, and protected route behavior"
+      },
+      "manual_steps": [
+        {
+          "step": 1,
+          "title": "Create an Express app",
+          "description": "Create your project and install the base dependencies:",
+          "code": {
+            "language": "terminal",
+            "content": "mkdir my-express-app\ncd my-express-app\nnpm init -y\nnpm install express cookie-parser"
+          }
+        },
+        {
+          "step": 2,
+          "title": "Install @thunderid/express",
+          "description": "Install the ThunderID Express SDK package:",
+          "code": {
+            "language": "terminal",
+            "content": "npm install @thunderid/express"
+          }
+        },
+        {
+          "step": 3,
+          "title": "Add ThunderID middleware and authentication routes",
+          "description": "Create an index.js file with middleware and auth route handlers:",
+          "code": {
+            "language": "javascript",
+            "filename": "index.js",
+            "content": "const express = require('express');\nconst cookieParser = require('cookie-parser');\nconst {thunderID, handleSignIn, handleSignOut, protect} = require('@thunderid/express');\n\nconst app = express();\nconst port = 3000;\n\napp.use(cookieParser());\napp.use(express.json());\n\napp.use(\n  thunderID({\n    baseUrl: 'https://localhost:8090',\n    clientId: '{{clientId}}',\n    clientSecret: '<your-client-secret>',\n    afterSignInUrl: 'http://localhost:3000/login',\n    afterSignOutUrl: 'http://localhost:3000/logout',\n  }),\n);\n\napp.get('/', (_req, res) => {\n  res.send('<a href=\"/protected\">Go to protected page</a>');\n});\n\napp.get('/login', handleSignIn());\napp.get('/logout', handleSignOut());\n\napp.get(\n  '/protected',\n  protect((res) => res.redirect('/login')),\n  (_req, res) => {\n    res.send('You are signed in and can access this protected route.');\n  },\n);\n\napp.get('/me', protect(), async (req, res) => {\n  const user = await req.thunderIDAuth.getUserFromRequest(req);\n  res.json(user);\n});\n\napp.listen(port, () => {\n  console.log(`Server running on http://localhost:${port}`);\n});"
+          }
+        },
+        {
+          "step": 4,
+          "title": "Update credentials",
+          "description": "Replace the placeholders with your actual application credentials from {{productName}}:",
+          "bullets": [
+            "Replace `{{clientId}}` with your Client ID",
+            "Replace `<your-client-secret>` with your Client Secret",
+            "Ensure your authorized redirect URL is `http://localhost:3000/login`",
+            "Ensure your allowed post-logout redirect URL is `http://localhost:3000/logout`"
+          ]
+        },
+        {
+          "step": 5,
+          "title": "Run the app",
+          "description": "Start your Express server:",
+          "code": {
+            "language": "terminal",
+            "content": "node index.js"
+          }
+        },
+        {
+          "step": 6,
+          "title": "Verify authentication flow",
+          "description": "Test the integration end-to-end:",
+          "bullets": [
+            "Open `http://localhost:3000/protected` and verify redirect to {{productName}} sign-in",
+            "Sign in and confirm access to the protected route",
+            "Open `http://localhost:3000/me` to inspect the signed-in user profile JSON",
+            "Open `http://localhost:3000/logout` while signed in and verify sign-out"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/frontend/apps/console/src/features/applications/models/__tests__/application-templates.test.ts
+++ b/frontend/apps/console/src/features/applications/models/__tests__/application-templates.test.ts
@@ -22,6 +22,10 @@ import type {IntegrationGuide, IntegrationStepCode} from '../application-templat
 
 describe('Application Templates Models', () => {
   describe('TechnologyApplicationTemplate', () => {
+    it('should have EXPRESS template', () => {
+      expect(TechnologyApplicationTemplate.EXPRESS).toBe('EXPRESS');
+    });
+
     it('should have REACT template', () => {
       expect(TechnologyApplicationTemplate.REACT).toBe('REACT');
     });
@@ -35,7 +39,7 @@ describe('Application Templates Models', () => {
     });
 
     it('should have all expected properties', () => {
-      const expectedKeys = ['REACT', 'NEXTJS', 'OTHER'];
+      const expectedKeys = ['REACT', 'EXPRESS', 'NEXTJS', 'OTHER'];
 
       expect(Object.keys(TechnologyApplicationTemplate)).toEqual(expectedKeys);
     });

--- a/frontend/apps/console/src/features/applications/models/application-templates.ts
+++ b/frontend/apps/console/src/features/applications/models/application-templates.ts
@@ -29,6 +29,7 @@ import type {OAuth2Config} from './oauth';
  */
 export const TechnologyApplicationTemplate = {
   REACT: 'REACT',
+  EXPRESS: 'EXPRESS',
   NEXTJS: 'NEXTJS',
   OTHER: 'OTHER',
 } as const;

--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -481,13 +481,21 @@ export default function ApplicationCreatePage(): JSX.Element {
         }
 
         const oauth2Config = createdApplication.inboundAuthConfig?.find((config) => config.type === 'oauth2');
+        const clientId = oauth2Config?.config?.clientId;
         const clientSecret = oauth2Config?.config?.clientSecret;
 
         if (!clientSecret) {
           return null;
         }
 
-        return <ShowClientSecret appName={appName} clientSecret={clientSecret} onContinue={handleNextStep} />;
+        return (
+          <ShowClientSecret
+            appName={appName}
+            clientId={clientId}
+            clientSecret={clientSecret}
+            onContinue={handleNextStep}
+          />
+        );
       }
 
       default:

--- a/frontend/apps/console/src/features/applications/utils/__tests__/getIntegrationGuidesForTemplate.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/getIntegrationGuidesForTemplate.test.ts
@@ -26,6 +26,35 @@ vi.mock('../../config/TechnologyBasedApplicationTemplateMetadata', () => ({
   default: [
     {
       template: {
+        id: 'express',
+        integrationGuides: {
+          inbuilt: {
+            llm_prompt: {
+              id: 'express-llm',
+              title: 'AI-Assisted Integration',
+              description: 'Express integration guide',
+              type: 'llm' as const,
+              icon: 'express',
+              content: 'LLM prompt content',
+            },
+            manual_steps: [
+              {
+                step: 1,
+                title: 'Step E1',
+                description: 'First step description',
+              },
+              {
+                step: 2,
+                title: 'Step E2',
+                description: 'Second step description',
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      template: {
         id: 'react',
         integrationGuides: {
           inbuilt: {
@@ -162,6 +191,31 @@ const mockReactGuides: IntegrationGuides = {
   },
 };
 
+const mockExpressGuides: IntegrationGuides = {
+  inbuilt: {
+    llm_prompt: {
+      id: 'express-llm',
+      title: 'AI-Assisted Integration',
+      description: 'Express integration guide',
+      type: 'llm' as const,
+      icon: 'express',
+      content: 'LLM prompt content',
+    },
+    manual_steps: [
+      {
+        step: 1,
+        title: 'Step E1',
+        description: 'First step description',
+      },
+      {
+        step: 2,
+        title: 'Step E2',
+        description: 'Second step description',
+      },
+    ],
+  },
+};
+
 const mockNextjsGuides: IntegrationGuides = {
   inbuilt: {
     llm_prompt: {
@@ -214,6 +268,12 @@ const mockBrowserGuides: IntegrationGuides = {
 
 describe('getIntegrationGuidesForTemplate', () => {
   describe('Technology-Based Templates', () => {
+    it('should return integration guides for express template', () => {
+      const result = getIntegrationGuidesForTemplate('express');
+
+      expect(result).toEqual(mockExpressGuides);
+    });
+
     it('should return integration guides for react template', () => {
       const result = getIntegrationGuidesForTemplate('react');
 

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1408,6 +1408,9 @@ const translations = {
       'Users will sign in or sign up through your app using the UI components or APIs provided by {{product}}. You can customize and brand the flows using the designer or through code.',
     'onboarding.configure.stack.technology.title': 'Technology',
     'onboarding.configure.stack.technology.subtitle': 'What technology are you using to build your application?',
+    'onboarding.configure.stack.technology.express.title': 'Express.js',
+    'onboarding.configure.stack.technology.express.description':
+      'Server-side Node.js application built with Express.js',
     'onboarding.configure.stack.technology.react.title': 'React',
     'onboarding.configure.stack.technology.react.description': 'Single-page application built with React',
     'onboarding.configure.stack.technology.nextjs.title': 'Next.js',


### PR DESCRIPTION
### Purpose
Add an Express.js technology template to the application creation flow and improve the final onboarding step for confidential applications by showing both the client ID and client secret.

### Approach
- Added a new `express.json` technology template with OAuth defaults, field constraints, and integration guides.
- Wired the Express template into the console technology metadata and added the corresponding i18n labels.
- Updated the final onboarding credential screen to display the generated client ID alongside the client secret.
- Added and updated unit tests for the new technology option, integration guide resolution, and final credential screen behavior.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2859

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Express.js as a selectable application technology with a ready template, OAuth2 defaults, and integration guidance
  * Credentials view now shows a read-only Client ID field with its own copy-to-clipboard control and improved accessibility labels
* **Tests**
  * Expanded test coverage for Express template, credentials UI, and integration guide retrieval
* **Localization**
  * Added English strings for the Express stack option

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->