### PR TITLE
Route OTP registration, Magic Link registration, Magic Link authentication through authnprovider

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -245,7 +245,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	// Initialize authn provider
 	authnProvider := authnprovidermgr.InitializeAuthnProviderManager(entityService, passkeyService, otpCoreService,
-		federatedAuths)
+		magicLinkService, federatedAuths)
 
 	// Initialize authentication services.
 	authAssertGen := authnAssert.Initialize()

--- a/backend/internal/authn/magiclink/service.go
+++ b/backend/internal/authn/magiclink/service.go
@@ -33,6 +33,14 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )
 
+// MagicLinkAuthnResult holds the result of a magic link authentication attempt.
+// When InternalEntity is nil the token was valid but no local user exists yet (registration flow);
+// VerifiedIdentifiers then carries the proven channel identifiers (e.g. email).
+type MagicLinkAuthnResult struct {
+	InternalEntity      *entityprovider.Entity
+	VerifiedIdentifiers map[string]interface{}
+}
+
 // MagicLinkAuthnServiceInterface defines the interface for magic link authentication operations.
 type MagicLinkAuthnServiceInterface interface {
 	GenerateMagicLink(
@@ -43,8 +51,8 @@ type MagicLinkAuthnServiceInterface interface {
 		additionalClaims map[string]interface{},
 		magicLinkURL string,
 	) (string, *serviceerror.ServiceError)
-	VerifyMagicLink(ctx context.Context, token string,
-		subjectAttribute string) (*entityprovider.Entity, *serviceerror.ServiceError)
+	Authenticate(ctx context.Context, token string,
+		subjectAttribute string) (*MagicLinkAuthnResult, *serviceerror.ServiceError)
 }
 
 // magicLinkAuthnService is the default implementation of MagicLinkAuthnServiceInterface.
@@ -114,45 +122,73 @@ func (s *magicLinkAuthnService) GenerateMagicLink(ctx context.Context,
 	return verifyURL, nil
 }
 
-// VerifyMagicLink verifies the validity of a magic link token and retrieves the associated user information.
-// Returns a user object on success or a localized service error if the token is invalid, expired, or malformed.
-func (s *magicLinkAuthnService) VerifyMagicLink(ctx context.Context,
-	token string, subjectAttribute string) (*entityprovider.Entity, *serviceerror.ServiceError) {
-	s.logger.Debug("Verifying magic link token")
+// Authenticate verifies a magic link token and returns an authentication result.
+// A missing local user is NOT an error — the result carries VerifiedIdentifiers instead,
+// allowing callers to handle registration flows.
+func (s *magicLinkAuthnService) Authenticate(ctx context.Context,
+	token string, subjectAttribute string) (*MagicLinkAuthnResult, *serviceerror.ServiceError) {
+	s.logger.Debug("Authenticating with magic link token")
 
 	token = strings.TrimSpace(token)
 	if token == "" {
 		return nil, &ErrorInvalidToken
 	}
 
+	if svcErr := s.verifyToken(ctx, token); svcErr != nil {
+		return nil, svcErr
+	}
+
+	subject, svcErr := s.extractSubject(token)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	subjectAttribute = strings.TrimSpace(subjectAttribute)
+	user, resolveErr := s.resolveUserFromSubject(subject, subjectAttribute)
+	if resolveErr != nil {
+		if resolveErr.Code == common.ErrorUserNotFound.Code {
+			identifiers := map[string]interface{}{}
+			if subjectAttribute != "" {
+				identifiers[subjectAttribute] = subject
+			}
+			return &MagicLinkAuthnResult{
+				VerifiedIdentifiers: identifiers,
+			}, nil
+		}
+		return nil, resolveErr
+	}
+
+	s.logger.Debug("Magic link authentication successful", log.String("userId", user.ID))
+	return &MagicLinkAuthnResult{InternalEntity: user}, nil
+}
+
+func (s *magicLinkAuthnService) verifyToken(ctx context.Context, token string) *serviceerror.ServiceError {
 	issuer := config.GetServerRuntime().Config.JWT.Issuer
 	verifyErr := s.jwtService.VerifyJWT(ctx, token, tokenAudience, issuer)
 	if verifyErr != nil {
 		if verifyErr.Code == jwt.ErrorTokenExpired.Code {
-			return nil, &ErrorExpiredToken
+			return &ErrorExpiredToken
 		}
 		s.logger.Debug("Invalid magic link token", log.String("errorCode", verifyErr.Code))
-		return nil, &ErrorInvalidToken
+		return &ErrorInvalidToken
 	}
+	return nil
+}
 
+func (s *magicLinkAuthnService) extractSubject(token string) (string, *serviceerror.ServiceError) {
 	payload, decodeErr := jwt.DecodeJWTPayload(token)
 	if decodeErr != nil {
 		s.logger.Debug("Failed to decode magic link token payload", log.Error(decodeErr))
-		return nil, &ErrorInvalidToken
+		return "", &ErrorInvalidToken
 	}
 
 	subject := utils.ConvertInterfaceValueToString(payload["sub"])
 	if subject == "" {
 		s.logger.Debug("Subject claim not found or invalid")
-		return nil, &ErrorMalformedTokenClaims
-	}
-	user, svcErr := s.resolveUserFromSubject(subject, strings.TrimSpace(subjectAttribute))
-	if svcErr != nil {
-		return nil, svcErr
+		return "", &ErrorMalformedTokenClaims
 	}
 
-	s.logger.Debug("Magic link verification successful", log.String("userId", user.ID))
-	return user, nil
+	return subject, nil
 }
 
 // resolveUserFromSubject resolves the token subject either as a user ID or as a configured destination attribute.

--- a/backend/internal/authn/magiclink/service_test.go
+++ b/backend/internal/authn/magiclink/service_test.go
@@ -55,10 +55,6 @@ var testMissingSubJWT = "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9." +
 	"eyJyZWNpcGllbnQiOiAidGVzdEBleGFtcGxlLmNvbSJ9." +
 	"test-signature"
 
-var testMismatchedUserIDJWT = "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9." +
-	"eyJyZWNpcGllbnQiOiAidGVzdEBleGFtcGxlLmNvbSIsICJzdWIiOiAidXNlci00NTYifQ." +
-	"test-signature"
-
 var (
 	testUserID   = "user-123"
 	runtimeMutex sync.Mutex
@@ -176,38 +172,38 @@ func (suite *MagicLinkServiceTestSuite) TestGenerateMagicLinkJWTGenerationError(
 	suite.Empty(magicLinkURL)
 }
 
-func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkEmptyToken() {
-	result, err := suite.service.VerifyMagicLink(context.Background(), "", "")
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateEmptyToken() {
+	result, err := suite.service.Authenticate(context.Background(), "", "")
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidToken.Code, err.Code)
 }
 
-func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkExpiredToken() {
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateExpiredToken() {
 	expiredErr := &serviceerror.ServiceError{
 		Code: jwt.ErrorTokenExpired.Code,
 	}
 	suite.mockJWTService.On("VerifyJWT", mock.Anything, testToken, tokenAudience, mock.Anything).Return(expiredErr)
 
-	result, err := suite.service.VerifyMagicLink(context.Background(), testToken, "")
+	result, err := suite.service.Authenticate(context.Background(), testToken, "")
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorExpiredToken.Code, err.Code)
 }
 
-func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkInvalidToken() {
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateInvalidToken() {
 	suite.mockJWTService.On("VerifyJWT", mock.Anything, testToken, tokenAudience, mock.Anything).
 		Return(&serviceerror.ServiceError{
 			Code: "JWT_INVALID",
 		})
 
-	result, err := suite.service.VerifyMagicLink(context.Background(), testToken, "")
+	result, err := suite.service.Authenticate(context.Background(), testToken, "")
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidToken.Code, err.Code)
 }
 
-func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkSuccess() {
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateSuccess() {
 	suite.mockJWTService.On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
 
 	testUser := &entityprovider.Entity{
@@ -217,14 +213,15 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkSuccess() {
 	}
 	suite.mockUserService.On("GetEntity", testUserID).Return(testUser, nil)
 
-	result, err := suite.service.VerifyMagicLink(context.Background(), testValidJWT, "")
+	result, err := suite.service.Authenticate(context.Background(), testValidJWT, "")
 	suite.Nil(err)
 	suite.NotNil(result)
-	suite.Equal(testUserID, result.ID)
-	suite.Equal(testUserOUID, result.OUID)
+	suite.NotNil(result.InternalEntity)
+	suite.Equal(testUserID, result.InternalEntity.ID)
+	suite.Equal(testUserOUID, result.InternalEntity.OUID)
 }
 
-func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkSuccessWithDestinationAttribute() {
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateSuccessWithDestinationAttribute() {
 	const (
 		workEmailAttr  = "workemail"
 		workEmailValue = "johnwork@company.lk"
@@ -243,62 +240,68 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkSuccessWithDestinatio
 	}
 	suite.mockUserService.On("GetEntity", workEmailUser).Return(testUser, nil)
 
-	result, err := suite.service.VerifyMagicLink(context.Background(), testWorkEmailJWT, workEmailAttr)
+	result, err := suite.service.Authenticate(context.Background(), testWorkEmailJWT, workEmailAttr)
 	suite.Nil(err)
 	suite.NotNil(result)
-	suite.Equal(workEmailUser, result.ID)
+	suite.NotNil(result.InternalEntity)
+	suite.Equal(workEmailUser, result.InternalEntity.ID)
 }
 
-func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkMissingSubjectClaim() {
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateMissingSubjectClaim() {
 	suite.mockJWTService.On("VerifyJWT", mock.Anything, testMissingSubJWT, tokenAudience, mock.Anything).Return(nil)
 
-	result, err := suite.service.VerifyMagicLink(context.Background(), testMissingSubJWT, "")
+	result, err := suite.service.Authenticate(context.Background(), testMissingSubJWT, "")
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorMalformedTokenClaims.Code, err.Code)
 }
 
-func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkUserIDMismatchClaim() {
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateUserNotFound_ReturnsVerifiedIdentifiers() {
 	suite.mockJWTService.
-		On("VerifyJWT", mock.Anything, testMismatchedUserIDJWT, tokenAudience, mock.Anything).Return(nil)
-	suite.mockUserService.On("GetEntity", "user-456").Return(nil, &entityprovider.EntityProviderError{
-		Code:    entityprovider.ErrorCodeEntityNotFound,
-		Message: "Entity not found",
-	})
-
-	result, err := suite.service.VerifyMagicLink(context.Background(), testMismatchedUserIDJWT, "")
-	suite.Nil(result)
-	suite.NotNil(err)
-	suite.Equal(common.ErrorUserNotFound.Code, err.Code)
-}
-
-func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkUserNotFoundOnVerify() {
-	suite.mockJWTService.On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
+		On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
 	suite.mockUserService.On("GetEntity", testUserID).Return(nil, &entityprovider.EntityProviderError{
 		Code:    entityprovider.ErrorCodeEntityNotFound,
 		Message: "Entity not found",
 	})
 
-	result, err := suite.service.VerifyMagicLink(context.Background(), testValidJWT, "")
-	suite.Nil(result)
-	suite.NotNil(err)
-	suite.Equal(common.ErrorUserNotFound.Code, err.Code)
+	result, err := suite.service.Authenticate(context.Background(), testValidJWT, "")
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Nil(result.InternalEntity)
+	suite.Empty(result.VerifiedIdentifiers)
 }
 
-func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkGetUserError() {
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateUserNotFound_WithSubjectAttribute() {
+	const destAttr = "email"
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
+	suite.mockUserService.On("IdentifyEntity", map[string]interface{}{
+		destAttr: testUserID,
+	}).Return(nil, &entityprovider.EntityProviderError{
+		Code:    entityprovider.ErrorCodeEntityNotFound,
+		Message: "Entity not found",
+	})
+
+	result, err := suite.service.Authenticate(context.Background(), testValidJWT, destAttr)
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.Nil(result.InternalEntity)
+	suite.Equal(testUserID, result.VerifiedIdentifiers[destAttr])
+}
+
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateGetUserError() {
 	suite.mockJWTService.On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
 	suite.mockUserService.On("GetEntity", testUserID).Return(nil, &entityprovider.EntityProviderError{
 		Code:    entityprovider.ErrorCodeInvalidRequestFormat,
 		Message: "Invalid request",
 	})
 
-	result, err := suite.service.VerifyMagicLink(context.Background(), testValidJWT, "")
+	result, err := suite.service.Authenticate(context.Background(), testValidJWT, "")
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorClientErrorWhileResolvingUser.Code, err.Code)
 }
 
-func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkEntityProviderSystemError() {
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateEntityProviderSystemError() {
 	suite.mockJWTService.On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
 	suite.mockUserService.On("GetEntity", testUserID).Return(nil, &entityprovider.EntityProviderError{
 		Code:        entityprovider.ErrorCodeSystemError,
@@ -306,7 +309,7 @@ func (suite *MagicLinkServiceTestSuite) TestVerifyMagicLinkEntityProviderSystemE
 		Description: "Database connection failed",
 	})
 
-	result, err := suite.service.VerifyMagicLink(context.Background(), testValidJWT, "")
+	result, err := suite.service.Authenticate(context.Background(), testValidJWT, "")
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(serviceerror.InternalServerError.Code, err.Code)

--- a/backend/internal/authn/otp/service.go
+++ b/backend/internal/authn/otp/service.go
@@ -41,13 +41,22 @@ const (
 
 var supportedChannels = []notifcommon.ChannelType{notifcommon.ChannelTypeSMS}
 
+// OTPAuthnResult is the result of an OTP authentication attempt.
+// InternalEntity is nil when no local user was found for the verified OTP.
+type OTPAuthnResult struct {
+	InternalEntity *entityprovider.Entity
+	// VerifiedIdentifiers holds the channel identifiers proven by the OTP challenge
+	// (e.g. "mobileNumber"). Populated only when InternalEntity is nil (no local user found).
+	VerifiedIdentifiers map[string]interface{}
+}
+
 // OTPAuthnServiceInterface defines the interface for OTP authentication operations.
 // This is a wrapper over the notification.OTPServiceInterface to perform user authentication.
+// Authenticate returns an error only for actual failures; a missing local user is NOT an error.
 type OTPAuthnServiceInterface interface {
 	SendOTP(ctx context.Context, senderID string, channel notifcommon.ChannelType,
 		recipient string) (string, *serviceerror.ServiceError)
-	VerifyOTP(ctx context.Context, sessionToken, otp string) *serviceerror.ServiceError
-	Authenticate(ctx context.Context, sessionToken, otp string) (*entityprovider.Entity, *serviceerror.ServiceError)
+	Authenticate(ctx context.Context, sessionToken, otp string) (*OTPAuthnResult, *serviceerror.ServiceError)
 }
 
 // otpAuthnService is the default implementation of OTPAuthnServiceInterface.
@@ -90,33 +99,9 @@ func (s *otpAuthnService) SendOTP(ctx context.Context, senderID string, channel 
 	return result.SessionToken, nil
 }
 
-// VerifyOTP verifies the provided OTP against the session token without resolving the user.
-func (s *otpAuthnService) VerifyOTP(ctx context.Context, sessionToken, otp string) *serviceerror.ServiceError {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Verifying OTP code")
-
-	if svcErr := s.validateOTPVerifyRequest(sessionToken, otp); svcErr != nil {
-		return svcErr
-	}
-
-	verifyData := notifcommon.VerifyOTPDTO{
-		SessionToken: sessionToken,
-		OTPCode:      otp,
-	}
-	result, svcErr := s.otpService.VerifyOTP(ctx, verifyData)
-	if svcErr != nil {
-		return s.handleOTPServiceError(svcErr, true, logger)
-	}
-
-	if result.Status != notifcommon.OTPVerifyStatusVerified {
-		return &ErrorIncorrectOTP
-	}
-	return nil
-}
-
 // Authenticate verifies the provided OTP against the session token and returns the authenticated user.
 func (s *otpAuthnService) Authenticate(ctx context.Context, sessionToken,
-	otp string) (*entityprovider.Entity, *serviceerror.ServiceError) {
+	otp string) (*OTPAuthnResult, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	logger.Debug("Verifying OTP for authentication")
 
@@ -189,7 +174,7 @@ func (s *otpAuthnService) validateOTPVerifyRequest(sessionToken, otp string) *se
 
 // handleVerifyOTPResponse processes the OTP verification result and resolves the user.
 func (s *otpAuthnService) handleVerifyOTPResponse(result *notifcommon.VerifyOTPResultDTO,
-	logger *log.Logger) (*entityprovider.Entity, *serviceerror.ServiceError) {
+	logger *log.Logger) (*OTPAuthnResult, *serviceerror.ServiceError) {
 	if result.Status != notifcommon.OTPVerifyStatusVerified {
 		return nil, &ErrorIncorrectOTP
 	}
@@ -201,10 +186,16 @@ func (s *otpAuthnService) handleVerifyOTPResponse(result *notifcommon.VerifyOTPR
 
 	user, svcErr := s.resolveUser(result.Recipient, notifcommon.ChannelTypeSMS, logger)
 	if svcErr != nil {
+		if svcErr.Code == common.ErrorUserNotFound.Code {
+			return &OTPAuthnResult{
+				InternalEntity:      nil,
+				VerifiedIdentifiers: map[string]interface{}{userAttributeMobileNumber: result.Recipient},
+			}, nil
+		}
 		return nil, svcErr
 	}
 
-	return user, nil
+	return &OTPAuthnResult{InternalEntity: user}, nil
 }
 
 // resolveUser retrieves a user by their recipient identifier (e.g., mobile number).

--- a/backend/internal/authn/otp/service_test.go
+++ b/backend/internal/authn/otp/service_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	notifcommon "github.com/thunder-id/thunderid/internal/notification/common"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
@@ -193,8 +192,9 @@ func (suite *OTPAuthnServiceTestSuite) TestAuthenticateSuccess() {
 	result, err := suite.service.Authenticate(context.Background(), testSessionToken, otp)
 	suite.Nil(err)
 	suite.NotNil(result)
-	suite.Equal(userID, result.ID)
-	suite.Equal(orgUnit, result.OUID)
+	suite.NotNil(result.InternalEntity)
+	suite.Equal(userID, result.InternalEntity.ID)
+	suite.Equal(orgUnit, result.InternalEntity.OUID)
 }
 
 func (suite *OTPAuthnServiceTestSuite) TestAuthenticateWithInvalidInputs() {
@@ -309,39 +309,32 @@ func (suite *OTPAuthnServiceTestSuite) TestAuthenticateWithUserServiceError() {
 		identifyErr  *entityprovider.EntityProviderError
 		getUserRet   *entityprovider.Entity
 		getUserErr   *entityprovider.EntityProviderError
+		expectNoUser bool
 		expectedCode string
 	}{
 		{
-			"NonExistentUser",
-			nil,
-			&entityprovider.EntityProviderError{Code: entityprovider.ErrorCodeEntityNotFound},
-			nil,
-			nil,
-			common.ErrorUserNotFound.Code,
+			name:         "NonExistentUser",
+			identifyRet:  nil,
+			identifyErr:  &entityprovider.EntityProviderError{Code: entityprovider.ErrorCodeEntityNotFound},
+			expectNoUser: true,
 		},
 		{
-			"IdentifyServerError",
-			nil,
-			serverErr,
-			nil,
-			nil,
-			serviceerror.InternalServerError.Code,
+			name:         "IdentifyServerError",
+			identifyRet:  nil,
+			identifyErr:  serverErr,
+			expectedCode: serviceerror.InternalServerError.Code,
 		},
 		{
-			"GetUserServerError",
-			&userID,
-			nil,
-			nil,
-			serverErr,
-			serviceerror.InternalServerError.Code,
+			name:         "GetUserServerError",
+			identifyRet:  &userID,
+			getUserErr:   serverErr,
+			expectedCode: serviceerror.InternalServerError.Code,
 		},
 		{
-			"UserIDNil",
-			nil,
-			(*entityprovider.EntityProviderError)(nil),
-			nil,
-			nil,
-			common.ErrorUserNotFound.Code,
+			name:         "UserIDNil",
+			identifyRet:  nil,
+			identifyErr:  (*entityprovider.EntityProviderError)(nil),
+			expectNoUser: true,
 		},
 	}
 
@@ -360,9 +353,16 @@ func (suite *OTPAuthnServiceTestSuite) TestAuthenticateWithUserServiceError() {
 			}
 
 			result, err := suite.service.Authenticate(context.Background(), testSessionToken, "123456")
-			suite.Nil(result)
-			suite.NotNil(err)
-			suite.Equal(tc.expectedCode, err.Code)
+			if tc.expectNoUser {
+				suite.NotNil(result)
+				suite.Nil(result.InternalEntity)
+				suite.Nil(err)
+				suite.Equal("+1234567890", result.VerifiedIdentifiers["mobileNumber"])
+			} else {
+				suite.Nil(result)
+				suite.NotNil(err)
+				suite.Equal(tc.expectedCode, err.Code)
+			}
 		})
 	}
 }

--- a/backend/internal/authnprovider/manager/init.go
+++ b/backend/internal/authnprovider/manager/init.go
@@ -20,6 +20,7 @@ package manager
 
 import (
 	authncommon "github.com/thunder-id/thunderid/internal/authn/common"
+	"github.com/thunder-id/thunderid/internal/authn/magiclink"
 	"github.com/thunder-id/thunderid/internal/authn/otp"
 	"github.com/thunder-id/thunderid/internal/authn/passkey"
 	"github.com/thunder-id/thunderid/internal/authnprovider/provider"
@@ -30,7 +31,8 @@ import (
 // InitializeAuthnProviderManager initializes and returns an AuthnProviderManagerInterface.
 func InitializeAuthnProviderManager(entitySvc entity.EntityServiceInterface,
 	passkeySvc passkey.PasskeyServiceInterface, otpSvc otp.OTPAuthnServiceInterface,
+	magicLinkSvc magiclink.MagicLinkAuthnServiceInterface,
 	federatedAuths map[idp.IDPType]authncommon.FederatedAuthenticator) AuthnProviderManagerInterface {
-	p := provider.InitializeAuthnProvider(entitySvc, passkeySvc, otpSvc, federatedAuths)
+	p := provider.InitializeAuthnProvider(entitySvc, passkeySvc, otpSvc, magicLinkSvc, federatedAuths)
 	return newAuthnProviderManager(p)
 }

--- a/backend/internal/authnprovider/manager/manager.go
+++ b/backend/internal/authnprovider/manager/manager.go
@@ -74,6 +74,10 @@ func (m *authnProviderManager) AuthenticateUser(ctx context.Context, identifiers
 		}
 	}
 	if !result.IsExistingUser {
+		authUser.setProviderData(defaultProvider, providerData{
+			attributes:                result.AttributesResponse,
+			isAttributeValuesIncluded: result.IsAttributeValuesIncluded,
+		})
 		return authUser, &AuthnBasicResult{
 			ExternalSub:     result.ExternalSub,
 			ExternalClaims:  result.ExternalClaims,

--- a/backend/internal/authnprovider/manager/manager_test.go
+++ b/backend/internal/authnprovider/manager/manager_test.go
@@ -87,12 +87,20 @@ func (s *ManagerTestSuite) TestAuthenticateUser_FederatedNewUser() {
 	credentials := map[string]interface{}{"federated": "token"}
 	meta := &authnprovidercm.AuthnMetadata{}
 
+	attrResp := &authnprovidercm.AttributesResponse{
+		Attributes: map[string]*authnprovidercm.AttributeResponse{
+			"email": {Value: "new@example.com"},
+		},
+		Verifications: make(map[string]*authnprovidercm.VerificationResponse),
+	}
 	s.mockProvider.On("Authenticate", context.Background(), identifiers, credentials, meta).
 		Return(&authnprovidercm.AuthnResult{
-			IsExistingUser:  false,
-			IsAmbiguousUser: false,
-			ExternalSub:     "ext-sub-123",
-			ExternalClaims:  map[string]interface{}{"email": "new@example.com"},
+			IsExistingUser:            false,
+			IsAmbiguousUser:           false,
+			ExternalSub:               "ext-sub-123",
+			ExternalClaims:            map[string]interface{}{"email": "new@example.com"},
+			IsAttributeValuesIncluded: true,
+			AttributesResponse:        attrResp,
 		}, (*serviceerror.ServiceError)(nil))
 
 	returnedAuthUser, result, svcErr := s.mgr.AuthenticateUser(context.Background(), identifiers, credentials,
@@ -106,8 +114,10 @@ func (s *ManagerTestSuite) TestAuthenticateUser_FederatedNewUser() {
 	s.Equal(map[string]interface{}{"email": "new@example.com"}, result.ExternalClaims)
 
 	s.False(returnedAuthUser.IsAuthenticated())
-	_, ok := returnedAuthUser.getProviderData(defaultProvider)
-	s.False(ok)
+	data, ok := returnedAuthUser.getProviderData(defaultProvider)
+	s.True(ok)
+	s.True(data.isAttributeValuesIncluded)
+	s.Equal(attrResp, data.attributes)
 }
 
 func (s *ManagerTestSuite) TestAuthenticateUser_ClientError() {

--- a/backend/internal/authnprovider/provider/default_authn_provider.go
+++ b/backend/internal/authnprovider/provider/default_authn_provider.go
@@ -92,18 +92,6 @@ func (p *defaultAuthnProvider) Authenticate(
 		}
 	}
 
-	attributesResponse := &authnprovidercm.AttributesResponse{
-		Attributes:    make(map[string]*authnprovidercm.AttributeResponse),
-		Verifications: make(map[string]*authnprovidercm.VerificationResponse),
-	}
-	for k := range attributes {
-		attributesResponse.Attributes[k] = &authnprovidercm.AttributeResponse{
-			AssuranceMetadataResponse: &authnprovidercm.AssuranceMetadataResponse{
-				IsVerified: false,
-			},
-		}
-	}
-
 	return &authnprovidercm.AuthnResult{
 		EntityID:                  authOutcome.entityID,
 		EntityCategory:            string(entityResult.Category),
@@ -112,8 +100,8 @@ func (p *defaultAuthnProvider) Authenticate(
 		UserID:                    authOutcome.entityID,
 		Token:                     authOutcome.entityID,
 		UserType:                  entityResult.Type,
-		IsAttributeValuesIncluded: false,
-		AttributesResponse:        attributesResponse,
+		IsAttributeValuesIncluded: true,
+		AttributesResponse:        buildAttributesResponse(attributes),
 		IsExistingUser:            true,
 		ExternalSub:               authOutcome.externalSub,
 		ExternalClaims:            authOutcome.externalClaims,
@@ -180,7 +168,7 @@ func (p *defaultAuthnProvider) authenticateWithOTP(
 		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
 			"Invalid OTP payload", "otp is required")
 	}
-	authResponse, authErr := p.otpService.Authenticate(ctx, sessionToken, otpValue)
+	authResult, authErr := p.otpService.Authenticate(ctx, sessionToken, otpValue)
 	if authErr != nil {
 		if authErr.Type == serviceerror.ClientErrorType {
 			if authErr.Code == otp.ErrorIncorrectOTP.Code {
@@ -194,7 +182,16 @@ func (p *defaultAuthnProvider) authenticateWithOTP(
 			log.String("error", authErr.Error.DefaultValue),
 			log.String("errorDescription", authErr.ErrorDescription.DefaultValue))
 	}
-	return &credentialOutcome{entityID: authResponse.ID}, nil
+	if authResult.InternalEntity == nil {
+		return &credentialOutcome{
+			earlyReturn: &authnprovidercm.AuthnResult{
+				IsExistingUser:            false,
+				IsAttributeValuesIncluded: true,
+				AttributesResponse:        buildAttributesResponse(authResult.VerifiedIdentifiers),
+			},
+		}, nil
+	}
+	return &credentialOutcome{entityID: authResult.InternalEntity.ID}, nil
 }
 
 func (p *defaultAuthnProvider) authenticateWithFederated(
@@ -231,10 +228,12 @@ func (p *defaultAuthnProvider) authenticateWithFederated(
 	if authResult.InternalEntity == nil {
 		return &credentialOutcome{
 			earlyReturn: &authnprovidercm.AuthnResult{
-				ExternalSub:     authResult.Sub,
-				ExternalClaims:  authResult.Claims,
-				IsExistingUser:  false,
-				IsAmbiguousUser: authResult.IsAmbiguousUser,
+				ExternalSub:               authResult.Sub,
+				ExternalClaims:            authResult.Claims,
+				IsExistingUser:            false,
+				IsAmbiguousUser:           authResult.IsAmbiguousUser,
+				IsAttributeValuesIncluded: true,
+				AttributesResponse:        buildAttributesResponse(authResult.Claims),
 			},
 		}, nil
 	}
@@ -347,6 +346,22 @@ func (p *defaultAuthnProvider) GetAttributes(
 		UserType:           entityResult.Type,
 		AttributesResponse: attributesResponse,
 	}, nil
+}
+
+func buildAttributesResponse(attrs map[string]interface{}) *authnprovidercm.AttributesResponse {
+	resp := &authnprovidercm.AttributesResponse{
+		Attributes:    make(map[string]*authnprovidercm.AttributeResponse),
+		Verifications: make(map[string]*authnprovidercm.VerificationResponse),
+	}
+	for k, v := range attrs {
+		resp.Attributes[k] = &authnprovidercm.AttributeResponse{
+			Value: v,
+			AssuranceMetadataResponse: &authnprovidercm.AssuranceMetadataResponse{
+				IsVerified: false,
+			},
+		}
+	}
+	return resp
 }
 
 func newClientError(code, msg, desc string) *serviceerror.ServiceError {

--- a/backend/internal/authnprovider/provider/default_authn_provider.go
+++ b/backend/internal/authnprovider/provider/default_authn_provider.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 
 	authncommon "github.com/thunder-id/thunderid/internal/authn/common"
+	"github.com/thunder-id/thunderid/internal/authn/magiclink"
 	"github.com/thunder-id/thunderid/internal/authn/otp"
 	"github.com/thunder-id/thunderid/internal/authn/passkey"
 	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
@@ -36,23 +37,26 @@ import (
 )
 
 type defaultAuthnProvider struct {
-	entitySvc      entity.EntityServiceInterface
-	passkeyService passkey.PasskeyServiceInterface
-	otpService     otp.OTPAuthnServiceInterface
-	federatedAuths map[idp.IDPType]authncommon.FederatedAuthenticator
-	logger         *log.Logger
+	entitySvc        entity.EntityServiceInterface
+	passkeyService   passkey.PasskeyServiceInterface
+	otpService       otp.OTPAuthnServiceInterface
+	magicLinkService magiclink.MagicLinkAuthnServiceInterface
+	federatedAuths   map[idp.IDPType]authncommon.FederatedAuthenticator
+	logger           *log.Logger
 }
 
 // newDefaultAuthnProvider creates a new internal user authn provider.
 func newDefaultAuthnProvider(entitySvc entity.EntityServiceInterface,
 	passkeyService passkey.PasskeyServiceInterface, otpService otp.OTPAuthnServiceInterface,
+	magicLinkService magiclink.MagicLinkAuthnServiceInterface,
 	federatedAuths map[idp.IDPType]authncommon.FederatedAuthenticator) AuthnProviderInterface {
 	return &defaultAuthnProvider{
-		entitySvc:      entitySvc,
-		passkeyService: passkeyService,
-		otpService:     otpService,
-		federatedAuths: federatedAuths,
-		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DefaultAuthnProvider")),
+		entitySvc:        entitySvc,
+		passkeyService:   passkeyService,
+		otpService:       otpService,
+		magicLinkService: magicLinkService,
+		federatedAuths:   federatedAuths,
+		logger:           log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DefaultAuthnProvider")),
 	}
 }
 
@@ -127,6 +131,9 @@ func (p *defaultAuthnProvider) resolveCredentials(
 	}
 	if fedCred, ok := credentials["federated"]; ok {
 		return p.authenticateWithFederated(ctx, fedCred)
+	}
+	if mlCred, ok := credentials["magiclink"]; ok {
+		return p.authenticateWithMagicLink(ctx, mlCred)
 	}
 	if userID, ok := identifiers["userID"]; ok && userID != "" {
 		return p.authenticateByUserID(ctx, userID, credentials)
@@ -242,6 +249,43 @@ func (p *defaultAuthnProvider) authenticateWithFederated(
 		externalSub:    authResult.Sub,
 		externalClaims: authResult.Claims,
 	}, nil
+}
+
+func (p *defaultAuthnProvider) authenticateWithMagicLink(
+	ctx context.Context, raw interface{},
+) (*credentialOutcome, *serviceerror.ServiceError) {
+	mlCredential, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Invalid magic link payload", "The provided magic link credential is invalid")
+	}
+	token, ok := mlCredential["token"].(string)
+	if !ok || token == "" {
+		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
+			"Invalid magic link payload", "token is required")
+	}
+	subjectAttribute, _ := mlCredential["subjectAttribute"].(string)
+
+	authResult, authErr := p.magicLinkService.Authenticate(ctx, token, subjectAttribute)
+	if authErr != nil {
+		if authErr.Type == serviceerror.ClientErrorType {
+			return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
+				authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
+		}
+		return nil, p.logAndReturnServerError("Magic link authentication failed with server error",
+			log.String("error", authErr.Error.DefaultValue),
+			log.String("errorDescription", authErr.ErrorDescription.DefaultValue))
+	}
+	if authResult.InternalEntity == nil {
+		return &credentialOutcome{
+			earlyReturn: &authnprovidercm.AuthnResult{
+				IsExistingUser:            false,
+				IsAttributeValuesIncluded: true,
+				AttributesResponse:        buildAttributesResponse(authResult.VerifiedIdentifiers),
+			},
+		}, nil
+	}
+	return &credentialOutcome{entityID: authResult.InternalEntity.ID}, nil
 }
 
 func (p *defaultAuthnProvider) authenticateByUserID(

--- a/backend/internal/authnprovider/provider/default_authn_provider_test.go
+++ b/backend/internal/authnprovider/provider/default_authn_provider_test.go
@@ -26,8 +26,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/thunder-id/thunderid/internal/authn/otp"
 	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/entity"
+	"github.com/thunder-id/thunderid/internal/entityprovider"
+	"github.com/thunder-id/thunderid/tests/mocks/authn/otpmock"
 	"github.com/thunder-id/thunderid/tests/mocks/entitymock"
 )
 
@@ -81,11 +84,11 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Success() {
 	suite.Equal("user123", result.Token)
 	suite.Equal("customer", result.UserType)
 	suite.Equal("ou1", result.OUID)
-	suite.False(result.IsAttributeValuesIncluded)
+	suite.True(result.IsAttributeValuesIncluded)
 	suite.NotNil(result.AttributesResponse)
 	suite.Len(result.AttributesResponse.Attributes, 1)
 	suite.Contains(result.AttributesResponse.Attributes, "email")
-	suite.Nil(result.AttributesResponse.Attributes["email"].Value)
+	suite.Equal("test@example.com", result.AttributesResponse.Attributes["email"].Value)
 }
 
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_EntityNotFound() {
@@ -292,4 +295,97 @@ func (suite *DefaultAuthnProviderTestSuite) TestGetAttributes_InvalidToken() {
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(authnprovidercm.ErrorCodeInvalidToken, err.Code)
+}
+
+func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_UserFound() {
+	mockOTP := otpmock.NewOTPAuthnServiceInterfaceMock(suite.T())
+	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil)
+
+	credentials := map[string]interface{}{
+		"otp": map[string]interface{}{
+			"sessionToken": "tok",
+			"otp":          "123456",
+		},
+	}
+	entityObj := &entity.Entity{
+		ID:         "u1",
+		Category:   entity.EntityCategoryUser,
+		Type:       "customer",
+		OUID:       "ou1",
+		Attributes: json.RawMessage(`{}`),
+	}
+
+	mockOTP.On("Authenticate", mock.Anything, "tok", "123456").
+		Return(&otp.OTPAuthnResult{InternalEntity: &entityprovider.Entity{ID: "u1"}}, nil).Once()
+	suite.mockService.On("GetEntity", mock.Anything, "u1").Return(entityObj, nil).Once()
+
+	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.True(result.IsExistingUser)
+	suite.Equal("u1", result.UserID)
+}
+
+func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_UserNotFound() {
+	mockOTP := otpmock.NewOTPAuthnServiceInterfaceMock(suite.T())
+	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil)
+
+	credentials := map[string]interface{}{
+		"otp": map[string]interface{}{
+			"sessionToken": "tok",
+			"otp":          "123456",
+		},
+	}
+
+	mockOTP.On("Authenticate", mock.Anything, "tok", "123456").
+		Return(&otp.OTPAuthnResult{
+			InternalEntity:      nil,
+			VerifiedIdentifiers: map[string]interface{}{"mobileNumber": "+1234567890"},
+		}, nil).Once()
+
+	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.False(result.IsExistingUser)
+	suite.True(result.IsAttributeValuesIncluded)
+	suite.NotNil(result.AttributesResponse)
+	suite.Equal("+1234567890", result.AttributesResponse.Attributes["mobileNumber"].Value)
+}
+
+func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_IncorrectOTP() {
+	mockOTP := otpmock.NewOTPAuthnServiceInterfaceMock(suite.T())
+	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil)
+
+	credentials := map[string]interface{}{
+		"otp": map[string]interface{}{
+			"sessionToken": "tok",
+			"otp":          "wrong",
+		},
+	}
+
+	mockOTP.On("Authenticate", mock.Anything, "tok", "wrong").
+		Return(nil, &otp.ErrorIncorrectOTP).Once()
+
+	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(authnprovidercm.ErrorCodeAuthenticationFailed, err.Code)
+}
+
+func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_InvalidPayload() {
+	mockOTP := otpmock.NewOTPAuthnServiceInterfaceMock(suite.T())
+	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil)
+
+	credentials := map[string]interface{}{
+		"otp": "not-a-map",
+	}
+
+	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(authnprovidercm.ErrorCodeInvalidRequest, err.Code)
 }

--- a/backend/internal/authnprovider/provider/default_authn_provider_test.go
+++ b/backend/internal/authnprovider/provider/default_authn_provider_test.go
@@ -26,10 +26,14 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/thunder-id/thunderid/internal/authn/magiclink"
 	"github.com/thunder-id/thunderid/internal/authn/otp"
 	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/entity"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
+	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	i18ncore "github.com/thunder-id/thunderid/internal/system/i18n/core"
+	"github.com/thunder-id/thunderid/tests/mocks/authn/magiclinkmock"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/otpmock"
 	"github.com/thunder-id/thunderid/tests/mocks/entitymock"
 )
@@ -42,7 +46,7 @@ type DefaultAuthnProviderTestSuite struct {
 
 func (suite *DefaultAuthnProviderTestSuite) SetupTest() {
 	suite.mockService = entitymock.NewEntityServiceInterfaceMock(suite.T())
-	suite.provider = newDefaultAuthnProvider(suite.mockService, nil, nil, nil)
+	suite.provider = newDefaultAuthnProvider(suite.mockService, nil, nil, nil, nil)
 }
 
 func TestDefaultAuthnProviderTestSuite(t *testing.T) {
@@ -297,9 +301,10 @@ func (suite *DefaultAuthnProviderTestSuite) TestGetAttributes_InvalidToken() {
 	suite.Equal(authnprovidercm.ErrorCodeInvalidToken, err.Code)
 }
 
+//nolint:dupl // intentionally mirrors MagicLink_UserFound/UserNotFound to cover the OTP credential path
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_UserFound() {
 	mockOTP := otpmock.NewOTPAuthnServiceInterfaceMock(suite.T())
-	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil)
+	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil, nil)
 
 	credentials := map[string]interface{}{
 		"otp": map[string]interface{}{
@@ -329,7 +334,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_UserFound() {
 
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_UserNotFound() {
 	mockOTP := otpmock.NewOTPAuthnServiceInterfaceMock(suite.T())
-	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil)
+	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil, nil)
 
 	credentials := map[string]interface{}{
 		"otp": map[string]interface{}{
@@ -356,7 +361,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_UserNotFound() 
 
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_IncorrectOTP() {
 	mockOTP := otpmock.NewOTPAuthnServiceInterfaceMock(suite.T())
-	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil)
+	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil, nil)
 
 	credentials := map[string]interface{}{
 		"otp": map[string]interface{}{
@@ -377,10 +382,148 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_IncorrectOTP() 
 
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_OTP_InvalidPayload() {
 	mockOTP := otpmock.NewOTPAuthnServiceInterfaceMock(suite.T())
-	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil)
+	provider := newDefaultAuthnProvider(suite.mockService, nil, mockOTP, nil, nil)
 
 	credentials := map[string]interface{}{
 		"otp": "not-a-map",
+	}
+
+	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(authnprovidercm.ErrorCodeInvalidRequest, err.Code)
+}
+
+//nolint:dupl // intentionally mirrors OTP_UserFound/UserNotFound to cover the magic link credential path
+func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_MagicLink_UserFound() {
+	mockML := magiclinkmock.NewMagicLinkAuthnServiceInterfaceMock(suite.T())
+	provider := newDefaultAuthnProvider(suite.mockService, nil, nil, mockML, nil)
+
+	credentials := map[string]interface{}{
+		"magiclink": map[string]interface{}{
+			"token":            "valid-jwt-token",
+			"subjectAttribute": "",
+		},
+	}
+	entityObj := &entity.Entity{
+		ID:         "u1",
+		Category:   entity.EntityCategoryUser,
+		Type:       "customer",
+		OUID:       "ou1",
+		Attributes: json.RawMessage(`{}`),
+	}
+
+	mockML.On("Authenticate", mock.Anything, "valid-jwt-token", "").
+		Return(&magiclink.MagicLinkAuthnResult{InternalEntity: &entityprovider.Entity{ID: "u1"}}, nil).Once()
+	suite.mockService.On("GetEntity", mock.Anything, "u1").Return(entityObj, nil).Once()
+
+	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.True(result.IsExistingUser)
+	suite.Equal("u1", result.UserID)
+}
+
+func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_MagicLink_UserNotFound() {
+	mockML := magiclinkmock.NewMagicLinkAuthnServiceInterfaceMock(suite.T())
+	provider := newDefaultAuthnProvider(suite.mockService, nil, nil, mockML, nil)
+
+	credentials := map[string]interface{}{
+		"magiclink": map[string]interface{}{
+			"token":            "valid-jwt-token",
+			"subjectAttribute": "email",
+		},
+	}
+
+	mockML.On("Authenticate", mock.Anything, "valid-jwt-token", "email").
+		Return(&magiclink.MagicLinkAuthnResult{
+			InternalEntity:      nil,
+			VerifiedIdentifiers: map[string]interface{}{"email": "test@example.com"},
+		}, nil).Once()
+
+	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.False(result.IsExistingUser)
+	suite.True(result.IsAttributeValuesIncluded)
+	suite.NotNil(result.AttributesResponse)
+	suite.Equal("test@example.com", result.AttributesResponse.Attributes["email"].Value)
+}
+
+func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_MagicLink_AuthenticationFailed() {
+	mockML := magiclinkmock.NewMagicLinkAuthnServiceInterfaceMock(suite.T())
+	provider := newDefaultAuthnProvider(suite.mockService, nil, nil, mockML, nil)
+
+	credentials := map[string]interface{}{
+		"magiclink": map[string]interface{}{
+			"token": "expired-token",
+		},
+	}
+
+	mockML.On("Authenticate", mock.Anything, "expired-token", "").
+		Return(nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ClientErrorType,
+			Code:             "AUTHN-ML-1002",
+			Error:            i18ncore.I18nMessage{DefaultValue: "Expired token"},
+			ErrorDescription: i18ncore.I18nMessage{DefaultValue: "The magic link token has expired"},
+		}).Once()
+
+	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(authnprovidercm.ErrorCodeAuthenticationFailed, err.Code)
+}
+
+func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_MagicLink_ServerError() {
+	mockML := magiclinkmock.NewMagicLinkAuthnServiceInterfaceMock(suite.T())
+	provider := newDefaultAuthnProvider(suite.mockService, nil, nil, mockML, nil)
+
+	credentials := map[string]interface{}{
+		"magiclink": map[string]interface{}{
+			"token": "valid-token",
+		},
+	}
+
+	mockML.On("Authenticate", mock.Anything, "valid-token", "").
+		Return(nil, &serviceerror.ServiceError{
+			Type:             serviceerror.ServerErrorType,
+			Code:             "INTERNAL",
+			Error:            i18ncore.I18nMessage{DefaultValue: "Internal error"},
+			ErrorDescription: i18ncore.I18nMessage{DefaultValue: "Something went wrong"},
+		}).Once()
+
+	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_MagicLink_InvalidPayload() {
+	mockML := magiclinkmock.NewMagicLinkAuthnServiceInterfaceMock(suite.T())
+	provider := newDefaultAuthnProvider(suite.mockService, nil, nil, mockML, nil)
+
+	credentials := map[string]interface{}{
+		"magiclink": "not-a-map",
+	}
+
+	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(authnprovidercm.ErrorCodeInvalidRequest, err.Code)
+}
+
+func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_MagicLink_MissingToken() {
+	mockML := magiclinkmock.NewMagicLinkAuthnServiceInterfaceMock(suite.T())
+	provider := newDefaultAuthnProvider(suite.mockService, nil, nil, mockML, nil)
+
+	credentials := map[string]interface{}{
+		"magiclink": map[string]interface{}{},
 	}
 
 	result, err := provider.Authenticate(context.Background(), nil, credentials, nil)

--- a/backend/internal/authnprovider/provider/init.go
+++ b/backend/internal/authnprovider/provider/init.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	authncommon "github.com/thunder-id/thunderid/internal/authn/common"
+	"github.com/thunder-id/thunderid/internal/authn/magiclink"
 	"github.com/thunder-id/thunderid/internal/authn/otp"
 	"github.com/thunder-id/thunderid/internal/authn/passkey"
 	"github.com/thunder-id/thunderid/internal/entity"
@@ -36,6 +37,7 @@ func InitializeAuthnProvider(
 	entitySvc entity.EntityServiceInterface,
 	passkeySvc passkey.PasskeyServiceInterface,
 	otpSvc otp.OTPAuthnServiceInterface,
+	magicLinkSvc magiclink.MagicLinkAuthnServiceInterface,
 	federatedAuths map[idp.IDPType]authncommon.FederatedAuthenticator,
 ) AuthnProviderInterface {
 	authnProviderConfig := config.GetServerRuntime().Config.AuthnProvider
@@ -43,7 +45,7 @@ func InitializeAuthnProvider(
 	case "rest":
 		return initializeRestAuthnProvider()
 	default:
-		return initializeDefaultAuthnProvider(entitySvc, passkeySvc, otpSvc, federatedAuths)
+		return initializeDefaultAuthnProvider(entitySvc, passkeySvc, otpSvc, magicLinkSvc, federatedAuths)
 	}
 }
 
@@ -52,9 +54,10 @@ func initializeDefaultAuthnProvider(
 	entitySvc entity.EntityServiceInterface,
 	passkeySvc passkey.PasskeyServiceInterface,
 	otpSvc otp.OTPAuthnServiceInterface,
+	magicLinkSvc magiclink.MagicLinkAuthnServiceInterface,
 	federatedAuths map[idp.IDPType]authncommon.FederatedAuthenticator,
 ) AuthnProviderInterface {
-	return newDefaultAuthnProvider(entitySvc, passkeySvc, otpSvc, federatedAuths)
+	return newDefaultAuthnProvider(entitySvc, passkeySvc, otpSvc, magicLinkSvc, federatedAuths)
 }
 
 // initializeRestAuthnProvider initializes the REST authentication provider.

--- a/backend/internal/flow/executor/init.go
+++ b/backend/internal/flow/executor/init.go
@@ -81,7 +81,7 @@ func Initialize(
 	reg.RegisterExecutor(ExecutorNamePasskeyAuth, newPasskeyAuthExecutor(
 		flowFactory, passkeyService, authnProvider, entityProvider))
 	reg.RegisterExecutor(ExecutorNameMagicLinkAuth, newMagicLinkAuthExecutor(
-		flowFactory, magicLinkService, entityProvider))
+		flowFactory, magicLinkService, authnProvider, entityProvider))
 	reg.RegisterExecutor(ExecutorNameOAuth, newOAuthExecutor(
 		"", []common.Input{}, []common.Input{}, flowFactory, idpService, entityTypeService,
 		oauthSvc, authnProvider, idp.IDPTypeOAuth))

--- a/backend/internal/flow/executor/magic_link_executor.go
+++ b/backend/internal/flow/executor/magic_link_executor.go
@@ -25,6 +25,7 @@ import (
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/authn/magiclink"
+	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
@@ -40,6 +41,7 @@ type magicLinkAuthExecutor struct {
 	identifyingExecutorInterface
 	entityProvider   entityprovider.EntityProviderInterface
 	magicLinkService magiclink.MagicLinkAuthnServiceInterface
+	authnProvider    authnprovidermgr.AuthnProviderManagerInterface
 	logger           *log.Logger
 }
 
@@ -59,6 +61,7 @@ func newMagicLinkExecutorResponse() *common.ExecutorResponse {
 func newMagicLinkAuthExecutor(
 	flowFactory core.FlowFactoryInterface,
 	magicLinkService magiclink.MagicLinkAuthnServiceInterface,
+	authnProvider authnprovidermgr.AuthnProviderManagerInterface,
 	entityProvider entityprovider.EntityProviderInterface,
 ) *magicLinkAuthExecutor {
 	defaultInputs := []common.Input{{
@@ -82,6 +85,7 @@ func newMagicLinkAuthExecutor(
 		identifyingExecutorInterface: identifyExec,
 		entityProvider:               entityProvider,
 		magicLinkService:             magicLinkService,
+		authnProvider:                authnProvider,
 		logger:                       logger,
 	}
 }
@@ -304,92 +308,93 @@ func (m *magicLinkAuthExecutor) executeVerify(ctx *core.NodeContext) (*common.Ex
 		return execResp, nil
 	}
 
-	tokenJTI, failure, err := m.validateMagicLinkToken(ctx, logger)
-	if err != nil {
-		return execResp, err
+	token := ctx.UserInputs[userInputMagicLinkToken]
+
+	subjectAttribute := ""
+	if ctx.FlowType == common.FlowTypeRegistration {
+		subjectAttribute = ctx.RuntimeData[common.RuntimeKeyMagicLinkDestinationAttribute]
+		if subjectAttribute == "" {
+			return execResp, errors.New("magic link destination attribute missing from runtime data")
+		}
 	}
+
+	creds := map[string]interface{}{
+		"magiclink": map[string]interface{}{
+			"token":            token,
+			"subjectAttribute": subjectAttribute,
+		},
+	}
+
+	newAuthUser, authnResult, svcErr := m.authnProvider.AuthenticateUser(
+		ctx.Context, nil, creds, nil, nil, ctx.AuthUser)
+	if svcErr != nil {
+		if svcErr.Code == authnprovidermgr.ErrorAuthenticationFailed.Code {
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = svcErr.ErrorDescription.DefaultValue
+			return execResp, nil
+		}
+		return execResp, fmt.Errorf("failed to verify magic link: %s", svcErr.ErrorDescription.DefaultValue)
+	}
+	execResp.AuthUser = newAuthUser
+
+	tokenJTI, failure := m.validateFlowClaims(ctx, token, logger)
 	if failure != "" {
 		execResp.Status = common.ExecFailure
 		execResp.FailureReason = failure
 		return execResp, nil
 	}
-
 	execResp.RuntimeData[common.RuntimeKeyMagicLinkUsedJti] = tokenJTI
 
-	if ctx.FlowType != common.FlowTypeRegistration {
-		userID := ctx.RuntimeData[userAttributeUserID]
-		authenticatedUser, err := m.getAuthenticatedUser(userID)
-		if err != nil {
-			return execResp, fmt.Errorf("failed to get authenticated user details: %w", err)
+	if ctx.FlowType == common.FlowTypeRegistration {
+		if authnResult.IsExistingUser {
+			logger.Debug("User already exists during magic link registration verification.")
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = "Invalid registration state"
+			return execResp, nil
 		}
-		execResp.AuthenticatedUser = *authenticatedUser
+		execResp.Status = common.ExecComplete
+		return execResp, nil
 	}
+
+	userID := authnResult.UserID
+	authenticatedUser, err := m.getAuthenticatedUser(userID)
+	if err != nil {
+		return execResp, fmt.Errorf("failed to get authenticated user details: %w", err)
+	}
+	execResp.AuthenticatedUser = *authenticatedUser
 
 	execResp.Status = common.ExecComplete
 	logger.Debug("Magic link verify completed successfully")
 	return execResp, nil
 }
 
-// validateMagicLinkToken validates the magic link token from user input and returns the associated subject.
-func (m *magicLinkAuthExecutor) validateMagicLinkToken(ctx *core.NodeContext,
-	logger *log.Logger) (string, string, error) {
-	token, ok := ctx.UserInputs[userInputMagicLinkToken]
-	if !ok || token == "" {
-		return "", "Magic link token is required", nil
-	}
-
-	isRegistration := ctx.FlowType == common.FlowTypeRegistration
-
-	destinationAttribute := ""
-	if isRegistration {
-		destinationAttribute = ctx.RuntimeData[common.RuntimeKeyMagicLinkDestinationAttribute]
-		if destinationAttribute == "" {
-			return "", "", errors.New("magic link destination attribute missing from runtime data")
-		}
-	}
-
-	// Verify the signature and expiry before trusting ANY payload data.
-	user, svcErr := m.magicLinkService.VerifyMagicLink(ctx.Context, token, destinationAttribute)
-
-	if svcErr != nil {
-		// In registration, it's expected that the user doesn't exist in the DB yet.
-		if !(isRegistration && svcErr.Code == authncm.ErrorUserNotFound.Code) {
-			if svcErr.Type == serviceerror.ClientErrorType {
-				return "", svcErr.ErrorDescription.DefaultValue, nil
-			}
-			return "", "", errors.New("failed to verify magic link token")
-		}
-	} else if isRegistration {
-		// If VerifyMagicLink found a user during a registration flow, something is wrong.
-		logger.Debug("User already exists during magic link registration verification.")
-		return "", "Invalid registration state", nil
-	} else if user == nil {
-		return "", failureReasonUserNotFound, nil
-	}
-
+// validateFlowClaims checks executionId and JTI claims in the magic link JWT token.
+// These are flow-specific concerns and not part of the auth provider contract.
+func (m *magicLinkAuthExecutor) validateFlowClaims(ctx *core.NodeContext,
+	token string, logger *log.Logger) (string, string) {
 	payload, decodeErr := jwt.DecodeJWTPayload(token)
 	if decodeErr != nil {
 		logger.Debug("Failed to decode magic link token", log.Error(decodeErr))
-		return "", failureReasonInvalidMagicLink, nil
+		return "", failureReasonInvalidMagicLink
 	}
 
 	executionIDClaim := utils.ConvertInterfaceValueToString(payload["executionId"])
 	if executionIDClaim == "" || executionIDClaim != ctx.ExecutionID {
 		logger.Debug("Magic link token executionId mismatch")
-		return "", failureReasonInvalidMagicLink, nil
+		return "", failureReasonInvalidMagicLink
 	}
 
 	jtiClaim := utils.ConvertInterfaceValueToString(payload["jti"])
 	if jtiClaim == "" {
-		return "", failureReasonInvalidMagicLink, nil
+		return "", failureReasonInvalidMagicLink
 	}
 	if usedJti, exists := ctx.RuntimeData[common.RuntimeKeyMagicLinkUsedJti]; exists && usedJti == jtiClaim {
 		logger.Debug("Magic link token has already been used", log.String("jti", jtiClaim))
-		return "", "Magic link has already been used", nil
+		return "", "Magic link has already been used"
 	}
 
 	logger.Debug("Magic link token validated successfully")
-	return jtiClaim, "", nil
+	return jtiClaim, ""
 }
 
 // resolveDestinationAttribute infers the destination attribute from the first configured node input.

--- a/backend/internal/flow/executor/magic_link_executor_test.go
+++ b/backend/internal/flow/executor/magic_link_executor_test.go
@@ -21,7 +21,6 @@ package executor
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -31,6 +30,7 @@ import (
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/authn/magiclink"
+	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
@@ -38,6 +38,7 @@ import (
 	i18ncore "github.com/thunder-id/thunderid/internal/system/i18n/core"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/magiclinkmock"
+	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
 	"github.com/thunder-id/thunderid/tests/mocks/entityprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
 )
@@ -80,6 +81,7 @@ type MagicLinkAuthExecutorTestSuite struct {
 	mockMagicLinkService *magiclinkmock.MagicLinkAuthnServiceInterfaceMock
 	mockFlowFactory      *coremock.FlowFactoryInterfaceMock
 	mockEntityProvider   *entityprovidermock.EntityProviderInterfaceMock
+	mockAuthnProvider    *managermock.AuthnProviderManagerInterfaceMock
 	executor             *magicLinkAuthExecutor
 }
 
@@ -111,6 +113,7 @@ func (suite *MagicLinkAuthExecutorTestSuite) SetupTest() {
 	suite.mockMagicLinkService = magiclinkmock.NewMagicLinkAuthnServiceInterfaceMock(suite.T())
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
 	suite.mockEntityProvider = entityprovidermock.NewEntityProviderInterfaceMock(suite.T())
+	suite.mockAuthnProvider = managermock.NewAuthnProviderManagerInterfaceMock(suite.T())
 
 	defaultInputs := []common.Input{testMagicLinkTokenInput}
 	var prerequisites []common.Input
@@ -126,6 +129,7 @@ func (suite *MagicLinkAuthExecutorTestSuite) SetupTest() {
 	suite.executor = newMagicLinkAuthExecutor(
 		suite.mockFlowFactory,
 		suite.mockMagicLinkService,
+		suite.mockAuthnProvider,
 		suite.mockEntityProvider)
 	suite.executor.ExecutorInterface = mockExec
 }
@@ -510,15 +514,10 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_GenerateMode_Success_Wi
 
 func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Success() {
 	testToken := createTestJWTWithClaims(magicLinkTestExecutionID, "jti-success")
-	attrs := map[string]interface{}{
-		"email": magicLinkTestEmail,
-	}
-	attrsJSON, _ := json.Marshal(attrs)
 	user := &entityprovider.Entity{
-		ID:         magicLinkTestUserID,
-		Type:       magicLinkTestUserType,
-		OUID:       magicLinkTestOUID,
-		Attributes: attrsJSON,
+		ID:   magicLinkTestUserID,
+		Type: magicLinkTestUserType,
+		OUID: magicLinkTestOUID,
 	}
 
 	ctx := &core.NodeContext{
@@ -534,7 +533,15 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Success() {
 		},
 	}
 
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, testToken, "").Return(user, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(
+		authnprovidermgr.AuthUser{},
+		&authnprovidermgr.AuthnBasicResult{
+			UserID:         magicLinkTestUserID,
+			OUID:           magicLinkTestOUID,
+			UserType:       magicLinkTestUserType,
+			IsExistingUser: true,
+		}, nil)
 	suite.mockEntityProvider.On("GetEntity", magicLinkTestUserID).Return(user, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -547,7 +554,7 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Success() {
 	assert.Equal(suite.T(), magicLinkTestUserType, resp.AuthenticatedUser.UserType)
 	assert.Equal(suite.T(), magicLinkTestOUID, resp.AuthenticatedUser.OUID)
 	assert.Equal(suite.T(), "jti-success", resp.RuntimeData[common.RuntimeKeyMagicLinkUsedJti])
-	suite.mockMagicLinkService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 	suite.mockEntityProvider.AssertExpectations(suite.T())
 }
 
@@ -567,8 +574,12 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Success_Regi
 		},
 	}
 
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, testToken, userAttributeEmail).
-		Return(nil, &authncm.ErrorUserNotFound)
+	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(
+		authnprovidermgr.AuthUser{},
+		&authnprovidermgr.AuthnBasicResult{
+			IsExistingUser: false,
+		}, nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -576,7 +587,7 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Success_Regi
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
 	assert.Equal(suite.T(), "jti-registration", resp.RuntimeData[common.RuntimeKeyMagicLinkUsedJti])
-	suite.mockMagicLinkService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 	suite.mockEntityProvider.AssertNotCalled(suite.T(), "GetEntity", mock.Anything)
 }
 
@@ -596,8 +607,12 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Success_Regi
 		},
 	}
 
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, testToken, "mobileNumber").
-		Return(nil, &authncm.ErrorUserNotFound)
+	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(
+		authnprovidermgr.AuthUser{},
+		&authnprovidermgr.AuthnBasicResult{
+			IsExistingUser: false,
+		}, nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -605,7 +620,7 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Success_Regi
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
 	assert.Equal(suite.T(), "jti-registration", resp.RuntimeData[common.RuntimeKeyMagicLinkUsedJti])
-	suite.mockMagicLinkService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 	suite.mockEntityProvider.AssertNotCalled(suite.T(), "GetEntity", mock.Anything)
 }
 
@@ -629,15 +644,19 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Registration
 		},
 	}
 
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, testToken, workEmailAttr).
-		Return(nil, &authncm.ErrorUserNotFound)
+	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(
+		authnprovidermgr.AuthUser{},
+		&authnprovidermgr.AuthnBasicResult{
+			IsExistingUser: false,
+		}, nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
-	suite.mockMagicLinkService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_RegistrationFlow_MissingDestinationAttribute() {
@@ -658,7 +677,7 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Registration
 
 	assert.Error(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
-	suite.mockMagicLinkService.AssertNotCalled(suite.T(), "VerifyMagicLink")
+	suite.mockAuthnProvider.AssertNotCalled(suite.T(), "AuthenticateUser")
 }
 
 func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Failure_TokenNotProvided() {
@@ -694,10 +713,12 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Failure_Inva
 		RuntimeData: make(map[string]string),
 	}
 
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, testToken, "").Return(
-		nil, &serviceerror.ServiceError{
+	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(
+		authnprovidermgr.AuthUser{}, nil,
+		&serviceerror.ServiceError{
 			Type:             serviceerror.ClientErrorType,
-			Code:             "AUTHN-ML-1002",
+			Code:             authnprovidermgr.ErrorAuthenticationFailed.Code,
 			ErrorDescription: i18ncore.I18nMessage{DefaultValue: "The provided magic link token is invalid"},
 		})
 
@@ -707,7 +728,7 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Failure_Inva
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
 	assert.Equal(suite.T(), "The provided magic link token is invalid", resp.FailureReason)
-	suite.mockMagicLinkService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Failure_ReplayAttack() {
@@ -726,8 +747,13 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Failure_Repl
 		},
 	}
 
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, testToken, "").Return(
-		&entityprovider.Entity{ID: magicLinkTestUserID}, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(
+		authnprovidermgr.AuthUser{},
+		&authnprovidermgr.AuthnBasicResult{
+			UserID:         magicLinkTestUserID,
+			IsExistingUser: true,
+		}, nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -759,7 +785,13 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Success_Repl
 		},
 	}
 
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, testToken, "").Return(user, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(
+		authnprovidermgr.AuthUser{},
+		&authnprovidermgr.AuthnBasicResult{
+			UserID:         magicLinkTestUserID,
+			IsExistingUser: true,
+		}, nil)
 	suite.mockEntityProvider.On("GetEntity", magicLinkTestUserID).Return(user, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -768,33 +800,8 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Success_Repl
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
 	assert.Equal(suite.T(), "jti-new", resp.RuntimeData[common.RuntimeKeyMagicLinkUsedJti])
-	suite.mockMagicLinkService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 	suite.mockEntityProvider.AssertExpectations(suite.T())
-}
-
-func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Failure_UserNotFoundAfterVerification() {
-	testToken := createTestJWTWithClaims(magicLinkTestExecutionID, "jti-user-not-found")
-
-	ctx := &core.NodeContext{
-		Context:      context.Background(),
-		ExecutionID:  magicLinkTestExecutionID,
-		FlowType:     common.FlowTypeAuthentication,
-		ExecutorMode: ExecutorModeVerify,
-		UserInputs: map[string]string{
-			userInputMagicLinkToken: testToken,
-		},
-		RuntimeData: make(map[string]string),
-	}
-
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, testToken, "").Return(nil, nil)
-
-	resp, err := suite.executor.Execute(ctx)
-
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), resp)
-	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
-	assert.Equal(suite.T(), failureReasonUserNotFound, resp.FailureReason)
-	suite.mockMagicLinkService.AssertExpectations(suite.T())
 }
 
 func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Failure_GetUserError() {
@@ -813,13 +820,13 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Failure_GetU
 		},
 	}
 
-	user := &entityprovider.Entity{
-		ID:   magicLinkTestUserID,
-		Type: magicLinkTestUserType,
-		OUID: magicLinkTestOUID,
-	}
-
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, testToken, "").Return(user, nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(
+		authnprovidermgr.AuthUser{},
+		&authnprovidermgr.AuthnBasicResult{
+			UserID:         magicLinkTestUserID,
+			IsExistingUser: true,
+		}, nil)
 	suite.mockEntityProvider.On("GetEntity", magicLinkTestUserID).Return(nil,
 		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeSystemError, "database error", ""))
 
@@ -827,7 +834,7 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_VerifyMode_Failure_GetU
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to get user")
-	suite.mockMagicLinkService.AssertExpectations(suite.T())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 	suite.mockEntityProvider.AssertExpectations(suite.T())
 }
 
@@ -1134,128 +1141,81 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestExecute_GenerateMode_Registrati
 	suite.mockMagicLinkService.AssertExpectations(suite.T())
 }
 
-func (suite *MagicLinkAuthExecutorTestSuite) TestValidateMagicLinkToken_FlowIdMismatch() {
+func (suite *MagicLinkAuthExecutorTestSuite) TestValidateFlowClaims_FlowIdMismatch() {
 	token := createTestJWTWithClaims("wrong-flow-id", "test-jti-123")
 	ctx := &core.NodeContext{
 		Context:     context.Background(),
 		ExecutionID: magicLinkTestExecutionID,
-		UserInputs:  map[string]string{userInputMagicLinkToken: token},
 		RuntimeData: make(map[string]string),
 	}
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, token, "").Return(
-		&entityprovider.Entity{ID: magicLinkTestUserID}, nil)
 
 	logger := log.GetLogger()
-	tokenJTI, failure, err := suite.executor.validateMagicLinkToken(ctx, logger)
+	tokenJTI, failure := suite.executor.validateFlowClaims(ctx, token, logger)
 
 	suite.Empty(tokenJTI)
 	suite.Equal("Invalid magic link token", failure)
-	suite.Nil(err)
 }
 
-func (suite *MagicLinkAuthExecutorTestSuite) TestValidateMagicLinkToken_MissingDestinationAttributeOnRegistration() {
-	token := createRegistrationMagicLinkJWT(magicLinkTestExecutionID, "test-jti-123", magicLinkTestEmail)
-	ctx := &core.NodeContext{
-		Context:     context.Background(),
-		ExecutionID: magicLinkTestExecutionID,
-		FlowType:    common.FlowTypeRegistration,
-		UserInputs:  map[string]string{userInputMagicLinkToken: token},
-		RuntimeData: make(map[string]string),
-	}
-
-	logger := log.GetLogger()
-	tokenJTI, failure, err := suite.executor.validateMagicLinkToken(ctx, logger)
-
-	suite.Empty(tokenJTI)
-	suite.Empty(failure)
-	suite.Error(err)
-	suite.Contains(err.Error(), "magic link destination attribute missing from runtime data")
-}
-
-func (suite *MagicLinkAuthExecutorTestSuite) TestValidateMagicLinkToken_ReplayAttack() {
+func (suite *MagicLinkAuthExecutorTestSuite) TestValidateFlowClaims_ReplayAttack() {
 	token := createTestJWTWithClaims(magicLinkTestExecutionID, "test-jti-123")
 	ctx := &core.NodeContext{
 		Context:     context.Background(),
 		ExecutionID: magicLinkTestExecutionID,
-		UserInputs:  map[string]string{userInputMagicLinkToken: token},
 		RuntimeData: map[string]string{common.RuntimeKeyMagicLinkUsedJti: "test-jti-123"},
 	}
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, token, "").Return(
-		&entityprovider.Entity{ID: magicLinkTestUserID}, nil)
 
 	logger := log.GetLogger()
-	tokenJTI, failure, err := suite.executor.validateMagicLinkToken(ctx, logger)
+	tokenJTI, failure := suite.executor.validateFlowClaims(ctx, token, logger)
 
 	suite.Empty(tokenJTI)
 	suite.Equal("Magic link has already been used", failure)
-	suite.Nil(err)
 }
 
-func (suite *MagicLinkAuthExecutorTestSuite) TestValidateMagicLinkToken_NewTokenReturnsJTI() {
+func (suite *MagicLinkAuthExecutorTestSuite) TestValidateFlowClaims_NewTokenReturnsJTI() {
 	newToken := createTestJWTWithClaims(magicLinkTestExecutionID, "new-jti-456")
-	testUser := &entityprovider.Entity{
-		ID:   magicLinkTestUserID,
-		OUID: magicLinkTestOUID,
-		Type: magicLinkTestUserType,
-	}
 	ctx := &core.NodeContext{
 		Context:     context.Background(),
 		ExecutionID: magicLinkTestExecutionID,
-		UserInputs:  map[string]string{userInputMagicLinkToken: newToken},
 		RuntimeData: map[string]string{common.RuntimeKeyMagicLinkUsedJti: "old-jti-123"},
 	}
 
-	suite.mockMagicLinkService.On("VerifyMagicLink", mock.Anything, newToken, "").Return(testUser, nil)
-
 	logger := log.GetLogger()
-	tokenJTI, failure, err := suite.executor.validateMagicLinkToken(ctx, logger)
+	tokenJTI, failure := suite.executor.validateFlowClaims(ctx, newToken, logger)
 
 	suite.Equal("new-jti-456", tokenJTI)
 	suite.Empty(failure)
-	suite.Nil(err)
 	suite.Equal("old-jti-123", ctx.RuntimeData[common.RuntimeKeyMagicLinkUsedJti])
 }
 
 func (suite *MagicLinkAuthExecutorTestSuite) TestCreateRegistrationMagicLinkJWT_Helper() {
-	// Calling the helper with a completely different executionID ("different-flow-id")
-	// satisfies the 'unparam' linter, proving the parameter is actually dynamic.
 	testEmail := "another@example.com"
 	differentExecutionID := "different-flow-id"
 
 	token := createRegistrationMagicLinkJWT(differentExecutionID, "test-jti", testEmail)
 
-	// Run a basic sanity check to ensure the token is generated successfully
 	suite.NotEmpty(token, "Generated token should not be empty")
 	suite.Contains(token, ".", "Generated token should contain JWT separators")
 }
 
-func (suite *MagicLinkAuthExecutorTestSuite) TestValidateMagicLinkToken_DecodeFailure() {
-	// Pass a completely malformed token string
+func (suite *MagicLinkAuthExecutorTestSuite) TestValidateFlowClaims_DecodeFailure() {
 	// nolint:gosec // G101: Test data for negative case, not a real credential
 	token := "not.a.valid.jwt.format"
 
 	ctx := &core.NodeContext{
 		Context:     context.Background(),
 		ExecutionID: magicLinkTestExecutionID,
-		UserInputs:  map[string]string{userInputMagicLinkToken: token},
 		RuntimeData: make(map[string]string),
 	}
 
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, token, "").Return(
-		&entityprovider.Entity{ID: magicLinkTestUserID}, nil)
-
 	logger := log.GetLogger()
-	tokenJTI, failure, err := suite.executor.validateMagicLinkToken(ctx, logger)
+	tokenJTI, failure := suite.executor.validateFlowClaims(ctx, token, logger)
 
 	suite.Empty(tokenJTI)
-	// Asserts that we gracefully fail with the new unexported constant
 	suite.Equal(failureReasonInvalidMagicLink, failure)
-	suite.Nil(err)
 }
 
-func (suite *MagicLinkAuthExecutorTestSuite) TestValidateMagicLinkToken_MissingJTI() {
+func (suite *MagicLinkAuthExecutorTestSuite) TestValidateFlowClaims_MissingJTI() {
 	header := magicLinkTestJWTHeader
-	// Create a payload that is missing the "jti" claim
 	payload := fmt.Sprintf(`{"sub":"user-123","executionId":%q,"exp":9999999999}`, magicLinkTestExecutionID)
 
 	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(header))
@@ -1265,17 +1225,12 @@ func (suite *MagicLinkAuthExecutorTestSuite) TestValidateMagicLinkToken_MissingJ
 	ctx := &core.NodeContext{
 		Context:     context.Background(),
 		ExecutionID: magicLinkTestExecutionID,
-		UserInputs:  map[string]string{userInputMagicLinkToken: token},
 		RuntimeData: make(map[string]string),
 	}
 
-	suite.mockMagicLinkService.On("VerifyMagicLink", ctx.Context, token, "").Return(
-		&entityprovider.Entity{ID: magicLinkTestUserID}, nil)
-
 	logger := log.GetLogger()
-	tokenJTI, failure, err := suite.executor.validateMagicLinkToken(ctx, logger)
+	tokenJTI, failure := suite.executor.validateFlowClaims(ctx, token, logger)
 
 	suite.Empty(tokenJTI)
 	suite.Equal(failureReasonInvalidMagicLink, failure)
-	suite.Nil(err)
 }

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -606,13 +606,19 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 		return nil, fmt.Errorf("no session token found for OTP validation")
 	}
 
+	creds := map[string]interface{}{
+		"otp": map[string]interface{}{
+			"sessionToken": sessionToken,
+			"otp":          providedOTP,
+		},
+	}
+
 	// Handle registration flows.
 	if ctx.FlowType == common.FlowTypeRegistration {
-		// For registration flows, we don't have a user in the system yet.
-		// So we just validate the OTP and return an authenticated user with the mobile number as an attribute.
-		svcErr := s.otpService.VerifyOTP(ctx.Context, sessionToken, providedOTP)
+		newAuthUser, authnResult, svcErr := s.authnProvider.AuthenticateUser(
+			ctx.Context, nil, creds, nil, nil, ctx.AuthUser)
 		if svcErr != nil {
-			if svcErr.Code == otp.ErrorIncorrectOTP.Code {
+			if svcErr.Code == authnprovidermgr.ErrorAuthenticationFailed.Code {
 				logger.Debug("OTP verification failed", log.MaskedString(log.LoggerKeyUserID, userID))
 				execResp.Status = common.ExecUserInputRequired
 				execResp.Inputs = s.GetRequiredInputs(ctx)
@@ -623,7 +629,12 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 				log.MaskedString(log.LoggerKeyUserID, userID), log.Any("serviceError", svcErr))
 			return nil, fmt.Errorf("failed to verify OTP: %s", svcErr.ErrorDescription.DefaultValue)
 		}
-
+		execResp.AuthUser = newAuthUser
+		if authnResult.IsExistingUser {
+			execResp.Status = common.ExecFailure
+			execResp.FailureReason = "User already exists with the provided mobile number."
+			return nil, nil
+		}
 		execResp.Status = common.ExecComplete
 		execResp.FailureReason = ""
 		return &authncm.AuthenticatedUser{
@@ -634,12 +645,6 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 		}, nil
 	}
 
-	creds := map[string]interface{}{
-		"otp": map[string]interface{}{
-			"sessionToken": sessionToken,
-			"otp":          providedOTP,
-		},
-	}
 	newAuthUser, authnResult, svcErr := s.authnProvider.AuthenticateUser(
 		ctx.Context, nil, creds, nil, nil, ctx.AuthUser)
 	if svcErr != nil {

--- a/backend/internal/flow/executor/sms_auth_executor_test.go
+++ b/backend/internal/flow/executor/sms_auth_executor_test.go
@@ -562,6 +562,72 @@ func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_EmptyOTP_Returns
 	assert.Equal(suite.T(), userInputOTP, execResp.Inputs[0].Identifier)
 }
 
+// TestGetAuthenticatedUser_Registration_OTPValid_NoLocalUser verifies that a valid OTP with no
+// existing local user returns an unauthenticated AuthenticatedUser carrying the mobile number.
+func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_Registration_OTPValid_NoLocalUser() {
+	suite.mockAuthnProvider.On("AuthenticateUser",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			IsExistingUser: false,
+		}, nil)
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-reg-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			userInputOTP: "123456",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeySMSOTPMobileNumber: "+1234567890",
+			"otpSessionToken":                   "test-session-token",
+		},
+	}
+	execResp := &common.ExecutorResponse{
+		RuntimeData: make(map[string]string),
+	}
+
+	result, err := suite.executor.getAuthenticatedUser(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.False(suite.T(), result.IsAuthenticated)
+	assert.Equal(suite.T(), "+1234567890", result.Attributes[common.AttributeMobileNumber])
+	assert.Equal(suite.T(), common.ExecComplete, execResp.Status)
+}
+
+// TestGetAuthenticatedUser_Registration_OTPValid_UserAlreadyExists verifies that a valid OTP
+// where a local user already exists fails with an appropriate failure reason.
+func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_Registration_OTPValid_UserAlreadyExists() {
+	suite.mockAuthnProvider.On("AuthenticateUser",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			IsExistingUser: true,
+			UserID:         "existing-user-123",
+		}, nil)
+
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-reg-456",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			userInputOTP: "123456",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeySMSOTPMobileNumber: "+1234567890",
+			"otpSessionToken":                   "test-session-token",
+		},
+	}
+	execResp := &common.ExecutorResponse{
+		RuntimeData: make(map[string]string),
+	}
+
+	result, err := suite.executor.getAuthenticatedUser(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), common.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), "User already exists with the provided mobile number.", execResp.FailureReason)
+}
+
 // TestGetAuthenticatedUser_FetchFromStore_NilAttrsAfterUnmarshal verifies that when
 // user attributes unmarshal to nil, the result is returned without error.
 func (suite *SMSAuthExecutorTestSuite) TestGetAuthenticatedUser_FetchFromStore_NilAttrsAfterUnmarshal() {

--- a/backend/tests/mocks/authn/magiclinkmock/MagicLinkAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/magiclinkmock/MagicLinkAuthnServiceInterface_mock.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
-	"github.com/thunder-id/thunderid/internal/entityprovider"
+	"github.com/thunder-id/thunderid/internal/authn/magiclink"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 )
 
@@ -37,6 +37,82 @@ type MagicLinkAuthnServiceInterfaceMock_Expecter struct {
 
 func (_m *MagicLinkAuthnServiceInterfaceMock) EXPECT() *MagicLinkAuthnServiceInterfaceMock_Expecter {
 	return &MagicLinkAuthnServiceInterfaceMock_Expecter{mock: &_m.Mock}
+}
+
+// Authenticate provides a mock function for the type MagicLinkAuthnServiceInterfaceMock
+func (_mock *MagicLinkAuthnServiceInterfaceMock) Authenticate(ctx context.Context, token string, subjectAttribute string) (*magiclink.MagicLinkAuthnResult, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, token, subjectAttribute)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Authenticate")
+	}
+
+	var r0 *magiclink.MagicLinkAuthnResult
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*magiclink.MagicLinkAuthnResult, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, token, subjectAttribute)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *magiclink.MagicLinkAuthnResult); ok {
+		r0 = returnFunc(ctx, token, subjectAttribute)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*magiclink.MagicLinkAuthnResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, token, subjectAttribute)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// MagicLinkAuthnServiceInterfaceMock_Authenticate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Authenticate'
+type MagicLinkAuthnServiceInterfaceMock_Authenticate_Call struct {
+	*mock.Call
+}
+
+// Authenticate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - token string
+//   - subjectAttribute string
+func (_e *MagicLinkAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, token interface{}, subjectAttribute interface{}) *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call {
+	return &MagicLinkAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, token, subjectAttribute)}
+}
+
+func (_c *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, token string, subjectAttribute string)) *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call) Return(magicLinkAuthnResult *magiclink.MagicLinkAuthnResult, serviceError *serviceerror.ServiceError) *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(magicLinkAuthnResult, serviceError)
+	return _c
+}
+
+func (_c *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, token string, subjectAttribute string) (*magiclink.MagicLinkAuthnResult, *serviceerror.ServiceError)) *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // GenerateMagicLink provides a mock function for the type MagicLinkAuthnServiceInterfaceMock
@@ -127,82 +203,6 @@ func (_c *MagicLinkAuthnServiceInterfaceMock_GenerateMagicLink_Call) Return(s st
 }
 
 func (_c *MagicLinkAuthnServiceInterfaceMock_GenerateMagicLink_Call) RunAndReturn(run func(ctx context.Context, subject string, expirySeconds int64, queryParams map[string]string, additionalClaims map[string]interface{}, magicLinkURL string) (string, *serviceerror.ServiceError)) *MagicLinkAuthnServiceInterfaceMock_GenerateMagicLink_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// VerifyMagicLink provides a mock function for the type MagicLinkAuthnServiceInterfaceMock
