### PR TITLE
Add Express SDK API documentation

### DIFF
--- a/docs/content/guides/quick-start/connect-your-application/express.mdx
+++ b/docs/content/guides/quick-start/connect-your-application/express.mdx
@@ -18,7 +18,7 @@ import {
 
 # Express Quickstart
 
-Use this guide to add ThunderID authentication to an Express app with sign-in, sign-out, and route protection.
+Use this guide to add <ProductName /> authentication to an Express app with sign-in, sign-out, and route protection.
 
 <TutorialHero>
 
@@ -104,7 +104,7 @@ Install the <ProductName /> Express SDK:
 
 ## Add Authentication Middleware and Routes
 
-Create an `index.js` file with ThunderID middleware and auth routes:
+Create an `index.js` file with <ProductName /> middleware and auth routes:
 
 ```js title="index.js" showLineNumbers
 const express = require('express');

--- a/docs/content/sdks/express/apis/client/thunderid-express-client.mdx
+++ b/docs/content/sdks/express/apis/client/thunderid-express-client.mdx
@@ -1,0 +1,58 @@
+---
+title: ThunderIDExpressClient
+description: Express-aware client built on top of ThunderIDNodeClient
+---
+
+# `ThunderIDExpressClient`
+
+`ThunderIDExpressClient` is the Express-aware client class exported by `@thunderid/express`. It extends `ThunderIDNodeClient` and adds Express-specific request and configuration access.
+
+## Import
+
+```js
+const {ThunderIDExpressClient} = require('@thunderid/express');
+```
+
+## Overview
+
+In most applications, you do not instantiate this class directly. The [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid) middleware creates and initializes it for you, then attaches it to `req.thunderIDAuth` and `res.thunderIDAuth`.
+
+## Express-Specific Members
+
+### `expressConfig`
+
+Returns the initialized `ExpressClientConfig` value or `undefined` if the client has not been initialized yet.
+
+| Member | Type | Description |
+| :--- | :--- | :--- |
+| `expressConfig` | `ExpressClientConfig \| undefined` | The Express SDK configuration used to initialize the client |
+
+### `getUserFromRequest(req)`
+
+Reads the session ID from `req.cookies[SESSION_COOKIE_NAME]` and returns the current user for that session.
+
+```ts
+getUserFromRequest(req: express.Request): Promise<User | undefined>
+```
+
+```js title="index.js" showLineNumbers
+app.get('/me', async (req, res) => {
+  const user = await req.thunderIDAuth.getUserFromRequest(req);
+  res.json(user);
+});
+```
+
+## Inherited Behavior
+
+Because `ThunderIDExpressClient` extends `ThunderIDNodeClient`, inherited Node client methods are also available. This Express SDK section does not provide a full reference for the inherited Node surface.
+
+## Notes
+
+- `getUserFromRequest(req)` depends on `req.cookies`, so mount `cookie-parser` before routes that use it
+- `signIn()` and `signOut()` are also overridden internally to integrate with Express request and response handling, but this page focuses on the public Express-specific additions
+
+## Related APIs
+
+- [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid)
+- [`ExpressClientConfig`](/docs/next/sdks/express/apis/configuration/express-client-config)
+- [`Redirect Flow`](/docs/next/sdks/express/guides/redirect-flow)

--- a/docs/content/sdks/express/apis/configuration/express-client-config.mdx
+++ b/docs/content/sdks/express/apis/configuration/express-client-config.mdx
@@ -1,0 +1,99 @@
+---
+title: ExpressClientConfig
+description: Configuration reference for the Express SDK
+---
+
+# `ExpressClientConfig`
+
+`ExpressClientConfig` is the main configuration type for `@thunderid/express`.
+
+## Type Relationships
+
+The Express SDK exports these related types:
+
+| Type | Definition |
+| :--- | :--- |
+| `StrictExpressClientConfig` | Express-specific callback fields |
+| `ExpressClientConfig` | `ThunderIDNodeConfig & StrictExpressClientConfig` |
+| `ThunderIDExpressConfig` | Alias of `ExpressClientConfig` |
+
+`ExpressClientConfig` extends `ThunderIDNodeConfig`, which itself extends the base JavaScript SDK configuration. This page focuses on the fields that directly affect Express integration.
+
+## Usage
+
+```js title="index.js" showLineNumbers
+const {thunderID} = require('@thunderid/express');
+
+app.use(
+  thunderID({
+    baseUrl: 'https://localhost:8090',
+    clientId: '<your-client-id>',
+    clientSecret: '<your-client-secret>',
+    afterSignInUrl: 'http://localhost:3000/login',
+    afterSignOutUrl: 'http://localhost:3000/logout',
+    sessionCookie: {
+      expiryTime: 28800,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: false,
+    },
+  }),
+);
+```
+
+## Core Fields
+
+| Field | Type | Required | Description |
+| :--- | :--- | :---: | :--- |
+| `baseUrl` | `string` | ✅ | Base URL of the <ProductName /> instance |
+| `clientId` | `string` | ❌ | Client ID for the application |
+| `clientSecret` | `string` | ❌ | Client secret for confidential clients |
+
+## Flow Fields
+
+| Field | Type | Required | Default | Description |
+| :--- | :--- | :---: | :--- | :--- |
+| `afterSignInUrl` | `string` | ❌ | `${origin}/login` | Callback URL used after sign-in when not explicitly set |
+| `afterSignOutUrl` | `string` | ❌ | `${origin}/logout` | Callback URL used after sign-out when not explicitly set |
+| `mode` | `'redirect' \| 'embedded'` | ❌ | `'redirect'` | Authentication interaction mode |
+| `signInOptions` | `Record<string, any>` | ❌ | None | Additional authorize request parameters |
+| `signOutOptions` | `Record<string, unknown>` | ❌ | None | Additional sign-out request parameters |
+| `applicationId` | `string` | ❌ | None | Application identifier used by some flows such as embedded sign-in |
+
+## Express Callbacks
+
+These fields come from `StrictExpressClientConfig`.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `onSignIn` | `(res: express.Response, tokenResponse: TokenResponse) => void` | Called after a successful sign-in callback exchange |
+| `onSignOut` | `(res: express.Response) => void` | Called after a successful sign-out completion request |
+| `onError` | `(res: express.Response, exception: ThunderIDRuntimeError) => void` | Called when authentication-related work fails |
+| `onUnauthenticated` | `(res: express.Response) => void` | Intended callback for unauthenticated access handling |
+
+:::note
+`protect()` accepts its own `onUnauthenticated` callback argument. The current `protect()` implementation does not read `config.onUnauthenticated`.
+:::
+
+## Session Cookie Configuration
+
+The `sessionCookie` field is inherited from `ThunderIDNodeConfig`.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `expiryTime` | `number` | `86400` | Session lifetime in seconds |
+| `httpOnly` | `boolean` | `true` | Makes the cookie inaccessible to JavaScript |
+| `sameSite` | `'lax' \| 'strict' \| 'none'` | `'lax'` | SameSite policy for the session cookie |
+| `secure` | `boolean` | `false` | Requires HTTPS when `true` |
+
+## Notes
+
+- `afterSignInUrl` and `afterSignOutUrl` are optional because the Express middleware can derive defaults from the first incoming request origin
+- Use `mode: 'embedded'` only when you plan to mount [`handleFlow()`](/docs/next/sdks/express/apis/middleware/handle-flow)
+- Other inherited `ThunderIDNodeConfig` and base JavaScript SDK options remain available, but they are outside the scope of this Express-first reference
+
+## Related APIs
+
+- [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid)
+- [`handleFlow()`](/docs/next/sdks/express/apis/middleware/handle-flow)
+- [`CookieConfig`](/docs/next/sdks/express/apis/constants/cookie-config)

--- a/docs/content/sdks/express/apis/constants/cookie-config.mdx
+++ b/docs/content/sdks/express/apis/constants/cookie-config.mdx
@@ -1,0 +1,47 @@
+---
+title: CookieConfig
+description: Session cookie constants used by the Express SDK
+---
+
+# `CookieConfig`
+
+The Express SDK exports `CookieConfig` and `SESSION_COOKIE_NAME` for the session cookie behavior used by the SDK.
+
+## Import
+
+```js
+const {CookieConfig, SESSION_COOKIE_NAME} = require('@thunderid/express');
+```
+
+## Session Cookie Name
+
+| Export | Value | Description |
+| :--- | :--- | :--- |
+| `SESSION_COOKIE_NAME` | `'THUNDERID_SESSION_ID'` | Session cookie key used by the Express SDK |
+
+## Default Cookie Values
+
+| Property | Value |
+| :--- | :--- |
+| `defaultExpirySeconds` | `86400` |
+| `defaultHttpOnly` | `true` |
+| `defaultSameSite` | `'lax'` |
+| `defaultSecure` | `false` |
+
+## Usage
+
+You do not need to set these values directly when `sessionCookie` options are omitted from `ExpressClientConfig`. The SDK uses these defaults automatically.
+
+```js title="index.js" showLineNumbers
+const {SESSION_COOKIE_NAME} = require('@thunderid/express');
+
+app.get('/session-id', (req, res) => {
+  res.json({sessionId: req.cookies?.[SESSION_COOKIE_NAME] ?? null});
+});
+```
+
+## Related APIs
+
+- [`ExpressClientConfig`](/docs/next/sdks/express/apis/configuration/express-client-config)
+- [`handleSignIn()`](/docs/next/sdks/express/apis/middleware/handle-sign-in)
+- [`handleSignOut()`](/docs/next/sdks/express/apis/middleware/handle-sign-out)

--- a/docs/content/sdks/express/apis/middleware/handle-flow.mdx
+++ b/docs/content/sdks/express/apis/middleware/handle-flow.mdx
@@ -1,0 +1,133 @@
+---
+title: handleFlow()
+description: Drive the embedded sign-in flow lifecycle through JSON requests
+---
+
+# `handleFlow()`
+
+The `handleFlow()` function returns an Express route handler that advances the embedded sign-in flow and responds with JSON.
+
+## Signature
+
+```ts
+handleFlow(): express.RequestHandler
+```
+
+## Import
+
+```js
+const {handleFlow} = require('@thunderid/express');
+```
+
+## Prerequisites
+
+- Mount [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid) with `mode: 'embedded'`
+- Mount `express.json()` before this handler so the SDK can read `req.body`
+- Keep `handleSignIn()` mounted on your callback route so the returned redirect URL can complete sign-in
+
+## Usage
+
+```js title="index.js" showLineNumbers
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const {thunderID, handleFlow, handleSignIn, handleSignOut} = require('@thunderid/express');
+
+const app = express();
+
+app.use(cookieParser());
+app.use(express.json());
+app.use(
+  thunderID({
+    baseUrl: 'https://localhost:8090',
+    clientId: '<your-client-id>',
+    clientSecret: '<your-client-secret>',
+    mode: 'embedded',
+  }),
+);
+
+app.post('/flow/sign-in', handleFlow());
+app.get('/login', handleSignIn());
+app.get('/logout', handleSignOut());
+```
+
+## Request Shapes
+
+### First Request
+
+When no `executionId` is present, send:
+
+```json
+{
+  "applicationId": "app-id",
+  "flowType": "SIGN_IN"
+}
+```
+
+If `flowType` is omitted, the SDK uses `'SIGN_IN'`.
+
+### Continuation Request
+
+When continuing an existing flow, send:
+
+```json
+{
+  "executionId": "...",
+  "challengeToken": "...",
+  "authId": "...",
+  "inputs": {
+    "...": "..."
+  }
+}
+```
+
+## Response Shapes
+
+### Flow Continues
+
+If the flow needs another step, the handler returns:
+
+```json
+{
+  "authId": "...",
+  "challengeToken": "...",
+  "components": [],
+  "executionId": "...",
+  "flowStatus": "..."
+}
+```
+
+### Flow Completes
+
+If the flow finishes and the next step is the OAuth callback, the handler returns:
+
+```json
+{
+  "done": true,
+  "redirectUrl": "/login?code=..."
+}
+```
+
+The client must navigate to `redirectUrl`, which is then handled by `handleSignIn()` to exchange the code and set the session cookie.
+
+## Runtime Behavior
+
+- Requires `req.thunderIDAuth` from `thunderID()`
+- Requires `baseUrl` in the initialized config
+- On the first request, if `authId` is not provided, the handler derives it from `client.getSignInUrl()`
+- Delegates flow execution to the embedded sign-in flow executor and normalizes the response into JSON
+
+## Failure Behavior
+
+The handler returns `500` JSON responses for these cases:
+
+| Condition | Response |
+| :--- | :--- |
+| `thunderID()` not mounted first | `{ "error": "SDK not initialised" }` |
+| `baseUrl` missing from config | `{ "error": "baseUrl is not configured" }` |
+| Flow execution failure | `{ "error": "<runtime message>" }` |
+
+## Related APIs
+
+- [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid)
+- [`handleSignIn()`](/docs/next/sdks/express/apis/middleware/handle-sign-in)
+- [`Embedded Sign-In`](/docs/next/sdks/express/guides/embedded-sign-in)

--- a/docs/content/sdks/express/apis/middleware/handle-sign-in.mdx
+++ b/docs/content/sdks/express/apis/middleware/handle-sign-in.mdx
@@ -1,0 +1,80 @@
+---
+title: handleSignIn()
+description: Handle sign-in redirects and authorization-code callbacks
+---
+
+# `handleSignIn()`
+
+The `handleSignIn()` function returns an Express route handler for the sign-in path.
+
+## Signature
+
+```ts
+handleSignIn(): express.RequestHandler
+```
+
+## Import
+
+```js
+const {handleSignIn} = require('@thunderid/express');
+```
+
+## Prerequisites
+
+- Mount [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid) before this handler
+- Register this handler on the route that matches your `afterSignInUrl`
+
+## Usage
+
+```js title="index.js" showLineNumbers
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const {thunderID, handleSignIn} = require('@thunderid/express');
+
+const app = express();
+
+app.use(cookieParser());
+app.use(
+  thunderID({
+    baseUrl: 'https://localhost:8090',
+    clientId: '<your-client-id>',
+    clientSecret: '<your-client-secret>',
+    afterSignInUrl: 'http://localhost:3000/login',
+  }),
+);
+
+app.get('/login', handleSignIn());
+```
+
+## Runtime Behavior
+
+`handleSignIn()` supports two stages on the same route:
+
+1. If the request does not include a `code` query parameter, the handler starts the OAuth 2.0 redirect flow.
+2. If the request includes a `code` query parameter, the handler exchanges the authorization code for tokens, writes the session cookie, and completes sign-in.
+
+## Default Callbacks
+
+The handler uses the initialized Express config callbacks if they are provided.
+
+| Callback | Default behavior |
+| :--- | :--- |
+| `onSignIn` | Calls `res.end()` |
+| `onError` | Logs the error message and returns `500` with an empty response body |
+
+## Failure Behavior
+
+- If `thunderID()` has not been mounted first, the handler logs an error and returns `500`
+- If sign-in fails, the handler calls `onError`
+- If the original request URL already contains an error parameter, the underlying client rejects the request
+
+## Notes
+
+- The session cookie is set during the authorization redirect and callback flow
+- The underlying Express client uses the configured `sessionCookie` settings when writing the cookie
+
+## Related APIs
+
+- [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid)
+- [`handleSignOut()`](/docs/next/sdks/express/apis/middleware/handle-sign-out)
+- [`Redirect Flow`](/docs/next/sdks/express/guides/redirect-flow)

--- a/docs/content/sdks/express/apis/middleware/handle-sign-out.mdx
+++ b/docs/content/sdks/express/apis/middleware/handle-sign-out.mdx
@@ -1,0 +1,84 @@
+---
+title: handleSignOut()
+description: Handle sign-out redirects and post-logout completion
+---
+
+# `handleSignOut()`
+
+The `handleSignOut()` function returns an Express route handler for the sign-out path.
+
+## Signature
+
+```ts
+handleSignOut(): express.RequestHandler
+```
+
+## Import
+
+```js
+const {handleSignOut} = require('@thunderid/express');
+```
+
+## Prerequisites
+
+- Mount [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid) before this handler
+- Mount `cookie-parser` before this handler so the SDK can read `req.cookies`
+- Register this handler on the route that matches your `afterSignOutUrl`
+
+## Usage
+
+```js title="index.js" showLineNumbers
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const {thunderID, handleSignOut} = require('@thunderid/express');
+
+const app = express();
+
+app.use(cookieParser());
+app.use(
+  thunderID({
+    baseUrl: 'https://localhost:8090',
+    clientId: '<your-client-id>',
+    clientSecret: '<your-client-secret>',
+    afterSignOutUrl: 'http://localhost:3000/logout',
+  }),
+);
+
+app.get('/logout', handleSignOut());
+```
+
+## Runtime Behavior
+
+The handler supports two sign-out stages:
+
+1. Normal sign-out request:
+   - reads the session ID from `req.cookies[SESSION_COOKIE_NAME]`
+   - requests the sign-out URL from the SDK
+   - clears the session cookie
+   - redirects the browser to the identity provider's end-session endpoint
+2. Post-logout completion request:
+   - if the request query contains `state=sign_out_success`, the handler calls `onSignOut`
+
+## Default Callbacks
+
+| Callback | Default behavior |
+| :--- | :--- |
+| `onSignOut` | Calls `res.end()` |
+| `onError` | Logs the error message and returns `500` with an empty response body |
+
+## Failure Behavior
+
+- If `thunderID()` has not been mounted first, the handler logs an error and returns `500`
+- If the request does not contain the session cookie, the handler calls `onError` with a `ThunderIDRuntimeError`
+- If sign-out URL generation fails, the handler calls `onError`
+
+## Notes
+
+- The missing-cookie error path uses the runtime error code `EXPRESS-AUTH_MW-LOGOUT-NF01`
+- The handler clears the session cookie by setting it to `null` with `maxAge: 0`
+
+## Related APIs
+
+- [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid)
+- [`CookieConfig`](/docs/next/sdks/express/apis/constants/cookie-config)
+- [`Redirect Flow`](/docs/next/sdks/express/guides/redirect-flow)

--- a/docs/content/sdks/express/apis/middleware/protect.mdx
+++ b/docs/content/sdks/express/apis/middleware/protect.mdx
@@ -1,0 +1,83 @@
+---
+title: protect()
+description: Block unauthenticated requests before a route handler runs
+---
+
+# `protect()`
+
+The `protect()` function returns Express middleware that blocks unauthenticated requests.
+
+## Signature
+
+```ts
+protect(
+  onUnauthenticated?: (res: express.Response) => void,
+): (req: express.Request, res: express.Response, next: express.NextFunction) => Promise<void>
+```
+
+## Import
+
+```js
+const {protect} = require('@thunderid/express');
+```
+
+## Prerequisites
+
+- Mount [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid) before this middleware
+- Mount `cookie-parser` before this middleware so the SDK can read `req.cookies`
+
+## Usage
+
+### Default 401 response
+
+```js title="index.js" showLineNumbers
+const {protect} = require('@thunderid/express');
+
+app.get('/protected', protect(), (_req, res) => {
+  res.send('Protected content');
+});
+```
+
+### Custom unauthenticated behavior
+
+```js title="index.js" showLineNumbers
+const {protect} = require('@thunderid/express');
+
+app.get(
+  '/protected',
+  protect((res) => res.redirect('/login')),
+  (_req, res) => {
+    res.send('Protected content');
+  },
+);
+```
+
+## Runtime Behavior
+
+For each request, the middleware:
+
+1. reads `req.thunderIDAuth`
+2. reads the session ID from `req.cookies[SESSION_COOKIE_NAME]`
+3. calls `client.isSignedIn(sessionId)`
+4. either continues to the next handler or rejects the request
+
+## Default Behavior
+
+If no `onUnauthenticated` callback is provided, the middleware returns `401` with an empty response body.
+
+## Failure Behavior
+
+- If the SDK client is missing or the session cookie is missing, the middleware rejects the request
+- If the session ID is invalid, the middleware rejects the request
+- In both cases, it uses your `onUnauthenticated` callback when provided, or the default `401` response otherwise
+
+## Notes
+
+- `protect()` checks authentication state for the session cookie value, not for the presence of user data on the request
+- A common pattern is to redirect to `/login` for browser routes and use the default `401` response for API routes
+
+## Related APIs
+
+- [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid)
+- [`handleSignIn()`](/docs/next/sdks/express/apis/middleware/handle-sign-in)
+- [`Redirect Flow`](/docs/next/sdks/express/guides/redirect-flow)

--- a/docs/content/sdks/express/apis/middleware/thunderid.mdx
+++ b/docs/content/sdks/express/apis/middleware/thunderid.mdx
@@ -1,0 +1,81 @@
+---
+title: ThunderID Middleware
+description: Initialize the Express SDK and attach the client to the request lifecycle
+---
+
+# `thunderID()`
+
+The `thunderID()` function returns Express middleware that initializes a `ThunderIDExpressClient` and attaches it to both `req.thunderIDAuth` and `res.thunderIDAuth`.
+
+## Signature
+
+```ts
+thunderID(config: ThunderIDExpressConfig): express.RequestHandler
+```
+
+## Import
+
+```js
+const {thunderID} = require('@thunderid/express');
+```
+
+## Overview
+
+Use `thunderID()` near the top of your middleware stack. It initializes the SDK once, then exposes the initialized client to later middleware and route handlers.
+
+Unlike the old `thunderID()` router, this middleware does **not** mount any routes automatically. Register sign-in and sign-out handlers explicitly.
+
+## Usage
+
+```js title="index.js" showLineNumbers
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const {thunderID, handleSignIn, handleSignOut} = require('@thunderid/express');
+
+const app = express();
+
+app.use(cookieParser());
+app.use(express.json());
+app.use(
+  thunderID({
+    baseUrl: 'https://localhost:8090',
+    clientId: '<your-client-id>',
+    clientSecret: '<your-client-secret>',
+  }),
+);
+
+app.get('/login', handleSignIn());
+app.get('/logout', handleSignOut());
+```
+
+## Middleware Ordering
+
+- Mount `cookie-parser` before routes that depend on `req.cookies`
+- Mount `express.json()` before `handleFlow()` if you use embedded sign-in
+- Mount `thunderID()` before `handleSignIn()`, `handleSignOut()`, `protect()`, or `handleFlow()`
+
+## Runtime Behavior
+
+- Creates a `ThunderIDExpressClient`
+- Initializes the client with the provided configuration
+- Attaches the initialized client to:
+  - `req.thunderIDAuth`
+  - `res.thunderIDAuth`
+
+If `afterSignInUrl` or `afterSignOutUrl` is not provided, the middleware resolves defaults from the first incoming request origin:
+
+- `afterSignInUrl`: `${origin}/login`
+- `afterSignOutUrl`: `${origin}/logout`
+
+## Notes
+
+- `ThunderIDExpressConfig` is currently an alias of `ExpressClientConfig`
+- The initialized client is available to later handlers such as `handleSignIn()` and to route handlers that call `req.thunderIDAuth.getUserFromRequest(req)`
+
+## Related APIs
+
+- [`handleSignIn()`](/docs/next/sdks/express/apis/middleware/handle-sign-in)
+- [`handleSignOut()`](/docs/next/sdks/express/apis/middleware/handle-sign-out)
+- [`protect()`](/docs/next/sdks/express/apis/middleware/protect)
+- [`handleFlow()`](/docs/next/sdks/express/apis/middleware/handle-flow)
+- [`ExpressClientConfig`](/docs/next/sdks/express/apis/configuration/express-client-config)

--- a/docs/content/sdks/express/guides/embedded-sign-in.mdx
+++ b/docs/content/sdks/express/guides/embedded-sign-in.mdx
@@ -1,0 +1,125 @@
+---
+title: Embedded Sign-In
+description: Drive the Express embedded sign-in flow with handleFlow()
+---
+
+# Embedded Sign-In
+
+Use embedded sign-in when your application needs to advance the sign-in flow through JSON requests.
+Use it when you do not want to rely on a browser redirect for every interaction.
+
+## Prerequisites
+
+- `express`
+- `cookie-parser`
+- `express.json()`
+- `mode: 'embedded'` in your Express SDK configuration
+
+## Middleware and Route Setup
+
+```js title="index.js" showLineNumbers
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const {thunderID, handleFlow, handleSignIn, handleSignOut} = require('@thunderid/express');
+
+const app = express();
+
+app.use(cookieParser());
+app.use(express.json());
+app.use(
+  thunderID({
+    baseUrl: 'https://localhost:8090',
+    clientId: '<your-client-id>',
+    clientSecret: '<your-client-secret>',
+    mode: 'embedded',
+    afterSignInUrl: 'http://localhost:3000/login',
+    afterSignOutUrl: 'http://localhost:3000/logout',
+  }),
+);
+
+app.post('/flow/sign-in', handleFlow());
+app.get('/login', handleSignIn());
+app.get('/logout', handleSignOut());
+```
+
+## Request Lifecycle
+
+### Start the Flow
+
+Send the first request without an `executionId`:
+
+```json
+{
+  "applicationId": "app-id",
+  "flowType": "SIGN_IN"
+}
+```
+
+If `flowType` is omitted, the handler uses `'SIGN_IN'`.
+
+### Continue the Flow
+
+When the SDK returns `executionId`, `challengeToken`, and `authId`, send them back with the next user inputs:
+
+```json
+{
+  "executionId": "...",
+  "challengeToken": "...",
+  "authId": "...",
+  "inputs": {
+    "...": "..."
+  }
+}
+```
+
+## Response Lifecycle
+
+### Continue rendering UI
+
+If the flow still needs more steps, `handleFlow()` returns:
+
+```json
+{
+  "authId": "...",
+  "challengeToken": "...",
+  "components": [],
+  "executionId": "...",
+  "flowStatus": "..."
+}
+```
+
+Render the returned `components`, collect input, and post the next request.
+
+### Complete Sign-In
+
+If the flow completes, `handleFlow()` returns:
+
+```json
+{
+  "done": true,
+  "redirectUrl": "/login?code=..."
+}
+```
+
+Navigate to `redirectUrl`. That request is handled by `handleSignIn()`, which exchanges the code and sets the session cookie.
+
+## How `GET /login` and `POST /flow/sign-in` Work Together
+
+- `POST /flow/sign-in` advances the embedded interaction and eventually returns a redirect URL
+- `GET /login` completes the OAuth callback after the embedded flow returns the authorization code redirect
+
+Both routes are required for the embedded sign-in flow shown in the current SDK source.
+
+## Failure Cases
+
+`handleFlow()` returns `500` JSON responses when:
+
+- the SDK is not initialized because `thunderID()` was not mounted first
+- `baseUrl` is missing from the config
+- flow execution fails at runtime
+
+## Related APIs
+
+- [`handleFlow()`](/docs/next/sdks/express/apis/middleware/handle-flow)
+- [`handleSignIn()`](/docs/next/sdks/express/apis/middleware/handle-sign-in)
+- [`ExpressClientConfig`](/docs/next/sdks/express/apis/configuration/express-client-config)

--- a/docs/content/sdks/express/guides/redirect-flow.mdx
+++ b/docs/content/sdks/express/guides/redirect-flow.mdx
@@ -1,0 +1,99 @@
+---
+title: Redirect Flow
+description: Build the standard Express sign-in and protected-route flow
+---
+
+# Redirect Flow
+
+Use the redirect flow when you want the SDK to drive a standard OAuth 2.0 authorization-code redirect cycle for your Express application.
+
+## Prerequisites
+
+- `express`
+- `cookie-parser`
+- an application configured in <ProductName />
+- a redirect route such as `http://localhost:3000/login`
+
+## Middleware Order
+
+Mount middleware in this order:
+
+1. `cookie-parser()`
+2. `express.json()` if you also need JSON request parsing
+3. `thunderID(config)`
+4. Route handlers that use `handleSignIn()`, `handleSignOut()`, or `protect()`
+
+## Example
+
+```js title="index.js" showLineNumbers
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const {thunderID, handleSignIn, handleSignOut, protect} = require('@thunderid/express');
+
+const app = express();
+const port = 3000;
+
+app.use(cookieParser());
+app.use(express.json());
+app.use(
+  thunderID({
+    baseUrl: 'https://localhost:8090',
+    clientId: '<your-client-id>',
+    clientSecret: '<your-client-secret>',
+    afterSignInUrl: 'http://localhost:3000/login',
+    afterSignOutUrl: 'http://localhost:3000/logout',
+  }),
+);
+
+app.get('/', (_req, res) => {
+  res.send('<a href="/protected">Go to protected page</a>');
+});
+
+app.get('/login', handleSignIn());
+app.get('/logout', handleSignOut());
+
+app.get(
+  '/protected',
+  protect((res) => res.redirect('/login')),
+  (_req, res) => {
+    res.send('You are signed in and can access this protected route.');
+  },
+);
+
+app.get('/me', protect(), async (req, res) => {
+  const user = await req.thunderIDAuth.getUserFromRequest(req);
+  res.json(user);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});
+```
+
+## Flow Lifecycle
+
+1. The user opens a protected route.
+2. `protect()` checks the session cookie and current sign-in state.
+3. If the request is unauthenticated, your `onUnauthenticated` callback can redirect to `/login`.
+4. `handleSignIn()` starts the redirect flow.
+5. <ProductName /> redirects back to the configured sign-in callback route.
+6. `handleSignIn()` exchanges the authorization code for tokens and sets the session cookie.
+7. Protected routes can now continue and route handlers can read the signed-in user.
+
+## Access the Current User
+
+After `thunderID()` runs, the initialized client is available on `req.thunderIDAuth`.
+
+```js title="index.js" showLineNumbers
+app.get('/me', protect(), async (req, res) => {
+  const user = await req.thunderIDAuth.getUserFromRequest(req);
+  res.json(user);
+});
+```
+
+## Related APIs
+
+- [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid)
+- [`handleSignIn()`](/docs/next/sdks/express/apis/middleware/handle-sign-in)
+- [`handleSignOut()`](/docs/next/sdks/express/apis/middleware/handle-sign-out)
+- [`protect()`](/docs/next/sdks/express/apis/middleware/protect)

--- a/docs/content/sdks/express/overview.mdx
+++ b/docs/content/sdks/express/overview.mdx
@@ -2,12 +2,12 @@
 title: Express SDK Overview
 sidebar_position: 1
 sidebar_label: Overview
-description: Express SDK for seamless authentication integration
+description: Express SDK reference for <ProductName /> authentication middleware and handlers
 ---
 
 # Express SDK
 
-The <ProductName /> Express SDK (`@thunderid/express`) provides middleware and route handlers to integrate <ProductName /> authentication into Express applications.
+The <ProductName /> Express SDK (`@thunderid/express`) provides Express middleware, route handlers, configuration types, and constants for integrating <ProductName /> authentication into Express applications.
 
 ## Installation
 
@@ -27,13 +27,121 @@ Install the <ProductName /> Express SDK using your preferred package manager:
   </CodeBlock>
 </CodeGroup>
 
-## Getting Started
+## Quick Start
 
-To get started quickly, see the [Express Quickstart Guide](/docs/next/guides/quick-start/connect-your-application/express).
+For end-to-end setup instructions, see the [Express quickstart guide](/docs/next/guides/quick-start/connect-your-application/express).
 
-## Features
+## Prerequisites
 
-- Add <ProductName /> authentication middleware to your Express application
-- Handle sign-in and sign-out with built-in route handlers
-- Protect routes with middleware
-- Access the authenticated user profile in route handlers
+- `express`
+- `cookie-parser` for flows that read `req.cookies`
+- `express.json()` for embedded sign-in requests handled by `handleFlow()`
+
+## What This Section Covers
+
+This SDK section focuses on the Express-specific public surface exported by `@thunderid/express`:
+
+- Middleware and handlers: [`thunderID()`](/docs/next/sdks/express/apis/middleware/thunderid), [`handleSignIn()`](/docs/next/sdks/express/apis/middleware/handle-sign-in), [`handleSignOut()`](/docs/next/sdks/express/apis/middleware/handle-sign-out), [`protect()`](/docs/next/sdks/express/apis/middleware/protect), and [`handleFlow()`](/docs/next/sdks/express/apis/middleware/handle-flow)
+- Client additions: [`ThunderIDExpressClient`](/docs/next/sdks/express/apis/client/thunderid-express-client)
+- Configuration types: [`ExpressClientConfig`](/docs/next/sdks/express/apis/configuration/express-client-config), `StrictExpressClientConfig`, and `ThunderIDExpressConfig`
+- Constants: [`CookieConfig`](/docs/next/sdks/express/apis/constants/cookie-config) and `SESSION_COOKIE_NAME`
+
+:::note
+`@thunderid/express` also re-exports the `@thunderid/node` surface. This Express SDK section only documents the inherited Node and JavaScript SDK behavior that directly affects Express integration.
+:::
+
+## Package Exports
+
+| Export Group | Members |
+| :--- | :--- |
+| Middleware | `thunderID`, `handleSignIn`, `handleSignOut`, `protect`, `handleFlow` |
+| Client | `ThunderIDExpressClient` |
+| Types | `ExpressClientConfig`, `ThunderIDExpressConfig`, `StrictExpressClientConfig` |
+| Constants | `CookieConfig`, `SESSION_COOKIE_NAME` |
+| Re-exports | Public exports from `@thunderid/node` |
+
+## Choose a Flow
+
+### Redirect Flow
+
+Use the redirect flow when you want standard OAuth 2.0 authorization-code redirects handled by the SDK.
+
+Typical building blocks:
+
+- `thunderID(config)` to initialize the SDK and attach the client to the request and response
+- `handleSignIn()` for the sign-in route
+- `handleSignOut()` for the sign-out route
+- `protect()` for protected routes
+
+```js title="index.js" showLineNumbers
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const {thunderID, handleSignIn, handleSignOut, protect} = require('@thunderid/express');
+
+const app = express();
+
+app.use(cookieParser());
+app.use(express.json());
+app.use(
+  thunderID({
+    baseUrl: 'https://localhost:8090',
+    clientId: '<your-client-id>',
+    clientSecret: '<your-client-secret>',
+  }),
+);
+
+app.get('/login', handleSignIn());
+app.get('/logout', handleSignOut());
+app.get('/protected', protect(), (_req, res) => {
+  res.send('Protected content');
+});
+```
+
+See the [redirect flow guide](/docs/next/sdks/express/guides/redirect-flow) for the full route wiring pattern.
+
+### Embedded Sign-In
+
+Use the embedded flow when your application drives the sign-in interaction step by step and posts flow state to the SDK.
+
+Typical building blocks:
+
+- `thunderID({ ..., mode: 'embedded' })`
+- `handleFlow()` for the embedded sign-in endpoint
+- `handleSignIn()` to complete the OAuth callback after the flow returns a redirect URL
+- `handleSignOut()` for sign-out
+
+```js title="index.js" showLineNumbers
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const {thunderID, handleFlow, handleSignIn, handleSignOut} = require('@thunderid/express');
+
+const app = express();
+
+app.use(cookieParser());
+app.use(express.json());
+app.use(
+  thunderID({
+    baseUrl: 'https://localhost:8090',
+    clientId: '<your-client-id>',
+    clientSecret: '<your-client-secret>',
+    mode: 'embedded',
+  }),
+);
+
+app.post('/flow/sign-in', handleFlow());
+app.get('/login', handleSignIn());
+app.get('/logout', handleSignOut());
+```
+
+See the [embedded sign-in guide](/docs/next/sdks/express/guides/embedded-sign-in) for the request and response lifecycle.
+
+## Default Behavior
+
+- `mode` defaults to `'redirect'`
+- If `afterSignInUrl` is not set, the SDK uses the first incoming request origin with `/login`
+- If `afterSignOutUrl` is not set, the SDK uses the first incoming request origin with `/logout`
+- Session cookie defaults come from `CookieConfig`:
+  - `defaultExpirySeconds = 86400`
+  - `defaultHttpOnly = true`
+  - `defaultSameSite = 'lax'`
+  - `defaultSecure = false`

--- a/docs/content/sdks/express/sidebar.ts
+++ b/docs/content/sdks/express/sidebar.ts
@@ -24,6 +24,98 @@ const sidebar: SidebarsConfig = {
       type: 'doc',
       id: 'sdks/express/overview',
     },
+    {
+      type: 'category',
+      label: 'APIs',
+      collapsed: false,
+      items: [
+        {
+          type: 'category',
+          label: 'Middleware',
+          collapsed: false,
+          items: [
+            {
+              type: 'doc',
+              id: 'sdks/express/apis/middleware/thunderid',
+              label: 'thunderID()',
+            },
+            {
+              type: 'doc',
+              id: 'sdks/express/apis/middleware/handle-sign-in',
+              label: 'handleSignIn()',
+            },
+            {
+              type: 'doc',
+              id: 'sdks/express/apis/middleware/handle-sign-out',
+              label: 'handleSignOut()',
+            },
+            {
+              type: 'doc',
+              id: 'sdks/express/apis/middleware/protect',
+              label: 'protect()',
+            },
+            {
+              type: 'doc',
+              id: 'sdks/express/apis/middleware/handle-flow',
+              label: 'handleFlow()',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Client',
+          collapsed: true,
+          items: [
+            {
+              type: 'doc',
+              id: 'sdks/express/apis/client/thunderid-express-client',
+              label: 'ThunderIDExpressClient',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Configuration',
+          collapsed: true,
+          items: [
+            {
+              type: 'doc',
+              id: 'sdks/express/apis/configuration/express-client-config',
+              label: 'ExpressClientConfig',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Constants',
+          collapsed: true,
+          items: [
+            {
+              type: 'doc',
+              id: 'sdks/express/apis/constants/cookie-config',
+              label: 'CookieConfig',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Guides',
+      collapsed: false,
+      items: [
+        {
+          type: 'doc',
+          id: 'sdks/express/guides/redirect-flow',
+          label: 'Redirect Flow',
+        },
+        {
+          type: 'doc',
+          id: 'sdks/express/guides/embedded-sign-in',
+          label: 'Embedded Sign-In',
+        },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
### Purpose
Expand the Express SDK documentation into a proper API docs section.

This PR turns the current Express SDK page into a structured, Express-first docs section with dedicated API reference pages, flow guides, and sidebar navigation. It also aligns the Express quickstart text with `<ProductName />` placeholders where appropriate.

### Approach
Implemented the Express SDK docs as a multi-page section under `docs/content/sdks/express/` and kept the content grounded in the current exported SDK surface.

The changes include:
- expanding the Express SDK overview page
- adding API reference pages for Express middleware, client additions, configuration, and constants
- adding redirect flow and embedded sign-in guides
- updating the Express SDK sidebar to expose the new structure

<img width="1512" height="856" alt="image" src="https://github.com/user-attachments/assets/555313a9-2dc9-4122-b452-b3d13e97217f" />


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - `docs/content/sdks/express/overview.mdx`
    - `docs/content/sdks/express/apis/`
    - `docs/content/sdks/express/guides/`
    - `docs/content/sdks/express/sidebar.ts`
    - `docs/content/guides/quick-start/connect-your-application/express.mdx`
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
