### PR TITLE
Bump npm package versions

### DIFF
--- a/samples/apps/agent-id-sample/frontend/package-lock.json
+++ b/samples/apps/agent-id-sample/frontend/package-lock.json
@@ -1,100 +1,20 @@
 {
-  "name": "asgardeo-b2c-sample-app",
+  "name": "thunderid-agent-id-sample",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "asgardeo-b2c-sample-app",
+      "name": "thunderid-agent-id-sample",
       "version": "0.1.0",
       "dependencies": {
-        "@asgardeo/react": "^0.23.6",
+        "@thunderid/react": "0.0.5",
         "@vitejs/plugin-react": "^4.4.1",
         "lucide-react": "^0.511.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.30.3",
         "vite": "^6.3.5"
-      }
-    },
-    "node_modules/@asgardeo/browser": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@asgardeo/browser/-/browser-0.7.2.tgz",
-      "integrity": "sha512-n9J153vQ0WehoSHZeMI/rBYgA/EAKnZiKSlik3+UPgmE+ZW/4TIPqcp/hLHGaF1nP1yz/d80nJpwDPYwcylKqA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@asgardeo/javascript": "0.19.1",
-        "base64url": "3.0.1",
-        "buffer": "6.0.3",
-        "core-js": "3.42.0",
-        "crypto-browserify": "3.12.1",
-        "fast-sha256": "1.3.0",
-        "jose": "6.0.11",
-        "process": "0.11.10",
-        "randombytes": "2.1.0",
-        "stream-browserify": "3.0.0",
-        "tslib": "2.8.1"
-      }
-    },
-    "node_modules/@asgardeo/i18n": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@asgardeo/i18n/-/i18n-0.4.5.tgz",
-      "integrity": "sha512-p1DVVI7lNu7KeDqhRNgAuSrHvVgCbbVXc04koyiiwjDx+sJaXychuC9pwVJ2PDUnIyEp3Xgdb3KqMq+Sx4e7xA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "2.8.1"
-      }
-    },
-    "node_modules/@asgardeo/javascript": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@asgardeo/javascript/-/javascript-0.19.1.tgz",
-      "integrity": "sha512-HWthqx9aIPqwA0fAUbqmN9+oy9UCunYkSnRFRYr+I8m5iTkvRl7A+nY5J37ohhUIYWZ2Phhj/SLPR13z57x7hw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@asgardeo/i18n": "0.4.5",
-        "jose": "^5.2.0",
-        "tslib": "2.8.1"
-      }
-    },
-    "node_modules/@asgardeo/javascript/node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/@asgardeo/react": {
-      "version": "0.23.6",
-      "resolved": "https://registry.npmjs.org/@asgardeo/react/-/react-0.23.6.tgz",
-      "integrity": "sha512-LmeJOR54Duwdi6KHkF2c7zugj5mEqmfDSJRsrlhKbks8Jeglgjn5/VAH8QKxtssoSKuSDJYGct4tSq2uU7kC3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@asgardeo/browser": "0.7.2",
-        "@asgardeo/i18n": "0.4.5",
-        "@emotion/css": "11.13.5",
-        "@floating-ui/react": "0.27.12",
-        "@types/react-dom": "19.2.3",
-        "dompurify": "3.3.1",
-        "react-dom": "19.2.4",
-        "tslib": "2.8.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@asgardeo/react/node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -125,7 +45,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -322,15 +241,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -375,100 +285,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@emotion/babel-plugin": {
-      "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/runtime": "^7.18.3",
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/serialize": "^1.3.3",
-        "babel-plugin-macros": "^3.1.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/cache": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/css": {
-      "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
-      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/cache": "^11.13.5",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.2",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -886,59 +702,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/react": {
-      "version": "0.27.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.12.tgz",
-      "integrity": "sha512-kKlWNrpIQxF1B/a2MZvE0/uyKby4960yjO91W7nVyNKmmfNi62xU9HCjL1M1eWzx/LFj/VPSwJVbwQk9Pq/68A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.3",
-        "@floating-ui/utils": "^0.2.9",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT"
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1323,6 +1086,68 @@
         "win32"
       ]
     },
