### PR TITLE
Add profile section for vanilla sample

### DIFF
--- a/samples/apps/react-vanilla-sample/README.md
+++ b/samples/apps/react-vanilla-sample/README.md
@@ -1,6 +1,6 @@
 # React Vanilla Sample Application
 
-This sample React application demonstrates integrating authentication and registration into your application using the app-native flow orchestration API.
+This sample React application demonstrates integrating authentication, registration, and basic self-service profile management into your application using the app-native flow orchestration API.
 
 ## Supported Authentication Methods
 

--- a/samples/apps/react-vanilla-sample/src/App.tsx
+++ b/samples/apps/react-vanilla-sample/src/App.tsx
@@ -16,10 +16,11 @@
  * under the License.
  */
 
-import { Route, BrowserRouter as Router, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, BrowserRouter as Router, Routes, useLocation } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import InvitePage from './pages/InvitePage';
 import LoginPage from './pages/LoginPage';
+import ProfilePage from './pages/ProfilePage';
 import AuthProvider from './contexts/AuthProvider';
 import useAuth from './hooks/useAuth';
 import './App.css';
@@ -31,6 +32,7 @@ const App = () => {
   return (
     <Routes>
       <Route path="/" element={token ? <HomePage /> : <LoginPage />} key={location.key} />
+      <Route path="/profile" element={token ? <ProfilePage /> : <Navigate to="/" replace />} />
       <Route path="/invite" element={<InvitePage />} />
     </Routes>
   );

--- a/samples/apps/react-vanilla-sample/src/components/Layout.tsx
+++ b/samples/apps/react-vanilla-sample/src/components/Layout.tsx
@@ -16,9 +16,21 @@
  * under the License.
  */
 
+import Avatar from '@mui/material/Avatar';
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Divider from '@mui/material/Divider';
 import Grid from "@mui/material/Grid";
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Typography from '@mui/material/Typography';
+import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
+import PersonOutlineRoundedIcon from '@mui/icons-material/PersonOutlineRounded';
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ThemeToggle from "../theme/ThemeToggle";
 import useAuth from "../hooks/useAuth";
 
@@ -26,7 +38,44 @@ import useAuth from "../hooks/useAuth";
  * PageLayout component serves as a wrapper for the main content of the application.
  */
 const PageLayout = ({ children }: { children: React.ReactNode }) => {
-    const { token, clearToken } = useAuth();
+    const { token, clearToken, userProfile } = useAuth();
+    const navigate = useNavigate();
+    const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
+    const isMenuOpen = Boolean(menuAnchorEl);
+
+    const userLabel = useMemo(() => {
+        const username = userProfile?.attributes.username;
+        const display = userProfile?.display;
+        const email = userProfile?.attributes.email;
+
+        if (typeof username === 'string' && username.trim()) {
+            return username;
+        }
+
+        if (typeof display === 'string' && display.trim()) {
+            return display;
+        }
+
+        if (typeof email === 'string' && email.trim()) {
+            return email;
+        }
+
+        return 'Profile';
+    }, [userProfile]);
+
+    const avatarUrl = useMemo(() => {
+        const picture = userProfile?.attributes.picture;
+        return typeof picture === 'string' && picture.trim() ? picture : '';
+    }, [userProfile]);
+
+    const avatarFallback = useMemo(() => {
+        const trimmed = userLabel.trim();
+        if (!trimmed) {
+            return '';
+        }
+
+        return trimmed.slice(0, 1).toUpperCase();
+    }, [userLabel]);
     
     const handleLogout = () => {
         sessionStorage.removeItem("isSignupMode");
@@ -34,21 +83,139 @@ const PageLayout = ({ children }: { children: React.ReactNode }) => {
         sessionStorage.removeItem("executionId");
         sessionStorage.removeItem("challengeToken");
         clearToken();
-    }
+        setMenuAnchorEl(null);
+        navigate('/');
+    };
+
+    const handleOpenMenu = (event: React.MouseEvent<HTMLElement>) => {
+        setMenuAnchorEl(event.currentTarget);
+    };
+
+    const handleCloseMenu = () => {
+        setMenuAnchorEl(null);
+    };
+
+    const handleProfileClick = () => {
+        navigate('/profile');
+        setMenuAnchorEl(null);
+    };
 
     return (
         <Box sx={{ height: "100vh", display: "flex", flexDirection: "column" }}>
-            <Box sx={{ pt: 4, pr: 4, pl: 4, textAlign: "right", flex: 0 }}>
+            <Box
+                sx={{
+                    pt: 4,
+                    pr: 4,
+                    pl: 4,
+                    flex: 0,
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    alignItems: 'center',
+                    gap: 2,
+                }}
+            >
                 <ThemeToggle />
                 { token &&
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={() => handleLogout()}
-                        sx={{ ml: 2 }}
-                    >
-                        Logout
-                    </Button>
+                    <>
+                        <Button
+                            variant="text"
+                            endIcon={<KeyboardArrowDownIcon />}
+                            onClick={handleOpenMenu}
+                            sx={{
+                                px: 1,
+                                py: 0.75,
+                                minWidth: 180,
+                                borderRadius: 999,
+                                textTransform: 'none',
+                                color: 'text.primary',
+                                backgroundColor: 'background.paper',
+                                border: '1px solid',
+                                borderColor: 'divider',
+                                boxShadow: '0 10px 30px rgba(15, 23, 42, 0.08)',
+                                '&:hover': {
+                                    backgroundColor: 'action.hover',
+                                },
+                            }}
+                        >
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+                                <Avatar
+                                    src={avatarUrl || undefined}
+                                    sx={{
+                                        width: 34,
+                                        height: 34,
+                                        bgcolor: 'action.selected',
+                                        color: 'text.primary',
+                                        fontSize: 16,
+                                        boxShadow: 'none',
+                                        border: '1px solid',
+                                        borderColor: 'divider',
+                                    }}
+                                >
+                                    {avatarUrl ? null : avatarFallback || <AccountCircleOutlinedIcon fontSize="small" />}
+                                </Avatar>
+                                <Box sx={{ textAlign: 'left', lineHeight: 1.1 }}>
+                                    <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                                        {userLabel}
+                                    </Typography>
+                                </Box>
+                            </Box>
+                        </Button>
+                        <Menu
+                            anchorEl={menuAnchorEl}
+                            open={isMenuOpen}
+                            onClose={handleCloseMenu}
+                            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                            slotProps={{
+                                paper: {
+                                    sx: {
+                                        mt: 1,
+                                        width: menuAnchorEl ? Math.max(menuAnchorEl.clientWidth, 220) : 220,
+                                        borderRadius: 3,
+                                        border: '1px solid',
+                                        borderColor: 'divider',
+                                        boxShadow: '0 20px 45px rgba(15, 23, 42, 0.12)',
+                                        overflow: 'hidden',
+                                    },
+                                },
+                                list: {
+                                    sx: {
+                                        p: 0,
+                                    },
+                                },
+                            }}
+                        >
+                            <Box sx={{ px: 2, py: 1.5, backgroundColor: 'action.hover' }}>
+                                <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                                    {userLabel}
+                                </Typography>
+                                <Typography variant="caption" color="text.secondary">
+                                    Account options
+                                </Typography>
+                            </Box>
+                            <Divider />
+                            <MenuItem onClick={handleProfileClick} sx={{ py: 1.5 }}>
+                                <ListItemIcon>
+                                    <PersonOutlineRoundedIcon fontSize="small" />
+                                </ListItemIcon>
+                                <Box>
+                                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                        Profile
+                                    </Typography>
+                                </Box>
+                            </MenuItem>
+                            <MenuItem onClick={handleLogout} sx={{ py: 1.5 }}>
+                                <ListItemIcon>
+                                    <LogoutRoundedIcon fontSize="small" />
+                                </ListItemIcon>
+                                <Box>
+                                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                        Logout
+                                    </Typography>
+                                </Box>
+                            </MenuItem>
+                        </Menu>
+                    </>
                 }
             </Box>
             <Box sx={{ flex: 1, display: "flex", alignItems: "center" }}>

--- a/samples/apps/react-vanilla-sample/src/contexts/AuthContext.ts
+++ b/samples/apps/react-vanilla-sample/src/contexts/AuthContext.ts
@@ -17,6 +17,7 @@
  */
 
 import React, { createContext } from 'react';
+import type { UserProfile } from '../services/userProfileService';
 
 /**
  * AuthContext provides authentication state management for the application.
@@ -27,6 +28,8 @@ type AuthContextType = {
   token: string | null;
   setToken: React.Dispatch<React.SetStateAction<string | null>>;
   clearToken: () => void;
+  userProfile: UserProfile | null;
+  refreshUserProfile: () => Promise<UserProfile | null>;
 };
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/samples/apps/react-vanilla-sample/src/contexts/AuthProvider.tsx
+++ b/samples/apps/react-vanilla-sample/src/contexts/AuthProvider.tsx
@@ -16,9 +16,10 @@
  * under the License.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import type { ReactNode } from 'react';
 import AuthContext from './AuthContext';
+import { getCurrentUserProfile, type UserProfile } from '../services/userProfileService';
 
 /**
  * AuthProvider component to manage authentication state.
@@ -28,6 +29,9 @@ import AuthContext from './AuthContext';
  */
 const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [token, setToken] = useState<string | null>(() => sessionStorage.getItem('authToken'));
+  const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
+  const tokenRef = useRef(token);
+  tokenRef.current = token;
 
   useEffect(() => {
     if (token === null) {
@@ -37,10 +41,39 @@ const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [token]);
 
-  const clearToken = useCallback(() => setToken(null), []);
+  const refreshUserProfile = useCallback(async () => {
+    if (!token) {
+      setUserProfile(null);
+      return null;
+    }
+
+    const tokenSnapshot = token;
+    const profile = await getCurrentUserProfile(tokenSnapshot);
+
+    if (tokenRef.current === tokenSnapshot) {
+      setUserProfile(profile);
+    }
+    return profile;
+  }, [token]);
+
+  useEffect(() => {
+    if (!token) {
+      setUserProfile(null);
+      return;
+    }
+
+    void refreshUserProfile().catch(() => {
+      setUserProfile(null);
+    });
+  }, [refreshUserProfile, token]);
+
+  const clearToken = useCallback(() => {
+    setToken(null);
+    setUserProfile(null);
+  }, []);
 
   return (
-    <AuthContext.Provider value={{ token, setToken, clearToken }}>
+    <AuthContext.Provider value={{ token, setToken, clearToken, userProfile, refreshUserProfile }}>
       {children}
     </AuthContext.Provider>
   );

--- a/samples/apps/react-vanilla-sample/src/pages/HomePage.tsx
+++ b/samples/apps/react-vanilla-sample/src/pages/HomePage.tsx
@@ -54,14 +54,14 @@ const HomePage = () => {
             <Box className="home-container">
                 {token ? (
                     <Box className="token-container">
-                        <Typography variant='h5' sx={{ mb: 3 }}>Access Token:</Typography>
+                        <Typography variant='h5' sx={{ mb: 3 }}>Auth Assertion:</Typography>
                         <pre style={{ margin: 0 }}>
                             <code>{token}</code>
                         </pre>
                         <Divider sx={{ my: 4 }} />
                         {decodedToken && (
                             <Box>
-                                <Typography variant='h5' sx={{ mb: 3 }}>Decoded Token:</Typography>
+                                <Typography variant='h5' sx={{ mb: 3 }}>Decoded Assertion:</Typography>
                                 <Box className="decoded-token-container">
                                     <Box className="decoded-token-section">
                                         <Typography variant='h6' sx={{ mt: 3, mb: 1 }}>Header:</Typography>
@@ -84,7 +84,7 @@ const HomePage = () => {
                         )}
                     </Box>
                 ) : (
-                    <Typography>No token available. Please log in.</Typography>
+                    <Typography>No auth assertion available. Please log in.</Typography>
                 )}
             </Box>
         </Layout>

--- a/samples/apps/react-vanilla-sample/src/pages/InvitePage.tsx
+++ b/samples/apps/react-vanilla-sample/src/pages/InvitePage.tsx
@@ -63,6 +63,7 @@ interface FlowResponse {
     data?: {
         inputs?: AuthInput[];
         actions?: ActionPrompt[];
+        redirectURL?: string;
     };
 }
 
@@ -126,6 +127,20 @@ const InvitePage = () => {
             setOtpDigits(Array(6).fill(''));
             setStep('form');
             setLoading(false);
+            return;
+        }
+
+        if (data.type === 'REDIRECTION') {
+            const redirectURL = data.data?.redirectURL;
+
+            if (!redirectURL) {
+                setStep('error');
+                setErrorMessage('Invalid invite flow response. Please request a new invite link.');
+                setLoading(false);
+                return;
+            }
+
+            window.location.href = redirectURL;
         }
     };
 

--- a/samples/apps/react-vanilla-sample/src/pages/LoginPage.tsx
+++ b/samples/apps/react-vanilla-sample/src/pages/LoginPage.tsx
@@ -1468,7 +1468,7 @@ const LoginPage = () => {
                                 } else if (isMobile) {
                                     label = getSocialLoginText(action.ref || '');
                                 } else if (isPasskey) {
-                                    label = "Sign in with Passkey";
+                                    label = `${isSignupMode ? 'Sign up' : 'Continue'} with Passkey`;
                                 } else if (action.label) {
                                     label = action.label;
                                 }

--- a/samples/apps/react-vanilla-sample/src/pages/ProfilePage.tsx
+++ b/samples/apps/react-vanilla-sample/src/pages/ProfilePage.tsx
@@ -1,0 +1,602 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Alert from '@mui/material/Alert';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import InputLabel from '@mui/material/InputLabel';
+import Link from '@mui/material/Link';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
+import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Layout from '../components/Layout';
+import useAuth from '../hooks/useAuth';
+import {
+    updateCurrentUserPassword,
+    updateCurrentUserProfile,
+} from '../services/userProfileService';
+
+const defaultProfileFields = [
+    'username',
+    'name',
+    'given_name',
+    'family_name',
+    'email',
+    'phone',
+    'phone_number',
+    'picture',
+] as const;
+
+const fieldLabels: Record<string, string> = {
+    username: 'Username',
+    name: 'Display Name',
+    given_name: 'First Name',
+    family_name: 'Last Name',
+    email: 'Email',
+    phone: 'Phone',
+    phone_number: 'Phone Number',
+    picture: 'Picture URL',
+};
+
+const toFormValue = (value: unknown): string => {
+    if (value === null || value === undefined) {
+        return '';
+    }
+
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+
+    return '';
+};
+
+const isEditableScalar = (value: unknown) => (
+    value === null ||
+    value === undefined ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+);
+
+const buildFormState = (attributes: Record<string, unknown>) => {
+    const nextState: Record<string, string> = {};
+
+    defaultProfileFields.forEach((key) => {
+        nextState[key] = toFormValue(attributes[key]);
+    });
+
+    Object.entries(attributes).forEach(([key, value]) => {
+        if (isEditableScalar(value) && !(key in nextState)) {
+            nextState[key] = toFormValue(value);
+        }
+    });
+
+    return nextState;
+};
+
+const ProfilePage = () => {
+    const { token, userProfile, refreshUserProfile } = useAuth();
+    const navigate = useNavigate();
+
+    const [formState, setFormState] = useState<Record<string, string>>({});
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [savingPassword, setSavingPassword] = useState(false);
+    const [showPassword, setShowPassword] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
+    const [error, setError] = useState('');
+    const [successMessage, setSuccessMessage] = useState('');
+    const [passwordState, setPasswordState] = useState({
+        newPassword: '',
+        confirmPassword: '',
+    });
+
+    useEffect(() => {
+        if (!token) {
+            setLoading(false);
+            return;
+        }
+
+        setLoading(true);
+
+        const loadProfile = async () => {
+            try {
+                const profile = userProfile ?? await refreshUserProfile();
+                if (profile) {
+                    setFormState(buildFormState(profile.attributes));
+                } else {
+                    setError('Failed to load user profile.');
+                }
+            } catch (loadError) {
+                setError(loadError instanceof Error ? loadError.message : 'Failed to load user profile.');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        void loadProfile();
+    }, [refreshUserProfile, token, userProfile]);
+
+    useEffect(() => {
+        if (userProfile && !isEditing) {
+            setFormState(buildFormState(userProfile.attributes));
+        }
+    }, [isEditing, userProfile]);
+
+    const editableFields = useMemo(() => {
+        return Object.keys(formState);
+    }, [formState]);
+
+    const complexAttributes = useMemo(() => {
+        if (!userProfile) {
+            return [];
+        }
+
+        return Object.entries(userProfile.attributes).filter(([, value]) => !isEditableScalar(value));
+    }, [userProfile]);
+
+    const handleChange = (key: string, value: string) => {
+        setFormState((prev) => ({
+            ...prev,
+            [key]: value,
+        }));
+        setSuccessMessage('');
+    };
+
+    const handlePasswordChange = (key: 'newPassword' | 'confirmPassword', value: string) => {
+        setPasswordState((prev) => ({
+            ...prev,
+            [key]: value,
+        }));
+        setSuccessMessage('');
+    };
+
+    const handleTogglePasswordVisibility = () => {
+        setShowPassword((prev) => !prev);
+    };
+
+    const handleMouseDownPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+    };
+
+    const handleSave = async () => {
+        if (!token || !userProfile) {
+            return;
+        }
+
+        setSaving(true);
+        setError('');
+        setSuccessMessage('');
+
+        const mergedAttributes: Record<string, unknown> = {
+            ...userProfile.attributes,
+        };
+
+        Object.entries(formState).forEach(([key, value]) => {
+            const hadKey = Object.prototype.hasOwnProperty.call(userProfile.attributes, key);
+            const existingValue = userProfile.attributes[key];
+
+            if (!hadKey && value.trim() === '') {
+                return;
+            }
+
+            if (hadKey && isEditableScalar(existingValue) && toFormValue(existingValue) === value) {
+                mergedAttributes[key] = existingValue;
+                return;
+            }
+
+            mergedAttributes[key] = value;
+        });
+
+        try {
+            await updateCurrentUserProfile(token, mergedAttributes);
+            const refreshedProfile = await refreshUserProfile();
+            if (refreshedProfile) {
+                setFormState(buildFormState(refreshedProfile.attributes));
+            }
+            setIsEditing(false);
+            setSuccessMessage('Profile updated successfully.');
+        } catch (saveError) {
+            setError(saveError instanceof Error ? saveError.message : 'Failed to update user profile.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleStartEdit = () => {
+        setError('');
+        setSuccessMessage('');
+        setIsEditing(true);
+    };
+
+    const handleCloseEdit = () => {
+        if (userProfile) {
+            setFormState(buildFormState(userProfile.attributes));
+        }
+        setError('');
+        setSuccessMessage('');
+        setIsEditing(false);
+    };
+
+    const handlePasswordSave = async () => {
+        if (!token) {
+            return;
+        }
+
+        const trimmedPassword = passwordState.newPassword.trim();
+
+        if (!trimmedPassword) {
+            setError('Enter a new password.');
+            setSuccessMessage('');
+            return;
+        }
+
+        if (trimmedPassword !== passwordState.confirmPassword.trim()) {
+            setError('Password confirmation does not match.');
+            setSuccessMessage('');
+            return;
+        }
+
+        setSavingPassword(true);
+        setError('');
+        setSuccessMessage('');
+
+        try {
+            await updateCurrentUserPassword(token, trimmedPassword);
+            setPasswordState({
+                newPassword: '',
+                confirmPassword: '',
+            });
+            setSuccessMessage('Password updated successfully.');
+        } catch (saveError) {
+            setError(saveError instanceof Error ? saveError.message : 'Failed to update password.');
+        } finally {
+            setSavingPassword(false);
+        }
+    };
+
+    const profileHeading = (
+        formState.username ||
+        userProfile?.display ||
+        formState.name ||
+        formState.email ||
+        'Your Profile'
+    );
+    const usernameValue = formState.username || userProfile?.display || formState.email || 'Signed-in user';
+
+    const profileAvatarUrl = typeof userProfile?.attributes.picture === 'string' ? userProfile.attributes.picture : '';
+    const avatarFallback = profileHeading.trim().slice(0, 1).toUpperCase();
+
+    const handleCopyUsername = async () => {
+        if (!usernameValue || usernameValue === 'Signed-in user') {
+            return;
+        }
+
+        try {
+            await navigator.clipboard.writeText(usernameValue);
+            setError('');
+            setSuccessMessage('Username copied.');
+        } catch {
+            setError('Failed to copy username.');
+            setSuccessMessage('');
+        }
+    };
+
+    return (
+        <Layout>
+            <Box sx={{ width: '100%', maxWidth: 960, px: 2, py: 4 }}>
+                <Stack spacing={3}>
+                    <Box>
+                        <Link
+                            component="button"
+                            type="button"
+                            underline="hover"
+                            color="primary"
+                            onClick={() => navigate('/')}
+                            sx={{
+                                px: 0,
+                                mb: 1.5,
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: 0.75,
+                                fontWeight: 600,
+                            }}
+                        >
+                            <ArrowBackRoundedIcon fontSize="small" />
+                            Home
+                        </Link>
+                    </Box>
+
+                    {error && <Alert severity="error">{error}</Alert>}
+                    {successMessage && <Alert severity="success">{successMessage}</Alert>}
+
+                    {loading ? (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+                            <CircularProgress />
+                        </Box>
+                    ) : !token ? (
+                        <Alert severity="warning">No auth assertion available. Please log in again.</Alert>
+                    ) : !userProfile ? (
+                        <Alert severity="warning">Unable to load the current user profile.</Alert>
+                    ) : (
+                        <>
+                            <Paper
+                                elevation={0}
+                                sx={{
+                                    p: 3,
+                                    borderRadius: 4,
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                    backgroundColor: 'background.paper',
+                                    boxShadow: (theme) => theme.palette.mode === 'dark'
+                                        ? '0 18px 42px rgba(2, 6, 23, 0.28)'
+                                        : '0 18px 42px rgba(15, 23, 42, 0.06)',
+                                }}
+                            >
+                                <Stack spacing={3}>
+                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2, alignItems: 'flex-start' }}>
+                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                                            <Avatar
+                                                src={profileAvatarUrl || undefined}
+                                                sx={{
+                                                    width: 68,
+                                                    height: 68,
+                                                    bgcolor: 'action.selected',
+                                                    color: 'text.primary',
+                                                    fontSize: 28,
+                                                    boxShadow: 'none',
+                                                    border: '1px solid',
+                                                    borderColor: 'divider',
+                                                }}
+                                            >
+                                                {profileAvatarUrl ? null : avatarFallback}
+                                            </Avatar>
+                                            <Box>
+                                                <Typography variant="h4" sx={{ mb: 0.5, fontWeight: 700 }}>
+                                                    {usernameValue}
+                                                </Typography>
+                                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                                                    <Typography
+                                                        variant="body1"
+                                                        color="text.secondary"
+                                                        sx={{ opacity: 0.78 }}
+                                                    >
+                                                        {userProfile.id || '-'}
+                                                    </Typography>
+                                                    <IconButton
+                                                        size="small"
+                                                        aria-label="copy username"
+                                                        onClick={() => void handleCopyUsername()}
+                                                        sx={{ color: 'text.secondary' }}
+                                                    >
+                                                        <ContentCopyRoundedIcon fontSize="inherit" />
+                                                    </IconButton>
+                                                </Box>
+                                            </Box>
+                                        </Box>
+                                        <Box sx={{ display: 'flex', gap: 1, flexShrink: 0 }}>
+                                            {isEditing ? (
+                                                <>
+                                                    <Button
+                                                        variant="contained"
+                                                        color="primary"
+                                                        disabled={saving || userProfile.isReadOnly}
+                                                        onClick={() => void handleSave()}
+                                                    >
+                                                        {saving ? 'Saving...' : 'Save'}
+                                                    </Button>
+                                                    <Button
+                                                        variant="outlined"
+                                                        color="primary"
+                                                        disabled={saving}
+                                                        onClick={handleCloseEdit}
+                                                    >
+                                                        Close
+                                                    </Button>
+                                                </>
+                                            ) : (
+                                                <Button
+                                                    variant="contained"
+                                                    color="primary"
+                                                    disabled={userProfile.isReadOnly}
+                                                    onClick={handleStartEdit}
+                                                >
+                                                    Edit
+                                                </Button>
+                                            )}
+                                        </Box>
+                                    </Box>
+
+                                    <Box
+                                        sx={{
+                                            display: 'grid',
+                                            gap: 2,
+                                            gridTemplateColumns: {
+                                                xs: '1fr',
+                                                md: 'repeat(2, minmax(0, 1fr))',
+                                            },
+                                        }}
+                                    >
+                                        <Box sx={{ minWidth: 0 }}>
+                                            <Typography variant="body2" color="text.secondary">User Type</Typography>
+                                            <Typography sx={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>
+                                                {userProfile.type || '-'}
+                                            </Typography>
+                                        </Box>
+                                        <Box sx={{ minWidth: 0 }}>
+                                            <Typography variant="body2" color="text.secondary">Organization Unit</Typography>
+                                            <Typography sx={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>
+                                                {userProfile.ouHandle || userProfile.ouId || '-'}
+                                            </Typography>
+                                        </Box>
+                                    </Box>
+
+                                    <Box
+                                        sx={{
+                                            display: 'grid',
+                                            gap: 2,
+                                            gridTemplateColumns: {
+                                                xs: '1fr',
+                                                md: 'repeat(2, minmax(0, 1fr))',
+                                            },
+                                        }}
+                                    >
+                                        {editableFields.map((fieldKey) => (
+                                            isEditing ? (
+                                                <TextField
+                                                    key={fieldKey}
+                                                    fullWidth
+                                                    label={fieldLabels[fieldKey] || fieldKey}
+                                                    value={formState[fieldKey]}
+                                                    onChange={(event) => handleChange(fieldKey, event.target.value)}
+                                                />
+                                            ) : (
+                                                <Box key={fieldKey} sx={{ minWidth: 0 }}>
+                                                    <Typography variant="body2" color="text.secondary">
+                                                        {fieldLabels[fieldKey] || fieldKey}
+                                                    </Typography>
+                                                    <Typography sx={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>
+                                                        {formState[fieldKey] || '-'}
+                                                    </Typography>
+                                                </Box>
+                                            )
+                                        ))}
+                                    </Box>
+
+                                    {complexAttributes.length > 0 && (
+                                        <Box>
+                                            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                                                Additional Attributes
+                                            </Typography>
+                                            <pre style={{ margin: 0 }}>
+                                                <code>{JSON.stringify(Object.fromEntries(complexAttributes), null, 2)}</code>
+                                            </pre>
+                                        </Box>
+                                    )}
+                                </Stack>
+                            </Paper>
+
+                            <Paper
+                                elevation={0}
+                                sx={{
+                                    p: 3,
+                                    borderRadius: 4,
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                    backgroundColor: 'background.paper',
+                                    boxShadow: (theme) => theme.palette.mode === 'dark'
+                                        ? '0 18px 42px rgba(2, 6, 23, 0.35)'
+                                        : '0 18px 42px rgba(15, 23, 42, 0.06)',
+                                }}
+                            >
+                                <Stack spacing={3}>
+                                    <Box>
+                                        <Typography variant="h6" sx={{ mb: 1 }}>
+                                            Update Password
+                                        </Typography>
+                                    </Box>
+
+                                    <Box
+                                        sx={{
+                                            display: 'grid',
+                                            gap: 2,
+                                            gridTemplateColumns: {
+                                                xs: '1fr',
+                                                md: 'repeat(2, minmax(0, 1fr))',
+                                            },
+                                        }}
+                                    >
+                                        <Box display="flex" flexDirection="column" gap={0.5}>
+                                            <InputLabel htmlFor="new-password">New Password</InputLabel>
+                                            <OutlinedInput
+                                                id="new-password"
+                                                type={showPassword ? 'text' : 'password'}
+                                                size="small"
+                                                value={passwordState.newPassword}
+                                                onChange={(event) => handlePasswordChange('newPassword', event.target.value)}
+                                                endAdornment={
+                                                    <InputAdornment position="end">
+                                                        <IconButton
+                                                            aria-label="toggle password visibility"
+                                                            onClick={handleTogglePasswordVisibility}
+                                                            onMouseDown={handleMouseDownPassword}
+                                                            edge="end"
+                                                        >
+                                                            {showPassword ? <VisibilityOff /> : <Visibility />}
+                                                        </IconButton>
+                                                    </InputAdornment>
+                                                }
+                                            />
+                                        </Box>
+                                        <Box display="flex" flexDirection="column" gap={0.5}>
+                                            <InputLabel htmlFor="confirm-password">Confirm Password</InputLabel>
+                                            <OutlinedInput
+                                                id="confirm-password"
+                                                type={showPassword ? 'text' : 'password'}
+                                                size="small"
+                                                value={passwordState.confirmPassword}
+                                                onChange={(event) => handlePasswordChange('confirmPassword', event.target.value)}
+                                                endAdornment={
+                                                    <InputAdornment position="end">
+                                                        <IconButton
+                                                            aria-label="toggle password visibility"
+                                                            onClick={handleTogglePasswordVisibility}
+                                                            onMouseDown={handleMouseDownPassword}
+                                                            edge="end"
+                                                        >
+                                                            {showPassword ? <VisibilityOff /> : <Visibility />}
+                                                        </IconButton>
+                                                    </InputAdornment>
+                                                }
+                                            />
+                                        </Box>
+                                    </Box>
+
+                                    <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                                        <Button
+                                            variant="contained"
+                                            color="primary"
+                                            disabled={savingPassword || userProfile.isReadOnly}
+                                            onClick={() => void handlePasswordSave()}
+                                        >
+                                            {savingPassword ? 'Updating...' : 'Update Password'}
+                                        </Button>
+                                    </Box>
+                                </Stack>
+                            </Paper>
+                        </>
+                    )}
+                </Stack>
+            </Box>
+        </Layout>
+    );
+};
+
+export default ProfilePage;

--- a/samples/apps/react-vanilla-sample/src/services/userProfileService.ts
+++ b/samples/apps/react-vanilla-sample/src/services/userProfileService.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import config from '../config';
+
+export interface UserProfile {
+    id: string;
+    ouId?: string;
+    ouHandle?: string;
+    type?: string;
+    display?: string;
+    isReadOnly?: boolean;
+    attributes: Record<string, unknown>;
+}
+
+const usersEndpoint = new URL('/users', config.flowEndpoint).toString();
+
+const getErrorMessage = async (response: Response, fallback: string) => {
+    const errorData = await response.json().catch(() => ({})) as {
+        message?: { defaultValue?: string } | string;
+        description?: { defaultValue?: string } | string;
+    };
+
+    if (typeof errorData.message === 'string' && errorData.message) {
+        return errorData.message;
+    }
+
+    if (typeof errorData.description === 'string' && errorData.description) {
+        return errorData.description;
+    }
+
+    if (typeof errorData.message === 'object' && errorData.message?.defaultValue) {
+        return errorData.message.defaultValue;
+    }
+
+    if (typeof errorData.description === 'object' && errorData.description?.defaultValue) {
+        return errorData.description.defaultValue;
+    }
+
+    return fallback;
+};
+
+const normalizeUserProfile = (data: Partial<UserProfile>): UserProfile => ({
+    id: data.id || '',
+    ouId: data.ouId,
+    ouHandle: data.ouHandle,
+    type: data.type,
+    display: data.display,
+    isReadOnly: data.isReadOnly,
+    attributes: data.attributes && typeof data.attributes === 'object' ? data.attributes : {},
+});
+
+export const getCurrentUserProfile = async (token: string): Promise<UserProfile> => {
+    const response = await fetch(`${usersEndpoint}/me?include=display`, {
+        method: 'GET',
+        headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(await getErrorMessage(response, 'Failed to load user profile.'));
+    }
+
+    return normalizeUserProfile(await response.json() as Partial<UserProfile>);
+};
+
+export const updateCurrentUserProfile = async (
+    token: string,
+    attributes: Record<string, unknown>
+): Promise<UserProfile> => {
+    const response = await fetch(`${usersEndpoint}/me`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ attributes }),
+    });
+
+    if (!response.ok) {
+        throw new Error(await getErrorMessage(response, 'Failed to update user profile.'));
+    }
+
+    return normalizeUserProfile(await response.json() as Partial<UserProfile>);
+};
+
+export const updateCurrentUserPassword = async (
+    token: string,
+    password: string
+): Promise<void> => {
+    const response = await fetch(`${usersEndpoint}/me/update-credentials`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+            attributes: {
+                password,
+            },
+        }),
+    });
+
+    if (!response.ok) {
+        throw new Error(await getErrorMessage(response, 'Failed to update password.'));
+    }
+};


### PR DESCRIPTION
### Purpose
Adds self-service profile management to the `react-vanilla-sample` app.

This change extends the sample beyond login and registration by allowing authenticated users to:
- navigate to a dedicated profile page
- view their current user details
- update editable profile attributes
- update their password

### Approach
Implemented a new profile route and top-level navigation entry in the sample app so logged-in users can open a profile page from the header.

Added a profile page that uses Thunder self-service user APIs to:
- load the current user
- update profile attributes
- update credentials

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token-gated Profile page: view/edit profile attributes and update password; changes persist and show success/error feedback.
  * Header now shows an account dropdown with avatar/name; includes Profile and Logout actions.
  * Invite flow supports validated redirection responses.

* **Documentation**
  * README updated to mention built-in self-service profile management.

* **UI**
  * Wording updated: “Access Token” → “Auth Assertion” and related empty-state text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->