### PR TITLE
Streamline user role assignments during import

### DIFF
--- a/samples/apps/wayfinder-sample/README.md
+++ b/samples/apps/wayfinder-sample/README.md
@@ -126,15 +126,6 @@ The import creates:
 
 The agent's client secret defaults to `wayfinder-agent-secret` (set in `thunderid.env`). Change it in the env file before importing if you prefer a different value.
 
-### Assign Users to Roles
-
-After the import, assign users to roles in the Console UI:
-
-1. Go to **Roles** > **Wayfinder Chat User** > **Assignments** > **User** > **Add**. Assign `john.doe`.
-2. Go to **Roles** > **Wayfinder User** > **Assignments** > **User** > **Add**. Assign both `john.doe` and `jane.smith`.
-
-> Role assignments reference entities by ID. User IDs are auto-generated during import, so they cannot be predicted in the YAML. Assign users to roles manually after the import.
-
 ## Configure the Sample
 
 `api/`, `ai-agent/`, and `frontend/` each ship with a `.env.example` listing only the variables you actually need to set. In each of those folders, copy it to `.env` and fill the placeholders. The `mcp/` server has no required configuration.

--- a/samples/apps/wayfinder-sample/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/thunderid-config.yaml
@@ -253,6 +253,11 @@ permissions:
   - resource_server_id: wayfinder-agent-rs
     permissions:
       - agent:access
+assignments:
+  - id: wayfinder-demo-user
+    type: user
+  - id: wayfinder-demo-user-2
+    type: user
 
 ---
 # resource_type: role
@@ -266,6 +271,11 @@ permissions:
       - booking:read
       - booking:create
       - booking:cancel
+assignments:
+  - id: wayfinder-demo-user
+    type: user
+  - id: wayfinder-demo-user-2
+    type: user
 
 ---
 # resource_type: user


### PR DESCRIPTION
### Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the manual post-import "assign users to roles" step from the Wayfinder sample setup and kept a note that the agent client secret has a default value and can be changed before import.

* **Chores**
  * Sample configuration now includes inline demo user-to-role assignments so roles are populated automatically after import.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->