### PR TITLE
Add default KM configuration implementation

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -73,7 +73,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/importer"
 	"github.com/thunder-id/thunderid/internal/system/jose"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/mcp"
@@ -97,11 +97,10 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		logger.Fatal("Failed to initialize certificate service", log.Error(err))
 	}
 
-	configCryptoSvc, err := defaultkm.InitConfigProvider()
+	runtimeCryptoSvc, _, err := kmprovider.Initialize(pkiService)
 	if err != nil {
-		logger.Fatal("Failed to initialize config crypto provider", log.Error(err))
+		logger.Fatal("Failed to initialize key manager provider", log.Error(err))
 	}
-	runtimeCryptoSvc := defaultkm.NewRuntimeCryptoService(pkiService, configCryptoSvc)
 
 	jwtService, jweService, err := jose.Initialize(runtimeCryptoSvc)
 	if err != nil {

--- a/backend/internal/flow/flowexec/init.go
+++ b/backend/internal/flow/flowexec/init.go
@@ -27,7 +27,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/inboundclient"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	dbprovider "github.com/thunder-id/thunderid/internal/system/database/provider"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
 	"github.com/thunder-id/thunderid/internal/system/observability"
 	"github.com/thunder-id/thunderid/internal/system/transaction"

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -35,7 +35,7 @@ import (
 	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/observability"
 	"github.com/thunder-id/thunderid/internal/system/observability/event"

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -20,6 +20,9 @@ package flowexec
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -38,7 +41,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	i18ncore "github.com/thunder-id/thunderid/internal/system/i18n/core"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
@@ -583,18 +586,28 @@ func TestDecryptCalledForEncryptedStoredContext(t *testing.T) {
 func TestEncryptedContext_SensitiveFieldsHidden(t *testing.T) {
 	// Verifies that after encryptEngineContext, sensitive fields (appId, userId, token, inputs)
 	// are not visible in the encrypted bytes stored — matching the protection guarantee.
-	testConfig := &config.Config{
-		Crypto: config.CryptoConfig{
-			Encryption: config.EncryptionConfig{
-				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
-			},
-		},
-	}
-	config.ResetServerRuntime()
-	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+	_ = config.InitializeServerRuntime("/tmp/test", &config.Config{})
 
-	cfgSvc, err := defaultkm.InitConfigProvider()
-	assert.NoError(t, err)
+	testKey, _ := hex.DecodeString("2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580")
+
+	mockConfigCryptoService := cryptomock.NewConfigCryptoProviderMock(t)
+	mockConfigCryptoService.EXPECT().Encrypt(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, plaintext []byte) ([]byte, error) {
+			ciphertext, _, err := cryptolib.Encrypt(
+				testKey,
+				&cryptolib.AlgorithmParams{Algorithm: cryptolib.AlgorithmAESGCM},
+				plaintext,
+			)
+			if err != nil {
+				return nil, err
+			}
+			encData := defaultkm.EncryptedData{
+				Algorithm:  defaultkm.AESGCM,
+				Ciphertext: base64.StdEncoding.EncodeToString(ciphertext),
+				KeyID:      "test-kid",
+			}
+			return json.Marshal(encData)
+		})
 
 	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
 	mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -604,7 +617,7 @@ func TestEncryptedContext_SensitiveFieldsHidden(t *testing.T) {
 				_ *kmprovider.KeyRef,
 				_ cryptolib.AlgorithmParams,
 				content []byte) ([]byte, *cryptolib.CryptoDetails, error) {
-				encrypted, encErr := cfgSvc.Encrypt(ctx, content)
+				encrypted, encErr := mockConfigCryptoService.Encrypt(ctx, content)
 				return encrypted, nil, encErr
 			})
 
@@ -653,18 +666,44 @@ func TestEncryptedContext_SensitiveFieldsHidden(t *testing.T) {
 func TestEncryptDecryptRoundTrip_AllFieldsPreserved(t *testing.T) {
 	// Full encrypt → decrypt round trip through encryptEngineContext / getFlowContext decrypt path.
 	// Verifies all context fields — including the auth token — survive the cycle intact.
-	testConfig := &config.Config{
-		Crypto: config.CryptoConfig{
-			Encryption: config.EncryptionConfig{
-				Key: "2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580",
-			},
-		},
-	}
-	config.ResetServerRuntime()
-	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+	_ = config.InitializeServerRuntime("/tmp/test", &config.Config{})
 
-	cfgSvc, err := defaultkm.InitConfigProvider()
-	assert.NoError(t, err)
+	testKey, _ := hex.DecodeString("2729a7928c79371e5f312167269294a14bb0660fd166b02a408a20fa73271580")
+
+	mockConfigCryptoService := cryptomock.NewConfigCryptoProviderMock(t)
+	mockConfigCryptoService.EXPECT().Encrypt(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, plaintext []byte) ([]byte, error) {
+			ciphertext, _, err := cryptolib.Encrypt(
+				testKey,
+				&cryptolib.AlgorithmParams{Algorithm: cryptolib.AlgorithmAESGCM},
+				plaintext,
+			)
+			if err != nil {
+				return nil, err
+			}
+			encData := defaultkm.EncryptedData{
+				Algorithm:  defaultkm.AESGCM,
+				Ciphertext: base64.StdEncoding.EncodeToString(ciphertext),
+				KeyID:      "test-kid",
+			}
+			return json.Marshal(encData)
+		})
+	mockConfigCryptoService.EXPECT().Decrypt(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, encodedData []byte) ([]byte, error) {
+			var encData defaultkm.EncryptedData
+			if err := json.Unmarshal(encodedData, &encData); err != nil {
+				return nil, err
+			}
+			ciphertext, err := base64.StdEncoding.DecodeString(encData.Ciphertext)
+			if err != nil {
+				return nil, err
+			}
+			return cryptolib.Decrypt(
+				testKey,
+				cryptolib.AlgorithmParams{Algorithm: cryptolib.AlgorithmAESGCM},
+				ciphertext,
+			)
+		})
 
 	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
 	mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -673,7 +712,7 @@ func TestEncryptDecryptRoundTrip_AllFieldsPreserved(t *testing.T) {
 			_ *kmprovider.KeyRef,
 			_ cryptolib.AlgorithmParams,
 			content []byte) ([]byte, *cryptolib.CryptoDetails, error) {
-			encrypted, encErr := cfgSvc.Encrypt(ctx, content)
+			encrypted, encErr := mockConfigCryptoService.Encrypt(ctx, content)
 			return encrypted, nil, encErr
 		})
 	mockCrypto.EXPECT().Decrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -681,7 +720,7 @@ func TestEncryptDecryptRoundTrip_AllFieldsPreserved(t *testing.T) {
 			ctx context.Context,
 			_ *kmprovider.KeyRef,
 			_ cryptolib.AlgorithmParams, content []byte) ([]byte, error) {
-			return cfgSvc.Decrypt(ctx, content)
+			return mockConfigCryptoService.Decrypt(ctx, content)
 		})
 
 	flowFactory, _ := core.Initialize(cache.Initialize())

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -51,7 +51,7 @@ import (
 	i18nmgt "github.com/thunder-id/thunderid/internal/system/i18n/mgt"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/observability"
 )
 

