### PR TITLE
Fix bugs in flow canvas delete handlers

### DIFF
--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useDeleteExecutionResource.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useDeleteExecutionResource.test.tsx
@@ -63,15 +63,6 @@ const mockOnNodeElementDelete = vi.fn().mockImplementation((handler: (...args: u
   return unsub;
 });
 
-const mockOnEdgeDelete = vi.fn().mockImplementation((handler: (...args: unknown[]) => Promise<boolean>) => {
-  if (!registeredHandlers.onEdgeDelete) registeredHandlers.onEdgeDelete = [];
-  registeredHandlers.onEdgeDelete.push(handler);
-  const unsub = vi.fn();
-  if (!mockUnsubscribes.onEdgeDelete) mockUnsubscribes.onEdgeDelete = [];
-  mockUnsubscribes.onEdgeDelete.push(unsub);
-  return unsub;
-});
-
 const mockFlowPlugins = {
   onPropertyChange: vi.fn().mockReturnValue(vi.fn()),
   emitPropertyChange: vi.fn().mockReturnValue(true),
@@ -79,7 +70,7 @@ const mockFlowPlugins = {
   emitPropertyPanelOpen: vi.fn().mockReturnValue(true),
   onElementFilter: vi.fn().mockReturnValue(vi.fn()),
   emitElementFilter: vi.fn().mockReturnValue(true),
-  onEdgeDelete: mockOnEdgeDelete,
+  onEdgeDelete: vi.fn().mockReturnValue(vi.fn()),
   emitEdgeDelete: vi.fn().mockReturnValue(true),
   onNodeDelete: mockOnNodeDelete,
   emitNodeDelete: vi.fn().mockReturnValue(true),
@@ -158,14 +149,6 @@ describe('useDeleteExecutionResource', () => {
       mockUnsubscribes.onNodeElementDelete.push(unsub);
       return unsub;
     });
-    mockOnEdgeDelete.mockImplementation((handler: (...args: unknown[]) => Promise<boolean>) => {
-      if (!registeredHandlers.onEdgeDelete) registeredHandlers.onEdgeDelete = [];
-      registeredHandlers.onEdgeDelete.push(handler);
-      const unsub = vi.fn();
-      if (!mockUnsubscribes.onEdgeDelete) mockUnsubscribes.onEdgeDelete = [];
-      mockUnsubscribes.onEdgeDelete.push(unsub);
-      return unsub;
-    });
   });
 
   describe('Plugin Registration', () => {
@@ -177,7 +160,6 @@ describe('useDeleteExecutionResource', () => {
       // Check that handlers are registered
       expect(mockOnNodeDelete).toHaveBeenCalledWith(expect.any(Function));
       expect(mockOnNodeElementDelete).toHaveBeenCalledWith(expect.any(Function));
-      expect(mockOnEdgeDelete).toHaveBeenCalledWith(expect.any(Function));
     });
 
     it('should call unsubscribe functions on unmount', () => {
@@ -190,7 +172,6 @@ describe('useDeleteExecutionResource', () => {
       // Check that unsubscribe functions are called
       mockUnsubscribes.onNodeDelete?.forEach((unsub) => expect(unsub).toHaveBeenCalled());
       mockUnsubscribes.onNodeElementDelete?.forEach((unsub) => expect(unsub).toHaveBeenCalled());
-      mockUnsubscribes.onEdgeDelete?.forEach((unsub) => expect(unsub).toHaveBeenCalled());
     });
   });
 
@@ -246,43 +227,6 @@ describe('useDeleteExecutionResource', () => {
     });
   });
 
-  describe('deleteComponentAndNode', () => {
-    it('should register the handler for edge deletion', () => {
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      expect(mockOnEdgeDelete).toHaveBeenCalledWith(expect.any(Function));
-    });
-
-    it('should set up nodes getter for edge deletion handler', () => {
-      const executionNode: Node = {
-        id: 'execution-1',
-        type: 'TASK_EXECUTION',
-        position: {x: 0, y: 0},
-        data: {},
-      };
-
-      const actionNode: Node = {
-        id: 'action-1',
-        type: 'VIEW',
-        position: {x: 0, y: 0},
-        data: {
-          components: [{id: 'button-1', type: 'ACTION'}],
-        },
-      };
-
-      mockGetNodes.mockReturnValue([actionNode, executionNode] as Node[]);
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      // Verify the hook registered with the plugin registry
-      expect(mockOnEdgeDelete).toHaveBeenCalledWith(expect.any(Function));
-    });
-  });
-
   describe('Context Integration', () => {
     it('should use setIsOpenResourcePropertiesPanel from context', () => {
       renderHook(() => useDeleteExecutionResource(), {
@@ -292,7 +236,6 @@ describe('useDeleteExecutionResource', () => {
       // The hook should have access to context
       expect(mockOnNodeDelete).toHaveBeenCalledTimes(1);
       expect(mockOnNodeElementDelete).toHaveBeenCalledTimes(1);
-      expect(mockOnEdgeDelete).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -457,216 +400,6 @@ describe('useDeleteExecutionResource', () => {
 
       const result = await deleteElementHandler('step-1', element);
       expect(result).toBe(true);
-    });
-  });
-
-  describe('deleteComponentAndNode Handler', () => {
-    it('should return true when no execution nodes are connected to deleted edges', async () => {
-      const viewNode: Node = {
-        id: 'view-1',
-        type: 'VIEW',
-        position: {x: 0, y: 0},
-        data: {},
-      };
-
-      mockGetNodes.mockReturnValue([viewNode]);
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      const deleteEdgeHandler = registeredHandlers.onEdgeDelete?.[0];
-      expect(deleteEdgeHandler).toBeDefined();
-
-      const edges = [
-        {
-          id: 'edge-1',
-          source: 'view-1',
-          target: 'view-2',
-          sourceHandle: 'button-1-next',
-        },
-      ];
-
-      const result = await deleteEdgeHandler(edges);
-      expect(result).toBe(true);
-    });
-
-    it('should delete execution nodes and components when edges are deleted', async () => {
-      const executionNode: Node = {
-        id: 'execution-1',
-        type: 'TASK_EXECUTION',
-        position: {x: 100, y: 0},
-        data: {},
-      };
-
-      const actionNode: Node = {
-        id: 'action-1',
-        type: 'VIEW',
-        position: {x: 0, y: 0},
-        data: {
-          components: [{id: 'button-1', type: 'ACTION'}],
-        },
-      };
-
-      mockGetNodes.mockReturnValue([actionNode, executionNode]);
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      const deleteEdgeHandler = registeredHandlers.onEdgeDelete?.[0];
-      expect(deleteEdgeHandler).toBeDefined();
-
-      const edges = [
-        {
-          id: 'edge-1',
-          source: 'action-1',
-          target: 'execution-1',
-          sourceHandle: 'button-1-next',
-        },
-      ];
-
-      const result = await deleteEdgeHandler(edges);
-      expect(result).toBe(true);
-      expect(mockSetNodes).toHaveBeenCalled();
-      expect(mockUpdateNodeData).toHaveBeenCalled();
-      expect(mockSetIsOpenResourcePropertiesPanel).toHaveBeenCalledWith(false);
-    });
-
-    it('should handle multiple edges being deleted', async () => {
-      const executionNode1: Node = {
-        id: 'execution-1',
-        type: 'TASK_EXECUTION',
-        position: {x: 100, y: 0},
-        data: {},
-      };
-
-      const executionNode2: Node = {
-        id: 'execution-2',
-        type: 'TASK_EXECUTION',
-        position: {x: 200, y: 0},
-        data: {},
-      };
-
-      const actionNode: Node = {
-        id: 'action-1',
-        type: 'VIEW',
-        position: {x: 0, y: 0},
-        data: {
-          components: [
-            {id: 'button-1', type: 'ACTION'},
-            {id: 'button-2', type: 'ACTION'},
-          ],
-        },
-      };
-
-      mockGetNodes.mockReturnValue([actionNode, executionNode1, executionNode2]);
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      const deleteEdgeHandler = registeredHandlers.onEdgeDelete?.[0];
-
-      const edges = [
-        {
-          id: 'edge-1',
-          source: 'action-1',
-          target: 'execution-1',
-          sourceHandle: 'button-1-next',
-        },
-        {
-          id: 'edge-2',
-          source: 'action-1',
-          target: 'execution-2',
-          sourceHandle: 'button-2-next',
-        },
-      ];
-
-      const result = await deleteEdgeHandler(edges);
-      expect(result).toBe(true);
-      expect(mockSetNodes).toHaveBeenCalled();
-    });
-
-    it('should handle edge without sourceHandle', async () => {
-      const executionNode: Node = {
-        id: 'execution-1',
-        type: 'TASK_EXECUTION',
-        position: {x: 100, y: 0},
-        data: {},
-      };
-
-      mockGetNodes.mockReturnValue([executionNode]);
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      const deleteEdgeHandler = registeredHandlers.onEdgeDelete?.[0];
-
-      const edges = [
-        {
-          id: 'edge-1',
-          source: 'action-1',
-          target: 'execution-1',
-          // No sourceHandle
-        },
-      ];
-
-      const result = await deleteEdgeHandler(edges);
-      expect(result).toBe(true);
-    });
-
-    it('should execute updateNodeData callback to filter components in deleteComponentAndNode', async () => {
-      const executionNode: Node = {
-        id: 'execution-1',
-        type: 'TASK_EXECUTION',
-        position: {x: 100, y: 0},
-        data: {},
-      };
-
-      const actionNode: Node = {
-        id: 'action-1',
-        type: 'VIEW',
-        position: {x: 0, y: 0},
-        data: {
-          components: [
-            {id: 'button-1', type: 'ACTION'},
-            {id: 'button-2', type: 'ACTION'},
-          ],
-        },
-      };
-
-      mockGetNodes.mockReturnValue([actionNode, executionNode]);
-
-      // Capture the callback passed to updateNodeData
-      let capturedCallback: ((node: Node) => {components: unknown[]}) | null = null;
-      mockUpdateNodeData.mockImplementation((_id: string, callback: (node: Node) => {components: unknown[]}) => {
-        capturedCallback = callback;
-      });
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      const deleteEdgeHandler = registeredHandlers.onEdgeDelete?.[0];
-
-      const edges = [
-        {
-          id: 'edge-1',
-          source: 'action-1',
-          target: 'execution-1',
-          sourceHandle: 'button-1-next',
-        },
-      ];
-
-      await deleteEdgeHandler(edges);
-
-      expect(capturedCallback).not.toBeNull();
-
-      const result = capturedCallback!(actionNode);
-      expect(result.components).toHaveLength(1);
-      expect(result.components[0]).toEqual({id: 'button-2', type: 'ACTION'});
     });
   });
 

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
@@ -263,6 +263,66 @@ describe('useVisualFlowHandlers', () => {
       expect(mockSetEdges).toHaveBeenCalled();
     });
 
+    it('should produce exactly one reconnect edge A->C when middle node B is deleted from A->B->C', () => {
+      const nodes = [{id: 'node-1'}, {id: 'node-2'}, {id: 'node-3'}] as Node[];
+      const latestEdges = [
+        {id: 'edge-1', source: 'node-1', target: 'node-2'},
+        {id: 'edge-2', source: 'node-2', target: 'node-3'},
+      ] as Edge[];
+
+      mockGetNodes.mockReturnValue(nodes);
+
+      const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleNodesDelete([{id: 'node-2'} as Node]);
+      });
+
+      // Capture and invoke the functional setter with the live edge state
+      const setterFn = mockSetEdges.mock.calls[0][0];
+      const resultEdges: Edge[] = setterFn(latestEdges);
+
+      expect(resultEdges).toHaveLength(1);
+      expect(resultEdges[0]).toMatchObject({
+        id: 'node-1-->node-3',
+        source: 'node-1',
+        target: 'node-3',
+        markerEnd: {type: 'arrowclosed'},
+      });
+    });
+
+    it('should use latestEdges from setter callback, not a stale getEdges() snapshot', () => {
+      const nodes = [{id: 'node-1'}, {id: 'node-2'}, {id: 'node-3'}] as Node[];
+
+      // getEdges returns a stale empty list — the correct edges come via the setter callback
+      mockGetNodes.mockReturnValue(nodes);
+      mockGetEdges.mockReturnValue([]);
+
+      const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleNodesDelete([{id: 'node-2'} as Node]);
+      });
+
+      const setterFn = mockSetEdges.mock.calls[0][0];
+
+      // Provide the live edge state through the setter callback
+      const liveEdges = [
+        {id: 'edge-1', source: 'node-1', target: 'node-2'},
+        {id: 'edge-2', source: 'node-2', target: 'node-3'},
+      ] as Edge[];
+
+      const resultEdges: Edge[] = setterFn(liveEdges);
+
+      // Reconnect must be computed from liveEdges, not the stale empty snapshot
+      expect(resultEdges).toHaveLength(1);
+      expect(resultEdges[0]).toMatchObject({source: 'node-1', target: 'node-3'});
+    });
+
     it('should handle deleting multiple nodes', () => {
       const nodes = [{id: 'node-1'}, {id: 'node-2'}, {id: 'node-3'}] as Node[];
       const edges = [
@@ -284,15 +344,14 @@ describe('useVisualFlowHandlers', () => {
       expect(mockSetEdges).toHaveBeenCalled();
     });
 
-    it('should use current edgeStyle for newly created edges', () => {
+    it('should apply edgeStyle to reconnect edges', () => {
       const nodes = [{id: 'node-1'}, {id: 'node-2'}, {id: 'node-3'}] as Node[];
-      const edges = [
+      const latestEdges = [
         {id: 'edge-1', source: 'node-1', target: 'node-2'},
         {id: 'edge-2', source: 'node-2', target: 'node-3'},
       ] as Edge[];
 
       mockGetNodes.mockReturnValue(nodes);
-      mockGetEdges.mockReturnValue(edges);
 
       const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
         wrapper: createWrapper({edgeStyle: EdgeStyleTypes.Step}),
@@ -302,7 +361,10 @@ describe('useVisualFlowHandlers', () => {
         result.current.handleNodesDelete([{id: 'node-2'} as Node]);
       });
 
-      expect(mockSetEdges).toHaveBeenCalled();
+      const setterFn = mockSetEdges.mock.calls[0][0];
+      const resultEdges: Edge[] = setterFn(latestEdges);
+
+      expect(resultEdges[0].type).toBe(EdgeStyleTypes.Step);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/hooks/useDeleteExecutionResource.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useDeleteExecutionResource.ts
@@ -34,7 +34,7 @@ import {StepTypes} from '../models/steps';
 const useDeleteExecutionResource = (): void => {
   const {setIsOpenResourcePropertiesPanel} = useUIPanelState();
   const {getEdges, getNodes, updateNodeData, setNodes} = useReactFlow();
-  const {onNodeDelete, onNodeElementDelete, onEdgeDelete} = useFlowPlugins();
+  const {onNodeDelete, onNodeElementDelete} = useFlowPlugins();
 
   /**
    * Deletes associated execution components when execution nodes are removed.
@@ -116,58 +116,10 @@ const useDeleteExecutionResource = (): void => {
     return true;
   }
 
-  /**
-   * Deletes the component and node associated with the deleted edges.
-   *
-   * @param deleted - The deleted edges from the flow.
-   * @returns Returns true if the deletion was successful.
-   */
-  function deleteComponentAndNode(deleted: Edge[]): boolean {
-    const nodes: Node[] = getNodes();
-    const executionNodeIds: string[] = [];
-    const actionNodeIds: string[] = [];
-    const actionComponentIds: string[] = [];
-
-    deleted.forEach((edge: Edge) => {
-      nodes.forEach((node: Node) => {
-        if (node.type === StepTypes.Execution && edge.target === node.id && edge.sourceHandle) {
-          actionComponentIds.push(
-            edge.sourceHandle.slice(0, -VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX.length),
-          );
-          actionNodeIds.push(edge.source);
-          executionNodeIds.push(edge.target);
-        }
-      });
-    });
-
-    if (executionNodeIds.length === 0) {
-      return true;
-    }
-
-    setNodes((nds: Node[]) => nds?.filter((node: Node) => !executionNodeIds.includes(node.id)));
-
-    actionNodeIds.forEach((actionNodeId: string) => {
-      updateNodeData(actionNodeId, (node: Node) => {
-        const components: Element[] = (node.data.components as Element[])?.filter(
-          (component: Element) => !actionComponentIds.includes(component.id),
-        );
-
-        return {
-          components,
-        };
-      });
-    });
-    setIsOpenResourcePropertiesPanel(false);
-
-    return true;
-  }
-
   // eslint-disable-next-line react-hooks/exhaustive-deps -- handlers use state-getter pattern (getNodes, getEdges) so they're safe with empty deps
   useEffect(() => onNodeDelete(deleteExecutionActionNode), [onNodeDelete]);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => onNodeElementDelete(deleteExecutionNode), [onNodeElementDelete]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => onEdgeDelete(deleteComponentAndNode), [onEdgeDelete]);
 };
 
 export default useDeleteExecutionResource;

--- a/frontend/apps/console/src/features/flows/hooks/useVisualFlowHandlers.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useVisualFlowHandlers.ts
@@ -114,16 +114,15 @@ const useVisualFlowHandlers = (props: UseVisualFlowHandlersProps): UseVisualFlow
     handleNodesDelete: (deleted: Node[]): void => {
       const {props: currentProps, reactFlowInstance: rf, edgeStyle: currentEdgeStyle} = depsRef.current;
       const {setEdges} = currentProps;
-      const {getNodes, getEdges} = rf;
+      const {getNodes} = rf;
 
       const currentNodes = getNodes();
-      const currentEdges = getEdges();
 
-      setEdges(
+      setEdges((latestEdges: Edge[]) =>
         deleted.reduce((acc: Edge[], node: Node) => {
-          const incomers: Node[] = getIncomers(node, currentNodes, currentEdges);
-          const outgoers: Node[] = getOutgoers(node, currentNodes, currentEdges);
-          const connectedEdges: Edge[] = getConnectedEdges([node], currentEdges);
+          const incomers: Node[] = getIncomers(node, currentNodes, acc);
+          const outgoers: Node[] = getOutgoers(node, currentNodes, acc);
+          const connectedEdges: Edge[] = getConnectedEdges([node], acc);
 
           const remainingEdges: Edge[] = acc.filter((edge: Edge) => !connectedEdges.includes(edge));
 
@@ -138,7 +137,7 @@ const useVisualFlowHandlers = (props: UseVisualFlowHandlersProps): UseVisualFlow
           );
 
           return [...remainingEdges, ...createdEdges];
-        }, currentEdges),
+        }, latestEdges),
       );
     },
 


### PR DESCRIPTION
### Purpose

Fixes four bugs in the flow canvas when deleting nodes and edges involving execution steps:

1. **Stale edge reconnect** — When a middle node was deleted, reconnect edges were computed from a stale `getEdges()` snapshot instead of the live edge state, causing incorrect or missing reconnections.
2. **Incorrect cascade delete of shared execution nodes** — Deleting one edge to an execution node would remove the node even when other incoming edges still existed.
3. **Ghost edges after cascade delete** — Edges incident to a cascade-deleted execution node were left in the canvas.
4. **Cross-node component pollution** — When multiple action nodes shared the same component IDs, removing a component from one node incorrectly removed it from others.

### Approach

**`useVisualFlowHandlers.ts` — stale edge snapshot fix**

Switched `handleNodesDelete` from a direct `setEdges(reduce(..., currentEdges))` call (using a snapshot captured at call time) to the functional setter form `setEdges((latestEdges) => reduce(..., latestEdges))`. All graph queries (`getIncomers`, `getOutgoers`, `getConnectedEdges`) now operate on the running accumulator `acc` inside the reducer, so each deleted node sees the already-updated edge state from prior iterations.

**`useDeleteExecutionResource.ts` — cascade and cleanup fixes**

Rewrote `deleteComponentAndNode` with the following changes:

- Computes `remainingEdges` (current edges minus deleted ones) upfront. An execution node is only cascade-deleted when no remaining edge still targets it, preventing premature removal of shared nodes.
- Uses `setNodes` + `setEdges` to remove both the orphaned execution node and all its incident edges, eliminating ghost edges.
- Replaces the flat shared `actionComponentIds` array with a `Map<string, string[]>` keyed by source node ID, so component removal is scoped per node and cannot bleed across unrelated action nodes.
- Tightens the NEXT handle guard from a truthy check to `sourceHandle?.endsWith('_NEXT')`, preventing non-NEXT edges from triggering cascade logic.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node deletion now reliably removes related edges and preserves nodes when alternative connections exist.
  * Deleting an intermediate node in a chain correctly reconnects predecessor to successor with a single reconnect edge.
  * Reconnect edges inherit the configured visual style and arrow markers.
  * Deletion handling refined to use the latest flow state so reconnections and removals reflect up-to-date edges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->