### PR TITLE
Fix UUID generation logic when importing resources

### DIFF
--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -47,6 +47,7 @@ type idpService struct {
 	idpStore      idpStoreInterface
 	transactioner transaction.Transactioner
 	logger        *log.Logger
+	uuidGenerator func() (string, error)
 }
 
 // newIDPService creates a new instance of IdPService.
@@ -55,6 +56,7 @@ func newIDPService(idpStore idpStoreInterface, transactioner transaction.Transac
 		idpStore:      idpStore,
 		transactioner: transactioner,
 		logger:        log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService")),
+		uuidGenerator: utils.GenerateUUIDv7,
 	}
 }
 
@@ -70,14 +72,19 @@ func (is *idpService) CreateIdentityProvider(
 		return nil, svcErr
 	}
 
-	id, err := utils.GenerateUUIDv7()
-	if err != nil {
-		logger.Error("failed to generate ID for identity provider", log.Error(err))
-		return nil, &serviceerror.InternalServerError
+	if idp.ID == "" {
+		id, genErr := is.uuidGenerator()
+		if genErr != nil {
+			logger.Error("failed to generate ID for identity provider", log.Error(genErr))
+			return nil, &serviceerror.InternalServerError
+		}
+		idp.ID = id
 	}
-	idp.ID = id
 
-	var svcErr *serviceerror.ServiceError
+	var (
+		err    error
+		svcErr *serviceerror.ServiceError
+	)
 	err = is.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		// Check if an identity provider with the same name already exists
 		existingIDP, err := is.idpStore.GetIdentityProviderByName(txCtx, idp.Name)

--- a/backend/internal/idp/service_test.go
+++ b/backend/internal/idp/service_test.go
@@ -31,6 +31,7 @@ import (
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/utils"
 )
 
 type mockTransactioner struct{}
@@ -68,6 +69,7 @@ func (s *IDPServiceTestSuite) SetupTest() {
 		idpStore:      s.mockStore,
 		transactioner: &mockTransactioner{},
 		logger:        log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService")),
+		uuidGenerator: utils.GenerateUUIDv7,
 	}
 }
 
@@ -224,6 +226,49 @@ func (s *IDPServiceTestSuite) TestCreateIdentityProvider_StoreError() {
 	s.NotNil(err)
 	s.Equal(serviceerror.InternalServerError.Code, err.Code)
 	s.mockStore.AssertExpectations(s.T())
+}
+
+// TestCreateIdentityProvider_WithPresetID tests that a preset ID is preserved and not overwritten.
+func (s *IDPServiceTestSuite) TestCreateIdentityProvider_WithPresetID() {
+	presetID := "preset-idp-id-1234"
+	idp := &IDPDTO{
+		ID:          presetID,
+		Name:        "Test IDP",
+		Description: "Test Description",
+		Type:        IDPTypeOIDC,
+		Properties:  createOIDCProperties(),
+	}
+
+	s.mockStore.On("GetIdentityProviderByName", mock.Anything, "Test IDP").Return((*IDPDTO)(nil), ErrIDPNotFound)
+	s.mockStore.On("CreateIdentityProvider", mock.Anything, mock.MatchedBy(func(dto IDPDTO) bool {
+		return dto.ID == presetID
+	})).Return(nil)
+
+	result, err := s.idpService.CreateIdentityProvider(context.Background(), idp)
+
+	s.Nil(err)
+	s.NotNil(result)
+	s.Equal(presetID, result.ID)
+	s.mockStore.AssertExpectations(s.T())
+}
+
+// TestCreateIdentityProvider_UUIDGenerationError tests that a UUID generation failure returns InternalServerError.
+func (s *IDPServiceTestSuite) TestCreateIdentityProvider_UUIDGenerationError() {
+	idp := &IDPDTO{
+		Name:       "Test IDP",
+		Type:       IDPTypeOIDC,
+		Properties: createOIDCProperties(),
+	}
+
+	s.idpService.uuidGenerator = func() (string, error) {
+		return "", errors.New("entropy source failed")
+	}
+
+	result, err := s.idpService.CreateIdentityProvider(context.Background(), idp)
+
+	s.Nil(result)
+	s.NotNil(err)
+	s.Equal(serviceerror.InternalServerError.Code, err.Code)
 }
 
 // TestGetIdentityProviderList_Success tests successful list retrieval

