### PR TITLE
Remove remaining Asgardeo references from docs and config

### DIFF
--- a/.agent/skills/console/SKILL.md
+++ b/.agent/skills/console/SKILL.md
@@ -51,7 +51,7 @@ All commands use the named session `-s=thunderid` so the browser persists across
 
 ## Authentication
 
-ThunderID Console requires authentication. The sign-in form is dynamically rendered by the Asgardeo SDK, so always use `snapshot` to get element refs before interacting.
+ThunderID Console requires authentication. The sign-in form is dynamically rendered by the ThunderID SDK, so always use `snapshot` to get element refs before interacting.
 
 Default credentials: `admin` / `admin`
 
@@ -224,5 +224,5 @@ playwright-cli screenshot --filename=console-users.png -s=thunderid
 
   **Important**: You must accept certs for **each origin** the console talks to. The console redirects to the gate for auth, which calls the backend. If the backend cert is not accepted in the same browser session, API calls will silently fail. Resolve the backend port from `deployment.yaml` (`server.port`) and the gate port from the console's runtime config. Accept certs for each origin before proceeding.
 
-- **Login form not visible**: The Asgardeo SDK renders the form dynamically. Take a snapshot after a brief wait. If you see a loading spinner, snapshot again after a few seconds.
+- **Login form not visible**: The ThunderID SDK renders the form dynamically. Take a snapshot after a brief wait. If you see a loading spinner, snapshot again after a few seconds.
 - **Session lost**: Run `playwright-cli list` to check active sessions. Start a new one with `playwright-cli open -s=thunderid`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ ThunderID is a lightweight user and identity management product. Go backend + Re
 - For build and running - [Makefile](Makefile) and [README.md](README.md)
 - Documentation at [docs/content](docs/content)
 