-func (_mock *MagicLinkAuthnServiceInterfaceMock) VerifyMagicLink(ctx context.Context, token string, subjectAttribute string) (*entityprovider.Entity, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, token, subjectAttribute)
-
-	if len(ret) == 0 {
-		panic("no return value specified for VerifyMagicLink")
-	}
-
-	var r0 *entityprovider.Entity
-	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*entityprovider.Entity, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, token, subjectAttribute)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *entityprovider.Entity); ok {
-		r0 = returnFunc(ctx, token, subjectAttribute)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*entityprovider.Entity)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, token, subjectAttribute)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*serviceerror.ServiceError)
-		}
-	}
-	return r0, r1
-}
-
-// MagicLinkAuthnServiceInterfaceMock_VerifyMagicLink_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'VerifyMagicLink'
-type MagicLinkAuthnServiceInterfaceMock_VerifyMagicLink_Call struct {
-	*mock.Call
-}
-
-// VerifyMagicLink is a helper method to define mock.On call
-//   - ctx context.Context
-//   - token string
-//   - subjectAttribute string
-func (_e *MagicLinkAuthnServiceInterfaceMock_Expecter) VerifyMagicLink(ctx interface{}, token interface{}, subjectAttribute interface{}) *MagicLinkAuthnServiceInterfaceMock_VerifyMagicLink_Call {
-	return &MagicLinkAuthnServiceInterfaceMock_VerifyMagicLink_Call{Call: _e.mock.On("VerifyMagicLink", ctx, token, subjectAttribute)}
-}
-
-func (_c *MagicLinkAuthnServiceInterfaceMock_VerifyMagicLink_Call) Run(run func(ctx context.Context, token string, subjectAttribute string)) *MagicLinkAuthnServiceInterfaceMock_VerifyMagicLink_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MagicLinkAuthnServiceInterfaceMock_VerifyMagicLink_Call) Return(entity *entityprovider.Entity, serviceError *serviceerror.ServiceError) *MagicLinkAuthnServiceInterfaceMock_VerifyMagicLink_Call {
-	_c.Call.Return(entity, serviceError)
-	return _c
-}
-
-func (_c *MagicLinkAuthnServiceInterfaceMock_VerifyMagicLink_Call) RunAndReturn(run func(ctx context.Context, token string, subjectAttribute string) (*entityprovider.Entity, *serviceerror.ServiceError)) *MagicLinkAuthnServiceInterfaceMock_VerifyMagicLink_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/otpmock/OTPAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/otpmock/OTPAuthnServiceInterface_mock.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
-	"github.com/thunder-id/thunderid/internal/entityprovider"
+	"github.com/thunder-id/thunderid/internal/authn/otp"
 	"github.com/thunder-id/thunderid/internal/notification/common"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 )
