### PR TITLE
Add invite base url node property

### DIFF
--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -101,6 +101,7 @@ const (
 	propertyKeyDynamicInputsIncludeOptional            = "includeOptional"
 	propertyKeyDynamicInputsIncludeOptionalCredentials = "includeOptionalCredentials"
 	propertyKeyMaxDynamicInputsPerPrompt               = "maxPerPrompt"
+	propertyKeyInviteBaseURL                           = "inviteBaseURL"
 )
 
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -166,14 +166,9 @@ func (e *inviteExecutor) getOrGenerateToken(ctx *core.NodeContext) (string, erro
 	return utils.GenerateUUIDv7()
 }
 
-// generateInviteLink constructs the invite link using the GateClient configuration.
+// generateInviteLink constructs the invite link. If the node declares an inviteBaseURL
+// property it is used as the base; otherwise the GateClient configuration is the fallback.
 func (e *inviteExecutor) generateInviteLink(ctx *core.NodeContext, inviteToken string) string {
-	gateConfig := config.GetServerRuntime().Config.GateClient
-	gateAppURL := fmt.Sprintf("%s://%s:%d%s",
-		gateConfig.Scheme,
-		gateConfig.Hostname,
-		gateConfig.Port,
-		gateConfig.Path)
 	queryParams := url.Values{
 		"executionId": []string{ctx.ExecutionID},
 		"inviteToken": []string{inviteToken},
@@ -182,6 +177,24 @@ func (e *inviteExecutor) generateInviteLink(ctx *core.NodeContext, inviteToken s
 	if ctx.EntityID != "" {
 		queryParams.Set(oauth2const.AppID, ctx.EntityID)
 	}
+
+	if baseURL, ok := ctx.NodeProperties[propertyKeyInviteBaseURL].(string); ok && baseURL != "" {
+		if u, err := url.Parse(baseURL); err == nil {
+			q := u.Query()
+			for k, vals := range queryParams {
+				q[k] = vals
+			}
+			u.RawQuery = q.Encode()
+			return u.String()
+		}
+	}
+
+	gateConfig := config.GetServerRuntime().Config.GateClient
+	gateAppURL := fmt.Sprintf("%s://%s:%d%s",
+		gateConfig.Scheme,
+		gateConfig.Hostname,
+		gateConfig.Port,
+		gateConfig.Path)
 
 	return fmt.Sprintf("%s/invite?%s", gateAppURL, queryParams.Encode())
 }

--- a/backend/internal/flow/executor/invite_executor_test.go
+++ b/backend/internal/flow/executor/invite_executor_test.go
@@ -257,6 +257,39 @@ func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_PopulatesTemplate
 	suite.Equal("Test App", templateData["appName"])
 }
 
+func (suite *InviteExecutorTestSuite) TestGenerateInviteLink_UsesInviteBaseURLProperty() {
+	ctx := &core.NodeContext{
+		ExecutionID:  "test-execution-id",
+		ExecutorMode: ExecutorModeGenerate,
+		UserInputs:   make(map[string]string),
+		RuntimeData:  make(map[string]string),
+		NodeProperties: map[string]interface{}{
+			propertyKeyInviteBaseURL: "http://localhost:3000",
+		},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], "http://localhost:3000?")
+}
+
+func (suite *InviteExecutorTestSuite) TestGenerateInviteLink_FallsBackToGateConfigWhenPropertyAbsent() {
+	ctx := &core.NodeContext{
+		ExecutionID:  "test-execution-id",
+		ExecutorMode: ExecutorModeGenerate,
+		UserInputs:   make(map[string]string),
+		RuntimeData:  make(map[string]string),
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyInviteLink], "https://localhost:5190/gate/invite?")
+}
+
 func (suite *InviteExecutorTestSuite) TestGetExecutionPolicy_GenerateMode_ReturnsNil() {
 	policy := suite.executor.GetExecutionPolicy(ExecutorModeGenerate)
 	assert.Nil(suite.T(), policy)


### PR DESCRIPTION
### Purpose
The invite executor always built the invite link from `GateClientConfig`, producing a gate-path URL (e.g. `https://<host>:<port>/gate/invite?...`). App-native clients (e.g. the react-vanilla-sample) need the link to point to their own invite route instead.

### Approach
Added an optional `inviteBaseURL` node property to the `invite_generate` executor node. When set, `generateInviteLink` uses it as the full base URL and appends only the query params (`executionId`, `inviteToken`, `applicationId`). When absent or empty, the existing `GateClientConfig` fallback is used unchanged — gate-facing flows require no modification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invite links can use a custom base URL when configured, with automatic fallback to the default runtime URL.
* **Tests**
  * Added tests validating invite-link generation for both custom-base and fallback behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->