### PR TITLE
Fix useNavigate error at /gate/callback caused by duplicate react-router pnpm instances

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2412,9 +2412,12 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.3
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.3(react@19.2.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.12.0(react-dom@19.2.6(react@19.2.3))(react@19.2.3)
+        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -22535,7 +22538,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(jsdom@27.0.1)(rolldown-vite@7.1.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.7.2)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.47.1)(yaml@2.8.3))
+      vitest: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(jsdom@27.0.1)(vite@8.0.12(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.47.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -29557,14 +29560,6 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.3(react@19.2.3)
-
-  react-router@7.12.0(react-dom@19.2.6(react@19.2.3))(react@19.2.3):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.3
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
-      react-dom: 19.2.6(react@19.2.3)
 
   react-syntax-highlighter@16.1.1(react@19.2.3):
     dependencies:

--- a/sdks/react-router/package.json
+++ b/sdks/react-router/package.json
@@ -55,6 +55,7 @@
     "eslint": "catalog:",
     "prettier": "catalog:",
     "react": "catalog:",
+    "react-dom": "catalog:",
     "react-router": "catalog:",
     "rimraf": "catalog:",
     "rolldown": "catalog:",


### PR DESCRIPTION
## Purpose
Fix \`useNavigate() may be used only in the context of a <Router> component\` crash at \`/gate/callback\`.

## Root Cause
pnpm resolves peer dependencies per-package based on what is available in each package's scope. \`react-router@7.12.0\` has \`react-dom\` as a peer dependency. Because \`@thunderid/react-router\` had no \`react-dom\` in its \`devDependencies\`, pnpm resolved \`react-dom\` from the ambient workspace context — specifically from \`@tanstack/react-router\`'s peer resolution — landing on \`react-dom@19.2.6\`.

The gate app declares \`react-dom: catalog:\` (= 19.2.3), so its \`react-router\` resolved with \`react-dom@19.2.3\`. pnpm treats these as distinct instances:

| Consumer | Instance |
|---|---|
| `sdks/react-router` | `react-router@7.12.0_react-dom@19.2.6` |
| `frontend/apps/gate` | `react-router@7.12.0_react-dom@19.2.3` |

The gate's \`<BrowserRouter>\` registers its router context in instance A. \`CallbackRoute\` (from \`@thunderid/react-router\`) calls \`useNavigate()\` against instance B — no context found → crash.

## Fix
Add \`react-dom: catalog:\` to \`sdks/react-router\` \`devDependencies\`. This pins \`react-dom@19.2.3\` in the SDK's scope, so pnpm resolves both packages to the same \`react-router\` store instance. Follows the existing pattern in \`@thunderid/react\`.

## Checklist
- [x] `pnpm-lock.yaml` updated — SDK now resolves `react-router@7.12.0(react-dom@19.2.3)`
- [x] No dist rebuild needed — the dist output is unchanged (react-router was already correctly externalized)
- [x] No application code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies for the React Router SDK to include an additional React DOM package (catalog-based). This is a development-time change; there are no user-facing feature changes or behavioral differences in the published SDK. It should reduce friction for contributors and local development workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->