### PR TITLE
Update download link in Get ThunderID page

### DIFF
--- a/docs/content/guides/getting-started/get-thunderid.mdx
+++ b/docs/content/guides/getting-started/get-thunderid.mdx
@@ -27,11 +27,7 @@ Get the latest release of <ProductName /> and run it locally on your machine.
 
 ## Download the Distribution
 
-Download `{{productSlug}}-<version>-<os>-<arch>.zip` from the <RepoLink path="/releases/latest">latest release</RepoLink> for your operating system and architecture.
-
-:::info Example
-If you're using a MacOS machine with Apple Silicon (ARM64) processor, download `{{productSlug}}-<version>-macos-arm64.zip`
-:::
+Download the latest release from the <a href="/docs/next/releases/" target="_blank">releases page</a>.
 
 ## Extract the Archive
 


### PR DESCRIPTION
### Purpose

This pull request updates the "Get the latest release" instructions in the getting started guide to simplify the download process and direct users to the correct documentation page.

Documentation update:

* The instructions for downloading the release archive have been updated to link directly to the `/docs/next/releases/` page, and the previous example and filename details have been removed for clarity.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the getting started guide's download instructions by providing a direct link to the releases page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->