### PR TITLE
Trust self-issued tokens on secured APIs when a trusted issuer is configured

### DIFF
--- a/backend/internal/system/security/jwt_authenticator.go
+++ b/backend/internal/system/security/jwt_authenticator.go
@@ -60,18 +60,11 @@ func (h *jwtAuthenticator) Authenticate(r *http.Request) (*SecurityContext, erro
 		return nil, errInvalidToken
 	}
 
-	// Step 2: Verify JWT.
-	// If a trusted issuer is configured, the server delegates token issuance to it
-	// and verifies tokens exclusively against its JWKS. Otherwise, verify with the
-	// server's own signing key.
-	if config.GetServerRuntime().Config.Server.SecurityConfig.TrustedIssuer.IsConfigured() {
-		if !h.verifyFederatedToken(token) {
-			return nil, errInvalidToken
-		}
-	} else {
-		if err := h.jwtService.VerifyJWT(token, "", ""); err != nil {
-			return nil, errInvalidToken
-		}
+	// Step 2: Verify the JWT, routing on its issuer. Tokens this server issued
+	// are verified with its own signing key; Additionally when a trusted issuer is
+	// configured, tokens from that issuer are verified against its JWKS.
+	if err := h.verifyToken(token); err != nil {
+		return nil, err
 	}
 
 	// Step 3: Decode JWT payload to extract attributes
@@ -93,6 +86,29 @@ func (h *jwtAuthenticator) Authenticate(r *http.Request) (*SecurityContext, erro
 
 	// Create immutable SecurityContext
 	return newSecurityContext(subject, ouID, token, scopes, attributes), nil
+}
+
+// verifyToken verifies the bearer token by routing on its iss claim against
+// an explicit allowlist of accepted issuers. Tokens from the configured
+// trusted issuer (when set) are verified against its JWKS. Tokens whose iss
+// matches this server's own JWT issuer are verified with the local signing
+// key. Any other iss is rejected. There is no cross-issuer fallback.
+func (h *jwtAuthenticator) verifyToken(token string) error {
+	trustedIssuer := config.GetServerRuntime().Config.Server.SecurityConfig.TrustedIssuer
+	iss := extractIssuer(token)
+	switch {
+	case trustedIssuer.IsConfigured() && iss == trustedIssuer.Issuer:
+		if !h.verifyFederatedToken(token) {
+			return errInvalidToken
+		}
+	case iss == config.GetServerRuntime().Config.JWT.Issuer:
+		if err := h.jwtService.VerifyJWT(token, "", ""); err != nil {
+			return errInvalidToken
+		}
+	default:
+		return errInvalidToken
+	}
+	return nil
 }
 
 // verifyFederatedToken checks if the token is from a trusted external issuer and verifies it via JWKS.
@@ -142,6 +158,17 @@ func extractToken(authHeader string) (string, error) {
 	}
 	token := strings.TrimSpace(utils.TrimPrefixFold(authHeader, constants.AuthSchemeBearer))
 	return token, nil
+}
+
+// extractIssuer returns the iss claim of the token, or an empty string if the
+// token payload cannot be decoded or carries no string iss claim.
+func extractIssuer(token string) string {
+	attributes, err := jwt.DecodeJWTPayload(token)
+	if err != nil {
+		return ""
+	}
+	iss, _ := attributes["iss"].(string)
+	return iss
 }
 
 // extractScopes extracts permissions from JWT claims.

--- a/backend/internal/system/security/jwt_authenticator_test.go
+++ b/backend/internal/system/security/jwt_authenticator_test.go
@@ -459,6 +459,7 @@ const (
 	testFederatedJWKSURL     = "https://external-auth:8090/oauth2/jwks"
 	testFederatedAudience    = "FEDERATED_CONSOLE"
 	testResourceServerAudURL = "https://resource-server:9443"
+	testLocalIssuer          = "https://localhost:8090"
 )
 
 // buildFakeJWT creates a fake JWT string with the given header and payload claims.
@@ -746,9 +747,10 @@ func (suite *JWTAuthenticatorTestSuite) TestVerifyFederatedToken_InvalidPayload(
 }
 
 func (suite *JWTAuthenticatorTestSuite) TestAuthenticate_FederatedTokenFailure() {
-	// When the trusted issuer is configured and federated verification fails
-	// (here, JWKS verification returns an error), Authenticate must reject the
-	// request with errInvalidToken and must NOT fall back to local-key verification.
+	// A token whose issuer is the trusted issuer is routed to federated
+	// verification. When that fails (here, JWKS verification returns an error),
+	// Authenticate must reject the request with errInvalidToken and must NOT
+	// fall back to local-key verification (no cross-issuer fallback).
 	config.ResetServerRuntime()
 	defer config.ResetServerRuntime()
 
@@ -790,9 +792,10 @@ func (suite *JWTAuthenticatorTestSuite) TestAuthenticate_FederatedTokenFailure()
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	authCtx, err := auth.Authenticate(req)
-	assert.Error(suite.T(), err)
+	assert.ErrorIs(suite.T(), err, errInvalidToken)
 	assert.Nil(suite.T(), authCtx)
 	mockJWT.AssertExpectations(suite.T())
+	mockJWT.AssertNotCalled(suite.T(), "VerifyJWT")
 	mockJWT.AssertNotCalled(suite.T(), "VerifyJWTSignature")
 }
 
