### PR TITLE
Update context.background usage with request context

### DIFF
--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -158,7 +158,7 @@ func (s *consentEnforcerService) RecordConsent(ctx context.Context, ouID, appID,
 	logger.Debug("Recording consent for user")
 
 	// Verify and decode the consent session token to retrieve the prompted purposes
-	sessionData, err := s.verifyAndDecodeConsentSession(sessionToken)
+	sessionData, err := s.verifyAndDecodeConsentSession(ctx, sessionToken)
 	if err != nil {
 		logger.Debug("Failed to verify consent session token", log.Error(err))
 		return nil, &ErrorConsentSessionInvalid
@@ -335,10 +335,10 @@ func (s *consentEnforcerService) createConsentSessionToken(
 
 // verifyAndDecodeConsentSession verifies the JWT consent session token and decodes the session data.
 func (s *consentEnforcerService) verifyAndDecodeConsentSession(
-	sessionToken string) (*consentSessionData, error) {
+	ctx context.Context, sessionToken string) (*consentSessionData, error) {
 	issuer := config.GetServerRuntime().Config.JWT.Issuer
 
-	if svcErr := s.jwtService.VerifyJWT(sessionToken, consentSessionTokenAudience, issuer); svcErr != nil {
+	if svcErr := s.jwtService.VerifyJWT(ctx, sessionToken, consentSessionTokenAudience, issuer); svcErr != nil {
 		return nil, errors.New("consent session token verification failed: " + svcErr.Error.DefaultValue)
 	}
 

--- a/backend/internal/authn/consent/service_test.go
+++ b/backend/internal/authn/consent/service_test.go
@@ -463,10 +463,10 @@ func (s *ConsentEnforcerServiceTestSuite) TestVerifyAndDecodeConsentSession_Deco
 	headerJSON, _ := json.Marshal(header)
 	token := base64.RawURLEncoding.EncodeToString(headerJSON) + ".invalid-payload.signature"
 
-	s.mockJWTSvc.On("VerifyJWT", token, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, token, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 
-	result, err := s.service.verifyAndDecodeConsentSession(token)
+	result, err := s.service.verifyAndDecodeConsentSession(context.Background(), token)
 
 	s.Nil(result)
 	s.Error(err)
@@ -475,10 +475,10 @@ func (s *ConsentEnforcerServiceTestSuite) TestVerifyAndDecodeConsentSession_Deco
 func (s *ConsentEnforcerServiceTestSuite) TestVerifyAndDecodeConsentSession_MissingClaim() {
 	token := buildSessionTokenWithPayload(map[string]interface{}{"sub": "user1"})
 
-	s.mockJWTSvc.On("VerifyJWT", token, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, token, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 
-	result, err := s.service.verifyAndDecodeConsentSession(token)
+	result, err := s.service.verifyAndDecodeConsentSession(context.Background(), token)
 
 	s.Nil(result)
 	s.Error(err)
@@ -488,10 +488,10 @@ func (s *ConsentEnforcerServiceTestSuite) TestVerifyAndDecodeConsentSession_Miss
 func (s *ConsentEnforcerServiceTestSuite) TestVerifyAndDecodeConsentSession_InvalidClaimFormat() {
 	token := buildSessionTokenWithPayload(map[string]interface{}{consentSessionClaimKey: "invalid"})
 
-	s.mockJWTSvc.On("VerifyJWT", token, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, token, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 
-	result, err := s.service.verifyAndDecodeConsentSession(token)
+	result, err := s.service.verifyAndDecodeConsentSession(context.Background(), token)
 
 	s.Nil(result)
 	s.Error(err)
@@ -503,7 +503,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_SessionTokenInvalid(
 			{PurposeName: "purpose1", Approved: true},
 		},
 	}
-	s.mockJWTSvc.On("VerifyJWT", "bad-token", consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, "bad-token", consentSessionTokenAudience, mock.Anything).
 		Return(&serviceerror.ServiceError{
 			Code:  "JWT-5001",
 			Error: core.I18nMessage{Key: "error.test.invalid_token", DefaultValue: "Invalid token"},
@@ -542,7 +542,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_MissingPurpose_Treat
 		},
 	}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
@@ -586,7 +586,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_SearchFails_ClientEr
 		Code: "CONSENT-4002",
 	}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return(nil, clientErr)
@@ -615,7 +615,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_SearchFails_ServerEr
 		Code: "CONSENT-5002",
 	}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return(nil, serverErr)
@@ -656,7 +656,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_NoExisting_CreateSuc
 		},
 	}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
@@ -687,7 +687,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_NoExisting_CreateFai
 		Code: "CONSENT-4003",
 	}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
@@ -718,7 +718,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_NoExisting_CreateFai
 		Code: "CONSENT-5003",
 	}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
@@ -775,7 +775,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_ExistingConsent_Upda
 		},
 	}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{existingConsent}, nil)
@@ -808,7 +808,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_ExistingConsent_Upda
 		Code: "CONSENT-4004",
 	}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{existingConsent}, nil)
@@ -840,7 +840,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_ExistingConsent_Upda
 		Code: "CONSENT-5004",
 	}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{existingConsent}, nil)
@@ -868,7 +868,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_WithValidityPeriod()
 	}
 	createdConsent := &consent.Consent{ID: "consent-timed"}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
@@ -898,7 +898,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_ZeroValidityPeriod()
 	}
 	createdConsent := &consent.Consent{ID: "consent-no-expiry"}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)
@@ -945,7 +945,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_EssentialDenied_Retu
 		},
 	}
 
