### PR TITLE
Resolve runtime product name in passkey flow templates

### DIFF
--- a/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowBuilderCoreResources.test.ts
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowBuilderCoreResources.test.ts
@@ -17,12 +17,29 @@
  */
 
 import {renderHook} from '@testing-library/react';
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
 import elements from '../../data/elements.json';
 import steps from '../../data/steps.json';
-import templates from '../../data/templates.json';
-import widgets from '../../data/widgets.json';
 import useGetFlowBuilderCoreResources from '../useGetFlowBuilderCoreResources';
+
+const TEST_PRODUCT_NAME = 'TestProduct';
+
+// Mock useConfig to avoid ConfigProvider requirement.
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const actual = (await importOriginal()) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {
+          product_name: TEST_PRODUCT_NAME,
+        },
+      },
+    }),
+  };
+});
 
 describe('useGetFlowBuilderCoreResources', () => {
   describe('Return Structure', () => {
@@ -77,18 +94,19 @@ describe('useGetFlowBuilderCoreResources', () => {
       expect(data.steps).toEqual(steps);
     });
 
-    it('should return data containing templates from JSON file', () => {
+    it('should return data containing templates resolved from JSON file', () => {
       const {result} = renderHook(() => useGetFlowBuilderCoreResources());
 
       const {data} = result.current;
-      expect(data.templates).toEqual(templates);
+      expect(Array.isArray(data.templates)).toBe(true);
+      expect(data.templates.length).toBeGreaterThan(0);
     });
 
-    it('should return data containing widgets from JSON file', () => {
+    it('should return data containing widgets resolved from JSON file', () => {
       const {result} = renderHook(() => useGetFlowBuilderCoreResources());
 
       const {data} = result.current;
-      expect(data.widgets).toEqual(widgets);
+      expect(Array.isArray(data.widgets)).toBe(true);
     });
 
     it('should return all resource types in data object', () => {
@@ -99,6 +117,17 @@ describe('useGetFlowBuilderCoreResources', () => {
       expect(data).toHaveProperty('steps');
       expect(data).toHaveProperty('templates');
       expect(data).toHaveProperty('widgets');
+    });
+  });
+
+  describe('Brand Placeholder Substitution', () => {
+    it('should substitute {{productName}} placeholders with the configured product name', () => {
+      const {result} = renderHook(() => useGetFlowBuilderCoreResources());
+
+      const serialised = JSON.stringify(result.current.data);
+
+      expect(serialised).not.toContain('{{productName}}');
+      expect(serialised).toContain(TEST_PRODUCT_NAME);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowsMeta.test.ts
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowsMeta.test.ts
@@ -17,7 +17,7 @@
  */
 
 import {renderHook} from '@testing-library/react';
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
 import actions from '../../data/actions.json';
 import elements from '../../data/elements.json';
 import steps from '../../data/steps.json';
@@ -25,6 +25,25 @@ import rawTemplates from '../../data/templates.json';
 import widgets from '../../data/widgets.json';
 import type {FlowTemplate} from '../../models/templates';
 import useGetFlowsMeta from '../useGetFlowsMeta';
+
+const TEST_PRODUCT_NAME = 'TestProduct';
+
+// Mock useConfig to avoid ConfigProvider requirement.
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const actual = (await importOriginal()) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {
+          product_name: TEST_PRODUCT_NAME,
+        },
+      },
+    }),
+  };
+});
 
 describe('useGetFlowsMeta', () => {
   describe('Return Structure', () => {
@@ -53,7 +72,16 @@ describe('useGetFlowsMeta', () => {
     it('should return all templates when no flowType filter is provided', () => {
       const {result} = renderHook(() => useGetFlowsMeta());
 
-      expect(result.current.data.templates).toEqual(rawTemplates);
+      expect(result.current.data.templates).toHaveLength((rawTemplates as FlowTemplate[]).length);
+    });
+
+    it('should substitute {{productName}} placeholders in templates with the configured product name', () => {
+      const {result} = renderHook(() => useGetFlowsMeta());
+
+      const serialised = JSON.stringify(result.current.data.templates);
+
+      expect(serialised).not.toContain('{{productName}}');
+      expect(serialised).toContain(TEST_PRODUCT_NAME);
     });
 
     it('should return actions from JSON file', () => {

--- a/frontend/apps/console/src/features/flows/api/useGetFlowBuilderCoreResources.ts
+++ b/frontend/apps/console/src/features/flows/api/useGetFlowBuilderCoreResources.ts
@@ -16,15 +16,21 @@
  * under the License.
  */
 
+import {useConfig} from '@thunderid/contexts';
 import {useMemo} from 'react';
 import elements from '../data/elements.json';
 import steps from '../data/steps.json';
 import templates from '../data/templates.json';
 import widgets from '../data/widgets.json';
 import {type Resources} from '../models/resources';
+import updateTemplatePlaceholderReferences from '../utils/updateTemplatePlaceholderReferences';
 
 /**
  * Hook to get all the resources supported by the flow builder.
+ *
+ * This resolves `{{productName}}` placeholders for any
+ * branded value that must reflect the deployment's configured product name,
+ * at load time from `config.brand.product_name`.
  *
  * This function calls the GET method of the following endpoint to get the resources.
  * - TODO: Fill this
@@ -34,15 +40,22 @@ import {type Resources} from '../models/resources';
  * @returns SWR response object containing the data, error, isLoading, isValidating, mutate.
  */
 const useGetFlowBuilderCoreResources = <Data = Resources>() => {
-  const data: unknown = useMemo(
-    () => ({
-      elements,
-      steps,
-      templates,
-      widgets,
-    }),
-    [],
-  );
+  const {config} = useConfig();
+  const productName = config?.brand?.product_name ?? '';
+
+  const data: unknown = useMemo(() => {
+    const [resolved] = updateTemplatePlaceholderReferences(
+      {
+        elements,
+        steps,
+        templates,
+        widgets,
+      },
+      [{key: 'productName', value: productName}],
+    );
+
+    return resolved;
+  }, [productName]);
 
   return {
     data: data as Data,

--- a/frontend/apps/console/src/features/flows/api/useGetFlowsMeta.ts
+++ b/frontend/apps/console/src/features/flows/api/useGetFlowsMeta.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import {useConfig} from '@thunderid/contexts';
 import {useMemo} from 'react';
 import actions from '../data/actions.json';
 import elements from '../data/elements.json';
@@ -24,6 +25,7 @@ import rawTemplates from '../data/templates.json';
 import widgets from '../data/widgets.json';
 import type {FlowType} from '../models/flows';
 import type {FlowTemplate} from '../models/templates';
+import updateTemplatePlaceholderReferences from '../utils/updateTemplatePlaceholderReferences';
 
 export interface FlowsMetaOptions {
   flowType?: FlowType;
@@ -43,6 +45,10 @@ export interface FlowsMeta {
  *
  * Templates are filtered by `flowType` when provided. Other resources are returned as-is.
  *
+ * This resolves `{{productName}}` placeholders for any
+ * branded value that must reflect the deployment's configured product name,
+ * at load time from `config.brand.product_name`.
+ *
  * TODO: Replace local data files with a REST API call (GET /flows/meta?flowType=...) when
  * the endpoint is available.
  *
@@ -50,10 +56,20 @@ export interface FlowsMeta {
  * @returns FlowsMeta object containing filtered templates and all other resource lists
  */
 const useGetFlowsMeta = (options?: FlowsMetaOptions): {data: FlowsMeta; error: null; isLoading: false} => {
-  const templates = useMemo<FlowTemplate[]>(() => {
-    const all = rawTemplates as FlowTemplate[];
-    return options?.flowType ? all.filter((t) => t.flowType === options.flowType) : all;
-  }, [options?.flowType]);
+  const {config} = useConfig();
+  const productName = config?.brand?.product_name ?? '';
+
+  const resolvedTemplates = useMemo<FlowTemplate[]>(() => {
+    const [resolved] = updateTemplatePlaceholderReferences(rawTemplates as FlowTemplate[], [
+      {key: 'productName', value: productName},
+    ]);
+    return resolved;
+  }, [productName]);
+
+  const templates = useMemo<FlowTemplate[]>(
+    () => (options?.flowType ? resolvedTemplates.filter((t) => t.flowType === options.flowType) : resolvedTemplates),
+    [resolvedTemplates, options?.flowType],
+  );
 
   const data = useMemo<FlowsMeta>(
     () => ({

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -2397,7 +2397,7 @@
           },
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID"
+            "relyingPartyName": "{{productName}}"
           },
           "executor": {
             "name": "PasskeyAuthExecutor",
@@ -2735,7 +2735,7 @@
           },
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID"
+            "relyingPartyName": "{{productName}}"
           },
           "executor": {
             "name": "PasskeyAuthExecutor",
@@ -2894,7 +2894,7 @@
           },
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID"
+            "relyingPartyName": "{{productName}}"
           },
           "executor": {
             "name": "PasskeyAuthExecutor",
@@ -4105,7 +4105,7 @@
           },
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID"
+            "relyingPartyName": "{{productName}}"
           },
           "executor": {
             "name": "PasskeyAuthExecutor",
@@ -4636,7 +4636,7 @@
           "type": "TASK_EXECUTION",
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID",
+            "relyingPartyName": "{{productName}}",
             "authenticatorSelection": {
               "authenticatorAttachment": "platform",
               "requireResidentKey": true,
@@ -4797,7 +4797,7 @@
           "type": "TASK_EXECUTION",
           "properties": {
             "relyingPartyId": "localhost",
-            "relyingPartyName": "ThunderID",
+            "relyingPartyName": "{{productName}}",
             "authenticatorSelection": {
               "authenticatorAttachment": "platform",
               "requireResidentKey": true,

--- a/frontend/apps/console/src/features/login-flow/api/__tests__/useGetLoginFlowBuilderResources.test.ts
+++ b/frontend/apps/console/src/features/login-flow/api/__tests__/useGetLoginFlowBuilderResources.test.ts
@@ -20,6 +20,23 @@ import {renderHook} from '@testing-library/react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import useGetLoginFlowBuilderResources from '../useGetLoginFlowBuilderResources';
 
+// Mock useConfig to avoid ConfigProvider requirement.
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const actual = (await importOriginal()) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {
+          product_name: 'TestProduct',
+        },
+      },
+    }),
+  };
+});
+
 // Mock the core resources hook
 vi.mock('@/features/flows/api/useGetFlowBuilderCoreResources', () => ({
   default: vi.fn(() => ({
@@ -46,7 +63,7 @@ vi.mock('../../data/steps.json', () => ({
 }));
 
 vi.mock('../../data/templates.json', () => ({
-  default: [{id: 'login-template'}],
+  default: [{id: 'login-template', relyingPartyName: '{{productName}}'}],
 }));
 
 vi.mock('../../data/widgets.json', () => ({
@@ -58,6 +75,15 @@ describe('useGetLoginFlowBuilderResources', () => {
     const {result} = renderHook(() => useGetLoginFlowBuilderResources());
 
     expect(result.current.data).toBeDefined();
+  });
+
+  it('should substitute {{productName}} placeholders in login-flow resources', () => {
+    const {result} = renderHook(() => useGetLoginFlowBuilderResources());
+
+    const serialised = JSON.stringify(result.current.data);
+
+    expect(serialised).not.toContain('{{productName}}');
+    expect(serialised).toContain('TestProduct');
   });
 
   it('should merge steps from core and login-flow', () => {
@@ -213,7 +239,7 @@ describe('useGetLoginFlowBuilderResources', () => {
       // Verify that the spread operator worked correctly and login-flow data is present
       expect(result.current.data.executors).toContainEqual({id: 'login-executor'});
       expect(result.current.data.steps).toContainEqual({id: 'login-step'});
-      expect(result.current.data.templates).toContainEqual({id: 'login-template'});
+      expect(result.current.data.templates).toContainEqual(expect.objectContaining({id: 'login-template'}));
       expect(result.current.data.widgets).toContainEqual({id: 'login-widget'});
     });
   });

--- a/frontend/apps/console/src/features/login-flow/api/useGetLoginFlowBuilderResources.ts
+++ b/frontend/apps/console/src/features/login-flow/api/useGetLoginFlowBuilderResources.ts
@@ -16,16 +16,23 @@
  * under the License.
  */
 
+import {useConfig} from '@thunderid/contexts';
+import {useMemo} from 'react';
 import executors from '../data/executors.json';
 import steps from '../data/steps.json';
 import templates from '../data/templates.json';
 import widgets from '../data/widgets.json';
 import useGetFlowBuilderCoreResources from '@/features/flows/api/useGetFlowBuilderCoreResources';
 import type {Resources} from '@/features/flows/models/resources';
+import updateTemplatePlaceholderReferences from '@/features/flows/utils/updateTemplatePlaceholderReferences';
 
 /**
  * Hook to get the resources supported by the password recovery flow builder.
  * This hook will aggregate the core resources and the password recovery specific resources.
+ *
+ * This resolves `{{productName}}` placeholders for any
+ * branded value that must reflect the deployment's configured product name,
+ * at load time from `config.brand.product_name`.
  *
  * This function calls the GET method of the following endpoint to get the resources.
  * - TODO: Fill this
@@ -36,15 +43,25 @@ import type {Resources} from '@/features/flows/models/resources';
  */
 const useGetLoginFlowBuilderResources = <Data = Resources>() => {
   const {data: coreResources} = useGetFlowBuilderCoreResources();
+  const {config} = useConfig();
+  const productName = config?.brand?.product_name ?? '';
+
+  const data = useMemo(() => {
+    const [resolvedLocal] = updateTemplatePlaceholderReferences({executors, steps, templates, widgets}, [
+      {key: 'productName', value: productName},
+    ]);
+
+    return {
+      ...coreResources,
+      steps: [...(coreResources?.steps ?? []), ...resolvedLocal.steps],
+      templates: [...(coreResources?.templates ?? []), ...resolvedLocal.templates],
+      widgets: [...(coreResources?.widgets ?? []), ...resolvedLocal.widgets],
+      executors: [...(coreResources?.executors ?? []), ...resolvedLocal.executors],
+    };
+  }, [coreResources, productName]);
 
   return {
-    data: {
-      ...coreResources,
-      steps: [...(coreResources?.steps ?? []), ...steps],
-      templates: [...(coreResources?.templates ?? []), ...templates],
-      widgets: [...(coreResources?.widgets ?? []), ...widgets],
-      executors: [...(coreResources?.executors ?? []), ...executors],
-    } as unknown as Data,
+    data: data as unknown as Data,
     error: null,
     isLoading: false,
     isValidating: false,

--- a/frontend/apps/console/src/features/login-flow/data/executors.json
+++ b/frontend/apps/console/src/features/login-flow/data/executors.json
@@ -202,7 +202,7 @@
       },
       "properties": {
         "relyingPartyId": "localhost",
-        "relyingPartyName": "ThunderID"
+        "relyingPartyName": "{{productName}}"
       }
     }
   },
@@ -252,7 +252,7 @@
       },
       "properties": {
         "relyingPartyId": "localhost",
-        "relyingPartyName": "ThunderID"
+        "relyingPartyName": "{{productName}}"
       }
     }
   },

--- a/frontend/apps/console/src/features/login-flow/data/templates.json
+++ b/frontend/apps/console/src/features/login-flow/data/templates.json
@@ -1259,7 +1259,7 @@
               },
               "properties": {
                 "relyingPartyId": "localhost",
-                "relyingPartyName": "ThunderID"
+                "relyingPartyName": "{{productName}}"
               }
             }
           },
@@ -1395,7 +1395,7 @@
               },
               "properties": {
                 "relyingPartyId": "localhost",
-                "relyingPartyName": "ThunderID"
+                "relyingPartyName": "{{productName}}"
               }
             }
           },

--- a/frontend/apps/console/src/features/login-flow/data/widgets.json
+++ b/frontend/apps/console/src/features/login-flow/data/widgets.json
@@ -725,7 +725,7 @@
               },
               "properties": {
                 "relyingPartyId": "localhost",
-                "relyingPartyName": "ThunderID"
+                "relyingPartyName": "{{productName}}"
               }
             }
           },
@@ -861,7 +861,7 @@
               },
               "properties": {
                 "relyingPartyId": "localhost",
-                "relyingPartyName": "ThunderID"
+                "relyingPartyName": "{{productName}}"
               }
             }
           },


### PR DESCRIPTION
## Summary

Fixes #2995.

Resolves the only end-user-visible surface that the existing `configuration.brand.productName` mechanism could not previously reach: the WebAuthn passkey **relying-party name** shipped in the flow-builder seed JSON.

### What changed

- Replaced the literal `"ThunderID"` with the `"{{productName}}"` placeholder in 12 lines across 4 seed JSON files (`flows/data/templates.json`, `login-flow/data/{templates,executors,widgets}.json`).
- `useGetFlowBuilderCoreResources` and `useGetLoginFlowBuilderResources` now resolve the placeholder at load time using the existing `updateTemplatePlaceholderReferences` util and `config.brand.product_name` from `useConfig()`.
- Updated existing tests to mock `useConfig`, and added a substitution assertion in `useGetFlowBuilderCoreResources.test.ts`.

No new util, no new placeholder syntax — reuses the `{{key}}` mechanism already present for ID generation and i18n. Hook return shapes are unchanged.

> _Note: this replaces #2996, which got disconnected when its fork branch was renamed. Same diff, single squashed commit._

## Test plan

- [x] `pnpm test useGetFlowBuilderCoreResources useGetLoginFlowBuilderResources` — 38/38 passing
- [ ] Full `pnpm test` and `pnpm lint` in `frontend/apps/console` — covered by CI
- [ ] Manual: with `configuration.brand.productName` overridden in Helm values, instantiate a passkey-based template and verify the relying-party-name field defaults to the configured product name in the Passkey properties panel.
- [ ] Manual: register a passkey using the resulting flow and confirm the OS-rendered passkey dialog reads the configured product name (not the literal `"ThunderID"`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flow and login builders now substitute the configured product name into shipped templates, executors, steps and widgets, replacing hardcoded relying-party names for passkey flows so UI flows reflect the brand.

* **Tests**
  * Test suites now mock configuration, relax exact-fixture assertions to presence/length checks, and add assertions verifying product-name placeholders are resolved at runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/2997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->