### PR TITLE
Remove unnecessary text in link

### DIFF
--- a/docs/content/guides/getting-started/register-an-application.mdx
+++ b/docs/content/guides/getting-started/register-an-application.mdx
@@ -18,7 +18,7 @@ By the end of this guide you will have:
 
 ## Prerequisites
 
-- ThunderID is running. If not, [get ThunderID first](../get-thunderid).
+- ThunderID is running. If not, [get ThunderID](../get-thunderid) first.
 - You can reach the ThunderID Console at [https://localhost:8090/console](https://localhost:8090/console).
 
 <Stepper>


### PR DESCRIPTION
### Purpose

This pull request makes a minor update to the prerequisites section of the "Register an Application" guide. The term `get ThunderID first` was linked to the get ThuderID page. Changed it such that only the `get ThunderID` term is linked and `first` is unlinked. 

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Register an Application" guide with improved hyperlink formatting and clarity in the prerequisites section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->