### PR TITLE
Upgrade js-cookie to 3.0.7 (CVE-2026-46625)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
     "generate:api-specs": "pnpm --dir docs run generate:api-specs",
     "generate:changelog": "pnpm --dir docs run generate:changelog"
   },
+  "pnpm": {
+    "overrides": {
+      "js-cookie": "3.0.7"
+    }
+  },
   "devDependencies": {
     "nx": "22.6.2",
     "prettier": "catalog:",

--- a/package.json
+++ b/package.json
@@ -46,11 +46,6 @@
     "generate:api-specs": "pnpm --dir docs run generate:api-specs",
     "generate:changelog": "pnpm --dir docs run generate:changelog"
   },
-  "pnpm": {
-    "overrides": {
-      "js-cookie": "3.0.7"
-    }
-  },
   "devDependencies": {
     "nx": "22.6.2",
     "prettier": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,7 @@ catalogs:
       version: 4.3.6
 
 overrides:
+  js-cookie: 3.0.7
   ws: '>=8.20.1'
   postcss: 8.5.10
   openapi-to-postmanv2>ajv: 8.18.0
@@ -11215,8 +11216,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=14'}
 
   js-tokens@4.0.0:
@@ -13964,6 +13965,11 @@ packages:
 
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -22535,7 +22541,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(jsdom@27.0.1)(rolldown-vite@7.1.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.7.2)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.47.1)(yaml@2.8.3))
+      vitest: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.1.3)(@vitest/coverage-istanbul@4.1.3)(jsdom@27.0.1)(vite@8.0.12(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.47.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -26684,10 +26690,10 @@ snapshots:
       config-chain: 1.1.13
       editorconfig: 1.0.7
       glob: 10.5.0
-      js-cookie: 3.0.5
+      js-cookie: 3.0.7
       nopt: 7.2.1
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.7: {}
 
   js-tokens@4.0.0: {}
 
@@ -30316,6 +30322,8 @@ snapshots:
 
   semver@7.8.0: {}
 
+  semver@7.8.1: {}
+
   send@0.19.2:
     dependencies:
       debug: 2.6.9
@@ -31836,7 +31844,7 @@ snapshots:
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0
       esquery: 1.7.0
-      semver: 7.8.0
+      semver: 7.8.1
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -116,6 +116,8 @@ overrides:
   js-yaml@>=4.0.0 <4.1.1: 4.1.1
   # TODO: Remove once `nuxt` bumps `devalue` to 5.8.1 or later.
   devalue: 5.8.1
+  # JUSTIFICATION: Transitive dep via js-beautify. Fixes CVE-2026-46625 (GHSA-qjx8-664m-686j) — prototype hijack in assign() allows cookie-attribute injection.
+  js-cookie: 3.0.7
 
 packageExtensions:
   '@hookform/resolvers':


### PR DESCRIPTION
## Summary

- Upgrades transitive dependency `js-cookie` from `3.0.5` to `3.0.7` via `pnpm.overrides`
- Fixes **CVE-2026-46625** / [GHSA-qjx8-664m-686j](https://github.com/advisories/GHSA-qjx8-664m-686j): prototype hijack in `assign()` allows attacker-controlled JSON to inject cookie attributes (`domain`, `secure`, `samesite`, etc.) into `Set-Cookie` headers
- `js-cookie` is pulled in as a transitive dependency of `js-beautify`; enforcing the version via `pnpm.overrides` is the standard fix pattern

## Test plan

- [ ] Verify `pnpm-lock.yaml` resolves `js-cookie` to `3.0.7` for all consumers
- [ ] CI passes (no functional changes — only a security patch to a utility library used for cookie formatting in `js-beautify`)

Closes Dependabot alert #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `js-cookie` dependency to address a security vulnerability affecting cookie handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->