### PR TITLE
Revert "Fix ThunderID docs Docker Compose URL for release updates"

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -155,30 +155,6 @@ jobs:
           echo "$VERSION" > version.txt
           echo "✅ Updated version.txt to $VERSION"
 
-      - name: 📝 Update README Version References
-        if: ${{ steps.get_version.outputs.use_existing_version != 'true' }}
-        run: |
-          VERSION="${{ steps.get_version.outputs.version }}"
-
-          echo "📝 Updating README.md docker-compose curl URL to $VERSION"
-
-          # Update the docker-compose.yml curl URL in README.md
-          sed -i -E "s|(https://raw\.githubusercontent\.com/thunder-id/thunderid/)v[0-9]+\.[0-9]+\.[0-9]+(/.+docker-compose\.yml)|\1${VERSION}\2|g" README.md
-
-          echo "✅ Updated README.md curl URL to $VERSION"
-          grep 'docker-compose.yml' README.md
-
-          echo "📝 Updating get-thunderid.mdx docker-compose curl URL to $VERSION"
-
-          # Update the docker-compose.yml curl URL in docs
-          sed -i -E "s|(https://raw\.githubusercontent\.com/thunder-id/thunderid/)v[0-9]+\.[0-9]+\.[0-9]+(/.+docker-compose\.yml)|\1${VERSION}\2|g" docs/content/guides/getting-started/get-thunderid.mdx
-
-          echo "✅ Updated get-thunderid.mdx curl URL to $VERSION"
-          grep -q "thunder-id/thunderid/${VERSION}/install/quick-start/docker-compose.yml" docs/content/guides/getting-started/get-thunderid.mdx || {
-            echo "❌ Error: Failed to update get-thunderid.mdx docker-compose URL to $VERSION"
-            exit 1
-          }
-
       - name: 📝 Update Helm and Sample App Versions
         if: ${{ steps.get_version.outputs.use_existing_version != 'true' }}
         run: |
@@ -227,7 +203,6 @@ jobs:
           git add \
             version.txt \
             README.md \
-            docs/content/guides/getting-started/get-thunderid.mdx \
             install/helm/Chart.yaml \
             install/openchoreo/helm/Chart.yaml \
             install/openchoreo/helm/charts/${PRODUCT_NAME_LOWER}-oc-componenttype/Chart.yaml \

--- a/docs/content/guides/getting-started/get-thunderid.mdx
+++ b/docs/content/guides/getting-started/get-thunderid.mdx
@@ -108,7 +108,7 @@ The quickest way to get <ProductName /> up and running with all dependencies con
 
 Download the `docker-compose.yml` file from the <ProductName /> repository:
 
-{/* The release workflow keeps this versioned URL in sync. */}
+{/* TODO: Fix the version in the URL below */}
 ```bash
 curl -o docker-compose.yml https://raw.githubusercontent.com/thunder-id/thunderid/v0.39.0/install/quick-start/docker-compose.yml
 ```


### PR DESCRIPTION
Reverts #2703.

## Changes
- Removes the release workflow step that auto-updated the `get-thunderid.mdx` Docker Compose URL on releases
- Restores the original `release-builder.yml` without the docs URL update step

## Note
The `get-thunderid.mdx` URL is retained at the current `v0.39.0` (rather than reverting to the stale `v0.16.0` from before #2703) since rolling it back to an older version would be incorrect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a note in the getting-started guide indicating the Docker Compose download URL’s version should be fixed, so users are alerted to verify the referenced release.

* **Chores**
  * Simplified the release process by removing automatic updates to guide files during version bumps, preventing automatic rewrite of the documented download link.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->