-	s.mockJWTSvc.On("VerifyJWT", sessionToken, consentSessionTokenAudience, mock.Anything).
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
 		Return((*serviceerror.ServiceError)(nil))
 	s.mockConsentSvc.On("SearchConsents", mock.Anything, "ou1",
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return([]consent.Consent{}, nil)

--- a/backend/internal/authn/magiclink/service.go
+++ b/backend/internal/authn/magiclink/service.go
@@ -116,7 +116,7 @@ func (s *magicLinkAuthnService) GenerateMagicLink(ctx context.Context,
 
 // VerifyMagicLink verifies the validity of a magic link token and retrieves the associated user information.
 // Returns a user object on success or a localized service error if the token is invalid, expired, or malformed.
-func (s *magicLinkAuthnService) VerifyMagicLink(_ context.Context,
+func (s *magicLinkAuthnService) VerifyMagicLink(ctx context.Context,
 	token string, subjectAttribute string) (*entityprovider.Entity, *serviceerror.ServiceError) {
 	s.logger.Debug("Verifying magic link token")
 
@@ -126,7 +126,7 @@ func (s *magicLinkAuthnService) VerifyMagicLink(_ context.Context,
 	}
 
 	issuer := config.GetServerRuntime().Config.JWT.Issuer
-	verifyErr := s.jwtService.VerifyJWT(token, tokenAudience, issuer)
+	verifyErr := s.jwtService.VerifyJWT(ctx, token, tokenAudience, issuer)
 	if verifyErr != nil {
 		if verifyErr.Code == jwt.ErrorTokenExpired.Code {
 			return nil, &ErrorExpiredToken

--- a/backend/internal/authn/magiclink/service_test.go
+++ b/backend/internal/authn/magiclink/service_test.go
@@ -187,7 +187,7 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkExpiredToken() {
 	expiredErr := &serviceerror.ServiceError{
 		Code: jwt.ErrorTokenExpired.Code,
 	}
-	suite.mockJWTService.On("VerifyJWT", testToken, tokenAudience, mock.Anything).Return(expiredErr)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testToken, tokenAudience, mock.Anything).Return(expiredErr)
 
 	result, err := suite.service.VerifyMagicLink(context.Background(), testToken, "")
 	suite.Nil(result)
@@ -196,9 +196,10 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkExpiredToken() {
 }
 
 func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkInvalidToken() {
-	suite.mockJWTService.On("VerifyJWT", testToken, tokenAudience, mock.Anything).Return(&serviceerror.ServiceError{
-		Code: "JWT_INVALID",
-	})
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testToken, tokenAudience, mock.Anything).
+		Return(&serviceerror.ServiceError{
+			Code: "JWT_INVALID",
+		})
 
 	result, err := suite.service.VerifyMagicLink(context.Background(), testToken, "")
 	suite.Nil(result)
@@ -207,7 +208,7 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkInvalidToken() {
 }
 
 func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkSuccess() {
-	suite.mockJWTService.On("VerifyJWT", testValidJWT, tokenAudience, mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
 
 	testUser := &entityprovider.Entity{
 		ID:   testUserID,
@@ -230,7 +231,7 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkSuccessWithDestinatio
 	)
 	workEmailUser := "user-work"
 	testWorkEmailJWT := createMagicLinkJWTWithSubject(workEmailValue)
-	suite.mockJWTService.On("VerifyJWT", testWorkEmailJWT, tokenAudience, mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testWorkEmailJWT, tokenAudience, mock.Anything).Return(nil)
 	suite.mockUserService.On("IdentifyEntity", map[string]interface{}{
 		workEmailAttr: workEmailValue,
 	}).Return(&workEmailUser, nil)
@@ -249,7 +250,7 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkSuccessWithDestinatio
 }
 
 func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkMissingSubjectClaim() {
-	suite.mockJWTService.On("VerifyJWT", testMissingSubJWT, tokenAudience, mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testMissingSubJWT, tokenAudience, mock.Anything).Return(nil)
 
 	result, err := suite.service.VerifyMagicLink(context.Background(), testMissingSubJWT, "")
 	suite.Nil(result)
@@ -258,7 +259,8 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkMissingSubjectClaim()
 }
 
 func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkUserIDMismatchClaim() {
-	suite.mockJWTService.On("VerifyJWT", testMismatchedUserIDJWT, tokenAudience, mock.Anything).Return(nil)
+	suite.mockJWTService.
+		On("VerifyJWT", mock.Anything, testMismatchedUserIDJWT, tokenAudience, mock.Anything).Return(nil)
 	suite.mockUserService.On("GetEntity", "user-456").Return(nil, &entityprovider.EntityProviderError{
 		Code:    entityprovider.ErrorCodeEntityNotFound,
 		Message: "Entity not found",
@@ -271,7 +273,7 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkUserIDMismatchClaim()
 }
 
 func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkUserNotFoundOnVerify() {
-	suite.mockJWTService.On("VerifyJWT", testValidJWT, tokenAudience, mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
 	suite.mockUserService.On("GetEntity", testUserID).Return(nil, &entityprovider.EntityProviderError{
 		Code:    entityprovider.ErrorCodeEntityNotFound,
 		Message: "Entity not found",
@@ -284,7 +286,7 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkUserNotFoundOnVerify(
 }
 
 func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkGetUserError() {
-	suite.mockJWTService.On("VerifyJWT", testValidJWT, tokenAudience, mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
 	suite.mockUserService.On("GetEntity", testUserID).Return(nil, &entityprovider.EntityProviderError{
 		Code:    entityprovider.ErrorCodeInvalidRequestFormat,
 		Message: "Invalid request",
@@ -297,7 +299,7 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkGetUserError() {
 }
 
 func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkEntityProviderSystemError() {
-	suite.mockJWTService.On("VerifyJWT", testValidJWT, tokenAudience, mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
 	suite.mockUserService.On("GetEntity", testUserID).Return(nil, &entityprovider.EntityProviderError{
 		Code:        entityprovider.ErrorCodeSystemError,
 		Message:     "System error",

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -314,7 +314,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 	}
 
 	// Verify and decode session token
-	sessionData, svcErr := as.verifyAndDecodeSessionToken(sessionToken, logger)
+	sessionData, svcErr := as.verifyAndDecodeSessionToken(ctx, sessionToken, logger)
 	if svcErr != nil {
 		return nil, svcErr
 	}
@@ -394,7 +394,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(
 	if strings.TrimSpace(existingAssertion) != "" {
 		var assertionSub string
 		var svcErr *serviceerror.ServiceError
-		existingAssurance, assertionSub, svcErr = as.extractClaimsFromAssertion(existingAssertion, logger)
+		existingAssurance, assertionSub, svcErr = as.extractClaimsFromAssertion(ctx, existingAssertion, logger)
 		if svcErr != nil {
 			return svcErr
 		}
@@ -468,11 +468,11 @@ func (as *authenticationService) getAssertionResult(existingContext *assert.Assu
 }
 
 // extractClaimsFromAssertion extracts assurance context and subject from an existing JWT assertion.
-func (as *authenticationService) extractClaimsFromAssertion(assertion string,
+func (as *authenticationService) extractClaimsFromAssertion(ctx context.Context, assertion string,
 	logger *log.Logger) (*assert.AssuranceContext, string, *serviceerror.ServiceError) {
 	jwtConfig := config.GetServerRuntime().Config.JWT
 
-	if err := as.jwtService.VerifyJWT(assertion, "", jwtConfig.Issuer); err != nil {
+	if err := as.jwtService.VerifyJWT(ctx, assertion, "", jwtConfig.Issuer); err != nil {
 		logger.Debug("Failed to verify JWT signature of the assertion", log.String("error", err.Error.DefaultValue))
 		return nil, "", &common.ErrorInvalidAssertion
 	}
@@ -624,11 +624,11 @@ func (as *authenticationService) createSessionToken(ctx context.Context, idpID s
 }
 
 // verifyAndDecodeSessionToken verifies the JWT signature and decodes the auth session data.
-func (as *authenticationService) verifyAndDecodeSessionToken(token string, logger *log.Logger) (
+func (as *authenticationService) verifyAndDecodeSessionToken(ctx context.Context, token string, logger *log.Logger) (
 	*AuthSessionData, *serviceerror.ServiceError) {
 	// Verify JWT signature and claims
 	jwtConfig := config.GetServerRuntime().Config.JWT
-	svcErr := as.jwtService.VerifyJWT(token, "auth-svc", jwtConfig.Issuer)
+	svcErr := as.jwtService.VerifyJWT(ctx, token, "auth-svc", jwtConfig.Issuer)
 	if svcErr != nil {
 		logger.Debug("Error verifying session token", log.String("error", svcErr.Error.DefaultValue))
 		return nil, &common.ErrorInvalidSessionToken

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -234,7 +234,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentials() {
 				suite.mockAuthnProvider.On("GetUserAttributes", mock.Anything, mock.Anything,
 					mock.Anything, mock.Anything).
 					Return(authnprovidermgr.AuthUser{}, &authnprovidercm.AttributesResponse{}, nil).Once()
-				suite.mockJWTService.On("VerifyJWT", mock.Anything, "", mock.Anything).Return(nil).Once()
+				suite.mockJWTService.On("VerifyJWT", mock.Anything, mock.Anything, "", mock.Anything).Return(nil).Once()
 				suite.mockAssertGenerator.On("UpdateAssertion", mock.Anything, mock.Anything).Return(
 					&assert.AssertionResult{
 						Context: &assert.AssuranceContext{
@@ -359,7 +359,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsSubj
 		}, nil)
 	suite.mockAuthnProvider.On("GetUserAttributes", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(authnprovidermgr.AuthUser{}, &authnprovidercm.AttributesResponse{}, nil)
-	suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, existingAssertion, "", mock.Anything).Return(nil)
 
 	result, err := suite.service.AuthenticateWithCredentials(context.Background(), identifiers,
 		authnCredentials, false, existingAssertion)
@@ -386,14 +386,15 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsInva
 		}, nil)
 	suite.mockAuthnProvider.On("GetUserAttributes", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		authnprovidermgr.AuthUser{}, &authnprovidercm.AttributesResponse{}, nil)
-	suite.mockJWTService.On("VerifyJWT", invalidAssertion, "", mock.Anything).Return(&serviceerror.ServiceError{
-		Type:  serviceerror.ServerErrorType,
-		Code:  "INVALID_JWT",
-		Error: core.I18nMessage{Key: "error.test.invalid_jwt", DefaultValue: "Invalid JWT"},
-		ErrorDescription: core.I18nMessage{
-			Key: "error.test.the_jwt_signature_is_invalid", DefaultValue: "The JWT signature is invalid",
-		},
-	})
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, invalidAssertion, "", mock.Anything).
+		Return(&serviceerror.ServiceError{
+			Type:  serviceerror.ServerErrorType,
+			Code:  "INVALID_JWT",
+			Error: core.I18nMessage{Key: "error.test.invalid_jwt", DefaultValue: "Invalid JWT"},
+			ErrorDescription: core.I18nMessage{
+				Key: "error.test.the_jwt_signature_is_invalid", DefaultValue: "The JWT signature is invalid",
+			},
+		})
 
 	result, err := suite.service.AuthenticateWithCredentials(context.Background(), identifiers,
 		authnCredentials, false, invalidAssertion)
@@ -423,7 +424,7 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsExis
 		}, nil)
 	suite.mockAuthnProvider.On("GetUserAttributes", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		authnprovidermgr.AuthUser{}, &authnprovidercm.AttributesResponse{}, nil)
-	suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, existingAssertion, "", mock.Anything).Return(nil)
 
 	result, err := suite.service.AuthenticateWithCredentials(context.Background(), identifiers,
 		authnCredentials, false, existingAssertion)
@@ -535,7 +536,8 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTP() {
 				suite.mockAuthnProvider.On("AuthenticateUser",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(authnprovidermgr.AuthUser{}, testAuthnResult, nil).Once()
-				suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil).Once()
+				suite.mockJWTService.
+					On("VerifyJWT", mock.Anything, existingAssertion, "", mock.Anything).Return(nil).Once()
 				suite.mockAssertGenerator.On("UpdateAssertion", mock.Anything, mock.Anything).Return(
 					&assert.AssertionResult{
 						Context: &assert.AssuranceContext{
@@ -769,7 +771,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationJWTGenera
 
 func (suite *AuthenticationServiceTestSuite) mockFederatedAuthnSuccess(idpType idp.IDPType) string {
 	sessionToken := suite.createSessionToken(idpType)
-	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, sessionToken, "auth-svc", mock.Anything).Return(nil)
 	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(creds map[string]interface{}) bool {
 			_, ok := creds["federated"]
@@ -835,7 +837,8 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 			existingAssertion: "",
 			setupMocks: func() {
 				sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
-				suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
+				suite.mockJWTService.
+					On("VerifyJWT", mock.Anything, sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
 				suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
 					mock.MatchedBy(func(creds map[string]interface{}) bool {
 						_, ok := creds["federated"]
@@ -869,8 +872,10 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationWithAsse
 			setupMocks: func() {
 				sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
 				existingAssertion := suite.createTestAssertion(testUserID)
-				suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
-				suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil).Once()
+				suite.mockJWTService.
+					On("VerifyJWT", mock.Anything, sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
+				suite.mockJWTService.
+					On("VerifyJWT", mock.Anything, existingAssertion, "", mock.Anything).Return(nil).Once()
 				suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
 					mock.MatchedBy(func(creds map[string]interface{}) bool {
 						_, ok := creds["federated"]
@@ -940,7 +945,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationEmptyAut
 }
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationInvalidSessionToken() {
-	suite.mockJWTService.On("VerifyJWT", "invalid_token", "auth-svc", mock.Anything).
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, "invalid_token", "auth-svc", mock.Anything).
 		Return(&serviceerror.ServiceError{
 			Type:  serviceerror.ServerErrorType,
 			Code:  "INVALID_TOKEN",
@@ -960,7 +965,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationInvalidS
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationTypeMismatch() {
 	sessionToken := suite.createSessionToken(idp.IDPTypeGoogle)
-	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, sessionToken, "auth-svc", mock.Anything).Return(nil)
 
 	result, err := suite.service.FinishIDPAuthentication(
 		context.Background(), idp.IDPTypeGitHub, sessionToken, false, "",
@@ -973,7 +978,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationTypeMism
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationUserNotFound() {
 	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
-	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, sessionToken, "auth-svc", mock.Anything).Return(nil)
 	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(creds map[string]interface{}) bool {
 			_, ok := creds["federated"]
@@ -994,7 +999,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationUserNotF
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationProviderAuthFailure() {
 	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
-	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, sessionToken, "auth-svc", mock.Anything).Return(nil)
 	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(creds map[string]interface{}) bool {
 			_, ok := creds["federated"]
@@ -1058,9 +1063,9 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyAndDecodeSessionTokenMalf
 	logger := log.GetLogger()
 	badToken := "header.invalid-base64.signature"
 
-	suite.mockJWTService.On("VerifyJWT", badToken, "auth-svc", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, badToken, "auth-svc", mock.Anything).Return(nil)
 
-	result, err := suite.service.verifyAndDecodeSessionToken(badToken, logger)
+	result, err := suite.service.verifyAndDecodeSessionToken(context.Background(), badToken, logger)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -1076,9 +1081,9 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyAndDecodeSessionTokenMiss
 	encoded := base64.RawURLEncoding.EncodeToString(payloadBytes)
 	tokenWithoutAuthData := "header." + encoded + ".signature"
 
-	suite.mockJWTService.On("VerifyJWT", tokenWithoutAuthData, "auth-svc", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, tokenWithoutAuthData, "auth-svc", mock.Anything).Return(nil)
 
-	result, err := suite.service.verifyAndDecodeSessionToken(tokenWithoutAuthData, logger)
+	result, err := suite.service.verifyAndDecodeSessionToken(context.Background(), tokenWithoutAuthData, logger)
 
 	suite.Nil(result)
 	suite.NotNil(err)
@@ -1114,7 +1119,7 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationBuildURLE
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationProviderServerError() {
 	sessionToken := suite.createSessionToken(idp.IDPTypeOIDC)
-	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, sessionToken, "auth-svc", mock.Anything).Return(nil)
 	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(creds map[string]interface{}) bool {
 			_, ok := creds["federated"]
@@ -1174,7 +1179,7 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionE
 	encodedPayload := base64.RawURLEncoding.EncodeToString(payloadBytes)
 	invalidAssertion := "header." + encodedPayload + ".signature"
 
-	suite.mockJWTService.On("VerifyJWT", invalidAssertion, "", mock.Anything).Return(nil).Once()
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, invalidAssertion, "", mock.Anything).Return(nil).Once()
 
 	svcErr := suite.service.validateAndAppendAuthAssertion(context.Background(),
 		authResponse, testUser, common.AuthenticatorSMSOTP, invalidAssertion, logger)
@@ -1185,7 +1190,7 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionE
 
 func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationAssertionGenerationError() {
 	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
-	suite.mockJWTService.On("VerifyJWT", sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, sessionToken, "auth-svc", mock.Anything).Return(nil).Once()
 	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(creds map[string]interface{}) bool {
 			_, ok := creds["federated"]
@@ -1199,7 +1204,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationAssertio
 		}, nil).Once()
 
 	// Create invalid existing assertion that will fail JWT verification
-	suite.mockJWTService.On("VerifyJWT", invalidAssertion, "", mock.Anything).
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, invalidAssertion, "", mock.Anything).
 		Return(&serviceerror.ServiceError{
 			Type:  serviceerror.ServerErrorType,
 			Code:  "INVALID_SIGNATURE",
@@ -1262,7 +1267,7 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionS
 	// Create assertion with different subject
 	existingAssertion := suite.createTestAssertion("different_user_id")
 
-	suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, existingAssertion, "", mock.Anything).Return(nil)
 
 	svcErr := suite.service.validateAndAppendAuthAssertion(context.Background(),
 		authResponse, testUser, common.AuthenticatorSMSOTP, existingAssertion, log.GetLogger())
@@ -1275,10 +1280,10 @@ func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionMissi
 	// Create assertion without assurance claim
 	assertionWithoutAssurance := suite.createTestAssertionWithoutAssurance(testUserID)
 
-	suite.mockJWTService.On("VerifyJWT", assertionWithoutAssurance, "", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, assertionWithoutAssurance, "", mock.Anything).Return(nil)
 
 	_, _, svcErr := suite.service.extractClaimsFromAssertion(
-		assertionWithoutAssurance, log.GetLogger())
+		context.Background(), assertionWithoutAssurance, log.GetLogger())
 
 	suite.NotNil(svcErr)
 	suite.Equal(common.ErrorInvalidAssertion.Code, svcErr.Code)
@@ -1308,7 +1313,7 @@ func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionError
 				},
 			},
 			setupMock: func(assertion string) {
-				suite.mockJWTService.On("VerifyJWT", assertion, "", mock.Anything).Return(nil).Once()
+				suite.mockJWTService.On("VerifyJWT", mock.Anything, assertion, "", mock.Anything).Return(nil).Once()
 			},
 		},
 		{
@@ -1328,7 +1333,7 @@ func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionError
 				},
 			},
 			setupMock: func(assertion string) {
-				suite.mockJWTService.On("VerifyJWT", assertion, "", mock.Anything).Return(nil).Once()
+				suite.mockJWTService.On("VerifyJWT", mock.Anything, assertion, "", mock.Anything).Return(nil).Once()
 			},
 		},
 		{
@@ -1348,7 +1353,7 @@ func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionError
 				},
 			},
 			setupMock: func(assertion string) {
-				suite.mockJWTService.On("VerifyJWT", assertion, "", mock.Anything).Return(nil).Once()
+				suite.mockJWTService.On("VerifyJWT", mock.Anything, assertion, "", mock.Anything).Return(nil).Once()
 			},
 		},
 		{
@@ -1357,7 +1362,7 @@ func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionError
 				"sub": testUserID,
 			},
 			setupMock: func(assertion string) {
-				suite.mockJWTService.On("VerifyJWT", assertion, "", mock.Anything).Return(nil).Once()
+				suite.mockJWTService.On("VerifyJWT", mock.Anything, assertion, "", mock.Anything).Return(nil).Once()
 			},
 		},
 	}
@@ -1370,7 +1375,8 @@ func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionError
 
 			tc.setupMock(testAssertion)
 
-			assuranceCtx, sub, err := suite.service.extractClaimsFromAssertion(testAssertion, logger)
+			assuranceCtx, sub, err := suite.service.
+				extractClaimsFromAssertion(context.Background(), testAssertion, logger)
 
 			suite.Nil(assuranceCtx)
 			suite.Empty(sub, "sub should be empty for test case: %s", tc.name)
@@ -1385,9 +1391,9 @@ func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionDecod
 
 	// Create a malformed JWT that will fail payload decoding
 	malformedAssertion := "header.not-valid-base64!!.signature"
-	suite.mockJWTService.On("VerifyJWT", malformedAssertion, "", mock.Anything).Return(nil).Once()
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, malformedAssertion, "", mock.Anything).Return(nil).Once()
 
-	assuranceCtx, sub, err := suite.service.extractClaimsFromAssertion(malformedAssertion, logger)
+	assuranceCtx, sub, err := suite.service.extractClaimsFromAssertion(context.Background(), malformedAssertion, logger)
 	suite.Nil(assuranceCtx)
 	suite.Empty(sub)
 	suite.NotNil(err)
@@ -1405,9 +1411,9 @@ func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionUnmar
 	payloadBytes, _ := json.Marshal(validPayload)
 	encodedPayload := base64.RawURLEncoding.EncodeToString(payloadBytes)
 	testAssertion := "header." + encodedPayload + ".signature"
-	suite.mockJWTService.On("VerifyJWT", testAssertion, "", mock.Anything).Return(nil).Once()
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testAssertion, "", mock.Anything).Return(nil).Once()
 
-	assuranceCtx, sub, err := suite.service.extractClaimsFromAssertion(testAssertion, logger)
+	assuranceCtx, sub, err := suite.service.extractClaimsFromAssertion(context.Background(), testAssertion, logger)
 	suite.Nil(assuranceCtx)
 	suite.Empty(sub)
 	suite.NotNil(err)
@@ -1456,7 +1462,7 @@ func (suite *AuthenticationServiceTestSuite) TestVerifyOTPJWTGenerationError() {
 func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionInvalidJWTSignature() {
 	logger := log.GetLogger()
 
-	suite.mockJWTService.On("VerifyJWT", invalidAssertion, "", mock.Anything).
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, invalidAssertion, "", mock.Anything).
 		Return(&serviceerror.ServiceError{
 			Type:  serviceerror.ServerErrorType,
 			Code:  "INVALID_SIGNATURE",
@@ -1466,7 +1472,7 @@ func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionInval
 			},
 		})
 
-	assuranceCtx, sub, err := suite.service.extractClaimsFromAssertion(invalidAssertion, logger)
+	assuranceCtx, sub, err := suite.service.extractClaimsFromAssertion(context.Background(), invalidAssertion, logger)
 
 	suite.Nil(assuranceCtx)
 	suite.Empty(sub)
@@ -1486,9 +1492,9 @@ func (suite *AuthenticationServiceTestSuite) TestExtractClaimsFromAssertionMalfo
 	encoded := base64.RawURLEncoding.EncodeToString(payloadBytes)
 	malformedAssertion := "header." + encoded + ".signature"
 
-	suite.mockJWTService.On("VerifyJWT", malformedAssertion, "", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, malformedAssertion, "", mock.Anything).Return(nil)
 
-	assuranceCtx, sub, err := suite.service.extractClaimsFromAssertion(malformedAssertion, logger)
+	assuranceCtx, sub, err := suite.service.extractClaimsFromAssertion(context.Background(), malformedAssertion, logger)
 
 	suite.Nil(assuranceCtx)
 	suite.Empty(sub)
@@ -1549,7 +1555,7 @@ func (suite *AuthenticationServiceTestSuite) TestValidateAndAppendAuthAssertionU
 	logger := log.GetLogger()
 	existingAssertion := suite.createTestAssertion(testUserID)
 
-	suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, existingAssertion, "", mock.Anything).Return(nil)
 
 	// Create a service with a mock assertion generator that returns an error on update
 	mockAssertGenerator := assertmock.NewAuthAssertGeneratorInterfaceMock(suite.T())
@@ -1865,7 +1871,7 @@ func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyAuthentication_Wit
 		mock.Anything).Return(authnprovidermgr.AuthUser{}, authResultFromPasskey, nil).Once()
 
 	// Mock JWT verification for existing assertion
-	suite.mockJWTService.On("VerifyJWT", existingAssertion, "", mock.Anything).Return(nil).Once()
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, existingAssertion, "", mock.Anything).Return(nil).Once()
 
 	// Mock assertion update
 	mockUpdatedResult := &assert.AssertionResult{

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -138,7 +138,7 @@ func (s *otpService) VerifyOTP(
 		return nil, err
 	}
 
-	sessionData, svcErr := s.verifyAndDecodeSessionToken(otpDTO.SessionToken, logger)
+	sessionData, svcErr := s.verifyAndDecodeSessionToken(ctx, otpDTO.SessionToken, logger)
 	if svcErr != nil {
 		return nil, svcErr
 	}
@@ -302,11 +302,11 @@ func (s *otpService) createSessionToken(ctx context.Context, sessionData common.
 }
 
 // verifyAndDecodeSessionToken verifies the JWT signature and decodes the session data.
-func (s *otpService) verifyAndDecodeSessionToken(token string, logger *log.Logger) (
+func (s *otpService) verifyAndDecodeSessionToken(ctx context.Context, token string, logger *log.Logger) (
 	*common.OTPSessionData, *serviceerror.ServiceError) {
 	// Verify JWT signature
 	jwtConfig := config.GetServerRuntime().Config.JWT
-	svcErr := s.jwtService.VerifyJWT(token, "otp-svc", jwtConfig.Issuer)
+	svcErr := s.jwtService.VerifyJWT(ctx, token, "otp-svc", jwtConfig.Issuer)
 	if svcErr != nil {
 		logger.Debug("Invalid session token", log.String("error", svcErr.Error.DefaultValue))
 		return nil, &ErrorInvalidSessionToken

--- a/backend/internal/notification/otp_service_test.go
+++ b/backend/internal/notification/otp_service_test.go
@@ -221,7 +221,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_InvalidSessionToken() {
 	}
 
 	// Expect VerifyJWT to be called; issuer can vary in tests so use Any
-	suite.mockJWTService.EXPECT().VerifyJWT("invalid-token", "otp-svc", mock.Anything).
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, "invalid-token", "otp-svc", mock.Anything).
 		Return(&ErrorInvalidSessionToken).Once()
 
 	result, err := suite.service.VerifyOTP(context.Background(), request)
@@ -417,7 +417,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_Success() {
 	payloadEnc := base64.RawURLEncoding.EncodeToString(payloadBytes)
 	token := fmt.Sprintf("%s.%s.", headerEnc, payloadEnc)
 
-	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: otpValue}
 	res, err := suite.service.VerifyOTP(context.Background(), req)
@@ -449,7 +449,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_Expired() {
 	payloadEnc := base64.RawURLEncoding.EncodeToString(payloadBytes)
 	token := fmt.Sprintf("%s.%s.", headerEnc, payloadEnc)
 
-	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: otpValue}
 	res, err := suite.service.VerifyOTP(context.Background(), req)
@@ -518,7 +518,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_MissingOTPData() {
 	payloadEnc := base64.RawURLEncoding.EncodeToString(payloadBytes)
 	token := fmt.Sprintf("%s.%s.", headerEnc, payloadEnc)
 
-	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: "123456"}
 	res, err := suite.service.VerifyOTP(context.Background(), req)
@@ -530,7 +530,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_MissingOTPData() {
 func (suite *OTPServiceTestSuite) TestVerifyOTP_BadPayloadDecode() {
 	// craft token with invalid base64 payload part
 	token := "hdr.invalid@@@.sig" // #nosec G101
-	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: "123456"}
 	res, err := suite.service.VerifyOTP(context.Background(), req)
@@ -563,7 +563,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_Mismatch() {
 	payloadEnc := base64.RawURLEncoding.EncodeToString(payloadBytes)
 	token := fmt.Sprintf("%s.%s.", headerEnc, payloadEnc)
 
-	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: otpValue}
 	res, err := suite.service.VerifyOTP(context.Background(), req)
@@ -606,7 +606,7 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_UnmarshalError() {
 	payloadEnc := base64.RawURLEncoding.EncodeToString(payloadBytes)
 	token := fmt.Sprintf("%s.%s.", headerEnc, payloadEnc)
 
-	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, token, mock.Anything, mock.Anything).Return(nil).Once()
 
 	req := common.VerifyOTPDTO{SessionToken: token, OTPCode: "123456"}
 	res, err := suite.service.VerifyOTP(context.Background(), req)
@@ -694,9 +694,9 @@ func (suite *OTPServiceTestSuite) TestVerifyAndDecode_Success() {
 	payloadEnc := base64.RawURLEncoding.EncodeToString(payloadBytes)
 	token := fmt.Sprintf("%s.%s.", headerEnc, payloadEnc)
 
-	suite.mockJWTService.EXPECT().VerifyJWT(token, mock.Anything, mock.Anything).Return(nil).Once()
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, token, mock.Anything, mock.Anything).Return(nil).Once()
 
-	sessionData, svcErr := suite.service.verifyAndDecodeSessionToken(token, log.GetLogger())
+	sessionData, svcErr := suite.service.verifyAndDecodeSessionToken(context.Background(), token, log.GetLogger())
 	suite.Nil(svcErr)
 	suite.NotNil(sessionData)
 	suite.Equal("+15559876543", sessionData.Recipient)

--- a/backend/internal/oauth/jwks/JWKSServiceInterface_mock_test.go
+++ b/backend/internal/oauth/jwks/JWKSServiceInterface_mock_test.go
@@ -5,6 +5,8 @@
 package jwks
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 )
@@ -37,8 +39,8 @@ func (_m *JWKSServiceInterfaceMock) EXPECT() *JWKSServiceInterfaceMock_Expecter 
 }
 
 // GetJWKS provides a mock function for the type JWKSServiceInterfaceMock
-func (_mock *JWKSServiceInterfaceMock) GetJWKS() (*JWKSResponse, *serviceerror.ServiceError) {
-	ret := _mock.Called()
+func (_mock *JWKSServiceInterfaceMock) GetJWKS(ctx context.Context) (*JWKSResponse, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetJWKS")
@@ -46,18 +48,18 @@ func (_mock *JWKSServiceInterfaceMock) GetJWKS() (*JWKSResponse, *serviceerror.S
 
 	var r0 *JWKSResponse
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func() (*JWKSResponse, *serviceerror.ServiceError)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (*JWKSResponse, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() *JWKSResponse); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) *JWKSResponse); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*JWKSResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() *serviceerror.ServiceError); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -72,13 +74,20 @@ type JWKSServiceInterfaceMock_GetJWKS_Call struct {
 }
 
 // GetJWKS is a helper method to define mock.On call
-func (_e *JWKSServiceInterfaceMock_Expecter) GetJWKS() *JWKSServiceInterfaceMock_GetJWKS_Call {
-	return &JWKSServiceInterfaceMock_GetJWKS_Call{Call: _e.mock.On("GetJWKS")}
+//   - ctx context.Context
+func (_e *JWKSServiceInterfaceMock_Expecter) GetJWKS(ctx interface{}) *JWKSServiceInterfaceMock_GetJWKS_Call {
+	return &JWKSServiceInterfaceMock_GetJWKS_Call{Call: _e.mock.On("GetJWKS", ctx)}
 }
 
-func (_c *JWKSServiceInterfaceMock_GetJWKS_Call) Run(run func()) *JWKSServiceInterfaceMock_GetJWKS_Call {
+func (_c *JWKSServiceInterfaceMock_GetJWKS_Call) Run(run func(ctx context.Context)) *JWKSServiceInterfaceMock_GetJWKS_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -88,7 +97,7 @@ func (_c *JWKSServiceInterfaceMock_GetJWKS_Call) Return(jWKSResponse *JWKSRespon
 	return _c
 }
 
-func (_c *JWKSServiceInterfaceMock_GetJWKS_Call) RunAndReturn(run func() (*JWKSResponse, *serviceerror.ServiceError)) *JWKSServiceInterfaceMock_GetJWKS_Call {
+func (_c *JWKSServiceInterfaceMock_GetJWKS_Call) RunAndReturn(run func(ctx context.Context) (*JWKSResponse, *serviceerror.ServiceError)) *JWKSServiceInterfaceMock_GetJWKS_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/oauth/jwks/handler.go
+++ b/backend/internal/oauth/jwks/handler.go
@@ -43,7 +43,8 @@ func newJWKSHandler(jwksService JWKSServiceInterface) *jwksHandler {
 func (h *jwksHandler) HandleJWKSRequest(w http.ResponseWriter, r *http.Request) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWKSHandler"))
 
-	jwksResponse, svcErr := h.jwksService.GetJWKS()
+	ctx := r.Context()
+	jwksResponse, svcErr := h.jwksService.GetJWKS(ctx)
 	if svcErr != nil {
 		h.logAndWriteError(w, logger, svcErr)
 		return

--- a/backend/internal/oauth/jwks/handler_test.go
+++ b/backend/internal/oauth/jwks/handler_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
@@ -69,7 +70,7 @@ func (s *JWKSHandlerTestSuite) TestHandleJWKSRequest_Success() {
 			},
 		},
 	}
-	s.mockService.On("GetJWKS").Return(jwksResponse, nil)
+	s.mockService.On("GetJWKS", mock.Anything).Return(jwksResponse, nil)
 
 	s.handler.HandleJWKSRequest(rr, req)
 
@@ -94,7 +95,7 @@ func (s *JWKSHandlerTestSuite) TestHandleJWKSRequest_ClientError() {
 		Error:            core.I18nMessage{Key: "error.test.invalid_request", DefaultValue: "invalid_request"},
 		ErrorDescription: core.I18nMessage{Key: "error.test.invalid_request", DefaultValue: "Invalid request"},
 	}
-	s.mockService.On("GetJWKS").Return(nil, svcErr)
+	s.mockService.On("GetJWKS", mock.Anything).Return(nil, svcErr)
 
 	s.handler.HandleJWKSRequest(rr, req)
 
@@ -111,7 +112,7 @@ func (s *JWKSHandlerTestSuite) TestHandleJWKSRequest_ServiceError() {
 		Key:          "error.test.failed_get_jwks",
 		DefaultValue: "Failed to get JWKS",
 	})
-	s.mockService.On("GetJWKS").Return(nil, svcErr)
+	s.mockService.On("GetJWKS", mock.Anything).Return(nil, svcErr)
 
 	s.handler.HandleJWKSRequest(rr, req)
 

--- a/backend/internal/oauth/jwks/service.go
+++ b/backend/internal/oauth/jwks/service.go
@@ -38,7 +38,7 @@ import (
 
 // JWKSServiceInterface defines the interface for JWKS service.
 type JWKSServiceInterface interface {
-	GetJWKS() (*JWKSResponse, *serviceerror.ServiceError)
+	GetJWKS(ctx context.Context) (*JWKSResponse, *serviceerror.ServiceError)
 }
 
 // jwksService implements the JWKSServiceInterface.
@@ -56,8 +56,8 @@ func newJWKSService(cryptoProvider kmprovider.RuntimeCryptoProvider) JWKSService
 }
 
 // GetJWKS retrieves the JSON Web Key Set (JWKS) from the runtime crypto provider.
-func (s *jwksService) GetJWKS() (*JWKSResponse, *serviceerror.ServiceError) {
-	publicKeys, err := s.cryptoProvider.GetPublicKeys(context.Background(), kmprovider.PublicKeyFilter{})
+func (s *jwksService) GetJWKS(ctx context.Context) (*JWKSResponse, *serviceerror.ServiceError) {
+	publicKeys, err := s.cryptoProvider.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
 	if err != nil {
 		s.logger.Error("Failed to retrieve public keys", log.Error(err))
 		return nil, &serviceerror.InternalServerError

--- a/backend/internal/oauth/jwks/service_test.go
+++ b/backend/internal/oauth/jwks/service_test.go
@@ -19,6 +19,7 @@
 package jwks
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -64,7 +65,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_RSA_Success() {
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 		Return([]kmprovider.PublicKeyInfo{info}, nil)
 
-	resp, svcErr := suite.jwksService.GetJWKS()
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 	assert.Nil(suite.T(), svcErr)
 	assert.NotNil(suite.T(), resp)
 	assert.Len(suite.T(), resp.Keys, 1)
@@ -90,7 +91,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_ECDSA_P256_Success() {
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 		Return([]kmprovider.PublicKeyInfo{info}, nil)
 
-	resp, svcErr := suite.jwksService.GetJWKS()
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 	assert.Nil(suite.T(), svcErr)
 	assert.NotNil(suite.T(), resp)
 	assert.Len(suite.T(), resp.Keys, 1)
@@ -117,7 +118,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_EdDSA_Success() {
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 		Return([]kmprovider.PublicKeyInfo{info}, nil)
 
-	resp, svcErr := suite.jwksService.GetJWKS()
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 	assert.Nil(suite.T(), svcErr)
 	assert.NotNil(suite.T(), resp)
 	assert.Len(suite.T(), resp.Keys, 1)
@@ -135,7 +136,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_GetPublicKeysError() {
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 		Return(nil, errors.New("provider error"))
 
-	resp, svcErr := suite.jwksService.GetJWKS()
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 	assert.Nil(suite.T(), resp)
 	assert.NotNil(suite.T(), svcErr)
 	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
@@ -145,7 +146,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_NoCertificatesFound() {
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 		Return([]kmprovider.PublicKeyInfo{}, nil)
 
-	resp, svcErr := suite.jwksService.GetJWKS()
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 	assert.Nil(suite.T(), resp)
 	assert.NotNil(suite.T(), svcErr)
 	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
@@ -170,7 +171,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_UnsupportedPublicKeyType() {
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 		Return(keys, nil)
 
-	resp, svcErr := suite.jwksService.GetJWKS()
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 	assert.Nil(suite.T(), svcErr)
 	assert.NotNil(suite.T(), resp)
 	assert.Len(suite.T(), resp.Keys, 1)
@@ -183,7 +184,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_OnlyUnsupportedKeys() {
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 		Return(keys, nil)
 
-	resp, svcErr := suite.jwksService.GetJWKS()
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 	assert.Nil(suite.T(), resp)
 	assert.NotNil(suite.T(), svcErr)
 	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
@@ -211,7 +212,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_MultipleCertificates() {
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 		Return(keys, nil)
 
-	resp, svcErr := suite.jwksService.GetJWKS()
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 	assert.Nil(suite.T(), svcErr)
 	assert.NotNil(suite.T(), resp)
 	assert.Len(suite.T(), resp.Keys, 2)
@@ -256,7 +257,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_ECDSA_AdditionalCurves() {
 			suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 				Return([]kmprovider.PublicKeyInfo{info}, nil).Once()
 
-			resp, svcErr := suite.jwksService.GetJWKS()
+			resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 			assert.Nil(suite.T(), svcErr)
 			assert.NotNil(suite.T(), resp)
 			assert.Len(suite.T(), resp.Keys, 1)
@@ -283,7 +284,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_RSA_ZeroExponent() {
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 		Return([]kmprovider.PublicKeyInfo{info}, nil)
 
-	resp, svcErr := suite.jwksService.GetJWKS()
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 	assert.Nil(suite.T(), svcErr)
 	assert.NotNil(suite.T(), resp)
 	assert.Len(suite.T(), resp.Keys, 1)
@@ -304,7 +305,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_NoCertificateDER() {
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
 		Return([]kmprovider.PublicKeyInfo{info}, nil)
 
-	resp, svcErr := suite.jwksService.GetJWKS()
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
 	assert.Nil(suite.T(), svcErr)
 	assert.NotNil(suite.T(), resp)
 	assert.Len(suite.T(), resp.Keys, 1)

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -425,7 +425,7 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 		}
 
 		// Verify the assertion.
-		if err := as.verifyAssertion(assertion); err != nil {
+		if err := as.verifyAssertion(ctx, assertion); err != nil {
 			as.logger.Debug("Assertion verification failed", log.Error(err))
 			authErr = &AuthorizationError{
 				Code:              oauth2const.ErrorInvalidRequest,
@@ -575,8 +575,8 @@ func (as *authorizeService) loadAuthRequestContext(ctx context.Context, authID s
 }
 
 // verifyAssertion verifies the JWT assertion.
-func (as *authorizeService) verifyAssertion(assertion string) error {
-	if err := as.jwtService.VerifyJWT(assertion, "", ""); err != nil {
+func (as *authorizeService) verifyAssertion(ctx context.Context, assertion string) error {
+	if err := as.jwtService.VerifyJWT(ctx, assertion, "", ""); err != nil {
 		as.logger.Debug("Invalid assertion signature", log.String("error", err.Error.DefaultValue))
 		return errors.New("invalid assertion signature")
 	}

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -461,7 +461,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_InvalidA
 	}
 	suite.mockAuthReqStore.EXPECT().GetRequest(mock.Anything, testAuthID).Return(true, authCtx, nil)
 	suite.mockAuthReqStore.EXPECT().ClearRequest(mock.Anything, testAuthID).Return(nil)
-	suite.mockJWTService.EXPECT().VerifyJWT("invalid-assertion", "", "").Return(&jwt.ErrorInvalidTokenSignature)
+	suite.mockJWTService.EXPECT().
+		VerifyJWT(mock.Anything, "invalid-assertion", "", "").Return(&jwt.ErrorInvalidTokenSignature)
 
 	svc := suite.newService()
 	redirectURI, authErr := svc.HandleAuthorizationCallback(context.Background(), testAuthID, "invalid-assertion")
@@ -485,7 +486,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_FailedTo
 	suite.mockAuthReqStore.EXPECT().GetRequest(mock.Anything, testAuthID).Return(true, authCtx, nil)
 	suite.mockAuthReqStore.EXPECT().ClearRequest(mock.Anything, testAuthID).Return(nil)
 	// VerifyJWT succeeds but "not.valid.jwt" cannot be decoded as a valid JWT payload.
-	suite.mockJWTService.EXPECT().VerifyJWT("not.valid.jwt", "", "").Return(nil)
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, "not.valid.jwt", "", "").Return(nil)
 
 	svc := suite.newService()
 	redirectURI, authErr := svc.HandleAuthorizationCallback(context.Background(), testAuthID, "not.valid.jwt")
@@ -509,7 +510,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_PersistA
 	}
 	suite.mockAuthReqStore.EXPECT().GetRequest(mock.Anything, testAuthID).Return(true, authCtx, nil)
 	suite.mockAuthReqStore.EXPECT().ClearRequest(mock.Anything, testAuthID).Return(nil)
-	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTWithIat, "", "").Return(nil)
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, svcJWTWithIat, "", "").Return(nil)
 	suite.mockAuthzCodeStore.EXPECT().
 		InsertAuthorizationCode(mock.Anything, mock.Anything).
 		Return(errors.New("db error"))
@@ -534,7 +535,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_Success(
 	}
 	suite.mockAuthReqStore.EXPECT().GetRequest(mock.Anything, testAuthID).Return(true, authCtx, nil)
 	suite.mockAuthReqStore.EXPECT().ClearRequest(mock.Anything, testAuthID).Return(nil)
-	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTWithIat, "", "").Return(nil)
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, svcJWTWithIat, "", "").Return(nil)
 	suite.mockAuthzCodeStore.EXPECT().InsertAuthorizationCode(mock.Anything, mock.Anything).Return(nil)
 
 	svc := suite.newService()
@@ -557,7 +558,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_WithStat
 	}
 	suite.mockAuthReqStore.EXPECT().GetRequest(mock.Anything, testAuthID).Return(true, authCtx, nil)
 	suite.mockAuthReqStore.EXPECT().ClearRequest(mock.Anything, testAuthID).Return(nil)
-	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTWithIat, "", "").Return(nil)
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, svcJWTWithIat, "", "").Return(nil)
 	suite.mockAuthzCodeStore.EXPECT().InsertAuthorizationCode(mock.Anything, mock.Anything).Return(nil)
 
 	svc := suite.newService()
@@ -581,7 +582,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_EmptyAut
 	}
 	suite.mockAuthReqStore.EXPECT().GetRequest(mock.Anything, testAuthID).Return(true, authCtx, nil)
 	suite.mockAuthReqStore.EXPECT().ClearRequest(mock.Anything, testAuthID).Return(nil)
-	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTWithIat, "", "").Return(nil)
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, svcJWTWithIat, "", "").Return(nil)
 	suite.mockAuthzCodeStore.EXPECT().InsertAuthorizationCode(mock.Anything, mock.Anything).Return(nil)
 
 	svc := suite.newService()
@@ -601,7 +602,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_CreateAu
 	}
 	suite.mockAuthReqStore.EXPECT().GetRequest(mock.Anything, testAuthID).Return(true, authCtx, nil)
 	suite.mockAuthReqStore.EXPECT().ClearRequest(mock.Anything, testAuthID).Return(nil)
-	suite.mockJWTService.EXPECT().VerifyJWT(svcJWTMinimal, "", "").Return(nil)
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, svcJWTMinimal, "", "").Return(nil)
 
 	svc := suite.newService()
 	redirectURI, authErr := svc.HandleAuthorizationCallback(context.Background(), testAuthID, svcJWTMinimal)

--- a/backend/internal/oauth/oauth2/dpop/context.go
+++ b/backend/internal/oauth/oauth2/dpop/context.go
@@ -31,9 +31,6 @@ const (
 
 // WithProof attaches a raw DPoP proof JWT to the context for downstream verification.
 func WithProof(ctx context.Context, proof string) context.Context {
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	return context.WithValue(ctx, proofKey, proof)
 }
 
@@ -51,9 +48,6 @@ func GetProof(ctx context.Context) string {
 // WithJkt attaches the verified DPoP proof's JWK thumbprint to the context so grant
 // handlers can sender-constrain the issued tokens.
 func WithJkt(ctx context.Context, jkt string) context.Context {
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	return context.WithValue(ctx, jktKey, jkt)
 }
 

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -189,8 +189,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 	}
 
 	// Generate access token using tokenBuilder (attributes will be filtered in BuildAccessToken)
-	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
-		Context:          ctx,
+	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, &tokenservice.AccessTokenBuildContext{
 		Subject:          authCode.AuthorizedUserID,
 		Audiences:        accessTokenAudiences,
 		ClientID:         tokenRequest.ClientID,
@@ -221,8 +220,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 
 	// Generate ID token if 'openid' scope is present
 	if slices.Contains(accessTokenScopes, constants.ScopeOpenID) {
-		idToken, err := h.tokenBuilder.BuildIDToken(&tokenservice.IDTokenBuildContext{
-			Context:        ctx,
+		idToken, err := h.tokenBuilder.BuildIDToken(ctx, &tokenservice.IDTokenBuildContext{
 			Subject:        authCode.AuthorizedUserID,
 			Audience:       tokenRequest.ClientID,
 			Scopes:         accessTokenScopes,

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -249,13 +249,14 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_Success() {
 		Return(&authCodeWithResource, nil)
 
 	// Mock token builder to generate access token
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testUserID &&
-			len(ctx.Audiences) == 1 &&
-			ctx.Audiences[0] == testResourceURL &&
-			ctx.ClientID == testClientID &&
-			ctx.GrantType == string(constants.GrantTypeAuthorizationCode)
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID &&
+				len(ctx.Audiences) == 1 &&
+				ctx.Audiences[0] == testResourceURL &&
+				ctx.ClientID == testClientID &&
+				ctx.GrantType == string(constants.GrantTypeAuthorizationCode)
+		})).Return(&model.TokenDTO{
 		Token:     "test-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -313,7 +314,8 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_JWTGenerati
 		Return(&suite.testAuthzCode, nil)
 
 	// Mock token builder to fail token generation
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(nil, errors.New("jwt generation failed"))
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).
+		Return(nil, errors.New("jwt generation failed"))
 
 	// Create token request with matching resource
 	tokenReqWithResource := *suite.testTokenReq
@@ -338,7 +340,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_EmptyScopes
 	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
 		Return(&authzCodeWithEmptyScopes, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "test-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -366,7 +368,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 	suite.mockAuthzService.On("GetAuthorizationCodeDetails", mock.Anything, testClientID, "test-auth-code").
 		Return(&suite.testAuthzCode, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "test-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -563,6 +565,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 
 			// Mock access token generation - use function return to access context at call time
 			suite.mockTokenBuilder.On("BuildAccessToken",
+				mock.Anything,
 				mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 					// Capture user attributes and groups (simulate filtering that happens in BuildAccessToken)
 					capturedAccessTokenClaims = make(map[string]interface{})
@@ -571,7 +574,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 					}
 					// Verify GrantType is authorization_code
 					return ctx.GrantType == string(constants.GrantTypeAuthorizationCode)
-				})).Return(func(ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
+				})).Return(func(_ context.Context, ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
 				// Simulate filtering that happens in BuildAccessToken
 				userAttrs := make(map[string]interface{})
 				for k, v := range ctx.UserAttributes {
@@ -591,6 +594,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithGroups(
 			// Mock ID token generation if openid scope is present
 			if tc.includeOpenIDScope {
 				suite.mockTokenBuilder.On("BuildIDToken",
+					mock.Anything,
 					mock.MatchedBy(func(ctx *tokenservice.IDTokenBuildContext) bool {
 						// Capture ID token claims
 						capturedIDTokenClaims = make(map[string]interface{})
@@ -757,6 +761,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 
 			// Mock access token generation - use function return to access context at call time
 			suite.mockTokenBuilder.On("BuildAccessToken",
+				mock.Anything,
 				mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 					// Capture user attributes which contain groups
 					capturedAccessTokenClaims = make(map[string]interface{})
@@ -765,7 +770,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 					}
 					// Verify GrantType is authorization_code
 					return ctx.GrantType == string(constants.GrantTypeAuthorizationCode)
-				})).Return(func(ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
+				})).Return(func(_ context.Context, ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
 				// Return user attributes from the actual call context
 				userAttrs := make(map[string]interface{})
 				for k, v := range ctx.UserAttributes {
@@ -785,6 +790,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_WithEmptyGr
 			// Mock ID token generation if openid scope is present
 			if tc.includeOpenIDScope {
 				suite.mockTokenBuilder.On("BuildIDToken",
+					mock.Anything,
 					mock.MatchedBy(func(ctx *tokenservice.IDTokenBuildContext) bool {
 						// Capture ID token claims from user attributes
 						capturedIDTokenClaims = ctx.UserAttributes
@@ -852,10 +858,11 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_ResourcePar
 		Return(&authCodeWithResource, nil)
 
 	var capturedAudiences []string
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudiences = ctx.Audiences
-		return true
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			capturedAudiences = ctx.Audiences
+			return true
+		})).Return(&model.TokenDTO{
 		Token:     "mock-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -882,10 +889,11 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_NoResourceP
 		Return(&suite.testAuthzCode, nil)
 
 	var capturedAudiences []string
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudiences = ctx.Audiences
-		return true
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			capturedAudiences = ctx.Audiences
+			return true
+		})).Return(&model.TokenDTO{
 		Token:     "mock-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -918,7 +926,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_IDTokenGene
 		Return(&authzCodeWithOpenID, nil)
 
 	// Mock access token generation succeeds
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "test-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -928,7 +936,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_IDTokenGene
 	}, nil)
 
 	// Mock ID token generation fails
-	suite.mockTokenBuilder.On("BuildIDToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildIDToken", mock.Anything, mock.Anything).
 		Return(nil, errors.New("failed to generate ID token"))
 
 	result, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
@@ -1008,17 +1016,18 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_FetchUserGr
 
 	// Groups come from the authorization code (extracted from assertion during authorization)
 	// Token builder will extract groups from UserAttributes - verify groups are in UserAttributes
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		// Verify groups are in UserAttributes (will be extracted by token builder)
-		groupsValue, ok := ctx.UserAttributes[constants.UserAttributeGroups]
-		if !ok {
-			return false
-		}
-		groupsArray := convertToStringSlice(groupsValue)
-		return len(groupsArray) == 2 &&
-			groupsArray[0] == "Admin" &&
-			groupsArray[1] == "Users"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			// Verify groups are in UserAttributes (will be extracted by token builder)
+			groupsValue, ok := ctx.UserAttributes[constants.UserAttributeGroups]
+			if !ok {
+				return false
+			}
+			groupsArray := convertToStringSlice(groupsValue)
+			return len(groupsArray) == 2 &&
+				groupsArray[0] == "Admin" &&
+				groupsArray[1] == "Users"
+		})).Return(&model.TokenDTO{
 		Token:     "test-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -1129,7 +1138,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestRetrieveAndValidateAuth
 		Return(&authCodeWithPKCE, nil)
 
 	// Mock token builder
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "test-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -1217,10 +1226,11 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_TokenReques
 		Return(&authCodeWithTwoResources, nil)
 
 	var capturedAudiences []string
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudiences = ctx.Audiences
-		return true
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			capturedAudiences = ctx.Audiences
+			return true
+		})).Return(&model.TokenDTO{
 		Token:     "mock-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -1252,10 +1262,11 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_TokenReques
 		Return(&authCodeWithTwoResources, nil)
 
 	var capturedAudiences []string
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudiences = ctx.Audiences
-		return true
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			capturedAudiences = ctx.Audiences
+			return true
+		})).Return(&model.TokenDTO{
 		Token:     "mock-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -1298,11 +1309,12 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_TokenReques
 
 	var capturedAudiences []string
 	var capturedScopes []string
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudiences = ctx.Audiences
-		capturedScopes = ctx.Scopes
-		return true
-	})).Return(func(ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			capturedAudiences = ctx.Audiences
+			capturedScopes = ctx.Scopes
+			return true
+		})).Return(func(_ context.Context, ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
 		return &model.TokenDTO{
 			Token:     "mock-jwt-token",
 			TokenType: constants.TokenTypeBearer,
@@ -1336,10 +1348,11 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_TokenReques
 		Return(&authCodeNoResources, nil)
 
 	var capturedAudiences []string
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudiences = ctx.Audiences
-		return true
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			capturedAudiences = ctx.Audiences
+			return true
+		})).Return(&model.TokenDTO{
 		Token:     "mock-jwt-token",
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  time.Now().Unix(),
@@ -1394,6 +1407,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestHandleGrant_DPoPBoundCo
 		Return(&authzCodeBound, nil)
 
 	suite.mockTokenBuilder.On("BuildAccessToken",
+		mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.DPoPJkt == testDPoPThumbprint
 		})).Return(&model.TokenDTO{

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
@@ -161,8 +161,7 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 		}
 	}
 
-	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
-		Context:          ctx,
+	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, &tokenservice.AccessTokenBuildContext{
 		Subject:          tokenRequest.ClientID,
 		Audiences:        audiences,
 		ClientID:         tokenRequest.ClientID,

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
@@ -203,6 +203,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 
 			expectedToken := testJWTToken
 			suite.mockTokenBuilder.On("BuildAccessToken",
+				mock.Anything,
 				mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 					return ctx.Subject == testClientID &&
 						(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
@@ -254,7 +255,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_JWTGenerati
 		AuthorizedPermissions: []string{"read"},
 	}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).
 		Return(nil, errors.New("JWT generation failed"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -284,10 +285,11 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 	}, nil)
 
 	expectedToken := testJWTToken
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testClientID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
-			tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testClientID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
+				tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
+		})).Return(&model.TokenDTO{
 		Token:     expectedToken,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  int64(1234567890),
@@ -329,7 +331,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_TokenTiming
 
 	expectedToken := testJWTToken
 	now := time.Now().Unix()
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).
 		Return(&model.TokenDTO{
 			Token:     expectedToken,
 			TokenType: constants.TokenTypeBearer,
@@ -413,12 +415,13 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithResourc
 	}, nil)
 
 	var capturedAudiences []string
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudiences = ctx.Audiences
-		return ctx.Subject == testClientID &&
-			len(ctx.Audiences) == 1 &&
-			ctx.Audiences[0] == "https://mcp.example.com/mcp"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			capturedAudiences = ctx.Audiences
+			return ctx.Subject == testClientID &&
+				len(ctx.Audiences) == 1 &&
+				ctx.Audiences[0] == "https://mcp.example.com/mcp"
+		})).Return(&model.TokenDTO{
 		Token:     testJWTToken,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  int64(1234567890),
@@ -455,12 +458,13 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithoutReso
 	}, nil)
 
 	var capturedAudience string
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		if len(ctx.Audiences) > 0 {
-			capturedAudience = ctx.Audiences[0]
-		}
-		return ctx.Subject == testClientID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID)
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			if len(ctx.Audiences) > 0 {
+				capturedAudience = ctx.Audiences[0]
+			}
+			return ctx.Subject == testClientID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID)
+		})).Return(&model.TokenDTO{
 		Token:     testJWTToken,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  int64(1234567890),
@@ -503,6 +507,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_PartialScop
 	}, nil)
 
 	suite.mockTokenBuilder.On("BuildAccessToken",
+		mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return tokenservice.JoinScopes(ctx.Scopes) == tokenservice.JoinScopes([]string{"read", "write"})
 		})).Return(&model.TokenDTO{
@@ -539,6 +544,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NoAuthorize
 	}, nil)
 
 	suite.mockTokenBuilder.On("BuildAccessToken",
+		mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return len(ctx.Scopes) == 0
 		})).Return(&model.TokenDTO{
@@ -593,6 +599,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_EmptyScope_
 	}
 
 	suite.mockTokenBuilder.On("BuildAccessToken",
+		mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return len(ctx.Scopes) == 0
 		})).Return(&model.TokenDTO{
@@ -658,10 +665,11 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ImplicitRSD
 		}, nil)
 
 	var capturedAudiences []string
-	mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudiences = ctx.Audiences
-		return true
-	})).Return(&model.TokenDTO{
+	mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			capturedAudiences = ctx.Audiences
+			return true
+		})).Return(&model.TokenDTO{
 		Token:     testJWTToken,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  int64(1234567890),
@@ -723,10 +731,11 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ImplicitRSD
 		}, nil)
 
 	var capturedAudiences []string
-	mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		capturedAudiences = ctx.Audiences
-		return true
-	})).Return(&model.TokenDTO{
+	mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			capturedAudiences = ctx.Audiences
+			return true
+		})).Return(&model.TokenDTO{
 		Token:     testJWTToken,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  int64(1234567890),
@@ -770,6 +779,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_DPoPProof_P
 	}, nil)
 
 	suite.mockTokenBuilder.On("BuildAccessToken",
+		mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.DPoPJkt == "thumbprint-cc"
 		})).Return(&model.TokenDTO{
@@ -806,6 +816,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NoDPoPProof
 	}, nil)
 
 	suite.mockTokenBuilder.On("BuildAccessToken",
+		mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.DPoPJkt == ""
 		})).Return(&model.TokenDTO{

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -101,7 +101,8 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "RefreshTokenGrantHandler"))
 
 	// Validate refresh token using token validator
-	refreshTokenClaims, err := h.tokenValidator.ValidateRefreshToken(tokenRequest.RefreshToken, tokenRequest.ClientID)
+	refreshTokenClaims, err := h.tokenValidator.ValidateRefreshToken(
+		ctx, tokenRequest.RefreshToken, tokenRequest.ClientID)
 	if err != nil {
 		logger.Debug("Failed to validate refresh token", log.Error(err))
 		return nil, &model.ErrorResponse{
@@ -185,8 +186,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 		attrs = cacheEntry.Attributes
 	}
 
-	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
-		Context:          ctx,
+	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, &tokenservice.AccessTokenBuildContext{
 		Subject:          refreshTokenClaims.Sub,
 		Audiences:        audiences,
 		ClientID:         tokenRequest.ClientID,
@@ -214,8 +214,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 
 	// Generate ID token if 'openid' scope is present
 	if slices.Contains(newTokenScopes, constants.ScopeOpenID) {
-		idToken, idErr := h.tokenBuilder.BuildIDToken(&tokenservice.IDTokenBuildContext{
-			Context:        ctx,
+		idToken, idErr := h.tokenBuilder.BuildIDToken(ctx, &tokenservice.IDTokenBuildContext{
 			Subject:        refreshTokenClaims.Sub,
 			Audience:       tokenRequest.ClientID,
 			Scopes:         newTokenScopes,
@@ -279,7 +278,6 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 	attributeCacheID string,
 ) *model.ErrorResponse {
 	tokenCtx := &tokenservice.RefreshTokenBuildContext{
-		Context:              ctx,
 		ClientID:             oauthApp.ClientID,
 		Scopes:               scopes,
 		GrantType:            grantType,
@@ -293,7 +291,7 @@ func (h *refreshTokenGrantHandler) IssueRefreshToken(
 	}
 
 	// Build refresh token using token builder
-	refreshToken, err := h.tokenBuilder.BuildRefreshToken(tokenCtx)
+	refreshToken, err := h.tokenBuilder.BuildRefreshToken(ctx, tokenCtx)
 	if err != nil {
 		return &model.ErrorResponse{
 			Error:            constants.ErrorServerError,

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
@@ -202,7 +202,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestValidateGrant_MissingClientI
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_InvalidSignature() {
 	// Mock token validator to return error (simulating signature verification failure)
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(nil, errors.New("public key not available"))
 
 	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
@@ -215,7 +216,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_InvalidSignature
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_Success() {
 	// Mock token builder for refresh token generation
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
 			return ctx.ClientID == testRefreshTokenClientID &&
 				ctx.GrantType == "authorization_code" &&
@@ -248,7 +249,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_Success() 
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_JWTGenerationError() {
 	// Mock token builder to return error
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.Anything).
 		Return(nil, errors.New("JWT generation failed"))
 
 	tokenResponse := &model.TokenResponseDTO{}
@@ -263,7 +264,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_JWTGenerat
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithEmptyTokenAttributes() {
 	// Mock token builder with matcher that checks for empty sub and aud
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
 			return ctx.AccessTokenSubject == "" && len(ctx.AccessTokenAudiences) == 0
 		})).Return(&model.TokenDTO{
@@ -281,7 +282,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithEmptyT
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithClaimsLocales() {
 	// Mock token builder with matcher that checks claimsLocales is propagated
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
 			return ctx.ClientID == testRefreshTokenClientID &&
 				ctx.GrantType == "authorization_code" &&
@@ -308,7 +309,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_WithClaims
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRenewOnGrantDisabled() {
 	// Mock successful refresh token validation
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -319,7 +321,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 		}, nil)
 
 	// Mock successful access token generation
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.Subject == testRefreshTokenUserID &&
 				ctx.ClientID == testRefreshTokenClientID &&
@@ -345,7 +347,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 	config.GetServerRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
 
 	// Mock successful refresh token validation
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -356,7 +359,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 		}, nil)
 
 	// Mock successful access token generation
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:          "new.access.token",
 		IssuedAt:       time.Now().Unix(),
 		ExpiresIn:      3600,
@@ -365,7 +368,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 	}, nil)
 
 	// Mock successful refresh token generation
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
 			return ctx.AccessTokenSubject == testRefreshTokenUserID &&
 				len(ctx.AccessTokenAudiences) == 1 && ctx.AccessTokenAudiences[0] == testRefreshTokenAudience
@@ -385,7 +388,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 }
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_GetAttributeCacheError() {
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -416,7 +420,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_GetAttributeCach
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_BuildAccessTokenError() {
 	// Mock successful refresh token validation
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -427,7 +432,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_BuildAccessToken
 		}, nil)
 
 	// Mock failed access token generation
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).
 		Return(nil, errors.New("failed to sign JWT"))
 
 	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
@@ -443,7 +448,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IssueRefreshToke
 	config.GetServerRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
 
 	// Mock successful refresh token validation
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -454,7 +460,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IssueRefreshToke
 		}, nil)
 
 	// Mock successful access token generation
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:          "new.access.token",
 		IssuedAt:       time.Now().Unix(),
 		ExpiresIn:      3600,
@@ -463,7 +469,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IssueRefreshToke
 	}, nil)
 
 	// Mock failed refresh token generation
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.Anything).
 		Return(nil, errors.New("refresh token generation failed"))
 
 	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
@@ -478,7 +484,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ExtractIatClaimE
 	// RenewOnGrant is disabled by default in SetupTest
 
 	// Mock validator to return error when iat is missing (validation fails)
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(nil, errors.New("missing or invalid 'iat' claim"))
 
 	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
@@ -537,7 +544,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestValidateAndApplyScopes_NoMat
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGenerated_WhenOpenIDScopePresent() {
 	// Mock successful refresh token validation with openid scope
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -548,7 +556,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGenerated
 		}, nil)
 
 	// Mock successful access token generation
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:          "new.access.token",
 		IssuedAt:       time.Now().Unix(),
 		ExpiresIn:      3600,
@@ -557,7 +565,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGenerated
 	}, nil)
 
 	// Mock successful ID token generation
-	suite.mockTokenBuilder.On("BuildIDToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildIDToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.IDTokenBuildContext) bool {
 			return ctx.Subject == testRefreshTokenUserID &&
 				ctx.Audience == testRefreshTokenClientID &&
@@ -590,7 +598,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGenerated
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoIDToken_WhenOpenIDScopeAbsent() {
 	// Mock successful refresh token validation without openid scope
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -601,7 +610,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoIDToken_WhenOp
 		}, nil)
 
 	// Mock successful access token generation
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.Subject == testRefreshTokenUserID &&
 				ctx.ClientID == testRefreshTokenClientID &&
@@ -624,7 +633,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoIDToken_WhenOp
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGenerationError() {
 	// Mock successful refresh token validation with openid scope
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -635,7 +645,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGeneratio
 		}, nil)
 
 	// Mock successful access token generation
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "new.access.token",
 		IssuedAt:  time.Now().Unix(),
 		ExpiresIn: 3600,
@@ -643,7 +653,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenGeneratio
 	}, nil)
 
 	// Mock failed ID token generation
-	suite.mockTokenBuilder.On("BuildIDToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildIDToken", mock.Anything, mock.Anything).
 		Return(nil, errors.New("failed to generate ID token"))
 
 	tokenReq := &model.TokenRequest{
@@ -667,7 +677,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoRenewOnGrant_R
 	// Access token ExpiresIn is 0 (< 82800), so the cache is extended to the refresh
 	// token's remaining lifetime (~82800 s).
 
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -681,7 +692,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoRenewOnGrant_R
 		Return(&attributecache.AttributeCache{ID: testCacheID, Attributes: map[string]interface{}{}},
 			(*serviceerror.ServiceError)(nil)).Once()
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:    "new.access.token",
 		IssuedAt: time.Now().Unix(),
 		Scopes:   []string{"read"},
@@ -704,7 +715,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ExtendsCache_Whe
 	// Access token ExpiresIn = 7200 > 3400, so the cache must be extended to 7200 s.
 
 	now := time.Now().Unix()
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -718,7 +730,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ExtendsCache_Whe
 		Return(&attributecache.AttributeCache{ID: testCacheID, Attributes: map[string]interface{}{}},
 			(*serviceerror.ServiceError)(nil)).Once()
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "new.access.token",
 		IssuedAt:  now,
 		ExpiresIn: 7200,
@@ -742,7 +754,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoRenewOnGrant_E
 	// ExtendAttributeCacheTTL fails → handler returns a server error.
 
 	now := time.Now().Unix()
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -756,7 +769,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoRenewOnGrant_E
 		Return(&attributecache.AttributeCache{ID: testCacheID, Attributes: map[string]interface{}{}},
 			(*serviceerror.ServiceError)(nil)).Once()
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "new.access.token",
 		IssuedAt:  now,
 		ExpiresIn: 7200,
@@ -785,7 +798,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoRenewOnGrant_E
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_ExtendsAttributeCacheTTL() {
 	config.GetServerRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
 
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -799,7 +813,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ext
 		Return(&attributecache.AttributeCache{ID: testCacheID, Attributes: map[string]interface{}{}},
 			(*serviceerror.ServiceError)(nil)).Once()
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:          "new.access.token",
 		IssuedAt:       time.Now().Unix(),
 		ExpiresIn:      3600,
@@ -807,7 +821,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ext
 		UserAttributes: map[string]interface{}{"aci": testCacheID},
 	}, nil)
 
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "new.refresh.token",
 		IssuedAt:  time.Now().Unix(),
 		ExpiresIn: 86400,
@@ -830,7 +844,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ext
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_ExtendAttributeCacheTTLError() {
 	config.GetServerRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
 
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -844,7 +859,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ext
 		Return(&attributecache.AttributeCache{ID: testCacheID, Attributes: map[string]interface{}{}},
 			(*serviceerror.ServiceError)(nil)).Once()
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:          "new.access.token",
 		IssuedAt:       time.Now().Unix(),
 		ExpiresIn:      3600,
@@ -852,7 +867,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ext
 		UserAttributes: map[string]interface{}{"aci": testCacheID},
 	}, nil)
 
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "new.refresh.token",
 		IssuedAt:  time.Now().Unix(),
 		ExpiresIn: 86400,
@@ -883,7 +898,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_SkipsCacheExtend
 	// (max of refresh remaining ≈ 82800 and access ExpiresIn 3600, plus buffer 60 = ≈ 82860), so
 	// ExtendAttributeCacheTTL must not be called.
 
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -900,7 +916,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_SkipsCacheExtend
 			TTLSeconds: 100000,
 		}, (*serviceerror.ServiceError)(nil)).Once()
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "new.access.token",
 		IssuedAt:  time.Now().Unix(),
 		ExpiresIn: 3600,
@@ -1020,7 +1036,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenWithRenew
 	config.GetServerRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
 
 	// Mock successful refresh token validation with openid scope
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRefreshTokenAudience},
@@ -1031,7 +1048,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenWithRenew
 		}, nil)
 
 	// Mock successful access token generation
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:          "new.access.token",
 		IssuedAt:       time.Now().Unix(),
 		ExpiresIn:      3600,
