### PR TITLE
Fix i18n key resolution in flow builder

### DIFF
--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/I18nConfigurationCard.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/I18nConfigurationCard.tsx
@@ -96,7 +96,7 @@ export function I18nConfigurationCardContent({
   onCreateModeChange,
 }: I18nConfigurationCardContentProps): ReactElement {
   const {t} = useTranslation();
-  const {i18nText, i18nTextLoading} = useI18nConfig();
+  const {i18nTextLoading} = useI18nConfig();
   const updateTranslation = useUpdateTranslation({
     onMutationSuccess: () => {
       invalidateI18nCache();
@@ -136,22 +136,18 @@ export function I18nConfigurationCardContent({
   }, [translationsData]);
 
   const resolvedValue: string = useMemo(() => {
-    if (!selectedI18nKey || !i18nText) {
+    if (!selectedI18nKey) {
       return '';
     }
-
-    let foundValue = '';
-
-    Object.values(i18nText).some((screenTexts: Record<string, string>) => {
-      if (screenTexts[selectedI18nKey]) {
-        foundValue = screenTexts[selectedI18nKey];
-        return true;
-      }
-      return false;
-    });
-
-    return foundValue;
-  }, [selectedI18nKey, i18nText]);
+    const resolved = t(selectedI18nKey);
+    const keyWithoutNamespace = selectedI18nKey.includes(':')
+      ? selectedI18nKey.slice(selectedI18nKey.indexOf(':') + 1)
+      : selectedI18nKey;
+    if (resolved === selectedI18nKey || resolved === keyWithoutNamespace) {
+      return '';
+    }
+    return resolved;
+  }, [selectedI18nKey, t]);
 
   const availableLanguages: string[] = useMemo(() => {
     if (languagesData?.languages && languagesData.languages.length > 0) {

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/I18nConfigurationCard.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/I18nConfigurationCard.test.tsx
@@ -30,7 +30,16 @@ vi.mock('react-i18next', () => ({
       if (params) {
         return `${key} ${JSON.stringify(params)}`;
       }
-      return key;
+      const translations: Record<string, string> = {
+        'login.title': 'Sign In',
+        'login.description': 'Enter your credentials',
+        'login.button.submit': 'Submit',
+        'common.continue': 'Continue',
+        'common.cancel': 'Cancel',
+        'custom:login.title': 'Sign In',
+        'signin:forms.credentials.title': 'Sign In',
+      };
+      return translations[key] ?? key;
     },
   }),
 }));
@@ -384,6 +393,39 @@ describe('I18nConfigurationCard', () => {
       );
 
       expect(screen.getByText('Continue')).toBeInTheDocument();
+    });
+
+    it('should display resolved value when a namespaced i18n key is selected', () => {
+      render(
+        <I18nConfigurationCard
+          open
+          anchorEl={anchorEl}
+          propertyKey="label"
+          onClose={mockOnClose}
+          onChange={mockOnChange}
+          i18nKey="custom:login.title"
+        />,
+        {wrapper: createWrapper()},
+      );
+
+      expect(screen.getByText('flows:core.elements.textPropertyField.resolvedValue')).toBeInTheDocument();
+      expect(screen.getByText('Sign In')).toBeInTheDocument();
+    });
+
+    it('should not display resolved value box when namespaced key has no matching translation', () => {
+      render(
+        <I18nConfigurationCard
+          open
+          anchorEl={anchorEl}
+          propertyKey="label"
+          onClose={mockOnClose}
+          onChange={mockOnChange}
+          i18nKey="signin:nonexistent.key"
+        />,
+        {wrapper: createWrapper()},
+      );
+
+      expect(screen.queryByText('flows:core.elements.textPropertyField.resolvedValue')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- Populate `FLOW_TRANSLATIONS_NAMESPACES` with the actual flow namespaces (`signin`, `signup`, `recovery`, `elements`) so `useGetTranslations` fetches the full set of flow translations from the backend API instead of requesting an empty namespace string.
- Replace the broken `resolvedValue` computation in `I18nConfigurationCard` that searched an always-empty `i18nText` map with a direct `t(selectedI18nKey)` call, which correctly resolves the translation once the i18next resource bundles are populated by `I18nProvider`.

Fixes #2864

## Test plan

- [ ] Open the flow builder and inspect a typography element whose label is a `{{ t(...) }}` template — the canvas should render the translated string (e.g. "Sign In") instead of the raw key
- [ ] Open the Text Properties panel for that element — the "Resolved Value" field should show the translated string
- [ ] Unit tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed internationalization translation resolution in resource property configuration
  * Improved handling of missing or namespaced translation keys
  * Resolved translation values now display accurately when available and hide when translations don't exist

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1413" height="904" alt="Screenshot 2026-05-20 at 17 02 08" src="https://github.com/user-attachments/assets/df4e1d62-3e5a-49b9-aff5-211c0c9b613d" />
