### PR TITLE
Allow SDK provider configuration to be overridden via config.js

### DIFF
--- a/frontend/apps/console/src/hocs/__tests__/withConfig.test.tsx
+++ b/frontend/apps/console/src/hocs/__tests__/withConfig.test.tsx
@@ -62,6 +62,7 @@ vi.mock('@thunderid/react', () => ({
     signInOptions,
     preferences,
     sendCookiesInRequests,
+    discovery,
     /* eslint-enable react/require-default-props */
   }: {
     children: React.ReactNode;
@@ -72,6 +73,7 @@ vi.mock('@thunderid/react', () => ({
     signInOptions?: Record<string, string>;
     preferences?: Record<string, unknown>;
     sendCookiesInRequests?: boolean;
+    discovery?: Record<string, unknown>;
   }) => {
     capturedProviderProps = {
       baseUrl,
@@ -81,6 +83,7 @@ vi.mock('@thunderid/react', () => ({
       signInOptions,
       preferences,
       sendCookiesInRequests,
+      discovery,
     };
     return (
       <div
@@ -339,6 +342,136 @@ describe('withConfig (console)', () => {
 
       render(<WithConfigComponent />);
       expect(capturedProviderProps.sendCookiesInRequests).toBe(false);
+    });
+  });
+
+  // --- config.sdk overrides ---
+
+  describe('sdk overrides', () => {
+    it('passes wellKnown.enabled=true by default when no sdk.discovery override', () => {
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.discovery).toEqual({wellKnown: {enabled: true}});
+    });
+
+    it('overrides discovery with config.sdk.discovery', () => {
+      mockConfig.sdk = {discovery: {wellKnown: {enabled: false}}};
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.discovery).toEqual({wellKnown: {enabled: false}});
+    });
+
+    it('overrides sendCookiesInRequests with config.sdk.sendCookiesInRequests', () => {
+      mockConfig.sdk = {sendCookiesInRequests: false};
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.sendCookiesInRequests).toBe(false);
+    });
+
+    it('config.sdk.sendCookiesInRequests=true overrides generic OIDC default of false', () => {
+      mockConfig.trusted_issuer = {hostname: 'tenant.auth0.com', port: 443, http_only: false, type: 'generic'};
+      mockConfig.sdk = {sendCookiesInRequests: true};
+      mockIsTrustedIssuerGenericOidc.mockReturnValue(true);
+      mockGetServerUrl.mockReturnValue('https://tenant.example.com:9443');
+      mockGetTrustedIssuerUrl.mockReturnValue('https://tenant.auth0.com');
+      mockGetTrustedIssuerClientId.mockReturnValue('AUTH0_CLIENT_ID');
+      mockGetClientUrl.mockReturnValue('https://tenant.example.com:9443/console');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.sendCookiesInRequests).toBe(true);
+    });
+
+    it('merges config.sdk.signInOptions on top of trusted_issuer resource param', () => {
+      mockConfig.trusted_issuer = {hostname: 'localhost', port: 8090, http_only: true};
+      mockConfig.sdk = {signInOptions: {prompt: 'login', acr_values: 'urn:example:silver'}};
+      mockGetServerUrl.mockReturnValue('http://localhost:9443');
+      mockGetTrustedIssuerUrl.mockReturnValue('http://localhost:8090');
+      mockGetTrustedIssuerClientId.mockReturnValue('FEDERATED_CONSOLE');
+      mockGetClientUrl.mockReturnValue('http://localhost:9443/console');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.signInOptions).toEqual({
+        resource: 'http://localhost:9443',
+        prompt: 'login',
+        acr_values: 'urn:example:silver',
+      });
+    });
+
+    it('sets signInOptions from config.sdk.signInOptions when no trusted_issuer', () => {
+      mockConfig.sdk = {signInOptions: {prompt: 'consent'}};
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.signInOptions).toEqual({prompt: 'consent'});
+    });
+
+    it('merges config.sdk.preferences on top of generic OIDC computed preferences', () => {
+      mockConfig.trusted_issuer = {hostname: 'tenant.auth0.com', port: 443, http_only: false, type: 'generic'};
+      mockConfig.sdk = {preferences: {resolveFromMeta: true}};
+      mockIsTrustedIssuerGenericOidc.mockReturnValue(true);
+      mockGetServerUrl.mockReturnValue('https://tenant.example.com:9443');
+      mockGetTrustedIssuerUrl.mockReturnValue('https://tenant.auth0.com');
+      mockGetTrustedIssuerClientId.mockReturnValue('AUTH0_CLIENT_ID');
+      mockGetClientUrl.mockReturnValue('https://tenant.example.com:9443/console');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.preferences).toEqual({
+        resolveFromMeta: true,
+        theme: {inheritFromBranding: false},
+      });
+    });
+
+    it('sets preferences from config.sdk.preferences when no generic OIDC', () => {
+      mockConfig.sdk = {preferences: {resolveFromMeta: false, theme: {inheritFromBranding: false}}};
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.preferences).toEqual({
+        resolveFromMeta: false,
+        theme: {inheritFromBranding: false},
+      });
+    });
+
+    it('overrides baseUrl with config.sdk.baseUrl', () => {
+      mockConfig.sdk = {baseUrl: 'https://override.example.com'};
+      mockGetTrustedIssuerUrl.mockReturnValue('https://trusted-issuer.example.com');
+      mockGetTrustedIssuerClientId.mockReturnValue('client-id');
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.baseUrl).toBe('https://override.example.com');
+    });
+
+    it('overrides clientId with config.sdk.clientId', () => {
+      mockConfig.sdk = {clientId: 'SDK_OVERRIDE_CLIENT'};
+      mockGetTrustedIssuerUrl.mockReturnValue('https://trusted-issuer.example.com');
+      mockGetTrustedIssuerClientId.mockReturnValue('TRUSTED_CLIENT');
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.clientId).toBe('SDK_OVERRIDE_CLIENT');
+    });
+
+    it('overrides afterSignInUrl with config.sdk.afterSignInUrl', () => {
+      mockConfig.sdk = {afterSignInUrl: 'https://override-redirect.example.com'};
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.afterSignInUrl).toBe('https://override-redirect.example.com');
+    });
+
+    it('overrides scopes with config.sdk.scopes', () => {
+      mockConfig.sdk = {scopes: ['openid', 'email', 'custom']};
+      mockGetTrustedIssuerScopes.mockReturnValue(['openid', 'profile']);
+      mockGetTrustedIssuerUrl.mockReturnValue('https://trusted-issuer.example.com');
+      mockGetTrustedIssuerClientId.mockReturnValue('client-id');
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.scopes).toEqual(['openid', 'email', 'custom']);
     });
   });
 });