@@ -1040,7 +1057,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenWithRenew
 	}, nil)
 
 	// Mock successful ID token generation
-	suite.mockTokenBuilder.On("BuildIDToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildIDToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.IDTokenBuildContext) bool {
 			return ctx.Subject == testRefreshTokenUserID &&
 				ctx.Audience == testRefreshTokenClientID
@@ -1054,7 +1071,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_IDTokenWithRenew
 	}, nil)
 
 	// Mock successful refresh token generation
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "new.refresh.token",
 		IssuedAt:  time.Now().Unix(),
 		ExpiresIn: 86400,
@@ -1097,7 +1114,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestValidateGrant_MalformedResou
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowing_KnownResource_NarrowsAud() {
 	// Original aud=[rs01, rs02]; request resource=[rs01] → issued aud=[rs01].
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRS01URI, testRS02URI},
@@ -1107,7 +1125,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowin
 			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
 		})).Return(&model.TokenDTO{
@@ -1134,7 +1152,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowin
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowing_UnknownResource_InvalidTarget() {
 	// Original aud=[rs01, rs02]; request resource=[rs99] (unknown) → empty intersection → invalid_target.
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRS01URI, testRS02URI},
@@ -1162,7 +1181,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowin
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowing_MixedResources_DropsUnknown() {
 	// Original aud=[rs01, rs02]; request resource=[rs99, rs01] → issued aud=[rs01] (rs99 dropped).
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRS01URI, testRS02URI},
@@ -1172,7 +1192,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowin
 			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
 		})).Return(&model.TokenDTO{
@@ -1198,7 +1218,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowin
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoResourceParam_AudUnchanged() {
 	// No resource param → issued aud equals original aud (regression guard).
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRS01URI, testRS02URI},
@@ -1208,7 +1229,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoResourceParam_
 			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return len(ctx.Audiences) == 2 &&
 				ctx.Audiences[0] == testRS01URI &&
@@ -1238,7 +1259,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ori
 	// carry the ORIGINAL (un-narrowed) audiences so future refreshes can recover dropped resources.
 	config.GetServerRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
 
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRS01URI, testRS02URI},
@@ -1248,7 +1270,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ori
 			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
 		})).Return(&model.TokenDTO{
@@ -1259,7 +1281,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ori
 	}, nil)
 
 	// New refresh token must carry the original full aud [rs01, rs02], not only the narrowed rs01.
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
 			return len(ctx.AccessTokenAudiences) == 2 &&
 				ctx.AccessTokenAudiences[0] == testRS01URI &&
