### PR TITLE
Replace asgardeo references with thunderid equivalents

### DIFF
--- a/docs/content/community/contributing/contributing-code/documentation-development/advanced-topics.mdx
+++ b/docs/content/community/contributing/contributing-code/documentation-development/advanced-topics.mdx
@@ -180,7 +180,7 @@ const config: Config = {
   baseUrl: '/',
   
   // GitHub Pages deployment
-  organizationName: 'asgardeo',
+  organizationName: 'thunderid',
   projectName: '{{productSlug}}',
   
   // Internationalization

--- a/docs/content/guides/guides/trusted-issuer.mdx
+++ b/docs/content/guides/guides/trusted-issuer.mdx
@@ -188,7 +188,7 @@ Create an IDP via the `/identity-providers` API with the following properties:
 
 | Property | Required | Description |
 |----------|----------|-------------|
-| `issuer` | Yes | The exact `iss` claim value in tokens from this IDP (e.g., `https://api.asgardeo.io/t/myorg/oauth2/token`). |
+| `issuer` | Yes | The exact `iss` claim value in tokens from this IDP (e.g., `https://localhost:8090/oauth2/token`). |
 | `jwks_endpoint` | Yes | The IDP's JWKS URL for signature verification. |
 | `token_exchange_enabled` | Yes | Set to `"true"` to enable this IDP for token exchange. |
 
@@ -206,8 +206,8 @@ curl -X POST https://thunder.example.com/identity-providers \
     "name": "Asgardeo",
     "type": "OIDC",
     "properties": [
-      {"name": "issuer", "value": "https://api.asgardeo.io/t/myorg/oauth2/token"},
-      {"name": "jwks_endpoint", "value": "https://api.asgardeo.io/t/myorg/oauth2/jwks"},
+      {"name": "issuer", "value": "https://localhost:8090/oauth2/token"},
+      {"name": "jwks_endpoint", "value": "https://localhost:8090/oauth2/jwks"},
       {"name": "token_exchange_enabled", "value": "true"}
     ]
   }'

--- a/docs/content/sdks/javascript/apis/utilities.mdx
+++ b/docs/content/sdks/javascript/apis/utilities.mdx
@@ -91,7 +91,7 @@ Check whether a URL matches a known <ProductName /> base URL pattern.
 ```ts
 import { isRecognizedBaseUrlPattern } from '@thunderid/javascript'
 
-isRecognizedBaseUrlPattern('https://api.asgardeo.io/t/myorg') // true
+isRecognizedBaseUrlPattern('https://localhost:8090') // true
 isRecognizedBaseUrlPattern('https://localhost:8090')           // false
 ```
 