+    "node_modules/@thunderid/browser": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@thunderid/browser/-/browser-0.0.5.tgz",
+      "integrity": "sha512-9SaH+s0F2LjjFZhSdcJd/KowxDJJwjwzTbsQ4A5KFD1tp2GSTDmQUBB+dEMwrUuOeGFXZ9LemzBgci6lHJNTNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@thunderid/javascript": "^0.0.5",
+        "base64url": "3.0.1",
+        "buffer": "6.0.3",
+        "core-js": "3.42.0",
+        "crypto-browserify": "3.12.1",
+        "fast-sha256": "1.3.0",
+        "jose": "5.2.0",
+        "process": "0.11.10",
+        "randombytes": "2.1.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@thunderid/browser/node_modules/jose": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
+      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@thunderid/javascript": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@thunderid/javascript/-/javascript-0.0.5.tgz",
+      "integrity": "sha512-lMjbHCsNgYWclUiPlN3CA6vjKSyjIBIxVGSnuJwiC9eVakVsWmRuxkO8KX6AWlA4SRHgpGLMnD4ZE5lpM+gi9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "5.2.0",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@thunderid/javascript/node_modules/jose": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
+      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@thunderid/react": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@thunderid/react/-/react-0.0.5.tgz",
+      "integrity": "sha512-3ZJ7+Qo/WeZfCgNPwjAtXRzubOsvfXf54eS3kYKqH4Cyvql4B99xYbfTdsvlUHcA8NiR9QAmIEW4s3mcBoxpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@thunderid/browser": "^0.0.5",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1370,12 +1195,6 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1385,22 +1204,6 @@
       "dependencies": {
         "csstype": "^3.2.2"
       }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1452,21 +1255,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
       }
     },
     "node_modules/base64-js": {
@@ -1612,7 +1400,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1704,15 +1491,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001792",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
@@ -1747,12 +1525,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT"
-    },
     "node_modules/core-js": {
       "version": "3.42.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.42.0.tgz",
@@ -1769,31 +1541,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
-    },
-    "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -1868,7 +1615,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1931,15 +1679,6 @@
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
-    "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1980,15 +1719,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2070,18 +1800,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -2114,12 +1832,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "license": "MIT"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -2322,54 +2034,17 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT"
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
-      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2398,15 +2073,6 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
-    "node_modules/jose": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
-      "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2425,12 +2091,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT"
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2442,12 +2102,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -2548,18 +2202,6 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "license": "MIT"
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/parse-asn1": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
@@ -2574,39 +2216,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pbkdf2": {
@@ -2637,7 +2246,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2741,7 +2349,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2751,7 +2358,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2818,36 +2424,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
-    },
-    "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/ripemd160": {
       "version": "2.0.3",
@@ -2993,15 +2569,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3048,30 +2615,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "license": "MIT"
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tabbable": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -3171,7 +2714,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/samples/apps/agent-id-sample/frontend/package.json
+++ b/samples/apps/agent-id-sample/frontend/package.json
@@ -8,6 +8,9 @@
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0"
   },