-Login Gate leverages v2 of the [Asgardeo JavaScript SDK](https://github.com/asgardeo/javascript), consumed via its published package in typical setups.
+Login Gate leverages v2 of the [ThunderID JavaScript SDK](https://github.com/thunder-id/thunderid/tree/main/sdks/javascript), consumed via its published package in typical setups.
 Clone the SDK repository only if you are developing or debugging the SDK itself, or testing the product against unreleased SDK changes.
 
 ## General Rules

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,8 +20,8 @@ backend/internal/
   consent/ application/ user/ group/ role/ ou/ idp/   # management domains
   system/               # config · database · cache · jose/jwt · security · mcp · log · i18n
 frontend/apps/
-  gate/         # login/registration SPA  (@asgardeo/react — app-native mode)
-  console/      # admin SPA               (@asgardeo/react — redirect mode)
+  gate/         # login/registration SPA  (@thunderid/react — app-native mode)
+  console/      # admin SPA               (@thunderid/react — redirect mode)
 frontend/packages/      # @thunderid/contexts · design · hooks · i18n · utils · types · logger
 samples/apps/           # react-sdk-sample · react-api-based-sample · react-vanilla-sample · wayfinder-sample
 ```
@@ -36,14 +36,14 @@ samples/apps/           # react-sdk-sample · react-api-based-sample · react-va
 
 Authentication/registration are JSON node graphs (`START → PROMPT → TASK → DECISION → COMPLETE`). The engine steps through nodes, persisting state in `runtimedb` across requests. Each `TASK` node names an executor (e.g. `"BasicAuthExecutor"`). To add one: implement `core.ExecutorInterface`, add name to `executor/constants.go`, register in `executor/init.go`.
 
-## Asgardeo React SDK
+## ThunderID React SDK
 
-| Mode | `AsgardeoProvider` props | Used in |
+| Mode | `ThunderIDProvider` props | Used in |
 |------|--------------------------|---------|
-| Redirect (ThunderID-hosted login) | `clientId` + `baseUrl` + `platform="AsgardeoV2"` | `Console`, `react-sdk-sample` |
-| App-native (Flow API) | `applicationId` + `baseUrl` + `platform="AsgardeoV2"` | `Gate`, `react-api-based-sample` |
+| Redirect (ThunderID-hosted login) | `clientId` + `baseUrl` | `Console`, `react-sdk-sample` |
+| App-native (Flow API) | `applicationId` + `baseUrl` | `Gate`, `react-api-based-sample` |
 
-`clientId` vs `applicationId` is the critical distinction. Common primitives: `useAsgardeo()`, `<SignedIn/Out>`, `<SignInButton/SignOutButton>`, `<ProtectedRoute>` (`@asgardeo/react-router@2.0`).
+`clientId` vs `applicationId` is the critical distinction. Common primitives: `useThunderID()`, `<SignedIn/Out>`, `<SignInButton/SignOutButton>`, `<ProtectedRoute>` (`@thunderid/react-router`).
 
 ## Auth Flow 
 

--- a/docs/content/community/contributing/contributing-code/documentation-development/advanced-topics.mdx
+++ b/docs/content/community/contributing/contributing-code/documentation-development/advanced-topics.mdx
@@ -180,7 +180,7 @@ const config: Config = {
   baseUrl: '/',
   
   // GitHub Pages deployment
-  organizationName: 'thunderid',
+  organizationName: 'thunder-id',
   projectName: '{{productSlug}}',
   
   // Internationalization

--- a/docs/content/sdks/node/apis/config/thunderid-node-config.mdx
+++ b/docs/content/sdks/node/apis/config/thunderid-node-config.mdx
@@ -29,14 +29,15 @@ const config: ThunderIDNodeConfig = {
 
 | Property | Type | Required | Default | Description |
 | :--- | :--- | :---: | :--- | :--- |
-| `sessionCookieExpiryTime` | `number` | ❌ | `86400` (24 hours) | Session cookie lifetime in seconds. Determines how long the session cookie remains valid after sign-in. |
+| `sessionCookie` | `SessionCookieConfig` | ❌ | — | Session cookie settings (expiry, httpOnly, sameSite, secure). |
+| `sessionCookie.expiryTime` | `number` | ❌ | `86400` (24 hours) | Session cookie lifetime in seconds. Determines how long the session cookie remains valid after sign-in. |
 
-#### Resolution Order for `sessionCookieExpiryTime`
+#### Resolution Order for `sessionCookie.expiryTime`
 
 The SDK resolves the session cookie expiry time in the following order, using the first defined value:
 
-1. The `sessionCookieExpiryTime` property in the configuration object.
-2. The `ASGARDEO_SESSION_COOKIE_EXPIRY_TIME` environment variable.
+1. The `sessionCookie.expiryTime` property in the configuration object.
+2. The `THUNDERID_SESSION_COOKIE_EXPIRY_TIME` environment variable.
 3. The built-in default of `86400` seconds (24 hours).
 
 ### Inherited Base Properties

--- a/docs/content/sdks/react/apis/components/sign-in-button.mdx
+++ b/docs/content/sdks/react/apis/components/sign-in-button.mdx
@@ -150,4 +150,4 @@ export default App
 
 ## Error Handling
 
-If sign-in fails, an `AsgardeoRuntimeError` is thrown with a descriptive message.
+If sign-in fails, a `ThunderIDRuntimeError` is thrown with a descriptive message.

--- a/docs/content/sdks/react/apis/components/sign-out-button.mdx
+++ b/docs/content/sdks/react/apis/components/sign-out-button.mdx
@@ -149,4 +149,4 @@ export default App
 ```
 
 ## Error Handling
-If sign-out fails, an `AsgardeoRuntimeError` is thrown with a descriptive message.
+If sign-out fails, a `ThunderIDRuntimeError` is thrown with a descriptive message.

--- a/docs/content/sdks/react/apis/components/sign-up-button.mdx
+++ b/docs/content/sdks/react/apis/components/sign-up-button.mdx
@@ -154,4 +154,4 @@ export default LandingPage
 
 ## Error Handling
 
-If sign-up fails, an `AsgardeoRuntimeError` is thrown with a descriptive message.
+If sign-up fails, a `ThunderIDRuntimeError` is thrown with a descriptive message.


### PR DESCRIPTION
### Purpose

Removes remaining Asgardeo branding references across documentation, architecture, and configuration files, replacing them with the correct ThunderID equivalents. References to Asgardeo as an external third-party OIDC provider (e.g., in the trusted-issuer guide) are preserved intentionally.

### Approach

Audited all files for Asgardeo references and categorised them:
- **Updated**: CSS class names (`.asgardeo-*` → `.thunderid-*`), CSS variables (`--asgardeo-*` → `--thunderid-*`), error type (`AsgardeoRuntimeError` → `ThunderIDRuntimeError`), env var (`ASGARDEO_SESSION_COOKIE_EXPIRY_TIME` → `THUNDERID_SESSION_COOKIE_EXPIRY_TIME`), hook (`useAsgardeo()` → `useThunderID()`), platform prop (`AsgardeoV2` removed — SDK defaults to `THUNDERID`), `@asgardeo/react-router` → `@thunderid/react-router`, coming-soon SDK package names, Docusaurus `organizationName`, and example URL in utilities docs.
- **Kept**: `trusted-issuer.mdx` references — Asgardeo is a legitimate external OIDC provider users may configure as a trusted issuer.

All changes are verified against the actual SDK source (`VendorConstants.VENDOR_PREFIX = 'thunderid'`, `ThunderIDRuntimeError`, `THUNDERID_SESSION_COOKIE_EXPIRY_TIME`, `useThunderID`).

### Related Issues
- Fixes #2976

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SDK references from Asgardeo to ThunderID across architecture, agent, and component documentation.
  * Updated React SDK provider configuration guidance with new property names and API methods.
  * Updated Node.js SDK session cookie configuration property structure.
  * Updated error handling documentation to reflect new error type names in authentication components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->