### PR TITLE
Fix ID part not visible in light mode

### DIFF
--- a/tools/npx-thunderid/src/index.ts
+++ b/tools/npx-thunderid/src/index.ts
@@ -71,7 +71,7 @@ async function main(): Promise<void> {
 
   const BRAND_BLUE = '\x1b[38;2;54;136;255m';
   const RESET = '\x1b[0m';
-  const WHITE = '\x1b[97m';
+  const GREY = '\x1b[38;2;128;128;128m';
 
   const thunderLines = [
     ' _____ _                     _           ',
@@ -89,7 +89,7 @@ async function main(): Promise<void> {
     ' _| |_| |/ / ',
     ' \\___/|___/  ',
   ];
-  const banner = thunderLines.map((t, i) => `  ${BRAND_BLUE}${t}${RESET}${WHITE}${idLines[i]}${RESET}`).join('\n');
+  const banner = thunderLines.map((t, i) => `  ${BRAND_BLUE}${t}${RESET}${GREY}${idLines[i]}${RESET}`).join('\n');
 
   intro(`\n${banner}\n\n${colors.dim('· High-performance open-source identity stack, engineered for developers')}\n`);
 


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
`ID` text wasn't visible in light mode terminals.

*Before*
<img width="603" height="397" alt="image (4)" src="https://github.com/user-attachments/assets/5dcc6d38-1a25-4bc2-a6c0-5430b3956655" />


*After*
<img width="559" height="282" alt="Screenshot 2026-05-21 at 22 25 49" src="https://github.com/user-attachments/assets/533cedca-4551-44c9-8f00-7789fc8b1730" />


### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
Make the `ID` grey.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the CLI banner's color scheme with refined styling for the identifier portion, enhancing visual clarity and distinction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->