+  "overrides": {
+    "dompurify": "3.4.0"
+  },
   "dependencies": {
     "@thunderid/react": "0.0.5",
     "@vitejs/plugin-react": "^4.4.1",

--- a/samples/apps/react-api-based-sample/package-lock.json
+++ b/samples/apps/react-api-based-sample/package-lock.json
@@ -52,7 +52,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/generator": "^7.28.6",
@@ -232,6 +231,7 @@
         "node_modules/@babel/runtime": {
             "version": "7.28.6",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -278,6 +278,7 @@
         "node_modules/@base-ui-components/utils": {
             "version": "0.1.2",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@floating-ui/utils": "^0.2.10",
@@ -332,6 +333,7 @@
         "node_modules/@emotion/babel-plugin": {
             "version": "11.13.5",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/runtime": "^7.18.3",
@@ -349,6 +351,7 @@
         "node_modules/@emotion/cache": {
             "version": "11.14.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.9.0",
                 "@emotion/sheet": "^1.4.0",
@@ -359,18 +362,21 @@
         },
         "node_modules/@emotion/hash": {
             "version": "0.9.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.4.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.9.0"
             }
         },
         "node_modules/@emotion/memoize": {
             "version": "0.9.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/react": {
             "version": "11.14.0",
@@ -398,6 +404,7 @@
         "node_modules/@emotion/serialize": {
             "version": "1.3.3",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/hash": "^0.9.2",
                 "@emotion/memoize": "^0.9.0",
@@ -408,7 +415,8 @@
         },
         "node_modules/@emotion/sheet": {
             "version": "1.4.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/styled": {
             "version": "11.14.1",
@@ -434,22 +442,26 @@
         },
         "node_modules/@emotion/unitless": {
             "version": "0.10.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.2.0",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
         },
         "node_modules/@emotion/utils": {
             "version": "1.4.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/weak-memoize": {
             "version": "0.4.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.1",
@@ -588,7 +600,8 @@
         },
         "node_modules/@floating-ui/utils": {
             "version": "0.2.10",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@fontsource-variable/inter": {
             "version": "5.2.8",
@@ -680,6 +693,7 @@
         "node_modules/@mui/core-downloads-tracker": {
             "version": "7.3.7",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mui-org"
@@ -736,6 +750,7 @@
         "node_modules/@mui/private-theming": {
             "version": "7.3.7",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@mui/utils": "^7.3.7",
@@ -761,6 +776,7 @@
         "node_modules/@mui/styled-engine": {
             "version": "7.3.7",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@emotion/cache": "^11.14.0",
@@ -832,6 +848,7 @@
         "node_modules/@mui/types": {
             "version": "7.4.10",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4"
             },
@@ -847,6 +864,7 @@
         "node_modules/@mui/utils": {
             "version": "7.3.7",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@mui/types": "^7.4.10",
@@ -911,6 +929,7 @@
         "node_modules/@mui/x-charts-vendor": {
             "version": "8.14.0",
             "license": "MIT AND ISC",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@types/d3-color": "^3.1.3",
@@ -936,6 +955,7 @@
         "node_modules/@mui/x-data-grid": {
             "version": "8.16.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@mui/utils": "^7.3.3",
@@ -972,6 +992,7 @@
         "node_modules/@mui/x-data-grid/node_modules/@mui/x-internals": {
             "version": "8.16.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@mui/utils": "^7.3.3",
@@ -992,6 +1013,7 @@
         "node_modules/@mui/x-date-pickers": {
             "version": "8.16.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@mui/utils": "^7.3.3",
@@ -1056,6 +1078,7 @@
         "node_modules/@mui/x-date-pickers/node_modules/@mui/x-internals": {
             "version": "8.16.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@mui/utils": "^7.3.3",
@@ -1076,6 +1099,7 @@
         "node_modules/@mui/x-internal-gestures": {
             "version": "0.3.3",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4"
             }
@@ -1083,6 +1107,7 @@
         "node_modules/@mui/x-internals": {
             "version": "8.14.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@mui/utils": "^7.3.3",
@@ -1141,6 +1166,7 @@
         "node_modules/@mui/x-virtualizer": {
             "version": "0.2.6",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@mui/utils": "^7.3.3",
@@ -1161,6 +1187,7 @@
         "node_modules/@mui/x-virtualizer/node_modules/@mui/x-internals": {
             "version": "8.16.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
                 "@mui/utils": "^7.3.3",
@@ -1214,6 +1241,7 @@
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -1510,37 +1538,44 @@
         },
         "node_modules/@types/d3-color": {
             "version": "3.1.3",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/d3-delaunay": {
             "version": "6.0.4",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/d3-interpolate": {
             "version": "3.0.4",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/d3-color": "*"
             }
         },
         "node_modules/@types/d3-path": {
             "version": "3.1.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/d3-sankey": {
             "version": "0.12.5",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/d3-shape": "^1"
             }
         },
         "node_modules/@types/d3-sankey/node_modules/@types/d3-path": {
             "version": "1.0.11",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/d3-sankey/node_modules/@types/d3-shape": {
             "version": "1.3.12",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/d3-path": "^1"
             }
@@ -1548,6 +1583,7 @@
         "node_modules/@types/d3-scale": {
             "version": "4.0.9",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/d3-time": "*"
             }
@@ -1555,17 +1591,20 @@
         "node_modules/@types/d3-shape": {
             "version": "3.1.8",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/d3-path": "*"
             }
         },
         "node_modules/@types/d3-time": {
             "version": "3.0.4",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/d3-timer": {
             "version": "3.0.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -1581,23 +1620,23 @@
             "version": "24.10.9",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.15",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/react": {
             "version": "19.2.9",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -1613,6 +1652,7 @@
         "node_modules/@types/react-transition-group": {
             "version": "4.4.12",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "*"
             }
@@ -1662,7 +1702,6 @@
             "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.57.2",
                 "@typescript-eslint/types": "8.57.2",
@@ -1942,7 +1981,6 @@
             "version": "8.15.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1995,6 +2033,7 @@
         "node_modules/babel-plugin-macros": {
             "version": "3.1.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
                 "cosmiconfig": "^7.0.0",
@@ -2025,7 +2064,8 @@
         },
         "node_modules/bezier-easing": {
             "version": "2.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/brace-expansion": {
             "version": "5.0.5",
@@ -2058,7 +2098,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2117,6 +2156,7 @@
         "node_modules/clsx": {
             "version": "2.1.1",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2146,7 +2186,8 @@
         },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/cookie": {
             "version": "1.1.1",
@@ -2164,6 +2205,7 @@
         "node_modules/cosmiconfig": {
             "version": "7.1.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -2195,6 +2237,7 @@
         "node_modules/d3-array": {
             "version": "2.12.1",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "internmap": "^1.0.0"
             }
@@ -2202,6 +2245,7 @@
         "node_modules/d3-color": {
             "version": "3.1.0",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -2209,6 +2253,7 @@
         "node_modules/d3-delaunay": {
             "version": "6.0.4",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "delaunator": "5"
             },
@@ -2219,6 +2264,7 @@
         "node_modules/d3-format": {
             "version": "3.1.2",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -2226,6 +2272,7 @@
         "node_modules/d3-interpolate": {
             "version": "3.0.1",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "d3-color": "1 - 3"
             },
@@ -2236,6 +2283,7 @@
         "node_modules/d3-path": {
             "version": "3.1.0",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -2243,6 +2291,7 @@
         "node_modules/d3-sankey": {
             "version": "0.12.3",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "d3-array": "1 - 2",
                 "d3-shape": "^1.2.0"
@@ -2250,11 +2299,13 @@
         },
         "node_modules/d3-sankey/node_modules/d3-path": {
             "version": "1.0.9",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/d3-sankey/node_modules/d3-shape": {
             "version": "1.3.7",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "d3-path": "1"
             }
@@ -2262,6 +2313,7 @@
         "node_modules/d3-scale": {
             "version": "4.0.2",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "d3-array": "2.10.0 - 3",
                 "d3-format": "1 - 3",
@@ -2276,6 +2328,7 @@
         "node_modules/d3-shape": {
             "version": "3.2.0",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "d3-path": "^3.1.0"
             },
@@ -2286,6 +2339,7 @@
         "node_modules/d3-time": {
             "version": "3.1.0",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "d3-array": "2 - 3"
             },
@@ -2296,6 +2350,7 @@
         "node_modules/d3-time-format": {
             "version": "4.1.0",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "d3-time": "1 - 3"
             },
@@ -2306,6 +2361,7 @@
         "node_modules/d3-timer": {
             "version": "3.0.1",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -2342,6 +2398,7 @@
         "node_modules/delaunator": {
             "version": "5.0.1",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "robust-predicates": "^3.0.2"
             }
@@ -2357,6 +2414,7 @@
         "node_modules/dom-helpers": {
             "version": "5.2.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.8.7",
                 "csstype": "^3.0.2"
@@ -2370,6 +2428,7 @@
         "node_modules/error-ex": {
             "version": "1.3.4",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -2396,7 +2455,6 @@
             "version": "9.39.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2601,7 +2659,8 @@
         },
         "node_modules/find-root": {
             "version": "1.1.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -2650,6 +2709,7 @@
         "node_modules/function-bind": {
             "version": "1.1.2",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -2695,6 +2755,7 @@
         "node_modules/hasown": {
             "version": "2.0.2",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -2718,13 +2779,15 @@
         "node_modules/hoist-non-react-statics": {
             "version": "3.3.2",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "react-is": "^16.7.0"
             }
         },
         "node_modules/hoist-non-react-statics/node_modules/react-is": {
             "version": "16.13.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/ignore": {
             "version": "5.3.2",
@@ -2758,15 +2821,18 @@
         },
         "node_modules/internmap": {
             "version": "1.0.1",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "hasown": "^2.0.2"
             },
@@ -2833,7 +2899,8 @@
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -3135,7 +3202,8 @@
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
@@ -3159,6 +3227,7 @@
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             },
@@ -3245,6 +3314,7 @@
         "node_modules/object-assign": {
             "version": "4.1.1",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3306,6 +3376,7 @@
         "node_modules/parse-json": {
             "version": "5.2.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -3337,11 +3408,13 @@
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/path-type": {
             "version": "4.0.0",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3356,7 +3429,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3365,7 +3437,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
+            "version": "8.5.10",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
             "dev": true,
             "funding": [
                 {
@@ -3402,6 +3476,7 @@
         "node_modules/prop-types": {
             "version": "15.8.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -3410,7 +3485,8 @@
         },
         "node_modules/prop-types/node_modules/react-is": {
             "version": "16.13.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -3423,7 +3499,6 @@
         "node_modules/react": {
             "version": "19.2.3",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3431,7 +3506,6 @@
         "node_modules/react-dom": {
             "version": "19.2.3",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -3441,7 +3515,8 @@
         },
         "node_modules/react-is": {
             "version": "19.2.3",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-refresh": {
             "version": "0.18.0",
@@ -3476,6 +3551,7 @@
         "node_modules/react-transition-group": {
             "version": "4.4.5",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.5.5",
                 "dom-helpers": "^5.0.1",
@@ -3489,11 +3565,13 @@
         },
         "node_modules/reselect": {
             "version": "5.1.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/resolve": {
             "version": "1.22.11",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
@@ -3518,7 +3596,8 @@
         },
         "node_modules/robust-predicates": {
             "version": "3.0.2",
-            "license": "Unlicense"
+            "license": "Unlicense",
+            "peer": true
         },
         "node_modules/rolldown": {
             "version": "1.0.0-beta.50",
@@ -3596,6 +3675,7 @@
         "node_modules/source-map": {
             "version": "0.5.7",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3621,7 +3701,8 @@
         },
         "node_modules/stylis": {
             "version": "4.2.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -3637,6 +3718,7 @@
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -3695,7 +3777,6 @@
             "version": "5.9.3",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -3773,6 +3854,7 @@
         "node_modules/use-sync-external-store": {
             "version": "1.6.0",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
@@ -3782,7 +3864,6 @@
             "version": "7.2.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@oxc-project/runtime": "0.97.0",
                 "fdir": "^6.5.0",
@@ -3885,6 +3966,7 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
             "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -3910,7 +3992,6 @@
             "version": "4.3.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/samples/apps/react-api-based-sample/package.json
+++ b/samples/apps/react-api-based-sample/package.json
@@ -35,6 +35,7 @@
         }
     },
     "overrides": {
+        "postcss": "8.5.10",
         "flatted": ">=3.4.2",
         "picomatch": ">=4.0.4",
         "yaml": ">=1.10.3"


### PR DESCRIPTION
### Purpose
Bump vulnerable npm dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned specific package versions in sample frontend projects (dompurify → 3.4.0; postcss → 8.5.10) to ensure build consistency and improve stability in development and deployment environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->