### PR TITLE
Allow configuring default admin credentials at setup time

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -245,15 +245,35 @@ echo ""
 # Create Admin User
 # ============================================================================
 
+ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
+
+if [[ "$ADMIN_USERNAME" == "admin" && "$ADMIN_PASSWORD" == "admin" ]]; then
+    log_warning "Using default admin credentials (admin/admin). Set ADMIN_USERNAME and ADMIN_PASSWORD or use --admin-username/--admin-password to override."
+fi
+
 log_info "Creating admin user..."
+
+# JSON-escape username and password to safely embed arbitrary characters in the payload.
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+ADMIN_USERNAME_JSON=$(json_escape "$ADMIN_USERNAME")
+ADMIN_PASSWORD_JSON=$(json_escape "$ADMIN_PASSWORD")
 
 RESPONSE=$(api_call POST "/users" '{
   "type": "Person",
   "ouId": "'${DEFAULT_OU_ID}'",
   "attributes": {
-    "username": "admin",
-    "password": "admin",
-    "sub": "admin",
+    "username": "'"${ADMIN_USERNAME_JSON}"'",
+    "password": "'"${ADMIN_PASSWORD_JSON}"'",
+    "sub": "'"${ADMIN_USERNAME_JSON}"'",
     "email": "admin@example.com",
     "name": "Administrator",
     "given_name": "Admin",
@@ -268,8 +288,7 @@ BODY="${RESPONSE%???}"
 
 if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]]; then
     log_success "Admin user created successfully"
