### PR TITLE
Add release step to publish docker compose

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -489,6 +489,26 @@ jobs:
           echo "📦 Image available at: ${IMAGE_NAME}:${DOCKER_VERSION}"
           echo "📦 Image available at: ${IMAGE_NAME}:latest"
 
+      - name: 📦 Publish Docker Compose (Quick Start) to GHCR
+        run: |
+          OWNER_NAME=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          DOCKER_VERSION="${{ needs.build.outputs.version }}"
+          if [[ $DOCKER_VERSION == v* ]]; then
+            DOCKER_VERSION="${DOCKER_VERSION#v}"
+          fi
+
+          COMPOSE_IMAGE="ghcr.io/${OWNER_NAME}/${PRODUCT_NAME_LOWER}-quick-start"
+
+          docker compose -f install/quick-start/docker-compose.yml publish \
+            --resolve-image-digests -y "${COMPOSE_IMAGE}:${DOCKER_VERSION}"
+
+          docker compose -f install/quick-start/docker-compose.yml publish \
+            --resolve-image-digests -y "${COMPOSE_IMAGE}:latest"
+
+          echo "✅ Docker Compose published successfully!"
+          echo "📦 Available at: ${COMPOSE_IMAGE}:${DOCKER_VERSION}"
+          echo "📦 Available at: ${COMPOSE_IMAGE}:latest"
+
       - name: 🏷️ Update Helm Values Image Tag
         run: |
           # Get version without 'v' prefix


### PR DESCRIPTION
### Purpose

This pull request adds a new step to the release workflow to automate publishing the Docker Compose "Quick Start" image to GitHub Container Registry (GHCR) after building the main Docker image. This ensures that users can easily access a pre-configured Docker Compose setup for quick deployments.

### Approach

**Docker Compose publishing automation:**

* Added a new workflow step in `.github/workflows/release-builder.yml` to publish the `install/quick-start/docker-compose.yml` setup as a Docker Compose image to GHCR, tagged with both the version and `latest` tags.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to publish the quick-start Docker Compose image to GHCR with version-specific and latest tags for streamlined distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->