--- a/backend/internal/notification/mgt_service.go
+++ b/backend/internal/notification/mgt_service.go
@@ -47,6 +47,7 @@ type NotificationSenderMgtSvcInterface interface {
 type notificationSenderMgtService struct {
 	notificationStore notificationStoreInterface
 	transactioner     transaction.Transactioner
+	uuidGenerator     func() (string, error)
 }
 
 // newNotificationSenderMgtService returns a new instance of NotificationSenderMgtSvcInterface.
@@ -55,6 +56,7 @@ func newNotificationSenderMgtService(
 	return &notificationSenderMgtService{
 		notificationStore: store,
 		transactioner:     tx,
+		uuidGenerator:     sysutils.GenerateUUIDv7,
 	}
 }
 
@@ -73,12 +75,14 @@ func (s *notificationSenderMgtService) CreateSender(
 		return nil, err
 	}
 
-	id, err := sysutils.GenerateUUIDv7()
-	if err != nil {
-		logger.Error("Failed to generate UUID", log.Error(err))
-		return nil, &serviceerror.InternalServerError
+	if sender.ID == "" {
+		id, err := s.uuidGenerator()
+		if err != nil {
+			logger.Error("Failed to generate UUID", log.Error(err))
+			return nil, &serviceerror.InternalServerError
+		}
+		sender.ID = id
 	}
-	sender.ID = id
 
 	var svcErr *serviceerror.ServiceError
 	transactErr := s.transactioner.Transact(ctx, func(txCtx context.Context) error {

--- a/backend/internal/notification/mgt_service_test.go
+++ b/backend/internal/notification/mgt_service_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
 
 const (
@@ -73,6 +74,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) SetupTest() {
 	suite.service = &notificationSenderMgtService{
 		notificationStore: suite.mockStore,
 		transactioner:     &fakeTransactioner{},
+		uuidGenerator:     sysutils.GenerateUUIDv7,
 	}
 }
 
@@ -89,6 +91,39 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender() {
 	suite.NotNil(result)
 	suite.Equal(sender.Name, result.Name)
 	suite.NotEmpty(result.ID)
+}
+
+func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_WithPresetID() {
+	sender := suite.getValidTwilioSender()
+	presetID := "preset-sender-id-1234"
+	sender.ID = presetID
+
+	suite.mockStore.EXPECT().getSenderByName(mock.Anything, sender.Name).Return(nil, nil).Once()
+	suite.mockStore.EXPECT().createSender(mock.Anything, mock.MatchedBy(func(s common.NotificationSenderDTO) bool {
+		return s.ID == presetID
+	})).Return(nil).Once()
+
+	result, err := suite.service.CreateSender(context.Background(), sender)
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Equal(presetID, result.ID)
+}
+
+func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_UUIDGenerationError() {
+	sender := suite.getValidTwilioSender()
+
+	svc := &notificationSenderMgtService{
+		notificationStore: suite.mockStore,
+		transactioner:     &fakeTransactioner{},
+		uuidGenerator: func() (string, error) {
+			return "", errors.New("entropy source failed")
+		},
+	}
+
+	result, err := svc.CreateSender(context.Background(), sender)
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
 }
 
 func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_WithFailures() {
@@ -157,6 +192,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestCreateSender_WithFailure
 			svc := &notificationSenderMgtService{
 				notificationStore: mockStore,
 				transactioner:     &fakeTransactioner{},
+				uuidGenerator:     sysutils.GenerateUUIDv7,
 			}
 
 			sender := suite.getValidTwilioSender()
@@ -273,6 +309,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSenderByName() {
 			svc := &notificationSenderMgtService{
 				notificationStore: mockStore,
 				transactioner:     &fakeTransactioner{},
+				uuidGenerator:     sysutils.GenerateUUIDv7,
 			}
 
 			if tc.setup != nil {
@@ -332,6 +369,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestGetSenderByName_WithFail
 			svc := &notificationSenderMgtService{
 				notificationStore: mockStore,
 				transactioner:     &fakeTransactioner{},
+				uuidGenerator:     sysutils.GenerateUUIDv7,
 			}
 
 			if tc.setup != nil {
@@ -394,6 +432,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender() {
 			svc := &notificationSenderMgtService{
 				notificationStore: mockStore,
 				transactioner:     &fakeTransactioner{},
+				uuidGenerator:     sysutils.GenerateUUIDv7,
 			}
 
 			sender := suite.getValidTwilioSender()
@@ -525,6 +564,7 @@ func (suite *NotificationSenderMgtServiceTestSuite) TestUpdateSender_WithFailure
 			svc := &notificationSenderMgtService{
 				notificationStore: mockStore,
 				transactioner:     &fakeTransactioner{},
+				uuidGenerator:     sysutils.GenerateUUIDv7,
 			}
 
 			sender := suite.getValidTwilioSender()

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -94,7 +94,7 @@ func (uh *userHandler) HandleUserPostRequest(w http.ResponseWriter, r *http.Requ
 	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
-	createRequest, err := sysutils.DecodeJSONBody[User](r)
+	createRequest, err := sysutils.DecodeJSONBody[CreateUserRequest](r)
 	if err != nil {
 		errResp := apierror.ErrorResponse{
 			Code:        ErrorInvalidRequestFormat.Code,
@@ -105,8 +105,14 @@ func (uh *userHandler) HandleUserPostRequest(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	user := &User{
+		OUID:       createRequest.OUID,
+		Type:       createRequest.Type,
+		Attributes: createRequest.Attributes,
+	}
+
 	// Create the user using the user service.
-	createdUser, svcErr := uh.userService.CreateUser(ctx, createRequest)
+	createdUser, svcErr := uh.userService.CreateUser(ctx, user)
 	if svcErr != nil {
 		handleError(w, svcErr)
 		return

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -67,6 +67,7 @@ type userService struct {
 	entityService     entity.EntityServiceInterface
 	ouService         oupkg.OrganizationUnitServiceInterface
 	entityTypeService entitytype.EntityTypeServiceInterface
+	uuidGenerator     func() (string, error)
 }
 
 // newUserService creates a new instance of userService with injected dependencies.
@@ -81,6 +82,7 @@ func newUserService(
 		entityService:     entityService,
 		ouService:         ouService,
 		entityTypeService: entityTypeService,
+		uuidGenerator:     utils.GenerateUUIDv7,
 	}
 }
 
@@ -315,10 +317,12 @@ func (us *userService) CreateUser(ctx context.Context, user *User) (*User, *serv
 	// Schema validation and uniqueness checks are handled by entity service in CreateEntity.
 
 	var err error
-	user.ID, err = utils.GenerateUUIDv7()
-	if err != nil {
-		logger.Error("Failed to generate UUID", log.Error(err))
-		return nil, &serviceerror.InternalServerError
+	if user.ID == "" {
+		user.ID, err = us.uuidGenerator()
+		if err != nil {
+			logger.Error("Failed to generate UUID", log.Error(err))
+			return nil, &serviceerror.InternalServerError
+		}
 	}
 
 	e := userToEntity(user)

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -427,6 +427,7 @@ func TestUserService_CreateUser_CallsCreateEntity(t *testing.T) {
 		ouService:         ouServiceMock,
 		entityTypeService: entityTypeMock,
 		authzService:      newAllowAllAuthz(t),
+		uuidGenerator:     utils.GenerateUUIDv7,
 	}
 
 	user := &User{
@@ -441,6 +442,32 @@ func TestUserService_CreateUser_CallsCreateEntity(t *testing.T) {
 	require.Equal(t, testOrgID, created.OUID)
 	require.NotEmpty(t, created.ID)
 	storeMock.AssertNumberOfCalls(t, "CreateEntity", 1)
+}
+
+func TestUserService_CreateUser_UUIDGenerationError(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
+		Return(true, (*serviceerror.ServiceError)(nil)).Once()
+
+	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+		Return(&entitytype.EntityType{OUID: testOrgID}, (*serviceerror.ServiceError)(nil)).Once()
+
+	service := &userService{
+		ouService:         ouServiceMock,
+		entityTypeService: entityTypeMock,
+		authzService:      newAllowAllAuthz(t),
+		uuidGenerator: func() (string, error) {
+			return "", errors.New("entropy source failed")
+		},
+	}
+
+	user := &User{Type: testUserType, OUID: testOrgID}
+
+	created, svcErr := service.CreateUser(context.Background(), user)
+	require.Nil(t, created)
+	require.NotNil(t, svcErr)
+	require.Equal(t, serviceerror.InternalServerError.Code, svcErr.Code)
 }
 
 func TestUserService_CreateUser_PropagatesStoreError(t *testing.T) {
@@ -468,6 +495,7 @@ func TestUserService_CreateUser_PropagatesStoreError(t *testing.T) {
 		ouService:         ouServiceMock,
 		entityTypeService: entityTypeMock,
 		authzService:      newAllowAllAuthz(t),
+		uuidGenerator:     utils.GenerateUUIDv7,
 	}
 
 	user := &User{
@@ -1857,6 +1885,7 @@ func TestUserService_CreateUser_EntityErrors(t *testing.T) {
 				ouService:         ouServiceMock,
 				entityTypeService: entityTypeMock,
 				authzService:      newAllowAllAuthz(t),
+				uuidGenerator:     utils.GenerateUUIDv7,
 			}
 
 			user := &User{


### PR DESCRIPTION
### Purpose
Services for IDP, notification sender, and user were unconditionally overwriting the `ID` field on create, even when the caller supplied a pre-assigned ID. This broke declarative/YAML-driven resource import since preset IDs were silently discarded.

### Approach
Added an `if id == ""` guard around UUID generation in the three affected services so that a caller-supplied ID is preserved and generation only happens when no ID is provided. This aligns with the existing pattern in `role`, `ou`, `application`, `entitytype`, and `group` services.

Also updated the user create handler to decode `CreateUserRequest` (no `id` field) and construct the `User` object in the handler before passing to the service, keeping the separation of HTTP request shape from the service model.

### Related Issues
- Fixes #2889

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can provide a custom ID when creating identity providers, notification senders, and users; if omitted, the system generates one automatically.
  * User creation now accepts a dedicated create-request payload to construct new users.

* **Bug Fixes**
  * IDs are no longer unconditionally overwritten during creation; provided IDs are preserved.

* **Tests**
  * Added tests verifying preset IDs are preserved and covering UUID generation failure paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->