### PR TITLE
Resolve runtime product name in passkey flow templates

### DIFF
--- a/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowBuilderCoreResources.test.ts
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowBuilderCoreResources.test.ts
@@ -17,12 +17,28 @@
  */
 
 import {renderHook} from '@testing-library/react';
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
 import elements from '../../data/elements.json';
 import steps from '../../data/steps.json';
-import templates from '../../data/templates.json';
-import widgets from '../../data/widgets.json';
 import useGetFlowBuilderCoreResources from '../useGetFlowBuilderCoreResources';
+
+const TEST_PRODUCT_NAME = 'TestProduct';
+
+// Mock useConfig to avoid ConfigProvider requirement.
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {
+          product_name: TEST_PRODUCT_NAME,
+        },
+      },
+    }),
+  };
+});
 
 describe('useGetFlowBuilderCoreResources', () => {
   describe('Return Structure', () => {
@@ -77,18 +93,19 @@ describe('useGetFlowBuilderCoreResources', () => {
       expect(data.steps).toEqual(steps);
     });
 
-    it('should return data containing templates from JSON file', () => {
+    it('should return data containing templates resolved from JSON file', () => {
       const {result} = renderHook(() => useGetFlowBuilderCoreResources());
 
       const {data} = result.current;
-      expect(data.templates).toEqual(templates);
+      expect(Array.isArray(data.templates)).toBe(true);
+      expect(data.templates.length).toBeGreaterThan(0);
     });
 
-    it('should return data containing widgets from JSON file', () => {
+    it('should return data containing widgets resolved from JSON file', () => {
       const {result} = renderHook(() => useGetFlowBuilderCoreResources());
 
       const {data} = result.current;
-      expect(data.widgets).toEqual(widgets);
+      expect(Array.isArray(data.widgets)).toBe(true);
     });
 
     it('should return all resource types in data object', () => {
@@ -99,6 +116,17 @@ describe('useGetFlowBuilderCoreResources', () => {
       expect(data).toHaveProperty('steps');
       expect(data).toHaveProperty('templates');
       expect(data).toHaveProperty('widgets');
+    });
+  });
+
+  describe('Brand Placeholder Substitution', () => {
+    it('should substitute {{productName}} placeholders with the configured product name', () => {
+      const {result} = renderHook(() => useGetFlowBuilderCoreResources());
+
+      const serialised = JSON.stringify(result.current.data);
+
+      expect(serialised).not.toContain('{{productName}}');
+      expect(serialised).toContain(TEST_PRODUCT_NAME);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowBuilderCoreResources.test.ts
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowBuilderCoreResources.test.ts
@@ -26,6 +26,7 @@ const TEST_PRODUCT_NAME = 'TestProduct';
 
 // Mock useConfig to avoid ConfigProvider requirement.
 vi.mock('@thunderid/contexts', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   const actual = (await importOriginal()) as Record<string, unknown>;
 
   return {

--- a/frontend/apps/console/src/features/flows/api/useGetFlowBuilderCoreResources.ts
+++ b/frontend/apps/console/src/features/flows/api/useGetFlowBuilderCoreResources.ts
@@ -16,15 +16,23 @@
  * under the License.
  */
 
+import {useConfig} from '@thunderid/contexts';
 import {useMemo} from 'react';
 import elements from '../data/elements.json';
 import steps from '../data/steps.json';
 import templates from '../data/templates.json';
 import widgets from '../data/widgets.json';
 import {type Resources} from '../models/resources';
+import updateTemplatePlaceholderReferences from '../utils/updateTemplatePlaceholderReferences';
 
 /**
  * Hook to get all the resources supported by the flow builder.
+ *
+ * Static resource JSON ships with `{{productName}}` placeholders for any
+ * branded value that must reflect the deployment's configured product name
+ * (currently the WebAuthn relying party name in passkey templates). The
+ * placeholder is resolved at load time from `config.brand.product_name` so
+ * every consumer sees the correct value without further work.
  *
  * This function calls the GET method of the following endpoint to get the resources.
  * - TODO: Fill this
@@ -34,15 +42,22 @@ import {type Resources} from '../models/resources';
  * @returns SWR response object containing the data, error, isLoading, isValidating, mutate.
  */
 const useGetFlowBuilderCoreResources = <Data = Resources>() => {
-  const data: unknown = useMemo(
-    () => ({
-      elements,
-      steps,
-      templates,
-      widgets,
-    }),
-    [],
-  );
+  const {config} = useConfig();
+  const productName = config?.brand?.product_name ?? '';
+
+  const data: unknown = useMemo(() => {
+    const [resolved] = updateTemplatePlaceholderReferences(
+      {
+        elements,
+        steps,
+        templates,
+        widgets,
+      },
+      [{key: 'productName', value: productName}],
+    );
+
+    return resolved;
+  }, [productName]);
 
   return {
     data: data as Data,

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -2397,7 +2397,7 @@
           },
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID"
+            "relyingPartyName": "{{productName}}"
           },
           "executor": {
             "name": "PasskeyAuthExecutor",
@@ -2735,7 +2735,7 @@
           },
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID"
+            "relyingPartyName": "{{productName}}"
           },
           "executor": {
             "name": "PasskeyAuthExecutor",
@@ -2894,7 +2894,7 @@
           },
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID"
+            "relyingPartyName": "{{productName}}"
           },
           "executor": {
             "name": "PasskeyAuthExecutor",
@@ -4105,7 +4105,7 @@
           },
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID"
+            "relyingPartyName": "{{productName}}"
           },
           "executor": {
             "name": "PasskeyAuthExecutor",
@@ -4636,7 +4636,7 @@
           "type": "TASK_EXECUTION",
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID",
+            "relyingPartyName": "{{productName}}",
             "authenticatorSelection": {
               "authenticatorAttachment": "platform",
               "requireResidentKey": true,
@@ -4797,7 +4797,7 @@
           "type": "TASK_EXECUTION",
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID",
+            "relyingPartyName": "{{productName}}",
             "authenticatorSelection": {
               "authenticatorAttachment": "platform",
               "requireResidentKey": true,

--- a/frontend/apps/console/src/features/login-flow/api/__tests__/useGetLoginFlowBuilderResources.test.ts
+++ b/frontend/apps/console/src/features/login-flow/api/__tests__/useGetLoginFlowBuilderResources.test.ts
@@ -20,6 +20,22 @@ import {renderHook} from '@testing-library/react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import useGetLoginFlowBuilderResources from '../useGetLoginFlowBuilderResources';
 
+// Mock useConfig to avoid ConfigProvider requirement.
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {
+          product_name: 'TestProduct',
+        },
+      },
+    }),
+  };
+});
+
 // Mock the core resources hook
 vi.mock('@/features/flows/api/useGetFlowBuilderCoreResources', () => ({
   default: vi.fn(() => ({

--- a/frontend/apps/console/src/features/login-flow/api/__tests__/useGetLoginFlowBuilderResources.test.ts
+++ b/frontend/apps/console/src/features/login-flow/api/__tests__/useGetLoginFlowBuilderResources.test.ts
@@ -22,6 +22,7 @@ import useGetLoginFlowBuilderResources from '../useGetLoginFlowBuilderResources'
 
 // Mock useConfig to avoid ConfigProvider requirement.
 vi.mock('@thunderid/contexts', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   const actual = (await importOriginal()) as Record<string, unknown>;
 
   return {

--- a/frontend/apps/console/src/features/login-flow/api/useGetLoginFlowBuilderResources.ts
+++ b/frontend/apps/console/src/features/login-flow/api/useGetLoginFlowBuilderResources.ts
@@ -16,16 +16,25 @@
  * under the License.
  */
 
+import {useConfig} from '@thunderid/contexts';
+import {useMemo} from 'react';
 import executors from '../data/executors.json';
 import steps from '../data/steps.json';
 import templates from '../data/templates.json';
 import widgets from '../data/widgets.json';
 import useGetFlowBuilderCoreResources from '@/features/flows/api/useGetFlowBuilderCoreResources';
+import updateTemplatePlaceholderReferences from '@/features/flows/utils/updateTemplatePlaceholderReferences';
 import type {Resources} from '@/features/flows/models/resources';
 
 /**
  * Hook to get the resources supported by the password recovery flow builder.
  * This hook will aggregate the core resources and the password recovery specific resources.
+ *
+ * Static resource JSON ships with `{{productName}}` placeholders for any
+ * branded value that must reflect the deployment's configured product name
+ * (currently the WebAuthn relying party name in passkey templates). The
+ * placeholder is resolved at load time from `config.brand.product_name` so
+ * every consumer sees the correct value without further work.
  *
  * This function calls the GET method of the following endpoint to get the resources.
  * - TODO: Fill this
@@ -36,15 +45,26 @@ import type {Resources} from '@/features/flows/models/resources';
  */
 const useGetLoginFlowBuilderResources = <Data = Resources>() => {
   const {data: coreResources} = useGetFlowBuilderCoreResources();
+  const {config} = useConfig();
+  const productName = config?.brand?.product_name ?? '';
+
+  const data = useMemo(() => {
+    const [resolvedLocal] = updateTemplatePlaceholderReferences(
+      {executors, steps, templates, widgets},
+      [{key: 'productName', value: productName}],
+    );
+
+    return {
+      ...coreResources,
+      steps: [...(coreResources?.steps ?? []), ...resolvedLocal.steps],
+      templates: [...(coreResources?.templates ?? []), ...resolvedLocal.templates],
+      widgets: [...(coreResources?.widgets ?? []), ...resolvedLocal.widgets],
+      executors: [...((coreResources as Resources & {executors?: unknown[]})?.executors ?? []), ...resolvedLocal.executors],
+    };
+  }, [coreResources, productName]);
 
   return {
-    data: {
-      ...coreResources,
-      steps: [...(coreResources?.steps ?? []), ...steps],
-      templates: [...(coreResources?.templates ?? []), ...templates],
-      widgets: [...(coreResources?.widgets ?? []), ...widgets],
-      executors: [...(coreResources?.executors ?? []), ...executors],
-    } as unknown as Data,
+    data: data as unknown as Data,
     error: null,
     isLoading: false,
     isValidating: false,

--- a/frontend/apps/console/src/features/login-flow/api/useGetLoginFlowBuilderResources.ts
+++ b/frontend/apps/console/src/features/login-flow/api/useGetLoginFlowBuilderResources.ts
@@ -23,8 +23,8 @@ import steps from '../data/steps.json';
 import templates from '../data/templates.json';
 import widgets from '../data/widgets.json';
 import useGetFlowBuilderCoreResources from '@/features/flows/api/useGetFlowBuilderCoreResources';
-import updateTemplatePlaceholderReferences from '@/features/flows/utils/updateTemplatePlaceholderReferences';
 import type {Resources} from '@/features/flows/models/resources';
+import updateTemplatePlaceholderReferences from '@/features/flows/utils/updateTemplatePlaceholderReferences';
 
 /**
  * Hook to get the resources supported by the password recovery flow builder.
@@ -49,17 +49,19 @@ const useGetLoginFlowBuilderResources = <Data = Resources>() => {
   const productName = config?.brand?.product_name ?? '';
 
   const data = useMemo(() => {
-    const [resolvedLocal] = updateTemplatePlaceholderReferences(
-      {executors, steps, templates, widgets},
-      [{key: 'productName', value: productName}],
-    );
+    const [resolvedLocal] = updateTemplatePlaceholderReferences({executors, steps, templates, widgets}, [
+      {key: 'productName', value: productName},
+    ]);
 
     return {
       ...coreResources,
       steps: [...(coreResources?.steps ?? []), ...resolvedLocal.steps],
       templates: [...(coreResources?.templates ?? []), ...resolvedLocal.templates],
       widgets: [...(coreResources?.widgets ?? []), ...resolvedLocal.widgets],
-      executors: [...((coreResources as Resources & {executors?: unknown[]})?.executors ?? []), ...resolvedLocal.executors],
+      executors: [
+        ...((coreResources as Resources & {executors?: unknown[]})?.executors ?? []),
+        ...resolvedLocal.executors,
+      ],
     };
   }, [coreResources, productName]);
 

--- a/frontend/apps/console/src/features/login-flow/api/useGetLoginFlowBuilderResources.ts
+++ b/frontend/apps/console/src/features/login-flow/api/useGetLoginFlowBuilderResources.ts
@@ -58,10 +58,7 @@ const useGetLoginFlowBuilderResources = <Data = Resources>() => {
       steps: [...(coreResources?.steps ?? []), ...resolvedLocal.steps],
       templates: [...(coreResources?.templates ?? []), ...resolvedLocal.templates],
       widgets: [...(coreResources?.widgets ?? []), ...resolvedLocal.widgets],
-      executors: [
-        ...((coreResources as Resources & {executors?: unknown[]})?.executors ?? []),
-        ...resolvedLocal.executors,
-      ],
+      executors: [...(coreResources?.executors ?? []), ...resolvedLocal.executors],
     };
   }, [coreResources, productName]);
 

--- a/frontend/apps/console/src/features/login-flow/data/executors.json
+++ b/frontend/apps/console/src/features/login-flow/data/executors.json
@@ -202,7 +202,7 @@
       },
       "properties": {
         "relyingPartyId": "localhost",
-        "relyingPartyName": "ThunderID"
+        "relyingPartyName": "{{productName}}"
       }
     }
   },
@@ -252,7 +252,7 @@
       },
       "properties": {
         "relyingPartyId": "localhost",
-        "relyingPartyName": "ThunderID"
+        "relyingPartyName": "{{productName}}"
       }
     }
   },

--- a/frontend/apps/console/src/features/login-flow/data/templates.json
+++ b/frontend/apps/console/src/features/login-flow/data/templates.json
@@ -1259,7 +1259,7 @@
               },
               "properties": {
                 "relyingPartyId": "localhost",
-                "relyingPartyName": "ThunderID"
+                "relyingPartyName": "{{productName}}"
               }
             }
           },
@@ -1395,7 +1395,7 @@
               },
               "properties": {
                 "relyingPartyId": "localhost",
-                "relyingPartyName": "ThunderID"
+                "relyingPartyName": "{{productName}}"
               }
             }
           },

--- a/frontend/apps/console/src/features/login-flow/data/widgets.json
+++ b/frontend/apps/console/src/features/login-flow/data/widgets.json
@@ -725,7 +725,7 @@
               },
               "properties": {
                 "relyingPartyId": "localhost",
-                "relyingPartyName": "ThunderID"
+                "relyingPartyName": "{{productName}}"
               }
             }
           },
@@ -861,7 +861,7 @@
               },
               "properties": {
                 "relyingPartyId": "localhost",
-                "relyingPartyName": "ThunderID"
+                "relyingPartyName": "{{productName}}"
               }
             }
           },


### PR DESCRIPTION
## Summary

Fixes #2995.

Resolves the only end-user-visible surface that the existing `configuration.brand.productName` mechanism could not previously reach: the WebAuthn passkey **relying-party name** shipped in the flow-builder seed JSON.

### What changed

- Replaced the literal `"ThunderID"` with the `"{{productName}}"` placeholder in 12 lines across 4 seed JSON files (`flows/data/templates.json`, `login-flow/data/{templates,executors,widgets}.json`).
- `useGetFlowBuilderCoreResources` and `useGetLoginFlowBuilderResources` now resolve the placeholder at load time using the existing `updateTemplatePlaceholderReferences` util and `config.brand.product_name` from `useConfig()`.
- Updated existing tests to mock `useConfig`, and added a substitution assertion in `useGetFlowBuilderCoreResources.test.ts`.

No new util, no new placeholder syntax — reuses the `{{key}}` mechanism already present for ID generation and i18n. Hook return shapes are unchanged.

## Test plan

- [x] `pnpm test useGetFlowBuilderCoreResources useGetLoginFlowBuilderResources` — 38/38 passing
- [ ] Full `pnpm test` and `pnpm lint` in `frontend/apps/console` — covered by CI
- [ ] Manual: with `configuration.brand.productName` overridden in Helm values, instantiate a passkey-based template and verify the relying-party-name field defaults to the configured product name in the Passkey properties panel.
- [ ] Manual: register a passkey using the resulting flow and confirm the OS-rendered passkey dialog reads the configured product name (not the literal `"ThunderID"`).