@@ -842,4 +845,113 @@ func (suite *JWTAuthenticatorTestSuite) TestAuthenticate_FederatedTokenSuccess()
 	assert.Equal(suite.T(), "federated-user", GetSubject(baseCtx))
 	mockJWT.AssertExpectations(suite.T())
 	mockJWT.AssertNotCalled(suite.T(), "VerifyJWTSignature")
+}
+
+// federatedConfigWithLocalIssuer returns a config where a trusted issuer is
+// configured (federated mode) and the server's own JWT issuer is set, so that
+// issuer-based routing can distinguish self-issued tokens from federated ones.
+func federatedConfigWithLocalIssuer() *config.Config {
+	return &config.Config{
+		Server: config.ServerConfig{
+			SecurityConfig: config.SecurityConfig{
+				TrustedIssuer: config.TrustedIssuerConfig{
+					Issuer:   testFederatedIssuer,
+					JWKSURL:  testFederatedJWKSURL,
+					Audience: testFederatedAudience,
+				},
+			},
+		},
+		JWT: config.JWTConfig{Issuer: testLocalIssuer},
+	}
+}
+
+func (suite *JWTAuthenticatorTestSuite) TestAuthenticate_SelfIssuedTokenUnderFederation() {
+	// Regression: a token this server issued itself (e.g. via client_credentials)
+	// must still authenticate against the server's own secured APIs even when a
+	// trusted issuer is configured. It is routed to local-key verification by its
+	// iss claim and must never be sent to the trusted issuer's JWKS.
+	config.ResetServerRuntime()
+	defer config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", federatedConfigWithLocalIssuer())
+
+	token := buildFakeJWT(
+		map[string]interface{}{"alg": "RS256", "kid": "local-kid"},
+		map[string]interface{}{
+			"sub":   "service-app",
+			"iss":   testLocalIssuer,
+			"scope": "system",
+		},
+	)
+
+	mockJWT := jwtmock.NewJWTServiceInterfaceMock(suite.T())
+	mockJWT.On("VerifyJWT", token, "", "").Return(nil)
+	auth := newJWTAuthenticator(mockJWT)
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	authCtx, err := auth.Authenticate(req)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), authCtx)
+
+	baseCtx := withSecurityContext(context.Background(), authCtx)
+	assert.Equal(suite.T(), "service-app", GetSubject(baseCtx))
+	mockJWT.AssertExpectations(suite.T())
+	mockJWT.AssertNotCalled(suite.T(), "VerifyJWTWithJWKS")
+}
+
+func (suite *JWTAuthenticatorTestSuite) TestAuthenticate_SelfIssuedTokenInvalidUnderFederation() {
+	// A self-issued token routed to local verification that fails the signature
+	// check is rejected; it must not be retried against the trusted issuer JWKS.
+	config.ResetServerRuntime()
+	defer config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", federatedConfigWithLocalIssuer())
+
+	token := buildFakeJWT(
+		map[string]interface{}{"alg": "RS256", "kid": "local-kid"},
+		map[string]interface{}{"sub": "service-app", "iss": testLocalIssuer},
+	)
+
+	mockJWT := jwtmock.NewJWTServiceInterfaceMock(suite.T())
+	mockJWT.On("VerifyJWT", token, "", "").Return(&serviceerror.ServiceError{
+		Type:  serviceerror.ServerErrorType,
+		Code:  "INVALID_SIGNATURE",
+		Error: i18ncore.I18nMessage{DefaultValue: "Invalid signature"},
+	})
+	auth := newJWTAuthenticator(mockJWT)
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	authCtx, err := auth.Authenticate(req)
+	assert.ErrorIs(suite.T(), err, errInvalidToken)
+	assert.Nil(suite.T(), authCtx)
+	mockJWT.AssertExpectations(suite.T())
+	mockJWT.AssertNotCalled(suite.T(), "VerifyJWTWithJWKS")
+}
+
+func (suite *JWTAuthenticatorTestSuite) TestAuthenticate_UnknownIssuerUnderFederation() {
+	// A token whose iss is neither the trusted issuer nor this server's own
+	// JWT issuer is rejected outright by the issuer allowlist, with no
+	// verifier invoked.
+	config.ResetServerRuntime()
+	defer config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", federatedConfigWithLocalIssuer())
+
+	token := buildFakeJWT(
+		map[string]interface{}{"alg": "RS256", "kid": "rogue-kid"},
+		map[string]interface{}{"sub": "attacker", "iss": "https://rogue-issuer:9999"},
+	)
+
+	mockJWT := jwtmock.NewJWTServiceInterfaceMock(suite.T())
+	auth := newJWTAuthenticator(mockJWT)
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	authCtx, err := auth.Authenticate(req)
+	assert.ErrorIs(suite.T(), err, errInvalidToken)
+	assert.Nil(suite.T(), authCtx)
+	mockJWT.AssertNotCalled(suite.T(), "VerifyJWT")
+	mockJWT.AssertNotCalled(suite.T(), "VerifyJWTWithJWKS")
 }

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -620,6 +620,8 @@ Controls server-wide security behavior that is not specific to any single authen
 
 Maps to `TrustedIssuerConfig` in the backend, nested under `server.security.trusted_issuer`. Setting `server.security.trusted_issuer.issuer` activates the feature: <ProductName /> trusts access tokens issued by an external authorization server and validates them against the external server's JWKS endpoint. When `issuer` is set, `jwks_url` and `audience` are required and <ProductName /> fails to start if either is missing. This is used for federated authentication scenarios where a central <ProductName /> instance issues tokens that tenant instances accept.
 
