### PR TITLE
Add recovery support for vanilla sample

### DIFF
--- a/samples/apps/react-vanilla-sample/README.md
+++ b/samples/apps/react-vanilla-sample/README.md
@@ -2,7 +2,7 @@
 
 This sample React application demonstrates integrating authentication and registration into your application using the app-native flow orchestration API.
 
-### Supported Authentication Methods
+## Supported Authentication Methods
 
 This sample supports the following authentication and registration methods:
 
@@ -47,6 +47,18 @@ passkey:
 ```
 
 If the sample is hosted at a different address, add that origin instead. Without this, passkey registration will fail with an origin validation error.
+
+### Invite Flow Configuration
+
+If you use invite-based flows such as password recovery, set `inviteBaseURL` on the `InviteExecutor` node that runs in `generate` mode in the flow definition.
+
+For this sample, it should point to the frontend invite page, for example:
+
+```text
+https://localhost:3000/invite
+```
+
+Without this, the generated invite link will fall back to the server's default Gate URL instead of this sample app.
 
 ## Quick Start
 

--- a/samples/apps/react-vanilla-sample/src/App.tsx
+++ b/samples/apps/react-vanilla-sample/src/App.tsx
@@ -18,6 +18,7 @@
 
 import { Route, BrowserRouter as Router, Routes, useLocation } from 'react-router-dom';
 import HomePage from './pages/HomePage';
+import InvitePage from './pages/InvitePage';
 import LoginPage from './pages/LoginPage';
 import AuthProvider from './contexts/AuthProvider';
 import useAuth from './hooks/useAuth';
@@ -30,6 +31,7 @@ const App = () => {
   return (
     <Routes>
       <Route path="/" element={token ? <HomePage /> : <LoginPage />} key={location.key} />
+      <Route path="/invite" element={<InvitePage />} />
     </Routes>
   );
 };

--- a/samples/apps/react-vanilla-sample/src/pages/InvitePage.tsx
+++ b/samples/apps/react-vanilla-sample/src/pages/InvitePage.tsx
@@ -1,0 +1,604 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+import Typography from '@mui/material/Typography';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import GoogleIcon from '@mui/icons-material/Google';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import FingerprintIcon from '@mui/icons-material/Fingerprint';
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import GradientCircularProgress from '../components/GradientCircularProgress';
+import Layout from '../components/Layout';
+import { FlowServerError, submitNativeAuth } from '../services/authService';
+
+interface AuthInput {
+    identifier: string;
+    type: string;
+    required: boolean;
+    ref?: string;
+    options?: string[];
+}
+
+interface ActionPrompt {
+    ref: string;
+    nextNode?: string;
+    label?: string;
+}
+
+interface FlowResponse {
+    flowStatus?: string;
+    failureReason?: string;
+    type?: string;
+    executionId?: string;
+    challengeToken?: string;
+    data?: {
+        inputs?: AuthInput[];
+        actions?: ActionPrompt[];
+    };
+}
+
+const isConnectionFailure = (error: Error) => {
+    const message = error.message?.toLowerCase() || '';
+    return message.includes('failed to fetch') || message.includes('network error');
+};
+
+const InvitePage = () => {
+    const navigate = useNavigate();
+    const isInitialized = useRef(false);
+    const otpInputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+    const [loading, setLoading] = useState<boolean>(true);
+    const [step, setStep] = useState<'verifying' | 'form' | 'success' | 'error'>('verifying');
+    const [errorMessage, setErrorMessage] = useState<string>('');
+    const [executionId, setExecutionId] = useState<string>('');
+    const [challengeToken, setChallengeToken] = useState<string>('');
+    const [inputs, setInputs] = useState<AuthInput[]>([]);
+    const [availableActions, setAvailableActions] = useState<ActionPrompt[]>([]);
+    const [formData, setFormData] = useState<Record<string, string>>({});
+    const [showPassword, setShowPassword] = useState<boolean>(false);
+    const [otpDigits, setOtpDigits] = useState(Array(6).fill(''));
+
+    useEffect(() => {
+        otpInputRefs.current = otpInputRefs.current.slice(0, otpDigits.length);
+    }, [otpDigits.length]);
+
+    const handleResponse = (data: FlowResponse) => {
+        if (data.flowStatus === 'COMPLETE') {
+            setStep('success');
+            setLoading(false);
+            return;
+        }
+
+        if (data.flowStatus === 'ERROR') {
+            setStep('error');
+            setErrorMessage(data.failureReason || 'Invite flow failed. Please request a new invite link.');
+            setLoading(false);
+            return;
+        }
+
+        if (data.type === 'VIEW') {
+            const nextExecutionId = data.executionId || '';
+            const nextActions = data.data?.actions || [];
+            const nextInputs = data.data?.inputs || [];
+
+            if (!nextExecutionId || nextActions.length === 0) {
+                setStep('error');
+                setErrorMessage('Invalid invite flow response. Please request a new invite link.');
+                setLoading(false);
+                return;
+            }
+
+            setExecutionId(nextExecutionId);
+            setChallengeToken(data.challengeToken || '');
+            setAvailableActions(nextActions);
+            setInputs(nextInputs);
+            setFormData({});
+            setShowPassword(false);
+            setOtpDigits(Array(6).fill(''));
+            setStep('form');
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (isInitialized.current) {
+            return;
+        }
+
+        isInitialized.current = true;
+
+        const params = new URLSearchParams(window.location.search);
+        const nextExecutionId = params.get('executionId') || '';
+        const inviteToken = params.get('inviteToken') || '';
+
+        if (!nextExecutionId || !inviteToken) {
+            setStep('error');
+            setErrorMessage('Invalid invite link. Please request a new invite link.');
+            setLoading(false);
+            return;
+        }
+
+        submitNativeAuth(nextExecutionId, { inviteToken }, undefined, undefined)
+            .then((result) => {
+                handleResponse(result.data);
+            })
+            .catch((error: Error) => {
+                setStep('error');
+                if (isConnectionFailure(error)) {
+                    setErrorMessage('Unable to connect right now. Please try again.');
+                } else if (error instanceof FlowServerError) {
+                    setErrorMessage(error.message || 'A server error occurred. Please try again.');
+                } else {
+                    setErrorMessage('Invalid or expired invite link. Please request a new invite link.');
+                }
+                setLoading(false);
+            });
+    }, []);
+
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        const { name, value } = event.target;
+        setFormData((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const handleSelectChange = (name: string, value: string) => {
+        setFormData((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const handleTogglePasswordVisibility = () => {
+        setShowPassword((prev) => !prev);
+    };
+
+    const handleMouseDownPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+    };
+
+    const handleOTPDigitChange = (index: number, value: string) => {
+        if (value.length > 1) {
+            value = value.slice(0, 1);
+        }
+
+        const nextOtpDigits = [...otpDigits];
+        nextOtpDigits[index] = value;
+        setOtpDigits(nextOtpDigits);
+        setFormData((prev) => ({ ...prev, otp: nextOtpDigits.join('') }));
+
+        if (value && index < otpDigits.length - 1) {
+            otpInputRefs.current[index + 1]?.focus();
+        }
+    };
+
+    const handleOTPKeyDown = (index: number, event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Backspace' && !otpDigits[index] && index > 0) {
+            otpInputRefs.current[index - 1]?.focus();
+        }
+    };
+
+    const handlePaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+        event.preventDefault();
+        const pastedData = event.clipboardData.getData('text');
+
+        if (pastedData.match(/^\d+$/) && pastedData.length <= otpDigits.length) {
+            const nextOtpDigits = [...otpDigits];
+
+            for (let i = 0; i < pastedData.length; i++) {
+                nextOtpDigits[i] = pastedData[i];
+            }
+
+            setOtpDigits(nextOtpDigits);
+            setFormData((prev) => ({ ...prev, otp: nextOtpDigits.join('') }));
+
+            const nextEmptyIndex = pastedData.length < otpDigits.length ? pastedData.length : otpDigits.length - 1;
+            otpInputRefs.current[nextEmptyIndex]?.focus();
+        }
+    };
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        handleActionSelection(availableActions[0]?.ref);
+    };
+
+    const handleActionSelection = (actionRef?: string, payload?: Record<string, string>) => {
+        if (!executionId || !actionRef) {
+            setStep('error');
+            setErrorMessage('Invalid invite flow response. Please request a new invite link.');
+            setLoading(false);
+            return;
+        }
+
+        setLoading(true);
+
+        const completeFormData = { ...(payload || formData) };
+        inputs.forEach((input) => {
+            if (!(input.identifier in completeFormData)) {
+                completeFormData[input.identifier] = '';
+            }
+        });
+
+        submitNativeAuth(executionId, completeFormData, actionRef, challengeToken)
+            .then((result) => {
+                handleResponse(result.data);
+            })
+            .catch((error: Error) => {
+                setStep('error');
+                if (isConnectionFailure(error)) {
+                    setErrorMessage('Unable to connect right now. Please try again.');
+                } else if (error instanceof FlowServerError) {
+                    setErrorMessage(error.message || 'A server error occurred. Please try again.');
+                } else {
+                    setErrorMessage(error.message || 'Unable to continue. Please try again.');
+                }
+                setLoading(false);
+            });
+    };
+
+    const getActionLabel = (actionRef: string, fallbackLabel?: string) => {
+        const normalizedRef = actionRef.toLowerCase();
+
+        if (normalizedRef.includes('signin') || normalizedRef.includes('sign_in')) {
+            return 'Sign In';
+        }
+
+        if (normalizedRef.includes('signup') || normalizedRef.includes('sign_up')) {
+            return 'Create Account';
+        }
+
+        if (normalizedRef.includes('passkey')) {
+            return 'Continue with Passkey';
+        }
+
+        if (normalizedRef.includes('github')) {
+            return 'Continue with GitHub';
+        }
+
+        if (normalizedRef.includes('google')) {
+            return 'Continue with Google';
+        }
+
+        if (normalizedRef.includes('sms') || normalizedRef.includes('mobile')) {
+            return 'Continue with SMS OTP';
+        }
+
+        if (fallbackLabel) {
+            return fallbackLabel;
+        }
+
+        return 'Continue';
+    };
+
+    const getActionIcon = (actionRef: string) => {
+        const normalizedRef = actionRef.toLowerCase();
+
+        if (normalizedRef.includes('github')) {
+            return <GitHubIcon />;
+        }
+
+        if (normalizedRef.includes('google')) {
+            return <GoogleIcon />;
+        }
+
+        if (normalizedRef.includes('passkey')) {
+            return <FingerprintIcon />;
+        }
+
+        return undefined;
+    };
+
+    const renderInputFields = () => {
+        return inputs.map((input, index) => {
+            const inputId = input.identifier || `input-${index}`;
+            const isPassword = input.type === 'password' || input.type === 'PASSWORD_INPUT' || input.identifier === 'password';
+            const isOTP = input.type === 'otp' || input.type === 'OTP_INPUT' || input.identifier === 'otp';
+            const isDropdown = input.type === 'SELECT' || input.type === 'dropdown' || input.type === 'DROPDOWN';
+            const isRequired = input.required;
+
+            let label = input.identifier;
+            if (label) {
+                label = label.charAt(0).toUpperCase() + label.slice(1).replace(/_/g, ' ');
+            }
+            label = label.replace(/([a-z])([A-Z])/g, '$1 $2');
+            if (isOTP) {
+                label = 'OTP Code';
+            } else if (isPassword) {
+                label = 'Password';
+            }
+
+            const placeholder = `Enter your ${label.toLowerCase()}`;
+
+            if (isDropdown && input.options) {
+                return (
+                    <Box key={inputId} display="flex" flexDirection="column" gap={0.5}>
+                        <InputLabel htmlFor={inputId} sx={{ mb: 1 }}>{label}</InputLabel>
+                        <Select
+                            id={inputId}
+                            name={input.identifier}
+                            size="small"
+                            value={formData[input.identifier] || ''}
+                            onChange={(e) => handleSelectChange(input.identifier, e.target.value)}
+                            required={isRequired}
+                            displayEmpty
+                        >
+                            <MenuItem value="" disabled sx={{ color: 'text.secondary' }}>
+                                Select {label.toLowerCase()}
+                            </MenuItem>
+                            {input.options.map((option) => (
+                                <MenuItem key={option} value={option}>
+                                    {option}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </Box>
+                );
+            }
+
+            if (isPassword) {
+                return (
+                    <Box key={inputId} display="flex" flexDirection="column" gap={0.5}>
+                        <InputLabel htmlFor={inputId} sx={{ mb: 1 }}>{label}</InputLabel>
+                        <OutlinedInput
+                            type={showPassword ? 'text' : 'password'}
+                            id={inputId}
+                            name={input.identifier}
+                            placeholder={placeholder}
+                            size="small"
+                            value={formData[input.identifier] || ''}
+                            onChange={handleInputChange}
+                            required={isRequired}
+                            endAdornment={
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        aria-label="toggle password visibility"
+                                        onClick={handleTogglePasswordVisibility}
+                                        onMouseDown={handleMouseDownPassword}
+                                        edge="end"
+                                    >
+                                        {showPassword ? <VisibilityOff /> : <Visibility />}
+                                    </IconButton>
+                                </InputAdornment>
+                            }
+                        />
+                    </Box>
+                );
+            }
+
+            if (isOTP) {
+                return (
+                    <Box key={inputId} display="flex" flexDirection="column" gap={0.5}>
+                        <InputLabel htmlFor={inputId} sx={{ mb: 1 }}>{label}</InputLabel>
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                gap: 1,
+                                justifyContent: 'space-between',
+                            }}
+                        >
+                            {otpDigits.map((digit, otpIndex) => (
+                                <OutlinedInput
+                                    key={`otp-digit-${otpIndex}`}
+                                    inputRef={(element) => { otpInputRefs.current[otpIndex] = element; }}
+                                    value={digit}
+                                    onChange={(e) => handleOTPDigitChange(otpIndex, e.target.value)}
+                                    onKeyDown={(e) => handleOTPKeyDown(otpIndex, e as React.KeyboardEvent<HTMLInputElement>)}
+                                    onPaste={otpIndex === 0 ? handlePaste : undefined}
+                                    inputProps={{
+                                        maxLength: 1,
+                                        style: { textAlign: 'center', padding: '8px 0' },
+                                    }}
+                                    sx={{
+                                        width: '40px',
+                                        height: '48px',
+                                        '& input': { padding: 0 },
+                                    }}
+                                />
+                            ))}
+                        </Box>
+                    </Box>
+                );
+            }
+
+            return (
+                <Box key={inputId} display="flex" flexDirection="column" gap={0.5}>
+                    <InputLabel htmlFor={inputId} sx={{ mb: 1 }}>{label}</InputLabel>
+                    <OutlinedInput
+                        type={input.type || 'text'}
+                        id={inputId}
+                        name={input.identifier}
+                        placeholder={placeholder}
+                        size="small"
+                        value={formData[input.identifier] || ''}
+                        onChange={handleInputChange}
+                        required={isRequired}
+                    />
+                </Box>
+            );
+        });
+    };
+
+    const renderInputPromptForm = () => {
+        const primaryAction = availableActions[0];
+        const hasPasswordInput = inputs.some((input) => input.identifier === 'password' || input.type === 'PASSWORD_INPUT');
+        const hasOTPInput = inputs.some((input) => input.identifier === 'otp' || input.type === 'OTP_INPUT');
+        let primaryLabel = 'Continue';
+
+        if (primaryAction?.ref) {
+            if (hasPasswordInput) {
+                primaryLabel = 'Reset Password';
+            } else if (hasOTPInput) {
+                primaryLabel = 'Verify OTP';
+            } else {
+                primaryLabel = getActionLabel(primaryAction.ref, primaryAction.label);
+            }
+        }
+
+        return (
+            <form onSubmit={handleSubmit}>
+                <Box display="flex" flexDirection="column" gap={2}>
+                    {renderInputFields()}
+
+                    {primaryAction && (
+                        <Button variant="contained" color="primary" type="submit" fullWidth sx={{ mt: 2 }}>
+                            {primaryLabel}
+                        </Button>
+                    )}
+
+                    {availableActions.length > 1 && (
+                        <Box sx={{ mt: 1 }}>
+                            <Divider sx={{ my: 2 }}>or</Divider>
+                            {availableActions.slice(1).map((action, index) => (
+                                <Button
+                                    key={`alt-action-${index}`}
+                                    fullWidth
+                                    variant="contained"
+                                    color="secondary"
+                                    type="button"
+                                    onClick={() => handleActionSelection(action.ref)}
+                                    sx={{ mb: 1 }}
+                                    startIcon={getActionIcon(action.ref)}
+                                >
+                                    {getActionLabel(action.ref, action.label)}
+                                </Button>
+                            ))}
+                        </Box>
+                    )}
+                </Box>
+            </form>
+        );
+    };
+
+    const renderContent = () => {
+        if (step === 'verifying') {
+            return (
+                <Box sx={{ textAlign: 'center', py: 4 }}>
+                    <GradientCircularProgress />
+                    <Typography sx={{ mt: 2 }}>Verifying your invite link...</Typography>
+                </Box>
+            );
+        }
+
+        if (step === 'error') {
+            return (
+                <Box>
+                    <Box sx={{ mb: 4 }}>
+                        <Typography variant="h5" gutterBottom>
+                            Unable to Continue
+                        </Typography>
+                    </Box>
+                    <Alert severity="error" sx={{ mb: 3 }}>
+                        {errorMessage}
+                    </Alert>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        fullWidth
+                        onClick={() => navigate('/')}
+                    >
+                        Back to Login
+                    </Button>
+                </Box>
+            );
+        }
+
+        if (step === 'success') {
+            return (
+                <Box sx={{ textAlign: 'center', py: 2 }}>
+                    <Typography variant="h3" sx={{ mb: 2 }}>✅</Typography>
+                    <Typography variant="h5" gutterBottom>
+                        Completed
+                    </Typography>
+                    <Typography sx={{ mb: 3 }}>
+                        Completed successfully.
+                    </Typography>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        fullWidth
+                        onClick={() => navigate('/')}
+                    >
+                        Go to Login
+                    </Button>
+                </Box>
+            );
+        }
+
+        return (
+            <Box>
+                <Box sx={{ mb: 4 }}>
+                    <Typography variant="h5" gutterBottom>
+                        Continue
+                    </Typography>
+                    <Typography>
+                        Provide the requested information to continue.
+                    </Typography>
+                </Box>
+                {renderInputPromptForm()}
+            </Box>
+        );
+    };
+
+    return (
+        <Layout>
+            {loading && step === 'verifying' ? (
+                <GradientCircularProgress />
+            ) : (
+                <Grid size={{ xs: 12, md: 6 }}>
+                    <Paper
+                        sx={{
+                            display: 'flex',
+                            width: '100%',
+                            height: '100%',
+                            flexDirection: 'column',
+                        }}
+                    >
+                        <Box
+                            sx={{
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                padding: 6,
+                                width: '100%',
+                                maxWidth: 500,
+                                margin: 'auto',
+                            }}
+                        >
+                            {renderContent()}
+                            <Box component="footer" sx={{ mt: 6 }}>
+                                <Typography sx={{ textAlign: 'center' }}>
+                                    © Copyright {new Date().getFullYear()}
+                                </Typography>
+                            </Box>
+                        </Box>
+                    </Paper>
+                </Grid>
+            )}
+        </Layout>
+    );
+};
+
+export default InvitePage;

--- a/samples/apps/react-vanilla-sample/src/pages/LoginPage.tsx
+++ b/samples/apps/react-vanilla-sample/src/pages/LoginPage.tsx
@@ -44,12 +44,13 @@ import Layout from '../components/Layout';
 import ConnectionErrorModal from '../components/ConnectionErrorModal';
 import PasskeyRegPrompt from '../components/PasskeyRegPrompt';
 import PasskeyAuthPrompt from '../components/PasskeyAuthPrompt';
-import { 
-    NativeAuthSubmitType, 
+import {
+    NativeAuthSubmitType,
+    FlowServerError,
     initiateNativeAuthFlow,
     initiateNativeAuthFlowWithData,
-    submitNativeAuth, 
-    submitAuthDecision 
+    submitNativeAuth,
+    submitAuthDecision
 } from '../services/authService';
 import type { PasskeyCredentialResponse, PasskeyAssertionResponse } from '../services/authService';
 import useAuth from '../hooks/useAuth';
@@ -84,17 +85,16 @@ interface AuthResponse {
             idpName?: string;
             passkeyCreationOptions?: string;
             passkeyChallenge?: string;
+            emailSent?: string;
         };
     };
     executionId?: string;
 }
 
-// Define the interface for the submission error
-interface SubmissionError {
-    code?: string;
-    message?: string;
-    description?: string;
-}
+const isConnectionFailure = (error: Error) => {
+    const message = error.message?.toLowerCase() || '';
+    return message.includes('failed to fetch') || message.includes('network error');
+};
 
 /**
  * LoginPage component renders the login page with dynamic options based on the server response.
@@ -108,10 +108,12 @@ const LoginPage = () => {
 
     const isComponentReMount = useRef(false);
     const initRef = useRef<((mode?: boolean) => void) | null>(null);
+    const initRecoveryRef = useRef<((resetErrorState?: boolean) => void) | null>(null);
     const { setToken, clearToken } = useAuth();
 
     const [showRememberMe] = useState<boolean>(false);
-    const [showForgotPassword] = useState<boolean>(false);
+    const [isRecoveryMode, setIsRecoveryMode] = useState<boolean>(false);
+    const [emailSent, setEmailSent] = useState<boolean>(false);
     const [error, setError] = useState<boolean>(false);
     const [errorMessage, setErrorMessage] = useState<string>('');
     const [connectionError, setConnectionError] = useState<boolean>(false);
@@ -142,6 +144,7 @@ const LoginPage = () => {
     );
     const [regOnlySuccess, setRegOnlySuccess] = useState<boolean>(false);
     const [promptRegistration, setPromptRegistration] = useState<boolean>(false);
+    const showForgotPassword = !isSignupMode && !isRecoveryMode;
     
     // Passkey registration state
     const [passkeyCreationOptions, setPasskeyCreationOptions] = useState<string | null>(null);
@@ -275,7 +278,7 @@ const LoginPage = () => {
     // Process authentication response
     const processAuthResponse = useCallback((data: AuthResponse, selectedAction?: string, autoRedirect: boolean = false) => {
         const isCameFromDecision = needsDecision || autoRedirect;
-        const isMobileLogin = selectedAction && selectedAction.includes('mobile');
+        const isMobileLogin = !!selectedAction && (selectedAction.includes('mobile') || selectedAction.includes('sms'));
 
         setExecutionId(data.executionId || '');
         setChallengeToken(data.challengeToken || '');
@@ -289,9 +292,11 @@ const LoginPage = () => {
                 return;
             }
 
-            const defaultMessage = isSignupMode
-                ? 'Registration failed. Please check your information.'
-                : 'Login failed. Please check your credentials.';
+            const defaultMessage = isRecoveryMode
+                ? 'Recovery failed. Please try again.'
+                : isSignupMode
+                    ? 'Registration failed. Please check your information.'
+                    : 'Login failed. Please check your credentials.';
             setError(true);
             setErrorMessage(data.failureReason || defaultMessage);
             setLoading(false);
@@ -300,7 +305,11 @@ const LoginPage = () => {
             // and restart to get a fresh session with valid executionId/challengeToken.
             sessionStorage.removeItem(EXECUTION_ID_KEY);
             sessionStorage.removeItem(CHALLENGE_TOKEN_KEY);
-            initRef.current?.(isSignupMode);
+            if (isRecoveryMode) {
+                initRecoveryRef.current?.(false);
+            } else {
+                initRef.current?.(isSignupMode);
+            }
             return;
         }
 
@@ -343,7 +352,21 @@ const LoginPage = () => {
                 setPasskeyChallenge(data.data.additionalData.passkeyChallenge);
             }
 
-            // Handle the VIEW response
+            if (data.data?.additionalData?.emailSent === "true") {
+                setEmailSent(true);
+                setLoading(false);
+                return;
+            }
+
+            const hasHiddenInviteToken = data.data?.inputs?.some(
+                (input: AuthInput) => input.identifier === 'inviteToken' && input.type === 'HIDDEN'
+            );
+            if (hasHiddenInviteToken) {
+                setEmailSent(true);
+                setLoading(false);
+                return;
+            }
+
             // Check if this is an input prompt (has inputs to collect)
             if (data.data?.inputs && data.data.inputs.length > 0) {
                 // This is an input prompt - show input fields
@@ -397,7 +420,7 @@ const LoginPage = () => {
         }
 
         setLoading(false);
-    }, [needsDecision, isSignupMode, clearToken, setToken, handleSocialLoginClick]);
+    }, [needsDecision, isRecoveryMode, isSignupMode, clearToken, setToken, handleSocialLoginClick]);
 
     // Handle when user selects an authentication option
     const handleAuthOptionSelection = (actionId: string) => {
@@ -431,6 +454,8 @@ const LoginPage = () => {
         setRegOnlySuccess(false);
         setPasskeyCreationOptions(null);
         setPasskeyChallenge(null);
+        setIsRecoveryMode(false);
+        setEmailSent(false);
 
         initiateNativeAuthFlow(isSignupMode ? 'REGISTRATION' : 'LOGIN')
             .then((result) => {
@@ -509,7 +534,64 @@ const LoginPage = () => {
             });
     }, [clearToken, processAuthResponse, setToken]);
 
+    const initRecovery = useCallback((resetErrorState: boolean = true) => {
+        clearToken();
+        sessionStorage.removeItem(SIGNUP_MODE_KEY);
+        setConnectionError(false);
+        setNeedsDecision(false);
+        setAvailableActions([]);
+        setSelectedAction(null);
+        setFormData({});
+        setInputs([]);
+        setRedirectURL(null);
+        setSocialIdpName('');
+        setRegOnlySuccess(false);
+        setPasskeyCreationOptions(null);
+        setPasskeyChallenge(null);
+        setIsSignupMode(false);
+        setIsRecoveryMode(true);
+        setEmailSent(false);
+        setLoading(true);
+
+        if (resetErrorState) {
+            setError(false);
+            setErrorMessage('');
+        }
+
+        initiateNativeAuthFlow('RECOVERY')
+            .then((result) => {
+                const data = result.data;
+
+                if (data.flowStatus === 'ERROR') {
+                    setError(true);
+                    setErrorMessage(data.failureReason || 'Failed to start recovery. Please try again.');
+                } else if (data.type === 'VIEW' && data.data?.inputs) {
+                    data.data.inputs.forEach((input: AuthInput) => {
+                        setInputs(prev => [...prev, input]);
+                    });
+                    if (data.data.actions) {
+                        setAvailableActions(data.data.actions);
+                    }
+                }
+
+                setExecutionId(data.executionId);
+                setChallengeToken(data.challengeToken || '');
+                setLoading(false);
+            })
+            .catch((nextError: Error) => {
+                console.error('Error during recovery initialization:', nextError);
+                if (isConnectionFailure(nextError)) {
+                    setConnectionError(true);
+                } else {
+                    setError(true);
+                    setErrorMessage(nextError.message || 'Failed to start recovery. Please try again.');
+                }
+                setLoading(false);
+            });
+    }, [clearToken]);
+
     useEffect(() => { initRef.current = init; }, [init]);
+    useEffect(() => { initRecoveryRef.current = initRecovery; }, [initRecovery]);
 
     // Initialize the prompt signup decision action
     const initPromptSignupDecision = () => {
@@ -655,16 +737,29 @@ const LoginPage = () => {
         }
     };
 
-    const handleSubmissionError = (error: SubmissionError) => {
-        // Check if it's a network error or authentication error
-        if (error.message && error.message.includes("Network Error")) {
+    const handleSubmissionError = useCallback((error: Error) => {
+        if (isConnectionFailure(error)) {
             setConnectionError(true);
+            setLoading(false);
+        } else if (error instanceof FlowServerError) {
+            setError(true);
+            setErrorMessage(error.message || 'An unexpected server error occurred. Please try again.');
+            sessionStorage.removeItem(EXECUTION_ID_KEY);
+            sessionStorage.removeItem(CHALLENGE_TOKEN_KEY);
+            sessionStorage.removeItem(SIGNUP_MODE_KEY);
+            sessionStorage.setItem(START_INIT_KEY, 'true');
+            setLoading(false);
+            if (isRecoveryMode) {
+                initRecoveryRef.current?.(false);
+            } else {
+                initRef.current?.(isSignupMode);
+            }
         } else {
             setError(true);
             setErrorMessage(error.message || 'Error during authentication');
+            setLoading(false);
         }
-        setLoading(false);
-    };
+    }, [isRecoveryMode, isSignupMode]);
 
     // Handler for passkey credential creation
     const handlePasskeyCredentialCreated = (credential: PasskeyCredentialResponse) => {
@@ -732,7 +827,11 @@ const LoginPage = () => {
 
     const handleRetry = () => {
         setTimeout(() => {
-            init();
+            if (isRecoveryMode) {
+                initRecoveryRef.current?.(false);
+            } else {
+                init();
+            }
         }, 500);
     };
     
@@ -767,6 +866,12 @@ const LoginPage = () => {
         }
     };
 
+    const isMobileAction = (action?: ActionPrompt) =>
+        !!action?.ref && (action.ref.includes("mobile") || action.ref.includes("sms"));
+
+    const usesMobileNumberField = (action?: ActionPrompt) =>
+        !!action && (action.ref.includes("prompt_mobile") || action.nextNode === "prompt_mobile");
+
     // This effect is to handle initial component mount
     useEffect(() => {
         // Prevent double mount due to React Strict Mode
@@ -799,7 +904,7 @@ const LoginPage = () => {
 
             sessionStorage.setItem(START_INIT_KEY, "true");
         }
-    },[startInit, init, executionId, challengeToken, setToken, processAuthResponse]);
+    }, [startInit, init, executionId, challengeToken, processAuthResponse, handleSubmissionError]);
 
     // Render input fields based on the current inputs array
     const renderInputFields = () => {
@@ -932,9 +1037,7 @@ const LoginPage = () => {
     // Render the login form with side-by-side layout based on the available actions
     const renderSideBySideLoginForm = () => {
         const basicAuthAction = availableActions.find(action => action.ref?.includes("basic_auth"));
-        const mobileAuthActions = availableActions.filter(action => 
-            action.nextNode === "mobile_prompt_username" || action.nextNode === "prompt_mobile"
-        );
+        const mobileAuthActions = availableActions.filter(isMobileAction);
         
         const hasSocialAuth = availableActions.some(action => 
             action.ref?.includes("google") || action.ref?.includes("github")
@@ -1007,7 +1110,11 @@ const LoginPage = () => {
                                             label="Remember me"
                                         />
                                     )}
-                                    {showForgotPassword && <Link href="#">Forgot your password?</Link>}
+                                    {showForgotPassword && (
+                                        <Link href="#" onClick={(e) => { e.preventDefault(); initRecovery(); }} underline="hover">
+                                            Forgot your password?
+                                        </Link>
+                                    )}
                                 </Box>
                                 )}
 
@@ -1061,16 +1168,16 @@ const LoginPage = () => {
                             >
                                 <Box display="flex" flexDirection="column" gap={2}>
                                     <Box display="flex" flexDirection="column" gap={0.5}>
-                                        <InputLabel htmlFor={mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "mobileNumber" : "username"}>
-                                            {mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "Mobile Number" : "Username"}
+                                        <InputLabel htmlFor={usesMobileNumberField(mobileAuthActions[0]) ? "mobileNumber" : "username"}>
+                                            {usesMobileNumberField(mobileAuthActions[0]) ? "Mobile Number" : "Username"}
                                         </InputLabel>
                                         <OutlinedInput
                                             type="text"
-                                            id={mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "mobileNumber" : "username"}
-                                            name={mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "mobileNumber" : "username"}
-                                            placeholder={`Enter your ${mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "mobile number" : "username"}`}
+                                            id={usesMobileNumberField(mobileAuthActions[0]) ? "mobileNumber" : "username"}
+                                            name={usesMobileNumberField(mobileAuthActions[0]) ? "mobileNumber" : "username"}
+                                            placeholder={`Enter your ${usesMobileNumberField(mobileAuthActions[0]) ? "mobile number" : "username"}`}
                                             size="small"
-                                            value={formData[mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "mobileNumber" : "username"] || ''}
+                                            value={formData[usesMobileNumberField(mobileAuthActions[0]) ? "mobileNumber" : "username"] || ''}
                                             onChange={handleInputChange}
                                             required
                                         />
@@ -1115,9 +1222,7 @@ const LoginPage = () => {
     // Render the regular login form with options stacked vertically
     const renderRegularLoginForm = () => {
         const basicAuthAction = availableActions.find(action => action.ref?.includes("basic_auth"));
-        const mobileAuthActions = availableActions.filter(action => 
-            action.nextNode === "mobile_prompt_username" || action.nextNode === "prompt_mobile"
-        );
+        const mobileAuthActions = availableActions.filter(isMobileAction);
         
         const hasBasicAuth = !!basicAuthAction;
         const hasSocialAuth = availableActions.some(action => 
@@ -1148,9 +1253,9 @@ const LoginPage = () => {
                                 color="secondary"
                                 onClick={() => handleAuthOptionSelection(action.ref)}
                                 sx={{ my: 1 }}
-                                startIcon={getSocialLoginIcon(action.nextNode || '')}
+                                startIcon={getSocialLoginIcon(action.ref || '')}
                             >
-                                {getSocialLoginText(action.nextNode || '')}
+                                {getSocialLoginText(action.ref || '')}
                             </Button>
                         ))}
                     </Box>
@@ -1218,9 +1323,11 @@ const LoginPage = () => {
                                             control={<Checkbox name="remember-me-checkbox" />} 
                                             label="Remember me" />
                                     )}
-                                    { showForgotPassword &&
-                                        <Link href="">Forgot your password?</Link>
-                                    }
+                                    {showForgotPassword && (
+                                        <Link href="#" onClick={(e) => { e.preventDefault(); initRecovery(); }} underline="hover">
+                                            Forgot your password?
+                                        </Link>
+                                    )}
                                 </Box>
                             )}
                             <Button
@@ -1249,16 +1356,16 @@ const LoginPage = () => {
                     >
                         <Box display="flex" flexDirection="column" gap={2}>
                             <Box display="flex" flexDirection="column" gap={0.5}>
-                                <InputLabel htmlFor={mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "mobileNumber" : "username"}>
-                                    {mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "Mobile Number" : "Username"}
+                                <InputLabel htmlFor={usesMobileNumberField(mobileAuthActions[0]) ? "mobileNumber" : "username"}>
+                                    {usesMobileNumberField(mobileAuthActions[0]) ? "Mobile Number" : "Username"}
                                 </InputLabel>
                                 <OutlinedInput
                                     type="text"
-                                    id={mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "mobileNumber" : "username"}
-                                    name={mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "mobileNumber" : "username"}
-                                    placeholder={`Enter your ${mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "mobile number" : "username"}`}
+                                    id={usesMobileNumberField(mobileAuthActions[0]) ? "mobileNumber" : "username"}
+                                    name={usesMobileNumberField(mobileAuthActions[0]) ? "mobileNumber" : "username"}
+                                    placeholder={`Enter your ${usesMobileNumberField(mobileAuthActions[0]) ? "mobile number" : "username"}`}
                                     size="small"
-                                    value={formData[mobileAuthActions[0]?.nextNode === "prompt_mobile" ? "mobileNumber" : "username"] || ''}
+                                    value={formData[usesMobileNumberField(mobileAuthActions[0]) ? "mobileNumber" : "username"] || ''}
                                     onChange={handleInputChange}
                                     required
                                 />
@@ -1317,9 +1424,11 @@ const LoginPage = () => {
                                     control={<Checkbox name="remember-me-checkbox" />} 
                                     label="Remember me" />
                             )}
-                            { showForgotPassword &&
-                                <Link href="">Forgot your password?</Link>
-                            }
+                            {showForgotPassword && (
+                                <Link href="#" onClick={(e) => { e.preventDefault(); initRecovery(); }} underline="hover">
+                                    Forgot your password?
+                                </Link>
+                            )}
                         </Box>
                     )}
 
@@ -1331,7 +1440,7 @@ const LoginPage = () => {
                         } else if (primaryRef.includes('signup') || primaryRef.includes('sign_up')) {
                             label = 'Create Account';
                         } else if (inputs.some(input => input.identifier === 'password' || input.type === 'PASSWORD_INPUT')) {
-                            label = isSignupMode ? 'Create Account' : 'Sign In';
+                            label = isRecoveryMode ? 'Reset Password' : isSignupMode ? 'Create Account' : 'Sign In';
                         } else if (inputs.some(input => input.identifier === 'otp' || input.type === 'OTP_INPUT')) {
                             label = 'Verify OTP';
                         } else {
@@ -1418,14 +1527,14 @@ const LoginPage = () => {
     // Calculate appropriate grid size based on layout complexity
     const gridMdSize = needsDecision 
         && !promptRegistration
-        && availableActions.some(action => action.ref?.includes("basic_auth")) 
-        && availableActions.some(action => action.nextNode === "mobile_prompt_username" || action.nextNode === "prompt_mobile") 
+        && availableActions.some(action => action.ref?.includes("basic_auth"))
+        && availableActions.some(action => action.ref?.includes("mobile") || action.ref?.includes("sms"))
         ? 10 : 6;
     const containerBoxMaxWidth = gridMdSize === 10 ? 1000 : 500;
 
     const basicAuthAction = availableActions.find(action => action.ref?.includes("basic_auth"));
-    const mobileAuthActions = availableActions.filter(action => 
-        action.nextNode === "mobile_prompt_username" || action.nextNode === "prompt_mobile"
+    const mobileAuthActions = availableActions.filter(action =>
+        action.ref?.includes("mobile") || action.ref?.includes("sms")
     );
     
     const hasBasicAuth = !!basicAuthAction;
@@ -1468,20 +1577,36 @@ const LoginPage = () => {
                                 ) : regOnlySuccess ? (
                                     <Box sx={{ mb: 4 }}>
                                         <Typography variant="h5" gutterBottom>
-                                            Registration Successful
+                                            {isRecoveryMode ? 'Password Reset Successful' : 'Registration Successful'}
                                         </Typography>
                                         <Typography>
                                             You can now log in to your account.
                                         </Typography>
                                     </Box>
-                                ) : (
+                                ) : !emailSent ? (
                                     <Box sx={{ mb: 4 }}>
                                         <Typography variant="h5" gutterBottom>
-                                            {isSignupMode ? 'Create Account' : 'Login to Account'}
+                                            {isRecoveryMode ? 'Reset Password' : isSignupMode ? 'Create Account' : 'Login to Account'}
                                         </Typography>
 
                                         <Typography>
-                                            {isSignupMode ? (
+                                            {isRecoveryMode ? (
+                                                <>
+                                                    Remember your password?{' '}
+                                                    <Link
+                                                        href="#"
+                                                        onClick={(e) => {
+                                                            e.preventDefault();
+                                                            setError(false);
+                                                            setErrorMessage('');
+                                                            init(false);
+                                                        }}
+                                                        underline="hover"
+                                                    >
+                                                        Sign in!
+                                                    </Link>
+                                                </>
+                                            ) : isSignupMode ? (
                                                 <>
                                                     Already have an account?{' '}
                                                     <Link 
@@ -1518,6 +1643,8 @@ const LoginPage = () => {
                                             )}
                                         </Typography>
                                     </Box>
+                                ) : (
+                                    <Box sx={{ mb: 4 }} />
                                 )}
                                 
                                 {connectionError && (
@@ -1534,7 +1661,28 @@ const LoginPage = () => {
                                     </Alert>
                                 )}
 
-                                {!connectionError && (
+                                {!connectionError && emailSent ? (
+                                    <Box sx={{ textAlign: 'center', py: 2 }}>
+                                        <Typography variant="h3" sx={{ mb: 2 }}>✉️</Typography>
+                                        <Typography variant="h5" gutterBottom>
+                                            Check Your Email
+                                        </Typography>
+                                        <Typography sx={{ mb: 3 }}>
+                                            If an account with that username exists, we&apos;ve sent a password reset link to the associated email address.
+                                        </Typography>
+                                        <Button
+                                            variant="outlined"
+                                            fullWidth
+                                            onClick={() => {
+                                                setError(false);
+                                                setErrorMessage('');
+                                                init(false);
+                                            }}
+                                        >
+                                            Back to Login
+                                        </Button>
+                                    </Box>
+                                ) : !connectionError && (
                                     promptRegistration ? (
                                         <Box sx={{ mb: 4 }}>
                                             <Button

--- a/samples/apps/react-vanilla-sample/src/services/authService.ts
+++ b/samples/apps/react-vanilla-sample/src/services/authService.ts
@@ -214,6 +214,14 @@ export const authenticateWithPasskey = async (
     };
 };
 
+export class FlowServerError extends Error {
+    isServerError = true;
+    constructor(message: string) {
+        super(message);
+        this.name = 'FlowServerError';
+    }
+}
+
 type NativeAuthSubmitPayload =
   | { type: typeof NativeAuthSubmitType.INPUT; [key: string]: string }
   | { type: typeof NativeAuthSubmitType.SOCIAL; code: string }
@@ -227,7 +235,7 @@ const { applicationID, flowEndpoint } = config;
  * @param {string} flowType - The type of flow to initiate. Defaults to 'LOGIN'.
  * @returns {Promise<object>} - A promise that resolves to the response data from the server.
  */
-export const initiateNativeAuthFlow = async (flowType: 'LOGIN' | 'REGISTRATION' = 'LOGIN') => {
+export const initiateNativeAuthFlow = async (flowType: 'LOGIN' | 'REGISTRATION' | 'RECOVERY' = 'LOGIN') => {
     const headers = {
         'Content-Type': 'application/json'
     };
@@ -238,6 +246,8 @@ export const initiateNativeAuthFlow = async (flowType: 'LOGIN' | 'REGISTRATION' 
 
     if (flowType === 'REGISTRATION') {
         data.flowType = 'REGISTRATION';
+    } else if (flowType === 'RECOVERY') {
+        data.flowType = 'RECOVERY';
     } else {
         data.flowType = 'AUTHENTICATION';
     }
@@ -250,7 +260,11 @@ export const initiateNativeAuthFlow = async (flowType: 'LOGIN' | 'REGISTRATION' 
 
     if (!response.ok) {
         const errorData = await response.json().catch(() => ({})) as { message?: { defaultValue?: string } };
-        const flowTypeName = flowType === 'REGISTRATION' ? 'registration' : 'authentication';
+        const flowTypeName = flowType === 'REGISTRATION'
+            ? 'registration'
+            : flowType === 'RECOVERY'
+                ? 'recovery'
+                : 'authentication';
         const message = response.status === 400
             ? `Error initiating native ${flowTypeName} request.`
             : errorData?.message?.defaultValue || 'Server error occurred.';
@@ -350,6 +364,7 @@ export const submitAuthDecision = async (executionId: string, actionId: string, 
         const message = response.status === 400
             ? 'Error processing authentication option.'
             : errorData?.message?.defaultValue || 'Server error occurred.';
+        if (response.status >= 500) throw new FlowServerError(message);
         throw new Error(message);
     }
 
@@ -418,9 +433,9 @@ export const submitNativeAuth = async (
         const message = response.status === 400
             ? 'Login failed. Please check your credentials.'
             : errorData?.message?.defaultValue || 'Server error occurred.';
+        if (response.status >= 500) throw new FlowServerError(message);
         throw new Error(message);
     }
 
     return { data: await response.json() };
 }
-


### PR DESCRIPTION
### Purpose
Add password recovery support to the `react-vanilla-sample`.

This PR updates the vanilla sample to support the recovery flow that exists in the newer implementation but was missing in the current sample. It also adds the invite/recovery page handling needed to complete the reset-password flow from the email link.

### Approach
Implemented recovery flow support in the vanilla sample with minimal changes.

Key updates:
- Added recovery flow initiation in the sample auth service
- Added recovery handling in the sign-in page
- Added the invite/recovery page to handle the reset link flow

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Invite page/route for invite-based setup.
  * Added an in-app recovery flow for password reset and account recovery.

* **Documentation**
  * Added Invite Flow Configuration guidance and clarified supported authentication methods.

* **Improvements**
  * Improved login UX for recovery, “email sent” screens, prompts, and mobile/SMS handling.
  * Better distinction and surfacing of server-side authentication errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->