### PR TITLE
Add label check to skip tests in pr builder.

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -228,7 +228,7 @@ jobs:
   build:
     name: 🛠️ Build Product
     needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
+    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') && !contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -322,7 +322,7 @@ jobs:
   test-frontend:
     name: 🧪 Frontend Tests (shard ${{ matrix.shard }}/4)
     needs: dependency-guard
-    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
+    if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') && !contains(github.event.pull_request.labels.*.name, 'skip-tests') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/pr-label-retrigger.yml
+++ b/.github/workflows/pr-label-retrigger.yml
@@ -1,17 +1,17 @@
-# Re-runs the PR Builder workflow when the `dependencies-approved` label is added.
-# The PR Builder intentionally does not trigger on `labeled` events to avoid
-# skipping all checks when unrelated labels are added.
+# Re-runs the PR Builder workflow when the `dependencies-approved` or `skip-tests`
+# label is added or removed. The PR Builder intentionally does not trigger on
+# `labeled`/`unlabeled` events to avoid re-running for unrelated label changes.
 
-name: 🔄 Re-run PR Builder on Dependency Approval
+name: 🔄 Re-run PR Builder on Label Change
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, unlabeled]
 
 jobs:
   retrigger:
     name: 🔄 Re-trigger PR Builder
-    if: github.event.label.name == 'dependencies-approved'
+    if: contains(fromJSON('["dependencies-approved", "skip-tests"]'), github.event.label.name)
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
- Add a skip-tests label to allow bypassing unit, integration, and E2E tests on PRs that only contain documentation changes, avoiding redundant CI runs.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
 - In pr-builder.yml, added a !contains(github.event.pull_request.labels.*.name, 'skip-tests') guard to the build and test-frontend job conditions. Skipping build naturally cascades to skip test-integration and test-e2e since they gate on needs.build.result == 'success'. Frontend coverage upload is also skipped as it gates on test-frontend succeeding.
  - Renamed dependency-approved-retrigger.yml → pr-label-retrigger.yml and extended it to also re-trigger the PR Builder when the skip-tests label is added or removed. This ensures the workflow re-evaluates immediately without needing a new push. The unlabeled event type is also added so removing the label restores normal test execution.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now supports skipping frontend and build jobs when a pull request has the "skip-tests" label, enabling selective test execution.
  * Pipeline retriggers are now emitted when the "dependencies-approved" or "skip-tests" label is added or removed, ensuring label changes re-evaluate the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->