+Enabling a trusted issuer is additive and non-breaking. <ProductName /> still accepts the tokens it issues itself, routed by the token's `iss` claim. Existing `client_credentials`, system, and console callers keep working without configuration changes. See [Self-Issued Tokens](/docs/next/guides/guides/trusted-issuer#self-issued-tokens) in the Trusted Issuer guide.
+
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `server.security.trusted_issuer.issuer` | `""` | Expected value of the token's `iss` claim. Must match the external authorization server's issuer URL exactly |

--- a/docs/content/guides/guides/trusted-issuer.mdx
+++ b/docs/content/guides/guides/trusted-issuer.mdx
@@ -84,7 +84,7 @@ The external authorization server must permit this <ProductName /> instance's or
 <ProductName />'s trusted issuer token validation now accepts tokens that omit the `nbf` (not before) claim, aligning with [RFC 7519 Section 4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5). The `aud` (audience) claim is now accepted as either a single string or a JSON array of strings per [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3). These changes improve compatibility with commercial OIDC providers that do not emit `nbf` or that issue array-form `aud`. No client-side migration is required; tokens that were accepted before remain valid.
 :::
 
-When trusted issuer is configured and a request carries a bearer token, <ProductName />:
+When trusted issuer is configured, <ProductName /> routes token verification by the bearer token's `iss` claim (see [Self-Issued Tokens](#self-issued-tokens) below). For a token whose `iss` matches `trusted_issuer.issuer`, <ProductName />:
 
 1. Parses the JWT and confirms its `iss` claim matches `trusted_issuer.issuer`.
 2. Fetches signing keys from `trusted_issuer.jwks_url` and verifies the signature.
@@ -103,9 +103,23 @@ If any step fails, the token is rejected.
 
 **`exp` (Expiry):** This claim is required. Tokens that omit `exp` or provide a non-numeric value are rejected.
 
-<ProductName /> picks the verification method based on the token's `iss` claim. If `iss` matches `trusted_issuer.issuer`, the token is verified against the configured JWKS endpoint. Otherwise, if `iss` matches one of this server's own issuers, <ProductName /> verifies it with its local signing key. Any other `iss` is rejected.
-
 Each `required_claims` entry is matched by exact string equality: the claim must be present on the token and its value must match the configured `value` exactly.
+
+### Self-Issued Tokens
+
+Configuring `server.security.trusted_issuer` is additive. It does not stop <ProductName /> from accepting the tokens it issues itself. <ProductName /> selects the verification method from the token's `iss` claim:
+
+- `iss` matches `trusted_issuer.issuer` — the token is verified against the configured JWKS endpoint, following the steps above.
+- `iss` matches this <ProductName /> instance's own issuer (`jwt.issuer`, which defaults to the instance's public URL) — the token is verified with the instance's local signing key, exactly as when no trusted issuer is configured.
+- Any other `iss`, or a token whose payload cannot be read, is rejected.
+
+Because of this, the tokens this instance issues for itself keep working against its own secured APIs, even with a trusted issuer configured. This includes:
+
+- access tokens from this instance's `client_credentials` grant (service-to-service callers),
+- the system token used during bootstrap and auto-provisioning, and
+- the console session, when console login is not delegated.
+
+Verification never falls back across issuers. A token routed to one verifier is not retried with the other. For example, a token that claims `trusted_issuer.issuer` but fails JWKS verification is rejected. <ProductName /> does not then check it against the local signing key. Setting an `iss` value alone grants nothing, because the signature must still verify against that issuer's keys.
 
 <ProductName /> accepts tokens signed with `RS256`, `PS256`, `RS512`, `ES256`, `ES384`, `ES512`, or `EdDSA`. Tokens using any other algorithm are rejected. JWKS responses are cached in-process for `server.security.jwks_cache_ttl` seconds (default: 300), so plan external-server key rotations with at least that much overlap.
 


