### PR TITLE
Link the cookie policy

### DIFF
--- a/docs/src/pages/privacy-policy.mdx
+++ b/docs/src/pages/privacy-policy.mdx
@@ -17,7 +17,7 @@ You do not share any information to use when you visit the Sites.
 
 **2) Information collected automatically from your devices**
 
-We also collect certain standard information that Your browser sends to every website you visit, such as your IP address, browser type and language, access times, and referring website addresses. Our website may also place certain cookies to help you access our sites and to track and analyze Your actions on our website such as navigation, number of visits, downloads, and search items to gain a better understanding of our visitors and their movements through the site. Please see our Cookie Policy (available via the cookie settings on this site) on how we use and store cookies.
+We also collect certain standard information that Your browser sends to every website you visit, such as your IP address, browser type and language, access times, and referring website addresses. Our website may also place certain cookies to help you access our sites and to track and analyze Your actions on our website such as navigation, number of visits, downloads, and search items to gain a better understanding of our visitors and their movements through the site. Please see our [Cookie Policy](/cookie-policy) (available via the cookie settings on this site) on how we use and store cookies.
 
 **3) Information received from third parties**
 


### PR DESCRIPTION
### Purpose
$subject, adding a hyperlink to the cookie policy



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Converted the cookie policy reference in the privacy policy into a clickable link for improved navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->