@@ -1288,7 +1310,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Ori
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowing_EmptyIntersection_InvalidTarget() {
 	// All requested resources are outside the original grant → invalid_target (Issue 2).
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRS01URI},
@@ -1323,7 +1346,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowin
 	suite.mockResourceService.On("ValidatePermissions", mock.Anything, testRS01URI, mock.Anything).
 		Return([]string{"write"}, nil)
 
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:              testRefreshTokenUserID,
 			Audiences:        []string{testRS01URI, testRS02URI},
@@ -1333,7 +1357,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowin
 			Iat:              int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI &&
 				len(ctx.Scopes) == 1 && ctx.Scopes[0] == testScopeRead
@@ -1362,7 +1386,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ResourceNarrowin
 const testRefreshTokenJkt = "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I" // #nosec G101
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DPoPBoundRT_MissingProof_Rejected() {
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:       testRefreshTokenUserID,
 			Audiences: []string{testRefreshTokenAudience},
@@ -1381,7 +1406,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DPoPBoundRT_Miss
 }
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DPoPBoundRT_WrongKey_Rejected() {
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:       testRefreshTokenUserID,
 			Audiences: []string{testRefreshTokenAudience},
@@ -1401,7 +1427,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DPoPBoundRT_Wron
 }
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DPoPBoundRT_ValidProof_AccessTokenBound() {
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:       testRefreshTokenUserID,
 			Audiences: []string{testRefreshTokenAudience},
@@ -1411,7 +1438,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DPoPBoundRT_Vali
 			DPoPJkt:   testRefreshTokenJkt,
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.DPoPJkt == testRefreshTokenJkt
 		})).Return(&model.TokenDTO{
@@ -1431,7 +1458,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DPoPBoundRT_Vali
 }
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_UnboundRT_NoProof_Succeeds() {
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:       testRefreshTokenUserID,
 			Audiences: []string{testRefreshTokenAudience},
@@ -1440,7 +1468,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_UnboundRT_NoProo
 			Iat:       int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.DPoPJkt == ""
 		})).Return(&model.TokenDTO{
@@ -1458,7 +1486,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_UnboundRT_NoProo
 }
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_UnboundRT_VoluntaryProof_AccessTokenBound() {
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:       testRefreshTokenUserID,
 			Audiences: []string{testRefreshTokenAudience},
@@ -1467,7 +1496,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_UnboundRT_Volunt
 			Iat:       int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.DPoPJkt == testRefreshTokenJkt
 		})).Return(&model.TokenDTO{
@@ -1490,7 +1519,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DPoPBoundRT_Rene
 	config.GetServerRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
 
 	suite.oauthApp.PublicClient = true
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:       testRefreshTokenUserID,
 			Audiences: []string{testRefreshTokenAudience},
@@ -1500,7 +1530,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DPoPBoundRT_Rene
 			DPoPJkt:   testRefreshTokenJkt,
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "new.access.token",
 		IssuedAt:  time.Now().Unix(),
 		ExpiresIn: 3600,
@@ -1508,7 +1538,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DPoPBoundRT_Rene
 		TokenType: constants.TokenTypeDPoP,
 	}, nil)
 
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
 			return ctx.DPoPJkt == testRefreshTokenJkt
 		})).Return(&model.TokenDTO{
@@ -1530,7 +1560,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Con
 	config.GetServerRuntime().Config.OAuth.RefreshToken.RenewOnGrant = true
 
 	suite.oauthApp.PublicClient = false
-	suite.mockTokenValidator.On("ValidateRefreshToken", suite.validRefreshToken, testRefreshTokenClientID).
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
 		Return(&tokenservice.RefreshTokenClaims{
 			Sub:       testRefreshTokenUserID,
 			Audiences: []string{testRefreshTokenAudience},
@@ -1539,14 +1570,14 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Con
 			Iat:       int64(suite.validClaims["iat"].(float64)),
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     "new.access.token",
 		IssuedAt:  time.Now().Unix(),
 		ExpiresIn: 3600,
 		Scopes:    []string{"read"},
 	}, nil)
 
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
 			return ctx.DPoPJkt == ""
 		})).Return(&model.TokenDTO{
@@ -1564,7 +1595,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewOnGrant_Con
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_PublicClient_BindsJkt() {
 	suite.oauthApp.PublicClient = true
 
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
 			return ctx.DPoPJkt == testRefreshTokenJkt
 		})).Return(&model.TokenDTO{
@@ -1586,7 +1617,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_PublicClie
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_ConfidentialClient_DoesNotBindJkt() {
 	suite.oauthApp.PublicClient = false
 
-	suite.mockTokenBuilder.On("BuildRefreshToken", mock.MatchedBy(
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.MatchedBy(
 		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
 			return ctx.DPoPJkt == ""
 		})).Return(&model.TokenDTO{

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -196,8 +196,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	finalAudiences := mergeAudiences(tokenRequest.Audiences, rsAudiences, tokenRequest.ClientID)
 
 	// Build access token using token builder
-	accessToken, err := h.tokenBuilder.BuildAccessToken(&tokenservice.AccessTokenBuildContext{
-		Context:        ctx,
+	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, &tokenservice.AccessTokenBuildContext{
 		Subject:        subjectClaims.Sub,
 		Audiences:      finalAudiences,
 		ClientID:       tokenRequest.ClientID,

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -169,17 +169,18 @@ func (suite *TokenExchangeGrantHandlerTestSuite) setupSuccessfulJWTMock(
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		if ctx.Subject != testUserID || len(ctx.Audiences) == 0 {
-			return false
-		}
-		for _, a := range ctx.Audiences {
-			if a == expectedAudience {
-				return true
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			if ctx.Subject != testUserID || len(ctx.Audiences) == 0 {
+				return false
 			}
-		}
-		return false
-	})).Return(&model.TokenDTO{
+			for _, a := range ctx.Audiences {
+				if a == expectedAudience {
+					return true
+				}
+			}
+			return false
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -204,10 +205,11 @@ func (suite *TokenExchangeGrantHandlerTestSuite) setupSuccessfulJWTMockWithScope
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testUserID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == expectedAudience) &&
-			tokenservice.JoinScopes(ctx.Scopes) == expectedScope
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == expectedAudience) &&
+				tokenservice.JoinScopes(ctx.Scopes) == expectedScope
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -430,14 +432,15 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_Basic()
 			UserAttributes: map[string]interface{}{"email": testUserEmail},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testUserID &&
-			(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
-			// Default audience is clientID when no resource/audience parameter
-			ctx.ClientID == testClientID &&
-			ctx.UserAttributes["email"] == testUserEmail &&
-			tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID &&
+				(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
+				// Default audience is clientID when no resource/audience parameter
+				ctx.ClientID == testClientID &&
+				ctx.UserAttributes["email"] == testUserEmail &&
+				tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -520,13 +523,14 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAct
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testUserID &&
-			(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
-			ctx.ActorClaims != nil &&
-			ctx.ActorClaims.Sub == "service456" &&
-			ctx.ActorClaims.Iss == testCustomIssuer
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID &&
+				(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
+				ctx.ActorClaims != nil &&
+				ctx.ActorClaims.Sub == "service456" &&
+				ctx.ActorClaims.Iss == testCustomIssuer
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -587,13 +591,14 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAct
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		if ctx.ActorClaims == nil {
-			return false
-		}
-		// Check new actor (from actor token)
-		return ctx.ActorClaims.Sub == "service456" && ctx.ActorClaims.Iss == testCustomIssuer
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			if ctx.ActorClaims == nil {
+				return false
+			}
+			// Check new actor (from actor token)
+			return ctx.ActorClaims.Sub == "service456" && ctx.ActorClaims.Iss == testCustomIssuer
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -701,12 +706,13 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_Preserv
 			},
 			NestedAct: nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testUserID &&
-			(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
-			ctx.UserAttributes["email"] == "user@example.com" &&
-			ctx.UserAttributes["name"] == "Test User"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID &&
+				(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
+				ctx.UserAttributes["email"] == "user@example.com" &&
+				ctx.UserAttributes["name"] == "Test User"
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -919,10 +925,11 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidScope() 
 			NestedAct:      nil,
 		}, nil)
 	// Expect token generation with only valid scopes ("read write", filtering out "delete")
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		// Verify only valid scopes are included (filtering out "delete")
-		return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			// Verify only valid scopes are included (filtering out "delete")
+			return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -999,7 +1006,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_JWTGenerationEr
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).
 		Return(nil, errors.New("failed to sign token"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -1040,7 +1047,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_UsesDefaultConf
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).
 		Return(&model.TokenDTO{
 			Token:     testTokenExchangeJWT,
 			TokenType: constants.TokenTypeBearer,
@@ -1081,7 +1088,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithJWT
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).
 		Return(&model.TokenDTO{
 			Token:     testTokenExchangeJWT,
 			TokenType: constants.TokenTypeBearer,
@@ -1167,17 +1174,18 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_CompleteTokenExchan
 			},
 			NestedAct: nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		// Verify claims structure per RFC 8693 - explicit audience is used verbatim; clientID
-		// fallback is dropped when explicit audience is non-empty.
-		return ctx.Subject == testUserID &&
-			len(ctx.Audiences) == 1 &&
-			ctx.Audiences[0] == "https://target-service.com" &&
-			ctx.ClientID == testClientID &&
-			tokenservice.JoinScopes(ctx.Scopes) == testScopeRead &&
-			ctx.UserAttributes["email"] == "user@example.com" &&
-			ctx.UserAttributes["name"] == "John Doe"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			// Verify claims structure per RFC 8693 - explicit audience is used verbatim; clientID
+			// fallback is dropped when explicit audience is non-empty.
+			return ctx.Subject == testUserID &&
+				len(ctx.Audiences) == 1 &&
+				ctx.Audiences[0] == "https://target-service.com" &&
+				ctx.ClientID == testClientID &&
+				tokenservice.JoinScopes(ctx.Scopes) == testScopeRead &&
+				ctx.UserAttributes["email"] == "user@example.com" &&
+				ctx.UserAttributes["name"] == "John Doe"
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -1232,14 +1240,15 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_AudienceCombinedWit
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		// explicit audience first, then RS-resolved audience; clientID fallback absent since
-		// explicit audiences were supplied.
-		return ctx.Subject == testUserID &&
-			len(ctx.Audiences) == 2 &&
-			ctx.Audiences[0] == "request-audience" &&
-			ctx.Audiences[1] == "https://resource.example.com"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			// explicit audience first, then RS-resolved audience; clientID fallback absent since
+			// explicit audiences were supplied.
+			return ctx.Subject == testUserID &&
+				len(ctx.Audiences) == 2 &&
+				ctx.Audiences[0] == "request-audience" &&
+				ctx.Audiences[1] == "https://resource.example.com"
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -1311,21 +1320,22 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_ActorDelegationChai
 				"iss": "https://nested-issuer.com",
 			},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		// Verify nested delegation chain per RFC 8693
-		if ctx.ActorClaims == nil {
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			// Verify nested delegation chain per RFC 8693
+			if ctx.ActorClaims == nil {
+				return false
+			}
+			// Current actor
+			if ctx.ActorClaims.Sub != "current-actor" || ctx.ActorClaims.Iss != testCustomIssuer {
+				return false
+			}
+			// Check that actor token's act claim is preserved
+			if len(ctx.ActorClaims.NestedAct) > 0 {
+				return ctx.ActorClaims.NestedAct["sub"] == "actor-of-actor"
+			}
 			return false
-		}
-		// Current actor
-		if ctx.ActorClaims.Sub != "current-actor" || ctx.ActorClaims.Iss != testCustomIssuer {
-			return false
-		}
-		// Check that actor token's act claim is preserved
-		if len(ctx.ActorClaims.NestedAct) > 0 {
-			return ctx.ActorClaims.NestedAct["sub"] == "actor-of-actor"
-		}
-		return false
-	})).Return(&model.TokenDTO{
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -1390,29 +1400,30 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAct
 				"iss": "https://nested-issuer.com",
 			},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		// Verify actor claim structure
-		if ctx.ActorClaims == nil {
-			return false
-		}
-		// Current actor should be present
-		if ctx.ActorClaims.Sub != "current-actor" || ctx.ActorClaims.Iss != testCustomIssuer {
-			return false
-		}
-		// Actor's act claim should be preserved directly
-		if len(ctx.ActorClaims.NestedAct) > 0 {
-			nestedAct := ctx.ActorClaims.NestedAct
-			nestedSub := nestedAct["sub"] == "actor-of-actor"
-			nestedIss := nestedAct["iss"] == "https://nested-issuer.com"
-			if !nestedSub || !nestedIss {
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			// Verify actor claim structure
+			if ctx.ActorClaims == nil {
 				return false
 			}
-			// Subject has no act claim, so it should not be nested
-			_, hasFurtherNesting := ctx.ActorClaims.NestedAct["act"]
-			return !hasFurtherNesting
-		}
-		return false
-	})).Return(&model.TokenDTO{
+			// Current actor should be present
+			if ctx.ActorClaims.Sub != "current-actor" || ctx.ActorClaims.Iss != testCustomIssuer {
+				return false
+			}
+			// Actor's act claim should be preserved directly
+			if len(ctx.ActorClaims.NestedAct) > 0 {
+				nestedAct := ctx.ActorClaims.NestedAct
+				nestedSub := nestedAct["sub"] == "actor-of-actor"
+				nestedIss := nestedAct["iss"] == "https://nested-issuer.com"
+				if !nestedSub || !nestedIss {
+					return false
+				}
+				// Subject has no act claim, so it should not be nested
+				_, hasFurtherNesting := ctx.ActorClaims.NestedAct["act"]
+				return !hasFurtherNesting
+			}
+			return false
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -1455,9 +1466,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_ScopeDownscopingEnf
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -1513,7 +1525,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_NoTokenLinkage() {
 			UserAttributes: map[string]interface{}{},
 			NestedAct:      nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).
 		Return(&model.TokenDTO{
 			Token:     testTokenExchangeJWT,
 			TokenType: constants.TokenTypeBearer,
@@ -1571,13 +1583,14 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_ClaimPreservation()
 			},
 			NestedAct: nil,
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		// Verify all custom claims are preserved in user attributes
-		return ctx.UserAttributes["email"] == testUserEmail &&
-			ctx.UserAttributes["given_name"] == "John" &&
-			ctx.UserAttributes["family_name"] == "Doe" &&
-			ctx.UserAttributes["organization"] == "ACME Corp"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			// Verify all custom claims are preserved in user attributes
+			return ctx.UserAttributes["email"] == testUserEmail &&
+				ctx.UserAttributes["given_name"] == "John" &&
+				ctx.UserAttributes["family_name"] == "Doe" &&
+				ctx.UserAttributes["organization"] == "ACME Corp"
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -1675,12 +1688,13 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ServerAuthAsser
 			NestedAct:      nil,
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testUserID &&
-			len(ctx.Scopes) == 2 &&
-			ctx.Scopes[0] == "read:documents" &&
-			ctx.Scopes[1] == "write:documents"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID &&
+				len(ctx.Scopes) == 2 &&
+				ctx.Scopes[0] == "read:documents" &&
+				ctx.Scopes[1] == "write:documents"
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -1792,7 +1806,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ServerAuthAsser
 			NestedAct:      nil,
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -1840,12 +1854,13 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ServerAuthAsser
 			NestedAct:      nil,
 		}, nil)
 
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.Subject == testUserID &&
-			len(ctx.Scopes) == 2 &&
-			ctx.Scopes[0] == "read:documents" &&
-			ctx.Scopes[1] == "write:documents"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID &&
+				len(ctx.Scopes) == 2 &&
+				ctx.Scopes[0] == "read:documents" &&
+				ctx.Scopes[1] == "write:documents"
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -1887,9 +1902,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyAudience_Au
 			Scopes:         []string{},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return len(ctx.Audiences) == 1 && ctx.Audiences[0] == "logical://x"
-	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == "logical://x"
+		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
 
@@ -1916,9 +1932,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyResource_Au
 			Scopes:         []string{},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
-	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
+		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
 
@@ -1946,11 +1963,12 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceAndReso
 			Scopes:         []string{},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return len(ctx.Audiences) == 2 &&
-			ctx.Audiences[0] == "logical://x" &&
-			ctx.Audiences[1] == testRS01URI
-	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 2 &&
+				ctx.Audiences[0] == "logical://x" &&
+				ctx.Audiences[1] == testRS01URI
+		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
 
@@ -1978,13 +1996,14 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_TwoAudiencesTwo
 			Scopes:         []string{},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return len(ctx.Audiences) == 4 &&
-			ctx.Audiences[0] == "https://a1.example.com" &&
-			ctx.Audiences[1] == "https://a2.example.com" &&
-			ctx.Audiences[2] == testRS01URI &&
-			ctx.Audiences[3] == "https://rs02.example.com"
-	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 4 &&
+				ctx.Audiences[0] == "https://a1.example.com" &&
+				ctx.Audiences[1] == "https://a2.example.com" &&
+				ctx.Audiences[2] == testRS01URI &&
+				ctx.Audiences[3] == "https://rs02.example.com"
+		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
 
@@ -2012,11 +2031,12 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceIsClien
 			Scopes:         []string{},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return len(ctx.Audiences) == 2 &&
-			ctx.Audiences[0] == testClientID &&
-			ctx.Audiences[1] == testRS01URI
-	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 2 &&
+				ctx.Audiences[0] == testClientID &&
+				ctx.Audiences[1] == testRS01URI
+		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
 
@@ -2043,9 +2063,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceOnly_Cl
 			Scopes:         []string{},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return len(ctx.Audiences) == 1 && ctx.Audiences[0] == "https://other-service.example.com"
-	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == "https://other-service.example.com"
+		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
 
@@ -2071,9 +2092,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_NeitherAudience
 			Scopes:         []string{},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testClientID
-	})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testClientID
+		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
 
@@ -2122,9 +2144,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_Resourc
 			Scopes:         []string{"read", "write", "admin"},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -2178,9 +2201,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_ScopeNo
 			Scopes:         []string{"read", "write", "admin"},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -2215,9 +2239,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_Resourc
 			Scopes:         []string{"read", "write"},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,
@@ -2250,9 +2275,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_DPoPProof_Propa
 			Iss:    testCustomIssuer,
 			Scopes: []string{"read"},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.DPoPJkt == "thumbprint-tx"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.DPoPJkt == "thumbprint-tx"
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeDPoP,
 		IssuedAt:  now,
@@ -2288,9 +2314,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_BoundSubjectTok
 			Scopes: []string{"read"},
 			CnfJkt: "thumbprint-tx",
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return ctx.DPoPJkt == "thumbprint-tx"
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.DPoPJkt == "thumbprint-tx"
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeDPoP,
 		IssuedAt:  now,
@@ -2408,9 +2435,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_Multipl
 			Scopes:         []string{"read", "write", "admin"},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-		return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
-	})).Return(&model.TokenDTO{
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
+		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
 		IssuedAt:  now,

--- a/backend/internal/oauth/oauth2/introspect/service.go
+++ b/backend/internal/oauth/oauth2/introspect/service.go
@@ -57,7 +57,7 @@ func (s *tokenIntrospectionService) IntrospectToken(
 		return nil, errors.New("token is required")
 	}
 
-	if !s.validateToken(logger, token) {
+	if !s.validateToken(ctx, logger, token) {
 		return &IntrospectResponse{
 			Active: false,
 		}, nil
@@ -78,8 +78,8 @@ func (s *tokenIntrospectionService) IntrospectToken(
 }
 
 // validateToken verifies the signature and validity of the token.
-func (s *tokenIntrospectionService) validateToken(logger *log.Logger, token string) bool {
-	if err := s.jwtService.VerifyJWT(token, "", ""); err != nil {
+func (s *tokenIntrospectionService) validateToken(ctx context.Context, logger *log.Logger, token string) bool {
+	if err := s.jwtService.VerifyJWT(ctx, token, "", ""); err != nil {
 		logger.Debug("Failed to verify refresh token", log.String("error", err.Error.DefaultValue))
 		return false
 	}

--- a/backend/internal/oauth/oauth2/introspect/service_test.go
+++ b/backend/internal/oauth/oauth2/introspect/service_test.go
@@ -81,7 +81,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_EmptyToken() {
 
 func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_PublicKeyNotAvailable() {
 	s.jwtServiceMock.On("GetPublicKey").Return(nil).Maybe()
-	s.jwtServiceMock.On("VerifyJWT", mock.Anything, "", "").Return(
+	s.jwtServiceMock.On("VerifyJWT", mock.Anything, mock.Anything, "", "").Return(
 		&serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 			Code: "PUBLIC_KEY_NOT_AVAILABLE",
@@ -126,7 +126,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_InvalidSignatur
 
 	invalidToken := signingInput + "." + signatureEncoded
 
-	s.jwtServiceMock.On("VerifyJWT", invalidToken, "", "").Return(
+	s.jwtServiceMock.On("VerifyJWT", mock.Anything, invalidToken, "", "").Return(
 		&serviceerror.ServiceError{
 			Type:  serviceerror.ServerErrorType,
 			Code:  "INVALID_SIGNATURE",
@@ -149,7 +149,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_DecodeFailsAfte
 	// This can happen with a malformed JWT structure (e.g., missing dots or invalid base64)
 	malformedToken := "header.payload" // Missing signature part
 
-	s.jwtServiceMock.On("VerifyJWT", malformedToken, "", "").Return(nil)
+	s.jwtServiceMock.On("VerifyJWT", mock.Anything, malformedToken, "", "").Return(nil)
 
 	response, err := s.introspectService.IntrospectToken(context.Background(), malformedToken, "")
 	assert.NoError(s.T(), err)
@@ -267,7 +267,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken() {
 			// Mock VerifyJWT based on test case
 			switch tc.name {
 			case "InvalidTokenFormat":
-				s.jwtServiceMock.On("VerifyJWT", token, "", "").Return(
+				s.jwtServiceMock.On("VerifyJWT", mock.Anything, token, "", "").Return(
 					&serviceerror.ServiceError{
 						Type: serviceerror.ServerErrorType,
 						Code: "INVALID_TOKEN_FORMAT",
@@ -279,7 +279,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken() {
 						},
 					})
 			case "ExpiredToken":
-				s.jwtServiceMock.On("VerifyJWT", token, "", "").Return(
+				s.jwtServiceMock.On("VerifyJWT", mock.Anything, token, "", "").Return(
 					&serviceerror.ServiceError{
 						Type: serviceerror.ClientErrorType,
 						Code: "TOKEN_EXPIRED",
@@ -291,7 +291,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken() {
 						},
 					})
 			case "FutureToken":
-				s.jwtServiceMock.On("VerifyJWT", token, "", "").Return(
+				s.jwtServiceMock.On("VerifyJWT", mock.Anything, token, "", "").Return(
 					&serviceerror.ServiceError{
 						Type: serviceerror.ClientErrorType,
 						Code: "TOKEN_NOT_VALID_YET",
@@ -304,7 +304,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken() {
 						},
 					})
 			case "TokenWithMissingExpClaim":
-				s.jwtServiceMock.On("VerifyJWT", token, "", "").Return(
+				s.jwtServiceMock.On("VerifyJWT", mock.Anything, token, "", "").Return(
 					&serviceerror.ServiceError{
 						Type: serviceerror.ClientErrorType,
 						Code: "MISSING_EXP_CLAIM",
@@ -317,7 +317,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken() {
 						},
 					})
 			case "TokenWithMissingNbfClaim":
-				s.jwtServiceMock.On("VerifyJWT", token, "", "").Return(
+				s.jwtServiceMock.On("VerifyJWT", mock.Anything, token, "", "").Return(
 					&serviceerror.ServiceError{
 						Type: serviceerror.ClientErrorType,
 						Code: "MISSING_NBF_CLAIM",
@@ -330,9 +330,9 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken() {
 						},
 					})
 			case "ValidToken", "TokenWithMissingOptionalClaims":
-				s.jwtServiceMock.On("VerifyJWT", token, "", "").Return(nil)
+				s.jwtServiceMock.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 			default:
-				s.jwtServiceMock.On("VerifyJWT", token, "", "").Return(nil)
+				s.jwtServiceMock.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 			}
 
 			response, err := s.introspectService.IntrospectToken(context.Background(), token, "")
@@ -390,7 +390,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_DPoPBoundToken_
 	token := s.createToken(claims)
 
 	s.jwtServiceMock.On("GetPublicKey").Return(&s.privateKey.PublicKey).Maybe()
-	s.jwtServiceMock.On("VerifyJWT", token, "", "").Return(nil)
+	s.jwtServiceMock.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
 	response, err := s.introspectService.IntrospectToken(context.Background(), token, "")
 	assert.NoError(s.T(), err)

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -32,18 +32,11 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 )
 
-func resolveContext(ctx context.Context) context.Context {
-	if ctx == nil {
-		return context.Background()
-	}
-	return ctx
-}
-
 // TokenBuilderInterface defines the interface for building OAuth2 tokens.
 type TokenBuilderInterface interface {
-	BuildAccessToken(ctx *AccessTokenBuildContext) (*oauth2model.TokenDTO, error)
-	BuildRefreshToken(ctx *RefreshTokenBuildContext) (*oauth2model.TokenDTO, error)
-	BuildIDToken(ctx *IDTokenBuildContext) (*oauth2model.TokenDTO, error)
+	BuildAccessToken(ctx context.Context, tokenCtx *AccessTokenBuildContext) (*oauth2model.TokenDTO, error)
+	BuildRefreshToken(ctx context.Context, tokenCtx *RefreshTokenBuildContext) (*oauth2model.TokenDTO, error)
+	BuildIDToken(ctx context.Context, tokenCtx *IDTokenBuildContext) (*oauth2model.TokenDTO, error)
 }
 
 // TokenBuilder implements TokenBuilderInterface.
@@ -67,40 +60,43 @@ func newTokenBuilder(
 }
 
 // BuildAccessToken builds an access token with all necessary claims.
-func (tb *tokenBuilder) BuildAccessToken(ctx *AccessTokenBuildContext) (*oauth2model.TokenDTO, error) {
-	if ctx == nil {
+func (tb *tokenBuilder) BuildAccessToken(
+	ctx context.Context,
+	tokenCtx *AccessTokenBuildContext,
+) (*oauth2model.TokenDTO, error) {
+	if tokenCtx == nil {
 		return nil, fmt.Errorf("build context cannot be nil")
 	}
 
-	tokenConfig := ResolveTokenConfig(ctx.OAuthApp, TokenTypeAccess)
+	tokenConfig := ResolveTokenConfig(tokenCtx.OAuthApp, TokenTypeAccess)
 
-	userAttributes := tb.buildAccessTokenUserAttributes(ctx.UserAttributes, ctx.OAuthApp)
-	jwtClaims, claimsErr := tb.buildAccessTokenClaims(ctx, userAttributes)
+	userAttributes := tb.buildAccessTokenUserAttributes(tokenCtx.UserAttributes, tokenCtx.OAuthApp)
+	jwtClaims, claimsErr := tb.buildAccessTokenClaims(tokenCtx, userAttributes)
 	if claimsErr != nil {
 		return nil, fmt.Errorf("failed to build access token claims: %w", claimsErr)
 	}
 
 	tokenType := constants.TokenTypeBearer
-	if ctx.DPoPJkt != "" {
+	if tokenCtx.DPoPJkt != "" {
 		tokenType = constants.TokenTypeDPoP
 	}
 
 	tokenDTO := &oauth2model.TokenDTO{
 		TokenType:        tokenType,
 		ExpiresIn:        tokenConfig.ValidityPeriod,
-		Scopes:           ctx.Scopes,
-		ClientID:         ctx.ClientID,
+		Scopes:           tokenCtx.Scopes,
+		ClientID:         tokenCtx.ClientID,
 		UserAttributes:   userAttributes,
-		AttributeCacheID: ctx.AttributeCacheID,
-		Subject:          ctx.Subject,
-		Audiences:        ctx.Audiences,
-		ClaimsRequest:    ctx.ClaimsRequest,
-		ClaimsLocales:    ctx.ClaimsLocales,
+		AttributeCacheID: tokenCtx.AttributeCacheID,
+		Subject:          tokenCtx.Subject,
+		Audiences:        tokenCtx.Audiences,
+		ClaimsRequest:    tokenCtx.ClaimsRequest,
+		ClaimsLocales:    tokenCtx.ClaimsLocales,
 	}
 
 	token, iat, err := tb.jwtService.GenerateJWT(
-		resolveContext(ctx.Context),
-		ctx.Subject,
+		ctx,
+		tokenCtx.Subject,
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
 		jwtClaims,
@@ -239,32 +235,35 @@ func (tb *tokenBuilder) buildActorClaim(actorClaims *SubjectTokenClaims) map[str
 }
 
 // BuildRefreshToken builds a refresh token with all necessary claims.
-func (tb *tokenBuilder) BuildRefreshToken(ctx *RefreshTokenBuildContext) (*oauth2model.TokenDTO, error) {
-	if ctx == nil {
+func (tb *tokenBuilder) BuildRefreshToken(
+	ctx context.Context,
+	tokenCtx *RefreshTokenBuildContext,
+) (*oauth2model.TokenDTO, error) {
+	if tokenCtx == nil {
 		return nil, fmt.Errorf("build context cannot be nil")
 	}
 
-	tokenConfig := ResolveTokenConfig(ctx.OAuthApp, TokenTypeRefresh)
+	tokenConfig := ResolveTokenConfig(tokenCtx.OAuthApp, TokenTypeRefresh)
 
-	claims, claimsErr := tb.buildRefreshTokenClaims(ctx)
+	claims, claimsErr := tb.buildRefreshTokenClaims(tokenCtx)
 	if claimsErr != nil {
 		return nil, fmt.Errorf("failed to build refresh token claims: %w", claimsErr)
 	}
 
 	tokenDTO := &oauth2model.TokenDTO{
 		ExpiresIn:     tokenConfig.ValidityPeriod,
-		Scopes:        ctx.Scopes,
-		ClientID:      ctx.ClientID,
-		Subject:       ctx.AccessTokenSubject,
+		Scopes:        tokenCtx.Scopes,
+		ClientID:      tokenCtx.ClientID,
+		Subject:       tokenCtx.AccessTokenSubject,
 		Audiences:     []string{tokenConfig.Issuer},
-		ClaimsLocales: ctx.ClaimsLocales,
+		ClaimsLocales: tokenCtx.ClaimsLocales,
 	}
 
 	claims["aud"] = tokenConfig.Issuer
 
 	token, iat, err := tb.jwtService.GenerateJWT(
-		resolveContext(ctx.Context),
-		ctx.ClientID,
+		ctx,
+		tokenCtx.ClientID,
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
 		claims,
@@ -322,28 +321,31 @@ func (tb *tokenBuilder) buildRefreshTokenClaims(ctx *RefreshTokenBuildContext) (
 }
 
 // BuildIDToken builds an OIDC ID token with all necessary claims.
-func (tb *tokenBuilder) BuildIDToken(ctx *IDTokenBuildContext) (*oauth2model.TokenDTO, error) {
-	if ctx == nil {
+func (tb *tokenBuilder) BuildIDToken(
+	ctx context.Context,
+	tokenCtx *IDTokenBuildContext,
+) (*oauth2model.TokenDTO, error) {
+	if tokenCtx == nil {
 		return nil, fmt.Errorf("build context cannot be nil")
 	}
 
-	tokenConfig := ResolveTokenConfig(ctx.OAuthApp, TokenTypeID)
+	tokenConfig := ResolveTokenConfig(tokenCtx.OAuthApp, TokenTypeID)
 
-	jwtClaims := tb.buildIDTokenClaims(ctx)
+	jwtClaims := tb.buildIDTokenClaims(tokenCtx)
 
 	tokenDTO := &oauth2model.TokenDTO{
 		ExpiresIn: tokenConfig.ValidityPeriod,
-		Scopes:    ctx.Scopes,
-		ClientID:  ctx.Audience,
-		Subject:   ctx.Subject,
-		Audiences: []string{ctx.Audience},
+		Scopes:    tokenCtx.Scopes,
+		ClientID:  tokenCtx.Audience,
+		Subject:   tokenCtx.Subject,
+		Audiences: []string{tokenCtx.Audience},
 	}
 
-	jwtClaims["aud"] = ctx.Audience
+	jwtClaims["aud"] = tokenCtx.Audience
 
 	token, iat, err := tb.jwtService.GenerateJWT(
-		resolveContext(ctx.Context),
-		ctx.Subject,
+		ctx,
+		tokenCtx.Subject,
 		tokenConfig.Issuer,
 		tokenConfig.ValidityPeriod,
 		jwtClaims,
@@ -355,16 +357,16 @@ func (tb *tokenBuilder) BuildIDToken(ctx *IDTokenBuildContext) (*oauth2model.Tok
 	}
 
 	// Optionally encrypt the signed ID token when responseType is JWE or NESTED_JWT.
-	if ctx.OAuthApp != nil && ctx.OAuthApp.Token != nil && ctx.OAuthApp.Token.IDToken != nil {
-		idTokenCfg := ctx.OAuthApp.Token.IDToken
+	if tokenCtx.OAuthApp != nil && tokenCtx.OAuthApp.Token != nil && tokenCtx.OAuthApp.Token.IDToken != nil {
+		idTokenCfg := tokenCtx.OAuthApp.Token.IDToken
 		rt := idTokenCfg.ResponseType
 		if rt == inboundmodel.IDTokenResponseTypeJWE || rt == inboundmodel.IDTokenResponseTypeNESTEDJWT {
 			if tb.jweService == nil {
 				return nil, fmt.Errorf("JWE service is not configured")
 			}
 			rpKey, rpKID, svcErr := tb.jwksResolver.ResolveEncryptionKey(
-				resolveContext(ctx.Context),
-				ctx.OAuthApp.Certificate,
+				ctx,
+				tokenCtx.OAuthApp.Certificate,
 				idTokenCfg.EncryptionAlg,
 				jwksresolver.KeyUseLenientEnc,
 			)

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -131,7 +131,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_Basic() {
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -179,7 +179,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithActorClaim(
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -222,7 +222,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithNestedActor
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -254,7 +254,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyScopes() {
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -286,7 +286,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyClientID()
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -318,7 +318,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_EmptyGrantType(
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -356,7 +356,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_CustomValidityP
 		mock.Anything, mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -365,7 +365,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_CustomValidityP
 }
 
 func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Error_NilContext() {
-	result, err := suite.builder.BuildAccessToken(nil)
+	result, err := suite.builder.BuildAccessToken(context.Background(), nil)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -400,7 +400,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Error_JWTGenerationFail
 		},
 	})
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -437,7 +437,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithClaimsLocal
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -471,7 +471,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithDPoPJkt() {
 		}), mock.Anything, mock.Anything,
 	).Return(testAccessToken, time.Now().Unix(), nil)
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -501,7 +501,7 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithoutDPoPJkt_
 		}), mock.Anything, mock.Anything,
 	).Return(testAccessToken, time.Now().Unix(), nil)
 
-	result, err := suite.builder.BuildAccessToken(ctx)
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), constants.TokenTypeBearer, result.TokenType)
@@ -547,7 +547,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_Basic() {
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildRefreshToken(ctx)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -583,7 +583,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithDPoPJkt() 
 		}), mock.Anything, mock.Anything,
 	).Return(testRefreshToken, time.Now().Unix(), nil)
 
-	result, err := suite.builder.BuildRefreshToken(ctx)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -611,7 +611,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutDPoPJkt
 		}), mock.Anything, mock.Anything,
 	).Return(testRefreshToken, time.Now().Unix(), nil)
 
-	result, err := suite.builder.BuildRefreshToken(ctx)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -643,7 +643,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithoutUserAtt
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildRefreshToken(ctx)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -674,7 +674,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilOAuthAp
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildRefreshToken(ctx)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -706,7 +706,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_EmptyScopes() 
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildRefreshToken(ctx)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -742,7 +742,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithTokenConfi
 		mock.Anything, mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildRefreshToken(ctx)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -781,7 +781,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilAccessT
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildRefreshToken(ctx)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -789,7 +789,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithNilAccessT
 }
 
 func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_NilContext() {
-	result, err := suite.builder.BuildRefreshToken(nil)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), nil)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -824,7 +824,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Error_JWTGenerationFai
 		},
 	})
 
-	result, err := suite.builder.BuildRefreshToken(ctx)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), ctx)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -861,7 +861,7 @@ func (suite *TokenBuilderTestSuite) TestBuildRefreshToken_Success_WithClaimsLoca
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildRefreshToken(ctx)
+	result, err := suite.builder.BuildRefreshToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -898,7 +898,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_Basic() {
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildIDToken(ctx)
+	result, err := suite.builder.BuildIDToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -935,7 +935,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithNonce() {
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildIDToken(ctx)
+	result, err := suite.builder.BuildIDToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -967,7 +967,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithoutNonce() {
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildIDToken(ctx)
+	result, err := suite.builder.BuildIDToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -998,7 +998,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_NoAuthTime() {
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildIDToken(ctx)
+	result, err := suite.builder.BuildIDToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1041,7 +1041,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithScopeClaims() {
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildIDToken(ctx)
+	result, err := suite.builder.BuildIDToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1082,7 +1082,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithStandardOIDCSco
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildIDToken(ctx)
+	result, err := suite.builder.BuildIDToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1112,7 +1112,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_NoUserAttributes() 
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildIDToken(ctx)
+	result, err := suite.builder.BuildIDToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1153,7 +1153,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_EmptyUserAttributes
 		}), mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildIDToken(ctx)
+	result, err := suite.builder.BuildIDToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1190,7 +1190,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_CustomValidityPerio
 		mock.Anything, mock.Anything, mock.Anything,
 	).Return(expectedToken, expectedIat, nil)
 
-	result, err := suite.builder.BuildIDToken(ctx)
+	result, err := suite.builder.BuildIDToken(context.Background(), ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1199,7 +1199,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_CustomValidityPerio
 }
 
 func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_NilContext() {
-	result, err := suite.builder.BuildIDToken(nil)
+	result, err := suite.builder.BuildIDToken(context.Background(), nil)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1233,7 +1233,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_JWTGenerationFailed()
 		},
 	})
 
-	result, err := suite.builder.BuildIDToken(ctx)
+	result, err := suite.builder.BuildIDToken(context.Background(), ctx)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1298,8 +1298,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithEncryption_Inli
 		jwksResolver: jwksresolver.Initialize(nil),
 	}
 
-	result, err := builder.BuildIDToken(&IDTokenBuildContext{
-		Context:  context.Background(),
+	result, err := builder.BuildIDToken(context.Background(), &IDTokenBuildContext{
 		Subject:  "user123",
 		Audience: "test-client",
 		Scopes:   []string{"openid"},
@@ -1348,8 +1347,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_EncryptionKeyNotFound
 		jwksResolver: jwksresolver.Initialize(nil),
 	}
 
-	result, err := builder.BuildIDToken(&IDTokenBuildContext{
-		Context:  context.Background(),
+	result, err := builder.BuildIDToken(context.Background(), &IDTokenBuildContext{
 		Subject:  "user123",
 		Audience: "test-client",
 		Scopes:   []string{"openid"},
@@ -1412,8 +1410,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_EncryptionFailed() {
 		jwksResolver: jwksresolver.Initialize(nil),
 	}
 
-	result, err := builder.BuildIDToken(&IDTokenBuildContext{
-		Context:  context.Background(),
+	result, err := builder.BuildIDToken(context.Background(), &IDTokenBuildContext{
 		Subject:  "user123",
 		Audience: "test-client",
 		Scopes:   []string{"openid"},
@@ -1480,8 +1477,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Success_WithEncryption_JWKS
 		jwksResolver: jwksresolver.Initialize(mockHTTP),
 	}
 
-	result, err := builder.BuildIDToken(&IDTokenBuildContext{
-		Context:  context.Background(),
+	result, err := builder.BuildIDToken(context.Background(), &IDTokenBuildContext{
 		Subject:  "user123",
 		Audience: "test-client",
 		Scopes:   []string{"openid"},
@@ -1528,8 +1524,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_NilJWEService() {
 		jweService: nil,
 	}
 
-	result, err := builder.BuildIDToken(&IDTokenBuildContext{
-		Context:  context.Background(),
+	result, err := builder.BuildIDToken(context.Background(), &IDTokenBuildContext{
 		Subject:  "user123",
 		Audience: "test-client",
 		Scopes:   []string{"openid"},
@@ -1564,8 +1559,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_NoEncryptionAlg() {
 		jweService: nil,
 	}
 
-	result, err := builder.BuildIDToken(&IDTokenBuildContext{
-		Context:  context.Background(),
+	result, err := builder.BuildIDToken(context.Background(), &IDTokenBuildContext{
 		Subject:  "user123",
 		Audience: "test-client",
 		Scopes:   []string{"openid"},
@@ -1609,8 +1603,7 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_UnsupportedCertType()
 		jwksResolver: jwksresolver.Initialize(nil),
 	}
 
-	result, err := builder.BuildIDToken(&IDTokenBuildContext{
-		Context:  context.Background(),
+	result, err := builder.BuildIDToken(context.Background(), &IDTokenBuildContext{
 		Subject:  "user123",
 		Audience: "test-client",
 		Scopes:   []string{"openid"},

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -20,8 +20,6 @@
 package tokenservice
 
 import (
-	"context"
-
 	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
 	oauth2model "github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
 )
@@ -48,7 +46,6 @@ type TokenConfig struct {
 // The aud claim is serialized as a JSON array when Audiences has 2+ entries, and as a string
 // when it has a single entry.
 type AccessTokenBuildContext struct {
-	Context          context.Context
 	Subject          string
 	Audiences        []string
 	ClientID         string
@@ -68,7 +65,6 @@ type AccessTokenBuildContext struct {
 
 // RefreshTokenBuildContext contains all the information needed to build a refresh token.
 type RefreshTokenBuildContext struct {
-	Context              context.Context
 	ClientID             string
 	Scopes               []string
 	GrantType            string
@@ -83,7 +79,6 @@ type RefreshTokenBuildContext struct {
 
 // IDTokenBuildContext contains all the information needed to build an ID token (OIDC).
 type IDTokenBuildContext struct {
-	Context        context.Context
 	Subject        string
 	Audience       string
 	Scopes         []string

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -35,8 +35,8 @@ import (
 
 // TokenValidatorInterface defines the interface for validating tokens.
 type TokenValidatorInterface interface {
-	ValidateAccessToken(token string) (*AccessTokenClaims, error)
-	ValidateRefreshToken(token string, clientID string) (*RefreshTokenClaims, error)
+	ValidateAccessToken(ctx context.Context, token string) (*AccessTokenClaims, error)
+	ValidateRefreshToken(ctx context.Context, token string, clientID string) (*RefreshTokenClaims, error)
 	ValidateSubjectToken(ctx context.Context, token string, oauthApp *inboundmodel.OAuthClient) (
 		*SubjectTokenClaims, error)
 }
@@ -56,10 +56,10 @@ func newTokenValidator(jwtService jwt.JWTServiceInterface, idpService idp.IDPSer
 }
 
 // ValidateAccessToken validates an access token and extracts the claims.
-func (tv *tokenValidator) ValidateAccessToken(token string) (*AccessTokenClaims, error) {
+func (tv *tokenValidator) ValidateAccessToken(ctx context.Context, token string) (*AccessTokenClaims, error) {
 	// Verify signature and standard claims.
 	expectedIss := config.GetServerRuntime().Config.JWT.Issuer
-	if err := tv.jwtService.VerifyJWT(token, "", expectedIss); err != nil {
+	if err := tv.jwtService.VerifyJWT(ctx, token, "", expectedIss); err != nil {
 		return nil, fmt.Errorf("access token verification failed: %v", err.Error)
 	}
 
@@ -114,8 +114,10 @@ func (tv *tokenValidator) ValidateAccessToken(token string) (*AccessTokenClaims,
 }
 
 // ValidateRefreshToken validates a refresh token and extracts the claims.
-func (tv *tokenValidator) ValidateRefreshToken(token string, clientID string) (*RefreshTokenClaims, error) {
-	if err := tv.jwtService.VerifyJWT(token, "", ""); err != nil {
+func (tv *tokenValidator) ValidateRefreshToken(
+	ctx context.Context, token string, clientID string,
+) (*RefreshTokenClaims, error) {
+	if err := tv.jwtService.VerifyJWT(ctx, token, "", ""); err != nil {
 		return nil, fmt.Errorf("invalid refresh token: %v", err.Error)
 	}
 
@@ -191,7 +193,7 @@ func (tv *tokenValidator) ValidateSubjectToken(
 
 	// Try the server's own issuer first.
 	if isSelfIssuer(iss) {
-		if err := tv.verifyTokenSignatureByIssuer(token, iss); err != nil {
+		if err := tv.verifyTokenSignatureByIssuer(ctx, token, iss); err != nil {
 			return nil, fmt.Errorf("invalid subject token signature: %w", err)
 		}
 		return tv.extractSubjectTokenClaims(token, iss, claims, oauthApp)
@@ -330,13 +332,14 @@ func (tv *tokenValidator) extractSubjectTokenClaims(
 
 // verifyTokenSignatureByIssuer verifies JWT signature using issuer-specific verification method.
 func (tv *tokenValidator) verifyTokenSignatureByIssuer(
+	ctx context.Context,
 	token string,
 	issuer string,
 ) error {
 	if !isSelfIssuer(issuer) {
 		return fmt.Errorf("no verification method configured for issuer: %s", issuer)
 	}
-	svcErr := tv.jwtService.VerifyJWTSignature(token)
+	svcErr := tv.jwtService.VerifyJWTSignature(ctx, token)
 	if svcErr != nil {
 		return fmt.Errorf("failed to verify token signature: %v", svcErr.Error)
 	}

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/idp"
@@ -130,7 +131,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_BasicToke
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -157,7 +158,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_WithToken
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, customOAuthApp)
 
@@ -180,7 +181,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_WithoutNb
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -202,7 +203,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_WithEmpty
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -289,7 +290,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_InvalidSign
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).
 		Return(&serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 			Code: "SIGNATURE_VERIFICATION_FAILED",
@@ -323,7 +324,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_MissingSubC
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -342,7 +343,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_InvalidSubT
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -362,7 +363,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_ExpiredToke
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -382,7 +383,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_NotYetValid
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -395,9 +396,9 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_NotYetValid
 func (suite *TokenValidatorTestSuite) TestVerifyTokenSignatureByIssuer_Success_ServerIssuer() {
 	token := testJWTTokenString
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
-	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://example.com")
+	err := suite.validator.verifyTokenSignatureByIssuer(context.Background(), token, "https://example.com")
 
 	assert.NoError(suite.T(), err)
 	suite.mockJWTService.AssertExpectations(suite.T())
@@ -407,9 +408,9 @@ func (suite *TokenValidatorTestSuite) TestVerifyTokenSignatureByIssuer_Success_W
 	// Server-level issuer is used for signature verification regardless of app token config
 	token := testJWTTokenString
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
-	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://example.com")
+	err := suite.validator.verifyTokenSignatureByIssuer(context.Background(), token, "https://example.com")
 
 	assert.NoError(suite.T(), err)
 	suite.mockJWTService.AssertExpectations(suite.T())
@@ -418,7 +419,7 @@ func (suite *TokenValidatorTestSuite) TestVerifyTokenSignatureByIssuer_Success_W
 func (suite *TokenValidatorTestSuite) TestVerifyTokenSignatureByIssuer_Error_SignatureFailure() {
 	token := testJWTTokenString
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).
 		Return(&serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 			Code: "SIGNATURE_MISMATCH",
@@ -430,7 +431,7 @@ func (suite *TokenValidatorTestSuite) TestVerifyTokenSignatureByIssuer_Error_Sig
 			},
 		})
 
-	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://example.com")
+	err := suite.validator.verifyTokenSignatureByIssuer(context.Background(), token, "https://example.com")
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to verify token signature")
@@ -441,7 +442,7 @@ func (suite *TokenValidatorTestSuite) TestVerifyTokenSignatureByIssuer_Error_Ext
 	// External issuer (not in trusted server issuers)
 	token := testJWTTokenString
 
-	err := suite.validator.verifyTokenSignatureByIssuer(token, "https://external-idp.com")
+	err := suite.validator.verifyTokenSignatureByIssuer(context.Background(), token, "https://external-idp.com")
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no verification method configured for issuer")
@@ -462,7 +463,7 @@ func (suite *TokenValidatorTestSuite) TestFederationScenario_DecodeBeforeVerify(
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -510,7 +511,7 @@ func (suite *TokenValidatorTestSuite) TestFederationScenario_OnlyServerIssuerIsV
 		"exp": float64(now + 3600),
 	}
 	tokenValid := suite.createTestJWT(claimsValid)
-	suite.mockJWTService.On("VerifyJWTSignature", tokenValid).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, tokenValid).Return(nil)
 
 	resultValid, errValid := suite.validator.ValidateSubjectToken(
 		context.Background(), tokenValid, appWithTokenConfig)
@@ -544,7 +545,7 @@ func (suite *TokenValidatorTestSuite) TestFederationScenario_FutureExternalIssue
 	externalIssuer := "https://external-idp.com"
 
 	// Currently returns error because no JWKS support yet
-	err := suite.validator.verifyTokenSignatureByIssuer(token, externalIssuer)
+	err := suite.validator.verifyTokenSignatureByIssuer(context.Background(), token, externalIssuer)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no verification method configured")
@@ -563,7 +564,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Security_RejectsT
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -597,7 +598,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_EdgeCase_VeryLong
 	}
 	token := suite.createTestJWT(largeClaims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -623,7 +624,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_AuthAssertion_Rej
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -654,7 +655,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_NonAssertion_Acce
 		ID:       "x", // Matches one element of the aud array.
 	}
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, oauthAppWithID)
 
@@ -677,7 +678,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_NonAssertion_Tole
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -703,9 +704,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_Basic() {
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -732,9 +733,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_WithoutUs
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -756,9 +757,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_EmptyScop
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -769,7 +770,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_EmptyScop
 func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_InvalidSignature() {
 	token := "invalid.token.signature"
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").
 		Return(&serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 			Code: "SIGNATURE_VERIFICATION_FAILED",
@@ -782,7 +783,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_InvalidSign
 			},
 		})
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -794,7 +795,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_InvalidJWTF
 	token := invalidJWTFormat
 
 	// VerifyJWT is called first and should fail for invalid format
-	suite.mockJWTService.On("VerifyJWT", token, "", "").
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").
 		Return(&serviceerror.ServiceError{
 			Type: serviceerror.ClientErrorType,
 			Code: "INVALID_JWT_FORMAT",
@@ -806,7 +807,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_InvalidJWTF
 			},
 		})
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -820,7 +821,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_DecodeFailu
 	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.invalid-base64.signature"
 
 	// VerifyJWT is called first and should fail for invalid base64
-	suite.mockJWTService.On("VerifyJWT", token, "", "").
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").
 		Return(&serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 			Code: "INVALID_JWT_SIGNATURE",
@@ -832,7 +833,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_DecodeFailu
 			},
 		})
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -855,9 +856,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_MissingIa
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -883,7 +884,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_ExpiredToke
 	token := suite.createTestJWT(claims)
 
 	// VerifyJWT should catch expired tokens
-	suite.mockJWTService.On("VerifyJWT", token, "", "").
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").
 		Return(&serviceerror.ServiceError{
 			Type:  serviceerror.ClientErrorType,
 			Code:  "TOKEN_EXPIRED",
@@ -893,7 +894,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_ExpiredToke
 			},
 		})
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -918,7 +919,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_NotYetValid
 	token := suite.createTestJWT(claims)
 
 	// VerifyJWT should catch not yet valid tokens
-	suite.mockJWTService.On("VerifyJWT", token, "", "").
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").
 		Return(&serviceerror.ServiceError{
 			Type: serviceerror.ClientErrorType,
 			Code: "TOKEN_NOT_VALID_YET",
@@ -930,7 +931,7 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_NotYetValid
 			},
 		})
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -952,9 +953,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_MissingSub(
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -976,9 +977,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_WrongClient
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1000,9 +1001,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_MissingAcce
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1024,9 +1025,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_MissingAcce
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1048,9 +1049,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Error_MissingGran
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1075,9 +1076,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_WithClaim
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1107,9 +1108,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_WithDPoPJ
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1131,9 +1132,9 @@ func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_WithoutDP
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 
-	result, err := suite.validator.ValidateRefreshToken(token, "test-client")
+	result, err := suite.validator.ValidateRefreshToken(context.Background(), token, "test-client")
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1161,7 +1162,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithAppI
 	suite.oauthApp.ID = testAppID
 	suite.oauthApp.ClientID = testClientID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1191,7 +1192,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithEmpt
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1219,7 +1220,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithScop
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1248,7 +1249,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithUser
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1278,7 +1279,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_MissingAud
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1303,7 +1304,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_AudienceMi
 	suite.oauthApp.ID = testAppID
 	suite.oauthApp.ClientID = testClientID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1329,7 +1330,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithDefa
 	suite.oauthApp.ID = testAppID // Different from audience
 	suite.oauthApp.ClientID = testClientID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1381,7 +1382,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_ExpiredTok
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1424,7 +1425,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_InvalidSig
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(&serviceerror.ServiceError{
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(&serviceerror.ServiceError{
 		Type:  serviceerror.ServerErrorType,
 		Code:  "INVALID_SIGNATURE",
 		Error: core.I18nMessage{Key: "error.test.invalid_signature", DefaultValue: "Invalid signature"},
@@ -1454,7 +1455,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_InvalidSub
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1477,7 +1478,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_TokenNotYe
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1500,7 +1501,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_MissingExp
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1524,7 +1525,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Error_InvalidAud
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1550,7 +1551,7 @@ func (suite *TokenValidatorTestSuite) TestValidateAuthAssertion_Success_WithEmpt
 
 	suite.oauthApp.ID = testAppID
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1578,7 +1579,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_ExpiredWit
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1599,7 +1600,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_ExpiredBey
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1623,7 +1624,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_NbfInFutur
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1644,7 +1645,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_NbfInFutur
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1697,7 +1698,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_Expiration
 			}
 			token := suite.createTestJWT(claims)
 
-			suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil).Once()
+			suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil).Once()
 
 			result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1736,7 +1737,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Leeway_ExpJustIns
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -1775,9 +1776,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Success() {
 	}
 	token := suite.createTestAccessToken(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil)
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1801,9 +1802,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Success_MinClaims(
 	}
 	token := suite.createTestAccessToken(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil)
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -1819,14 +1820,14 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Success_MinClaims(
 func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_VerifyFails() {
 	token := "invalid.token.signature"
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").
 		Return(&serviceerror.ServiceError{
 			Type:  serviceerror.ServerErrorType,
 			Code:  "JWT-1004",
 			Error: core.I18nMessage{Key: "error.test.invalid_token_signature", DefaultValue: "Invalid token signature"},
 		})
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1843,9 +1844,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_WrongTyp() {
 	}
 	token := suite.createTestJWT(claims) // Uses typ: "JWT"
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil)
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1869,9 +1870,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_MissingTyp()
 	claimsB64 := base64.RawURLEncoding.EncodeToString(claimsJSON)
 	token := fmt.Sprintf("%s.%s.signature", headerB64, claimsB64)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil)
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1887,9 +1888,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_MissingSub()
 	}
 	token := suite.createTestAccessToken(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil)
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1905,9 +1906,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_MissingAud()
 	}
 	token := suite.createTestAccessToken(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil)
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1923,9 +1924,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_MissingIss()
 	}
 	token := suite.createTestAccessToken(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil)
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1941,9 +1942,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_MissingClien
 	}
 	token := suite.createTestAccessToken(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil)
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1960,9 +1961,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_EmptySub() {
 	}
 	token := suite.createTestAccessToken(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil)
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -1979,9 +1980,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_EmptyClientI
 	}
 	token := suite.createTestAccessToken(claims)
 
-	suite.mockJWTService.On("VerifyJWT", token, "", "https://example.com").Return(nil)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil)
 
-	result, err := suite.validator.ValidateAccessToken(token)
+	result, err := suite.validator.ValidateAccessToken(context.Background(), token)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -2283,7 +2284,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_PopulatesCnfJkt()
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -2305,7 +2306,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_NoCnf_EmptyJkt() 
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 
@@ -2327,7 +2328,7 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_MalformedCnf_Erro
 	}
 	token := suite.createTestJWT(claims)
 
-	suite.mockJWTService.On("VerifyJWTSignature", token).Return(nil)
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
 
 	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
 

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -101,7 +101,7 @@ func (s *userInfoService) GetUserInfo(
 		return nil, &errorInvalidAccessToken
 	}
 
-	accessTokenClaims, err := s.tokenValidator.ValidateAccessToken(accessToken)
+	accessTokenClaims, err := s.tokenValidator.ValidateAccessToken(ctx, accessToken)
 	if err != nil {
 		s.logger.Debug("Failed to verify access token", log.Error(err))
 		return nil, &errorInvalidAccessToken
@@ -126,7 +126,7 @@ func (s *userInfoService) GetUserInfoForDPoP(
 		return nil, &errorInvalidAccessToken
 	}
 
-	accessTokenClaims, err := s.tokenValidator.ValidateAccessToken(accessToken)
+	accessTokenClaims, err := s.tokenValidator.ValidateAccessToken(ctx, accessToken)
 	if err != nil {
 		s.logger.Debug("Failed to verify access token", log.Error(err))
 		return nil, &errorInvalidAccessToken

--- a/backend/internal/oauth/oauth2/userinfo/service_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_test.go
@@ -116,7 +116,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_EmptyToken() {
 // TestGetUserInfo_InvalidTokenSignature tests that invalid token signature returns an error
 func (s *UserInfoServiceTestSuite) TestGetUserInfo_InvalidTokenSignature() {
 	token := "invalid.token.signature"
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		nil, errors.New("invalid signature"))
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -154,7 +154,7 @@ func (s *UserInfoServiceTestSuite) createToken(claims map[string]interface{}) st
 func (s *UserInfoServiceTestSuite) TestGetUserInfo_InvalidTokenFormat() {
 	// nolint:gosec // This is a test token, not a real credential
 	invalidToken := "not.a.valid.jwt"
-	s.mockTokenValidator.On("ValidateAccessToken", invalidToken).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, invalidToken).Return(
 		nil, errors.New("invalid token format"))
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), invalidToken)
@@ -173,12 +173,31 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_NoScopes() {
 	}
 	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.NotNil(s.T(), svcErr)
 	assert.Equal(s.T(), "insufficient_scope", svcErr.Code)
+	assert.Nil(s.T(), response)
+	s.mockTokenValidator.AssertExpectations(s.T())
+}
+
+func (s *UserInfoServiceTestSuite) assertInsufficientScope(
+	claims map[string]interface{},
+	errorDescriptionContains string,
+) {
+	token := s.createToken(claims)
+
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
+		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+
+	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), "insufficient_scope", svcErr.Code)
+	if errorDescriptionContains != "" {
+		assert.Contains(s.T(), svcErr.ErrorDescription.DefaultValue, errorDescriptionContains)
+	}
 	assert.Nil(s.T(), response)
 	s.mockTokenValidator.AssertExpectations(s.T())
 }
@@ -191,16 +210,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_NoScopesEmptyScopeString() {
 		"sub":   "user123",
 		"scope": "",
 	}
-	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-
-	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
-	assert.NotNil(s.T(), svcErr)
-	assert.Equal(s.T(), "insufficient_scope", svcErr.Code)
-	assert.Nil(s.T(), response)
-	s.mockTokenValidator.AssertExpectations(s.T())
+	s.assertInsufficientScope(claims, "")
 }
 
 // TestGetUserInfo_ErrorFetchingUserAttributes tests error when fetching user attributes fails
@@ -214,7 +225,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ErrorFetchingUserAttributes()
 	}
 	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-err-123").Return(
 		nil, &serviceerror.InternalServerError)
@@ -244,7 +255,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ErrorFetchingGroups() {
 			UserAttributes: []string{"name", constants.UserAttributeGroups},
 		},
 	}
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-groups-123").Return(
 		nil, &serviceerror.InternalServerError)
@@ -287,7 +298,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_StandardScopes() {
 		},
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-std-123").Return(
 		&attributecache.AttributeCache{ID: "cache-std-123", Attributes: userAttrs}, nil)
@@ -336,7 +347,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithGroups() {
 		},
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-grp-123").Return(
 		&attributecache.AttributeCache{ID: "cache-grp-123", Attributes: userAttrs}, nil)
@@ -392,7 +403,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithScopeClaimsMappin
 		},
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-scope-123").Return(
 		&attributecache.AttributeCache{ID: "cache-scope-123", Attributes: userAttrs}, nil)
@@ -428,7 +439,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_NoAppConfig() {
 		"email": "john@example.com",
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-noapp-123").Return(
 		&attributecache.AttributeCache{ID: "cache-noapp-123", Attributes: userAttrs}, nil)
@@ -460,7 +471,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_AppNotFound_ReturnsInvalidTok
 
 	userAttrs := map[string]interface{}{}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-anf-123").Return(
 		&attributecache.AttributeCache{ID: "cache-anf-123", Attributes: userAttrs}, nil)
@@ -506,7 +517,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_GroupsNotInAllowedAtt
 		},
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-gnaa-123").Return(
 		&attributecache.AttributeCache{ID: "cache-gnaa-123", Attributes: userAttrs}, nil)
@@ -548,7 +559,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_EmptyUserAttributes()
 		},
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
 
@@ -572,16 +583,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_ScopeAsNonString() {
 		"sub":   "user123",
 		"scope": 123, // Invalid type
 	}
-	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-
-	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
-	assert.NotNil(s.T(), svcErr)
-	assert.Equal(s.T(), "insufficient_scope", svcErr.Code)
-	assert.Nil(s.T(), response)
-	s.mockTokenValidator.AssertExpectations(s.T())
+	s.assertInsufficientScope(claims, "")
 }
 
 // TestGetUserInfo_ScopeExistsButNotString tests when scope exists but is not a string returns insufficient_scope error
@@ -594,7 +597,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ScopeExistsButNotString() {
 	}
 	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -620,7 +623,7 @@ func (s *UserInfoServiceTestSuite) testGetUserInfoInvalidClientID(clientIDValue 
 		"name": "John Doe",
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-inv-cid-123").Return(
 		&attributecache.AttributeCache{ID: "cache-inv-cid-123", Attributes: userAttrs}, nil)
@@ -663,7 +666,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilOAuthApp() {
 		"name": "John Doe",
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-nil-app-123").Return(
 		&attributecache.AttributeCache{ID: "cache-nil-app-123", Attributes: userAttrs}, nil)
@@ -698,7 +701,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilToken() {
 		Token: nil, // Token is nil
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-nil-tok-123").Return(
 		&attributecache.AttributeCache{ID: "cache-nil-tok-123", Attributes: userAttrs}, nil)
@@ -739,7 +742,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilIDToken() {
 		},
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-nil-idt-123").Return(
 		&attributecache.AttributeCache{ID: "cache-nil-idt-123", Attributes: userAttrs}, nil)
@@ -788,7 +791,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithEmptyGroups() {
 		},
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-eg-123").Return(
 		&attributecache.AttributeCache{ID: "cache-eg-123", Attributes: userAttrs}, nil)
@@ -820,7 +823,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ClientCredentialsGrant_Reject
 	}
 	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "client123", Claims: claims}, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -862,7 +865,7 @@ func (s *UserInfoServiceTestSuite) testGetUserInfoAllowedGrantType(grantTypeValu
 		},
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-agt-123").Return(
 		&attributecache.AttributeCache{ID: "cache-agt-123", Attributes: userAttrs}, nil)
@@ -916,7 +919,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_MissingOpenIDScope_WithOtherS
 	}
 	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -935,16 +938,8 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_CaseSensitive() {
 		"sub":   "user123",
 		"scope": "OpenID profile", // Wrong case - should fail
 	}
-	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
-
-	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
-	assert.NotNil(s.T(), svcErr)
-	assert.Equal(s.T(), "insufficient_scope", svcErr.Code)
-	assert.Nil(s.T(), response)
-	s.mockTokenValidator.AssertExpectations(s.T())
+	s.assertInsufficientScope(claims, "")
 }
 
 // TestGetUserInfo_OnlyOpenIDScope_Success tests that only openid scope returns sub claim
@@ -958,7 +953,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OnlyOpenIDScope_Success() {
 	}
 	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-oid-only-123").Return(
 		&attributecache.AttributeCache{ID: "cache-oid-only-123", Attributes: map[string]interface{}{}}, nil)
@@ -997,7 +992,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_InMiddleOfScopeSt
 		},
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-mid-123").Return(
 		&attributecache.AttributeCache{ID: "cache-mid-123", Attributes: userAttrs}, nil)
@@ -1037,7 +1032,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_AtEnd() {
 		},
 	}
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-end-123").Return(
 		&attributecache.AttributeCache{ID: "cache-end-123", Attributes: userAttrs}, nil)
@@ -1085,7 +1080,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_ResponseType() {
 	issuer := "test-issuer"
 
 	// JWT verification
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 
 	// Attribute cache fetch
@@ -1132,7 +1127,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_BearerScheme_DPoPBoundToken_R
 	}
 	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -1158,7 +1153,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfoForDPoP_NotBoundToken_Rejected
 	}
 	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfoForDPoP(
@@ -1185,7 +1180,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfoForDPoP_VerifierFails_Rejected
 	}
 	token := s.createToken(claims)
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 	verifier.EXPECT().Verify(mock.Anything, mock.MatchedBy(func(p dpop.VerifyParams) bool {
 		return p.Proof == "proof" && p.HTM == "GET" && p.AccessToken == token &&
@@ -1228,7 +1223,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_GenerateJWTFailure() {
 	}
 	issuer := "test-issuer"
 
-	s.mockTokenValidator.On("ValidateAccessToken", token).Return(
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
 		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
 
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-jws-fail-123").Return(

--- a/backend/internal/system/jose/jwe/service.go
+++ b/backend/internal/system/jose/jwe/service.go
@@ -36,7 +36,7 @@ import (
 type JWEServiceInterface interface {
 	Encrypt(payload []byte, recipientPublicKey crypto.PublicKey,
 		alg KeyEncAlgorithm, enc ContentEncAlgorithm, cty string, kid string) (string, *serviceerror.ServiceError)
-	Decrypt(jweToken string) ([]byte, *serviceerror.ServiceError)
+	Decrypt(ctx context.Context, jweToken string) ([]byte, *serviceerror.ServiceError)
 }
 
 // jweService implements the JWEServiceInterface.
@@ -137,7 +137,7 @@ func (js *jweService) Encrypt(payload []byte, recipientPublicKey crypto.PublicKe
 }
 
 // Decrypt decrypts the JWE compact serialization using the server's private key via the crypto provider.
-func (js *jweService) Decrypt(jweToken string) ([]byte, *serviceerror.ServiceError) {
+func (js *jweService) Decrypt(ctx context.Context, jweToken string) ([]byte, *serviceerror.ServiceError) {
 	header, headerBase64, encryptedKey, iv, ciphertext, tag, err := DecodeJWE(jweToken)
 	if err != nil {
 		js.logger.Debug("Failed to decode JWE: " + err.Error())
@@ -164,7 +164,7 @@ func (js *jweService) Decrypt(jweToken string) ([]byte, *serviceerror.ServiceErr
 	}
 
 	// Decrypt CEK via the runtime crypto provider (uses server's private key).
-	cek, err := js.cryptoProvider.Decrypt(context.Background(), &js.keyRef, params, encryptedKey)
+	cek, err := js.cryptoProvider.Decrypt(ctx, &js.keyRef, params, encryptedKey)
 	if err != nil {
 		js.logger.Error("Failed to decrypt CEK: " + err.Error())
 		return nil, &ErrorJWEDecryptionFailed

--- a/backend/internal/system/jose/jwe/service_test.go
+++ b/backend/internal/system/jose/jwe/service_test.go
@@ -92,7 +92,7 @@ func (suite *JWEServiceTestSuite) TestEncryptDecrypt_RSA() {
 	for _, enc := range encAlgs {
 		jweToken, sErr := suite.jweService.Encrypt(payload, recipientPublicKey, RSAOAEP256, enc, "", "")
 		assert.Nil(suite.T(), sErr)
-		decrypted, sErr := suite.jweService.Decrypt(jweToken)
+		decrypted, sErr := suite.jweService.Decrypt(context.Background(), jweToken)
 		assert.Nil(suite.T(), sErr)
 		assert.Equal(suite.T(), payload, decrypted)
 	}
@@ -131,7 +131,7 @@ func (suite *JWEServiceTestSuite) TestEncryptDecrypt_ECDH() {
 	for _, tc := range testCases {
 		jweToken, sErr := suite.jweService.Encrypt(payload, recipientPublicKey, tc.alg, tc.enc, "", "")
 		assert.Nil(suite.T(), sErr)
-		decrypted, sErr := suite.jweService.Decrypt(jweToken)
+		decrypted, sErr := suite.jweService.Decrypt(context.Background(), jweToken)
 		assert.Nil(suite.T(), sErr)
 		assert.Equal(suite.T(), payload, decrypted)
 	}
@@ -162,7 +162,7 @@ func (suite *JWEServiceTestSuite) TestDecrypt_Errors() {
 	}
 
 	// Invalid JWE format — no provider call
-	_, sErr := suite.jweService.Decrypt("invalid.jwe")
+	_, sErr := suite.jweService.Decrypt(context.Background(), "invalid.jwe")
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorDecodingJWE, *sErr)
 
@@ -173,7 +173,7 @@ func (suite *JWEServiceTestSuite) TestDecrypt_Errors() {
 	// DecryptKey failure: provider returns an error
 	mockProvider.EXPECT().Decrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, errors.New("key decryption error")).Once()
-	_, sErr = suite.jweService.Decrypt(jweToken)
+	_, sErr = suite.jweService.Decrypt(context.Background(), jweToken)
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorJWEDecryptionFailed, *sErr)
 
@@ -188,7 +188,7 @@ func (suite *JWEServiceTestSuite) TestDecrypt_Errors() {
 	parts := strings.Split(jweToken, ".")
 	parts[4] = base64.RawURLEncoding.EncodeToString([]byte("wrong-tag"))
 	tamperedToken := strings.Join(parts, ".")
-	_, sErr = suite.jweService.Decrypt(tamperedToken)
+	_, sErr = suite.jweService.Decrypt(context.Background(), tamperedToken)
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorJWEDecryptionFailed, *sErr)
 }
@@ -224,24 +224,24 @@ func (suite *JWEServiceTestSuite) TestDecrypt_EdgeCases() {
 	}
 
 	// Test with malformed JWE (wrong number of parts)
-	_, sErr := suite.jweService.Decrypt("malformed.jwe")
+	_, sErr := suite.jweService.Decrypt(context.Background(), "malformed.jwe")
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorDecodingJWE, *sErr)
 
 	// Test with invalid base64 in header
-	_, sErr = suite.jweService.Decrypt("invalid-base64.key.iv.ciphertext.tag")
+	_, sErr = suite.jweService.Decrypt(context.Background(), "invalid-base64.key.iv.ciphertext.tag")
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorDecodingJWE, *sErr)
 
 	// Test with invalid JSON in header
 	invalidHeader := base64.RawURLEncoding.EncodeToString([]byte("{invalid json"))
-	_, sErr = suite.jweService.Decrypt(invalidHeader + ".key.iv.ciphertext.tag")
+	_, sErr = suite.jweService.Decrypt(context.Background(), invalidHeader+".key.iv.ciphertext.tag")
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorDecodingJWE, *sErr)
 
 	// Test with missing required header fields
 	headerMissingAlg := base64.RawURLEncoding.EncodeToString([]byte(`{"enc":"A128GCM"}`))
-	_, sErr = suite.jweService.Decrypt(headerMissingAlg + ".key.iv.ciphertext.tag")
+	_, sErr = suite.jweService.Decrypt(context.Background(), headerMissingAlg+".key.iv.ciphertext.tag")
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorUnsupportedJWEAlgorithm, *sErr)
 }
@@ -343,7 +343,7 @@ func (suite *JWEServiceTestSuite) TestDecrypt_MissingEncField() {
 	}
 
 	headerNoEnc := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RSA-OAEP-256"}`))
-	_, sErr := suite.jweService.Decrypt(headerNoEnc + ".key.iv.ciphertext.tag")
+	_, sErr := suite.jweService.Decrypt(context.Background(), headerNoEnc+".key.iv.ciphertext.tag")
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorUnsupportedEncryptionAlgorithm, *sErr)
 }
@@ -355,7 +355,7 @@ func (suite *JWEServiceTestSuite) TestDecrypt_UnsupportedAlgorithmForDecrypt() {
 
 	// A128KW is valid for encrypt but hits the default branch in buildDecryptParams
 	headerAESKW := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"A128KW","enc":"A128GCM"}`))
-	_, sErr := suite.jweService.Decrypt(headerAESKW + ".key.iv.ciphertext.tag")
+	_, sErr := suite.jweService.Decrypt(context.Background(), headerAESKW+".key.iv.ciphertext.tag")
 	assert.NotNil(suite.T(), sErr)
 	assert.Equal(suite.T(), ErrorUnsupportedJWEAlgorithm, *sErr)
 }
@@ -382,7 +382,7 @@ func (suite *JWEServiceTestSuite) TestEncryptDecrypt_CBC() {
 	for _, enc := range encAlgs {
 		jweToken, sErr := suite.jweService.Encrypt(payload, &suite.testRSAPrivateKey.PublicKey, RSAOAEP256, enc, "", "")
 		assert.Nil(suite.T(), sErr, "enc=%s", enc)
-		decrypted, sErr := suite.jweService.Decrypt(jweToken)
+		decrypted, sErr := suite.jweService.Decrypt(context.Background(), jweToken)
 		assert.Nil(suite.T(), sErr, "enc=%s", enc)
 		assert.Equal(suite.T(), payload, decrypted, "enc=%s", enc)
 	}

--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -45,11 +45,11 @@ import (
 type JWTServiceInterface interface {
 	GenerateJWT(ctx context.Context, sub, iss string, validityPeriod int64,
 		claims map[string]interface{}, typ, alg string) (string, int64, *serviceerror.ServiceError)
-	VerifyJWT(jwtToken string, expectedAud, expectedIss string) *serviceerror.ServiceError
+	VerifyJWT(ctx context.Context, jwtToken string, expectedAud, expectedIss string) *serviceerror.ServiceError
 	VerifyJWTWithPublicKey(jwtToken string, jwtPublicKey crypto.PublicKey, expectedAud,
 		expectedIss string) *serviceerror.ServiceError
 	VerifyJWTWithJWKS(jwtToken, jwksURL, expectedAud, expectedIss string) *serviceerror.ServiceError
-	VerifyJWTSignature(jwtToken string) *serviceerror.ServiceError
+	VerifyJWTSignature(ctx context.Context, jwtToken string) *serviceerror.ServiceError
 	VerifyJWTSignatureWithPublicKey(jwtToken string, jwtPublicKey crypto.PublicKey) *serviceerror.ServiceError
 	VerifyJWTSignatureWithJWKS(jwtToken string, jwksURL string) *serviceerror.ServiceError
 }
@@ -115,10 +115,6 @@ func newJWTService(
 func (js *jwtService) GenerateJWT(
 	ctx context.Context, sub, iss string, validityPeriod int64, claims map[string]interface{}, typ, alg string,
 ) (string, int64, *serviceerror.ServiceError) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	jwsAlg := js.jwsAlg
 	if alg != "" {
 		mapped, err := jws.MapAlgorithmToSignAlg(jws.Algorithm(alg))
@@ -224,14 +220,16 @@ func (js *jwtService) GenerateJWT(
 }
 
 // VerifyJWT verifies the JWT token using the server's public key.
-func (js *jwtService) VerifyJWT(jwtToken string, expectedAud, expectedIss string) *serviceerror.ServiceError {
+func (js *jwtService) VerifyJWT(
+	ctx context.Context, jwtToken string, expectedAud, expectedIss string,
+) *serviceerror.ServiceError {
 	if js.cryptoProvider == nil {
 		js.logger.Error("Crypto provider not initialized for JWT verification")
 		return &serviceerror.InternalServerError
 	}
 
 	// First verify signature using the configured server key and algorithm
-	if err := js.VerifyJWTSignature(jwtToken); err != nil {
+	if err := js.VerifyJWTSignature(ctx, jwtToken); err != nil {
 		return &ErrorInvalidTokenSignature
 	}
 
@@ -270,7 +268,7 @@ func (js *jwtService) VerifyJWTWithJWKS(
 }
 
 // VerifyJWTSignature verifies the signature of a JWT token using the server's public key.
-func (js *jwtService) VerifyJWTSignature(jwtToken string) *serviceerror.ServiceError {
+func (js *jwtService) VerifyJWTSignature(ctx context.Context, jwtToken string) *serviceerror.ServiceError {
 	if js.cryptoProvider == nil {
 		js.logger.Error("Crypto provider not initialized for JWT verification")
 		return &serviceerror.InternalServerError
@@ -302,7 +300,7 @@ func (js *jwtService) VerifyJWTSignature(jwtToken string) *serviceerror.ServiceE
 	}
 
 	// Retrieve all public keys from the provider and match by thumbprint
-	keys, providerErr := js.cryptoProvider.GetPublicKeys(context.Background(), kmprovider.PublicKeyFilter{})
+	keys, providerErr := js.cryptoProvider.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
 	if providerErr != nil {
 		js.logger.Error("Failed to retrieve public keys for JWT verification: " + providerErr.Error())
 		return &serviceerror.InternalServerError

--- a/backend/internal/system/jose/jwt/service_test.go
+++ b/backend/internal/system/jose/jwt/service_test.go
@@ -821,7 +821,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWT() {
 				}
 			}
 
-			err := jwtSvc.VerifyJWT(token, expectedAud, expectedIss)
+			err := jwtSvc.VerifyJWT(context.Background(), token, expectedAud, expectedIss)
 
 			if tc.expectError {
 				assert.NotNil(t, err)
@@ -1443,7 +1443,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 			token := tc.setupFunc()
 			jwtSvc := tc.setupSvc()
 
-			err := jwtSvc.VerifyJWTSignature(token)
+			err := jwtSvc.VerifyJWTSignature(context.Background(), token)
 			if tc.expectError {
 				assert.NotNil(t, err)
 			} else {
@@ -2019,7 +2019,7 @@ func (suite *JWTServiceTestSuite) TestInitWithECDSAKeys() {
 			assert.NoError(t, err)
 			assert.Equal(t, string(tc.expectedAlg), header["alg"])
 
-			svcErr = service.VerifyJWTSignature(token)
+			svcErr = service.VerifyJWTSignature(context.Background(), token)
 			assert.Nil(t, svcErr)
 		})
 	}
@@ -2072,7 +2072,7 @@ func (suite *JWTServiceTestSuite) TestInitWithEd25519Key() {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "EdDSA", header["alg"])
 
-	svcErr = service.VerifyJWTSignature(token)
+	svcErr = service.VerifyJWTSignature(context.Background(), token)
 	assert.Nil(suite.T(), svcErr)
 }
 
@@ -2417,7 +2417,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTWithLeeway() {
 			tc.setupConfig()
 			token, expectedAud, expectedIss := tc.setupFunc()
 
-			err := suite.jwtService.VerifyJWT(token, expectedAud, expectedIss)
+			err := suite.jwtService.VerifyJWT(context.Background(), token, expectedAud, expectedIss)
 
 			if tc.expectError {
 				assert.NotNil(t, err)
@@ -2459,7 +2459,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTWithZeroLeeway() {
 	expiredTime := time.Now().Add(-1 * time.Second).Unix()
 	token := suite.createBasicJWT(testAudience, testIssuer, expiredTime, time.Now().Add(-time.Hour).Unix())
 
-	svcErr := suite.jwtService.VerifyJWT(token, testAudience, testIssuer)
+	svcErr := suite.jwtService.VerifyJWT(context.Background(), token, testAudience, testIssuer)
 	assert.NotNil(suite.T(), svcErr)
 	assert.Equal(suite.T(), ErrorTokenExpired, *svcErr)
 }

--- a/backend/internal/system/mcp/auth/token_verifier.go
+++ b/backend/internal/system/mcp/auth/token_verifier.go
@@ -43,7 +43,7 @@ func NewTokenVerifier(
 
 	return func(ctx context.Context, token string, req *http.Request) (*auth.TokenInfo, error) {
 		// Verify JWT signature and claims (iss, aud, exp, nbf)
-		if err := jwtService.VerifyJWT(token, mcpURL, issuer); err != nil {
+		if err := jwtService.VerifyJWT(ctx, token, mcpURL, issuer); err != nil {
 			logger.Error("JWT verification failed", log.String("error", err.Error.DefaultValue))
 			return nil, auth.ErrInvalidToken
 		}

--- a/backend/internal/system/mcp/auth/token_verifier_test.go
+++ b/backend/internal/system/mcp/auth/token_verifier_test.go
@@ -67,11 +67,12 @@ func (m *MockJWTService) GenerateJWT(
 }
 
 func (m *MockJWTService) VerifyJWT(
+	ctx context.Context,
 	jwtToken string,
 	expectedAud string,
 	expectedIss string,
 ) *serviceerror.ServiceError {
-	args := m.Called(jwtToken, expectedAud, expectedIss)
+	args := m.Called(ctx, jwtToken, expectedAud, expectedIss)
 	if args.Get(0) == nil {
 		return nil
 	}
@@ -104,8 +105,8 @@ func (m *MockJWTService) VerifyJWTWithJWKS(
 	return args.Get(0).(*serviceerror.ServiceError)
 }
 
-func (m *MockJWTService) VerifyJWTSignature(jwtToken string) *serviceerror.ServiceError {
-	args := m.Called(jwtToken)
+func (m *MockJWTService) VerifyJWTSignature(ctx context.Context, jwtToken string) *serviceerror.ServiceError {
+	args := m.Called(ctx, jwtToken)
 	if args.Get(0) == nil {
 		return nil
 	}
@@ -159,7 +160,7 @@ func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_Success() {
 	testToken := "header." + payloadB64 + ".signature"
 
 	// Mock JWT verification to succeed
-	mockJWTService.On("VerifyJWT", testToken, mcpURL, issuer).Return(nil)
+	mockJWTService.On("VerifyJWT", mock.Anything, testToken, mcpURL, issuer).Return(nil)
 
 	// Create token verifier
 	verifier := NewTokenVerifier(mockJWTService, issuer, mcpURL)
@@ -190,7 +191,7 @@ func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_JWTVerificationFailed(
 	testToken := "invalid.token.here"
 
 	// Mock JWT verification to fail
-	mockJWTService.On("VerifyJWT", testToken, mcpURL, issuer).Return(&serviceerror.ServiceError{
+	mockJWTService.On("VerifyJWT", mock.Anything, testToken, mcpURL, issuer).Return(&serviceerror.ServiceError{
 		ErrorDescription: i18ncore.I18nMessage{DefaultValue: "invalid token"},
 	})
 
@@ -221,7 +222,7 @@ func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_InvalidPayload() {
 	testToken := "header.invalid-payload.signature"
 
 	// Mock JWT verification to succeed
-	mockJWTService.On("VerifyJWT", testToken, mcpURL, issuer).Return(nil)
+	mockJWTService.On("VerifyJWT", mock.Anything, testToken, mcpURL, issuer).Return(nil)
 
 	// Create token verifier
 	verifier := NewTokenVerifier(mockJWTService, issuer, mcpURL)
@@ -257,7 +258,7 @@ func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_NoScopes() {
 	testToken := "header." + payloadB64 + ".signature"
 
 	// Mock JWT verification to succeed
-	mockJWTService.On("VerifyJWT", testToken, mcpURL, issuer).Return(nil)
+	mockJWTService.On("VerifyJWT", mock.Anything, testToken, mcpURL, issuer).Return(nil)
 
 	// Create token verifier
 	verifier := NewTokenVerifier(mockJWTService, issuer, mcpURL)
@@ -294,7 +295,7 @@ func (suite *TokenVerifierTestSuite) TestNewTokenVerifier_EmptyUserID() {
 	testToken := "header." + payloadB64 + ".signature"
 
 	// Mock JWT verification to succeed
-	mockJWTService.On("VerifyJWT", testToken, mcpURL, issuer).Return(nil)
+	mockJWTService.On("VerifyJWT", mock.Anything, testToken, mcpURL, issuer).Return(nil)
 
 	// Create token verifier
 	verifier := NewTokenVerifier(mockJWTService, issuer, mcpURL)

--- a/backend/internal/system/security/jwt_authenticator.go
+++ b/backend/internal/system/security/jwt_authenticator.go
@@ -19,6 +19,7 @@
 package security
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -49,6 +50,7 @@ func (h *jwtAuthenticator) CanHandle(r *http.Request) bool {
 
 // Authenticate validates the JWT token and builds a SecurityContext.
 func (h *jwtAuthenticator) Authenticate(r *http.Request) (*SecurityContext, error) {
+	ctx := r.Context()
 	// Step 1: Extract Bearer token
 	authHeader := r.Header.Get(constants.AuthorizationHeaderName)
 	token, err := extractToken(authHeader)
@@ -63,7 +65,7 @@ func (h *jwtAuthenticator) Authenticate(r *http.Request) (*SecurityContext, erro
 	// Step 2: Verify the JWT, routing on its issuer. Tokens this server issued
 	// are verified with its own signing key; Additionally when a trusted issuer is
 	// configured, tokens from that issuer are verified against its JWKS.
-	if err := h.verifyToken(token); err != nil {
+	if err := h.verifyToken(ctx, token); err != nil {
 		return nil, err
 	}
 
@@ -93,7 +95,7 @@ func (h *jwtAuthenticator) Authenticate(r *http.Request) (*SecurityContext, erro
 // trusted issuer (when set) are verified against its JWKS. Tokens whose iss
 // matches this server's own JWT issuer are verified with the local signing
 // key. Any other iss is rejected. There is no cross-issuer fallback.
-func (h *jwtAuthenticator) verifyToken(token string) error {
+func (h *jwtAuthenticator) verifyToken(ctx context.Context, token string) error {
 	trustedIssuer := config.GetServerRuntime().Config.Server.SecurityConfig.TrustedIssuer
 	iss := extractIssuer(token)
 	switch {
@@ -102,7 +104,7 @@ func (h *jwtAuthenticator) verifyToken(token string) error {
 			return errInvalidToken
 		}
 	case iss == config.GetServerRuntime().Config.JWT.Issuer:
-		if err := h.jwtService.VerifyJWT(token, "", ""); err != nil {
+		if err := h.jwtService.VerifyJWT(ctx, token, "", ""); err != nil {
 			return errInvalidToken
 		}
 	default:

--- a/backend/internal/system/security/jwt_authenticator_test.go
+++ b/backend/internal/system/security/jwt_authenticator_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
@@ -124,7 +125,7 @@ func (suite *JWTAuthenticatorTestSuite) TestAuthenticate() {
 			name:       "Successful authentication with system scope",
 			authHeader: "Bearer " + validToken,
 			setupMock: func(m *jwtmock.JWTServiceInterfaceMock) {
-				m.On("VerifyJWT", validToken, "", "").Return(nil)
+				m.On("VerifyJWT", mock.Anything, validToken, "", "").Return(nil)
 			},
 			expectedError: nil,
 			validateResult: func(t *testing.T, ctx *SecurityContext) {
@@ -155,7 +156,7 @@ func (suite *JWTAuthenticatorTestSuite) TestAuthenticate() {
 			name:       "Invalid JWT signature",
 			authHeader: "Bearer invalid.jwt.token",
 			setupMock: func(m *jwtmock.JWTServiceInterfaceMock) {
-				m.On("VerifyJWT", "invalid.jwt.token", "", "").Return(&serviceerror.ServiceError{
+				m.On("VerifyJWT", mock.Anything, "invalid.jwt.token", "", "").Return(&serviceerror.ServiceError{
 					Type:             serviceerror.ServerErrorType,
 					Code:             "INVALID_SIGNATURE",
 					Error:            i18ncore.I18nMessage{DefaultValue: "Invalid signature"},
@@ -168,7 +169,7 @@ func (suite *JWTAuthenticatorTestSuite) TestAuthenticate() {
 			name:       "Expired JWT token",
 			authHeader: "Bearer expired.jwt.token",
 			setupMock: func(m *jwtmock.JWTServiceInterfaceMock) {
-				m.On("VerifyJWT", "expired.jwt.token", "", "").Return(&serviceerror.ServiceError{
+				m.On("VerifyJWT", mock.Anything, "expired.jwt.token", "", "").Return(&serviceerror.ServiceError{
 					Type:             serviceerror.ClientErrorType,
 					Code:             "JWT-60005",
 					Error:            i18ncore.I18nMessage{DefaultValue: "Token has expired"},
@@ -181,7 +182,7 @@ func (suite *JWTAuthenticatorTestSuite) TestAuthenticate() {
 			name:       "Invalid JWT format - decoding error",
 			authHeader: "Bearer invalidjwtformat", // Not 3 parts separated by dots
 			setupMock: func(m *jwtmock.JWTServiceInterfaceMock) {
-				m.On("VerifyJWT", "invalidjwtformat", "", "").Return(nil)
+				m.On("VerifyJWT", mock.Anything, "invalidjwtformat", "", "").Return(nil)
 			},
 			expectedError: errInvalidToken,
 		},
@@ -189,7 +190,8 @@ func (suite *JWTAuthenticatorTestSuite) TestAuthenticate() {
 			name:       "Invalid JWT payload - malformed base64",
 			authHeader: "Bearer eyJhbGciOiJIUzI1NiJ9.invalid!base64!payload.signature",
 			setupMock: func(m *jwtmock.JWTServiceInterfaceMock) {
-				m.On("VerifyJWT", "eyJhbGciOiJIUzI1NiJ9.invalid!base64!payload.signature", "", "").Return(nil)
+				const tok = "eyJhbGciOiJIUzI1NiJ9.invalid!base64!payload.signature"
+				m.On("VerifyJWT", mock.Anything, tok, "", "").Return(nil)
 			},
 			expectedError: errInvalidToken,
 		},
@@ -197,7 +199,8 @@ func (suite *JWTAuthenticatorTestSuite) TestAuthenticate() {
 			name:       "Invalid JWT payload - malformed JSON",
 			authHeader: "Bearer eyJhbGciOiJIUzI1NiJ9.bm90X3ZhbGlkX2pzb24.signature", // "not_valid_json" base64 encoded
 			setupMock: func(m *jwtmock.JWTServiceInterfaceMock) {
-				m.On("VerifyJWT", "eyJhbGciOiJIUzI1NiJ9.bm90X3ZhbGlkX2pzb24.signature", "", "").Return(nil)
+				const tok = "eyJhbGciOiJIUzI1NiJ9.bm90X3ZhbGlkX2pzb24.signature"
+				m.On("VerifyJWT", mock.Anything, tok, "", "").Return(nil)
 			},
 			expectedError: errInvalidToken,
 		},
@@ -884,7 +887,7 @@ func (suite *JWTAuthenticatorTestSuite) TestAuthenticate_SelfIssuedTokenUnderFed
 	)
 
 	mockJWT := jwtmock.NewJWTServiceInterfaceMock(suite.T())
-	mockJWT.On("VerifyJWT", token, "", "").Return(nil)
+	mockJWT.On("VerifyJWT", mock.Anything, token, "", "").Return(nil)
 	auth := newJWTAuthenticator(mockJWT)
 
 	req := httptest.NewRequest(http.MethodGet, "/users", nil)
@@ -913,7 +916,7 @@ func (suite *JWTAuthenticatorTestSuite) TestAuthenticate_SelfIssuedTokenInvalidU
 	)
 
 	mockJWT := jwtmock.NewJWTServiceInterfaceMock(suite.T())
-	mockJWT.On("VerifyJWT", token, "", "").Return(&serviceerror.ServiceError{
+	mockJWT.On("VerifyJWT", mock.Anything, token, "", "").Return(&serviceerror.ServiceError{
 		Type:  serviceerror.ServerErrorType,
 		Code:  "INVALID_SIGNATURE",
 		Error: i18ncore.I18nMessage{DefaultValue: "Invalid signature"},

--- a/backend/tests/mocks/jose/jwemock/JWEServiceInterface_mock.go
+++ b/backend/tests/mocks/jose/jwemock/JWEServiceInterface_mock.go
@@ -5,6 +5,7 @@
 package jwemock
 
 import (
+	"context"
 	"crypto"
 
 	mock "github.com/stretchr/testify/mock"
@@ -40,8 +41,8 @@ func (_m *JWEServiceInterfaceMock) EXPECT() *JWEServiceInterfaceMock_Expecter {
 }
 
 // Decrypt provides a mock function for the type JWEServiceInterfaceMock
-func (_mock *JWEServiceInterfaceMock) Decrypt(jweToken string) ([]byte, *serviceerror.ServiceError) {
-	ret := _mock.Called(jweToken)
+func (_mock *JWEServiceInterfaceMock) Decrypt(ctx context.Context, jweToken string) ([]byte, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, jweToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Decrypt")
@@ -49,18 +50,18 @@ func (_mock *JWEServiceInterfaceMock) Decrypt(jweToken string) ([]byte, *service
 
 	var r0 []byte
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) ([]byte, *serviceerror.ServiceError)); ok {
-		return returnFunc(jweToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]byte, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, jweToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) []byte); ok {
-		r0 = returnFunc(jweToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
+		r0 = returnFunc(ctx, jweToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(jweToken)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, jweToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -75,19 +76,25 @@ type JWEServiceInterfaceMock_Decrypt_Call struct {
 }
 
 // Decrypt is a helper method to define mock.On call
+//   - ctx context.Context
 //   - jweToken string
-func (_e *JWEServiceInterfaceMock_Expecter) Decrypt(jweToken interface{}) *JWEServiceInterfaceMock_Decrypt_Call {
-	return &JWEServiceInterfaceMock_Decrypt_Call{Call: _e.mock.On("Decrypt", jweToken)}
+func (_e *JWEServiceInterfaceMock_Expecter) Decrypt(ctx interface{}, jweToken interface{}) *JWEServiceInterfaceMock_Decrypt_Call {
+	return &JWEServiceInterfaceMock_Decrypt_Call{Call: _e.mock.On("Decrypt", ctx, jweToken)}
 }
 
-func (_c *JWEServiceInterfaceMock_Decrypt_Call) Run(run func(jweToken string)) *JWEServiceInterfaceMock_Decrypt_Call {
+func (_c *JWEServiceInterfaceMock_Decrypt_Call) Run(run func(ctx context.Context, jweToken string)) *JWEServiceInterfaceMock_Decrypt_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -98,7 +105,7 @@ func (_c *JWEServiceInterfaceMock_Decrypt_Call) Return(bytes []byte, serviceErro
 	return _c
 }
 
-func (_c *JWEServiceInterfaceMock_Decrypt_Call) RunAndReturn(run func(jweToken string) ([]byte, *serviceerror.ServiceError)) *JWEServiceInterfaceMock_Decrypt_Call {
+func (_c *JWEServiceInterfaceMock_Decrypt_Call) RunAndReturn(run func(ctx context.Context, jweToken string) ([]byte, *serviceerror.ServiceError)) *JWEServiceInterfaceMock_Decrypt_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/jose/jwtmock/JWTServiceInterface_mock.go
+++ b/backend/tests/mocks/jose/jwtmock/JWTServiceInterface_mock.go
@@ -144,16 +144,16 @@ func (_c *JWTServiceInterfaceMock_GenerateJWT_Call) RunAndReturn(run func(ctx co
 }
 
 // VerifyJWT provides a mock function for the type JWTServiceInterfaceMock
-func (_mock *JWTServiceInterfaceMock) VerifyJWT(jwtToken string, expectedAud string, expectedIss string) *serviceerror.ServiceError {
-	ret := _mock.Called(jwtToken, expectedAud, expectedIss)
+func (_mock *JWTServiceInterfaceMock) VerifyJWT(ctx context.Context, jwtToken string, expectedAud string, expectedIss string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, jwtToken, expectedAud, expectedIss)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyJWT")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(jwtToken, expectedAud, expectedIss)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, jwtToken, expectedAud, expectedIss)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -168,18 +168,19 @@ type JWTServiceInterfaceMock_VerifyJWT_Call struct {
 }
 
 // VerifyJWT is a helper method to define mock.On call
+//   - ctx context.Context
 //   - jwtToken string
 //   - expectedAud string
 //   - expectedIss string
-func (_e *JWTServiceInterfaceMock_Expecter) VerifyJWT(jwtToken interface{}, expectedAud interface{}, expectedIss interface{}) *JWTServiceInterfaceMock_VerifyJWT_Call {
-	return &JWTServiceInterfaceMock_VerifyJWT_Call{Call: _e.mock.On("VerifyJWT", jwtToken, expectedAud, expectedIss)}
+func (_e *JWTServiceInterfaceMock_Expecter) VerifyJWT(ctx interface{}, jwtToken interface{}, expectedAud interface{}, expectedIss interface{}) *JWTServiceInterfaceMock_VerifyJWT_Call {
+	return &JWTServiceInterfaceMock_VerifyJWT_Call{Call: _e.mock.On("VerifyJWT", ctx, jwtToken, expectedAud, expectedIss)}
 }
 
-func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) Run(run func(jwtToken string, expectedAud string, expectedIss string)) *JWTServiceInterfaceMock_VerifyJWT_Call {
+func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) Run(run func(ctx context.Context, jwtToken string, expectedAud string, expectedIss string)) *JWTServiceInterfaceMock_VerifyJWT_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -189,10 +190,15 @@ func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) Run(run func(jwtToken string, 
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -203,22 +209,22 @@ func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) Return(serviceError *serviceer
 	return _c
 }
 
-func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) RunAndReturn(run func(jwtToken string, expectedAud string, expectedIss string) *serviceerror.ServiceError) *JWTServiceInterfaceMock_VerifyJWT_Call {
+func (_c *JWTServiceInterfaceMock_VerifyJWT_Call) RunAndReturn(run func(ctx context.Context, jwtToken string, expectedAud string, expectedIss string) *serviceerror.ServiceError) *JWTServiceInterfaceMock_VerifyJWT_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // VerifyJWTSignature provides a mock function for the type JWTServiceInterfaceMock
-func (_mock *JWTServiceInterfaceMock) VerifyJWTSignature(jwtToken string) *serviceerror.ServiceError {
-	ret := _mock.Called(jwtToken)
+func (_mock *JWTServiceInterfaceMock) VerifyJWTSignature(ctx context.Context, jwtToken string) *serviceerror.ServiceError {
+	ret := _mock.Called(ctx, jwtToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyJWTSignature")
 	}
 
 	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(jwtToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r0 = returnFunc(ctx, jwtToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*serviceerror.ServiceError)
@@ -233,19 +239,25 @@ type JWTServiceInterfaceMock_VerifyJWTSignature_Call struct {
 }
 
 // VerifyJWTSignature is a helper method to define mock.On call
+//   - ctx context.Context
 //   - jwtToken string
-func (_e *JWTServiceInterfaceMock_Expecter) VerifyJWTSignature(jwtToken interface{}) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
-	return &JWTServiceInterfaceMock_VerifyJWTSignature_Call{Call: _e.mock.On("VerifyJWTSignature", jwtToken)}
+func (_e *JWTServiceInterfaceMock_Expecter) VerifyJWTSignature(ctx interface{}, jwtToken interface{}) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
+	return &JWTServiceInterfaceMock_VerifyJWTSignature_Call{Call: _e.mock.On("VerifyJWTSignature", ctx, jwtToken)}
 }
 
-func (_c *JWTServiceInterfaceMock_VerifyJWTSignature_Call) Run(run func(jwtToken string)) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
+func (_c *JWTServiceInterfaceMock_VerifyJWTSignature_Call) Run(run func(ctx context.Context, jwtToken string)) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -256,7 +268,7 @@ func (_c *JWTServiceInterfaceMock_VerifyJWTSignature_Call) Return(serviceError *
 	return _c
 }
 
-func (_c *JWTServiceInterfaceMock_VerifyJWTSignature_Call) RunAndReturn(run func(jwtToken string) *serviceerror.ServiceError) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
+func (_c *JWTServiceInterfaceMock_VerifyJWTSignature_Call) RunAndReturn(run func(ctx context.Context, jwtToken string) *serviceerror.ServiceError) *JWTServiceInterfaceMock_VerifyJWTSignature_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenBuilderInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenBuilderInterface_mock.go
@@ -5,6 +5,8 @@
 package tokenservicemock
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
@@ -38,8 +40,8 @@ func (_m *TokenBuilderInterfaceMock) EXPECT() *TokenBuilderInterfaceMock_Expecte
 }
 
 // BuildAccessToken provides a mock function for the type TokenBuilderInterfaceMock
-func (_mock *TokenBuilderInterfaceMock) BuildAccessToken(ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
-	ret := _mock.Called(ctx)
+func (_mock *TokenBuilderInterfaceMock) BuildAccessToken(ctx context.Context, tokenCtx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error) {
+	ret := _mock.Called(ctx, tokenCtx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAccessToken")
@@ -47,18 +49,18 @@ func (_mock *TokenBuilderInterfaceMock) BuildAccessToken(ctx *tokenservice.Acces
 
 	var r0 *model.TokenDTO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error)); ok {
-		return returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error)); ok {
+		return returnFunc(ctx, tokenCtx)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*tokenservice.AccessTokenBuildContext) *model.TokenDTO); ok {
-		r0 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *tokenservice.AccessTokenBuildContext) *model.TokenDTO); ok {
+		r0 = returnFunc(ctx, tokenCtx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.TokenDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*tokenservice.AccessTokenBuildContext) error); ok {
-		r1 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *tokenservice.AccessTokenBuildContext) error); ok {
+		r1 = returnFunc(ctx, tokenCtx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -71,19 +73,25 @@ type TokenBuilderInterfaceMock_BuildAccessToken_Call struct {
 }
 
 // BuildAccessToken is a helper method to define mock.On call
-//   - ctx *tokenservice.AccessTokenBuildContext
-func (_e *TokenBuilderInterfaceMock_Expecter) BuildAccessToken(ctx interface{}) *TokenBuilderInterfaceMock_BuildAccessToken_Call {
-	return &TokenBuilderInterfaceMock_BuildAccessToken_Call{Call: _e.mock.On("BuildAccessToken", ctx)}
+//   - ctx context.Context
+//   - tokenCtx *tokenservice.AccessTokenBuildContext
+func (_e *TokenBuilderInterfaceMock_Expecter) BuildAccessToken(ctx interface{}, tokenCtx interface{}) *TokenBuilderInterfaceMock_BuildAccessToken_Call {
+	return &TokenBuilderInterfaceMock_BuildAccessToken_Call{Call: _e.mock.On("BuildAccessToken", ctx, tokenCtx)}
 }
 
-func (_c *TokenBuilderInterfaceMock_BuildAccessToken_Call) Run(run func(ctx *tokenservice.AccessTokenBuildContext)) *TokenBuilderInterfaceMock_BuildAccessToken_Call {
+func (_c *TokenBuilderInterfaceMock_BuildAccessToken_Call) Run(run func(ctx context.Context, tokenCtx *tokenservice.AccessTokenBuildContext)) *TokenBuilderInterfaceMock_BuildAccessToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *tokenservice.AccessTokenBuildContext
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*tokenservice.AccessTokenBuildContext)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *tokenservice.AccessTokenBuildContext
+		if args[1] != nil {
+			arg1 = args[1].(*tokenservice.AccessTokenBuildContext)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -94,14 +102,14 @@ func (_c *TokenBuilderInterfaceMock_BuildAccessToken_Call) Return(tokenDTO *mode
 	return _c
 }
 
-func (_c *TokenBuilderInterfaceMock_BuildAccessToken_Call) RunAndReturn(run func(ctx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error)) *TokenBuilderInterfaceMock_BuildAccessToken_Call {
+func (_c *TokenBuilderInterfaceMock_BuildAccessToken_Call) RunAndReturn(run func(ctx context.Context, tokenCtx *tokenservice.AccessTokenBuildContext) (*model.TokenDTO, error)) *TokenBuilderInterfaceMock_BuildAccessToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // BuildIDToken provides a mock function for the type TokenBuilderInterfaceMock
-func (_mock *TokenBuilderInterfaceMock) BuildIDToken(ctx *tokenservice.IDTokenBuildContext) (*model.TokenDTO, error) {
-	ret := _mock.Called(ctx)
+func (_mock *TokenBuilderInterfaceMock) BuildIDToken(ctx context.Context, tokenCtx *tokenservice.IDTokenBuildContext) (*model.TokenDTO, error) {
+	ret := _mock.Called(ctx, tokenCtx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildIDToken")
@@ -109,18 +117,18 @@ func (_mock *TokenBuilderInterfaceMock) BuildIDToken(ctx *tokenservice.IDTokenBu
 
 	var r0 *model.TokenDTO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*tokenservice.IDTokenBuildContext) (*model.TokenDTO, error)); ok {
-		return returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *tokenservice.IDTokenBuildContext) (*model.TokenDTO, error)); ok {
+		return returnFunc(ctx, tokenCtx)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*tokenservice.IDTokenBuildContext) *model.TokenDTO); ok {
-		r0 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *tokenservice.IDTokenBuildContext) *model.TokenDTO); ok {
+		r0 = returnFunc(ctx, tokenCtx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.TokenDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*tokenservice.IDTokenBuildContext) error); ok {
-		r1 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *tokenservice.IDTokenBuildContext) error); ok {
+		r1 = returnFunc(ctx, tokenCtx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -133,19 +141,25 @@ type TokenBuilderInterfaceMock_BuildIDToken_Call struct {
 }
 
 // BuildIDToken is a helper method to define mock.On call
-//   - ctx *tokenservice.IDTokenBuildContext
-func (_e *TokenBuilderInterfaceMock_Expecter) BuildIDToken(ctx interface{}) *TokenBuilderInterfaceMock_BuildIDToken_Call {
-	return &TokenBuilderInterfaceMock_BuildIDToken_Call{Call: _e.mock.On("BuildIDToken", ctx)}
+//   - ctx context.Context
+//   - tokenCtx *tokenservice.IDTokenBuildContext
+func (_e *TokenBuilderInterfaceMock_Expecter) BuildIDToken(ctx interface{}, tokenCtx interface{}) *TokenBuilderInterfaceMock_BuildIDToken_Call {
+	return &TokenBuilderInterfaceMock_BuildIDToken_Call{Call: _e.mock.On("BuildIDToken", ctx, tokenCtx)}
 }
 
-func (_c *TokenBuilderInterfaceMock_BuildIDToken_Call) Run(run func(ctx *tokenservice.IDTokenBuildContext)) *TokenBuilderInterfaceMock_BuildIDToken_Call {
+func (_c *TokenBuilderInterfaceMock_BuildIDToken_Call) Run(run func(ctx context.Context, tokenCtx *tokenservice.IDTokenBuildContext)) *TokenBuilderInterfaceMock_BuildIDToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *tokenservice.IDTokenBuildContext
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*tokenservice.IDTokenBuildContext)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *tokenservice.IDTokenBuildContext
+		if args[1] != nil {
+			arg1 = args[1].(*tokenservice.IDTokenBuildContext)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -156,14 +170,14 @@ func (_c *TokenBuilderInterfaceMock_BuildIDToken_Call) Return(tokenDTO *model.To
 	return _c
 }
 
-func (_c *TokenBuilderInterfaceMock_BuildIDToken_Call) RunAndReturn(run func(ctx *tokenservice.IDTokenBuildContext) (*model.TokenDTO, error)) *TokenBuilderInterfaceMock_BuildIDToken_Call {
+func (_c *TokenBuilderInterfaceMock_BuildIDToken_Call) RunAndReturn(run func(ctx context.Context, tokenCtx *tokenservice.IDTokenBuildContext) (*model.TokenDTO, error)) *TokenBuilderInterfaceMock_BuildIDToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // BuildRefreshToken provides a mock function for the type TokenBuilderInterfaceMock
-func (_mock *TokenBuilderInterfaceMock) BuildRefreshToken(ctx *tokenservice.RefreshTokenBuildContext) (*model.TokenDTO, error) {
-	ret := _mock.Called(ctx)
+func (_mock *TokenBuilderInterfaceMock) BuildRefreshToken(ctx context.Context, tokenCtx *tokenservice.RefreshTokenBuildContext) (*model.TokenDTO, error) {
+	ret := _mock.Called(ctx, tokenCtx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildRefreshToken")
@@ -171,18 +185,18 @@ func (_mock *TokenBuilderInterfaceMock) BuildRefreshToken(ctx *tokenservice.Refr
 
 	var r0 *model.TokenDTO
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*tokenservice.RefreshTokenBuildContext) (*model.TokenDTO, error)); ok {
-		return returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *tokenservice.RefreshTokenBuildContext) (*model.TokenDTO, error)); ok {
+		return returnFunc(ctx, tokenCtx)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*tokenservice.RefreshTokenBuildContext) *model.TokenDTO); ok {
-		r0 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *tokenservice.RefreshTokenBuildContext) *model.TokenDTO); ok {
+		r0 = returnFunc(ctx, tokenCtx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.TokenDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*tokenservice.RefreshTokenBuildContext) error); ok {
-		r1 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *tokenservice.RefreshTokenBuildContext) error); ok {
+		r1 = returnFunc(ctx, tokenCtx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -195,19 +209,25 @@ type TokenBuilderInterfaceMock_BuildRefreshToken_Call struct {
 }
 
 // BuildRefreshToken is a helper method to define mock.On call
-//   - ctx *tokenservice.RefreshTokenBuildContext
-func (_e *TokenBuilderInterfaceMock_Expecter) BuildRefreshToken(ctx interface{}) *TokenBuilderInterfaceMock_BuildRefreshToken_Call {
-	return &TokenBuilderInterfaceMock_BuildRefreshToken_Call{Call: _e.mock.On("BuildRefreshToken", ctx)}
+//   - ctx context.Context
+//   - tokenCtx *tokenservice.RefreshTokenBuildContext
+func (_e *TokenBuilderInterfaceMock_Expecter) BuildRefreshToken(ctx interface{}, tokenCtx interface{}) *TokenBuilderInterfaceMock_BuildRefreshToken_Call {
+	return &TokenBuilderInterfaceMock_BuildRefreshToken_Call{Call: _e.mock.On("BuildRefreshToken", ctx, tokenCtx)}
 }
 
-func (_c *TokenBuilderInterfaceMock_BuildRefreshToken_Call) Run(run func(ctx *tokenservice.RefreshTokenBuildContext)) *TokenBuilderInterfaceMock_BuildRefreshToken_Call {
+func (_c *TokenBuilderInterfaceMock_BuildRefreshToken_Call) Run(run func(ctx context.Context, tokenCtx *tokenservice.RefreshTokenBuildContext)) *TokenBuilderInterfaceMock_BuildRefreshToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *tokenservice.RefreshTokenBuildContext
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*tokenservice.RefreshTokenBuildContext)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *tokenservice.RefreshTokenBuildContext
+		if args[1] != nil {
+			arg1 = args[1].(*tokenservice.RefreshTokenBuildContext)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -218,7 +238,7 @@ func (_c *TokenBuilderInterfaceMock_BuildRefreshToken_Call) Return(tokenDTO *mod
 	return _c
 }
 
-func (_c *TokenBuilderInterfaceMock_BuildRefreshToken_Call) RunAndReturn(run func(ctx *tokenservice.RefreshTokenBuildContext) (*model.TokenDTO, error)) *TokenBuilderInterfaceMock_BuildRefreshToken_Call {
+func (_c *TokenBuilderInterfaceMock_BuildRefreshToken_Call) RunAndReturn(run func(ctx context.Context, tokenCtx *tokenservice.RefreshTokenBuildContext) (*model.TokenDTO, error)) *TokenBuilderInterfaceMock_BuildRefreshToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenValidatorInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenValidatorInterface_mock.go
@@ -40,8 +40,8 @@ func (_m *TokenValidatorInterfaceMock) EXPECT() *TokenValidatorInterfaceMock_Exp
 }
 
 // ValidateAccessToken provides a mock function for the type TokenValidatorInterfaceMock
-func (_mock *TokenValidatorInterfaceMock) ValidateAccessToken(token string) (*tokenservice.AccessTokenClaims, error) {
-	ret := _mock.Called(token)
+func (_mock *TokenValidatorInterfaceMock) ValidateAccessToken(ctx context.Context, token string) (*tokenservice.AccessTokenClaims, error) {
+	ret := _mock.Called(ctx, token)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateAccessToken")
@@ -49,18 +49,18 @@ func (_mock *TokenValidatorInterfaceMock) ValidateAccessToken(token string) (*to
 
 	var r0 *tokenservice.AccessTokenClaims
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*tokenservice.AccessTokenClaims, error)); ok {
-		return returnFunc(token)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*tokenservice.AccessTokenClaims, error)); ok {
+		return returnFunc(ctx, token)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *tokenservice.AccessTokenClaims); ok {
-		r0 = returnFunc(token)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *tokenservice.AccessTokenClaims); ok {
+		r0 = returnFunc(ctx, token)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*tokenservice.AccessTokenClaims)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(token)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, token)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -73,79 +73,17 @@ type TokenValidatorInterfaceMock_ValidateAccessToken_Call struct {
 }
 
 // ValidateAccessToken is a helper method to define mock.On call
+//   - ctx context.Context
 //   - token string
-func (_e *TokenValidatorInterfaceMock_Expecter) ValidateAccessToken(token interface{}) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
-	return &TokenValidatorInterfaceMock_ValidateAccessToken_Call{Call: _e.mock.On("ValidateAccessToken", token)}
+func (_e *TokenValidatorInterfaceMock_Expecter) ValidateAccessToken(ctx interface{}, token interface{}) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
+	return &TokenValidatorInterfaceMock_ValidateAccessToken_Call{Call: _e.mock.On("ValidateAccessToken", ctx, token)}
 }
 
-func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) Run(run func(token string)) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
+func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) Run(run func(ctx context.Context, token string)) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) Return(accessTokenClaims *tokenservice.AccessTokenClaims, err error) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
-	_c.Call.Return(accessTokenClaims, err)
-	return _c
-}
-
-func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) RunAndReturn(run func(token string) (*tokenservice.AccessTokenClaims, error)) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ValidateRefreshToken provides a mock function for the type TokenValidatorInterfaceMock
-func (_mock *TokenValidatorInterfaceMock) ValidateRefreshToken(token string, clientID string) (*tokenservice.RefreshTokenClaims, error) {
-	ret := _mock.Called(token, clientID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ValidateRefreshToken")
-	}
-
-	var r0 *tokenservice.RefreshTokenClaims
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (*tokenservice.RefreshTokenClaims, error)); ok {
-		return returnFunc(token, clientID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) *tokenservice.RefreshTokenClaims); ok {
-		r0 = returnFunc(token, clientID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*tokenservice.RefreshTokenClaims)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(token, clientID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// TokenValidatorInterfaceMock_ValidateRefreshToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateRefreshToken'
-type TokenValidatorInterfaceMock_ValidateRefreshToken_Call struct {
-	*mock.Call
-}
-
-// ValidateRefreshToken is a helper method to define mock.On call
-//   - token string
-//   - clientID string
-func (_e *TokenValidatorInterfaceMock_Expecter) ValidateRefreshToken(token interface{}, clientID interface{}) *TokenValidatorInterfaceMock_ValidateRefreshToken_Call {
-	return &TokenValidatorInterfaceMock_ValidateRefreshToken_Call{Call: _e.mock.On("ValidateRefreshToken", token, clientID)}
-}
-
-func (_c *TokenValidatorInterfaceMock_ValidateRefreshToken_Call) Run(run func(token string, clientID string)) *TokenValidatorInterfaceMock_ValidateRefreshToken_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -159,12 +97,86 @@ func (_c *TokenValidatorInterfaceMock_ValidateRefreshToken_Call) Run(run func(to
 	return _c
 }
 
+func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) Return(accessTokenClaims *tokenservice.AccessTokenClaims, err error) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
+	_c.Call.Return(accessTokenClaims, err)
+	return _c
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) RunAndReturn(run func(ctx context.Context, token string) (*tokenservice.AccessTokenClaims, error)) *TokenValidatorInterfaceMock_ValidateAccessToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ValidateRefreshToken provides a mock function for the type TokenValidatorInterfaceMock
+func (_mock *TokenValidatorInterfaceMock) ValidateRefreshToken(ctx context.Context, token string, clientID string) (*tokenservice.RefreshTokenClaims, error) {
+	ret := _mock.Called(ctx, token, clientID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateRefreshToken")
+	}
+
+	var r0 *tokenservice.RefreshTokenClaims
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*tokenservice.RefreshTokenClaims, error)); ok {
+		return returnFunc(ctx, token, clientID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *tokenservice.RefreshTokenClaims); ok {
+		r0 = returnFunc(ctx, token, clientID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*tokenservice.RefreshTokenClaims)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, token, clientID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// TokenValidatorInterfaceMock_ValidateRefreshToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateRefreshToken'
+type TokenValidatorInterfaceMock_ValidateRefreshToken_Call struct {
+	*mock.Call
+}
+
+// ValidateRefreshToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - token string
+//   - clientID string
+func (_e *TokenValidatorInterfaceMock_Expecter) ValidateRefreshToken(ctx interface{}, token interface{}, clientID interface{}) *TokenValidatorInterfaceMock_ValidateRefreshToken_Call {
+	return &TokenValidatorInterfaceMock_ValidateRefreshToken_Call{Call: _e.mock.On("ValidateRefreshToken", ctx, token, clientID)}
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateRefreshToken_Call) Run(run func(ctx context.Context, token string, clientID string)) *TokenValidatorInterfaceMock_ValidateRefreshToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
 func (_c *TokenValidatorInterfaceMock_ValidateRefreshToken_Call) Return(refreshTokenClaims *tokenservice.RefreshTokenClaims, err error) *TokenValidatorInterfaceMock_ValidateRefreshToken_Call {
 	_c.Call.Return(refreshTokenClaims, err)
 	return _c
 }
 
-func (_c *TokenValidatorInterfaceMock_ValidateRefreshToken_Call) RunAndReturn(run func(token string, clientID string) (*tokenservice.RefreshTokenClaims, error)) *TokenValidatorInterfaceMock_ValidateRefreshToken_Call {
+func (_c *TokenValidatorInterfaceMock_ValidateRefreshToken_Call) RunAndReturn(run func(ctx context.Context, token string, clientID string) (*tokenservice.RefreshTokenClaims, error)) *TokenValidatorInterfaceMock_ValidateRefreshToken_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
Along with the keymanager implementation, there were couple of context.background that was introduced. They need to be updated with the request context.

Issue 
- https://github.com/thunder-id/thunderid/issues/2751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Request contexts are now propagated into JWT/JWE/JWKS, token, and crypto operations for proper cancellation/timeouts; token builder and validator APIs accept explicit context.
  * Key-manager initialization now accepts an injected PKI dependency and consolidates runtime/config provider wiring.

* **New Features**
  * SDK runtime overrides support: new SDK config type and HOC changes allow merging provider-level SDK settings into the app.

* **Tests**
  * Unit tests and generated mocks updated to match new context-aware APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->