### PR DESCRIPTION
### Purpose

Fixes the limitation where **tokens Thunder issues for itself are rejected by Thunder's own secured APIs when `server.security.trusted_issuer` is configured**. In a federated deployment this broke every `client_credentials` (machine-to-machine) caller, as well as the admin/system tokens used by the Console and by bootstrap/auto-provisioning.

Root cause: `jwtAuthenticator.Authenticate()` branched on `TrustedIssuer.IsConfigured()` with a mutually exclusive `if/else`. With a trusted issuer set, only federated (JWKS) verification ran and the local-key path was unreachable, so a self-issued token failed at the `iss != trustedIssuer.Issuer` check before signature/audience were ever evaluated. The token endpoint still minted these tokens and `/oauth2/introspect` still accepted them — only the API gate rejected them.

### Approach

Verification is now **routed by the token's `iss` claim against an explicit allowlist of accepted issuers**:

- `iss` matches the configured trusted issuer (when set) → verify against its JWKS (existing `verifyFederatedToken`, unchanged).
- `iss` matches this server's own JWT issuer (`jwt.issuer`, which defaults to the server's public URL) → verify with the server's signing key.
- Any other / unreadable `iss` → reject (no verifier invoked).

A configured trusted issuer is **additive, not a replacement**: this server keeps accepting the tokens it issues for itself (e.g. `client_credentials`, system/admin) alongside tokens from the configured trusted issuer. There is **no cross-issuer fallback** — a token routed to one verifier is never retried with the other, so spoofing `iss` gains nothing (the signature must still verify against that issuer's key material). This restores consistency with `/oauth2/introspect` and the token service, which already validate self-issued tokens.

The design follows the OAuth/JWT best practice of issuer allowlisting:
- [RFC 8725 §3.1 (JWT BCP)](https://datatracker.ietf.org/doc/html/rfc8725#section-3.1): *"Always validate the issuer of a JWT and accept it only from trusted issuers."*
- [RFC 9068 §4 (JWT Access Tokens)](https://datatracker.ietf.org/doc/html/rfc9068#section-4): the resource server validates `iss` against a configured allowlist and uses it to select the verifier when multiple authorization servers are accepted.

Security note: this changes a previously intentional, unit-tested "exclusive federation" behavior. That contract (`TestAuthenticate_FederatedTokenFailure`) has been deliberately re-encoded to the new model — a token claiming the trusted issuer that fails JWKS is still rejected with **no fallback to local verification** (asserted explicitly), and a token whose `iss` is outside the allowlist is rejected before any verifier is invoked (`TestAuthenticate_UnknownIssuerUnderFederation`). The change only *adds* acceptance of tokens this server itself signed; no existing configuration changes behavior for external/unknown tokens, and no API or config surface changes.

Verified end-to-end on a real local instance with `trusted_issuer` configured (identical config + seeded data, only the code differing):

| Check (trusted_issuer ON) | Before | After |
| --- | --- | --- |
| self-issued admin token (authorization_code + PKCE, the Console's own flow) → `GET /applications` | 401 | 200 |
| `client_credentials` self-issued token → secured API | 401 | 200 |
| no token / unknown issuer / token spoofing the trusted issuer | 401 | 401 (unchanged) |

Verification was performed by driving Thunder's real OAuth2 endpoints (the same `authorization_code` + PKCE + native authentication flow the Console uses to obtain its token, and the `client_credentials` grant) against a running instance with `trusted_issuer` configured. The Console's user-facing breakage under federation is a direct consequence of that self-issued token being rejected; accepting it (200) is what restores the Console and auto-provisioning.

### Related Issues

- Fixes #2830

### Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

Notes: Documentation updated in `docs/content/guides/guides/trusted-issuer.mdx` (new "Self-Issued Tokens" subsection) and `docs/content/guides/getting-started/configuration.mdx` (operator note on additive behavior); changed regions validated locally with Vale (zero warnings on changed lines). No new integration tests added; the behavior is covered by unit tests in `jwt_authenticator_test.go` (self-issued token accepted under federation, unknown issuer rejected, federated failure with no local fallback) and verified manually end-to-end. Not a breaking change: existing configurations keep working and the change is strictly additive for accepted issuers.

### Security checks

- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.