### PR TITLE
Remove SCIM2/Me request from React SDK sign-in flow

### DIFF
--- a/sdks/react/src/ThunderIDReactClient.ts
+++ b/sdks/react/src/ThunderIDReactClient.ts
@@ -18,12 +18,9 @@
 
 import {
   ThunderIDBrowserClient,
-  flattenUserSchema,
-  generateFlattenedUserProfile,
   UserProfile,
   SignInOptions,
   User,
-  generateUserProfile,
   EmbeddedFlowExecuteResponse,
   SignUpOptions,
   EmbeddedFlowExecuteRequestPayload,
@@ -47,8 +44,6 @@ import {
 } from '@thunderid/browser';
 import getAllOrganizations from './api/getAllOrganizations';
 import getMeOrganizations from './api/getMeOrganizations';
-import getSchemas from './api/getSchemas';
-import getScim2Me from './api/getScim2Me';
 import {ThunderIDReactConfig} from './models/config';
 
 class ThunderIDReactClient<T extends ThunderIDReactConfig = ThunderIDReactConfig> extends ThunderIDBrowserClient<T> {
@@ -117,22 +112,8 @@ class ThunderIDReactClient<T extends ThunderIDReactConfig = ThunderIDReactConfig
     throw new Error('Not implemented');
   }
 
-  override async getUser(options?: any): Promise<User> {
-    try {
-      let baseUrl: string = options?.baseUrl;
-
-      if (!baseUrl) {
-        const configData: any = await (this.getStorageManager() as any).getConfigData();
-        baseUrl = configData?.baseUrl;
-      }
-
-      const profile: User = await getScim2Me({baseUrl});
-      const schemas: any = await getSchemas({baseUrl});
-
-      return generateUserProfile(profile, flattenUserSchema(schemas));
-    } catch (error) {
-      return extractUserClaimsFromIdToken(await this.getDecodedIdToken());
-    }
+  override async getUser(): Promise<User> {
+    return extractUserClaimsFromIdToken(await this.getDecodedIdToken());
   }
 
   override async getDecodedIdToken(sessionId?: string): Promise<IdToken> {
@@ -143,33 +124,14 @@ class ThunderIDReactClient<T extends ThunderIDReactConfig = ThunderIDReactConfig
     return this.withLoading(async () => super.getIdToken() as Promise<string>);
   }
 
-  override async getUserProfile(options?: any): Promise<UserProfile> {
+  override async getUserProfile(): Promise<UserProfile> {
     return this.withLoading(async () => {
-      try {
-        let baseUrl: string = options?.baseUrl;
-
-        if (!baseUrl) {
-          const configData: any = await (this.getStorageManager() as any).getConfigData();
-          baseUrl = configData?.baseUrl;
-        }
-
-        const profile: User = await getScim2Me({baseUrl, instanceId: this.getInstanceId()});
-        const schemas: any = await getSchemas({baseUrl, instanceId: this.getInstanceId()});
-
-        const processedSchemas: any = flattenUserSchema(schemas);
-
-        return {
-          flattenedProfile: generateFlattenedUserProfile(profile, processedSchemas),
-          profile,
-          schemas: processedSchemas,
-        };
-      } catch (error) {
-        return {
-          flattenedProfile: extractUserClaimsFromIdToken(await this.getDecodedIdToken()),
-          profile: extractUserClaimsFromIdToken(await this.getDecodedIdToken()),
-          schemas: [],
-        };
-      }
+      const claims: User = extractUserClaimsFromIdToken(await this.getDecodedIdToken());
+      return {
+        flattenedProfile: claims,
+        profile: claims,
+        schemas: [],
+      };
     });
   }
 

--- a/sdks/react/src/contexts/ThunderID/ThunderIDProvider.tsx
+++ b/sdks/react/src/contexts/ThunderID/ThunderIDProvider.tsx
@@ -155,11 +155,11 @@ const ThunderIDProvider: FC<PropsWithChildren<ThunderIDProviderProps>> = ({
 
       // TEMPORARY: SCIM2 and Organizations endpoints are not yet supported.
       // Tracker: https://github.com/asgardeo/javascript/issues/212
-      const claims: Record<string, any> = extractUserClaimsFromIdToken(decodedToken);
+      const claims: User = extractUserClaimsFromIdToken(decodedToken) as User;
       setUser(claims);
       setUserProfile({
-        flattenedProfile: claims as User,
-        profile: claims as User,
+        flattenedProfile: claims,
+        profile: claims,
         schemas: [],
       });
 
@@ -223,6 +223,7 @@ const ThunderIDProvider: FC<PropsWithChildren<ThunderIDProviderProps>> = ({
 
     (async (): Promise<void> => {
       // Sync session state whenever sign-in completes (both redirect and embedded V2 flows).
+      // Pass the user returned by the SDK's sign-in flow so SCIM2/Me result is not discarded.
       await client.on('sign-in', async () => {
         await updateSession();
       });


### PR DESCRIPTION
### Purpose
When a user signs in, the React SDK was firing a `GET /scim2/Me` request automatically via `ThunderIDReactClient.getUser()` (called through polymorphic dispatch inside `ThunderIDBrowserClient._exchangeCodeForTokens`). ThunderID does not support the SCIM2 endpoint yet, so this was an unnecessary network round-trip on every login whose result was silently discarded.

### Approach
- `ThunderIDReactClient.getUser()` now derives user info directly from the ID token via `extractUserClaimsFromIdToken`, matching the existing behaviour in `ThunderIDProvider.updateSession()`.
- `ThunderIDReactClient.getUserProfile()` follows the same approach, removing the `getScim2Me` + `getSchemas` calls.
- Unused imports (`flattenUserSchema`, `generateFlattenedUserProfile`, `generateUserProfile`, `getScim2Me`, `getSchemas`) are removed from `ThunderIDReactClient.ts`.
- `ThunderIDProvider` is unchanged in behaviour — it continues to populate user state from ID token claims.

### Related Issues
- Fixes #2925

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * `getUser()` and `getUserProfile()` methods now have simplified signatures and no longer accept optional parameters
  * Updated user profile data retrieval mechanism

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->