### PR TITLE
Add ou_handle support to role, user, resource server, and group

### DIFF
--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -912,7 +912,11 @@ func (as *applicationService) validateApplicationForUpdate(
 func (as *applicationService) validateApplicationFields(
 	ctx context.Context, app *model.ApplicationDTO) *serviceerror.ServiceError {
 	// Resolve ou_handle to an ID when the direct ID is absent.
-	if app.OUID == "" && app.OUHandle != "" {
+	// If both are provided, ou_id wins and a warning is logged.
+	if app.OUID != "" && app.OUHandle != "" {
+		as.logger.Warn("Both ou_id and ou_handle provided for application; ou_handle ignored",
+			log.String("appID", app.ID), log.String("name", app.Name))
+	} else if app.OUID == "" && app.OUHandle != "" {
 		ou, svcErr := as.ouService.GetOrganizationUnitByPath(ctx, app.OUHandle)
 		if svcErr != nil {
 			return &ErrorInvalidRequestFormat

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -3348,6 +3348,35 @@ func (suite *ServiceTestSuite) TestValidateApplicationFields_OUHandleNotFound() 
 	assert.Equal(suite.T(), ErrorInvalidRequestFormat.Code, svcErr.Code)
 }
 
+// TestValidateApplicationFields_OUIDWinsWhenBothProvided verifies that when both ou_id and
+// ou_handle are supplied, ou_id wins and no handle resolution is attempted (the absence of a
+// GetOrganizationUnitByPath mock expectation asserts that). This covers the WARN-on-collision
+// branch in validateApplicationFields.
+func (suite *ServiceTestSuite) TestValidateApplicationFields_OUIDWinsWhenBothProvided() {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{Enabled: false},
+	}
+	config.ResetServerRuntime()
+	require.NoError(suite.T(), config.InitializeServerRuntime("/tmp/test", testConfig))
+	defer config.ResetServerRuntime()
+
+	service, _ := suite.setupTestService()
+
+	app := &model.ApplicationDTO{
+		Name:     "test-app",
+		OUID:     testOUID,
+		OUHandle: "some-handle",
+	}
+
+	svcErr := service.validateApplicationFields(context.Background(), app)
+
+	assert.Nil(suite.T(), svcErr)
+	assert.Equal(suite.T(), testOUID, app.OUID)
+
+	ouMock := service.ouService.(*oumock.OrganizationUnitServiceInterfaceMock)
+	ouMock.AssertNotCalled(suite.T(), "GetOrganizationUnitByPath", mock.Anything, mock.Anything)
+}
+
 func (suite *ServiceTestSuite) TestValidateApplicationFields_FlowHandleResolutionError() {
 	testConfig := &config.Config{
 		DeclarativeResources: config.DeclarativeResources{Enabled: false},

--- a/backend/internal/entitytype/service.go
+++ b/backend/internal/entitytype/service.go
@@ -227,13 +227,11 @@ func (us *entityTypeService) CreateEntityType(
 		return nil, &ErrorCannotModifyDeclarativeResource
 	}
 
-	if request.OUID == "" && request.OUHandle != "" {
-		ou, svcErr := us.ouService.GetOrganizationUnitByPath(ctx, request.OUHandle)
-		if svcErr != nil {
-			return nil, invalidEntityTypeRequestErr(category, "organization unit with handle not found")
-		}
-		request.OUID = ou.ID
+	ouOnly := &EntityType{ID: request.ID, Name: request.Name, OUID: request.OUID, OUHandle: request.OUHandle}
+	if svcErr := us.resolveEntityTypeOUHandle(ctx, ouOnly); svcErr != nil {
+		return nil, invalidEntityTypeRequestErr(category, "organization unit with handle not found")
 	}
+	request.OUID = ouOnly.OUID
 
 	schemaToValidate := EntityType{
 		Category:         category,
@@ -397,13 +395,11 @@ func (us *entityTypeService) UpdateEntityType(ctx context.Context, category Type
 		return nil, &ErrorCannotModifyDeclarativeResource
 	}
 
-	if request.OUID == "" && request.OUHandle != "" {
-		ou, svcErr := us.ouService.GetOrganizationUnitByPath(ctx, request.OUHandle)
-		if svcErr != nil {
-			return nil, invalidEntityTypeRequestErr(category, "organization unit with handle not found")
-		}
-		request.OUID = ou.ID
+	ouOnly := &EntityType{ID: schemaID, Name: request.Name, OUID: request.OUID, OUHandle: request.OUHandle}
+	if svcErr := us.resolveEntityTypeOUHandle(ctx, ouOnly); svcErr != nil {
+		return nil, invalidEntityTypeRequestErr(category, "organization unit with handle not found")
 	}
+	request.OUID = ouOnly.OUID
 
 	schemaToValidate := EntityType{
 		Category:         category,
@@ -764,16 +760,32 @@ func (us *entityTypeService) getAccessibleResources(
 }
 
 // ResolveEntityTypeHandles resolves ou_handle to an OU ID on the given entity type in-place.
-// Called by the declarative loader validator so that file-based entity types support ou_handle.
+// Called by the declarative loader validator (startup, no user context) so that file-based
+// entity types support ou_handle. It elevates to runtime context internally.
 func (us *entityTypeService) ResolveEntityTypeHandles(
 	ctx context.Context, entityType *EntityType,
 ) *serviceerror.ServiceError {
+	return us.resolveEntityTypeOUHandle(security.WithRuntimeContext(ctx), entityType)
+}
+
+// resolveEntityTypeOUHandle resolves ou_handle to an OU ID on the given entity type in-place
+// using the caller's context. API/importer paths must pass their own caller context so the
+// underlying OU lookup is still subject to the caller's ou:read authorization.
+// If both ou_id and ou_handle are provided, ou_id wins and a warning is logged.
+func (us *entityTypeService) resolveEntityTypeOUHandle(
+	ctx context.Context, entityType *EntityType,
+) *serviceerror.ServiceError {
+	if entityType.OUID != "" && entityType.OUHandle != "" {
+		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, entityTypeLoggerComponentName))
+		logger.Warn("Both ou_id and ou_handle provided for entity type; ou_handle ignored",
+			log.String("entityTypeID", entityType.ID), log.String("name", entityType.Name))
+		return nil
+	}
 	if entityType.OUID == "" && entityType.OUHandle != "" {
 		if us.ouService == nil {
 			return &serviceerror.InternalServerError
 		}
-		ou, svcErr := us.ouService.GetOrganizationUnitByPath(
-			security.WithRuntimeContext(ctx), entityType.OUHandle)
+		ou, svcErr := us.ouService.GetOrganizationUnitByPath(ctx, entityType.OUHandle)
 		if svcErr != nil {
 			return &ErrorInvalidRequestFormat
 		}

--- a/backend/internal/entitytype/service_test.go
+++ b/backend/internal/entitytype/service_test.go
@@ -33,6 +33,7 @@ import (
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/tests/mocks/consentmock"
 	"github.com/thunder-id/thunderid/tests/mocks/oumock"
@@ -342,6 +343,93 @@ func TestUpdateEntityTypeReturnsErrorWhenOUHandleNotFound(t *testing.T) {
 	require.Equal(t, ErrorInvalidEntityTypeRequest.Code, svcErr.Code)
 }
 
+// TestCreateEntityTypeOUIDWinsWhenBothOUIDAndOUHandleProvided verifies that when both
+// ou_id and ou_handle are supplied to CreateEntityType, ou_id wins and no handle
+// resolution is attempted (the absence of a GetOrganizationUnitByPath mock expectation
+// asserts that). This covers the WARN-on-collision branch used by the importer/REST path.
+func TestCreateEntityTypeOUIDWinsWhenBothOUIDAndOUHandleProvided(t *testing.T) {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{Enabled: false},
+	}
+	config.ResetServerRuntime()
+	require.NoError(t, config.InitializeServerRuntime("/tmp/test", testConfig))
+	defer config.ResetServerRuntime()
+
+	storeMock := newEntityTypeStoreInterfaceMock(t)
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOUID1).
+		Return(true, (*serviceerror.ServiceError)(nil)).Once()
+	storeMock.On("GetEntityTypeByName", mock.Anything, TypeCategoryUser, "test-schema").
+		Return(EntityType{}, ErrEntityTypeNotFound).Once()
+	storeMock.On("CreateEntityType", mock.Anything, mock.Anything).Return(nil).Once()
+
+	consentMock := newConsentServiceMockDisabled(t)
+
+	service := &entityTypeService{
+		entityTypeStore: storeMock,
+		ouService:       ouServiceMock,
+		transactioner:   &mockTransactioner{},
+		consentService:  consentMock,
+	}
+
+	result, svcErr := service.CreateEntityType(context.Background(), TypeCategoryUser, CreateEntityTypeRequestWithID{
+		Name:     "test-schema",
+		OUID:     testOUID1,
+		OUHandle: "some-handle",
+		Schema:   json.RawMessage(`{"email":{"type":"string"}}`),
+	})
+
+	require.Nil(t, svcErr)
+	require.NotNil(t, result)
+	require.Equal(t, testOUID1, result.OUID)
+}
+
+// TestUpdateEntityTypeOUIDWinsWhenBothOUIDAndOUHandleProvided verifies that when both
+// ou_id and ou_handle are supplied to UpdateEntityType, ou_id wins and no handle
+// resolution is attempted (the absence of a GetOrganizationUnitByPath mock expectation
+// asserts that). This covers the WARN-on-collision branch used by the importer/REST path.
+func TestUpdateEntityTypeOUIDWinsWhenBothOUIDAndOUHandleProvided(t *testing.T) {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{Enabled: false},
+	}
+	config.ResetServerRuntime()
+	require.NoError(t, config.InitializeServerRuntime("/tmp/test", testConfig))
+	defer config.ResetServerRuntime()
+
+	storeMock := newEntityTypeStoreInterfaceMock(t)
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+
+	storeMock.On("IsEntityTypeDeclarative", TypeCategoryUser, "schema-id").Return(false).Once()
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOUID1).
+		Return(true, (*serviceerror.ServiceError)(nil)).Once()
+	storeMock.On("GetEntityTypeByID", mock.Anything, TypeCategoryUser, "schema-id").
+		Return(EntityType{ID: "schema-id", Name: "test-schema", OUID: testOUID1}, nil).Once()
+	storeMock.On("UpdateEntityTypeByID", mock.Anything, TypeCategoryUser, "schema-id", mock.Anything).
+		Return(nil).Once()
+
+	consentMock := newConsentServiceMockDisabled(t)
+
+	service := &entityTypeService{
+		entityTypeStore: storeMock,
+		ouService:       ouServiceMock,
+		transactioner:   &mockTransactioner{},
+		consentService:  consentMock,
+	}
+
+	req := UpdateEntityTypeRequest{
+		Name:     "test-schema",
+		OUID:     testOUID1,
+		OUHandle: "some-handle",
+		Schema:   json.RawMessage(`{"email":{"type":"string"}}`),
+	}
+	result, svcErr := service.UpdateEntityType(context.Background(), TypeCategoryUser, "schema-id", req)
+
+	require.Nil(t, svcErr)
+	require.NotNil(t, result)
+	require.Equal(t, testOUID1, result.OUID)
+}
+
 func TestResolveEntityTypeHandles_OUHandleResolved(t *testing.T) {
 	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	ouServiceMock.On("GetOrganizationUnitByPath", mock.Anything, "default").
@@ -388,6 +476,131 @@ func TestResolveEntityTypeHandles_NilOUService(t *testing.T) {
 
 	require.NotNil(t, svcErr)
 	require.Equal(t, serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestResolveEntityTypeHandles_DeclarativeLoaderUsesRuntimeContext verifies the public
+// ResolveEntityTypeHandles entry point (used by the startup-time declarative loader, which
+// has no user context) elevates the caller context to a runtime context before invoking the
+// OU lookup. This is what allows file-based entity types to be loaded without an authenticated
+// subject.
+func TestResolveEntityTypeHandles_DeclarativeLoaderUsesRuntimeContext(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	var capturedCtx context.Context
+	ouServiceMock.On("GetOrganizationUnitByPath", mock.Anything, "default").
+		Run(func(args mock.Arguments) {
+			capturedCtx = args.Get(0).(context.Context)
+		}).
+		Return(oupkg.OrganizationUnit{ID: testOUID1}, (*serviceerror.ServiceError)(nil)).Once()
+
+	svc := &entityTypeService{ouService: ouServiceMock}
+	et := &EntityType{OUHandle: "default"}
+
+	svcErr := svc.ResolveEntityTypeHandles(context.Background(), et)
+
+	require.Nil(t, svcErr)
+	require.NotNil(t, capturedCtx)
+	require.True(t, security.IsRuntimeContext(capturedCtx),
+		"declarative loader path should elevate to runtime context")
+}
+
+// TestCreateEntityType_OUHandleLookupUsesCallerContext verifies that the API/REST path
+// (CreateEntityType) does NOT elevate to a runtime context when resolving ou_handle. The
+// caller's context must propagate so that the underlying OU lookup is still subject to the
+// caller's ou:read authorization. Without this, an API caller without ou:read could bypass
+// authorization by supplying ou_handle instead of ou_id.
+func TestCreateEntityType_OUHandleLookupUsesCallerContext(t *testing.T) {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{Enabled: false},
+	}
+	config.ResetServerRuntime()
+	require.NoError(t, config.InitializeServerRuntime("/tmp/test", testConfig))
+	defer config.ResetServerRuntime()
+
+	storeMock := newEntityTypeStoreInterfaceMock(t)
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+
+	var capturedCtx context.Context
+	ouServiceMock.On("GetOrganizationUnitByPath", mock.Anything, "default").
+		Run(func(args mock.Arguments) {
+			capturedCtx = args.Get(0).(context.Context)
+		}).
+		Return(oupkg.OrganizationUnit{ID: testOUID1}, (*serviceerror.ServiceError)(nil)).Once()
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOUID1).
+		Return(true, (*serviceerror.ServiceError)(nil)).Once()
+	storeMock.On("GetEntityTypeByName", mock.Anything, TypeCategoryUser, "test-schema").
+		Return(EntityType{}, ErrEntityTypeNotFound).Once()
+	storeMock.On("CreateEntityType", mock.Anything, mock.Anything).Return(nil).Once()
+
+	consentMock := newConsentServiceMockDisabled(t)
+
+	service := &entityTypeService{
+		entityTypeStore: storeMock,
+		ouService:       ouServiceMock,
+		transactioner:   &mockTransactioner{},
+		consentService:  consentMock,
+	}
+
+	result, svcErr := service.CreateEntityType(context.Background(), TypeCategoryUser, CreateEntityTypeRequestWithID{
+		Name:     "test-schema",
+		OUHandle: "default",
+		Schema:   json.RawMessage(`{"email":{"type":"string"}}`),
+	})
+
+	require.Nil(t, svcErr)
+	require.NotNil(t, result)
+	require.NotNil(t, capturedCtx)
+	require.False(t, security.IsRuntimeContext(capturedCtx),
+		"API path must propagate the caller's context (not runtime) so ou:read is enforced")
+}
+
+// TestUpdateEntityType_OUHandleLookupUsesCallerContext is the UpdateEntityType analog of
+// TestCreateEntityType_OUHandleLookupUsesCallerContext.
+func TestUpdateEntityType_OUHandleLookupUsesCallerContext(t *testing.T) {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{Enabled: false},
+	}
+	config.ResetServerRuntime()
+	require.NoError(t, config.InitializeServerRuntime("/tmp/test", testConfig))
+	defer config.ResetServerRuntime()
+
+	storeMock := newEntityTypeStoreInterfaceMock(t)
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+
+	var capturedCtx context.Context
+	storeMock.On("IsEntityTypeDeclarative", TypeCategoryUser, "schema-id").Return(false).Once()
+	ouServiceMock.On("GetOrganizationUnitByPath", mock.Anything, "default").
+		Run(func(args mock.Arguments) {
+			capturedCtx = args.Get(0).(context.Context)
+		}).
+		Return(oupkg.OrganizationUnit{ID: testOUID1}, (*serviceerror.ServiceError)(nil)).Once()
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOUID1).
+		Return(true, (*serviceerror.ServiceError)(nil)).Once()
+	storeMock.On("GetEntityTypeByID", mock.Anything, TypeCategoryUser, "schema-id").
+		Return(EntityType{ID: "schema-id", Name: "test-schema", OUID: testOUID1}, nil).Once()
+	storeMock.On("UpdateEntityTypeByID", mock.Anything, TypeCategoryUser, "schema-id", mock.Anything).
+		Return(nil).Once()
+
+	consentMock := newConsentServiceMockDisabled(t)
+
+	service := &entityTypeService{
+		entityTypeStore: storeMock,
+		ouService:       ouServiceMock,
+		transactioner:   &mockTransactioner{},
+		consentService:  consentMock,
+	}
+
+	req := UpdateEntityTypeRequest{
+		Name:     "test-schema",
+		OUHandle: "default",
+		Schema:   json.RawMessage(`{"email":{"type":"string"}}`),
+	}
+	result, svcErr := service.UpdateEntityType(context.Background(), TypeCategoryUser, "schema-id", req)
+
+	require.Nil(t, svcErr)
+	require.NotNil(t, result)
+	require.NotNil(t, capturedCtx)
+	require.False(t, security.IsRuntimeContext(capturedCtx),
+		"API path must propagate the caller's context (not runtime) so ou:read is enforced")
 }
 
 func TestGetEntityTypeByNameReturnsSchema(t *testing.T) {

--- a/backend/internal/resource/ResourceServiceInterface_mock_test.go
+++ b/backend/internal/resource/ResourceServiceInterface_mock_test.go
@@ -1132,6 +1132,65 @@ func (_c *ResourceServiceInterfaceMock_IsResourceServerDeclarative_Call) RunAndR
 	return _c
 }
 
+// ResolveResourceServerOUHandle provides a mock function for the type ResourceServiceInterfaceMock
+func (_mock *ResourceServiceInterfaceMock) ResolveResourceServerOUHandle(ctx context.Context, rs *ResourceServer) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, rs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveResourceServerOUHandle")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *ResourceServer) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, rs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveResourceServerOUHandle'
+type ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call struct {
+	*mock.Call
+}
+
+// ResolveResourceServerOUHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - rs *ResourceServer
+func (_e *ResourceServiceInterfaceMock_Expecter) ResolveResourceServerOUHandle(ctx interface{}, rs interface{}) *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call {
+	return &ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call{Call: _e.mock.On("ResolveResourceServerOUHandle", ctx, rs)}
+}
+
+func (_c *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call) Run(run func(ctx context.Context, rs *ResourceServer)) *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *ResourceServer
+		if args[1] != nil {
+			arg1 = args[1].(*ResourceServer)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call) Return(serviceError *serviceerror.ServiceError) *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call) RunAndReturn(run func(ctx context.Context, rs *ResourceServer) *serviceerror.ServiceError) *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateAction provides a mock function for the type ResourceServiceInterfaceMock
 func (_mock *ResourceServiceInterfaceMock) UpdateAction(ctx context.Context, resourceServerID string, resourceID *string, id string, action Action) (*Action, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, resourceServerID, resourceID, id, action)

--- a/backend/internal/resource/declarative_resource.go
+++ b/backend/internal/resource/declarative_resource.go
@@ -254,7 +254,7 @@ func loadDeclarativeResources(resourceStore resourceStoreInterface, resourceServ
 		DirectoryName: "resource_servers",
 		Parser:        parseAndValidateResourceServerWrapper(resourceService),
 		Validator: func(data interface{}) error {
-			return validateResourceServerWrapper(data, fileStore, dbStore)
+			return validateResourceServerWrapper(data, fileStore, dbStore, resourceService)
 		},
 		IDExtractor: func(data interface{}) string {
 			return data.(*ResourceServer).ID
@@ -299,9 +299,6 @@ func parseToResourceServer(data []byte) (*ResourceServer, error) {
 	}
 	if rs.Name == "" {
 		return nil, fmt.Errorf("resource server name cannot be empty")
-	}
-	if rs.OUID == "" {
-		return nil, fmt.Errorf("resource server organization unit ID cannot be empty")
 	}
 
 	return &rs, nil
@@ -419,6 +416,7 @@ func validateResourceServerWrapper(
 	data interface{},
 	fileStore resourceStoreInterface,
 	dbStore resourceStoreInterface,
+	service ResourceServiceInterface,
 ) error {
 	rs, ok := data.(*ResourceServer)
 	if !ok {
@@ -427,6 +425,17 @@ func validateResourceServerWrapper(
 
 	if rs.Name == "" {
 		return fmt.Errorf("resource server name cannot be empty")
+	}
+
+	if service != nil {
+		if svcErr := service.ResolveResourceServerOUHandle(context.Background(), rs); svcErr != nil {
+			return fmt.Errorf("organization unit with handle %q not found for resource server '%s'",
+				rs.OUHandle, rs.Name)
+		}
+	}
+
+	if rs.OUID == "" {
+		return fmt.Errorf("ou_id or ou_handle is required for resource server '%s'", rs.Name)
 	}
 
 	// Check for duplicate ID in the file store

--- a/backend/internal/resource/declarative_resource_test.go
+++ b/backend/internal/resource/declarative_resource_test.go
@@ -514,7 +514,7 @@ func TestParseAndValidateResourceServerWrapper_InvalidYAML(t *testing.T) {
 }
 
 func TestValidateResourceServerWrapper_InvalidType(t *testing.T) {
-	err := validateResourceServerWrapper("invalid", newResourceStoreInterfaceMock(t), nil)
+	err := validateResourceServerWrapper("invalid", newResourceStoreInterfaceMock(t), nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid type")
@@ -523,7 +523,7 @@ func TestValidateResourceServerWrapper_InvalidType(t *testing.T) {
 func TestValidateResourceServerWrapper_EmptyName(t *testing.T) {
 	fileStore := newResourceStoreInterfaceMock(t)
 
-	err := validateResourceServerWrapper(&ResourceServer{ID: "rs1"}, fileStore, nil)
+	err := validateResourceServerWrapper(&ResourceServer{ID: "rs1"}, fileStore, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "name cannot be empty")
@@ -533,7 +533,8 @@ func TestValidateResourceServerWrapper_DuplicateInFileStore(t *testing.T) {
 	fileStore := newResourceStoreInterfaceMock(t)
 	fileStore.On("GetResourceServer", mock.Anything, "rs1").Return(ResourceServer{ID: "rs1"}, nil)
 
-	err := validateResourceServerWrapper(&ResourceServer{ID: "rs1", Name: "Server"}, fileStore, nil)
+	err := validateResourceServerWrapper(
+		&ResourceServer{ID: "rs1", Name: "Server", OUID: "ou1"}, fileStore, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate resource server ID")
@@ -543,7 +544,8 @@ func TestValidateResourceServerWrapper_FileStoreError(t *testing.T) {
 	fileStore := newResourceStoreInterfaceMock(t)
 	fileStore.On("GetResourceServer", mock.Anything, "rs1").Return(ResourceServer{}, errors.New("file error"))
 
-	err := validateResourceServerWrapper(&ResourceServer{ID: "rs1", Name: "Server"}, fileStore, nil)
+	err := validateResourceServerWrapper(
+		&ResourceServer{ID: "rs1", Name: "Server", OUID: "ou1"}, fileStore, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to check")
@@ -555,7 +557,8 @@ func TestValidateResourceServerWrapper_DuplicateInDBStore(t *testing.T) {
 	fileStore.On("GetResourceServer", mock.Anything, "rs1").Return(ResourceServer{}, errResourceServerNotFound)
 	dbStore.On("GetResourceServer", mock.Anything, "rs1").Return(ResourceServer{ID: "rs1"}, nil)
 
-	err := validateResourceServerWrapper(&ResourceServer{ID: "rs1", Name: "Server"}, fileStore, dbStore)
+	err := validateResourceServerWrapper(
+		&ResourceServer{ID: "rs1", Name: "Server", OUID: "ou1"}, fileStore, dbStore, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "database store")
@@ -567,7 +570,8 @@ func TestValidateResourceServerWrapper_DBStoreError(t *testing.T) {
 	fileStore.On("GetResourceServer", mock.Anything, "rs1").Return(ResourceServer{}, errResourceServerNotFound)
 	dbStore.On("GetResourceServer", mock.Anything, "rs1").Return(ResourceServer{}, errors.New("db error"))
 
-	err := validateResourceServerWrapper(&ResourceServer{ID: "rs1", Name: "Server"}, fileStore, dbStore)
+	err := validateResourceServerWrapper(
+		&ResourceServer{ID: "rs1", Name: "Server", OUID: "ou1"}, fileStore, dbStore, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "database store")
@@ -577,7 +581,8 @@ func TestValidateResourceServerWrapper_Success(t *testing.T) {
 	fileStore := newResourceStoreInterfaceMock(t)
 	fileStore.On("GetResourceServer", mock.Anything, "rs1").Return(ResourceServer{}, errResourceServerNotFound)
 
-	err := validateResourceServerWrapper(&ResourceServer{ID: "rs1", Name: "Server"}, fileStore, nil)
+	err := validateResourceServerWrapper(
+		&ResourceServer{ID: "rs1", Name: "Server", OUID: "ou1"}, fileStore, nil, nil)
 
 	assert.NoError(t, err)
 }

--- a/backend/internal/resource/model.go
+++ b/backend/internal/resource/model.go
@@ -197,7 +197,8 @@ type ResourceServer struct {
 	Description string     `yaml:"description,omitempty" json:"description,omitempty"`
 	Handle      string     `yaml:"handle" json:"handle"`
 	Identifier  string     `yaml:"identifier,omitempty" json:"identifier,omitempty"`
-	OUID        string     `yaml:"ou_id" json:"ouId"`
+	OUID        string     `yaml:"ou_id,omitempty" json:"ouId"`
+	OUHandle    string     `yaml:"ou_handle,omitempty" json:"-"`
 	Delimiter   string     `yaml:"delimiter,omitempty" json:"delimiter,omitempty" yamlfmt:"quoted"`
 	IsReadOnly  bool       `yaml:"-" json:"-"`
 	Resources   []Resource `yaml:"resources,omitempty" json:"resources,omitempty"`

--- a/backend/internal/resource/service.go
+++ b/backend/internal/resource/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	"github.com/thunder-id/thunderid/internal/system/i18n/core"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )
@@ -108,6 +109,13 @@ type ResourceServiceInterface interface {
 	FindResourceServersByPermissions(
 		ctx context.Context, permissions []string,
 	) ([]ResourceServer, *serviceerror.ServiceError)
+
+	// ResolveResourceServerOUHandle resolves ou_handle to an OU ID on the given resource server
+	// in-place. Called by the declarative loader validator so that file-based resource servers
+	// support ou_handle.
+	ResolveResourceServerOUHandle(
+		ctx context.Context, rs *ResourceServer,
+	) *serviceerror.ServiceError
 }
 
 // resourceService is the default implementation of ResourceServiceInterface.
@@ -1381,6 +1389,31 @@ func (rs *resourceService) FindResourceServersByPermissions(
 		return nil, &serviceerror.InternalServerError
 	}
 	return resourceServers, nil
+}
+
+// ResolveResourceServerOUHandle resolves ou_handle to an OU ID on the given resource server
+// in-place. Called by the declarative loader validator so that file-based resource servers
+// support ou_handle. If both ou_id and ou_handle are provided, ou_id wins and a warning is logged.
+func (rs *resourceService) ResolveResourceServerOUHandle(
+	ctx context.Context, server *ResourceServer,
+) *serviceerror.ServiceError {
+	if server.OUID != "" && server.OUHandle != "" {
+		rs.logger.Warn("Both ou_id and ou_handle provided for resource server; ou_handle ignored",
+			log.String("resourceServerID", server.ID), log.String("name", server.Name))
+		return nil
+	}
+	if server.OUID == "" && server.OUHandle != "" {
+		if rs.ouService == nil {
+			return &serviceerror.InternalServerError
+		}
+		ou, svcErr := rs.ouService.GetOrganizationUnitByPath(
+			security.WithRuntimeContext(ctx), server.OUHandle)
+		if svcErr != nil {
+			return &ErrorInvalidRequestFormat
+		}
+		server.OUID = ou.ID
+	}
+	return nil
 }
 
 // Validation helper methods

--- a/backend/internal/resource/service_test.go
+++ b/backend/internal/resource/service_test.go
@@ -5057,3 +5057,98 @@ func (suite *ResourceServiceTestSuite) TestConsentSyncError_IsClientError() {
 	emptyErr := &consentSyncError{}
 	require.False(suite.T(), emptyErr.IsClientError())
 }
+
+// TestResolveResourceServerOUHandle_OUHandleResolved verifies that when only ou_handle is set,
+// it is resolved to ou_id via the OU service.
+func (suite *ResourceServiceTestSuite) TestResolveResourceServerOUHandle_OUHandleResolved() {
+	suite.mockOU.On("GetOrganizationUnitByPath", mock.Anything, "default").
+		Return(oupkg.OrganizationUnit{ID: "ou-resolved"}, (*serviceerror.ServiceError)(nil)).Once()
+
+	rs := &ResourceServer{OUHandle: "default"}
+	svcErr := suite.service.ResolveResourceServerOUHandle(context.Background(), rs)
+
+	suite.Nil(svcErr)
+	suite.Equal("ou-resolved", rs.OUID)
+}
+
+// TestResolveResourceServerOUHandle_OUIDAlreadySet verifies that no resolution happens when
+// ou_id is set and ou_handle is empty.
+func (suite *ResourceServiceTestSuite) TestResolveResourceServerOUHandle_OUIDAlreadySet() {
+	rs := &ResourceServer{OUID: "ou-direct"}
+	svcErr := suite.service.ResolveResourceServerOUHandle(context.Background(), rs)
+
+	suite.Nil(svcErr)
+	suite.Equal("ou-direct", rs.OUID)
+}
+
+// TestResolveResourceServerOUHandle_BothProvided verifies that when both ou_id and ou_handle
+// are provided, ou_id is retained and the OU service is never called.
+func (suite *ResourceServiceTestSuite) TestResolveResourceServerOUHandle_BothProvided() {
+	rs := &ResourceServer{ID: "rs1", Name: "Server", OUID: "ou-direct", OUHandle: "default"}
+
+	svcErr := suite.service.ResolveResourceServerOUHandle(context.Background(), rs)
+
+	suite.Nil(svcErr)
+	suite.Equal("ou-direct", rs.OUID)
+	// AssertExpectations in t.Cleanup confirms GetOrganizationUnitByPath was never invoked.
+}
+
+// TestResolveResourceServerOUHandle_OUHandleNotFound verifies that a not-found response from
+// the OU service is surfaced as ErrorInvalidRequestFormat.
+func (suite *ResourceServiceTestSuite) TestResolveResourceServerOUHandle_OUHandleNotFound() {
+	suite.mockOU.On("GetOrganizationUnitByPath", mock.Anything, "missing").
+		Return(oupkg.OrganizationUnit{}, &oupkg.ErrorOrganizationUnitNotFound).Once()
+
+	rs := &ResourceServer{OUHandle: "missing"}
+	svcErr := suite.service.ResolveResourceServerOUHandle(context.Background(), rs)
+
+	suite.NotNil(svcErr)
+	suite.Equal(ErrorInvalidRequestFormat.Code, svcErr.Code)
+}
+
+// TestResolveResourceServerOUHandle_NeitherProvided verifies the call is a no-op when neither
+// ou_id nor ou_handle is provided.
+func (suite *ResourceServiceTestSuite) TestResolveResourceServerOUHandle_NeitherProvided() {
+	rs := &ResourceServer{}
+	svcErr := suite.service.ResolveResourceServerOUHandle(context.Background(), rs)
+
+	suite.Nil(svcErr)
+	suite.Empty(rs.OUID)
+}
+
+// TestResolveResourceServerOUHandle_NilOUService verifies that a clear error is returned when
+// the OU service is nil and ou_handle is supplied (no nil-pointer panic).
+func (suite *ResourceServiceTestSuite) TestResolveResourceServerOUHandle_NilOUService() {
+	svc := &resourceService{
+		logger:    *log.GetLogger(),
+		ouService: nil,
+	}
+	rs := &ResourceServer{OUHandle: "default"}
+
+	svcErr := svc.ResolveResourceServerOUHandle(context.Background(), rs)
+
+	suite.NotNil(svcErr)
+	suite.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestResourceServerYAML_OUHandleParsed verifies that ou_handle is parsed off the YAML
+// document into the ResourceServer struct.
+func TestResourceServerYAML_OUHandleParsed(t *testing.T) {
+	yamlData := []byte(`
+id: rs1
+name: Server
+handle: server
+ou_handle: default
+`)
+	rs, err := parseToResourceServer(yamlData)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rs.OUHandle != "default" {
+		t.Errorf("OUHandle = %q, want %q", rs.OUHandle, "default")
+	}
+	if rs.OUID != "" {
+		t.Errorf("OUID = %q, want empty (resolution happens later)", rs.OUID)
+	}
+}

--- a/backend/internal/role/RoleServiceInterface_mock_test.go
+++ b/backend/internal/role/RoleServiceInterface_mock_test.go
@@ -539,6 +539,65 @@ func (_c *RoleServiceInterfaceMock_IsRoleDeclarative_Call) RunAndReturn(run func
 	return _c
 }
 
+// ResolveRoleOUHandle provides a mock function for the type RoleServiceInterfaceMock
+func (_mock *RoleServiceInterfaceMock) ResolveRoleOUHandle(ctx context.Context, role *RoleWithPermissionsAndAssignments) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, role)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveRoleOUHandle")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *RoleWithPermissionsAndAssignments) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, role)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// RoleServiceInterfaceMock_ResolveRoleOUHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveRoleOUHandle'
+type RoleServiceInterfaceMock_ResolveRoleOUHandle_Call struct {
+	*mock.Call
+}
+
+// ResolveRoleOUHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - role *RoleWithPermissionsAndAssignments
+func (_e *RoleServiceInterfaceMock_Expecter) ResolveRoleOUHandle(ctx interface{}, role interface{}) *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call {
+	return &RoleServiceInterfaceMock_ResolveRoleOUHandle_Call{Call: _e.mock.On("ResolveRoleOUHandle", ctx, role)}
+}
+
+func (_c *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call) Run(run func(ctx context.Context, role *RoleWithPermissionsAndAssignments)) *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *RoleWithPermissionsAndAssignments
+		if args[1] != nil {
+			arg1 = args[1].(*RoleWithPermissionsAndAssignments)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call) Return(serviceError *serviceerror.ServiceError) *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call) RunAndReturn(run func(ctx context.Context, role *RoleWithPermissionsAndAssignments) *serviceerror.ServiceError) *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateRoleWithPermissions provides a mock function for the type RoleServiceInterfaceMock
 func (_mock *RoleServiceInterfaceMock) UpdateRoleWithPermissions(ctx context.Context, id string, role RoleUpdateDetail) (*RoleWithPermissions, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, id, role)

--- a/backend/internal/role/declarative_resource.go
+++ b/backend/internal/role/declarative_resource.go
@@ -147,13 +147,16 @@ func (e *roleExporter) GetResourceRules() *declarativeresource.ResourceRules {
 
 // loadDeclarativeResources loads immutable role resources from files.
 // The dbStore parameter is optional (can be nil) and is used for duplicate checking in composite mode.
-func loadDeclarativeResources(fileStore *fileBasedStore, dbStore roleStoreInterface) error {
+// The service parameter is optional (can be nil) and is used to resolve ou_handle to ou_id.
+func loadDeclarativeResources(
+	fileStore *fileBasedStore, dbStore roleStoreInterface, service RoleServiceInterface,
+) error {
 	resourceConfig := declarativeresource.ResourceConfig{
 		ResourceType:  "Role",
 		DirectoryName: "roles",
 		Parser:        parseToRoleWrapper,
 		Validator: func(data interface{}) error {
-			return validateRoleWrapper(data, fileStore, dbStore)
+			return validateRoleWrapper(data, fileStore, dbStore, service)
 		},
 		IDExtractor: func(data interface{}) string {
 			// Use safe type assertion to prevent panic
@@ -185,7 +188,8 @@ type roleDeclarativeResource struct {
 	ID          string                      `yaml:"id"`
 	Name        string                      `yaml:"name"`
 	Description string                      `yaml:"description,omitempty"`
-	OUID        string                      `yaml:"ou_id"`
+	OUID        string                      `yaml:"ou_id,omitempty"`
+	OUHandle    string                      `yaml:"ou_handle,omitempty"`
 	Permissions []roleDeclarativePermission `yaml:"permissions"`
 	Assignments []RoleAssignment            `yaml:"assignments,omitempty"`
 }
@@ -219,6 +223,7 @@ func parseToRole(data []byte) (*RoleWithPermissionsAndAssignments, error) {
 		Name:        roleResource.Name,
 		Description: roleResource.Description,
 		OUID:        roleResource.OUID,
+		OUHandle:    roleResource.OUHandle,
 		Permissions: permissions,
 		Assignments: roleResource.Assignments,
 	}
@@ -227,7 +232,10 @@ func parseToRole(data []byte) (*RoleWithPermissionsAndAssignments, error) {
 }
 
 // validateRoleWrapper validates role declarative resources and checks for duplicates.
-func validateRoleWrapper(data interface{}, fileStore *fileBasedStore, dbStore roleStoreInterface) error {
+// When a service is provided, OU handles are resolved before validation runs.
+func validateRoleWrapper(
+	data interface{}, fileStore *fileBasedStore, dbStore roleStoreInterface, service RoleServiceInterface,
+) error {
 	role, ok := data.(*RoleWithPermissionsAndAssignments)
 	if !ok {
 		return fmt.Errorf("invalid type: expected *RoleWithPermissionsAndAssignments")
@@ -239,8 +247,14 @@ func validateRoleWrapper(data interface{}, fileStore *fileBasedStore, dbStore ro
 	if role.Name == "" {
 		return fmt.Errorf("role name is required")
 	}
+	if service != nil {
+		if svcErr := service.ResolveRoleOUHandle(context.Background(), role); svcErr != nil {
+			return fmt.Errorf("organization unit with handle %q not found for role '%s'",
+				role.OUHandle, role.Name)
+		}
+	}
 	if role.OUID == "" {
-		return fmt.Errorf("organization unit ID is required")
+		return fmt.Errorf("ou_id or ou_handle is required for role '%s'", role.Name)
 	}
 
 	for _, assignment := range role.Assignments {

--- a/backend/internal/role/declarative_resource_test.go
+++ b/backend/internal/role/declarative_resource_test.go
@@ -344,7 +344,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_ValidRole() {
 	}
 
 	// Pass nil for fileStore to skip duplicate check (for unit test purposes)
-	err := validateRoleWrapper(role, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil)
 
 	assert.NoError(suite.T(), err)
 }
@@ -356,7 +356,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingID() {
 		OUID: "ou1",
 	}
 
-	err := validateRoleWrapper(role, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "role ID is required")
@@ -369,7 +369,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingName() {
 		OUID: "ou1",
 	}
 
-	err := validateRoleWrapper(role, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "role name is required")
@@ -382,10 +382,10 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingOUID() {
 		Name: "Admin",
 	}
 
-	err := validateRoleWrapper(role, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "organization unit ID is required")
+	assert.Contains(suite.T(), err.Error(), "ou_id or ou_handle is required for role 'Admin'")
 }
 
 // Test validateRoleWrapper - invalid assignment type
@@ -399,7 +399,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_InvalidAssignmentTyp
 		},
 	}
 
-	err := validateRoleWrapper(role, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "invalid assignment type")
@@ -416,7 +416,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingAssignmentID(
 		},
 	}
 
-	err := validateRoleWrapper(role, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "assignment ID is required")
@@ -433,7 +433,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingResourceServe
 		},
 	}
 
-	err := validateRoleWrapper(role, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "resource server ID is required")

--- a/backend/internal/role/init.go
+++ b/backend/internal/role/init.go
@@ -42,8 +42,8 @@ func Initialize(
 	resourceService resourcepkg.ResourceServiceInterface,
 	entityTypeService entitytype.EntityTypeServiceInterface,
 ) (RoleServiceInterface, RoleAssignmentServiceInterface, declarativeresource.ResourceExporter, error) {
-	// Step 1: Initialize store and transactioner based on store mode
-	roleStore, transactioner, err := initializeStore()
+	// Step 1: Initialize store and transactioner based on store mode (no declarative loading yet)
+	roleStore, transactioner, fileStore, dbStore, err := initializeStore()
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -53,6 +53,14 @@ func Initialize(
 		roleStore, entityService, groupService, ouService, resourceService,
 		transactioner,
 	)
+
+	// Step 3: Load declarative resources into store (if applicable)
+	if fileStore != nil {
+		if err := loadDeclarativeResources(fileStore, dbStore, roleService); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
 	assignmentService := newRoleAssignmentService(
 		roleStore, entityService, groupService, entityTypeService, transactioner,
 	)
@@ -86,7 +94,14 @@ func Initialize(
 // - If role.store is not specified, falls back to global declarative_resources.enabled:
 //   - If declarative_resources.enabled = true: behaves as IMMUTABLE mode
 //   - If declarative_resources.enabled = false: behaves as MUTABLE mode
-func initializeStore() (roleStoreInterface, transaction.Transactioner, error) {
+//
+// Returns the active role store, transactioner, and the file/db stores used for declarative
+// resource loading. fileStore is non-nil only in declarative or composite modes; dbStore is non-nil
+// only in composite mode. Callers in those modes invoke loadDeclarativeResources after the
+// role service has been constructed so it can resolve ou_handle.
+func initializeStore() (
+	roleStoreInterface, transaction.Transactioner, *fileBasedStore, roleStoreInterface, error,
+) {
 	storeMode := getRoleStoreMode()
 
 	switch storeMode {
@@ -95,24 +110,22 @@ func initializeStore() (roleStoreInterface, transaction.Transactioner, error) {
 		fileStore := fileStoreInterface.(*fileBasedStore)
 		dbStore, transactioner, err := newRoleStore()
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 		roleStore := newCompositeRoleStore(fileStoreInterface, dbStore)
-		if err := loadDeclarativeResources(fileStore, dbStore); err != nil {
-			return nil, nil, err
-		}
-		return roleStore, transactioner, nil
+		return roleStore, transactioner, fileStore, dbStore, nil
 
 	case serverconst.StoreModeDeclarative:
 		fileStoreInterface, transactioner := newFileBasedStore()
 		fileStore := fileStoreInterface.(*fileBasedStore)
-		if err := loadDeclarativeResources(fileStore, nil); err != nil {
-			return nil, nil, err
-		}
-		return fileStoreInterface, transactioner, nil
+		return fileStoreInterface, transactioner, fileStore, nil, nil
 
 	default:
-		return newRoleStore()
+		store, transactioner, err := newRoleStore()
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		return store, transactioner, nil, nil, nil
 	}
 }
 

--- a/backend/internal/role/init_test.go
+++ b/backend/internal/role/init_test.go
@@ -77,7 +77,7 @@ func (suite *InitTestSuite) TestInitializeStoreMutableMode() {
 	getDBProvider = func() provider.DBProviderInterface { return mockProvider }
 	defer func() { getDBProvider = originalGetDBProvider }()
 
-	store, _, err := initializeStore()
+	store, _, _, _, err := initializeStore()
 
 	suite.NoError(err)
 	suite.NotNil(store)
@@ -94,7 +94,7 @@ func (suite *InitTestSuite) TestInitializeStoreDeclarativeMode() {
 	runtime.Config.Role.Store = string(serverconst.StoreModeDeclarative)
 	runtime.Config.DeclarativeResources.Enabled = true
 
-	store, _, err := initializeStore()
+	store, _, _, _, err := initializeStore()
 
 	suite.NoError(err)
 	suite.NotNil(store)
@@ -117,7 +117,7 @@ func (suite *InitTestSuite) TestInitializeStoreCompositeMode() {
 	getDBProvider = func() provider.DBProviderInterface { return mockProvider }
 	defer func() { getDBProvider = originalGetDBProvider }()
 
-	store, _, err := initializeStore()
+	store, _, _, _, err := initializeStore()
 
 	suite.NoError(err)
 	suite.NotNil(store)
@@ -136,7 +136,7 @@ func (suite *InitTestSuite) TestInitializeStoreDeclarativeFallback() {
 	runtime.Config.Role.Store = ""
 	runtime.Config.DeclarativeResources.Enabled = true
 
-	store, _, err := initializeStore()
+	store, _, _, _, err := initializeStore()
 
 	suite.NoError(err)
 	suite.NotNil(store)
@@ -160,7 +160,7 @@ func (suite *InitTestSuite) TestInitializeStoreMutableModeFallback() {
 	getDBProvider = func() provider.DBProviderInterface { return mockProvider }
 	defer func() { getDBProvider = originalGetDBProvider }()
 
-	store, _, err := initializeStore()
+	store, _, _, _, err := initializeStore()
 
 	suite.NoError(err)
 	suite.NotNil(store)
@@ -176,7 +176,7 @@ func (suite *InitTestSuite) TestInitializeStoreNormalizeCaseSensitivity() {
 	runtime := config.GetServerRuntime()
 	runtime.Config.Role.Store = "DECLARATIVE"
 
-	store, _, err := initializeStore()
+	store, _, _, _, err := initializeStore()
 
 	suite.NoError(err)
 	suite.NotNil(store)
@@ -199,7 +199,7 @@ func (suite *InitTestSuite) TestInitializeStoreTrimsWhitespace() {
 	getDBProvider = func() provider.DBProviderInterface { return mockProvider }
 	defer func() { getDBProvider = originalGetDBProvider }()
 
-	store, _, err := initializeStore()
+	store, _, _, _, err := initializeStore()
 
 	suite.NoError(err)
 	suite.NotNil(store)
@@ -240,7 +240,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesWith
 	genericStore := declarativeresource.NewGenericFileBasedStoreForTest(entity.KeyTypeRole)
 	fileStore := &fileBasedStore{GenericFileBasedStore: genericStore}
 
-	err := loadDeclarativeResources(fileStore, nil)
+	err := loadDeclarativeResources(fileStore, nil, nil)
 
 	// Should not error even if no resources are found (empty directory)
 	suite.NoError(err)
@@ -252,7 +252,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesWith
 	fileStore := &fileBasedStore{GenericFileBasedStore: genericStore}
 
 	// Should handle nil dbStore gracefully (no duplicate checking against DB)
-	err := loadDeclarativeResources(fileStore, nil)
+	err := loadDeclarativeResources(fileStore, nil, nil)
 
 	suite.NoError(err)
 }
@@ -266,7 +266,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesWith
 	mockDbStore := newRoleStoreInterfaceMock(suite.T())
 	// Don't setup any expectations since no resources are loaded by default
 
-	err := loadDeclarativeResources(fileStore, mockDbStore)
+	err := loadDeclarativeResources(fileStore, mockDbStore, nil)
 
 	suite.NoError(err)
 }
@@ -291,7 +291,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 	}
 
 	// Validate the role with no dbStore (validation should pass for valid role)
-	err := validateRoleWrapper(testRole, fileStore, nil)
+	err := validateRoleWrapper(testRole, fileStore, nil, nil)
 
 	suite.NoError(err)
 }
@@ -311,7 +311,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesIDEx
 	suite.NoError(err)
 
 	// Load should correctly extract the ID
-	err = loadDeclarativeResources(fileStore, nil)
+	err = loadDeclarativeResources(fileStore, nil, nil)
 
 	suite.NoError(err)
 	// Verify the role is still in the store with correct ID
@@ -366,7 +366,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 		Name: "No ID",
 		OUID: "ou1",
 	}
-	err := validateRoleWrapper(roleNoID, fileStore, nil)
+	err := validateRoleWrapper(roleNoID, fileStore, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "role ID is required")
 
@@ -375,7 +375,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 		ID:   "role1",
 		OUID: "ou1",
 	}
-	err = validateRoleWrapper(roleNoName, fileStore, nil)
+	err = validateRoleWrapper(roleNoName, fileStore, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "role name is required")
 
@@ -384,9 +384,9 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 		ID:   "role1",
 		Name: "Test Role",
 	}
-	err = validateRoleWrapper(roleNoOU, fileStore, nil)
+	err = validateRoleWrapper(roleNoOU, fileStore, nil, nil)
 	suite.Error(err)
-	suite.Contains(err.Error(), "organization unit ID is required")
+	suite.Contains(err.Error(), "ou_id or ou_handle is required for role 'Test Role'")
 }
 
 // TestLoadDeclarativeResourcesValidateAssignmentTypes tests validation of assignment types.
@@ -403,7 +403,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			{ID: "user1", Type: assigneeTypeEntity},
 		},
 	}
-	err := validateRoleWrapper(roleValidUser, fileStore, nil)
+	err := validateRoleWrapper(roleValidUser, fileStore, nil, nil)
 	suite.NoError(err)
 
 	// Test role with valid group assignment
@@ -415,7 +415,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			{ID: "group1", Type: AssigneeTypeGroup},
 		},
 	}
-	err = validateRoleWrapper(roleValidGroup, fileStore, nil)
+	err = validateRoleWrapper(roleValidGroup, fileStore, nil, nil)
 	suite.NoError(err)
 
 	// Test role with invalid assignment type
@@ -427,7 +427,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			{ID: "invalid1", Type: "invalid_type"},
 		},
 	}
-	err = validateRoleWrapper(roleInvalidType, fileStore, nil)
+	err = validateRoleWrapper(roleInvalidType, fileStore, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "invalid assignment type")
 
@@ -440,7 +440,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			{Type: assigneeTypeEntity},
 		},
 	}
-	err = validateRoleWrapper(roleNoAssignmentID, fileStore, nil)
+	err = validateRoleWrapper(roleNoAssignmentID, fileStore, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "assignment ID is required")
 }
@@ -459,7 +459,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			{Permissions: []string{"read"}},
 		},
 	}
-	err := validateRoleWrapper(roleNoResourceServer, fileStore, nil)
+	err := validateRoleWrapper(roleNoResourceServer, fileStore, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "resource server ID is required")
 
@@ -475,7 +475,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			},
 		},
 	}
-	err = validateRoleWrapper(roleValidPermission, fileStore, nil)
+	err = validateRoleWrapper(roleValidPermission, fileStore, nil, nil)
 	suite.NoError(err)
 }
 
@@ -494,7 +494,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 	suite.NoError(err)
 
 	// Try to validate same role again
-	err = validateRoleWrapper(existingRole, fileStore, nil)
+	err = validateRoleWrapper(existingRole, fileStore, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "duplicate role ID")
 	suite.Contains(err.Error(), "declarative resources")
@@ -515,7 +515,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 	// Mock database store to indicate role exists
 	mockDbStore.On("IsRoleExist", mock.Anything, "db-duplicate").Return(true, nil).Once()
 
-	err := validateRoleWrapper(role, fileStore, mockDbStore)
+	err := validateRoleWrapper(role, fileStore, mockDbStore, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "duplicate role ID")
 	suite.Contains(err.Error(), "database store")
@@ -539,7 +539,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 		false, fmt.Errorf("database error"),
 	).Once()
 
-	err := validateRoleWrapper(role, fileStore, mockDbStore)
+	err := validateRoleWrapper(role, fileStore, mockDbStore, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "database error")
 	mockDbStore.AssertExpectations(suite.T())

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -30,6 +30,7 @@ import (
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )
@@ -50,6 +51,9 @@ type RoleServiceInterface interface {
 		ctx context.Context, entityID string, groups []string, requestedPermissions []string,
 	) ([]string, *serviceerror.ServiceError)
 	GetUserRoles(ctx context.Context, entityID string, groupIDs []string) ([]string, *serviceerror.ServiceError)
+	ResolveRoleOUHandle(
+		ctx context.Context, role *RoleWithPermissionsAndAssignments,
+	) *serviceerror.ServiceError
 }
 
 // roleService is the default implementation of the RoleServiceInterface.
@@ -468,6 +472,32 @@ func (rs *roleService) IsRoleDeclarative(ctx context.Context, id string) (bool, 
 	}
 
 	return isDeclarative, nil
+}
+
+// ResolveRoleOUHandle resolves ou_handle to an OU ID on the given role in-place.
+// Called by the declarative loader validator so that file-based roles support ou_handle.
+// If both ou_id and ou_handle are provided, ou_id wins and a warning is logged.
+func (rs *roleService) ResolveRoleOUHandle(
+	ctx context.Context, role *RoleWithPermissionsAndAssignments,
+) *serviceerror.ServiceError {
+	if role.OUID != "" && role.OUHandle != "" {
+		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+		logger.Warn("Both ou_id and ou_handle provided for role; ou_handle ignored",
+			log.String("roleID", role.ID), log.String("name", role.Name))
+		return nil
+	}
+	if role.OUID == "" && role.OUHandle != "" {
+		if rs.ouService == nil {
+			return &serviceerror.InternalServerError
+		}
+		ou, svcErr := rs.ouService.GetOrganizationUnitByPath(
+			security.WithRuntimeContext(ctx), role.OUHandle)
+		if svcErr != nil {
+			return &ErrorInvalidRequestFormat
+		}
+		role.OUID = ou.ID
+	}
+	return nil
 }
 
 // validateCreateRoleRequest validates the create role request.

--- a/backend/internal/role/service_test.go
+++ b/backend/internal/role/service_test.go
@@ -1457,3 +1457,98 @@ func (suite *RoleServiceTestSuite) TestIsRoleDeclarative_StoreReturnsError() {
 	suite.False(isDeclarative)
 	suite.Equal(&serviceerror.InternalServerError, err)
 }
+
+// TestResolveRoleOUHandle_OUHandleResolved verifies that when only ou_handle is set, it is
+// resolved to ou_id via the OU service.
+func (suite *RoleServiceTestSuite) TestResolveRoleOUHandle_OUHandleResolved() {
+	suite.mockOUService.On("GetOrganizationUnitByPath", mock.Anything, "default").
+		Return(oupkg.OrganizationUnit{ID: "ou-resolved"}, (*serviceerror.ServiceError)(nil)).Once()
+
+	role := &RoleWithPermissionsAndAssignments{OUHandle: "default"}
+	svcErr := suite.service.ResolveRoleOUHandle(context.Background(), role)
+
+	suite.Nil(svcErr)
+	suite.Equal("ou-resolved", role.OUID)
+}
+
+// TestResolveRoleOUHandle_OUIDAlreadySet verifies that no resolution happens when ou_id is set
+// and ou_handle is empty.
+func (suite *RoleServiceTestSuite) TestResolveRoleOUHandle_OUIDAlreadySet() {
+	role := &RoleWithPermissionsAndAssignments{OUID: "ou-direct"}
+	svcErr := suite.service.ResolveRoleOUHandle(context.Background(), role)
+
+	suite.Nil(svcErr)
+	suite.Equal("ou-direct", role.OUID)
+}
+
+// TestResolveRoleOUHandle_BothProvided verifies that when both ou_id and ou_handle are
+// provided, ou_id is retained and the OU service is never called.
+func (suite *RoleServiceTestSuite) TestResolveRoleOUHandle_BothProvided() {
+	role := &RoleWithPermissionsAndAssignments{ID: "r1", Name: "Admin", OUID: "ou-direct", OUHandle: "default"}
+
+	svcErr := suite.service.ResolveRoleOUHandle(context.Background(), role)
+
+	suite.Nil(svcErr)
+	suite.Equal("ou-direct", role.OUID)
+	// AssertExpectations in t.Cleanup will confirm GetOrganizationUnitByPath was never invoked.
+}
+
+// TestResolveRoleOUHandle_OUHandleNotFound verifies that a not-found response from the OU
+// service is surfaced as ErrorInvalidRequestFormat.
+func (suite *RoleServiceTestSuite) TestResolveRoleOUHandle_OUHandleNotFound() {
+	suite.mockOUService.On("GetOrganizationUnitByPath", mock.Anything, "missing").
+		Return(oupkg.OrganizationUnit{}, &oupkg.ErrorOrganizationUnitNotFound).Once()
+
+	role := &RoleWithPermissionsAndAssignments{OUHandle: "missing"}
+	svcErr := suite.service.ResolveRoleOUHandle(context.Background(), role)
+
+	suite.NotNil(svcErr)
+	suite.Equal(ErrorInvalidRequestFormat.Code, svcErr.Code)
+}
+
+// TestResolveRoleOUHandle_NeitherProvided verifies that the call is a no-op when neither
+// ou_id nor ou_handle is provided.
+func (suite *RoleServiceTestSuite) TestResolveRoleOUHandle_NeitherProvided() {
+	role := &RoleWithPermissionsAndAssignments{}
+	svcErr := suite.service.ResolveRoleOUHandle(context.Background(), role)
+
+	suite.Nil(svcErr)
+	suite.Empty(role.OUID)
+}
+
+// TestResolveRoleOUHandle_NilOUService verifies that a clear error is returned when the OU
+// service is nil and ou_handle is supplied (no nil-pointer panic).
+func (suite *RoleServiceTestSuite) TestResolveRoleOUHandle_NilOUService() {
+	svc := &roleService{ouService: nil}
+	role := &RoleWithPermissionsAndAssignments{OUHandle: "default"}
+
+	svcErr := svc.ResolveRoleOUHandle(context.Background(), role)
+
+	suite.NotNil(svcErr)
+	suite.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestRoleDeclarativeYAML_OUHandleParsed verifies that ou_handle is parsed off the YAML
+// document into the role declarative resource.
+func TestRoleDeclarativeYAML_OUHandleParsed(t *testing.T) {
+	yamlData := []byte(`
+id: role-1
+name: Admin
+ou_handle: default
+permissions:
+  - resource_server_id: rs1
+    permissions:
+      - read
+`)
+	role, err := parseToRole(yamlData)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if role.OUHandle != "default" {
+		t.Errorf("OUHandle = %q, want %q", role.OUHandle, "default")
+	}
+	if role.OUID != "" {
+		t.Errorf("OUID = %q, want empty (resolution happens later)", role.OUID)
+	}
+}

--- a/backend/internal/system/importer/parser.go
+++ b/backend/internal/system/importer/parser.go
@@ -201,7 +201,7 @@ func classifyResourceType(node *yaml.Node) string {
 		matches = append(matches, resourceTypeLayout)
 	}
 
-	if hasAllKeys(node, "type", "attributes", "ou_id") {
+	if hasAllKeys(node, "type", "attributes") && hasAnyKey(node, "ou_id", "ou_handle") {
 		matches = append(matches, resourceTypeUser)
 	}
 
@@ -228,8 +228,9 @@ func classifyResourceType(node *yaml.Node) string {
 		matches = append(matches, resourceTypeApplication)
 	}
 
-	if hasAllKeys(node, "name", "ou_id") &&
-		!hasAnyKey(node, "handle", "permissions", "identifier", "type", "flowType", "displayName", "properties") {
+	if hasAllKeys(node, "name") && hasAnyKey(node, "ou_id", "ou_handle") &&
+		!hasAnyKey(node, "handle", "permissions", "identifier", "type", "flowType",
+			"displayName", "properties", "schema") {
 		matches = append(matches, resourceTypeGroup)
 	}
 

--- a/backend/internal/system/importer/service_adapters.go
+++ b/backend/internal/system/importer/service_adapters.go
@@ -41,11 +41,39 @@ import (
 	"github.com/thunder-id/thunderid/internal/user"
 )
 
+// resolveImportOUHandle resolves an ou_handle to its corresponding OU ID for import operations.
+// If both ouID and ouHandle are provided, ouID wins and a warning is logged.
+// Returns the (possibly resolved) ouID and any service error from the OU lookup.
+func (s *importService) resolveImportOUHandle(
+	ctx context.Context, resourceType, resourceID, resourceName, ouID, ouHandle string,
+) (string, *serviceerror.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ImportService"))
+	if ouID != "" && ouHandle != "" {
+		logger.Warn("Both ou_id and ou_handle provided; ou_handle ignored",
+			log.String("resourceType", resourceType),
+			log.String("resourceID", resourceID),
+			log.String("resourceName", resourceName))
+		return ouID, nil
+	}
+	if ouID == "" && ouHandle != "" {
+		if s.ouService == nil {
+			return "", &serviceerror.InternalServerError
+		}
+		resolved, svcErr := s.ouService.GetOrganizationUnitByPath(ctx, ouHandle)
+		if svcErr != nil {
+			return "", svcErr
+		}
+		return resolved.ID, nil
+	}
+	return ouID, nil
+}
+
 type roleDeclarativeYAML struct {
 	ID          string                     `yaml:"id"`
 	Name        string                     `yaml:"name"`
 	Description string                     `yaml:"description,omitempty"`
-	OUID        string                     `yaml:"ou_id"`
+	OUID        string                     `yaml:"ou_id,omitempty"`
+	OUHandle    string                     `yaml:"ou_handle,omitempty"`
 	Permissions []role.ResourcePermissions `yaml:"permissions"`
 	Assignments []role.RoleAssignment      `yaml:"assignments,omitempty"`
 }
@@ -53,7 +81,8 @@ type roleDeclarativeYAML struct {
 type userDeclarativeYAML struct {
 	ID          string                 `yaml:"id"`
 	Type        string                 `yaml:"type"`
-	OUID        string                 `yaml:"ou_id"`
+	OUID        string                 `yaml:"ou_id,omitempty"`
+	OUHandle    string                 `yaml:"ou_handle,omitempty"`
 	Attributes  map[string]interface{} `yaml:"attributes"`
 	Credentials map[string]interface{} `yaml:"credentials,omitempty"`
 }
@@ -270,6 +299,13 @@ func (s *importService) importRole(
 		return decodeErrorOutcome(resourceTypeRole, req.ID, req.Name, err)
 	}
 
+	resolvedOUID, svcErr := s.resolveImportOUHandle(
+		ctx, resourceTypeRole, req.ID, req.Name, req.OUID, req.OUHandle)
+	if svcErr != nil {
+		return serviceErrorOutcome(resourceTypeRole, req.ID, req.Name, operationCreate, svcErr)
+	}
+	req.OUID = resolvedOUID
+
 	createReq := role.RoleCreationDetail{
 		ID:          req.ID,
 		Name:        req.Name,
@@ -346,12 +382,21 @@ func (s *importService) importGroup(
 		ID          string         `yaml:"id"`
 		Name        string         `yaml:"name"`
 		Description string         `yaml:"description,omitempty"`
-		OUID        string         `yaml:"ou_id"`
+		OUID        string         `yaml:"ou_id,omitempty"`
+		OUHandle    string         `yaml:"ou_handle,omitempty"`
 		Members     []group.Member `yaml:"members,omitempty"`
 	}
 	if err := doc.Node.Decode(&raw); err != nil {
 		return decodeErrorOutcome(resourceTypeGroup, raw.ID, raw.Name, err)
 	}
+
+	resolvedOUID, svcErr := s.resolveImportOUHandle(
+		ctx, resourceTypeGroup, raw.ID, raw.Name, raw.OUID, raw.OUHandle)
+	if svcErr != nil {
+		return serviceErrorOutcome(resourceTypeGroup, raw.ID, raw.Name, operationCreate, svcErr)
+	}
+	raw.OUID = resolvedOUID
+
 	req = group.CreateGroupRequest{
 		ID:          raw.ID,
 		Name:        raw.Name,
@@ -420,6 +465,13 @@ func (s *importService) importResourceServer(
 	if err := doc.Node.Decode(&req); err != nil {
 		return decodeErrorOutcome(resourceTypeResourceServer, req.ID, req.Name, err)
 	}
+
+	resolvedOUID, svcErr := s.resolveImportOUHandle(
+		ctx, resourceTypeResourceServer, req.ID, req.Name, req.OUID, req.OUHandle)
+	if svcErr != nil {
+		return serviceErrorOutcome(resourceTypeResourceServer, req.ID, req.Name, operationCreate, svcErr)
+	}
+	req.OUID = resolvedOUID
 
 	if dryRun {
 		if options.IsUpsertEnabled() && req.ID != "" {
@@ -605,6 +657,13 @@ func (s *importService) importUser(
 	if err := doc.Node.Decode(&req); err != nil {
 		return decodeErrorOutcome(resourceTypeUser, req.ID, "", err)
 	}
+
+	resolvedOUID, svcErr := s.resolveImportOUHandle(
+		ctx, resourceTypeUser, req.ID, "", req.OUID, req.OUHandle)
+	if svcErr != nil {
+		return serviceErrorOutcome(resourceTypeUser, req.ID, "", operationCreate, svcErr)
+	}
+	req.OUID = resolvedOUID
 
 	attributesJSON, err := json.Marshal(req.Attributes)
 	if err != nil {

--- a/backend/internal/system/importer/service_test.go
+++ b/backend/internal/system/importer/service_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/idp"
 	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
 	"github.com/thunder-id/thunderid/internal/ou"
+	"github.com/thunder-id/thunderid/internal/resource"
 	"github.com/thunder-id/thunderid/internal/role"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
@@ -460,12 +461,14 @@ func (f *fakeOUService) UpdateOrganizationUnit(
 }
 
 type fakeRoleService struct {
+	created []role.RoleCreationDetail
 	updated []role.RoleUpdateDetail
 }
 
 func (f *fakeRoleService) CreateRole(
 	_ context.Context, req role.RoleCreationDetail,
 ) (*role.RoleWithPermissionsAndAssignments, *serviceerror.ServiceError) {
+	f.created = append(f.created, req)
 	return &role.RoleWithPermissionsAndAssignments{ID: "role-1", Name: req.Name}, nil
 }
 
@@ -2055,4 +2058,372 @@ func TestImportAgent_StripsClientSecretForPublicAgentWithNoneAuthMethod(t *testi
 func TestGetAgentOAuthConfigForImport_NilRequest(t *testing.T) {
 	result := getAgentOAuthConfigForImport(nil)
 	assert.Nil(t, result)
+}
+
+// fakeResourceServerService is a test double for the resource server adapter used by importer tests.
+type fakeResourceServerService struct {
+	created []resource.ResourceServer
+	updated []resource.ResourceServer
+}
+
+func (f *fakeResourceServerService) CreateResourceServer(
+	_ context.Context, rs resource.ResourceServer,
+) (*resource.ResourceServer, *serviceerror.ServiceError) {
+	f.created = append(f.created, rs)
+	return &resource.ResourceServer{ID: rs.ID, Name: rs.Name, OUID: rs.OUID}, nil
+}
+
+func (f *fakeResourceServerService) GetResourceServer(
+	_ context.Context, id string,
+) (*resource.ResourceServer, *serviceerror.ServiceError) {
+	return nil, &serviceerror.ServiceError{
+		Type:  serviceerror.ClientErrorType,
+		Code:  resource.ErrorResourceServerNotFound.Code,
+		Error: core.I18nMessage{DefaultValue: "not found: " + id},
+	}
+}
+
+func (f *fakeResourceServerService) UpdateResourceServer(
+	_ context.Context, _ string, rs resource.ResourceServer,
+) (*resource.ResourceServer, *serviceerror.ServiceError) {
+	f.updated = append(f.updated, rs)
+	return &resource.ResourceServer{ID: rs.ID, Name: rs.Name, OUID: rs.OUID}, nil
+}
+
+func (f *fakeResourceServerService) CreateResource(
+	_ context.Context, _ string, _ resource.Resource,
+) (*resource.Resource, *serviceerror.ServiceError) {
+	return &resource.Resource{}, nil
+}
+
+func (f *fakeResourceServerService) GetResourceList(
+	_ context.Context, _ string, _ *string, _, _ int,
+) (*resource.ResourceList, *serviceerror.ServiceError) {
+	return &resource.ResourceList{}, nil
+}
+
+func (f *fakeResourceServerService) CreateAction(
+	_ context.Context, _ string, _ *string, _ resource.Action,
+) (*resource.Action, *serviceerror.ServiceError) {
+	return &resource.Action{}, nil
+}
+
+// TestImportRole_OUHandleResolved verifies that ou_handle on a role document is resolved
+// to ou_id via the OU service before the role create request is built.
+func TestImportRole_OUHandleResolved(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{
+		"ou-default": {ID: "ou-default", Handle: "default"},
+	}}
+	roleSvc := &fakeRoleService{}
+	roleAssignmentSvc := &fakeRoleAssignmentService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil)
+
+	content := strings.Join([]string{
+		"id: role-new",
+		"name: Viewer",
+		"ou_handle: default",
+		"permissions: []",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	require.Len(t, roleSvc.created, 1)
+	assert.Equal(t, "ou-default", roleSvc.created[0].OUID)
+}
+
+// TestImportRole_OUHandleNotFound verifies that an unknown ou_handle on a role document
+// causes the import to fail with a clear error.
+func TestImportRole_OUHandleNotFound(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
+	roleSvc := &fakeRoleService{}
+	roleAssignmentSvc := &fakeRoleAssignmentService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil)
+
+	content := strings.Join([]string{
+		"id: role-new",
+		"name: Viewer",
+		"ou_handle: missing",
+		"permissions: []",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Empty(t, roleSvc.created)
+}
+
+// TestImportRole_OUIDWinsOverHandle verifies that ou_id wins when both ou_id and ou_handle
+// are provided, and the OU service is never consulted.
+func TestImportRole_OUIDWinsOverHandle(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
+	roleSvc := &fakeRoleService{}
+	roleAssignmentSvc := &fakeRoleAssignmentService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil)
+
+	content := strings.Join([]string{
+		"id: role-new",
+		"name: Viewer",
+		"ou_id: ou-explicit",
+		"ou_handle: default",
+		"permissions: []",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	require.Len(t, roleSvc.created, 1)
+	assert.Equal(t, "ou-explicit", roleSvc.created[0].OUID)
+}
+
+// TestImportGroup_OUHandleResolved verifies that ou_handle on a group document is resolved
+// to ou_id via the OU service before the group create request is built.
+func TestImportGroup_OUHandleResolved(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{
+		"ou-default": {ID: "ou-default", Handle: "default"},
+	}}
+	groupSvc := &fakeGroupService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil)
+
+	content := strings.Join([]string{
+		"id: group-new",
+		"name: Engineers",
+		"ou_handle: default",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	require.Len(t, groupSvc.created, 1)
+	assert.Equal(t, "ou-default", groupSvc.created[0].OUID)
+}
+
+// TestImportGroup_OUHandleNotFound verifies that an unknown ou_handle on a group document
+// causes the import to fail with a clear error.
+func TestImportGroup_OUHandleNotFound(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
+	groupSvc := &fakeGroupService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil)
+
+	content := strings.Join([]string{
+		"id: group-new",
+		"name: Engineers",
+		"ou_handle: missing",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Empty(t, groupSvc.created)
+}
+
+// TestImportGroup_OUIDWinsOverHandle verifies that ou_id wins when both ou_id and ou_handle
+// are provided, and the OU service is never consulted.
+func TestImportGroup_OUIDWinsOverHandle(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
+	groupSvc := &fakeGroupService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil)
+
+	content := strings.Join([]string{
+		"id: group-new",
+		"name: Engineers",
+		"ou_id: ou-explicit",
+		"ou_handle: default",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	require.Len(t, groupSvc.created, 1)
+	assert.Equal(t, "ou-explicit", groupSvc.created[0].OUID)
+}
+
+// TestImportUser_OUHandleResolved verifies that ou_handle on a user document is resolved
+// to ou_id via the OU service before the user create request is built.
+func TestImportUser_OUHandleResolved(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{
+		"ou-default": {ID: "ou-default", Handle: "default"},
+	}}
+	userSvc := &fakeUserService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil)
+
+	content := strings.Join([]string{
+		"id: user-new",
+		"type: person",
+		"ou_handle: default",
+		"attributes:",
+		"  username: alice",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: content,
+		Options: &ImportOptions{Upsert: boolPtr(false)},
+	})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	require.Len(t, userSvc.created, 1)
+	assert.Equal(t, "ou-default", userSvc.created[0].OUID)
+}
+
+// TestImportUser_OUHandleNotFound verifies that an unknown ou_handle on a user document
+// causes the import to fail with a clear error.
+func TestImportUser_OUHandleNotFound(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
+	userSvc := &fakeUserService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil)
+
+	content := strings.Join([]string{
+		"id: user-new",
+		"type: person",
+		"ou_handle: missing",
+		"attributes:",
+		"  username: alice",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Empty(t, userSvc.created)
+}
+
+// TestImportUser_OUIDWinsOverHandle verifies that ou_id wins when both ou_id and ou_handle
+// are provided, and the OU service is never consulted.
+func TestImportUser_OUIDWinsOverHandle(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
+	userSvc := &fakeUserService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil)
+
+	content := strings.Join([]string{
+		"id: user-new",
+		"type: person",
+		"ou_id: ou-explicit",
+		"ou_handle: default",
+		"attributes:",
+		"  username: alice",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: content,
+		Options: &ImportOptions{Upsert: boolPtr(false)},
+	})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	require.Len(t, userSvc.created, 1)
+	assert.Equal(t, "ou-explicit", userSvc.created[0].OUID)
+}
+
+// TestImportResourceServer_OUHandleResolved verifies that ou_handle on a resource server
+// document is resolved to ou_id via the OU service before the create request is built.
+func TestImportResourceServer_OUHandleResolved(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{
+		"ou-default": {ID: "ou-default", Handle: "default"},
+	}}
+	rsSvc := &fakeResourceServerService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil)
+
+	content := strings.Join([]string{
+		"# resource_type: resource_server",
+		"id: rs-new",
+		"name: Test RS",
+		"handle: test-rs",
+		"identifier: test-rs",
+		"ou_handle: default",
+		"resources: []",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: content,
+		Options: &ImportOptions{Upsert: boolPtr(false)},
+	})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	require.Len(t, rsSvc.created, 1)
+	assert.Equal(t, "ou-default", rsSvc.created[0].OUID)
+}
+
+// TestImportResourceServer_OUHandleNotFound verifies that an unknown ou_handle on a resource
+// server document causes the import to fail with a clear error.
+func TestImportResourceServer_OUHandleNotFound(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
+	rsSvc := &fakeResourceServerService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil)
+
+	content := strings.Join([]string{
+		"# resource_type: resource_server",
+		"id: rs-new",
+		"name: Test RS",
+		"handle: test-rs",
+		"identifier: test-rs",
+		"ou_handle: missing",
+		"resources: []",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Empty(t, rsSvc.created)
+}
+
+// TestImportResourceServer_OUIDWinsOverHandle verifies that ou_id wins when both ou_id and
+// ou_handle are provided, and the OU service is never consulted.
+func TestImportResourceServer_OUIDWinsOverHandle(t *testing.T) {
+	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
+	rsSvc := &fakeResourceServerService{}
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil)
+
+	content := strings.Join([]string{
+		"# resource_type: resource_server",
+		"id: rs-new",
+		"name: Test RS",
+		"handle: test-rs",
+		"identifier: test-rs",
+		"ou_id: ou-explicit",
+		"ou_handle: default",
+		"resources: []",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: content,
+		Options: &ImportOptions{Upsert: boolPtr(false)},
+	})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	require.Len(t, rsSvc.created, 1)
+	assert.Equal(t, "ou-explicit", rsSvc.created[0].OUID)
 }

--- a/backend/internal/user/UserServiceInterface_mock_test.go
+++ b/backend/internal/user/UserServiceInterface_mock_test.go
@@ -584,6 +584,65 @@ func (_c *UserServiceInterfaceMock_GetUsersByPath_Call) RunAndReturn(run func(ct
 	return _c
 }
 
+// ResolveUserOUHandle provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) ResolveUserOUHandle(ctx context.Context, user *User) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, user)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveUserOUHandle")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *User) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, user)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// UserServiceInterfaceMock_ResolveUserOUHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveUserOUHandle'
+type UserServiceInterfaceMock_ResolveUserOUHandle_Call struct {
+	*mock.Call
+}
+
+// ResolveUserOUHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - user *User
+func (_e *UserServiceInterfaceMock_Expecter) ResolveUserOUHandle(ctx interface{}, user interface{}) *UserServiceInterfaceMock_ResolveUserOUHandle_Call {
+	return &UserServiceInterfaceMock_ResolveUserOUHandle_Call{Call: _e.mock.On("ResolveUserOUHandle", ctx, user)}
+}
+
+func (_c *UserServiceInterfaceMock_ResolveUserOUHandle_Call) Run(run func(ctx context.Context, user *User)) *UserServiceInterfaceMock_ResolveUserOUHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *User
+		if args[1] != nil {
+			arg1 = args[1].(*User)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_ResolveUserOUHandle_Call) Return(serviceError *serviceerror.ServiceError) *UserServiceInterfaceMock_ResolveUserOUHandle_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_ResolveUserOUHandle_Call) RunAndReturn(run func(ctx context.Context, user *User) *serviceerror.ServiceError) *UserServiceInterfaceMock_ResolveUserOUHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateUser provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) UpdateUser(ctx context.Context, userID string, user *User) (*User, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, userID, user)

--- a/backend/internal/user/declarative_resource.go
+++ b/backend/internal/user/declarative_resource.go
@@ -182,21 +182,32 @@ func (e *userExporter) GetResourceRules() *declarativeresource.ResourceRules {
 
 // makeUserDeclarativeConfig creates the declarative loader configuration for user resources.
 // This provides user-specific parser and validator callbacks to the entity service.
-func makeUserDeclarativeConfig() entity.DeclarativeLoaderConfig {
+// When userService is non-nil, ou_handle is resolved to ou_id during parsing.
+func makeUserDeclarativeConfig(userService UserServiceInterface) entity.DeclarativeLoaderConfig {
 	return entity.DeclarativeLoaderConfig{
 		Directory: "users",
 		Category:  entity.EntityCategoryUser,
-		Parser:    makeUserParser(),
+		Parser:    makeUserParser(userService),
 		Validator: makeUserValidator(),
 	}
 }
 
 // makeUserParser creates a parser callback that converts YAML data into an Entity with credentials.
-func makeUserParser() func(data []byte) (*entity.Entity, json.RawMessage, json.RawMessage, error) {
+// When userService is non-nil, ou_handle is resolved to ou_id before producing the entity.
+func makeUserParser(
+	userService UserServiceInterface,
+) func(data []byte) (*entity.Entity, json.RawMessage, json.RawMessage, error) {
 	return func(data []byte) (*entity.Entity, json.RawMessage, json.RawMessage, error) {
 		user, creds, err := parseToUser(data)
 		if err != nil {
 			return nil, nil, nil, err
+		}
+
+		if userService != nil {
+			if svcErr := userService.ResolveUserOUHandle(context.Background(), &user); svcErr != nil {
+				return nil, nil, nil, fmt.Errorf(
+					"organization unit with handle %q not found for user '%s'", user.OUHandle, user.ID)
+			}
 		}
 
 		e := userToEntity(&user)
@@ -219,7 +230,7 @@ func makeUserValidator() func(e *entity.Entity, svc entity.EntityServiceInterfac
 			return fmt.Errorf("user type is required")
 		}
 		if e.OUID == "" {
-			return fmt.Errorf("organization unit ID is required")
+			return fmt.Errorf("ou_id or ou_handle is required for user '%s'", e.ID)
 		}
 		if len(e.Attributes) == 0 {
 			return fmt.Errorf("user attributes are required")
@@ -251,12 +262,14 @@ func makeUserValidator() func(e *entity.Entity, svc entity.EntityServiceInterfac
 type userDeclarativeResource struct {
 	ID          string                 `yaml:"id"`
 	Type        string                 `yaml:"type"`
-	OUID        string                 `yaml:"ou_id"`
+	OUID        string                 `yaml:"ou_id,omitempty"`
+	OUHandle    string                 `yaml:"ou_handle,omitempty"`
 	Attributes  map[string]interface{} `yaml:"attributes"`
 	Credentials map[string]interface{} `yaml:"credentials,omitempty"` // Flexible format for YAML
 }
 
-// parseToUser parses YAML data into a User and its Credentials.
+// parseToUser parses YAML data into a User and its Credentials. The ou_handle from YAML is
+// populated onto User.OUHandle so callers can resolve it to an ou_id via the user service.
 func parseToUser(data []byte) (User, Credentials, error) {
 	var userRes userDeclarativeResource
 	if err := yaml.Unmarshal(data, &userRes); err != nil {
@@ -273,6 +286,7 @@ func parseToUser(data []byte) (User, Credentials, error) {
 		ID:         userRes.ID,
 		Type:       userRes.Type,
 		OUID:       userRes.OUID,
+		OUHandle:   userRes.OUHandle,
 		Attributes: json.RawMessage(attributesJSON),
 	}
 

--- a/backend/internal/user/declarative_resource_test.go
+++ b/backend/internal/user/declarative_resource_test.go
@@ -234,7 +234,7 @@ func (suite *DeclarativeResourceTestSuite) TestMakeUserParser_ParsesYAMLToEntity
 		"credentials:\n" +
 		"  password: \"secret\"\n")
 
-	parser := makeUserParser()
+	parser := makeUserParser(nil)
 	e, _, systemCreds, err := parser(userYAML)
 
 	suite.NoError(err)

--- a/backend/internal/user/init.go
+++ b/backend/internal/user/init.go
@@ -51,7 +51,7 @@ func Initialize(
 	// Step 3: Load declarative resources if user store mode requires it.
 	storeMode := getUserStoreMode()
 	if storeMode == serverconst.StoreModeDeclarative || storeMode == serverconst.StoreModeComposite {
-		if err := entityService.LoadDeclarativeResources(makeUserDeclarativeConfig()); err != nil {
+		if err := entityService.LoadDeclarativeResources(makeUserDeclarativeConfig(userService)); err != nil {
 			return nil, nil, nil, err
 		}
 	}

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -58,6 +58,7 @@ type UserServiceInterface interface {
 	UpdateUserCredentials(ctx context.Context, userID string,
 		credentials json.RawMessage) *serviceerror.ServiceError
 	DeleteUser(ctx context.Context, userID string) *serviceerror.ServiceError
+	ResolveUserOUHandle(ctx context.Context, user *User) *serviceerror.ServiceError
 }
 
 // userService is the default implementation of the UserServiceInterface.
@@ -1037,4 +1038,30 @@ func (us *userService) checkUserAccess(
 func buildTreePaginationLinks(handlePath string, limit, offset, totalResults int, displayQuery string) []utils.Link {
 	treePath := fmt.Sprintf("/users/tree/%s", path.Clean(handlePath))
 	return utils.BuildPaginationLinks(treePath, limit, offset, totalResults, displayQuery)
+}
+
+// ResolveUserOUHandle resolves ou_handle to an OU ID on the given user in-place.
+// Called by the declarative loader parser so that file-based users support ou_handle.
+// If both ou_id and ou_handle are provided, ou_id wins and a warning is logged.
+func (us *userService) ResolveUserOUHandle(
+	ctx context.Context, user *User,
+) *serviceerror.ServiceError {
+	if user.OUID != "" && user.OUHandle != "" {
+		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+		logger.Warn("Both ou_id and ou_handle provided for user; ou_handle ignored",
+			log.MaskedString(log.LoggerKeyUserID, user.ID))
+		return nil
+	}
+	if user.OUID == "" && user.OUHandle != "" {
+		if us.ouService == nil {
+			return &serviceerror.InternalServerError
+		}
+		ou, svcErr := us.ouService.GetOrganizationUnitByPath(
+			security.WithRuntimeContext(ctx), user.OUHandle)
+		if svcErr != nil {
+			return &ErrorInvalidRequestFormat
+		}
+		user.OUID = ou.ID
+	}
+	return nil
 }

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -3179,3 +3179,103 @@ func TestUserService_GetUserList_WithIncludeDisplay(t *testing.T) {
 	require.Equal(t, "Bob", resp.Users[1].Display)
 	require.Equal(t, "sales", resp.Users[1].OUHandle)
 }
+
+// TestResolveUserOUHandle_OUHandleResolved verifies that when only ou_handle is set,
+// it is resolved to ou_id via the OU service.
+func TestResolveUserOUHandle_OUHandleResolved(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("GetOrganizationUnitByPath", mock.Anything, "default").
+		Return(oupkg.OrganizationUnit{ID: "ou-resolved"}, (*serviceerror.ServiceError)(nil)).Once()
+
+	svc := &userService{ouService: ouServiceMock}
+	u := &User{OUHandle: "default"}
+
+	svcErr := svc.ResolveUserOUHandle(context.Background(), u)
+
+	require.Nil(t, svcErr)
+	require.Equal(t, "ou-resolved", u.OUID)
+}
+
+// TestResolveUserOUHandle_OUIDAlreadySet verifies that no resolution happens when
+// ou_id is set and ou_handle is empty.
+func TestResolveUserOUHandle_OUIDAlreadySet(t *testing.T) {
+	svc := &userService{}
+	u := &User{OUID: "ou-direct"}
+
+	svcErr := svc.ResolveUserOUHandle(context.Background(), u)
+
+	require.Nil(t, svcErr)
+	require.Equal(t, "ou-direct", u.OUID)
+}
+
+// TestResolveUserOUHandle_BothProvided verifies that when both ou_id and ou_handle are
+// provided, ou_id is retained and the OU service is never called.
+func TestResolveUserOUHandle_BothProvided(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+
+	svc := &userService{ouService: ouServiceMock}
+	u := &User{ID: "u1", OUID: "ou-direct", OUHandle: "default"}
+
+	svcErr := svc.ResolveUserOUHandle(context.Background(), u)
+
+	require.Nil(t, svcErr)
+	require.Equal(t, "ou-direct", u.OUID)
+	// Cleanup-time AssertExpectations confirms GetOrganizationUnitByPath was never called.
+}
+
+// TestResolveUserOUHandle_OUHandleNotFound verifies that a not-found response from the OU
+// service is surfaced as ErrorInvalidRequestFormat.
+func TestResolveUserOUHandle_OUHandleNotFound(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("GetOrganizationUnitByPath", mock.Anything, "missing").
+		Return(oupkg.OrganizationUnit{}, &oupkg.ErrorOrganizationUnitNotFound).Once()
+
+	svc := &userService{ouService: ouServiceMock}
+	u := &User{OUHandle: "missing"}
+
+	svcErr := svc.ResolveUserOUHandle(context.Background(), u)
+
+	require.NotNil(t, svcErr)
+	require.Equal(t, ErrorInvalidRequestFormat.Code, svcErr.Code)
+}
+
+// TestResolveUserOUHandle_NeitherProvided verifies the call is a no-op when neither
+// ou_id nor ou_handle is provided.
+func TestResolveUserOUHandle_NeitherProvided(t *testing.T) {
+	svc := &userService{}
+	u := &User{}
+
+	svcErr := svc.ResolveUserOUHandle(context.Background(), u)
+
+	require.Nil(t, svcErr)
+	require.Empty(t, u.OUID)
+}
+
+// TestResolveUserOUHandle_NilOUService verifies that a clear error is returned when the OU
+// service is nil and ou_handle is supplied (no nil-pointer panic).
+func TestResolveUserOUHandle_NilOUService(t *testing.T) {
+	svc := &userService{ouService: nil}
+	u := &User{OUHandle: "default"}
+
+	svcErr := svc.ResolveUserOUHandle(context.Background(), u)
+
+	require.NotNil(t, svcErr)
+	require.Equal(t, serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestUserDeclarativeYAML_OUHandleParsed verifies that ou_handle is parsed off the YAML
+// document into the user declarative resource.
+func TestUserDeclarativeYAML_OUHandleParsed(t *testing.T) {
+	yamlData := []byte("" +
+		"id: user-1\n" +
+		"type: person\n" +
+		"ou_handle: default\n" +
+		"attributes:\n" +
+		"  username: alice\n")
+
+	user, _, err := parseToUser(yamlData)
+
+	require.NoError(t, err)
+	require.Equal(t, "default", user.OUHandle)
+	require.Empty(t, user.OUID)
+}

--- a/backend/tests/mocks/resourcemock/ResourceServiceInterface_mock.go
+++ b/backend/tests/mocks/resourcemock/ResourceServiceInterface_mock.go
@@ -1133,6 +1133,65 @@ func (_c *ResourceServiceInterfaceMock_IsResourceServerDeclarative_Call) RunAndR
 	return _c
 }
 
+// ResolveResourceServerOUHandle provides a mock function for the type ResourceServiceInterfaceMock
+func (_mock *ResourceServiceInterfaceMock) ResolveResourceServerOUHandle(ctx context.Context, rs *resource.ResourceServer) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, rs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveResourceServerOUHandle")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *resource.ResourceServer) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, rs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveResourceServerOUHandle'
+type ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call struct {
+	*mock.Call
+}
+
+// ResolveResourceServerOUHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - rs *resource.ResourceServer
+func (_e *ResourceServiceInterfaceMock_Expecter) ResolveResourceServerOUHandle(ctx interface{}, rs interface{}) *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call {
+	return &ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call{Call: _e.mock.On("ResolveResourceServerOUHandle", ctx, rs)}
+}
+
+func (_c *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call) Run(run func(ctx context.Context, rs *resource.ResourceServer)) *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *resource.ResourceServer
+		if args[1] != nil {
+			arg1 = args[1].(*resource.ResourceServer)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call) Return(serviceError *serviceerror.ServiceError) *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call) RunAndReturn(run func(ctx context.Context, rs *resource.ResourceServer) *serviceerror.ServiceError) *ResourceServiceInterfaceMock_ResolveResourceServerOUHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateAction provides a mock function for the type ResourceServiceInterfaceMock
 func (_mock *ResourceServiceInterfaceMock) UpdateAction(ctx context.Context, resourceServerID string, resourceID *string, id string, action resource.Action) (*resource.Action, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, resourceServerID, resourceID, id, action)

--- a/backend/tests/mocks/rolemock/RoleServiceInterface_mock.go
+++ b/backend/tests/mocks/rolemock/RoleServiceInterface_mock.go
@@ -540,6 +540,65 @@ func (_c *RoleServiceInterfaceMock_IsRoleDeclarative_Call) RunAndReturn(run func
 	return _c
 }
 
+// ResolveRoleOUHandle provides a mock function for the type RoleServiceInterfaceMock
+func (_mock *RoleServiceInterfaceMock) ResolveRoleOUHandle(ctx context.Context, role1 *role.RoleWithPermissionsAndAssignments) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, role1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveRoleOUHandle")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *role.RoleWithPermissionsAndAssignments) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, role1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// RoleServiceInterfaceMock_ResolveRoleOUHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveRoleOUHandle'
+type RoleServiceInterfaceMock_ResolveRoleOUHandle_Call struct {
+	*mock.Call
+}
+
+// ResolveRoleOUHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - role1 *role.RoleWithPermissionsAndAssignments
+func (_e *RoleServiceInterfaceMock_Expecter) ResolveRoleOUHandle(ctx interface{}, role1 interface{}) *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call {
+	return &RoleServiceInterfaceMock_ResolveRoleOUHandle_Call{Call: _e.mock.On("ResolveRoleOUHandle", ctx, role1)}
+}
+
+func (_c *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call) Run(run func(ctx context.Context, role1 *role.RoleWithPermissionsAndAssignments)) *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *role.RoleWithPermissionsAndAssignments
+		if args[1] != nil {
+			arg1 = args[1].(*role.RoleWithPermissionsAndAssignments)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call) Return(serviceError *serviceerror.ServiceError) *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call) RunAndReturn(run func(ctx context.Context, role1 *role.RoleWithPermissionsAndAssignments) *serviceerror.ServiceError) *RoleServiceInterfaceMock_ResolveRoleOUHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateRoleWithPermissions provides a mock function for the type RoleServiceInterfaceMock
 func (_mock *RoleServiceInterfaceMock) UpdateRoleWithPermissions(ctx context.Context, id string, role1 role.RoleUpdateDetail) (*role.RoleWithPermissions, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, id, role1)

--- a/backend/tests/mocks/usermock/UserServiceInterface_mock.go
+++ b/backend/tests/mocks/usermock/UserServiceInterface_mock.go
@@ -585,6 +585,65 @@ func (_c *UserServiceInterfaceMock_GetUsersByPath_Call) RunAndReturn(run func(ct
 	return _c
 }
 
+// ResolveUserOUHandle provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) ResolveUserOUHandle(ctx context.Context, user1 *user.User) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, user1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveUserOUHandle")
+	}
+
+	var r0 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *user.User) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, user1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceerror.ServiceError)
+		}
+	}
+	return r0
+}
+
+// UserServiceInterfaceMock_ResolveUserOUHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveUserOUHandle'
+type UserServiceInterfaceMock_ResolveUserOUHandle_Call struct {
+	*mock.Call
+}
+
+// ResolveUserOUHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - user1 *user.User
+func (_e *UserServiceInterfaceMock_Expecter) ResolveUserOUHandle(ctx interface{}, user1 interface{}) *UserServiceInterfaceMock_ResolveUserOUHandle_Call {
+	return &UserServiceInterfaceMock_ResolveUserOUHandle_Call{Call: _e.mock.On("ResolveUserOUHandle", ctx, user1)}
+}
+
+func (_c *UserServiceInterfaceMock_ResolveUserOUHandle_Call) Run(run func(ctx context.Context, user1 *user.User)) *UserServiceInterfaceMock_ResolveUserOUHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *user.User
+		if args[1] != nil {
+			arg1 = args[1].(*user.User)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_ResolveUserOUHandle_Call) Return(serviceError *serviceerror.ServiceError) *UserServiceInterfaceMock_ResolveUserOUHandle_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_ResolveUserOUHandle_Call) RunAndReturn(run func(ctx context.Context, user1 *user.User) *serviceerror.ServiceError) *UserServiceInterfaceMock_ResolveUserOUHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateUser provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) UpdateUser(ctx context.Context, userID string, user1 *user.User) (*user.User, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, userID, user1)


### PR DESCRIPTION
### Purpose

Adds ou_handle as an alternative to ou_id (UUID) for role, user, resource server, and group declarative loaders and importer paths, matching the existing pattern for application and entity type. Keeps YAMLs portable across environments by resolving the handle to an OU UUID at load/import time.

Each affected service exposes a Resolve*OUHandle method that wraps the OU lookup; the declarative loaders invoke it with runtime context (startup, no user ctx), while API/importer paths invoke it with the caller's context so ou:read remains enforced. When both ou_id and ou_handle are provided, ou_id wins and a WARN log fires; the same warning is also retrofitted into application and entity type for consistency.

### Related Issue(s)
- https://github.com/thunder-id/thunderid/issues/2878


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for referencing organization units by handle (ou_handle) across applications, entity types, resources, roles, and users; ou_id still takes precedence when both are supplied.
  * Declarative/import flows and resource classification updated to accept ou_handle alongside ou_id.

* **Tests**
  * Added broad test coverage for handle resolution, precedence, error mappings, context propagation, importer behavior, and YAML parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->