@@ -41,27 +41,27 @@ func (_m *OTPAuthnServiceInterfaceMock) EXPECT() *OTPAuthnServiceInterfaceMock_E
 }
 
 // Authenticate provides a mock function for the type OTPAuthnServiceInterfaceMock
-func (_mock *OTPAuthnServiceInterfaceMock) Authenticate(ctx context.Context, sessionToken string, otp string) (*entityprovider.Entity, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, sessionToken, otp)
+func (_mock *OTPAuthnServiceInterfaceMock) Authenticate(ctx context.Context, sessionToken string, otp1 string) (*otp.OTPAuthnResult, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, sessionToken, otp1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Authenticate")
 	}
 
-	var r0 *entityprovider.Entity
+	var r0 *otp.OTPAuthnResult
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*entityprovider.Entity, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, sessionToken, otp)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*otp.OTPAuthnResult, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, sessionToken, otp1)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *entityprovider.Entity); ok {
-		r0 = returnFunc(ctx, sessionToken, otp)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *otp.OTPAuthnResult); ok {
+		r0 = returnFunc(ctx, sessionToken, otp1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*entityprovider.Entity)
+			r0 = ret.Get(0).(*otp.OTPAuthnResult)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, sessionToken, otp)
+		r1 = returnFunc(ctx, sessionToken, otp1)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -78,12 +78,12 @@ type OTPAuthnServiceInterfaceMock_Authenticate_Call struct {
 // Authenticate is a helper method to define mock.On call
 //   - ctx context.Context
 //   - sessionToken string
-//   - otp string
-func (_e *OTPAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, sessionToken interface{}, otp interface{}) *OTPAuthnServiceInterfaceMock_Authenticate_Call {
-	return &OTPAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, sessionToken, otp)}
+//   - otp1 string
+func (_e *OTPAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, sessionToken interface{}, otp1 interface{}) *OTPAuthnServiceInterfaceMock_Authenticate_Call {
+	return &OTPAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, sessionToken, otp1)}
 }
 
