### PR TITLE
Fix Start-Service-Process to use platform-specific npm executable

### DIFF
--- a/samples/apps/wayfinder-sample/start.ps1
+++ b/samples/apps/wayfinder-sample/start.ps1
@@ -76,7 +76,10 @@ if (-not (Test-Path (Join-Path "api" "wayfinder.sqlite"))) {
 function Start-Service-Process {
     param([string]$Dir, [string]$Script, [string]$Log)
     $logPath = Join-Path $ScriptDir "logs/$Log"
-    return Start-Process -FilePath "npm" `
+    
+    $npmExecutable = if ($IsWindows -or $env:OS -match "Windows") { "npm.cmd" } else { "npm" }
+
+    return Start-Process -FilePath $npmExecutable `
         -ArgumentList @("run", $Script) `
         -WorkingDirectory (Join-Path $ScriptDir $Dir) `
         -PassThru `


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
Fixes a bug in the `start.ps1` script on Windows environments where the background services fail to start. The `Start-Process` cmdlet fails to execute `npm` because it requires the `.cmd` extension (`npm.cmd`) to recognize it as a valid Win32 application. This PR updates the script to use the correct executable based on the operating system, which also resolves the subsequent `Wait-Process` crash on the 'System Idle' process.
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
Updated the `Start-Service-Process` function inside `start.ps1` to dynamically resolve the npm executable name. Added a conditional check (`$IsWindows -or $env:OS -match "Windows"`) to assign `"npm.cmd"` on Windows machines and `"npm"` on Unix-like environments. This resolved executable is then passed to the `-FilePath` parameter of `Start-Process`.
### Related Issues
- Fixes #2985 
### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed npm executable selection for Windows platforms in the sample app startup process, ensuring the correct command is used based on the operating system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->