### PR TITLE
Update docs to reflect configurable admin credentials

### DIFF
--- a/docs/content/community/contributing/contributing-code/configure-and-run.mdx
+++ b/docs/content/community/contributing/contributing-code/configure-and-run.mdx
@@ -83,7 +83,7 @@ This command will automatically set up your complete development environment:
 - Starts the backend server
 - Runs the bootstrap script which creates:
   - The `Console` application with the correct redirect URIs
-  - The default admin user (`admin` / `admin`)
+  - The default admin user (credentials default to `admin` / `admin`; configurable via `ADMIN_USERNAME` / `ADMIN_PASSWORD` env vars)
 
 **Services that start:**
 
@@ -134,7 +134,7 @@ $env:API_BASE = "https://localhost:8090"
   </CodeBlock>
 </CodeGroup>
 
-This creates the `Console` application and the default admin user (`admin` / `admin`). You only need to do this once — the data persists in the SQLite databases.
+This creates the `Console` application and the default admin user (credentials default to `admin` / `admin`). You only need to do this once — the data persists in the SQLite databases.
 
 :::warning
 Don't use `./setup.sh` here. That script is designed for the packaged distribution zip and expects a compiled `./thunderid` binary at the project root. From source code, always use the bootstrap script directly as shown above, or use `make run` (Option A) which handles everything for you.
@@ -155,7 +155,7 @@ For development environments, `make run` executes the `backend/cmd/server/bootst
 
 - Default Organization Unit
 - Default User Type (Person)
-- Admin user (`admin` / `admin`)
+- Admin user (credentials default to `admin` / `admin`; configurable via `ADMIN_USERNAME` / `ADMIN_PASSWORD` env vars)
 - System resource server with system actions and permissions
 - Administrator role and role assignment
 - `Console` application

--- a/docs/content/community/contributing/contributing-code/configure-and-run.mdx
+++ b/docs/content/community/contributing/contributing-code/configure-and-run.mdx
@@ -83,7 +83,7 @@ This command will automatically set up your complete development environment:
 - Starts the backend server
 - Runs the bootstrap script which creates:
   - The `Console` application with the correct redirect URIs
-  - The default admin user (credentials default to `admin` / `admin`; configurable via `ADMIN_USERNAME` / `ADMIN_PASSWORD` env vars)
+  - The default admin user (credentials default to `admin` / `admin`; configurable via `ADMIN_USERNAME` / `ADMIN_PASSWORD` environment variables)
 
 **Services that start:**
 
@@ -155,7 +155,7 @@ For development environments, `make run` executes the `backend/cmd/server/bootst
 
 - Default Organization Unit
 - Default User Type (Person)
-- Admin user (credentials default to `admin` / `admin`; configurable via `ADMIN_USERNAME` / `ADMIN_PASSWORD` env vars)
+- Admin user (credentials default to `admin` / `admin`; configurable via `ADMIN_USERNAME` / `ADMIN_PASSWORD` environment variables)
 - System resource server with system actions and permissions
 - Administrator role and role assignment
 - `Console` application

--- a/docs/content/community/contributing/contributing-code/debugging.mdx
+++ b/docs/content/community/contributing/contributing-code/debugging.mdx
@@ -187,7 +187,7 @@ In VS Code, open these files and set breakpoints:
 ### 3. Trigger the Flow
 
 1. Navigate to [https://localhost:5191/console](https://localhost:5191/console)
-2. Log in with admin credentials (`admin` / `admin`)
+2. Log in with the admin credentials configured during setup (default: `admin` / `admin`)
 3. Go to **Users** section
 4. Click **Add User**
 5. Select **User Type: Person**


### PR DESCRIPTION
### Purpose

Update documentation references that instructed users to log in with hardcoded `admin` / `admin` credentials. Now that admin credentials are configurable at setup time (via interactive prompt, CLI flags, or env vars — see #2876), the docs should reflect that the default is `admin` / `admin` but can be changed.

### Changes

| File | Change |
|------|--------|
| `docs/content/guides/getting-started/get-thunderid.mdx` | Note credentials are configured during setup, with `admin` / `admin` as default |
| `docs/content/guides/quick-start/quickstart.mdx` | Same |
| `docs/content/community/contributing/contributing-code/configure-and-run.mdx` | Same, plus mention `ADMIN_USERNAME` / `ADMIN_PASSWORD` env vars where relevant for developer context |
| `docs/content/community/contributing/contributing-code/debugging.mdx` | Same |

### Related Issues
- Relates to #2876

### Related PRs
- #2857 — introduced configurable admin credentials

### Checklist
- [ ] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided.
    - [x] Ran Vale and fixed all errors and warnings
- [ ] Tests provided.
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup documentation to clarify that default admin credentials can be configured using environment variables, rather than being fixed values.
  * Improved debugging guide with clearer instructions for logging in with configured admin credentials during development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->