### PR TITLE
Update ThunderID MCP guides

### DIFF
--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -94,3 +94,5 @@ Sif
 Baldur
 [Rr]ecommender
 [Uu]ncheck
+[Hh]ardcoded
+[Ss]ignup

--- a/docs/content/guides/working-with-ai/get-started-with-mcp.mdx
+++ b/docs/content/guides/working-with-ai/get-started-with-mcp.mdx
@@ -1,0 +1,247 @@
+---
+title: Getting Started with MCP
+sidebar_position: 4
+persona: iam
+hide_table_of_contents: true
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Stepper from '../../../src/components/Stepper';
+
+# Getting Started with MCP
+
+Connect Claude Desktop, Claude Code, or VS Code with Copilot to <ProductName /> using the built-in MCP server. Once connected, your AI tool can manage applications, authentication flows, users, and themes directly from your conversation.
+
+The MCP server is available at `https://localhost:8090/mcp` (or your configured `PUBLIC_URL`). See the [MCP Server guide](./mcp-server.mdx) for the full list of available tools.
+
+## Prerequisites
+
+- <ProductName /> server running (default: `https://localhost:8090`)
+- <ProductName /> certificate trusted by your system — add `backend/cmd/server/repository/resources/security/server.cert` to your system's trusted certificate store (Keychain on macOS, certificate store on Linux/Windows)
+- One of the following installed: Claude Desktop, Claude Code CLI, or VS Code with the GitHub Copilot extension
+- Access to the <ProductName /> Console
+
+<Stepper stepNode="h2" as="h2">
+
+## Create an Application
+
+In the <ProductName /> Console, create a Backend Service application to use as your MCP client.
+
+1. Go to **Applications** and click **Add Application**.
+2. Select **Backend Service** as the application type.
+3. Provide a name for the application (for example, `My MCP Client`).
+4. Select an organization unit and click **Create**.
+
+:::warning Save your client secret
+Copy and store the client secret now — it will not be shown again.
+:::
+
+After saving the secret, note the **Client ID** from the application details view. You will need both values in the next steps.
+
+## Assign the Application to the Administrator Role
+
+Assign your application to the Administrator role so it has the permissions needed to access <ProductName /> APIs through the MCP server.
+
+1. Go to **Roles** and select **Administrator**.
+2. Click the **Assignments** tab.
+3. Under **Apps**, click **Add** and select the application you created.
+
+## Get an Access Token
+
+Exchange your application credentials for a bearer token scoped to the MCP server. Replace `<CLIENT_ID>` and `<CLIENT_SECRET>` with the values from your application.
+
+```bash
+curl -kL -X POST https://localhost:8090/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "<CLIENT_ID>:<CLIENT_SECRET>" \
+  -d "grant_type=client_credentials" \
+  -d "scope=system"
+```
+
+Copy the `access_token` value from the response. This token is valid for 3600 seconds (1 hour). You will need to repeat this step when it expires.
+
+:::tip Refresh the token
+When you receive a 401 from the MCP server, generate a new token using the same command and update your configuration with the new value.
+:::
+
+## Configure Your AI Tool
+
+<Tabs>
+<TabItem value="claude-desktop" label="Claude Desktop" default>
+
+Add the following to your Claude Desktop configuration file. Replace `<ACCESS_TOKEN>` with the token from the previous step.
+
+**Configuration file locations:**
+
+| OS | Path |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
+
+```json
+{
+  "mcpServers": {
+    "{{productSlug}}-mcp": {
+      "type": "http",
+      "url": "https://localhost:8090/mcp",
+      "headers": {
+        "Authorization": "Bearer <ACCESS_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving the file. The <ProductName /> tools will appear in Claude's tool list.
+
+</TabItem>
+<TabItem value="claude-code" label="Claude Code">
+
+Run the following command to add the MCP server to your Claude Code configuration. Replace `<ACCESS_TOKEN>` with the token from the previous step.
+
+```bash
+claude mcp add --transport http {{productSlug}}-mcp https://localhost:8090/mcp \
+  --header "Authorization: Bearer <ACCESS_TOKEN>"
+```
+
+To verify the server was added:
+
+```bash
+claude mcp list
+```
+
+You should see `{{productSlug}}-mcp` listed with the MCP server URL.
+
+</TabItem>
+<TabItem value="vscode-copilot" label="VS Code with Copilot">
+
+VS Code reads MCP server configuration from a `.vscode/mcp.json` file in your workspace, or from your user-level MCP configuration for global access.
+
+### Workspace Configuration
+
+Create or edit `.vscode/mcp.json` in your project root. Use the `inputs` field to avoid storing the token in plain text — VS Code will prompt for it once and store it securely:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "thunderid-token",
+      "description": "ThunderID MCP access token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "{{productSlug}}-mcp": {
+      "type": "http",
+      "url": "https://localhost:8090/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:thunderid-token}"
+      }
+    }
+  }
+}
+```
+
+### User Configuration
+
+To make the server available across all workspaces, open the VS Code command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run **MCP: Open User Configuration**, then add the same JSON above.
+
+### Start the Server
+
+Open the command palette and run **MCP: List Servers** to see `{{productSlug}}-mcp`. Click **Start** next to it, or select it and choose **Start Server**. VS Code will prompt for the access token the first time.
+
+:::note Token storage
+VS Code stores the token securely using the system keychain after the first prompt. When the token expires, run **MCP: Reset Stored Inputs** from the command palette, then restart the server to enter a new token.
+:::
+
+</TabItem>
+</Tabs>
+
+## Verify the Connection
+
+Ask your AI assistant to confirm the MCP tools are working:
+
+> "List the applications registered in <ProductName />"
+
+The assistant will call the `{{productSlug}}_list_applications` tool and return the list of registered applications.
+
+If the assistant cannot reach the server, see the [Troubleshooting](#troubleshooting) section below.
+
+</Stepper>
+
+## Sample Use Case: Integrating Login via React SDK
+
+This example shows how to use the <ProductName /> MCP server to scaffold a React application with authentication wired up end-to-end — using just two prompts.
+
+The MCP server gives your AI assistant direct access to <ProductName />'s APIs. Rather than you manually creating an application, configuring OAuth settings, and reading through SDK documentation, the assistant handles that automatically. Both prompts will create an application in <ProductName /> if one does not already exist. The assistant selects the right OAuth template, picks a theme, and resolves your organization unit, then generates integration code tailored to that application's configuration.
+
+### Prompt 1: Create a React Application with Authentication
+
+> "Create a new React application with authentication using <ProductName />"
+
+The assistant scaffolds a React project using Vite, installs the <ProductName /> React SDK, and wires up the auth provider with the correct `clientId` and server URL from the application registered in <ProductName />.
+
+By the end of this prompt you have a running React app with a working sign-in button backed by <ProductName />.
+
+### Prompt 2: Add Authentication to an Existing React Application
+
+> "Integrate authentication with <ProductName /> for this application"
+
+Use this prompt when you already have a React application and want to add <ProductName /> authentication to it. The assistant generates the integration code for your existing codebase. It installs the SDK, configures the auth provider with the correct `clientId` and server URL, and adds sign-in and sign-out components. It also shows how to access the authenticated user's profile.
+
+Unlike Prompt 1, this does not scaffold a new project. It works on top of your existing app and adds only what is needed for authentication.
+
+## Sample Use Case: Integrating Signup via React SDK
+
+This example extends the login integration to add a signup page using the app-native registration flow.
+
+### Step 1: Enable Signup and Integrate a Signup Page
+
+After integrating login, ask your AI assistant:
+
+> "Integrate a signup page in the application and enable signup"
+
+The assistant enables self-registration on your <ProductName /> application and generates a signup page for your React app — wired to the registration flow configured in <ProductName />. New users can register directly from your application without going through the admin Console.
+
+### Step 2: Verify Signup Works
+
+New users can now register directly from your application. Users created through the signup flow appear in the <ProductName /> Console under **User Management**.
+
+## Troubleshooting
+
+### 401 Unauthorized
+
+The access token has expired or is invalid.
+
+1. Generate a new token using the command in [Step 3](#step-3-get-an-access-token).
+2. Update the `Authorization` header value in your configuration with the new token.
+3. **Claude Desktop**: restart after saving the config file.
+4. **Claude Code**: re-add the server with the new token (`claude mcp add ...`).
+5. **VS Code**: run **MCP: Reset Stored Inputs** from the command palette, then restart the server.
+
+### Certificate / TLS Errors
+
+The <ProductName /> certificate is not trusted by your system.
+
+1. Add `backend/cmd/server/repository/resources/security/server.cert` to your system's trusted certificate store.
+2. Restart your AI tool so it picks up the updated certificate trust settings.
+
+### MCP Server Not Responding
+
+Verify <ProductName /> is running and the MCP endpoint is reachable:
+
+```bash
+curl -k https://localhost:8090/mcp
+```
+
+A `401 Unauthorized` response with a `WWW-Authenticate` header confirms the server is up and secured. Any other error indicates the server is not running or the URL is incorrect.
+
+## Related Documentation
+
+- [MCP Server](./mcp-server.mdx) — Full list of available tools and the DCR-based authorization flow
+- [VS Code MCP Configuration](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration) — VS Code MCP reference
+- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) — MCP auth protocol details
+- [API Reference](/docs/next/apis) — Application and Flow Management REST APIs

--- a/docs/content/guides/working-with-ai/mcp-server.mdx
+++ b/docs/content/guides/working-with-ai/mcp-server.mdx
@@ -26,9 +26,9 @@ The MCP endpoint is secured with OAuth 2.0 Bearer Token authentication following
 | `{{productSlug}}_list_applications` | List all registered applications. | None |
 | `{{productSlug}}_get_application_by_id` | Retrieve full details of an application by ID including OAuth settings, customizations, and flow associations. | `id` (string, required) |
 | `{{productSlug}}_get_application_by_client_id` | Retrieve full details of an application by `client_id` including OAuth settings, customizations, and flow associations. | `client_id` (string, required) |
-| `{{productSlug}}_create_application` | Create a new application optionally with OAuth configuration. Use `{{productSlug}}_get_application_templates` to get pre-configured minimal templates for common app types (SPA, Mobile, Server, M2M). | Application object (see schema) |
+| `{{productSlug}}_create_application` | Create a new application optionally with OAuth configuration. Use `{{productSlug}}_get_application_templates` to get pre-configured minimal templates for common app types (SPA, Mobile, Server, M2M). Use `{{productSlug}}_list_themes` to pick a theme before creating the application (skip for M2M — no login page). | Application object (see schema) |
 | `{{productSlug}}_update_application` | Update an existing application (full replacement). Provide the complete application object. | Application object with `id` (required) |
-| `{{productSlug}}_get_application_templates` | Get minimal OAuth configuration templates for common application types (SPA, Mobile, Server, M2M). | None |
+| `{{productSlug}}_get_application_templates` | Get minimal OAuth configuration templates for common application types (SPA, Mobile, Server, M2M). SPA, Mobile, and Server templates include a `themeId` field — call `{{productSlug}}_list_themes` first and replace the placeholder. M2M templates do not include `themeId`. | None |
 
 ### Flow Tools
 
@@ -40,228 +40,34 @@ The MCP endpoint is secured with OAuth 2.0 Bearer Token authentication following
 | `{{productSlug}}_create_flow` | Create a new authentication or registration flow. | Flow definition object (see schema) |
 | `{{productSlug}}_update_flow` | Update an existing flow definition. | `id` (string, required), `name` (string, required), `nodes` (array, required) |
 
+### Theme Tools
+
+| Tool Name | Description | Parameters |
+|---|---|---|
+| `{{productSlug}}_list_themes` | List all themes with summary information (ID, handle, display name). Use before creating an application to pick a theme. | None |
+| `{{productSlug}}_get_theme_by_id` | Retrieve full details of a theme by ID including color schemes and typography configuration. | `id` (string, required) |
+
+### Organization Unit Tools
+
+| Tool Name | Description | Parameters |
+|---|---|---|
+| `{{productSlug}}_list_organization_units` | List all organization units. | None |
+
+### User Type Tools
+
+| Tool Name | Description | Parameters |
+|---|---|---|
+| `{{productSlug}}_list_user_types` | List all user types including self-registration settings. | None |
+
 ### React SDK Tools
 
 | Tool Name | Description | Parameters |
 |---|---|---|
-| `{{productSlug}}_integrate_react_sdk` | Provides instructions and code snippets for integrating <ProductName /> authentication via the ThunderID React SDK. Supports redirect-based (Mode 1) and self-hosted login (Mode 2). | `{{productSlug}}_url` (string, optional) |
+| `{{productSlug}}_integrate_react_sdk` | Provides instructions and code snippets for integrating <ProductName /> authentication and signup via the ThunderID React SDK. Supports redirect-based login (Mode 1), self-hosted login (Mode 2), and app-native signup flows. | `{{productSlug}}_url` (string, optional) |
 
-## Prerequisites
+## Getting Started
 
-- <ProductName /> server running (default: `https://localhost:8090`)
-- VS Code with MCP support (or another MCP-compatible client)
-- Choose an authentication approach — see [Add MCP Server to VS Code](#add-mcp-server-to-vs-code) for detailed setup:
-  - **Option A**: Standard MCP authorization flow using DCR (recommended)
-  - **Option B**: Client credentials with a pre-registered application
-
-<Stepper>
-
-## Add Certificate to System Certificates
-
-<ProductName /> uses HTTPS with a self-signed certificate by default. Add the <ProductName /> certificate (`backend/cmd/server/repository/resources/security/server.cert`) to your system's trusted certificates (Keychain on macOS, certificate store on Linux/Windows).
-
-## Configure MCP Client to Trust System Certificates
-
-The MCP client (VS Code) needs to be configured to trust system certificates and should be restarted.
-
-## Add MCP Server to VS Code
-
-Two approaches are available to authenticate with the <ProductName /> MCP server: the standard MCP authorization flow using DCR (recommended), or client credentials with a pre-registered application.
-
-### Option A: Standard MCP Authorization Flow (DCR)
-
-This approach follows the MCP Authorization Specification. The MCP client handles the entire OAuth flow automatically.
-
-1. **Enable open DCR** by adding the following to your `deployment.yaml`. By default, the DCR endpoint requires a JWT with `system` permission, which creates a chicken-and-egg problem for new MCP clients — enabling open DCR allows them to register dynamically:
-
-   ```yaml
-   oauth:
-     dcr:
-       insecure: true
-   ```
-
-2. **Add MCP Server Configuration** to your VS Code settings (typically in `~/.vscode/settings.json` or workspace settings):
-
-   ```json
-   {
-     "servers": {
-       "{{productSlug}}-mcp": {
-         "url": "https://localhost:8090/mcp",
-         "type": "http"
-       }
-     },
-     "inputs": []
-   }
-   ```
-
-   When you first use the MCP server, VS Code automatically handles the OAuth authorization flow. It discovers the authorization server, registers via DCR, and prompts you to log in. After authentication, the access token is managed automatically.
-
-### Option B: Client Credentials with Pre-Registered Application
-
-If you prefer not to enable open DCR, you can pre-register an application and use client credentials to get a token manually.
-
-1. **Create an M2M application** via the <ProductName /> REST API with the `client_credentials` grant type and `system` scope:
-
-   ```bash
-   curl -kL -X POST https://localhost:8090/applications \
-     -H 'Content-Type: application/json' \
-     -H 'Authorization: Bearer <ADMIN_TOKEN>' \
-     -d '{
-       "name": "MCP Access",
-       "inboundAuthConfig": [
-         {
-           "type": "oauth2",
-           "config": {
-             "grantTypes": ["client_credentials"],
-             "scope": "system"
-           }
-         }
-       ]
-     }'
-   ```
-
-   Note the `clientId` and `clientSecret` from the response.
-
-2. **Get an access token** using the client credentials grant:
-
-   ```bash
-   curl -kL -X POST https://localhost:8090/oauth2/token \
-     -H 'Content-Type: application/x-www-form-urlencoded' \
-     -u '<CLIENT_ID>:<CLIENT_SECRET>' \
-     -d "grant_type=client_credentials" \
-     -d "scope=system"
-   ```
-
-3. **Add MCP Server Configuration** with the token in headers (typically in `~/.vscode/settings.json` or workspace settings) — replace `<ACCESS_TOKEN>` with the token from the previous step:
-
-   ```json
-   {
-     "servers": {
-       "{{productSlug}}-mcp": {
-         "url": "https://localhost:8090/mcp",
-         "type": "http",
-         "headers": {
-           "Authorization": "Bearer <ACCESS_TOKEN>"
-         }
-       }
-     },
-     "inputs": []
-   }
-   ```
-
-   The token must be refreshed manually when it expires.
-
-### Verify Connection
-
-Check the MCP server status in VS Code's MCP panel or output logs.
-
-</Stepper>
-
-## Sample Use Case: Integrating Login via React SDK
-
-Here's a complete example of using the <ProductName /> MCP server to set up React SDK authentication:
-
-<Stepper stepNode="h3" as="h3">
-
-### Create an Application
-
-Ask your AI assistant:
-> "Create a new SPA application in <ProductName /> for React SDK integration"
-
-The assistant will:
-
-1. Use `{{productSlug}}_get_application_templates` to get the SPA template
-2. Use `{{productSlug}}_create_application` to create the application with appropriate OAuth settings
-3. Return the `clientId` for use in your React app
-
-### Get React SDK Integration Instructions
-
-Ask your AI assistant:
-> "Provide React SDK integration instructions for the application I just created"
-
-The assistant will:
-
-1. Use `{{productSlug}}_integrate_react_sdk` with your <ProductName /> URL
-2. Provide complete integration instructions including:
-   - Provider configuration
-   - Component usage examples
-   - Authentication flow setup
-   - Code snippets
-
-### Customize the Login Flow (Optional)
-
-Ask your AI assistant:
-> "Show me the current authentication flow for my application and suggest modifications"
-
-The assistant will:
-
-1. Use `{{productSlug}}_get_application_by_client_id` to retrieve your application details
-2. Use `{{productSlug}}_get_flow_by_id` to retrieve the current authentication flow
-3. Suggest modifications or use `{{productSlug}}_update_flow` to customize the flow
-
-### Update Application Flow
-
-Ask your AI assistant:
-> "Change the login flow of my application to use a custom flow with email OTP"
-
-The assistant will:
-
-1. Check if a custom flow exists using `{{productSlug}}_list_flows`
-2. Create a new flow with email OTP using `{{productSlug}}_create_flow` if needed
-3. Update your application using `{{productSlug}}_update_application` to use the new flow
-
-</Stepper>
-
-## Troubleshooting
-
-Common issues and solutions when setting up the <ProductName /> MCP server:
-
-### Authentication Errors
-
-If you encounter 401 Unauthorized errors:
-
-1. **Complete the login flow**: When prompted by your MCP client, log in to <ProductName /> to authorize access
-2. **Verify DCR is available**: Ensure the DCR endpoint is accessible at `/oauth2/dcr/register`
-3. **Check the scopes**: The MCP server requires the `system` scope. Verify that the authorization server metadata at `/.well-known/oauth-authorization-server` includes `system` in `scopes_supported`
-4. **Check the protected resource metadata**: Verify the discovery endpoint is accessible:
-
-   ```bash
-   curl -k https://localhost:8090/.well-known/oauth-protected-resource
-   ```
-
-### Certificate Errors
-
-If you encounter certificate/TLS errors:
-
-1. **Verify certificate is trusted**: Ensure the certificate is properly added to your system's certificate store
-
-2. **Check VS Code certificate settings**: Ensure trusting of system certificates is enabled
-
-3. **Re-add certificate**: Follow [Add Certificate to System Certificates](#add-certificate-to-system-certificates) again to ensure the certificate is properly installed
-
-### Connection Issues
-
-1. **Verify <ProductName /> is running**:
-
-   ```bash
-   curl -k https://localhost:8090/health/liveness
-   ```
-
-2. **Check MCP endpoint**:
-
-   ```bash
-   curl -k https://localhost:8090/mcp
-   ```
-
-   You should receive a `401 Unauthorized` response with a `WWW-Authenticate` header — this confirms the MCP server is running and secured.
-
-3. **Check authorization server metadata**:
-
-   ```bash
-   curl -k https://localhost:8090/.well-known/oauth-authorization-server
-   ```
-
-4. **Review VS Code MCP logs**: Check the output panel for MCP-related errors
+To connect an MCP client to the <ProductName /> MCP server, see [Getting Started with MCP](./get-started-with-mcp.mdx).
 
 ## Related Documentation
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -161,6 +161,11 @@ const sidebars: SidebarsConfig = {
           id: 'guides/working-with-ai/mcp-server',
           label: 'MCP Server',
         },
+        {
+          type: 'doc',
+          id: 'guides/working-with-ai/get-started-with-mcp',
+          label: 'Getting Started with MCP',
+        },
       ],
     },
 

--- a/docs/src/components/DocsGetStarted.tsx
+++ b/docs/src/components/DocsGetStarted.tsx
@@ -249,7 +249,7 @@ function QuickstartPanel({isVisible}: {isVisible: boolean}): JSX.Element {
         </Typography>
         <Box
           component={Link}
-          to="/docs/next/guides/working-with-ai/mcp-server"
+          to="/docs/next/guides/working-with-ai/get-started-with-mcp"
           sx={{
             flexShrink: 0,
             display: 'inline-flex',


### PR DESCRIPTION
### Purpose
Update ThunderID MCP guides
- Introduce a new default Application for MCP server
- Add guide on MCP server

### Approach
This pull request introduces support for automatic creation and assignment of the ThunderID MCP application during the server bootstrap process, and adds comprehensive documentation for getting started with MCP and integrating with AI tools. It also improves robustness in handling the retrieval of admin role and application IDs if they already exist, ensuring smoother setup and idempotency. Additionally, the documentation is updated for clarity on application creation and theme selection.

**Bootstrap Script Enhancements:**

* Added logic to both `01-default-resources.ps1` and `01-default-resources.sh` to automatically create the "ThunderID MCP" M2M application with hardcoded credentials (`THUNDER_MCP` / `thunder_mcp_secret`) during bootstrap, or retrieve its ID if it already exists. The application is also assigned to the Administrator role if both IDs are available. This ensures the MCP server is ready for use out-of-the-box. [[1]](diffhunk://#diff-251727c4cd4b985ce306b3bceda1a46916f4559e9aa429037689e8271628e3ceR1454-R1560) [[2]](diffhunk://#diff-6d74830c30ce5c2ca7051199231495bf8a7da9f37b249c4fc10629553d91297aR1409-R1503)
* Improved handling of the case where the Administrator role already exists by retrieving the role ID via a GET request, both in PowerShell and Bash scripts, to ensure the ID is available for subsequent assignments. [[1]](diffhunk://#diff-251727c4cd4b985ce306b3bceda1a46916f4559e9aa429037689e8271628e3ceL901-R920) [[2]](diffhunk://#diff-6d74830c30ce5c2ca7051199231495bf8a7da9f37b249c4fc10629553d91297aL826-R842)

**Documentation Additions and Improvements:**

* Added a new guide, `get-started-with-mcp.mdx`, detailing how to connect Claude Desktop, Claude Code, or VS Code Copilot to the MCP server, obtain tokens, configure clients, and troubleshoot common issues. The guide includes sample use cases for integrating login and signup via the React SDK using the MCP server tools.
* Updated the MCP server documentation to clarify that when creating applications (except for M2M), a theme should be selected using `list_themes` before creation, and that SPA, Mobile, and Server templates include a `themeId` field, while M2M templates do not.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New Getting Started guide for MCP — step‑by‑step setup, editor-specific configuration for Claude Desktop/Code and VS Code, sample prompts, verification steps, and troubleshooting.
  * Improved MCP Server docs — clarified tool behaviors, added Theme/Organization Unit/User Type tool categories, and expanded React SDK signup guidance.
  * Updated navigation and in‑site links to surface the new MCP guide.
  * Minor docs/style vocabulary updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->