--- a/backend/internal/oauth/jwks/init.go
+++ b/backend/internal/oauth/jwks/init.go
@@ -21,7 +21,7 @@ package jwks
 import (
 	"net/http"
 
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
 )
 

--- a/backend/internal/oauth/jwks/init_test.go
+++ b/backend/internal/oauth/jwks/init_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )
 

--- a/backend/internal/oauth/jwks/service.go
+++ b/backend/internal/oauth/jwks/service.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/cryptolib/hash"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
 

--- a/backend/internal/oauth/jwks/service_test.go
+++ b/backend/internal/oauth/jwks/service_test.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )
 

--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )
 

--- a/backend/internal/oauth/oauth2/discovery/init.go
+++ b/backend/internal/oauth/oauth2/discovery/init.go
@@ -21,7 +21,7 @@ package discovery
 import (
 	"net/http"
 
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
 )
 

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -28,7 +28,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/pkce"
 	"github.com/thunder-id/thunderid/internal/system/config"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
 

--- a/backend/internal/system/jose/init.go
+++ b/backend/internal/system/jose/init.go
@@ -23,7 +23,7 @@ package jose
 import (
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 )
 
 // Initialize initializes the JOSE services (JWT and JWE).

--- a/backend/internal/system/jose/init_test.go
+++ b/backend/internal/system/jose/init_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )
 

--- a/backend/internal/system/jose/jwe/init.go
+++ b/backend/internal/system/jose/jwe/init.go
@@ -19,7 +19,7 @@
 // Package jwe provides functionalities for handling JSON Web Encryption (JWE).
 package jwe
 
-import "github.com/thunder-id/thunderid/internal/system/kmprovider"
+import kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 
 // Initialize initializes the JWE service.
 func Initialize(cryptoProvider kmprovider.RuntimeCryptoProvider) (JWEServiceInterface, error) {

--- a/backend/internal/system/jose/jwe/service.go
+++ b/backend/internal/system/jose/jwe/service.go
@@ -28,7 +28,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
 

--- a/backend/internal/system/jose/jwe/service_test.go
+++ b/backend/internal/system/jose/jwe/service_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 

--- a/backend/internal/system/jose/jwt/init.go
+++ b/backend/internal/system/jose/jwt/init.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	httpservice "github.com/thunder-id/thunderid/internal/system/http"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 )
 
 // Initialize initializes the JWT service.

--- a/backend/internal/system/jose/jwt/init_test.go
+++ b/backend/internal/system/jose/jwt/init_test.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )
 