-    log_info "Username: admin"
-    log_info "Password: admin"
+    log_info "Username: ${ADMIN_USERNAME}"
 
     # Extract admin user ID
     ADMIN_USER_ID=$(echo "$BODY" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
@@ -287,12 +306,15 @@ elif [[ "$HTTP_CODE" == "409" ]]; then
     BODY="${RESPONSE%???}"
 
     if [[ "$HTTP_CODE" == "200" ]]; then
+        # Escape regex metacharacters so usernames like "admin.test" match literally.
+        ADMIN_USERNAME_REGEX=$(printf '%s' "$ADMIN_USERNAME" | sed 's/[.[*^$()+?{|\\]/\\&/g')
+
         # Parse JSON to find admin user
-        ADMIN_USER_ID=$(echo "$BODY" | grep -o '"id":"[^"]*","[^"]*":"[^"]*","attributes":{[^}]*"username":"admin"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+        ADMIN_USER_ID=$(echo "$BODY" | grep -o "\"id\":\"[^\"]*\",\"[^\"]*\":\"[^\"]*\",\"attributes\":{[^}]*\"username\":\"${ADMIN_USERNAME_REGEX}\"" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 
         # Fallback parsing
         if [[ -z "$ADMIN_USER_ID" ]]; then
-            ADMIN_USER_ID=$(echo "$BODY" | sed 's/},{/}\n{/g' | grep '"username":"admin"' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+            ADMIN_USER_ID=$(echo "$BODY" | sed 's/},{/}\n{/g' | grep "\"username\":\"${ADMIN_USERNAME_REGEX}\"" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
         fi
 
         if [[ -n "$ADMIN_USER_ID" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -1097,6 +1097,8 @@ function run() {
     API_BASE="$BASE_URL" \
         SYSTEM_RS_HANDLE="$SYSTEM_RS_HANDLE" \
         SYSTEM_RS_IDENTIFIER="$SYSTEM_RS_IDENTIFIER" \
+        ADMIN_USERNAME="${ADMIN_USERNAME:-}" \
+        ADMIN_PASSWORD="${ADMIN_PASSWORD:-}" \
         "$BACKEND_BASE_DIR/cmd/server/bootstrap/01-default-resources.sh" \
         --console-redirect-uris "https://localhost:$CONSOLE_APP_DEFAULT_PORT/console"
 

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -682,8 +682,61 @@ The setup job runs `setup.sh` as a one-time Helm pre-install hook to initialize 
 | `setup.resources.requests.memory`      | Memory request for setup job                                    | `50Mi`                       |
 | `setup.resources.limits.cpu`           | CPU limit for setup job                                         | `200m`                       |
 | `setup.resources.limits.memory`        | Memory limit for setup job                                      | `100Mi`                      |
+| `setup.admin.username`                 | Username for the default admin user                             | `admin`                      |
+| `setup.admin.password`                 | Password for the default admin user. Ignored when `setup.admin.passwordRef.name` is set | `admin` |
+| `setup.admin.passwordRef.name`         | Existing Kubernetes Secret name containing the admin password. Must be set together with `passwordRef.key` | `""` |
+| `setup.admin.passwordRef.key`          | Key in the Secret whose value is used as the admin password. Must be set together with `passwordRef.name` | `""` |
 | `setup.extraVolumeMounts`              | Additional volume mounts for setup job                          | `[]`                         |
 | `setup.extraVolumes`                   | Additional volumes for setup job                                | `[]`                         |
+
+### Admin Credentials
+
+The setup job seeds a default admin user during first install. The password can be supplied as a plain value (for development) or sourced from an existing Kubernetes Secret (recommended for production).
+
+#### Security Warning
+
+⚠️ **The default `admin`/`admin` credentials must be changed before any non-development deployment.** When defaults are used, the credentials are printed in the setup completion summary. Always set explicit credentials for any non-development environment.
+
+#### Pattern 1: Plain value (Development / Quick-start)
+
+```yaml
+setup:
+  admin:
+    username: "myAdmin"
+    password: "MyP@ssw0rd!"
+```
+
+Or via `--set` to avoid committing the password:
+
+```bash
+helm install my-thunderid oci://ghcr.io/thunder-id/helm-charts/thunderid \
+  --set setup.admin.username=myAdmin \
+  --set setup.admin.password='MyP@ssw0rd!'
+```
+
+#### Pattern 2: External Kubernetes Secret (Production — Recommended)
+
+**Step 1:** Create the Secret:
+
+```bash
+kubectl create secret generic thunderid-admin-credentials \
+  --from-literal=password='MyP@ssw0rd!'
+```
+
+**Step 2:** Reference it in your values:
+
+```yaml
+setup:
+  admin:
+    username: "myAdmin"
+    passwordRef:
+      name: "thunderid-admin-credentials"
+      key: "password"
+```
+
+When `passwordRef.name` and `passwordRef.key` are both set, the `password` field is ignored and the admin password is injected directly from the Secret — no plaintext appears in the rendered Job manifest.
+
+**Validation:** The chart fails at render time if only one of `passwordRef.name` / `passwordRef.key` is provided. Both must be set together or both must be left empty.
 
 Environment variable item structure for plain value environment variables in `deployment.env` and `setup.env`:
 

--- a/install/helm/templates/setup-job.yaml
+++ b/install/helm/templates/setup-job.yaml
@@ -148,6 +148,24 @@ spec:
             - name: WITH_CONSENT
               value: "false"
             {{- end }}
+            - name: ADMIN_USERNAME
+              value: {{ .Values.setup.admin.username | quote }}
+            {{- if and .Values.setup.admin.passwordRef.key (not .Values.setup.admin.passwordRef.name) }}
+            {{- fail "setup.admin.passwordRef.name is required when setup.admin.passwordRef.key is set" }}
+            {{- end }}
+            {{- if .Values.setup.admin.passwordRef.name }}
+            {{- if not .Values.setup.admin.passwordRef.key }}
+            {{- fail "setup.admin.passwordRef.key is required when setup.admin.passwordRef.name is set" }}
+            {{- end }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.setup.admin.passwordRef.name | quote }}
+                  key: {{ .Values.setup.admin.passwordRef.key | quote }}
+            {{- else }}
+            - name: ADMIN_PASSWORD
+              value: {{ .Values.setup.admin.password | quote }}
+            {{- end }}
             {{- include "thunderid.databasePasswordEnvVars" . | nindent 12 }}
             {{- include "thunderid.secretEnvVars" (dict "secretEnv" .Values.setup.secretEnv) | nindent 12 }}
             {{- include "thunderid.cacheRedisPasswordEnvVars" . | nindent 12 }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -488,6 +488,16 @@ setup:
   ttlSecondsAfterFinished: 86400  # 24 hours
   # Enable debug mode for setup
   debug: false
+  # Default admin user credentials seeded by the setup job.
+  # WARNING: Replace the default password before deploying to any non-development environment.
+  admin:
+    username: "admin"
+    password: "admin"
+    # Optional: source the admin password from an existing Kubernetes Secret.
+    # When `passwordRef.name` is set, it takes precedence over the plain `password` above.
+    passwordRef:
+      name: ""
+      key: ""
   # Additional command-line arguments for setup.sh
   args: []
     # Example:

--- a/setup.sh
+++ b/setup.sh
@@ -50,6 +50,16 @@ BOOTSTRAP_SKIP_PATTERN="${BOOTSTRAP_SKIP_PATTERN:-}"
 BOOTSTRAP_ONLY_PATTERN="${BOOTSTRAP_ONLY_PATTERN:-}"
 BOOTSTRAP_DIR="${BOOTSTRAP_DIR:-./bootstrap}"
 WITH_CONSENT=${WITH_CONSENT:-true}
+ADMIN_USERNAME_PROVIDED=false
+ADMIN_PASSWORD_PROVIDED=false
+if [[ -n "${ADMIN_USERNAME:-}" ]]; then
+    ADMIN_USERNAME_PROVIDED=true
+fi
+if [[ -n "${ADMIN_PASSWORD:-}" ]]; then
+    ADMIN_PASSWORD_PROVIDED=true
+fi
+ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
 
 # Color codes
 RED='\033[0;31m'
@@ -131,6 +141,10 @@ print_help() {
     echo "  --debug                  Enable debug mode with remote debugging"
     echo "  --debug-port PORT        Set debug port (default: 2345)"
     echo "  --without-consent        Disable the bundled consent server"
+    echo "  --admin-username VALUE   Username for the default admin user (default: admin)"
+    echo "                           Falls back to ADMIN_USERNAME env var if flag not set"
+    echo "  --admin-password VALUE   Password for the default admin user (default: admin)"
+    echo "                           Falls back to ADMIN_PASSWORD env var if flag not set"
     echo "  --help                   Show this help message"
     echo ""
     echo "Description:"
@@ -166,6 +180,24 @@ while [[ $# -gt 0 ]]; do
             WITH_CONSENT=false
             shift
             ;;
+        --admin-username)
+            if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+                echo -e "${RED}--admin-username requires a non-empty value${NC}"
+                exit 1
+            fi
+            ADMIN_USERNAME="$2"
+            ADMIN_USERNAME_PROVIDED=true
+            shift 2
+            ;;
+        --admin-password)
+            if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+                echo -e "${RED}--admin-password requires a non-empty value${NC}"
+                exit 1
+            fi
+            ADMIN_PASSWORD="$2"
+            ADMIN_PASSWORD_PROVIDED=true
+            shift 2
+            ;;
         --help)
             print_help
             exit 0
@@ -177,6 +209,28 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# ============================================================================
+# Prompt for Admin Credentials (interactive mode only)
+# ============================================================================
+
+# Prompt for any credential not supplied via CLI flags or environment
+# variables, but only when stdin is a terminal.
+if [ -t 0 ] && [[ "$ADMIN_USERNAME_PROVIDED" == "false" || "$ADMIN_PASSWORD_PROVIDED" == "false" ]]; then
+    echo ""
+    echo "Configure the default admin user (press Enter to accept defaults):"
+    echo ""
+    if [[ "$ADMIN_USERNAME_PROVIDED" == "false" ]]; then
+        read -r -p "  Admin username [admin]: " _input_username
+        ADMIN_USERNAME="${_input_username:-admin}"
+    fi
+    if [[ "$ADMIN_PASSWORD_PROVIDED" == "false" ]]; then
+        read -r -s -p "  Admin password [admin]: " _input_password
+        echo ""
+        ADMIN_PASSWORD="${_input_password:-admin}"
+    fi
+    echo ""
+fi
 
 # ============================================================================
 # Read Configuration from deployment.yaml
@@ -440,6 +494,8 @@ export PUBLIC_URL="${PUBLIC_URL}"
 export SYSTEM_RS_HANDLE="${SYSTEM_RS_HANDLE}"
 export SYSTEM_RS_IDENTIFIER="${SYSTEM_RS_IDENTIFIER}"
 export SETUP_SILENT_MODE="${SILENT_MODE}"
+export ADMIN_USERNAME
+export ADMIN_PASSWORD
 
 # FD3 always points to the real terminal stdout.
 # Quiet-mode result markers write to FD3 so they reach the terminal even
@@ -617,10 +673,7 @@ if [ "$SILENT_MODE" = "true" ]; then
     echo "✅ Setup completed successfully!"
     echo "========================================="
     echo ""
-    echo "Admin credentials:"
-    echo "  URL:      ${PUBLIC_URL}/console"
-    echo "  Username: admin"
-    echo "  Password: admin"
+    echo "Console URL: ${PUBLIC_URL}/console"
     echo ""
     echo "Run ./start.sh to start ${PRODUCT_NAME}."
     echo ""

--- a/tests/integration/testutils/api_security.go
+++ b/tests/integration/testutils/api_security.go
@@ -139,13 +139,21 @@ func GetHTTPClientForUser(username, password string) (*http.Client, error) {
 // ObtainAdminAccessToken obtains an admin access token using the CONSOLE app and stores it globally
 func ObtainAdminAccessToken() error {
 	log.Println("Obtaining admin access token...")
+	adminUsername := os.Getenv("ADMIN_USERNAME")
+	if adminUsername == "" {
+		adminUsername = "admin"
+	}
+	adminPassword := os.Getenv("ADMIN_PASSWORD")
+	if adminPassword == "" {
+		adminPassword = "admin"
+	}
 	var err error
 	adminTokenState, err = ObtainAccessTokenWithPassword(
 		"CONSOLE",
 		"https://localhost:8095/console",
 		"system",
-		"admin",
-		"admin",
+		adminUsername,
+		adminPassword,
 		true,
 	)
 	if err != nil {


### PR DESCRIPTION
### Purpose

The default admin user was always created with hardcoded `admin`/`admin` credentials. This PR makes those credentials configurable at setup time, regardless of how ThunderID is started.

### Approach

ThunderID can be set up in three ways, each now supporting custom admin credentials:

---

#### 1. `./setup.sh` (local / packaged distribution)

**Interactive terminal** — when no credentials are provided and stdin is a terminal, the script prompts with defaults shown:

https://github.com/user-attachments/assets/2ae0dcb2-c3ab-4af3-a5cc-d5d55fb452ea



```
Configure the default admin user (press Enter to accept defaults):

  Admin username [admin]: myAdmin
  Admin password [admin]:
  Confirm password:
```

Pressing Enter on both fields uses the `admin`/`admin` defaults. The password input is silent and requires confirmation before proceeding.

**CLI flags** — skip the prompt and set credentials directly:

```bash
./setup.sh --admin-username myAdmin --admin-password 'MyP@ssw0rd!'
```

**Environment variables** — useful for scripted or non-interactive runs:

```bash
ADMIN_USERNAME=myAdmin ADMIN_PASSWORD='MyP@ssw0rd!' ./setup.sh
```

Precedence: CLI flag → env var → interactive prompt → default (`admin`/`admin`).

The setup summary shows only the console URL — credentials are never echoed on completion.

---

#### 2. `make run` (local development)

`make run` calls `01-default-resources.sh` directly (bypassing `setup.sh`), so only env vars apply:

```bash
ADMIN_USERNAME=myAdmin ADMIN_PASSWORD='MyP@ssw0rd!' make run
```

---

#### 3. Helm chart (Kubernetes)

New `setup.admin` block in `values.yaml`:

```yaml
setup:
  admin:
    username: "admin"
    password: "admin"
    # Optional: source password from an existing Kubernetes Secret.
    # Takes precedence over `password` when set.
    passwordRef:
      name: ""
      key: ""
```

Using a Secret (recommended for production):

```bash
kubectl create secret generic thunderid-admin --from-literal=password='MyP@ssw0rd!'

helm install my-release ./install/helm \
  --set setup.admin.username=myAdmin \
  --set setup.admin.passwordRef.name=thunderid-admin \
  --set setup.admin.passwordRef.key=password
```

`passwordRef` follows the same pattern used for database credentials. The Helm template fails at render time if only one of `passwordRef.name` / `passwordRef.key` is provided.

---

### Changes

| File | Change |
|------|--------|
| `setup.sh` | Interactive prompt when running in a terminal with no credentials supplied; `--admin-username`/`--admin-password` flags; export vars to bootstrap; console URL only in summary |
| `build.sh` | Explicitly forward `ADMIN_USERNAME`/`ADMIN_PASSWORD` to the bootstrap script in the `run` target |
| `backend/cmd/server/bootstrap/01-default-resources.sh` | Read credentials from env; JSON-escape values; regex-escape username for safe 409 lookup |
| `install/helm/values.yaml` | Add `setup.admin` block with `username`, `password`, `passwordRef` |
| `install/helm/templates/setup-job.yaml` | Inject `ADMIN_USERNAME`/`ADMIN_PASSWORD` env; `fail` guard for incomplete or mismatched `passwordRef` |
| `install/helm/README.md` | Document `setup.admin` parameters and both credential patterns |

### Related Issues
Closes #2876

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.