--- a/frontend/apps/console/src/hocs/withConfig.tsx
+++ b/frontend/apps/console/src/hocs/withConfig.tsx
@@ -16,8 +16,10 @@
  * under the License.
  */
 
-import {ThunderIDProvider} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
+import {ThunderIDProvider} from '@thunderid/react';
+import type {ThunderIDProviderProps} from '@thunderid/react';
+import {merge} from 'lodash-es';
 import type {JSX, ComponentType} from 'react';
 
 export default function withConfig<P extends object>(WrappedComponent: ComponentType<P>) {
@@ -32,41 +34,40 @@ export default function withConfig<P extends object>(WrappedComponent: Component
       config,
     } = useConfig();
 
-    const signInOptions: Record<string, string> | undefined = config.trusted_issuer
-      ? {resource: getServerUrl()}
-      : undefined;
-
-    // When the trusted issuer is a generic OIDC provider, suppress the SDK's
-    // product specific bootstrap calls that would otherwise 404 / be CORS-blocked
-    // at the external authorization server: flow metadata (`{baseUrl}/flow/meta`)
-    // and branding preferences. The user profile is already derived from ID token
-    // claims under the ThunderID platform, so no additional profile configuration
-    // is required.
     const genericOidc = isTrustedIssuerGenericOidc();
-    const preferences = genericOidc
-      ? {
-          resolveFromMeta: false,
-          theme: {
-            inheritFromBranding: false,
-          },
-        }
-      : undefined;
 
-    // Generic OIDC authorization servers typically respond to the `/oauth/token`
-    // endpoint with `access-control-allow-credentials:
-    // false`, so a credentialed fetch from the browser is blocked by CORS and the
-    // SDK never sees the issued token. The ThunderID SDK defaults
-    // `sendCookiesInRequests` to `true`, which makes it issue the token request
-    // with `credentials: 'include'`. Forcing it to `false` switches the request
-    // to `credentials: 'same-origin'`, which is uncredentialed for cross-origin
-    // requests and therefore CORS-safe against any compliant OIDC provider.
-    //
-    // The field is declared on the SDK's legacy auth client config and read at
-    // runtime (see @thunderid/browser DefaultConfig and requestAccessToken),
-    // but it is not surfaced on the v2 `ThunderIDProvider` prop type. The
-    // provider spreads unknown props through to the underlying client via
-    // `...rest`, so passing it here is the SDK-supported escape hatch.
-    const genericOidcExtraProps: {sendCookiesInRequests?: boolean} = genericOidc ? {sendCookiesInRequests: false} : {};
+    // Behavioral defaults derived from app config and runtime heuristics.
+    // config.sdk values are deep-merged on top, so operators can override any of these.
+    const sdkDefaults: Partial<ThunderIDProviderProps> = {
+      discovery: {wellKnown: {enabled: true}},
+      ...(config.trusted_issuer ? {signInOptions: {resource: getServerUrl()}} : {}),
+      // When the trusted issuer is a generic OIDC provider, suppress the SDK's
+      // product-specific bootstrap calls that would otherwise 404 / be CORS-blocked
+      // at the external authorization server: flow metadata (`{baseUrl}/flow/meta`)
+      // and branding preferences. The user profile is already derived from ID token
+      // claims under the ThunderID platform, so no additional profile configuration
+      // is required.
+      ...(genericOidc
+        ? {
+            preferences: {resolveFromMeta: false, theme: {inheritFromBranding: false}},
+            // Generic OIDC authorization servers typically respond to the `/oauth/token`
+            // endpoint with `access-control-allow-credentials: false`, so a credentialed
+            // fetch from the browser is blocked by CORS and the SDK never sees the issued
+            // token. The ThunderID SDK defaults `sendCookiesInRequests` to `true`, which
+            // makes it issue the token request with `credentials: 'include'`. Forcing it
+            // to `false` switches the request to `credentials: 'same-origin'`, which is
+            // uncredentialed for cross-origin requests and therefore CORS-safe against any
+            // compliant OIDC provider.
+            //
+            // The field is not surfaced in the v2 `ThunderIDProvider` prop destructuring
+            // but is read from `...rest` at runtime (see @thunderid/browser DefaultConfig
+            // and requestAccessToken), so it is part of the supported config shape.
+            sendCookiesInRequests: false,
+          }
+        : {}),
+    };
+
+    const sdkProps = merge({}, sdkDefaults, config.sdk ?? {}) as Partial<ThunderIDProviderProps>;
 
     return (
       <ThunderIDProvider
@@ -74,14 +75,7 @@ export default function withConfig<P extends object>(WrappedComponent: Component
         clientId={getTrustedIssuerClientId() ?? (import.meta.env.VITE_THUNDER_CLIENT_ID as string)}
         afterSignInUrl={getClientUrl() ?? (import.meta.env.VITE_THUNDER_AFTER_SIGN_IN_URL as string)}
         scopes={getTrustedIssuerScopes().length > 0 ? getTrustedIssuerScopes() : undefined}
-        signInOptions={signInOptions}
-        discovery={{
-          wellKnown: {
-            enabled: true,
-          },
-        }}
-        preferences={preferences}
-        {...genericOidcExtraProps}
+        {...sdkProps}
       >
         <WrappedComponent {...props} />
       </ThunderIDProvider>

--- a/frontend/apps/gate/src/hocs/__tests__/withConfig.test.tsx
+++ b/frontend/apps/gate/src/hocs/__tests__/withConfig.test.tsx
@@ -16,39 +16,54 @@
  * under the License.
  */
 
+/* eslint-disable react/require-default-props */
 import {render} from '@testing-library/react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import withConfig from '../withConfig';
 
-// Track the baseUrl passed to ThunderIDProvider
-let capturedBaseUrl: string | undefined;
+let capturedProviderProps: Record<string, unknown> = {};
 
 function MockChild() {
   return <div data-testid="app-with-theme">App With Theme</div>;
 }
 const AppWithConfig = withConfig(MockChild);
 
-// Mock ThunderIDProvider to capture baseUrl
 vi.mock('@thunderid/react', () => ({
-  ThunderIDProvider: ({children, baseUrl}: {children: React.ReactNode; baseUrl: string}) => {
-    capturedBaseUrl = baseUrl;
+  ThunderIDProvider: ({
+    children,
+    baseUrl,
+    discovery,
+    preferences,
+    sendCookiesInRequests,
+    signInOptions,
+  }: {
+    children: React.ReactNode;
+    baseUrl?: string;
+    discovery?: Record<string, unknown>;
+    preferences?: Record<string, unknown>;
+    sendCookiesInRequests?: boolean;
+    signInOptions?: Record<string, string>;
+  }) => {
+    capturedProviderProps = {baseUrl, discovery, preferences, sendCookiesInRequests, signInOptions};
     return <div data-testid="thunderid-provider">{children}</div>;
   },
 }));
 
-// Create mock for useConfig
 const mockGetServerUrl = vi.fn();
+const mockConfig: Record<string, unknown> = {};
+
 vi.mock('@thunderid/contexts', () => ({
   useConfig: () => ({
     getServerUrl: mockGetServerUrl,
+    config: mockConfig,
   }),
 }));
 
 describe('AppWithConfig', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    capturedBaseUrl = undefined;
-    // Set up default environment variable for fallback tests
+    capturedProviderProps = {};
+    Object.keys(mockConfig).forEach((key) => delete mockConfig[key]);
     import.meta.env.VITE_THUNDER_BASE_URL = 'https://env-fallback-url.example.com';
   });
 
@@ -67,18 +82,75 @@ describe('AppWithConfig', () => {
   it('uses getServerUrl when available', () => {
     mockGetServerUrl.mockReturnValue('https://custom-server.com');
     render(<AppWithConfig />);
-    expect(capturedBaseUrl).toBe('https://custom-server.com');
+    expect(capturedProviderProps.baseUrl).toBe('https://custom-server.com');
   });
 
   it('falls back to VITE_THUNDER_BASE_URL when getServerUrl returns undefined', () => {
     mockGetServerUrl.mockReturnValue(undefined);
     render(<AppWithConfig />);
-    expect(capturedBaseUrl).toBe('https://env-fallback-url.example.com');
+    expect(capturedProviderProps.baseUrl).toBe('https://env-fallback-url.example.com');
   });
 
   it('falls back to VITE_THUNDER_BASE_URL when getServerUrl returns null', () => {
     mockGetServerUrl.mockReturnValue(null);
     render(<AppWithConfig />);
-    expect(capturedBaseUrl).toBe('https://env-fallback-url.example.com');
+    expect(capturedProviderProps.baseUrl).toBe('https://env-fallback-url.example.com');
+  });
+
+  // --- config.sdk overrides ---
+
+  describe('sdk overrides', () => {
+    it('passes no extra sdk props when config.sdk is absent', () => {
+      mockGetServerUrl.mockReturnValue('https://server-url.com');
+
+      render(<AppWithConfig />);
+      expect(capturedProviderProps.discovery).toBeUndefined();
+      expect(capturedProviderProps.preferences).toBeUndefined();
+      expect(capturedProviderProps.sendCookiesInRequests).toBeUndefined();
+      expect(capturedProviderProps.signInOptions).toBeUndefined();
+    });
+
+    it('passes config.sdk.discovery to ThunderIDProvider', () => {
+      mockConfig.sdk = {discovery: {wellKnown: {enabled: false}}};
+      mockGetServerUrl.mockReturnValue('https://server-url.com');
+
+      render(<AppWithConfig />);
+      expect(capturedProviderProps.discovery).toEqual({wellKnown: {enabled: false}});
+    });
+
+    it('passes config.sdk.sendCookiesInRequests to ThunderIDProvider', () => {
+      mockConfig.sdk = {sendCookiesInRequests: false};
+      mockGetServerUrl.mockReturnValue('https://server-url.com');
+
+      render(<AppWithConfig />);
+      expect(capturedProviderProps.sendCookiesInRequests).toBe(false);
+    });
+
+    it('passes config.sdk.signInOptions to ThunderIDProvider', () => {
+      mockConfig.sdk = {signInOptions: {prompt: 'login'}};
+      mockGetServerUrl.mockReturnValue('https://server-url.com');
+
+      render(<AppWithConfig />);
+      expect(capturedProviderProps.signInOptions).toEqual({prompt: 'login'});
+    });
+
+    it('passes config.sdk.preferences to ThunderIDProvider', () => {
+      mockConfig.sdk = {preferences: {resolveFromMeta: false, theme: {inheritFromBranding: false}}};
+      mockGetServerUrl.mockReturnValue('https://server-url.com');
+
+      render(<AppWithConfig />);
+      expect(capturedProviderProps.preferences).toEqual({
+        resolveFromMeta: false,
+        theme: {inheritFromBranding: false},
+      });
+    });
+
+    it('overrides baseUrl with config.sdk.baseUrl', () => {
+      mockConfig.sdk = {baseUrl: 'https://sdk-override.example.com'};
+      mockGetServerUrl.mockReturnValue('https://server-url.com');
+
+      render(<AppWithConfig />);
+      expect(capturedProviderProps.baseUrl).toBe('https://sdk-override.example.com');
+    });
   });
 });

--- a/frontend/apps/gate/src/hocs/withConfig.tsx
+++ b/frontend/apps/gate/src/hocs/withConfig.tsx
@@ -16,19 +16,23 @@
  * under the License.
  */
 
-import {ThunderIDProvider} from '@thunderid/react';
 import {useConfig} from '@thunderid/contexts';
+import {ThunderIDProvider} from '@thunderid/react';
+import type {ThunderIDProviderProps} from '@thunderid/react';
 import type {JSX, ComponentType} from 'react';
 
 export default function withConfig<P extends object>(WrappedComponent: ComponentType<P>) {
   return function WithConfig(props: P): JSX.Element {
-    const {getServerUrl} = useConfig();
+    const {getServerUrl, config} = useConfig();
     const applicationId = new URL(window.location.href).searchParams.get('applicationId');
+
+    const sdkProps = (config.sdk ?? {}) as Partial<ThunderIDProviderProps>;
 
     return (
       <ThunderIDProvider
         baseUrl={getServerUrl() ?? (import.meta.env.VITE_THUNDER_BASE_URL as string)}
         applicationId={applicationId!}
+        {...sdkProps}
       >
         <WrappedComponent {...props} />
       </ThunderIDProvider>

--- a/frontend/packages/contexts/src/Config/types.ts
+++ b/frontend/packages/contexts/src/Config/types.ts
@@ -214,6 +214,20 @@ export interface TrustedIssuerConfig {
 }
 
 /**
+ * Runtime overrides for the ThunderID SDK provider (ThunderIDProvider props).
+ *
+ * Accepts any valid ThunderIDProvider prop. Values are deep-merged on top of
+ * the defaults derived from the application config, so only fields that need
+ * to differ from the computed defaults must be specified.
+ * `config.sdk` takes the highest precedence — it overrides both the defaults
+ * derived from `trusted_issuer` and the identity-related props (baseUrl,
+ * clientId, afterSignInUrl, scopes) resolved from the server/client config.
+ *
+ * @public
+ */
+export type SdkConfig = Record<string, unknown>;
+
+/**
  * Runtime configuration interface that contains all configuration
  * settings for applications.
  *
@@ -238,6 +252,9 @@ export interface ProductConfig {
 
   /** Optional design configuration for theming and UI customization */
   design?: DesignConfig;
+
+  /** Optional SDK provider overrides. Values here take precedence over computed defaults. */
+  sdk?: SdkConfig;
 }
 
 /**

--- a/frontend/packages/contexts/src/index.ts
+++ b/frontend/packages/contexts/src/index.ts
@@ -17,7 +17,7 @@
  */
 
 // Export types
-export type {ProductConfig, ServerConfig, TrustedIssuerConfig, BrandConfig} from './Config/types';
+export type {ProductConfig, ServerConfig, TrustedIssuerConfig, BrandConfig, SdkConfig} from './Config/types';
 export type {ToastContextType, ToastSeverity} from './Toast/ToastContext';
 
 // Export React components and hooks


### PR DESCRIPTION
### Purpose

Operators who deploy ThunderID today have no way to customise how the ThunderID SDK provider behaves at runtime. Behavioral props such as `discovery.wellKnown.enabled`, `sendCookiesInRequests`, `signInOptions`, and `preferences` are either hardcoded or derived from build-time heuristics, requiring a rebuild to change.

This PR introduces an optional top-level `sdk` block in `window.__THUNDERID_RUNTIME_CONFIG__` that maps directly to `ThunderIDProvider` props. Values in `sdk` are applied to both the **console** and **gate** apps, so operators get a single, consistent override point across all frontend applications.

Example `config.js` usage:
```js
window.__THUNDERID_RUNTIME_CONFIG__ = {
  // ... existing config ...
  sdk: {
    discovery: { wellKnown: { enabled: false } },
    sendCookiesInRequests: false,
    signInOptions: { prompt: 'login', acr_values: 'urn:mace:incommon:iap:silver' },
    preferences: { resolveFromMeta: false, theme: { inheritFromBranding: false } },
    // identity props are also overridable:
    baseUrl: 'https://custom-auth.example.com',
  },
};
```

### Approach

**`SdkConfig` type** (`@thunderid/contexts`) — Added as `type SdkConfig = Record<string, unknown>` to match the full shape of `ThunderIDProvider` props without adding a new package dependency. Exported from `@thunderid/contexts` and added as `sdk?: SdkConfig` on `ProductConfig`.

**`withConfig.tsx`** (console) — Replaced the previous per-field conditional merge logic with:
1. A single `sdkDefaults` object (`Partial<ThunderIDProviderProps>`) that captures all behavioral defaults computed from `trusted_issuer` and the generic-OIDC heuristic.
2. `lodash-es merge()` to deep-merge `config.sdk` on top — nested objects like `preferences.theme` and `signInOptions` merge correctly without clobbering sibling keys.
3. The merged result is spread **after** the identity-related props (`baseUrl`, `clientId`, `afterSignInUrl`, `scopes`), giving `config.sdk` the highest priority. The prop order establishes the following precedence (highest to lowest): `config.sdk` → `trusted_issuer` computed values → environment variables.

The existing `trusted_issuer` behaviour is fully preserved — its computed defaults are the base that `config.sdk` overrides on top of.

**`withConfig.tsx`** (gate) — Gate has no computed behavioral defaults, so `config.sdk` is spread directly onto `ThunderIDProvider` **after** the fixed `baseUrl` and `applicationId` props. Precedence: `config.sdk` → `getServerUrl()` → environment variable.

> **Note:** This is Phase 1 of a two-phase plan. A follow-up will deprecate and remove the `trusted_issuer` config block in favour of expressing the same behaviour directly through `config.sdk`, once operators have had time to migrate.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2982

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.