### PR TITLE
Fix application URL not being set in add application flow

### DIFF
--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -89,6 +89,7 @@ export default function ApplicationCreatePage(): JSX.Element {
     setSignInApproach,
     selectedTechnology,
     selectedPlatform,
+    hostingUrl,
     setHostingUrl,
     callbackUrlFromConfig,
     setCallbackUrlFromConfig,
@@ -217,6 +218,7 @@ export default function ApplicationCreatePage(): JSX.Element {
 
     const applicationData: CreateApplicationRequest = {
       name: appName,
+      ...(hostingUrl && {url: hostingUrl}),
       ...(authFlowId && {authFlowId}),
       ...(effectiveOuId && {ouId: effectiveOuId}),
       ...(finalTemplateId && {template: finalTemplateId}),

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -292,6 +292,7 @@ vi.mock('../../components/create-application/ConfigureDetails', () => ({
   default: ({
     onReadyChange,
     onCallbackUrlChange,
+    onHostingUrlChange,
   }: {
     onReadyChange: (ready: boolean) => void;
     onCallbackUrlChange: (url: string) => void;
@@ -302,6 +303,11 @@ vi.mock('../../components/create-application/ConfigureDetails', () => ({
     setTimeout(() => onReadyChange(true), 0);
     return (
       <div data-testid="application-configure-details">
+        <input
+          data-testid="hosting-url-input"
+          onChange={(e) => onHostingUrlChange(e.target.value)}
+          placeholder="Hosting URL"
+        />
         <input
           data-testid="callback-url-input"
           onChange={(e) => onCallbackUrlChange(e.target.value)}
@@ -1422,6 +1428,95 @@ describe('ApplicationCreatePage', () => {
       });
 
       expect(screen.queryByText(/no.*flow/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Hosting URL / Application URL', () => {
+    it('should include url in create request when hosting URL is provided', async () => {
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        onSuccess({id: 'app-123', name: 'My App'} as Application);
+      });
+
+      renderWithProviders();
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
+      });
+      // OPTIONS → EXPERIENCE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
+      });
+      // EXPERIENCE → CONFIGURE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByTestId('hosting-url-input'), 'https://myapp.example.com');
+
+      // CONFIGURE → Create
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      const createAppCall = mockCreateApplication.mock.calls[0][0] as Record<string, unknown>;
+      expect(createAppCall.url).toBe('https://myapp.example.com');
+    });
+
+    it('should not include url in create request when hosting URL is not provided', async () => {
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        onSuccess({id: 'app-123', name: 'My App'} as Application);
+      });
+
+      renderWithProviders();
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
+      });
+      // OPTIONS → EXPERIENCE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
+      });
+      // EXPERIENCE → CONFIGURE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
+      });
+
+      // Do not type a hosting URL — proceed directly
+      // CONFIGURE → Create
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      const createAppCall = mockCreateApplication.mock.calls[0][0] as Record<string, unknown>;
+      expect(createAppCall.url).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
### Purpose

When creating a browser-based application through the wizard, the URL entered in the \"Where is your application hosted?\" field was not being saved as the Application URL of the created app.

The hosting URL was correctly collected from the user and stored in the `ApplicationCreateContext`, but was never included in the payload sent to the backend when the application was created.

### Approach

In `ApplicationCreatePage.tsx`:
- Destructure `hostingUrl` from `useApplicationCreate()` (only `setHostingUrl` was previously pulled from context)
- Map `hostingUrl` to the `url` field in the `applicationData` object passed to `createApplication`

### Related Issues
- Fixes #2848

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Applications can now include an optional Hosting URL during creation; when provided it is attached to the created application.

* **Tests**
  * Added tests verifying Hosting URL is sent when entered and omitted when left blank.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->