### PR TITLE
Fix square row rendering in Agents listing view

### DIFF
--- a/frontend/apps/console/src/features/agents/components/AgentsList.tsx
+++ b/frontend/apps/console/src/features/agents/components/AgentsList.tsx
@@ -182,8 +182,8 @@ export default function AgentsList(): JSX.Element {
             pageSizeOptions={[5, 10, 25, 50]}
             disableRowSelectionOnClick
             localeText={dataGridLocaleText}
+            autoHeight
             sx={{
-              height: 'auto',
               '& .MuiDataGrid-row': {cursor: 'pointer'},
             }}
           />


### PR DESCRIPTION
## Purpose
Fixes square-cornered row rendering in the Agents listing view (`/agents`). The rows should appear as rounded cards, consistent with the Users and Groups listing views.

## Related Issues
Fixes #2954

## Approach
`AgentsList.tsx` was using `sx={{ height: 'auto' }}` on `ListingTable.DataGrid` instead of the `autoHeight` prop. Without `autoHeight`, the DataGrid does not receive the `MuiDataGrid-root--autoHeight` class, which the oxygen-ui `data-grid-card` variant relies on for proper row sizing and rounded card styling.

Changed to use `autoHeight` prop, matching the established pattern in `UsersList.tsx` and `GroupsList.tsx`.

## Checklist
- [x] Linked issue
- [x] Change is consistent with existing patterns in the codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved agents list display by optimizing grid auto-height behavior for better layout management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->