### PR TITLE
Add agent summary display to configuration import page

### DIFF
--- a/frontend/apps/console/src/features/import-export/pages/ImportConfigurationSummaryPage.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/ImportConfigurationSummaryPage.tsx
@@ -34,6 +34,7 @@ import {
 } from '@wso2/oxygen-ui';
 import {
   Bell,
+  Bot,
   Building,
   ChevronRight,
   Languages,
@@ -187,6 +188,7 @@ export default function ImportConfigurationSummaryPage(): JSX.Element {
   const [expandedTranslations, setExpandedTranslations] = useState(false);
   const [expandedUsers, setExpandedUsers] = useState(false);
   const [expandedSchemas, setExpandedSchemas] = useState(false);
+  const [expandedAgents, setExpandedAgents] = useState(false);
 
   // Extract data from configuration
   const applicationsCount = Array.isArray(configData?.application) ? configData.application.length : 0;
@@ -201,6 +203,7 @@ export default function ImportConfigurationSummaryPage(): JSX.Element {
     ? configData.notification_sender.length
     : 0;
   const layoutsCount = Array.isArray(configData?.layout) ? configData.layout.length : 0;
+  const agentsCount = Array.isArray(configData?.agent) ? configData.agent.length : 0;
 
   const envVariables = useMemo(() => parseEnvData(envData), [envData]);
 
@@ -941,6 +944,73 @@ export default function ImportConfigurationSummaryPage(): JSX.Element {
                   size="small"
                   variant="outlined"
                   onClick={() => setExpandedSchemas(!expandedSchemas)}
+                  sx={{cursor: 'pointer'}}
+                />
+              </Box>
+            )}
+          </Stack>
+        </Box>
+      ),
+    });
+  }
+
+  // 11. Agents
+  if (agentsCount > 0) {
+    const agents =
+      (configData?.agent as {
+        id?: string;
+        name?: string;
+        description?: string;
+        inbound_auth_config?: {type?: string; config?: {client_id?: string}}[];
+      }[]) ?? [];
+    const displayedAgents = expandedAgents ? agents : agents.slice(0, 5);
+    const remainingCount = agents.length - 5;
+
+    summaryItems.push({
+      id: 'agents',
+      icon: <Bot size={16} />,
+      label: t('configureExport.labels.agents'),
+      value: agentsCount,
+      content: (
+        <Box sx={{px: 3, py: 2, bgcolor: 'background.default'}}>
+          <Stack spacing={2}>
+            <Stack spacing={2} divider={<Box sx={{borderBottom: 1, borderColor: 'divider'}} />}>
+              {displayedAgents.map((agent, idx) => {
+                const clientId = agent.inbound_auth_config?.find((cfg) => cfg.type === 'oauth2')?.config?.client_id;
+                const agentKey = agent.id ?? agent.name ?? `agent-${idx}`;
+                return (
+                  <Stack key={agentKey} spacing={0.5}>
+                    <Stack direction="row" alignItems="center" spacing={1}>
+                      <Bot size={14} />
+                      <Typography variant="body2" fontWeight={600}>
+                        {agent.name ?? t('configureExport.fallback.unnamedAgent')}
+                      </Typography>
+                    </Stack>
+                    {agent.description && (
+                      <Typography variant="caption" color="text.secondary" sx={{pl: 2.5}}>
+                        {agent.description}
+                      </Typography>
+                    )}
+                    {clientId && (
+                      <Box sx={{pl: 2.5}}>
+                        <TemplateVariableDisplay text={clientId} envData={envData} label={t('export.app.clientId')} />
+                      </Box>
+                    )}
+                  </Stack>
+                );
+              })}
+            </Stack>
+            {remainingCount > 0 && (
+              <Box sx={{pt: 1, textAlign: 'center'}}>
+                <Chip
+                  label={
+                    expandedAgents
+                      ? t('configureExport.actions.showLess')
+                      : t('configureExport.actions.more', {count: remainingCount})
+                  }
+                  size="small"
+                  variant="outlined"
+                  onClick={() => setExpandedAgents(!expandedAgents)}
                   sx={{cursor: 'pointer'}}
                 />
               </Box>

--- a/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationSummaryPage.test.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationSummaryPage.test.tsx
@@ -489,5 +489,28 @@ describe('ImportConfigurationSummaryPage', () => {
 
       expect(screen.getByText(/application.*3/i)).toBeInTheDocument();
     });
+
+    it('displays agents when agent data is present', () => {
+      mockLocationState.configData = {
+        agent: [
+          {id: 'agent1', name: 'Test Agent', description: 'A test agent'},
+          {id: 'agent2', name: 'Another Agent'},
+        ],
+      } as ProductConfig;
+
+      render(<ImportConfigurationSummaryPage />);
+
+      expect(screen.getByText(/configureExport\.labels\.agents.*2/i)).toBeInTheDocument();
+    });
+
+    it('does not display agents section when no agents present', () => {
+      mockLocationState.configData = {
+        application: [{id: 'app1', name: 'App 1'}],
+      } as ProductConfig;
+
+      render(<ImportConfigurationSummaryPage />);
+
+      expect(screen.queryByText(/configureExport\.labels\.agents/i)).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
### Purpose
This pull request adds support for displaying agent configuration details in the `ImportConfigurationSummaryPage`. The main focus is on including agents as a new summary section, similar to existing sections for applications, users, and schemas. This includes UI improvements and the ability to expand/collapse the agent list.

**New feature: Agent summary section**

* Added a new state variable `expandedAgents` to manage the expand/collapse state for the agents section.
* Calculated `agentsCount` from the configuration data and included it as a summary item.
* Rendered a new summary section for agents, displaying agent details (name, description, OAuth2 client ID if present), with support for showing more/less agents using a chip control.
* Imported the `Bot` icon from the UI library to visually represent agents in the summary.

<img width="1506" height="904" alt="Screenshot 2026-05-21 at 14 53 02" src="https://github.com/user-attachments/assets/4ea1643d-011a-44ee-b772-d182eb219732" />

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2842

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Agents" resource category to the configuration import/export summary page with an expandable/compact list (show more/less), showing agent names, optional descriptions, and optional OAuth2 credential display.
* **Tests**
  * Added tests verifying agents are shown with correct counts and omitted when no agent data exists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->