-func (_c *OTPAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, sessionToken string, otp string)) *OTPAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *OTPAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, sessionToken string, otp1 string)) *OTPAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -106,12 +106,12 @@ func (_c *OTPAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx conte
 	return _c
 }
 
-func (_c *OTPAuthnServiceInterfaceMock_Authenticate_Call) Return(entity *entityprovider.Entity, serviceError *serviceerror.ServiceError) *OTPAuthnServiceInterfaceMock_Authenticate_Call {
-	_c.Call.Return(entity, serviceError)
+func (_c *OTPAuthnServiceInterfaceMock_Authenticate_Call) Return(oTPAuthnResult *otp.OTPAuthnResult, serviceError *serviceerror.ServiceError) *OTPAuthnServiceInterfaceMock_Authenticate_Call {
+	_c.Call.Return(oTPAuthnResult, serviceError)
 	return _c
 }
 
-func (_c *OTPAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, sessionToken string, otp string) (*entityprovider.Entity, *serviceerror.ServiceError)) *OTPAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *OTPAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, sessionToken string, otp1 string) (*otp.OTPAuthnResult, *serviceerror.ServiceError)) *OTPAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -192,71 +192,6 @@ func (_c *OTPAuthnServiceInterfaceMock_SendOTP_Call) Return(s string, serviceErr
 }
 
 func (_c *OTPAuthnServiceInterfaceMock_SendOTP_Call) RunAndReturn(run func(ctx context.Context, senderID string, channel common.ChannelType, recipient string) (string, *serviceerror.ServiceError)) *OTPAuthnServiceInterfaceMock_SendOTP_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// VerifyOTP provides a mock function for the type OTPAuthnServiceInterfaceMock