--- a/docs/content/sdks/overview.mdx
+++ b/docs/content/sdks/overview.mdx
@@ -29,12 +29,12 @@ export const SDKsContent = () => {
     {icon: <ReactRouterLogo size={64} />, title: 'React Router', packageName: '@thunderid/react-router', packageManager: 'npm', description: `Protect routes and handle OAuth callbacks in React Router v6 applications.`, href: '/docs/next/sdks/react-router/overview', category: 'router'},
     {icon: <TanStackLogo size={64} />, title: 'TanStack Router', packageName: '@thunderid/tanstack-router', packageManager: 'npm', description: `Protect routes and handle OAuth callbacks in TanStack Router applications.`, href: '/docs/next/sdks/tanstack-router/overview', category: 'router'},
     {icon: <AngularLogo size={64} />, title: 'Angular SDK', packageName: '@thunderid/angular', packageManager: 'npm', description: `Add ${productName} authentication to your Angular application.`, comingSoon: true, category: 'frontend'},
-    {icon: <GoLogo size={64} />, title: 'Go SDK', packageName: 'github.com/asgardeo/go', packageManager: 'go', description: `${productName} authentication SDK for Go applications.`, comingSoon: true, category: 'backend'},
-    {icon: <PythonLogo size={64} />, title: 'Python SDK', packageName: 'asgardeo', packageManager: 'pip', description: `Integrate ${productName} authentication in your Python applications.`, comingSoon: true, category: 'backend'},
-    {icon: <IOSLogo size={64} />, title: 'iOS SDK', packageName: 'Asgardeo', packageManager: 'pod', description: `Native iOS SDK for ${productName} authentication in Swift applications.`, comingSoon: true, category: 'mobile'},
-    {icon: <AndroidLogo size={64} />, title: 'Android SDK', packageName: 'io.asgardeo:android', packageManager: 'gradle', description: `Native Android SDK for ${productName} authentication in Kotlin/Java applications.`, comingSoon: true, category: 'mobile'},
+    {icon: <GoLogo size={64} />, title: 'Go SDK', packageName: 'github.com/thunder-id/go', packageManager: 'go', description: `${productName} authentication SDK for Go applications.`, comingSoon: true, category: 'backend'},
+    {icon: <PythonLogo size={64} />, title: 'Python SDK', packageName: 'thunderid', packageManager: 'pip', description: `Integrate ${productName} authentication in your Python applications.`, comingSoon: true, category: 'backend'},
+    {icon: <IOSLogo size={64} />, title: 'iOS SDK', packageName: 'ThunderID', packageManager: 'pod', description: `Native iOS SDK for ${productName} authentication in Swift applications.`, comingSoon: true, category: 'mobile'},
+    {icon: <AndroidLogo size={64} />, title: 'Android SDK', packageName: 'io.thunderid:android', packageManager: 'gradle', description: `Native Android SDK for ${productName} authentication in Kotlin/Java applications.`, comingSoon: true, category: 'mobile'},
     {icon: <ReactLogo size={64} />, title: 'React Native SDK', packageName: '@thunderid/react-native', packageManager: 'npm', description: `Cross-platform React Native SDK for ${productName} authentication.`, comingSoon: true, category: 'mobile'},
-    {icon: <FlutterLogo size={64} />, title: 'Flutter SDK', packageName: 'asgardeo_flutter', packageManager: 'pub', description: `Cross-platform Flutter SDK for ${productName} authentication.`, comingSoon: true, category: 'mobile'},
+    {icon: <FlutterLogo size={64} />, title: 'Flutter SDK', packageName: 'thunderid_flutter', packageManager: 'pub', description: `Cross-platform Flutter SDK for ${productName} authentication.`, comingSoon: true, category: 'mobile'},
   ];
 
   const filters = [

--- a/docs/content/sdks/react/apis/components/sign-in-button.mdx
+++ b/docs/content/sdks/react/apis/components/sign-in-button.mdx
@@ -64,7 +64,7 @@ export default App
 #### Default CSS Classes
 
 The button includes a default vendor-prefixed class for targeting:
-- `.asgardeo-sign-in-button` – Main sign-in button element
+- `.thunderid-sign-in-button` – Main sign-in button element
 
 ### CSS Custom Properties (CSS Variables)
 
@@ -72,11 +72,11 @@ You can theme the button and other SDK components using CSS variables:
 
 ```css title="index.css" showLineNumbers
 :root {
-  --asgardeo-primary-color: #007bff;
-  --asgardeo-primary-hover: #0056b3;
-  --asgardeo-border-radius: 8px;
-  --asgardeo-font-family: 'Inter', sans-serif;
-  --asgardeo-button-padding: 12px 24px;
+  --thunderid-primary-color: #007bff;
+  --thunderid-primary-hover: #0056b3;
+  --thunderid-border-radius: 8px;
+  --thunderid-font-family: 'Inter', sans-serif;
+  --thunderid-button-padding: 12px 24px;
 }
 ```
 

--- a/docs/content/sdks/react/apis/components/sign-out-button.mdx
+++ b/docs/content/sdks/react/apis/components/sign-out-button.mdx
@@ -65,7 +65,7 @@ export default App
 #### Default CSS Classes
 
 The button includes a default vendor-prefixed class for targeting:
-- `.asgardeo-sign-out-button` – Main sign-out button element
+- `.thunderid-sign-out-button` – Main sign-out button element
 
 ### CSS Custom Properties (CSS Variables)
 
@@ -73,11 +73,11 @@ You can theme the button and other SDK components using CSS variables:
 
 ```css title="index.css" showLineNumbers
 :root {
-  --asgardeo-primary-color: #007bff;
-  --asgardeo-primary-hover: #0056b3;
-  --asgardeo-border-radius: 8px;
-  --asgardeo-font-family: 'Inter', sans-serif;
-  --asgardeo-button-padding: 12px 24px;
+  --thunderid-primary-color: #007bff;
+  --thunderid-primary-hover: #0056b3;
+  --thunderid-border-radius: 8px;
+  --thunderid-font-family: 'Inter', sans-serif;
+  --thunderid-button-padding: 12px 24px;
 }
 ```
 

--- a/docs/content/sdks/react/apis/components/sign-up-button.mdx
+++ b/docs/content/sdks/react/apis/components/sign-up-button.mdx
@@ -69,7 +69,7 @@ export default LandingPage
 #### Default CSS Classes
 
 The button includes a default vendor-prefixed class for targeting:
-- `.asgardeo-sign-up-button` – Main sign-up button element
+- `.thunderid-sign-up-button` – Main sign-up button element
 
 ### CSS Custom Properties (CSS Variables)
 
@@ -77,11 +77,11 @@ You can theme the button and other SDK components using CSS variables:
 
 ```css title="index.css" showLineNumbers
 :root {
-  --asgardeo-primary-color: #007bff;
-  --asgardeo-primary-hover: #0056b3;
-  --asgardeo-border-radius: 8px;
-  --asgardeo-font-family: 'Inter', sans-serif;
-  --asgardeo-button-padding: 12px 24px;
+  --thunderid-primary-color: #007bff;
+  --thunderid-primary-hover: #0056b3;
+  --thunderid-border-radius: 8px;
+  --thunderid-font-family: 'Inter', sans-serif;
+  --thunderid-button-padding: 12px 24px;
 }
 ```
 

--- a/docs/content/sdks/vue/apis/components/sign-in-button.mdx
+++ b/docs/content/sdks/vue/apis/components/sign-in-button.mdx
@@ -76,7 +76,7 @@ import { SignInButton } from '@thunderid/vue'
 
 The button includes a default vendor-prefixed class for targeting:
 
-- `.asgardeo-sign-in-button` – Main sign-in button element
+- `.thunderid-sign-in-button` – Main sign-in button element
 
 ### CSS Custom Properties (CSS Variables)
 
@@ -84,11 +84,11 @@ You can theme the button and other SDK components using CSS variables:
 
 ```css title="src/style.css" showLineNumbers
 :root {
-  --asgardeo-primary-color: #007bff;
-  --asgardeo-primary-hover: #0056b3;
-  --asgardeo-border-radius: 8px;
-  --asgardeo-font-family: 'Inter', sans-serif;
-  --asgardeo-button-padding: 12px 24px;
+  --thunderid-primary-color: #007bff;
+  --thunderid-primary-hover: #0056b3;
+  --thunderid-border-radius: 8px;
+  --thunderid-font-family: 'Inter', sans-serif;
+  --thunderid-button-padding: 12px 24px;
 }
 ```
 

--- a/docs/content/sdks/vue/apis/components/sign-out-button.mdx
+++ b/docs/content/sdks/vue/apis/components/sign-out-button.mdx
@@ -75,7 +75,7 @@ import { SignOutButton } from '@thunderid/vue'
 
 The button includes a default vendor-prefixed class for targeting:
 
-- `.asgardeo-sign-out-button` – Main sign-out button element
+- `.thunderid-sign-out-button` – Main sign-out button element
 
 ### CSS Custom Properties (CSS Variables)
 
@@ -83,11 +83,11 @@ You can theme the button and other SDK components using CSS variables:
 
 ```css title="src/style.css" showLineNumbers
 :root {
-  --asgardeo-primary-color: #007bff;
-  --asgardeo-primary-hover: #0056b3;
-  --asgardeo-border-radius: 8px;
-  --asgardeo-font-family: 'Inter', sans-serif;
-  --asgardeo-button-padding: 12px 24px;
+  --thunderid-primary-color: #007bff;
+  --thunderid-primary-hover: #0056b3;
+  --thunderid-border-radius: 8px;
+  --thunderid-font-family: 'Inter', sans-serif;
+  --thunderid-button-padding: 12px 24px;
 }
 ```
 

--- a/docs/content/sdks/vue/apis/components/sign-up-button.mdx
+++ b/docs/content/sdks/vue/apis/components/sign-up-button.mdx
@@ -75,7 +75,7 @@ import { SignUpButton } from '@thunderid/vue'
 
 The button includes a default vendor-prefixed class for targeting:
 
-- `.asgardeo-sign-up-button` – Main sign-up button element
+- `.thunderid-sign-up-button` – Main sign-up button element
 
 ### CSS Custom Properties (CSS Variables)
 
@@ -83,11 +83,11 @@ You can theme the button and other SDK components using CSS variables:
 
 ```css title="src/style.css" showLineNumbers
 :root {
-  --asgardeo-primary-color: #007bff;
-  --asgardeo-primary-hover: #0056b3;
-  --asgardeo-border-radius: 8px;
-  --asgardeo-font-family: 'Inter', sans-serif;
-  --asgardeo-button-padding: 12px 24px;
+  --thunderid-primary-color: #007bff;
+  --thunderid-primary-hover: #0056b3;
+  --thunderid-border-radius: 8px;
+  --thunderid-font-family: 'Inter', sans-serif;
+  --thunderid-button-padding: 12px 24px;
 }
 ```
 

--- a/docs/plugins/shims/thunderid-react.cjs
+++ b/docs/plugins/shims/thunderid-react.cjs
@@ -1,9 +1,9 @@
 /**
- * No-op shim for @asgardeo/react.
+ * No-op shim for @thunderid/react.
  *
- * The frontend design package dist imports these symbols from @asgardeo/react,
+ * The frontend design package dist imports these symbols from @thunderid/react,
  * but docs only uses theme utilities from that package. This shim prevents
- * webpack from failing when it cannot resolve @asgardeo/react in the docs build.
+ * webpack from failing when it cannot resolve @thunderid/react in the docs build.
  */
 module.exports = {
   Consent: () => null,
@@ -14,5 +14,5 @@ module.exports = {
   FlowTimer: () => null,
   extractEmojiFromUri: () => undefined,
   isEmojiUri: () => false,
-  useAsgardeo: () => ({}),
+  useThunderID: () => ({}),
 };

--- a/docs/plugins/webpackPlugin.ts
+++ b/docs/plugins/webpackPlugin.ts
@@ -57,9 +57,9 @@ export default function () {
         },
       };
 
-      // @asgardeo/react is an external used by the frontend design package dist
+      // @thunderid/react is an external used by the frontend design package dist
       // but is not needed at all in the docs build. Alias it to a no-op shim.
-      const asgardeoReactShim = path.resolve(__dirname, 'shims/asgardeo-react.cjs');
+      const thunderidReactShim = path.resolve(__dirname, 'shims/thunderid-react.cjs');
 
       // @emotion/css calls document.createElement at module init, which fails
       // in Node.js SSR. Alias it to a no-op shim for the server build only.
@@ -69,7 +69,7 @@ export default function () {
           resolve: {
             alias: {
               '@emotion/css': path.resolve(__dirname, 'shims/emotion-css.cjs'),
-              '@asgardeo/react': asgardeoReactShim,
+              '@thunderid/react': thunderidReactShim,
             },
           },
         };
@@ -79,7 +79,7 @@ export default function () {
         ...baseConfig,
         resolve: {
           alias: {
-            '@asgardeo/react': asgardeoReactShim,
+            '@thunderid/react': thunderidReactShim,
           },
         },
       };

--- a/samples/api/postman/authentication/README.md
+++ b/samples/api/postman/authentication/README.md
@@ -107,7 +107,7 @@ Import the `environment.json` file into Postman and fill in the required values.
 |----------|-------------|
 | `ASGARDEO_CLIENT_ID` | Asgardeo OAuth client ID |
 | `ASGARDEO_CLIENT_SECRET` | Asgardeo OAuth client secret |
-| `ASGARDEO_BASE_URI` | Asgardeo organization base URI (Ex: https://api.asgardeo.io/t/your-org) |
+| `THUNDERID_BASE_URI` | Asgardeo organization base URI (Ex: https://localhost:8090) |
 
 Note: Replace `your-org` with your actual Asgardeo organization name.
 
@@ -174,7 +174,7 @@ These variables will be auto-populated during the resource setup phase:
 | `demoSchemaName` | Created demo user schema name |
 | `googleIDPId` | Created Google IDP ID |
 | `githubIDPId` | Created GitHub IDP ID |
-| `asgardeoIDPId` | Created Asgardeo IDP ID |
+| `thunderidIDPId` | Created Asgardeo IDP ID |
 | `messageNotificationSenderId` | Created SMS notification sender ID |
 | `loginApplicationId` | Created demo application ID |
 | `basicAuthFlowGraphId` | Created basic authentication flow graph ID |
@@ -205,7 +205,7 @@ These variables are automatically populated during the demo execution:
 | `first_factor_assertion` | First factor authentication assertion for MFA flows |
 | `google_session_token` | Google authentication session token |
 | `github_session_token` | GitHub authentication session token |
-| `asgardeo_session_token` | Asgardeo authentication session token |
+| `thunderid_session_token` | Asgardeo authentication session token |
 | `exec_flow_id` | Flow execution ID for flow-native APIs |
 | `exec_challenge_token` | Challenge token for flow execution |
 | `auth_std_auth_id` | OAuth standard flow auth ID |

--- a/samples/api/postman/authentication/authentication_demo.json
+++ b/samples/api/postman/authentication/authentication_demo.json
@@ -557,7 +557,7 @@
                   "    const response = pm.response.json();",
                   "    ",
                   "    // Store the IDP id",
-                  "    pm.environment.set(\"asgardeoIDPId\", response.id);",
+                  "    pm.environment.set(\"thunderidIDPId\", response.id);",
                   "    ",
                   "    console.log(\"✓ Asgardeo IDP created\");",
                   "    console.log(\"  ID:\", response.id);",
@@ -592,7 +592,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"Asgardeo Prod\",\n    \"description\": \"Login with Asgardeo\",\n    \"type\": \"OAUTH\",\n    \"properties\": [\n        {\n            \"name\": \"client_id\",\n            \"value\": \"{{ASGARDEO_CLIENT_ID}}\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"client_secret\",\n            \"value\": \"{{ASGARDEO_CLIENT_SECRET}}\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"redirect_uri\",\n            \"value\": \"{{FED_IDP_REDIRECT_URI}}\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"scopes\",\n            \"value\": \"openid,custom,email,groups,profile\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"authorization_endpoint\",\n            \"value\": \"{{ASGARDEO_BASE_URI}}/oauth2/authorize\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"token_endpoint\",\n            \"value\": \"{{ASGARDEO_BASE_URI}}/oauth2/token\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"userinfo_endpoint\",\n            \"value\": \"{{ASGARDEO_BASE_URI}}/oauth2/userinfo\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"logout_endpoint\",\n            \"value\": \"{{ASGARDEO_BASE_URI}}/oidc/logout\",\n            \"isSecret\": false\n        }\n    ]\n}",
+              "raw": "{\n    \"name\": \"Asgardeo Prod\",\n    \"description\": \"Login with Asgardeo\",\n    \"type\": \"OAUTH\",\n    \"properties\": [\n        {\n            \"name\": \"client_id\",\n            \"value\": \"{{ASGARDEO_CLIENT_ID}}\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"client_secret\",\n            \"value\": \"{{ASGARDEO_CLIENT_SECRET}}\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"redirect_uri\",\n            \"value\": \"{{FED_IDP_REDIRECT_URI}}\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"scopes\",\n            \"value\": \"openid,custom,email,groups,profile\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"authorization_endpoint\",\n            \"value\": \"{{THUNDERID_BASE_URI}}/oauth2/authorize\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"token_endpoint\",\n            \"value\": \"{{THUNDERID_BASE_URI}}/oauth2/token\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"userinfo_endpoint\",\n            \"value\": \"{{THUNDERID_BASE_URI}}/oauth2/userinfo\",\n            \"isSecret\": false\n        },\n        {\n            \"name\": \"logout_endpoint\",\n            \"value\": \"{{THUNDERID_BASE_URI}}/oidc/logout\",\n            \"isSecret\": false\n        }\n    ]\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1613,7 +1613,7 @@
                       "const sessionToken = jsonResponse.sessionToken;",
                       "",
                       "// Store it as a collection variable",
-                      "pm.collectionVariables.set(\"asgardeo_session_token\", sessionToken);",
+                      "pm.collectionVariables.set(\"thunderid_session_token\", sessionToken);",
                       ""
                     ],
                     "type": "text/javascript",
@@ -1636,7 +1636,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"idp_id\": \"{{asgardeoIDPId}}\"\n}",
+                  "raw": "{\n  \"idp_id\": \"{{thunderidIDPId}}\"\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -1674,7 +1674,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"sessionToken\": \"{{asgardeo_session_token}}\",\n  \"code\": \"<ASGARDEO_AUTHORIZATION_CODE>\"\n//   \"skip_assertion\": false,\n//   \"assertion\": \"\"\n}\n",
+                  "raw": "{\n  \"sessionToken\": \"{{thunderid_session_token}}\",\n  \"code\": \"<THUNDERID_AUTHORIZATION_CODE>\"\n//   \"skip_assertion\": false,\n//   \"assertion\": \"\"\n}\n",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -3726,7 +3726,7 @@
       "value": ""
     },
     {
-      "key": "asgardeo_session_token",
+      "key": "thunderid_session_token",
       "value": ""
     },
     {

--- a/samples/api/postman/authentication/environment.json
+++ b/samples/api/postman/authentication/environment.json
@@ -189,13 +189,13 @@
       "enabled": true
     },
     {
-      "key": "ASGARDEO_BASE_URI",
+      "key": "THUNDERID_BASE_URI",
       "value": "",
       "type": "default",
       "enabled": true
     },
     {
-      "key": "asgardeoIDPId",
+      "key": "thunderidIDPId",
       "value": "",
       "type": "default",
       "enabled": true

--- a/samples/apps/react-sdk-sample/README.md
+++ b/samples/apps/react-sdk-sample/README.md
@@ -1,6 +1,6 @@
 # ThunderID React SDK Sample Application
 
-This sample application demonstrates how to integrate authentication into a React application using the `@asgardeo/react` SDK. It showcases OAuth 2.0/OIDC based user authentication, token management, and user profile display.
+This sample application demonstrates how to integrate authentication into a React application using the `@thunderid/react` SDK. It showcases OAuth 2.0/OIDC based user authentication, token management, and user profile display.
 
 ## Features
 
@@ -173,9 +173,9 @@ Before running the app, ensure your application is configured with:
 
 **Using Authentication Hooks:**
 ```tsx
-import { useAsgardeo } from "@asgardeo/react";
+import { useThunderID } from "@thunderid/react";
 
-const { getAccessToken, signIn } = useAsgardeo();
+const { getAccessToken, signIn } = useThunderID();
 const accessToken = await getAccessToken();
 ```
 

--- a/sdks/browser/src/ThunderIDBrowserClient.ts
+++ b/sdks/browser/src/ThunderIDBrowserClient.ts
@@ -392,7 +392,6 @@ class ThunderIDBrowserClient<T = BrowserAuthConfig> extends ThunderIDJavaScriptC
 
     // TEMPORARY: Handle sign-out by clearing the session and navigating back to sign-in,
     // until the OIDC end-session flow is fully supported.
-    // Tracker: https://github.com/asgardeo/javascript/issues/212#issuecomment-3435713699
     this.clearSession();
 
     if (config?.signInUrl) {

--- a/sdks/browser/src/utils/__tests__/navigate.test.ts
+++ b/sdks/browser/src/utils/__tests__/navigate.test.ts
@@ -66,7 +66,7 @@ describe('navigate', () => {
   });
 
   it('should use window.location.assign for cross-origin URLs', () => {
-    const crossOriginUrl = 'https://accounts.asgardeo.io/t/dxlab/accountrecoveryendpoint/register.do';
+    const crossOriginUrl = 'https://localhost:8090/accountrecoveryendpoint/register.do';
     navigate(crossOriginUrl);
     expect(window.location.assign).toHaveBeenCalledWith(crossOriginUrl);
     expect(window.history.pushState).not.toHaveBeenCalled();

--- a/sdks/browser/src/utils/navigate.ts
+++ b/sdks/browser/src/utils/navigate.ts
@@ -36,7 +36,7 @@
  * navigate('/search?q=thunderid');
  *
  * // Cross-origin navigation (full page load)
- * navigate('https://accounts.asgardeo.io/t/dxlab/accountrecoveryendpoint/register.do');
+ * navigate('https://localhost:8090/accountrecoveryendpoint/register.do');
  * ```
  */
 const navigate = (url: string): void => {

--- a/sdks/javascript/src/api/__tests__/createOrganization.test.ts
+++ b/sdks/javascript/src/api/__tests__/createOrganization.test.ts
@@ -46,7 +46,7 @@ describe('createOrganization', (): void => {
       type: 'TENANT',
     };
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const result: Organization = await createOrganization({baseUrl, payload});
 
     expect(fetch).toHaveBeenCalledWith(`${baseUrl}/api/server/v1/organizations`, {
@@ -79,7 +79,7 @@ describe('createOrganization', (): void => {
       type: 'TENANT',
     };
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const result: Organization = await createOrganization({
       baseUrl,
       fetcher: customFetcher,
@@ -111,7 +111,7 @@ describe('createOrganization', (): void => {
       type: 'TENANT',
     };
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(createOrganization({baseUrl, fetcher: customFetcher, payload})).rejects.toThrow(
       'Network or parsing error: Custom fetcher failure',
@@ -154,7 +154,7 @@ describe('createOrganization', (): void => {
   });
 
   it('should throw ThunderIDAPIError when payload is missing', async (): Promise<void> => {
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(createOrganization({baseUrl} as any)).rejects.toThrow(ThunderIDAPIError);
     await expect(createOrganization({baseUrl} as any)).rejects.toThrow('Organization payload is required');
@@ -179,7 +179,7 @@ describe('createOrganization', (): void => {
       type: 'GROUP', // Intentionally incorrect to test override
     };
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await createOrganization({baseUrl, payload});
 
     expect(fetch).toHaveBeenCalledWith(`${baseUrl}/api/server/v1/organizations`, {
@@ -210,7 +210,7 @@ describe('createOrganization', (): void => {
       type: 'TENANT',
     };
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(createOrganization({baseUrl, payload})).rejects.toThrow(ThunderIDAPIError);
     await expect(createOrganization({baseUrl, payload})).rejects.toThrow(
@@ -228,7 +228,7 @@ describe('createOrganization', (): void => {
       type: 'TENANT',
     };
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(createOrganization({baseUrl, payload})).rejects.toThrow(ThunderIDAPIError);
     await expect(createOrganization({baseUrl, payload})).rejects.toThrow('Network or parsing error: Network error');
@@ -244,7 +244,7 @@ describe('createOrganization', (): void => {
       type: 'TENANT',
     };
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(createOrganization({baseUrl, payload})).rejects.toThrow('Network or parsing error: Unknown error');
   });
@@ -273,7 +273,7 @@ describe('createOrganization', (): void => {
       'X-Custom-Header': 'custom-value',
     };
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await createOrganization({
       baseUrl,

--- a/sdks/javascript/src/api/__tests__/executeEmbeddedSignInFlow.test.ts
+++ b/sdks/javascript/src/api/__tests__/executeEmbeddedSignInFlow.test.ts
@@ -37,7 +37,7 @@ describe('executeEmbeddedSignInFlow', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/demo/oauth2/authn';
+    const url = 'https://localhost:8090/oauth2/authn';
     const payload: Record<string, string> = {client_id: 'abc123', password: 'pass', username: 'test'};
 
     const result: EmbeddedSignInFlowHandleResponse = await executeEmbeddedSignInFlow({payload, url});
@@ -64,7 +64,7 @@ describe('executeEmbeddedSignInFlow', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, string> = {grant_type: 'password'};
 
     const result: EmbeddedSignInFlowHandleResponse = await executeEmbeddedSignInFlow({baseUrl, payload});
@@ -105,7 +105,7 @@ describe('executeEmbeddedSignInFlow', (): void => {
   });
 
   it('should throw ThunderIDAPIError when payload is missing', async (): Promise<void> => {
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(executeEmbeddedSignInFlow({baseUrl} as any)).rejects.toThrow(ThunderIDAPIError);
     await expect(executeEmbeddedSignInFlow({baseUrl} as any)).rejects.toThrow('Authorization payload is required');
@@ -121,8 +121,8 @@ describe('executeEmbeddedSignInFlow', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/demo/oauth2/authn';
-    const baseUrl = 'https://api.asgardeo.io/t/ignored';
+    const url = 'https://localhost:8090/oauth2/authn';
+    const baseUrl = 'https://localhost:8090';
     await executeEmbeddedSignInFlow({baseUrl, payload: {a: 1}, url});
 
     expect(fetch).toHaveBeenCalledWith(url, expect.any(Object));
@@ -135,7 +135,7 @@ describe('executeEmbeddedSignInFlow', (): void => {
     };
     global.fetch = vi.fn().mockResolvedValue({json: () => Promise.resolve(mockData), ok: true});
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await executeEmbeddedSignInFlow({baseUrl, method: 'PUT' as any, payload: {a: 1}});
 
     expect(fetch).toHaveBeenCalledWith(`${baseUrl}/oauth2/authn`, expect.objectContaining({method: 'PUT'}));
@@ -150,7 +150,7 @@ describe('executeEmbeddedSignInFlow', (): void => {
     });
 
     const payload: Record<string, string> = {password: 'invalid', username: 'wrong'};
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(executeEmbeddedSignInFlow({baseUrl, payload})).rejects.toThrow(ThunderIDAPIError);
     await expect(executeEmbeddedSignInFlow({baseUrl, payload})).rejects.toThrow('Invalid credentials');
@@ -174,7 +174,7 @@ describe('executeEmbeddedSignInFlow', (): void => {
     });
 
     const payload: Record<string, string> = {password: 'pass', username: 'user'};
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(executeEmbeddedSignInFlow({baseUrl, payload})).rejects.toThrow(
       'An unexpected error occurred while processing the request',
@@ -185,7 +185,7 @@ describe('executeEmbeddedSignInFlow', (): void => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
     const payload: Record<string, string> = {password: 'pass', username: 'user'};
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(executeEmbeddedSignInFlow({baseUrl, payload})).rejects.toThrow(ThunderIDAPIError);
     await expect(executeEmbeddedSignInFlow({baseUrl, payload})).rejects.toThrow(
@@ -197,7 +197,7 @@ describe('executeEmbeddedSignInFlow', (): void => {
     global.fetch = vi.fn().mockRejectedValue('Unexpected failure');
 
     const payload: Record<string, string> = {password: 'pass', username: 'user'};
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(executeEmbeddedSignInFlow({baseUrl, payload})).rejects.toThrow(
       'Network or parsing error: Unknown error',
@@ -216,7 +216,7 @@ describe('executeEmbeddedSignInFlow', (): void => {
     });
 
     const payload: Record<string, string> = {password: 'pass', username: 'user'};
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const customHeaders: Record<string, string> = {
       Authorization: 'Bearer token',
       'X-Custom-Header': 'custom-value',

--- a/sdks/javascript/src/api/__tests__/executeEmbeddedSignUpFlow.test.ts
+++ b/sdks/javascript/src/api/__tests__/executeEmbeddedSignUpFlow.test.ts
@@ -44,7 +44,7 @@ describe('executeEmbeddedSignUpFlow', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/demo/api/server/v1/flow/execute';
+    const url = 'https://localhost:8090/api/server/v1/flow/execute';
     const payload: Record<string, string> = {foo: 'bar'};
 
     const result: EmbeddedFlowExecuteResponse = await executeEmbeddedSignUpFlow({payload, url});
@@ -82,7 +82,7 @@ describe('executeEmbeddedSignUpFlow', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, number> = {a: 1};
 
     const result: EmbeddedFlowExecuteResponse = await executeEmbeddedSignUpFlow({baseUrl, payload});
@@ -114,8 +114,8 @@ describe('executeEmbeddedSignUpFlow', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/demo/api/server/v1/flow/execute';
-    const baseUrl = 'https://api.asgardeo.io/t/ignored';
+    const url = 'https://localhost:8090/api/server/v1/flow/execute';
+    const baseUrl = 'https://localhost:8090';
 
     await executeEmbeddedSignUpFlow({baseUrl, payload: {x: 1}, url});
 
@@ -135,7 +135,7 @@ describe('executeEmbeddedSignUpFlow', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await executeEmbeddedSignUpFlow({
       baseUrl,
@@ -162,7 +162,7 @@ describe('executeEmbeddedSignUpFlow', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, unknown> = {flowType: 'SOMETHING_ELSE', p: 1} as any;
 
     await executeEmbeddedSignUpFlow({baseUrl, payload});
@@ -187,7 +187,7 @@ describe('executeEmbeddedSignUpFlow', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await executeEmbeddedSignUpFlow({baseUrl});
 
     const [, init]: [string, RequestInit] = (fetch as unknown as Mock).mock.calls[0];
@@ -234,7 +234,7 @@ describe('executeEmbeddedSignUpFlow', (): void => {
       text: () => Promise.resolve('Bad payload'),
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await expect(executeEmbeddedSignUpFlow({baseUrl, payload: {a: 1}})).rejects.toThrow(ThunderIDAPIError);
     await expect(executeEmbeddedSignUpFlow({baseUrl, payload: {a: 1}})).rejects.toThrow(
       'Embedded SignUp flow execution failed: Bad payload',
@@ -244,7 +244,7 @@ describe('executeEmbeddedSignUpFlow', (): void => {
   it('should handle network or parsing errors', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await expect(executeEmbeddedSignUpFlow({baseUrl, payload: {a: 1}})).rejects.toThrow(ThunderIDAPIError);
     await expect(executeEmbeddedSignUpFlow({baseUrl, payload: {a: 1}})).rejects.toThrow(
       'Network or parsing error: Network error',
@@ -254,7 +254,7 @@ describe('executeEmbeddedSignUpFlow', (): void => {
   it('should handle non-Error rejections', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue('boom');
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await expect(executeEmbeddedSignUpFlow({baseUrl, payload: {a: 1}})).rejects.toThrow(
       'Network or parsing error: Unknown error',
     );
@@ -273,7 +273,7 @@ describe('executeEmbeddedSignUpFlow', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const headers: Record<string, string> = {
       Authorization: 'Bearer token',
       'X-Custom-Header': 'custom',

--- a/sdks/javascript/src/api/__tests__/getAllOrganizations.test.ts
+++ b/sdks/javascript/src/api/__tests__/getAllOrganizations.test.ts
@@ -42,7 +42,7 @@ describe('getAllOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const result: AllOrganizationsApiResponse = await getAllOrganizations({baseUrl});
 
     expect(fetch).toHaveBeenCalledWith(`${baseUrl}/api/server/v1/organizations?limit=10&recursive=false`, {
@@ -68,7 +68,7 @@ describe('getAllOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await getAllOrganizations({
       baseUrl,
       filter: 'type eq TENANT',
@@ -95,7 +95,7 @@ describe('getAllOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const result: AllOrganizationsApiResponse = await getAllOrganizations({baseUrl, fetcher: customFetcher});
 
     expect(result).toEqual(mockResponse);
@@ -112,7 +112,7 @@ describe('getAllOrganizations', (): void => {
       throw new Error('Custom fetcher failure');
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getAllOrganizations({baseUrl, fetcher: customFetcher})).rejects.toThrow(
       'Network or parsing error: Custom fetcher failure',
@@ -142,7 +142,7 @@ describe('getAllOrganizations', (): void => {
       text: () => Promise.resolve('Invalid query'),
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getAllOrganizations({baseUrl})).rejects.toThrow(ThunderIDAPIError);
     await expect(getAllOrganizations({baseUrl})).rejects.toThrow('Failed to get organizations: Invalid query');
@@ -151,7 +151,7 @@ describe('getAllOrganizations', (): void => {
   it('should handle network or parsing errors', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getAllOrganizations({baseUrl})).rejects.toThrow(ThunderIDAPIError);
     await expect(getAllOrganizations({baseUrl})).rejects.toThrow('Network or parsing error: Network error');
@@ -160,7 +160,7 @@ describe('getAllOrganizations', (): void => {
   it('should handle non-Error rejections', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue('unexpected failure');
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getAllOrganizations({baseUrl})).rejects.toThrow('Network or parsing error: Unknown error');
   });
@@ -178,7 +178,7 @@ describe('getAllOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const customHeaders: Record<string, string> = {
       Accept: 'text/plain',
       Authorization: 'Bearer token',
@@ -213,7 +213,7 @@ describe('getAllOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const result: AllOrganizationsApiResponse = await getAllOrganizations({baseUrl});
 
     expect(result.organizations).toEqual([]);

--- a/sdks/javascript/src/api/__tests__/getBrandingPreference.test.ts
+++ b/sdks/javascript/src/api/__tests__/getBrandingPreference.test.ts
@@ -101,7 +101,7 @@ describe('getBrandingPreference', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/dxlab';
+    const baseUrl = 'https://localhost:8090';
     const result: BrandingPreference = await getBrandingPreference({baseUrl});
 
     expect(fetch).toHaveBeenCalledWith(`${baseUrl}/api/server/v1/branding-preference/resolve`, {
@@ -126,7 +126,7 @@ describe('getBrandingPreference', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/dxlab';
+    const baseUrl = 'https://localhost:8090';
     await getBrandingPreference({
       baseUrl,
       locale: 'en-US',
@@ -157,7 +157,7 @@ describe('getBrandingPreference', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/dxlab';
+    const baseUrl = 'https://localhost:8090';
     await getBrandingPreference({baseUrl, fetcher: customFetcher});
 
     expect(customFetcher).toHaveBeenCalledWith(`${baseUrl}/api/server/v1/branding-preference/resolve`, {
@@ -174,7 +174,7 @@ describe('getBrandingPreference', (): void => {
       throw new Error('Custom fetcher failure');
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/dxlab';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getBrandingPreference({baseUrl, fetcher: customFetcher})).rejects.toThrow(ThunderIDAPIError);
     await expect(getBrandingPreference({baseUrl, fetcher: customFetcher})).rejects.toThrow(
@@ -207,7 +207,7 @@ describe('getBrandingPreference', (): void => {
       text: () => Promise.resolve('Branding preference not found'),
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/dxlab';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getBrandingPreference({baseUrl})).rejects.toThrow(ThunderIDAPIError);
     await expect(getBrandingPreference({baseUrl})).rejects.toThrow(
@@ -218,7 +218,7 @@ describe('getBrandingPreference', (): void => {
   it('should handle network errors', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
-    const baseUrl = 'https://api.asgardeo.io/t/dxlab';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getBrandingPreference({baseUrl})).rejects.toThrow(ThunderIDAPIError);
     await expect(getBrandingPreference({baseUrl})).rejects.toThrow('Network or parsing error: Network error');
@@ -227,7 +227,7 @@ describe('getBrandingPreference', (): void => {
   it('should handle non-Error rejections', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue('unexpected failure');
 
-    const baseUrl = 'https://api.asgardeo.io/t/dxlab';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getBrandingPreference({baseUrl})).rejects.toThrow(ThunderIDAPIError);
     await expect(getBrandingPreference({baseUrl})).rejects.toThrow('Network or parsing error: Unknown error');
@@ -244,7 +244,7 @@ describe('getBrandingPreference', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/dxlab';
+    const baseUrl = 'https://localhost:8090';
     const customHeaders: Record<string, string> = {
       Authorization: 'Bearer token',
       'X-Custom-Header': 'custom-value',

--- a/sdks/javascript/src/api/__tests__/getMeOrganizations.test.ts
+++ b/sdks/javascript/src/api/__tests__/getMeOrganizations.test.ts
@@ -39,7 +39,7 @@ describe('getMeOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const result: Organization[] = await getMeOrganizations({baseUrl});
 
     expect(fetch).toHaveBeenCalledWith(`${baseUrl}/api/users/v1/me/organizations?limit=10&recursive=false`, {
@@ -60,7 +60,7 @@ describe('getMeOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await getMeOrganizations({
       after: 'YWZ0',
       authorizedAppName: 'my-app',
@@ -85,7 +85,7 @@ describe('getMeOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const result: Organization[] = await getMeOrganizations({baseUrl, fetcher: customFetcher});
 
     expect(result).toEqual(mock.organizations);
@@ -100,7 +100,7 @@ describe('getMeOrganizations', (): void => {
       throw new Error('Custom fetcher failure');
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getMeOrganizations({baseUrl, fetcher: customFetcher})).rejects.toThrow(
       'Network or parsing error: Custom fetcher failure',
@@ -130,7 +130,7 @@ describe('getMeOrganizations', (): void => {
       text: () => Promise.resolve('Not authorized'),
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getMeOrganizations({baseUrl})).rejects.toThrow(ThunderIDAPIError);
     await expect(getMeOrganizations({baseUrl})).rejects.toThrow(
@@ -141,7 +141,7 @@ describe('getMeOrganizations', (): void => {
   it('should handle network or parsing errors', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getMeOrganizations({baseUrl})).rejects.toThrow(ThunderIDAPIError);
     await expect(getMeOrganizations({baseUrl})).rejects.toThrow('Network or parsing error: Network error');
@@ -150,7 +150,7 @@ describe('getMeOrganizations', (): void => {
   it('should handle non-Error rejections', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue('unexpected failure');
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getMeOrganizations({baseUrl})).rejects.toThrow('Network or parsing error: Unknown error');
   });
@@ -163,7 +163,7 @@ describe('getMeOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const customHeaders: Record<string, string> = {
       Authorization: 'Bearer token',
       'X-Custom-Header': 'custom-value',
@@ -188,7 +188,7 @@ describe('getMeOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const result: Organization[] = await getMeOrganizations({baseUrl});
 
     expect(result).toEqual([]);
@@ -202,7 +202,7 @@ describe('getMeOrganizations', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const customHeaders: Record<string, string> = {
       Authorization: 'Bearer token',
       'X-Custom-Header': 'custom-value',

--- a/sdks/javascript/src/api/__tests__/getOrganization.test.ts
+++ b/sdks/javascript/src/api/__tests__/getOrganization.test.ts
@@ -39,7 +39,7 @@ describe('getOrganization', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/dxlab';
+    const baseUrl = 'https://localhost:8090';
     const organizationId: string = mockOrg.id;
     const result: OrganizationDetails = await getOrganization({baseUrl, organizationId});
 
@@ -65,7 +65,7 @@ describe('getOrganization', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const organizationId = 'org-123';
     const result: OrganizationDetails = await getOrganization({
       baseUrl,
@@ -91,7 +91,7 @@ describe('getOrganization', (): void => {
       throw new Error('Custom fetcher failure');
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const organizationId = 'org-1';
 
     await expect(getOrganization({baseUrl, fetcher: customFetcher, organizationId})).rejects.toThrow(
@@ -124,7 +124,7 @@ describe('getOrganization', (): void => {
   });
 
   it('should throw ThunderIDAPIError when organizationId is missing', async (): Promise<void> => {
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getOrganization({baseUrl, organizationId: '' as any})).rejects.toThrow(ThunderIDAPIError);
     await expect(getOrganization({baseUrl, organizationId: '' as any})).rejects.toThrow('Organization ID is required');
@@ -138,7 +138,7 @@ describe('getOrganization', (): void => {
       text: () => Promise.resolve('Organization not found'),
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const organizationId = 'missing-org';
 
     await expect(getOrganization({baseUrl, organizationId})).rejects.toThrow(ThunderIDAPIError);
@@ -150,7 +150,7 @@ describe('getOrganization', (): void => {
   it('should handle network or parsing errors', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const organizationId = 'org-1';
 
     await expect(getOrganization({baseUrl, organizationId})).rejects.toThrow(ThunderIDAPIError);
@@ -160,7 +160,7 @@ describe('getOrganization', (): void => {
   it('should handle non-Error rejections', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue('unexpected failure');
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const organizationId = 'org-1';
 
     await expect(getOrganization({baseUrl, organizationId})).rejects.toThrow('Network or parsing error: Unknown error');
@@ -178,7 +178,7 @@ describe('getOrganization', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const organizationId = 'org-003';
     const customHeaders: Record<string, string> = {
       Authorization: 'Bearer token',

--- a/sdks/javascript/src/api/__tests__/getSchemas.test.ts
+++ b/sdks/javascript/src/api/__tests__/getSchemas.test.ts
@@ -37,7 +37,7 @@ describe('getSchemas', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/demo/scim2/Schemas';
+    const url = 'https://localhost:8090/scim2/Schemas';
     const result: Schema[] = await getSchemas({url});
 
     expect(fetch).toHaveBeenCalledWith(url, {
@@ -58,7 +58,7 @@ describe('getSchemas', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const result: Schema[] = await getSchemas({baseUrl});
 
     expect(fetch).toHaveBeenCalledWith(`${baseUrl}/scim2/Schemas`, {
@@ -79,7 +79,7 @@ describe('getSchemas', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const result: Schema[] = await getSchemas({baseUrl, fetcher: customFetcher});
 
     expect(result).toEqual(mockSchemas);
@@ -100,7 +100,7 @@ describe('getSchemas', (): void => {
       throw new Error('Custom fetcher failure');
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getSchemas({baseUrl, fetcher: customFetcher})).rejects.toThrow(
       'Network or parsing error: Custom fetcher failure',
@@ -132,7 +132,7 @@ describe('getSchemas', (): void => {
       text: () => Promise.resolve('Server exploded'),
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getSchemas({baseUrl})).rejects.toThrow(ThunderIDAPIError);
     await expect(getSchemas({baseUrl})).rejects.toThrow('Failed to fetch SCIM2 schemas: Server exploded');
@@ -141,7 +141,7 @@ describe('getSchemas', (): void => {
   it('should handle network or parsing errors', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getSchemas({baseUrl})).rejects.toThrow(ThunderIDAPIError);
     await expect(getSchemas({baseUrl})).rejects.toThrow('Network or parsing error: Network error');
@@ -150,7 +150,7 @@ describe('getSchemas', (): void => {
   it('should handle non-Error rejections gracefully', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue('unexpected failure');
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getSchemas({baseUrl})).rejects.toThrow('Network or parsing error: Unknown error');
   });
@@ -163,8 +163,8 @@ describe('getSchemas', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/demo/scim2/Schemas';
-    const baseUrl = 'https://api.asgardeo.io/t/ignored';
+    const url = 'https://localhost:8090/scim2/Schemas';
+    const baseUrl = 'https://localhost:8090';
     await getSchemas({baseUrl, url});
 
     expect(fetch).toHaveBeenCalledWith(url, expect.any(Object));
@@ -178,7 +178,7 @@ describe('getSchemas', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const customHeaders: Record<string, string> = {
       Authorization: 'Bearer token',
       'X-Custom-Header': 'custom-value',

--- a/sdks/javascript/src/api/__tests__/getScim2Me.test.ts
+++ b/sdks/javascript/src/api/__tests__/getScim2Me.test.ts
@@ -44,11 +44,11 @@ describe('getScim2Me', () => {
     global.fetch = mockFetch;
 
     const result: Record<string, unknown> = await getScim2Me({
-      url: 'https://api.asgardeo.io/t/test/scim2/Me',
+      url: 'https://localhost:8090/scim2/Me',
     });
 
     expect(result).toEqual(mockUser);
-    expect(mockFetch).toHaveBeenCalledWith('https://api.asgardeo.io/t/test/scim2/Me', {
+    expect(mockFetch).toHaveBeenCalledWith('https://localhost:8090/scim2/Me', {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/scim+json',
@@ -68,11 +68,11 @@ describe('getScim2Me', () => {
 
     const result: Record<string, unknown> = await getScim2Me({
       fetcher: customFetcher,
-      url: 'https://api.asgardeo.io/t/test/scim2/Me',
+      url: 'https://localhost:8090/scim2/Me',
     });
 
     expect(result).toEqual(mockUser);
-    expect(customFetcher).toHaveBeenCalledWith('https://api.asgardeo.io/t/test/scim2/Me', {
+    expect(customFetcher).toHaveBeenCalledWith('https://localhost:8090/scim2/Me', {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/scim+json',
@@ -89,13 +89,13 @@ describe('getScim2Me', () => {
     await expect(
       getScim2Me({
         fetcher: customFetcher,
-        url: 'https://api.asgardeo.io/t/test/scim2/Me',
+        url: 'https://localhost:8090/scim2/Me',
       }),
     ).rejects.toThrow(ThunderIDAPIError);
     await expect(
       getScim2Me({
         fetcher: customFetcher,
-        url: 'https://api.asgardeo.io/t/test/scim2/Me',
+        url: 'https://localhost:8090/scim2/Me',
       }),
     ).rejects.toThrow('Network or parsing error: Custom fetcher failure');
   });
@@ -153,7 +153,7 @@ describe('getScim2Me', () => {
 
     await expect(
       getScim2Me({
-        url: 'https://api.asgardeo.io/t/test/scim2/Me',
+        url: 'https://localhost:8090/scim2/Me',
       }),
     ).rejects.toThrow(ThunderIDAPIError);
   });
@@ -165,7 +165,7 @@ describe('getScim2Me', () => {
 
     await expect(
       getScim2Me({
-        url: 'https://api.asgardeo.io/t/test/scim2/Me',
+        url: 'https://localhost:8090/scim2/Me',
       }),
     ).rejects.toThrow(ThunderIDAPIError);
   });
@@ -173,7 +173,7 @@ describe('getScim2Me', () => {
   it('should handle non-Error rejections', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue('unexpected failure');
 
-    const baseUrl = 'https://api.asgardeo.io/t/dxlab';
+    const baseUrl = 'https://localhost:8090';
 
     await expect(getScim2Me({baseUrl})).rejects.toThrow(ThunderIDAPIError);
     await expect(getScim2Me({baseUrl})).rejects.toThrow('Network or parsing error: Unknown error');
@@ -196,10 +196,10 @@ describe('getScim2Me', () => {
 
     await getScim2Me({
       headers: customHeaders,
-      url: 'https://api.asgardeo.io/t/test/scim2/Me',
+      url: 'https://localhost:8090/scim2/Me',
     });
 
-    expect(mockFetch).toHaveBeenCalledWith('https://api.asgardeo.io/t/test/scim2/Me', {
+    expect(mockFetch).toHaveBeenCalledWith('https://localhost:8090/scim2/Me', {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/scim+json',
@@ -219,7 +219,7 @@ describe('getScim2Me', () => {
     });
     global.fetch = mockFetch;
 
-    const baseUrl = 'https://api.asgardeo.io/t/test';
+    const baseUrl = 'https://localhost:8090';
     await getScim2Me({
       baseUrl,
     });

--- a/sdks/javascript/src/api/__tests__/getUserInfo.test.ts
+++ b/sdks/javascript/src/api/__tests__/getUserInfo.test.ts
@@ -40,7 +40,7 @@ describe('getUserInfo', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/<ORGANIZATION>/oauth2/userinfo';
+    const url = 'https://localhost:8090/oauth2/userinfo';
     const result: User = await getUserInfo({url});
 
     expect(fetch).toHaveBeenCalledWith(url, {
@@ -72,7 +72,7 @@ describe('getUserInfo', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/<ORGANIZATION>/oauth2/userinfo';
+    const url = 'https://localhost:8090/oauth2/userinfo';
     const result: User = await getUserInfo({url});
 
     expect(result).toEqual({
@@ -92,7 +92,7 @@ describe('getUserInfo', (): void => {
       text: () => Promise.resolve(errorText),
     });
 
-    const url = 'https://api.asgardeo.io/t/<ORGANIZATION>/oauth2/userinfo';
+    const url = 'https://localhost:8090/oauth2/userinfo';
 
     await expect(getUserInfo({url})).rejects.toThrow(ThunderIDAPIError);
     await expect(getUserInfo({url})).rejects.toThrow(`Failed to fetch user info: ${errorText}`);
@@ -142,12 +142,12 @@ describe('getUserInfo', (): void => {
 
     await expect(
       getUserInfo({
-        url: 'https://api.asgardeo.io/t/test/oauth2/userinfo',
+        url: 'https://localhost:8090/oauth2/userinfo',
       }),
     ).rejects.toThrow(ThunderIDAPIError);
     await expect(
       getUserInfo({
-        url: 'https://api.asgardeo.io/t/test/oauth2/userinfo',
+        url: 'https://localhost:8090/oauth2/userinfo',
       }),
     ).rejects.toThrow('Network or parsing error: Network error');
   });
@@ -155,7 +155,7 @@ describe('getUserInfo', (): void => {
   it('should handle non-Error rejections', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue('unexpected failure');
 
-    const url = 'https://api.asgardeo.io/t/dxlab';
+    const url = 'https://localhost:8090';
 
     await expect(getUserInfo({url})).rejects.toThrow(ThunderIDAPIError);
     await expect(getUserInfo({url})).rejects.toThrow('Network or parsing error: Unknown error');
@@ -178,7 +178,7 @@ describe('getUserInfo', (): void => {
       Authorization: 'Bearer token',
       'X-Custom-Header': 'custom-value',
     };
-    const url = 'https://api.asgardeo.io/t/<ORGANIZATION>/oauth2/userinfo';
+    const url = 'https://localhost:8090/oauth2/userinfo';
     const result: User = await getUserInfo({headers: customHeaders, url});
 
     expect(result).toEqual(mockUserInfo);

--- a/sdks/javascript/src/api/__tests__/initializeEmbeddedSignInFlow.test.ts
+++ b/sdks/javascript/src/api/__tests__/initializeEmbeddedSignInFlow.test.ts
@@ -37,7 +37,7 @@ describe('initializeEmbeddedSignInFlow', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/demo/oauth2/authorize';
+    const url = 'https://localhost:8090/oauth2/authorize';
     const payload: Record<string, string> = {
       client_id: 'cid',
       code_challenge: 'abc',
@@ -72,7 +72,7 @@ describe('initializeEmbeddedSignInFlow', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, string> = {client_id: 'cid', response_type: 'code'};
 
     const result: EmbeddedSignInFlowInitiateResponse = await initializeEmbeddedSignInFlow({baseUrl, payload});
@@ -99,7 +99,7 @@ describe('initializeEmbeddedSignInFlow', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, string> = {client_id: 'cid', response_type: 'code'};
 
     await initializeEmbeddedSignInFlow({baseUrl, method: 'PUT' as any, payload});
@@ -118,8 +118,8 @@ describe('initializeEmbeddedSignInFlow', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/demo/oauth2/authorize';
-    const baseUrl = 'https://api.asgardeo.io/t/ignored';
+    const url = 'https://localhost:8090/oauth2/authorize';
+    const baseUrl = 'https://localhost:8090';
     await initializeEmbeddedSignInFlow({baseUrl, payload: {response_type: 'code'}, url});
 
     expect(fetch).toHaveBeenCalledWith(url, expect.any(Object));
@@ -135,7 +135,7 @@ describe('initializeEmbeddedSignInFlow', (): void => {
   });
 
   it('should throw ThunderIDAPIError when payload is missing', async (): Promise<void> => {
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await expect(initializeEmbeddedSignInFlow({baseUrl} as any)).rejects.toThrow(ThunderIDAPIError);
     await expect(initializeEmbeddedSignInFlow({baseUrl} as any)).rejects.toThrow('Authorization payload is required');
   });
@@ -148,7 +148,7 @@ describe('initializeEmbeddedSignInFlow', (): void => {
       text: () => Promise.resolve('invalid request'),
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, string> = {client_id: 'cid', response_type: 'code'};
 
     await expect(initializeEmbeddedSignInFlow({baseUrl, payload})).rejects.toThrow(ThunderIDAPIError);
@@ -172,7 +172,7 @@ describe('initializeEmbeddedSignInFlow', (): void => {
       text: () => Promise.resolve(structuredError),
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, string> = {client_id: 'cid', response_type: 'code'};
 
     await expect(initializeEmbeddedSignInFlow({baseUrl, payload})).rejects.toThrow(
@@ -183,7 +183,7 @@ describe('initializeEmbeddedSignInFlow', (): void => {
   it('should handle network or parsing errors', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network down'));
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, string> = {client_id: 'cid', response_type: 'code'};
 
     await expect(initializeEmbeddedSignInFlow({baseUrl, payload})).rejects.toThrow(ThunderIDAPIError);
@@ -195,7 +195,7 @@ describe('initializeEmbeddedSignInFlow', (): void => {
   it('should handle non-Error rejections', async (): Promise<void> => {
     global.fetch = vi.fn().mockRejectedValue('weird failure');
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, string> = {client_id: 'cid', response_type: 'code'};
 
     await expect(initializeEmbeddedSignInFlow({baseUrl, payload})).rejects.toThrow(
@@ -214,7 +214,7 @@ describe('initializeEmbeddedSignInFlow', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, string> = {client_id: 'cid', response_type: 'code'};
     const customHeaders: Record<string, string> = {
       Accept: 'text/plain',
@@ -252,7 +252,7 @@ describe('initializeEmbeddedSignInFlow', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, string> = {
       client_id: 'cid',
       redirect_uri: 'https://app.example.com/cb?x=1&y=2',

--- a/sdks/javascript/src/api/__tests__/updateMeProfile.test.ts
+++ b/sdks/javascript/src/api/__tests__/updateMeProfile.test.ts
@@ -38,7 +38,7 @@ describe('updateMeProfile', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/demo/scim2/Me';
+    const url = 'https://localhost:8090/scim2/Me';
     const payload: Record<string, unknown> = {'urn:scim:wso2:schema': {mobileNumbers: ['0777933830']}};
 
     const result: User = await updateMeProfile({payload, url});
@@ -70,7 +70,7 @@ describe('updateMeProfile', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, unknown> = {profile: {givenName: 'Bob'}};
 
     const result: User = await updateMeProfile({baseUrl, payload});
@@ -87,7 +87,7 @@ describe('updateMeProfile', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, unknown> = {profile: {familyName: 'Doe'}};
 
     const result: User = await updateMeProfile({baseUrl, fetcher: customFetcher, payload});
@@ -112,8 +112,8 @@ describe('updateMeProfile', (): void => {
       ok: true,
     });
 
-    const url = 'https://api.asgardeo.io/t/demo/scim2/Me';
-    const baseUrl = 'https://api.asgardeo.io/t/ignored';
+    const url = 'https://localhost:8090/scim2/Me';
+    const baseUrl = 'https://localhost:8090';
     await updateMeProfile({baseUrl, payload: {x: 1}, url});
 
     expect(fetch).toHaveBeenCalledWith(url, expect.any(Object));
@@ -145,7 +145,7 @@ describe('updateMeProfile', (): void => {
       text: () => Promise.resolve('SCIM validation failed'),
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await expect(updateMeProfile({baseUrl, payload: {bad: 'data'}})).rejects.toThrow(ThunderIDAPIError);
 
     await expect(updateMeProfile({baseUrl, payload: {bad: 'data'}})).rejects.toThrow(
@@ -156,16 +156,16 @@ describe('updateMeProfile', (): void => {
   it('should handle network or unknown errors with the generic message', async (): Promise<void> => {
     // Rejection with Error
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
-    await expect(updateMeProfile({payload: {a: 1}, url: 'https://api.asgardeo.io/t/demo/scim2/Me'})).rejects.toThrow(
+    await expect(updateMeProfile({payload: {a: 1}, url: 'https://localhost:8090/scim2/Me'})).rejects.toThrow(
       ThunderIDAPIError,
     );
-    await expect(updateMeProfile({payload: {a: 1}, url: 'https://api.asgardeo.io/t/demo/scim2/Me'})).rejects.toThrow(
+    await expect(updateMeProfile({payload: {a: 1}, url: 'https://localhost:8090/scim2/Me'})).rejects.toThrow(
       'An error occurred while updating the user profile. Please try again.',
     );
 
     // Rejection with non-Error
     global.fetch = vi.fn().mockRejectedValue('weird failure');
-    await expect(updateMeProfile({payload: {a: 1}, url: 'https://api.asgardeo.io/t/demo/scim2/Me'})).rejects.toThrow(
+    await expect(updateMeProfile({payload: {a: 1}, url: 'https://localhost:8090/scim2/Me'})).rejects.toThrow(
       'An error occurred while updating the user profile. Please try again.',
     );
   });
@@ -178,7 +178,7 @@ describe('updateMeProfile', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const customHeaders: Record<string, string> = {
       Accept: 'text/plain',
       Authorization: 'Bearer token',
@@ -203,7 +203,7 @@ describe('updateMeProfile', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     const payload: Record<string, unknown> = {'urn:scim:wso2:schema': {mobileNumbers: ['123']}};
 
     await updateMeProfile({baseUrl, payload});
@@ -223,7 +223,7 @@ describe('updateMeProfile', (): void => {
       ok: true,
     });
 
-    const baseUrl = 'https://api.asgardeo.io/t/demo';
+    const baseUrl = 'https://localhost:8090';
     await updateMeProfile({baseUrl, method: 'PUT' as any, payload: {z: 9}});
 
     const [, init]: [string, RequestInit] = (fetch as unknown as Mock).mock.calls[0];

--- a/sdks/javascript/src/api/__tests__/updateOrganization.test.ts
+++ b/sdks/javascript/src/api/__tests__/updateOrganization.test.ts
@@ -28,7 +28,7 @@ interface PatchOp {
 }
 
 describe('updateOrganization', (): void => {
-  const baseUrl = 'https://api.asgardeo.io/t/demo';
+  const baseUrl = 'https://localhost:8090';
   const organizationId = '0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1';
 
   beforeEach((): void => {

--- a/sdks/javascript/src/api/createOrganization.ts
+++ b/sdks/javascript/src/api/createOrganization.ts
@@ -74,7 +74,7 @@ export interface CreateOrganizationConfig extends Omit<RequestInit, 'method' | '
  * // Using default fetch
  * try {
  *   const organization = await createOrganization({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     payload: {
  *       description: "Share your screens",
  *       name: "Team Viewer",
@@ -96,7 +96,7 @@ export interface CreateOrganizationConfig extends Omit<RequestInit, 'method' | '
  * // Using custom fetcher (e.g., axios-based httpClient)
  * try {
  *   const organization = await createOrganization({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     payload: {
  *       description: "Share your screens",
  *       name: "Team Viewer",

--- a/sdks/javascript/src/api/executeEmbeddedSignUpFlow.ts
+++ b/sdks/javascript/src/api/executeEmbeddedSignUpFlow.ts
@@ -30,7 +30,7 @@ import {EmbeddedFlowType, EmbeddedFlowExecuteResponse, EmbeddedFlowExecuteReques
  * ```typescript
  * try {
  *   const embeddedSignUpResponse = await executeEmbeddedSignUpFlow({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/api/server/v1/flow/execute",
+ *     url: "https://localhost:8090/api/server/v1/flow/execute",
  *     payload: {
  *       flowType: "REGISTRATION"
  *     }

--- a/sdks/javascript/src/api/getAllOrganizations.ts
+++ b/sdks/javascript/src/api/getAllOrganizations.ts
@@ -56,7 +56,7 @@ export interface GetAllOrganizationsConfig extends Omit<RequestInit, 'method'> {
  * // Using default fetch
  * try {
  *   const response = await getAllOrganizations({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     filter: "",
  *     limit: 10,
  *     recursive: false
@@ -74,7 +74,7 @@ export interface GetAllOrganizationsConfig extends Omit<RequestInit, 'method'> {
  * // Using custom fetcher (e.g., axios-based httpClient)
  * try {
  *   const response = await getAllOrganizations({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     filter: "",
  *     limit: 10,
  *     recursive: false,

--- a/sdks/javascript/src/api/getBrandingPreference.ts
+++ b/sdks/javascript/src/api/getBrandingPreference.ts
@@ -59,7 +59,7 @@ export interface GetBrandingPreferenceConfig extends Omit<RequestInit, 'method'>
  * // Using default fetch
  * try {
  *   const response = await getBrandingPreference({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     locale: "en-US",
  *     name: "my-branding",
  *     type: "org"
@@ -77,7 +77,7 @@ export interface GetBrandingPreferenceConfig extends Omit<RequestInit, 'method'>
  * // Using custom fetcher (e.g., axios-based httpClient)
  * try {
  *   const response = await getBrandingPreference({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     locale: "en-US",
  *     name: "my-branding",
  *     type: "org",

--- a/sdks/javascript/src/api/getMeOrganizations.ts
+++ b/sdks/javascript/src/api/getMeOrganizations.ts
@@ -68,7 +68,7 @@ export interface GetMeOrganizationsConfig extends Omit<RequestInit, 'method'> {
  * // Using default fetch
  * try {
  *   const organizations = await getMeOrganizations({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     after: "",
  *     before: "",
  *     filter: "",
@@ -88,7 +88,7 @@ export interface GetMeOrganizationsConfig extends Omit<RequestInit, 'method'> {
  * // Using custom fetcher (e.g., axios-based httpClient)
  * try {
  *   const organizations = await getMeOrganizations({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     after: "",
  *     before: "",
  *     filter: "",

--- a/sdks/javascript/src/api/getOrganization.ts
+++ b/sdks/javascript/src/api/getOrganization.ts
@@ -67,7 +67,7 @@ export interface GetOrganizationConfig extends Omit<RequestInit, 'method'> {
  * // Using default fetch
  * try {
  *   const organization = await getOrganization({
- *     baseUrl: "https://api.asgardeo.io/t/dxlab",
+ *     baseUrl: "https://localhost:8090",
  *     organizationId: "0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1"
  *   });
  *   console.log(organization);
@@ -83,7 +83,7 @@ export interface GetOrganizationConfig extends Omit<RequestInit, 'method'> {
  * // Using custom fetcher (e.g., axios-based httpClient)
  * try {
  *   const organization = await getOrganization({
- *     baseUrl: "https://api.asgardeo.io/t/dxlab",
+ *     baseUrl: "https://localhost:8090",
  *     organizationId: "0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1",
  *     fetcher: async (url, config) => {
  *       const response = await httpClient({

--- a/sdks/javascript/src/api/getSchemas.ts
+++ b/sdks/javascript/src/api/getSchemas.ts
@@ -48,7 +48,7 @@ export interface GetSchemasConfig extends Omit<RequestInit, 'method'> {
  * // Using default fetch
  * try {
  *   const schemas = await getSchemas({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/scim2/Schemas",
+ *     url: "https://localhost:8090/scim2/Schemas",
  *   });
  *   console.log(schemas);
  * } catch (error) {
@@ -63,7 +63,7 @@ export interface GetSchemasConfig extends Omit<RequestInit, 'method'> {
  * // Using custom fetcher (e.g., axios-based httpClient)
  * try {
  *   const schemas = await getSchemas({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/scim2/Schemas",
+ *     url: "https://localhost:8090/scim2/Schemas",
  *     fetcher: async (url, config) => {
  *       const response = await httpClient({
  *         url,

--- a/sdks/javascript/src/api/getScim2Me.ts
+++ b/sdks/javascript/src/api/getScim2Me.ts
@@ -49,7 +49,7 @@ export interface GetScim2MeConfig extends Omit<RequestInit, 'method'> {
  * // Using default fetch
  * try {
  *   const userProfile = await getScim2Me({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/scim2/Me",
+ *     url: "https://localhost:8090/scim2/Me",
  *   });
  *   console.log(userProfile);
  * } catch (error) {
@@ -64,7 +64,7 @@ export interface GetScim2MeConfig extends Omit<RequestInit, 'method'> {
  * // Using custom fetcher (e.g., axios-based httpClient)
  * try {
  *   const userProfile = await getScim2Me({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/scim2/Me",
+ *     url: "https://localhost:8090/scim2/Me",
  *     fetcher: async (url, config) => {
  *       const response = await httpClient({
  *         url,

--- a/sdks/javascript/src/api/getUserInfo.ts
+++ b/sdks/javascript/src/api/getUserInfo.ts
@@ -26,7 +26,7 @@ import {User} from '../models/user';
  * @returns A promise that resolves with the user information.
  * @throw
  *   const userInfo = await getUserInfo({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/oauth2/userinfo",
+ *     url: "https://localhost:8090/oauth2/userinfo",
  *   });
  *   console.log(userInfo);
  * } catch (error) {

--- a/sdks/javascript/src/api/initializeEmbeddedSignInFlow.ts
+++ b/sdks/javascript/src/api/initializeEmbeddedSignInFlow.ts
@@ -31,7 +31,7 @@ import {EmbeddedSignInFlowInitiateResponse} from '../models/embedded-signin-flow
  * ```typescript
  * try {
  *   const authResponse = await initializeEmbeddedSignInFlow({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/oauth2/authorize",
+ *     url: "https://localhost:8090/oauth2/authorize",
  *     payload: {
  *       response_type: "code",
  *       client_id: "your-client-id",

--- a/sdks/javascript/src/api/updateMeProfile.ts
+++ b/sdks/javascript/src/api/updateMeProfile.ts
@@ -52,7 +52,7 @@ export interface UpdateMeProfileConfig extends Omit<RequestInit, 'method' | 'bod
  * ```typescript
  * // Using default fetch
  * await updateMeProfile({
- *   url: "https://api.asgardeo.io/t/<ORG>/scim2/Me",
+ *   url: "https://localhost:8090/scim2/Me",
  *   payload: { "urn:scim:wso2:schema": { mobileNumbers: ["0777933830"] } }
  * });
  * ```
@@ -61,7 +61,7 @@ export interface UpdateMeProfileConfig extends Omit<RequestInit, 'method' | 'bod
  * ```typescript
  * // Using custom fetcher (e.g., axios-based httpClient)
  * await updateMeProfile({
- *   url: "https://api.asgardeo.io/t/<ORG>/scim2/Me",
+ *   url: "https://localhost:8090/scim2/Me",
  *   payload: { "urn:scim:wso2:schema": { mobileNumbers: ["0777933830"] } },
  *   fetcher: async (url, config) => {
  *     const response = await httpClient({

--- a/sdks/javascript/src/api/updateOrganization.ts
+++ b/sdks/javascript/src/api/updateOrganization.ts
@@ -62,14 +62,14 @@ export interface UpdateOrganizationConfig extends Omit<RequestInit, 'method' | '
  * });
  *
  * await updateOrganization({
- *   baseUrl: "https://api.asgardeo.io/t/<ORG>",
+ *   baseUrl: "https://localhost:8090",
  *   organizationId: "0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1",
  *   operations
  * });
  *
  * // Or manually specify operations
  * await updateOrganization({
- *   baseUrl: "https://api.asgardeo.io/t/<ORG>",
+ *   baseUrl: "https://localhost:8090",
  *   organizationId: "0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1",
  *   operations: [
  *     { operation: "REPLACE", path: "/name", value: "Updated Organization Name" },
@@ -82,7 +82,7 @@ export interface UpdateOrganizationConfig extends Omit<RequestInit, 'method' | '
  * ```typescript
  * // Using custom fetcher (e.g., axios-based httpClient)
  * await updateOrganization({
- *   baseUrl: "https://api.asgardeo.io/t/<ORG>",
+ *   baseUrl: "https://localhost:8090",
  *   organizationId: "0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1",
  *   operations: [
  *     { operation: "REPLACE", path: "/name", value: "Updated Organization Name" }

--- a/sdks/javascript/src/api/v2/executeEmbeddedRecoveryFlowV2.ts
+++ b/sdks/javascript/src/api/v2/executeEmbeddedRecoveryFlowV2.ts
@@ -36,7 +36,7 @@ import {EmbeddedRecoveryFlowResponse} from '../../models/v2/embedded-recovery-fl
  * ```typescript
  * // Initiate recovery flow
  * const response = await executeEmbeddedRecoveryFlowV2({
- *   baseUrl: 'https://api.asgardeo.io/t/myorg',
+ *   baseUrl: 'https://localhost:8090',
  *   payload: {
  *     flowType: 'RECOVERY',
  *     applicationId: 'my-app-id',
@@ -45,7 +45,7 @@ import {EmbeddedRecoveryFlowResponse} from '../../models/v2/embedded-recovery-fl
  *
  * // Continue recovery flow with user input
  * const nextResponse = await executeEmbeddedRecoveryFlowV2({
- *   baseUrl: 'https://api.asgardeo.io/t/myorg',
+ *   baseUrl: 'https://localhost:8090',
  *   payload: {
  *     executionId: response.executionId,
  *     action: 'submit',

--- a/sdks/javascript/src/models/config.ts
+++ b/sdks/javascript/src/models/config.ts
@@ -146,7 +146,7 @@ export interface BaseConfig<T = unknown> extends WithPreferences, WithExtensions
 
   /**
    * The base URL of the ThunderID identity server.
-   * Example: "https://api.asgardeo.io/t/{org_name}"
+   * Example: "https://localhost:8090"
    */
   baseUrl: string | undefined;
 
@@ -555,7 +555,6 @@ export interface Preferences {
   /**
    * User profile preferences for controlling user data fetching behavior.
    * TEMPORARY CONFIG
-   * TODO: Remove this once https://github.com/asgardeo/javascript/issues/412 is properly fixed.
    */
   user?: UserPreferences;
 }

--- a/sdks/javascript/src/models/v2/embedded-flow-v2.ts
+++ b/sdks/javascript/src/models/v2/embedded-flow-v2.ts
@@ -583,7 +583,7 @@ export interface ConsentPromptData {
  * @example
  * ```typescript
  * const config: EmbeddedFlowExecuteRequestConfigV2 = {
- *   baseUrl: 'https://api.asgardeo.io/t/myorg',
+ *   baseUrl: 'https://localhost:8090',
  *   payload: {
  *     flowType: 'AUTHENTICATION',
  *     inputs: { username: 'user@example.com' }

--- a/sdks/javascript/src/models/v2/embedded-signin-flow-v2.ts
+++ b/sdks/javascript/src/models/v2/embedded-signin-flow-v2.ts
@@ -279,7 +279,7 @@ export interface EmbeddedSignInFlowCompleteResponse {
  * };
  *
  * const response = await executeEmbeddedSignInFlow({
- *   baseUrl: "https://api.asgardeo.io/t/myorg",
+ *   baseUrl: "https://localhost:8090",
  *   payload: initRequest
  * });
  * ```
@@ -321,7 +321,7 @@ export interface EmbeddedSignInFlowInitiateRequest {
  *
  * // Submit to continue the flow
  * const response = await executeEmbeddedSignInFlow({
- *   baseUrl: "https://api.asgardeo.io/t/myorg",
+ *   baseUrl: "https://localhost:8090",
  *   payload: stepRequest
  * });
  * ```

--- a/sdks/javascript/src/utils/__tests__/deriveOrganizationHandleFromBaseUrl.test.ts
+++ b/sdks/javascript/src/utils/__tests__/deriveOrganizationHandleFromBaseUrl.test.ts
@@ -20,41 +20,26 @@ import ThunderIDRuntimeError from '../../errors/ThunderIDRuntimeError';
 import deriveOrganizationHandleFromBaseUrl from '../deriveOrganizationHandleFromBaseUrl';
 
 describe('deriveOrganizationHandleFromBaseUrl', () => {
-  describe('Valid asgardeo.io URLs', () => {
-    it('should extract organization handle from dev.asgardeo.io URL', () => {
-      const result: string = deriveOrganizationHandleFromBaseUrl('https://dev.asgardeo.io/t/dxlab');
-      expect(result).toBe('dxlab');
-    });
-
-    it('should extract organization handle from stage.asgardeo.io URL', () => {
-      const result: string = deriveOrganizationHandleFromBaseUrl('https://stage.asgardeo.io/t/dxlab');
-      expect(result).toBe('dxlab');
-    });
-
-    it('should extract organization handle from prod.asgardeo.io URL', () => {
-      const result: string = deriveOrganizationHandleFromBaseUrl('https://prod.asgardeo.io/t/dxlab');
-      expect(result).toBe('dxlab');
-    });
-
-    it('should extract organization handle from custom subdomain asgardeo.io URL', () => {
-      const result: string = deriveOrganizationHandleFromBaseUrl('https://xxx.asgardeo.io/t/dxlab');
+  describe('Valid ThunderID URLs', () => {
+    it('should extract organization handle from URL with /t/{org} pattern', () => {
+      const result: string = deriveOrganizationHandleFromBaseUrl('https://localhost:8090/t/dxlab');
       expect(result).toBe('dxlab');
     });
 
     it('should extract organization handle with trailing slash', () => {
-      const result: string = deriveOrganizationHandleFromBaseUrl('https://dev.asgardeo.io/t/dxlab/');
+      const result: string = deriveOrganizationHandleFromBaseUrl('https://localhost:8090/t/dxlab/');
       expect(result).toBe('dxlab');
     });
 
     it('should extract organization handle with additional path segments', () => {
-      const result: string = deriveOrganizationHandleFromBaseUrl('https://dev.asgardeo.io/t/dxlab/api/v1');
+      const result: string = deriveOrganizationHandleFromBaseUrl('https://localhost:8090/t/dxlab/api/v1');
       expect(result).toBe('dxlab');
     });
 
     it('should handle different organization handles', () => {
-      expect(deriveOrganizationHandleFromBaseUrl('https://dev.asgardeo.io/t/myorg')).toBe('myorg');
-      expect(deriveOrganizationHandleFromBaseUrl('https://dev.asgardeo.io/t/test-org')).toBe('test-org');
-      expect(deriveOrganizationHandleFromBaseUrl('https://dev.asgardeo.io/t/org123')).toBe('org123');
+      expect(deriveOrganizationHandleFromBaseUrl('https://localhost:8090/t/myorg')).toBe('myorg');
+      expect(deriveOrganizationHandleFromBaseUrl('https://localhost:8090/t/test-org')).toBe('test-org');
+      expect(deriveOrganizationHandleFromBaseUrl('https://localhost:8090/t/org123')).toBe('org123');
     });
   });
 
@@ -69,7 +54,7 @@ describe('deriveOrganizationHandleFromBaseUrl', () => {
       warnSpy.mockRestore();
     });
 
-    it('should return empty string and warn for custom domain without asgardeo.io', () => {
+    it('should return empty string and warn for URLs without /t/{org} pattern', () => {
       const result: string = deriveOrganizationHandleFromBaseUrl('https://custom.example.com/auth');
 
       expect(result).toBe('');
@@ -81,7 +66,7 @@ describe('deriveOrganizationHandleFromBaseUrl', () => {
     });
 
     it('should return empty string and warn for URLs without /t/ pattern', () => {
-      const result: string = deriveOrganizationHandleFromBaseUrl('https://auth.asgardeo.io/oauth2/token');
+      const result: string = deriveOrganizationHandleFromBaseUrl('https://localhost:8090/oauth2/token');
 
       expect(result).toBe('');
       expect(warnSpy).toHaveBeenCalled();
@@ -91,8 +76,8 @@ describe('deriveOrganizationHandleFromBaseUrl', () => {
     });
 
     it('should return empty string and warn for URLs with malformed /t/ pattern', () => {
-      const result1: string = deriveOrganizationHandleFromBaseUrl('https://dev.asgardeo.io/t/');
-      const result2: string = deriveOrganizationHandleFromBaseUrl('https://dev.asgardeo.io/t');
+      const result1: string = deriveOrganizationHandleFromBaseUrl('https://localhost:8090/t/');
+      const result2: string = deriveOrganizationHandleFromBaseUrl('https://localhost:8090/t');
 
       expect(result1).toBe('');
       expect(result2).toBe('');
@@ -100,7 +85,7 @@ describe('deriveOrganizationHandleFromBaseUrl', () => {
     });
 
     it('should return empty string and warn for URLs with empty organization handle', () => {
-      const result: string = deriveOrganizationHandleFromBaseUrl('https://dev.asgardeo.io/t//');
+      const result: string = deriveOrganizationHandleFromBaseUrl('https://localhost:8090/t//');
 
       expect(result).toBe('');
       expect(warnSpy).toHaveBeenCalled();

--- a/sdks/javascript/src/utils/__tests__/getRedirectBasedSignUpUrl.test.ts
+++ b/sdks/javascript/src/utils/__tests__/getRedirectBasedSignUpUrl.test.ts
@@ -24,8 +24,8 @@ import isRecognizedBaseUrlPattern from '../isRecognizedBaseUrlPattern';
 vi.mock('../isRecognizedBaseUrlPattern', () => ({default: vi.fn()}));
 
 describe('getRedirectBasedSignUpUrl', () => {
-  const baseUrl = 'https://api.asgardeo.io/t/org';
-  const expectedBaseUrl = 'https://accounts.asgardeo.io/t/org';
+  const baseUrl = 'https://api.thunderid.io/t/org';
+  const expectedBaseUrl = 'https://accounts.thunderid.io/t/org';
   const clientId = 'client123';
   const applicationId = 'app456';
 

--- a/sdks/javascript/src/utils/__tests__/identifyPlatform.test.ts
+++ b/sdks/javascript/src/utils/__tests__/identifyPlatform.test.ts
@@ -30,9 +30,9 @@ describe('identifyPlatform', () => {
 
   it('should return Platform.ThunderID for recognized thunderid domains', () => {
     const configs: Config[] = [
-      {applicationId: '', baseUrl: 'https://api.asgardeo.io/t/org', clientId: ''},
-      {applicationId: '', baseUrl: 'https://accounts.asgardeo.io/t/org', clientId: ''},
-      {applicationId: '', baseUrl: 'https://asgardeo.io/t/org', clientId: ''},
+      {applicationId: '', baseUrl: 'https://api.thunderid.io/t/org', clientId: ''},
+      {applicationId: '', baseUrl: 'https://accounts.thunderid.io/t/org', clientId: ''},
+      {applicationId: '', baseUrl: 'https://thunderid.io/t/org', clientId: ''},
     ];
 
     configs.forEach((config: Config) => {

--- a/sdks/javascript/src/utils/__tests__/isRecognizedBaseUrlPattern.test.ts
+++ b/sdks/javascript/src/utils/__tests__/isRecognizedBaseUrlPattern.test.ts
@@ -24,17 +24,17 @@ vi.mock('../logger', () => ({default: {warn: vi.fn()}}));
 
 describe('isRecognizedBaseUrlPattern', () => {
   it('should return true for recognized base URL pattern', () => {
-    expect(isRecognizedBaseUrlPattern('https://dev.asgardeo.io/t/dxlab')).toBe(true);
+    expect(isRecognizedBaseUrlPattern('https://localhost:8090/t/dxlab')).toBe(true);
     expect(isRecognizedBaseUrlPattern('https://example.com/t/org')).toBe(true);
     expect(isRecognizedBaseUrlPattern('https://foo.com/t/bar/')).toBe(true);
     expect(isRecognizedBaseUrlPattern('https://foo.com/t/bar/extra')).toBe(true);
   });
 
   it('should return false for unrecognized base URL pattern', () => {
-    expect(isRecognizedBaseUrlPattern('https://dev.asgardeo.io/tenant/dxlab')).toBe(false);
-    expect(isRecognizedBaseUrlPattern('https://dev.asgardeo.io/')).toBe(false);
-    expect(isRecognizedBaseUrlPattern('https://dev.asgardeo.io/t')).toBe(false);
-    expect(isRecognizedBaseUrlPattern('https://dev.asgardeo.io/other/path')).toBe(false);
+    expect(isRecognizedBaseUrlPattern('https://localhost:8090/tenant/dxlab')).toBe(false);
+    expect(isRecognizedBaseUrlPattern('https://localhost:8090/')).toBe(false);
+    expect(isRecognizedBaseUrlPattern('https://localhost:8090/t')).toBe(false);
+    expect(isRecognizedBaseUrlPattern('https://localhost:8090/other/path')).toBe(false);
   });
 
   it('should throw ThunderIDRuntimeError if baseUrl is undefined', () => {

--- a/sdks/javascript/src/utils/deriveOrganizationHandleFromBaseUrl.ts
+++ b/sdks/javascript/src/utils/deriveOrganizationHandleFromBaseUrl.ts
@@ -20,13 +20,9 @@ import logger from './logger';
 import ThunderIDRuntimeError from '../errors/ThunderIDRuntimeError';
 
 /**
- * Extracts the organization handle from an ThunderID base URL.
+ * Extracts the organization handle from a ThunderID base URL.
  *
- * This function parses ThunderID URLs with the standard pattern:
- * - https://dev.asgardeo.io/t/{orgHandle}
- * - https://stage.asgardeo.io/t/{orgHandle}
- * - https://prod.asgardeo.io/t/{orgHandle}
- * - https://{subdomain}.asgardeo.io/t/{orgHandle}
+ * Parses URLs following the `/t/{orgHandle}` pattern.
  *
  * @param baseUrl - The base URL of the ThunderID identity server
  * @returns The extracted organization handle
@@ -35,12 +31,8 @@ import ThunderIDRuntimeError from '../errors/ThunderIDRuntimeError';
  *
  * @example
  * ```typescript
- * // Standard ThunderID URLs
- * const handle1 = deriveOrganizationHandleFromBaseUrl('https://dev.asgardeo.io/t/dxlab');
+ * const handle = deriveOrganizationHandleFromBaseUrl('https://localhost:8090/t/dxlab');
  * // Returns: 'dxlab'
- *
- * const handle2 = deriveOrganizationHandleFromBaseUrl('https://stage.asgardeo.io/t/myorg');
- * // Returns: 'myorg'
  *
  * // Custom domain - returns empty string with a warning
  * const handle2 = deriveOrganizationHandleFromBaseUrl('https://custom.example.com/auth');

--- a/sdks/javascript/src/utils/identifyPlatform.ts
+++ b/sdks/javascript/src/utils/identifyPlatform.ts
@@ -37,7 +37,7 @@ const identifyPlatform = (config: Config): Platform => {
     if (isRecognizedBaseUrlPattern(baseUrl)) {
       try {
         const url: URL = new URL(baseUrl);
-        // Check for asgardeo domain (e.g., api.asgardeo.io, etc.)
+        // Check for thunderid.io domain
         if (/\.thunderid\.io$/i.test(url.hostname) || /thunderid\.io$/i.test(url.hostname)) {
           return Platform.ThunderID;
         }

--- a/sdks/javascript/src/utils/isRecognizedBaseUrlPattern.ts
+++ b/sdks/javascript/src/utils/isRecognizedBaseUrlPattern.ts
@@ -29,7 +29,7 @@ import ThunderIDRuntimeError from '../errors/ThunderIDRuntimeError';
  * @returns boolean - true if sensible fallbacks can be used, false otherwise
  *
  * @example
- * isRecognizedBaseUrlPattern('https://dev.asgardeo.io/t/dxlab'); // true
+ * isRecognizedBaseUrlPattern('https://localhost:8090/t/dxlab'); // true
  * isRecognizedBaseUrlPattern('https://custom.example.com/auth'); // false
  */
 const isRecognizedBaseUrlPattern = (baseUrl: string | undefined): boolean => {

--- a/sdks/nuxt/src/runtime/types.ts
+++ b/sdks/nuxt/src/runtime/types.ts
@@ -40,7 +40,7 @@ export interface ThunderIDNuxtConfig {
    * URL when present. Mirrors `applicationId` in the React/Next.js SDKs.
    */
   applicationId?: string;
-  /** Base URL of the ThunderID org tenant (e.g. https://api.asgardeo.io/t/your_org) */
+  /** Base URL of the ThunderID org tenant (e.g. https://localhost:8090) */
   baseUrl?: string;
   /** OAuth2 Client ID */
   clientId?: string;

--- a/sdks/nuxt/tests/unit/signin-post.test.ts
+++ b/sdks/nuxt/tests/unit/signin-post.test.ts
@@ -34,14 +34,14 @@ import {
 const state = vi.hoisted(() => ({
   cookieStore: {} as Record<string, string>,
   tempCookie: undefined as string | undefined,
-  mockAuthorizeUrl: 'https://api.asgardeo.io/t/org/oauth2/authorize?code_challenge=x',
+  mockAuthorizeUrl: 'https://localhost:8090/oauth2/authorize?code_challenge=x',
   liveSession: null as any,
 }));
 
 const mockClientInstance = vi.hoisted(() => ({
   getAuthorizeRequestUrl: vi
     .fn<() => Promise<string>>()
-    .mockResolvedValue('https://api.asgardeo.io/t/org/oauth2/authorize?code_challenge=x'),
+    .mockResolvedValue('https://localhost:8090/oauth2/authorize?code_challenge=x'),
   signIn: vi.fn<() => Promise<any>>().mockResolvedValue(undefined),
 }));
 
@@ -118,7 +118,7 @@ describe('POST /api/auth/signin', () => {
       const result = await (signinHandler as any)(mockEvent);
 
       expect(result.success).toBe(true);
-      expect(result.data.signInUrl).toBe('https://api.asgardeo.io/t/org/oauth2/authorize?code_challenge=x');
+      expect(result.data.signInUrl).toBe('https://localhost:8090/oauth2/authorize?code_challenge=x');
     });
 
     it('mints a temp session cookie when no existing session', async () => {

--- a/sdks/nuxt/tests/unit/thunderid-ssr.test.ts
+++ b/sdks/nuxt/tests/unit/thunderid-ssr.test.ts
@@ -72,7 +72,7 @@ vi.mock('h3', () => ({
 
 vi.mock('#imports', () => ({
   useRuntimeConfig: vi.fn(() => ({
-    public: {thunderid: {baseUrl: 'https://api.asgardeo.io/t/testorg', preferences: undefined}},
+    public: {thunderid: {baseUrl: 'https://localhost:8090', preferences: undefined}},
   })),
 }));
 
@@ -159,7 +159,7 @@ describe('thunderid-ssr Nitro plugin', () => {
     // Default runtime config — all preferences enabled (undefined = default true).
     vi.mocked(useRuntimeConfig).mockReturnValue({
       public: {
-        thunderid: {baseUrl: 'https://api.asgardeo.io/t/testorg', clientId: 'test-client-id', preferences: undefined},
+        thunderid: {baseUrl: 'https://localhost:8090', clientId: 'test-client-id', preferences: undefined},
       },
     } as any);
 
@@ -248,7 +248,7 @@ describe('thunderid-ssr Nitro plugin', () => {
     vi.mocked(useRuntimeConfig).mockReturnValue({
       public: {
         thunderid: {
-          baseUrl: 'https://api.asgardeo.io/t/testorg',
+          baseUrl: 'https://localhost:8090',
           preferences: {user: {fetchUserProfile: false}},
         },
       },
@@ -267,7 +267,7 @@ describe('thunderid-ssr Nitro plugin', () => {
     vi.mocked(useRuntimeConfig).mockReturnValue({
       public: {
         thunderid: {
-          baseUrl: 'https://api.asgardeo.io/t/testorg',
+          baseUrl: 'https://localhost:8090',
           preferences: {user: {fetchOrganizations: false}},
         },
       },
@@ -288,7 +288,7 @@ describe('thunderid-ssr Nitro plugin', () => {
     vi.mocked(useRuntimeConfig).mockReturnValue({
       public: {
         thunderid: {
-          baseUrl: 'https://api.asgardeo.io/t/testorg',
+          baseUrl: 'https://localhost:8090',
           preferences: {theme: {inheritFromBranding: false}},
         },
       },
@@ -347,7 +347,7 @@ describe('thunderid-ssr Nitro plugin', () => {
 
     const event = await callHandler('/', 'valid-cookie');
 
-    expect(event.context.thunderid.ssr.resolvedBaseUrl).toBe('https://api.asgardeo.io/t/testorg/o');
+    expect(event.context.thunderid.ssr.resolvedBaseUrl).toBe('https://localhost:8090/o');
   });
 
   it('uses plain baseUrl when session has no organizationId and ID token has no user_org', async () => {
@@ -356,7 +356,7 @@ describe('thunderid-ssr Nitro plugin', () => {
 
     const event = await callHandler('/', 'valid-cookie');
 
-    expect(event.context.thunderid.ssr.resolvedBaseUrl).toBe('https://api.asgardeo.io/t/testorg');
+    expect(event.context.thunderid.ssr.resolvedBaseUrl).toBe('https://localhost:8090');
   });
 
   it('sets resolvedBaseUrl to baseUrl/o when ID token contains user_org claim', async () => {
@@ -364,6 +364,6 @@ describe('thunderid-ssr Nitro plugin', () => {
 
     const event = await callHandler('/', 'valid-cookie');
 
-    expect(event.context.thunderid.ssr.resolvedBaseUrl).toBe('https://api.asgardeo.io/t/testorg/o');
+    expect(event.context.thunderid.ssr.resolvedBaseUrl).toBe('https://localhost:8090/o');
   });
 });

--- a/sdks/nuxt/tests/unit/token-refresh.test.ts
+++ b/sdks/nuxt/tests/unit/token-refresh.test.ts
@@ -67,7 +67,7 @@ const fakeEvent = {} as Parameters<typeof getValidAccessToken>[0];
 const mockConfig = {
   public: {
     thunderid: {
-      baseUrl: 'https://api.asgardeo.io/t/testorg',
+      baseUrl: 'https://localhost:8090',
       clientId: 'test-client-id',
     },
   },
@@ -177,7 +177,7 @@ describe('getValidAccessToken — successful refresh', () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://api.asgardeo.io/t/testorg/oauth2/token');
+    expect(url).toBe('https://localhost:8090/oauth2/token');
     expect(init.method).toBe('POST');
 
     const bodyParams = new URLSearchParams(init.body as string);

--- a/sdks/react/src/ThunderIDReactClient.ts
+++ b/sdks/react/src/ThunderIDReactClient.ts
@@ -264,7 +264,6 @@ class ThunderIDReactClient<T extends ThunderIDReactConfig = ThunderIDReactConfig
       // NOTE: With React 19 strict mode, the initialization logic runs twice, and there's an intermittent
       // issue where the config object is not getting stored in the storage layer with Vite scaffolding.
       // Hence, we need to check if the client is initialized but the config object is empty, and reinitialize.
-      // Tracker: https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/240
       if (!config || Object.keys(config).length === 0) {
         await this.initialize(this._initializeConfig);
       }

--- a/sdks/react/src/api/createOrganization.ts
+++ b/sdks/react/src/api/createOrganization.ts
@@ -51,7 +51,7 @@ export interface CreateOrganizationConfig extends Omit<BaseCreateOrganizationCon
  * // Using default ThunderID SPA client httpClient
  * try {
  *   const organization = await createOrganization({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     payload: {
  *       description: "Share your screens",
  *       name: "Team Viewer",
@@ -73,7 +73,7 @@ export interface CreateOrganizationConfig extends Omit<BaseCreateOrganizationCon
  * // Using custom fetcher
  * try {
  *   const organization = await createOrganization({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     payload: {
  *       description: "Share your screens",
  *       name: "Team Viewer",

--- a/sdks/react/src/api/getAllOrganizations.ts
+++ b/sdks/react/src/api/getAllOrganizations.ts
@@ -51,7 +51,7 @@ export interface GetAllOrganizationsConfig extends Omit<BaseGetAllOrganizationsC
  * // Using default ThunderID SPA client httpClient
  * try {
  *   const response = await getAllOrganizations({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     filter: "",
  *     limit: 10,
  *     recursive: false
@@ -69,7 +69,7 @@ export interface GetAllOrganizationsConfig extends Omit<BaseGetAllOrganizationsC
  * // Using custom fetcher
  * try {
  *   const response = await getAllOrganizations({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     filter: "",
  *     limit: 10,
  *     recursive: false,

--- a/sdks/react/src/api/getMeOrganizations.ts
+++ b/sdks/react/src/api/getMeOrganizations.ts
@@ -51,7 +51,7 @@ export interface GetMeOrganizationsConfig extends Omit<BaseGetMeOrganizationsCon
  * // Using default ThunderID SPA client httpClient
  * try {
  *   const organizations = await getMeOrganizations({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     after: "",
  *     before: "",
  *     filter: "",
@@ -71,7 +71,7 @@ export interface GetMeOrganizationsConfig extends Omit<BaseGetMeOrganizationsCon
  * // Using custom fetcher
  * try {
  *   const organizations = await getMeOrganizations({
- *     baseUrl: "https://api.asgardeo.io/t/<ORGANIZATION>",
+ *     baseUrl: "https://localhost:8090",
  *     after: "",
  *     before: "",
  *     filter: "",

--- a/sdks/react/src/api/getOrganization.ts
+++ b/sdks/react/src/api/getOrganization.ts
@@ -51,7 +51,7 @@ export interface GetOrganizationConfig extends Omit<BaseGetOrganizationConfig, '
  * // Using default ThunderID SPA client httpClient
  * try {
  *   const organization = await getOrganization({
- *     baseUrl: "https://api.asgardeo.io/t/dxlab",
+ *     baseUrl: "https://localhost:8090",
  *     organizationId: "0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1"
  *   });
  *   console.log(organization);
@@ -67,7 +67,7 @@ export interface GetOrganizationConfig extends Omit<BaseGetOrganizationConfig, '
  * // Using custom fetcher
  * try {
  *   const organization = await getOrganization({
- *     baseUrl: "https://api.asgardeo.io/t/dxlab",
+ *     baseUrl: "https://localhost:8090",
  *     organizationId: "0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1",
  *     fetcher: customFetchFunction
  *   });

--- a/sdks/react/src/api/getSchemas.ts
+++ b/sdks/react/src/api/getSchemas.ts
@@ -51,7 +51,7 @@ export interface GetSchemasConfig extends Omit<BaseGetSchemasConfig, 'fetcher'> 
  * // Using default ThunderID SPA client httpClient
  * try {
  *   const schemas = await getSchemas({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/scim2/Schemas",
+ *     url: "https://localhost:8090/scim2/Schemas",
  *   });
  *   console.log(schemas);
  * } catch (error) {
@@ -66,7 +66,7 @@ export interface GetSchemasConfig extends Omit<BaseGetSchemasConfig, 'fetcher'> 
  * // Using custom fetcher
  * try {
  *   const schemas = await getSchemas({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/scim2/Schemas",
+ *     url: "https://localhost:8090/scim2/Schemas",
  *     fetcher: customFetchFunction
  *   });
  *   console.log(schemas);

--- a/sdks/react/src/api/getScim2Me.ts
+++ b/sdks/react/src/api/getScim2Me.ts
@@ -51,7 +51,7 @@ export interface GetScim2MeConfig extends Omit<BaseGetScim2MeConfig, 'fetcher'> 
  * // Using default ThunderID SPA client httpClient
  * try {
  *   const userProfile = await getScim2Me({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/scim2/Me",
+ *     url: "https://localhost:8090/scim2/Me",
  *   });
  *   console.log(userProfile);
  * } catch (error) {
@@ -66,7 +66,7 @@ export interface GetScim2MeConfig extends Omit<BaseGetScim2MeConfig, 'fetcher'> 
  * // Using custom fetcher
  * try {
  *   const userProfile = await getScim2Me({
- *     url: "https://api.asgardeo.io/t/<ORGANIZATION>/scim2/Me",
+ *     url: "https://localhost:8090/scim2/Me",
  *     fetcher: customFetchFunction
  *   });
  *   console.log(userProfile);

--- a/sdks/react/src/api/updateMeProfile.ts
+++ b/sdks/react/src/api/updateMeProfile.ts
@@ -50,7 +50,7 @@ export interface UpdateMeProfileConfig extends Omit<BaseUpdateMeProfileConfig, '
  * ```typescript
  * // Using default ThunderID SPA client httpClient
  * await updateMeProfile({
- *   url: "https://api.asgardeo.io/t/<ORG>/scim2/Me",
+ *   url: "https://localhost:8090/scim2/Me",
  *   payload: { "urn:scim:wso2:schema": { mobileNumbers: ["0777933830"] } }
  * });
  * ```
@@ -59,7 +59,7 @@ export interface UpdateMeProfileConfig extends Omit<BaseUpdateMeProfileConfig, '
  * ```typescript
  * // Using custom fetcher
  * await updateMeProfile({
- *   url: "https://api.asgardeo.io/t/<ORG>/scim2/Me",
+ *   url: "https://localhost:8090/scim2/Me",
  *   payload: { "urn:scim:wso2:schema": { mobileNumbers: ["0777933830"] } },
  *   fetcher: customFetchFunction
  * });

--- a/sdks/react/src/api/updateOrganization.ts
+++ b/sdks/react/src/api/updateOrganization.ts
@@ -57,14 +57,14 @@ export interface UpdateOrganizationConfig extends Omit<BaseUpdateOrganizationCon
  * });
  *
  * await updateOrganization({
- *   baseUrl: "https://api.asgardeo.io/t/<ORG>",
+ *   baseUrl: "https://localhost:8090",
  *   organizationId: "0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1",
  *   operations
  * });
  *
  * // Or manually specify operations
  * await updateOrganization({
- *   baseUrl: "https://api.asgardeo.io/t/<ORG>",
+ *   baseUrl: "https://localhost:8090",
  *   organizationId: "0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1",
  *   operations: [
  *     { operation: "REPLACE", path: "/name", value: "Updated Organization Name" },
@@ -77,7 +77,7 @@ export interface UpdateOrganizationConfig extends Omit<BaseUpdateOrganizationCon
  * ```typescript
  * // Using custom fetcher
  * await updateOrganization({
- *   baseUrl: "https://api.asgardeo.io/t/<ORG>",
+ *   baseUrl: "https://localhost:8090",
  *   organizationId: "0d5e071b-d3d3-475d-b3c6-1a20ee2fa9b1",
  *   operations: [
  *     { operation: "REPLACE", path: "/name", value: "Updated Organization Name" }

--- a/sdks/react/src/contexts/ThunderID/ThunderIDProvider.tsx
+++ b/sdks/react/src/contexts/ThunderID/ThunderIDProvider.tsx
@@ -154,7 +154,6 @@ const ThunderIDProvider: FC<PropsWithChildren<ThunderIDProviderProps>> = ({
       }
 
       // TEMPORARY: SCIM2 and Organizations endpoints are not yet supported.
-      // Tracker: https://github.com/asgardeo/javascript/issues/212
       const claims: User = extractUserClaimsFromIdToken(decodedToken) as User;
       setUser(claims);
       setUserProfile({
@@ -410,7 +409,6 @@ const ThunderIDProvider: FC<PropsWithChildren<ThunderIDProviderProps>> = ({
   // Auto-fetch branding when initialized and configured
   useEffect(() => {
     // TEMPORARY: Branding preference is not yet supported.
-    // Tracker: https://github.com/asgardeo/javascript/issues/212
     return;
 
     // Only fetch branding when explicitly enabled via preferences.theme.inheritFromBranding

--- a/sdks/react/src/hooks/useBranding.ts
+++ b/sdks/react/src/hooks/useBranding.ts
@@ -122,7 +122,7 @@ export interface UseBrandingReturn {
  * For new implementations, use BrandingProvider with useBrandingContext:
  * ```tsx
  * // In your root component
- * <BrandingProvider baseUrl="https://api.asgardeo.io/t/your-org">
+ * <BrandingProvider baseUrl="https://localhost:8090">
  *   <App />
  * </BrandingProvider>
  *


### PR DESCRIPTION
## Summary

- Replace all `api.asgardeo.io/t/<org>` example URLs with `https://localhost:8090` in JSDoc comments and test fixtures across the JavaScript, React, Browser, and Nuxt SDKs (Thunder has no tenanted paths)
- Fix `identifyPlatform.ts` stale comment and update test fixtures to use `thunderid.io` domain (which the function actually checks for)
- Rewrite `deriveOrganizationHandleFromBaseUrl` JSDoc and test suite to use `localhost:8090/t/{org}` pattern; rename describe block from "Valid asgardeo.io URLs" to "Valid ThunderID URLs"
- Update `getRedirectBasedSignUpUrl` test fixtures to use `thunderid.io`
- Rename `@asgardeo/react` webpack shim in docs to `@thunderid/react` (`asgardeo-react.cjs` → `thunderid-react.cjs`)
- Replace `--asgardeo-*` CSS variable names and `.asgardeo-*` class names with `--thunderid-*` in SDK component docs
- Update coming-soon SDK package names in docs overview (Go, Python, Android, Flutter, iOS)
- Update Postman collection variable names (`asgardeoIDPId` → `thunderidIDPId`, `asgardeo_session_token` → `thunderid_session_token`)
- Replace `@asgardeo/react` and `useAsgardeo` references in `react-sdk-sample` README
- Remove stale GitHub issue tracker comments pointing to `github.com/asgardeo/*` repos

## Test plan

- [ ] Verify `sdks/javascript` tests pass: `cd sdks/javascript && npm test` — 5 pre-existing `createTheme` failures remain (unrelated to this PR); `identifyPlatform` and `getRedirectBasedSignUpUrl` tests now pass (were failing before due to stale asgardeo.io fixtures)
- [ ] Verify no remaining `asgardeo` references in `sdks/`, `docs/`, `samples/` (excluding `releases.json`)
- [ ] Docs build: `cd docs && npm run build` to confirm webpack shim rename doesn't break the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all SDK and API documentation to reflect ThunderID branding, including CSS class names, variable naming conventions, and package references.
  * Replaced example URLs and configurations with localhost development endpoints throughout documentation and code samples.
  * Updated component theming documentation for React and Vue SDKs with new CSS variable names.

* **Chores**
  * Updated configuration files and examples to use ThunderID naming conventions across samples and test fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->