### PR TITLE
Fix DEV MODE CORS issue in Translations

### DIFF
--- a/frontend/apps/console/src/i18n/I18nProvider.tsx
+++ b/frontend/apps/console/src/i18n/I18nProvider.tsx
@@ -74,7 +74,7 @@ function I18nProvider({children}: I18nProviderProps): ReactElement {
         url: string;
         method: string;
         attachToken?: boolean;
-        withCredentials?: boolean;
+        credentials?: RequestCredentials;
       }) => Promise<{data: TranslationsResponse}>;
     };
   };
@@ -95,7 +95,7 @@ function I18nProvider({children}: I18nProviderProps): ReactElement {
         url,
         method: 'GET',
         attachToken: false,
-        withCredentials: false,
+        credentials: 'omit',
       });
 
       return response.data;

--- a/frontend/apps/console/src/i18n/__tests__/I18nProvider.test.tsx
+++ b/frontend/apps/console/src/i18n/__tests__/I18nProvider.test.tsx
@@ -377,7 +377,7 @@ describe('I18nProvider', () => {
         url: 'https://api.example.com/i18n/languages/en-US/translations/resolve',
         method: 'GET',
         attachToken: false,
-        withCredentials: false,
+        credentials: 'omit',
       });
       expect(result).toEqual(expectedResponse);
     });

--- a/frontend/packages/i18n/src/api/useGetLanguages.ts
+++ b/frontend/packages/i18n/src/api/useGetLanguages.ts
@@ -71,8 +71,8 @@ export default function useGetLanguages(options?: UseGetLanguagesOptions): UseQu
         url: `${serverUrl}/i18n/languages`,
         method: 'GET',
         attachToken: false,
-        withCredentials: false,
-      } as unknown as Parameters<typeof http.request>[0]);
+        credentials: 'omit',
+      });
 
       return response.data;
     },

--- a/frontend/packages/i18n/src/api/useGetTranslations.ts
+++ b/frontend/packages/i18n/src/api/useGetTranslations.ts
@@ -93,8 +93,8 @@ export default function useGetTranslations({
         url,
         method: 'GET',
         attachToken: false,
-        withCredentials: false,
-      } as unknown as Parameters<typeof http.request>[0]);
+        credentials: 'omit',
+      });
 
       return response.data;
     },

--- a/sdks/javascript/src/HttpClient.ts
+++ b/sdks/javascript/src/HttpClient.ts
@@ -109,7 +109,9 @@ export abstract class HttpClient {
   }
 
   protected async requestHandler(config: HttpRequestConfig): Promise<HttpRequestConfig> {
-    await this.attachToken(config);
+    if (config.attachToken !== false) {
+      await this.attachToken(config);
+    }
 
     if (config.shouldEncodeToFormData && config.data) {
       const formData: FormData = new FormData();


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
`withCredentials` (an Axios/XHR concept) was being passed to the `FetchHttpClient` which uses the native Fetch API. The Fetch API silently ignores `withCredentials`, so `credentials: 'include'` remained in effect on every request regardless — meaning unauthenticated endpoints (e.g. i18n language/translation APIs) were still sending session cookies. Additionally, the `attachToken: false` flag was only checked by convention inside `AuthenticationHelper`, with no enforcement in the base `HttpClient`.

### Approach
- Replace `withCredentials: false` with `credentials: 'omit'` across all i18n callers (`useGetLanguages`, `useGetTranslations`, `I18nProvider`). `credentials` is a first-class `RequestInit` field already present on `HttpRequestConfig` via its `Omit<RequestInit, ...>` base, so the `as unknown as` casts are removed too.
- Reorder the `FetchHttpClient.transport()` fetch call so `credentials: 'include'` is the SDK default set *before* `...fetchOptions`. This means any `RequestInit` option supplied by the caller — `credentials`, `cache`, `mode`, `signal`, `keepalive`, etc. — overrides the default via the spread, with no special-casing needed.
- Move the `attachToken: false` guard into `HttpClient.requestHandler` (`if (config.attachToken !== false)`), enforcing the flag at the base class level rather than relying on each injected function to implement the check itself.


### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/2463

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated credential handling mechanisms for internationalization API requests and HTTP request configurations to support more flexible security settings across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->