-func (_mock *OTPAuthnServiceInterfaceMock) VerifyOTP(ctx context.Context, sessionToken string, otp string) *serviceerror.ServiceError {
-	ret := _mock.Called(ctx, sessionToken, otp)
-
-	if len(ret) == 0 {
-		panic("no return value specified for VerifyOTP")
-	}
-
-	var r0 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *serviceerror.ServiceError); ok {
-		r0 = returnFunc(ctx, sessionToken, otp)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*serviceerror.ServiceError)
-		}
-	}
-	return r0
-}
-
-// OTPAuthnServiceInterfaceMock_VerifyOTP_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'VerifyOTP'
-type OTPAuthnServiceInterfaceMock_VerifyOTP_Call struct {
-	*mock.Call
-}
-
-// VerifyOTP is a helper method to define mock.On call
-//   - ctx context.Context
-//   - sessionToken string
-//   - otp string
-func (_e *OTPAuthnServiceInterfaceMock_Expecter) VerifyOTP(ctx interface{}, sessionToken interface{}, otp interface{}) *OTPAuthnServiceInterfaceMock_VerifyOTP_Call {
-	return &OTPAuthnServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", ctx, sessionToken, otp)}
-}
-
-func (_c *OTPAuthnServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Context, sessionToken string, otp string)) *OTPAuthnServiceInterfaceMock_VerifyOTP_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *OTPAuthnServiceInterfaceMock_VerifyOTP_Call) Return(serviceError *serviceerror.ServiceError) *OTPAuthnServiceInterfaceMock_VerifyOTP_Call {
-	_c.Call.Return(serviceError)
-	return _c
-}
-
-func (_c *OTPAuthnServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(ctx context.Context, sessionToken string, otp string) *serviceerror.ServiceError) *OTPAuthnServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose

This PR incorporates 3 main changes
1. Route OTP registration through authnprovider
2. Route Magic Link registration through authnprovider
3. Route Magic Link authentications through authnprovider

### Approach

For 1 above :

  - OTP service: 
Merged the separate VerifyOTP (verify-only) and Authenticate (verify + resolve user) methods into a single Authenticate that returns an OTPAuthnResult struct. When OTP verification succeeds but no local user exists, it returns {InternalEntity: nil, VerifiedIdentifiers: {"mobileNumber": recipient}} instead of an error. This lets callers distinguish "valid OTP, no user yet" from actual failures without inspecting error codes.
  - Authn provider: 
Updated authenticateWithOTP to handle the new result shape — nil entity triggers an early return with IsExistingUser: false and the verified identifiers, matching how federated auth already works. Also extracted a shared buildAttributesResponse helper and fixed the existing-user path to include attribute values (IsAttributeValuesIncluded: true).
  - SMS OTP executor: 
Registration flow now calls authnProvider.AuthenticateUser instead of otpService.VerifyOTP directly, so registration and login both go through the same provider abstraction.

For 2 and 3 above : 

 - Magic link service: 
Renamed VerifyMagicLink → Authenticate, introduced MagicLinkAuthnResult struct. User-not-found is now a successful result (InternalEntity: nil + VerifiedIdentifiers carrying the proven email/attribute) instead of an error. Token verification logic is extracted into a private verifyTokenAndExtractSubject helper.
  - Authn provider: 
 Wired magicLinkService as a dependency through the initialization chain. Added authenticateWithMagicLink in the provider and registered the "magiclink" credential key in resolveCredentials — following the same entity-ID-or-early-return pattern as OTP and federated.
  - Magic link executor: 
 Verification now calls authnProvider.AuthenticateUser instead of magicLinkService.VerifyMagicLink directly. The old validateMagicLinkToken (which mixed auth concerns with flow concerns) is split: authentication moves to the provider, and flow-specific checks (execution-ID binding, JTI replay detection) stay in the executor as validateFlowClaims.



### Related Issues
- https://github.com/thunder-id/thunderid/issues/2963

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Magic link authentication integrated into the centralized auth provider and flows.
  - Credential flows (magic link, OTP) now surface verified identifiers and attributes for registration when no local account exists.

* **Refactor**
  - Auth services and providers return richer result objects distinguishing resolved users vs. verified-but-unresolved identities; executors now route verification through the authn provider.

* **Tests**
  - Coverage expanded with new unit tests for magic link, OTP, flow-claim validation, and registration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->