--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -36,7 +36,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	httpservice "github.com/thunder-id/thunderid/internal/system/http"
 	"github.com/thunder-id/thunderid/internal/system/jose/jws"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )

--- a/backend/internal/system/jose/jwt/service_test.go
+++ b/backend/internal/system/jose/jwt/service_test.go
@@ -51,7 +51,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	httpservice "github.com/thunder-id/thunderid/internal/system/http"
 	"github.com/thunder-id/thunderid/internal/system/jose/jws"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )

--- a/backend/internal/system/kmprovider/common/interface.go
+++ b/backend/internal/system/kmprovider/common/interface.go
@@ -16,8 +16,8 @@
  * under the License.
  */
 
-// Package kmprovider defines interfaces for key manager providers.
-package kmprovider
+// Package common defines interfaces for key manager providers.
+package common
 
 import (
 	"context"

--- a/backend/internal/system/kmprovider/defaultkm/config_crypto_provider.go
+++ b/backend/internal/system/kmprovider/defaultkm/config_crypto_provider.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib/hash"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 )
 
 type configCryptoService struct {

--- a/backend/internal/system/kmprovider/defaultkm/init.go
+++ b/backend/internal/system/kmprovider/defaultkm/init.go
@@ -25,9 +25,8 @@ import (
 	"sync"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
-	"github.com/thunder-id/thunderid/internal/system/log"
 )
 
 var (
@@ -41,7 +40,7 @@ var (
 // Deprecated
 func GetConfigCryptoService() (kmprovider.ConfigCryptoProvider, error) {
 	globalOnce.Do(func() {
-		_, globalCfgSvc, initErr = Initialize()
+		globalCfgSvc, initErr = initConfigProvider()
 	})
 	if initErr != nil {
 		return nil, initErr
@@ -49,24 +48,13 @@ func GetConfigCryptoService() (kmprovider.ConfigCryptoProvider, error) {
 	return globalCfgSvc, nil
 }
 
-// InitConfigProvider returns a ConfigCryptoProvider initialized from the server config.
-func InitConfigProvider() (kmprovider.ConfigCryptoProvider, error) {
-	return initConfigProvider()
-}
-
 // Initialize returns a fully wired RuntimeCryptoProvider and ConfigCryptoProvider.
-func Initialize() (kmprovider.RuntimeCryptoProvider, kmprovider.ConfigCryptoProvider, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "defaultkm"))
-
+func Initialize(pkiSvc pki.PKIServiceInterface) (
+	kmprovider.RuntimeCryptoProvider, kmprovider.ConfigCryptoProvider, error,
+) {
 	cfgSvc, err := initConfigProvider()
 	if err != nil {
 		return nil, nil, err
-	}
-
-	pkiSvc, err := pki.Initialize()
-	if err != nil {
-		logger.Warn("PKI service unavailable; asymmetric operations will fail",
-			log.String("reason", err.Error()))
 	}
 
 	runtimeSvc := NewRuntimeCryptoService(pkiSvc, cfgSvc)

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider_test.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	"github.com/thunder-id/thunderid/internal/system/i18n/core"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/pki/pkimock"
 )

--- a/backend/internal/system/kmprovider/init.go
+++ b/backend/internal/system/kmprovider/init.go
@@ -16,6 +16,19 @@
  * under the License.
  */
 
+// Package kmprovider provides the key manager provider abstraction and initialization.
 package kmprovider
 
-// TODO: Define the key manager registry and provider selection interface.
+import (
+	"github.com/thunder-id/thunderid/internal/system/kmprovider/common"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
+)
+
+// Initialize initializes and returns both RuntimeCryptoProvider and ConfigCryptoProvider.
+// The pkiService is injected as a dependency.
+// Currently hardcoded to use the default KM provider, but structured to support
+// provider selection based on server configuration in the future.
+func Initialize(pkiService pki.PKIServiceInterface) (common.RuntimeCryptoProvider, common.ConfigCryptoProvider, error) {
+	return defaultkm.Initialize(pkiService)
+}

--- a/backend/tests/mocks/crypto/cryptomock/RuntimeCryptoProvider_mock.go
+++ b/backend/tests/mocks/crypto/cryptomock/RuntimeCryptoProvider_mock.go
@@ -9,7 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 )
 
 // NewRuntimeCryptoProviderMock creates a new instance of RuntimeCryptoProviderMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.


### PR DESCRIPTION
### Purpose
We are making the crypto provider configurable, and default is set for default KM

Issue : https://github.com/thunder-id/thunderid/issues/2353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Rewrote crypto and key-management bootstrapping so PKI is initialized before runtime crypto and provider types were consolidated across the codebase.
  * Adjusted initialization entrypoints and wiring for the runtime/config crypto services.
* **Tests**
  * Updated crypto tests to match the new initialization and provider wiring, including encryption/decryption test paths.
* **Impact**
  * No user-facing behavior changes; startup still aborts on critical crypto/PKI initialization failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->