### PR TITLE
Support single-file declarative resources via -resources startup flag

### DIFF
--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -167,6 +167,7 @@ Twilio
 [Ll]oopback
 [Ss]treamable
 client_id
+resource_type
 [Dd]ownscope
 [Dd]ownscoping
 [Ss]uperset

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -57,6 +57,7 @@ func main() {
 	startupStartedAt := time.Now()
 	logger := log.GetLogger()
 
+	flag.String("resources", "", "Path to declarative resources YAML file")
 	serverHome := getThunderHome(logger)
 
 	cfg := initThunderConfigurations(logger, serverHome)

--- a/backend/internal/system/declarative_resource/loader.go
+++ b/backend/internal/system/declarative_resource/loader.go
@@ -19,7 +19,10 @@
 package declarativeresource
 
 import (
+	"flag"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
@@ -48,17 +51,44 @@ func NewResourceLoader(config ResourceConfig, store Storer) *ResourceLoader {
 	}
 }
 
-// LoadResources loads all resources from the configured directory.
-// It reads YAML files, parses them, validates them, and stores them.
+// LoadResources loads all resources using the following precedence:
+//  1. A file supplied via the --resources startup argument.
+//  2. YAML files found directly in repository/resources/ (multi-document format with
+//     "# resource_type: <type>" headers), when present.
+//  3. Individual YAML files inside the repository/resources/<DirectoryName>/ subdirectory.
+//
 // Returns an error if any step fails.
 func (l *ResourceLoader) LoadResources() error {
-	// Read configuration files from the directory
-	configs, err := GetConfigs(l.config.DirectoryName)
+	var configs [][]byte
+	var err error
+
+	resourceType := strings.TrimSuffix(l.config.DirectoryName, "s")
+
+	resourcesFile := ""
+	if f := flag.Lookup("resources"); f != nil {
+		if v := f.Value.String(); v != "" {
+			absPath, absErr := filepath.Abs(v)
+			if absErr == nil {
+				resourcesFile = absPath
+			}
+		}
+	}
+
+	if resourcesFile != "" {
+		configs, err = GetConfigsFromFile(resourcesFile, resourceType)
+	} else {
+		var rootConfigs [][]byte
+		rootConfigs, err = GetConfigsFromRootDir(resourceType)
+		if err == nil && len(rootConfigs) > 0 {
+			configs = rootConfigs
+		} else if err == nil {
+			configs, err = GetConfigs(l.config.DirectoryName)
+		}
+	}
 	if err != nil {
 		return err
 	}
 
-	// Process each configuration file
 	for _, cfg := range configs {
 		if err := l.loadSingleResource(cfg); err != nil {
 			return err

--- a/backend/internal/system/declarative_resource/loader_test.go
+++ b/backend/internal/system/declarative_resource/loader_test.go
@@ -20,6 +20,7 @@ package declarativeresource
 
 import (
 	"errors"
+	"flag"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -31,6 +32,12 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/config"
 )
+
+func init() {
+	if flag.Lookup("resources") == nil {
+		flag.String("resources", "", "Path to declarative resources YAML file")
+	}
+}
 
 // Mock Storer implementation for testing
 type mockStorer struct {
@@ -618,6 +625,153 @@ value: -100`
 // TestResourceLoader runs the test suite
 func TestResourceLoader(t *testing.T) {
 	suite.Run(t, new(ResourceLoaderTestSuite))
+}
+
+// ─── Three-level precedence tests ────────────────────────────────────────────
+
+// createRootYAMLFile creates a multi-document YAML file directly in repository/resources/.
+func (suite *ResourceLoaderTestSuite) createRootYAMLFile(filename, content string) {
+	err := os.WriteFile(filepath.Join(suite.resourcesDir, filename), []byte(content), 0600)
+	suite.Require().NoError(err)
+}
+
+// removeRootYAMLFile removes a file from repository/resources/.
+func (suite *ResourceLoaderTestSuite) removeRootYAMLFile(filename string) {
+	_ = os.Remove(filepath.Join(suite.resourcesDir, filename))
+}
+
+// TestLoadResources_FromRootDirFile verifies that a YAML file placed directly in
+// repository/resources/ is picked up when no --resources flag is set and no subdir exists.
+func (suite *ResourceLoaderTestSuite) TestLoadResources_FromRootDirFile() {
+	content := `# resource_type: testresource
+id: root-res-1
+name: Root Resource
+description: Loaded from root dir
+value: 42
+`
+	suite.createRootYAMLFile("root-prec.yaml", content)
+	defer suite.removeRootYAMLFile("root-prec.yaml")
+
+	cfg := ResourceConfig{
+		ResourceType:  "TestResource",
+		DirectoryName: "testresources",
+		Parser:        testParser,
+		IDExtractor:   testIDExtractor,
+		Validator:     testValidator,
+	}
+	store := newMockStorer()
+	loader := NewResourceLoader(cfg, store)
+
+	err := loader.LoadResources()
+
+	suite.NoError(err)
+	suite.Len(store.stored, 1)
+	suite.NotNil(store.stored["root-res-1"])
+}
+
+// TestLoadResources_RootDirTakesPrecedenceOverSubdir verifies level-2 beats level-3:
+// when a matching document exists in a root YAML file AND in a subdir file, only the
+// root dir resources are loaded.
+func (suite *ResourceLoaderTestSuite) TestLoadResources_RootDirTakesPrecedenceOverSubdir() {
+	// level-3: subdir file
+	suite.createYAMLFile("prec-subdir-dir", "sub.yaml", `id: sub-res
+name: Subdir Resource
+description: Should be shadowed
+value: 1`)
+
+	// level-2: root dir file with matching resource_type
+	suite.createRootYAMLFile("root-prec2.yaml", `# resource_type: prec-subdir-di
+id: root-res
+name: Root Resource
+description: From root dir
+value: 99
+`)
+	defer suite.removeRootYAMLFile("root-prec2.yaml")
+
+	cfg := ResourceConfig{
+		ResourceType:  "TestResource",
+		DirectoryName: "prec-subdir-di",
+		Parser:        testParser,
+		IDExtractor:   testIDExtractor,
+		Validator:     testValidator,
+	}
+	store := newMockStorer()
+	loader := NewResourceLoader(cfg, store)
+
+	err := loader.LoadResources()
+
+	suite.NoError(err)
+	suite.Len(store.stored, 1)
+	suite.NotNil(store.stored["root-res"])
+	suite.Nil(store.stored["sub-res"])
+}
+
+// TestLoadResources_ArgFileTakesPrecedenceOverRootDir verifies level-1 beats level-2.
+func (suite *ResourceLoaderTestSuite) TestLoadResources_ArgFileTakesPrecedenceOverRootDir() {
+	// level-2: root dir file
+	suite.createRootYAMLFile("root-prec3.yaml", `# resource_type: argvresource
+id: from-root
+name: Root File Resource
+description: Should be ignored
+value: 1
+`)
+	defer suite.removeRootYAMLFile("root-prec3.yaml")
+
+	// level-1: explicit arg file (wins)
+	argContent := `# resource_type: argvresource
+id: from-arg
+name: Arg File Resource
+description: From arg file
+value: 99
+`
+	argFile := filepath.Join(suite.T().TempDir(), "arg-resources.yaml")
+	suite.Require().NoError(os.WriteFile(argFile, []byte(argContent), 0600))
+
+	suite.Require().NoError(flag.Set("resources", argFile))
+	defer func() { suite.Require().NoError(flag.Set("resources", "")) }()
+
+	cfg := ResourceConfig{
+		ResourceType:  "TestResource",
+		DirectoryName: "argvresources",
+		Parser:        testParser,
+		IDExtractor:   testIDExtractor,
+		Validator:     testValidator,
+	}
+	store := newMockStorer()
+	loader := NewResourceLoader(cfg, store)
+
+	err := loader.LoadResources()
+
+	suite.NoError(err)
+	suite.Len(store.stored, 1)
+	suite.NotNil(store.stored["from-arg"])
+	suite.Nil(store.stored["from-root"])
+}
+
+// TestLoadResources_FallsBackToSubdirWhenNoRootFiles verifies that when no YAML files
+// matching the resource type exist in repository/resources/, the loader falls through to
+// the subdirectory (level-3).
+func (suite *ResourceLoaderTestSuite) TestLoadResources_FallsBackToSubdirWhenNoRootFiles() {
+	suite.createYAMLFile("fallback-subdir", "sub.yaml", `id: sub-only
+name: Subdir Only
+description: No root file present
+value: 7`)
+
+	cfg := ResourceConfig{
+		ResourceType:  "TestResource",
+		DirectoryName: "fallback-subdir",
+		Parser:        testParser,
+		IDExtractor:   testIDExtractor,
+		Validator:     testValidator,
+	}
+	store := newMockStorer()
+	loader := NewResourceLoader(cfg, store)
+
+	err := loader.LoadResources()
+
+	suite.NoError(err)
+	suite.Len(store.stored, 1)
+	suite.NotNil(store.stored["sub-only"])
 }
 
 // Additional unit tests without test suite

--- a/backend/internal/system/declarative_resource/manager.go
+++ b/backend/internal/system/declarative_resource/manager.go
@@ -19,16 +19,137 @@
 package declarativeresource
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )
+
+// GetConfigsFromFile reads documents for the given resourceType from a single multi-document YAML file.
+// Documents are matched by a "# resource_type: <type>" comment header.
+// Environment variable substitution is applied per-document so that non-variable content (e.g.
+// UI template expressions like {{ t(...) }}) in other documents does not interfere.
+func GetConfigsFromFile(filePath, resourceType string) ([][]byte, error) {
+	cleanPath := filepath.Clean(filePath)
+	file, err := os.Open(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read resources file: %w", err)
+	}
+	defer func() {
+		if cerr := file.Close(); cerr != nil {
+			log.GetLogger().Warn("Failed to close resources file", log.Error(cerr))
+		}
+	}()
+	fileContent, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read resources file: %w", err)
+	}
+
+	docs := splitYAMLDocuments(fileContent)
+	results := make([][]byte, 0, len(docs))
+	for _, doc := range docs {
+		if len(bytes.TrimSpace(doc)) == 0 {
+			continue
+		}
+		if !documentMatchesResourceType(doc, resourceType) {
+			continue
+		}
+		processed, err := utils.SubstituteEnvironmentVariables(doc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to substitute environment variables in resources file: %w", err)
+		}
+		results = append(results, processed)
+	}
+	return results, nil
+}
+
+// splitYAMLDocuments splits a multi-document YAML byte slice on "---" document separators.
+func splitYAMLDocuments(content []byte) [][]byte {
+	var docs [][]byte
+	var current []byte
+
+	for _, line := range bytes.Split(content, []byte("\n")) {
+		if bytes.Equal(bytes.TrimSpace(line), []byte("---")) && bytes.HasPrefix(line, []byte("---")) {
+			if len(bytes.TrimSpace(current)) > 0 {
+				docs = append(docs, current)
+			}
+			current = nil
+		} else {
+			current = append(current, line...)
+			current = append(current, '\n')
+		}
+	}
+	if len(bytes.TrimSpace(current)) > 0 {
+		docs = append(docs, current)
+	}
+	return docs
+}
+
+// documentMatchesResourceType checks whether a YAML document chunk declares the given resource type
+// via a "# resource_type: <type>" comment.
+func documentMatchesResourceType(doc []byte, resourceType string) bool {
+	for _, line := range bytes.Split(doc, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		if line[0] != '#' {
+			break
+		}
+		normalized := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(string(line), "#")))
+		for _, prefix := range []string{"resource_type:", "resource type:", "resourcetype:"} {
+			if strings.HasPrefix(normalized, prefix) {
+				t := strings.TrimSpace(strings.TrimPrefix(normalized, prefix))
+				t = strings.Trim(t, "\"'")
+				if t == resourceType {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// GetConfigsFromRootDir scans the repository/resources/ directory for YAML files (*.yaml, *.yml)
+// that sit directly in that directory (not in subdirectories) and returns all documents whose
+// resource_type header matches resourceType.  Returns nil, nil when no matching YAML files exist
+// so callers can fall through to directory-based loading.
+func GetConfigsFromRootDir(resourceType string) ([][]byte, error) {
+	serverHome := config.GetServerRuntime().ServerHome
+	rootDir := filepath.Join(serverHome, "repository", "resources")
+
+	entries, err := os.ReadDir(rootDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read resources directory: %w", err)
+	}
+
+	var results [][]byte
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		docs, err := GetConfigsFromFile(filepath.Join(rootDir, name), resourceType)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, docs...)
+	}
+	return results, nil
+}
 
 // GetConfigs reads all configuration files from the specified directory within the resources directory.
 func GetConfigs(configDirectoryPath string) ([][]byte, error) {

--- a/backend/internal/system/declarative_resource/manager_file_test.go
+++ b/backend/internal/system/declarative_resource/manager_file_test.go
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package declarativeresource
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// ResourcesFileTestSuite tests the single-file declarative resource loading functions:
+// GetConfigsFromFile, splitYAMLDocuments, and documentMatchesResourceType.
+type ResourcesFileTestSuite struct {
+	suite.Suite
+	originalEnvVars map[string]string
+}
+
+func TestResourcesFileTestSuite(t *testing.T) {
+	suite.Run(t, new(ResourcesFileTestSuite))
+}
+
+func (s *ResourcesFileTestSuite) SetupTest() {
+	s.originalEnvVars = make(map[string]string)
+}
+
+func (s *ResourcesFileTestSuite) TearDownTest() {
+	for key, value := range s.originalEnvVars {
+		if value == "" {
+			_ = os.Unsetenv(key)
+		} else {
+			_ = os.Setenv(key, value)
+		}
+	}
+}
+
+func (s *ResourcesFileTestSuite) setEnvVar(key, value string) {
+	if _, exists := s.originalEnvVars[key]; !exists {
+		if orig, has := os.LookupEnv(key); has {
+			s.originalEnvVars[key] = orig
+		} else {
+			s.originalEnvVars[key] = ""
+		}
+	}
+	s.Require().NoError(os.Setenv(key, value))
+}
+
+func (s *ResourcesFileTestSuite) writeResourcesFile(content string) string {
+	f, err := os.CreateTemp(s.T().TempDir(), "resources-*.yaml")
+	s.Require().NoError(err)
+	_, err = f.WriteString(content)
+	s.Require().NoError(err)
+	s.Require().NoError(f.Close())
+	return f.Name()
+}
+
+// ─── splitYAMLDocuments ──────────────────────────────────────────────────────
+
+func (s *ResourcesFileTestSuite) TestSplitYAMLDocuments_SingleDocument() {
+	content := []byte("key: value\nother: 123\n")
+	docs := splitYAMLDocuments(content)
+	s.Len(docs, 1)
+	s.Contains(string(docs[0]), "key: value")
+}
+
+func (s *ResourcesFileTestSuite) TestSplitYAMLDocuments_MultipleDocuments() {
+	content := []byte("# resource_type: identity_provider\nname: idp1\n---\n# resource_type: flow\nhandle: flow1\n")
+	docs := splitYAMLDocuments(content)
+	s.Len(docs, 2)
+	s.Contains(string(docs[0]), "identity_provider")
+	s.Contains(string(docs[1]), "flow1")
+}
+
+func (s *ResourcesFileTestSuite) TestSplitYAMLDocuments_LeadingSeparator() {
+	content := []byte("---\n# resource_type: identity_provider\nname: idp1\n")
+	docs := splitYAMLDocuments(content)
+	s.Len(docs, 1)
+	s.Contains(string(docs[0]), "identity_provider")
+}
+
+func (s *ResourcesFileTestSuite) TestSplitYAMLDocuments_EmptyContent() {
+	docs := splitYAMLDocuments([]byte{})
+	s.Empty(docs)
+}
+
+func (s *ResourcesFileTestSuite) TestSplitYAMLDocuments_OnlyWhitespace() {
+	docs := splitYAMLDocuments([]byte("  \n  \n---\n  \n"))
+	s.Empty(docs)
+}
+
+// ─── documentMatchesResourceType ─────────────────────────────────────────────
+
+func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_Match() {
+	doc := []byte("# resource_type: identity_provider\nname: my-idp\n")
+	s.True(documentMatchesResourceType(doc, "identity_provider"))
+}
+
+func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_NoMatch() {
+	doc := []byte("# resource_type: flow\nhandle: my-flow\n")
+	s.False(documentMatchesResourceType(doc, "identity_provider"))
+}
+
+func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_NoComment() {
+	doc := []byte("name: my-idp\ntype: GOOGLE\n")
+	s.False(documentMatchesResourceType(doc, "identity_provider"))
+}
+
+func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_QuotedType() {
+	doc := []byte("# resource_type: \"translation\"\nlanguage: en-US\n")
+	s.True(documentMatchesResourceType(doc, "translation"))
+}
+
+func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_AlternativePrefix() {
+	doc := []byte("# resource type: flow\nhandle: signin\n")
+	s.True(documentMatchesResourceType(doc, "flow"))
+}
+
+// ─── GetConfigsFromFile ───────────────────────────────────────────────────────
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_ReturnsOnlyMatchingType() {
+	content := `# resource_type: identity_provider
+name: google-idp
+type: GOOGLE
+---
+# resource_type: flow
+handle: signin
+name: Sign-in Flow
+---
+# resource_type: identity_provider
+name: github-idp
+type: GITHUB
+`
+	filePath := s.writeResourcesFile(content)
+
+	configs, err := GetConfigsFromFile(filePath, "identity_provider")
+
+	s.NoError(err)
+	s.Len(configs, 2)
+	s.Contains(string(configs[0])+string(configs[1]), "google-idp")
+	s.Contains(string(configs[0])+string(configs[1]), "github-idp")
+}
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_NoMatchingType_ReturnsEmpty() {
+	content := `# resource_type: flow
+handle: signin
+---
+# resource_type: flow
+handle: signup
+`
+	filePath := s.writeResourcesFile(content)
+
+	configs, err := GetConfigsFromFile(filePath, "identity_provider")
+
+	s.NoError(err)
+	s.Empty(configs)
+}
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_SubstitutesEnvVars() {
+	s.setEnvVar("TEST_IDP_CLIENT_ID", "my-client-id-123")
+
+	content := `# resource_type: identity_provider
+name: oauth-idp
+client_id: {{.TEST_IDP_CLIENT_ID}}
+`
+	filePath := s.writeResourcesFile(content)
+
+	configs, err := GetConfigsFromFile(filePath, "identity_provider")
+
+	s.NoError(err)
+	s.Len(configs, 1)
+	s.Contains(string(configs[0]), "my-client-id-123")
+	s.NotContains(string(configs[0]), "{{.TEST_IDP_CLIENT_ID}}")
+}
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_NonGoTemplateExpressionsPassThrough() {
+	// Flow document contains {{ t(...) }} and {{meta(...)}} — these are UI expressions
+	// that must not be mangled by the env-var substitution step.
+	content := `# resource_type: flow
+handle: signin
+name: Sign-in Flow
+meta: '{"label":"{{ t(signin:title) }}","url":"{{meta(application.url)}}"}'
+`
+	filePath := s.writeResourcesFile(content)
+
+	configs, err := GetConfigsFromFile(filePath, "flow")
+
+	s.NoError(err)
+	s.Len(configs, 1)
+	s.Contains(string(configs[0]), `{{ t(signin:title) }}`)
+	s.Contains(string(configs[0]), `{{meta(application.url)}}`)
+}
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_BareIdentifierExpressionsPassThrough() {
+	// Translation documents may contain {{appName}} (no dot) as a runtime placeholder.
+	content := `# resource_type: translation
+language: en-US
+translations:
+  complete: Welcome back to {{appName}}
+`
+	filePath := s.writeResourcesFile(content)
+
+	configs, err := GetConfigsFromFile(filePath, "translation")
+
+	s.NoError(err)
+	s.Len(configs, 1)
+	s.Contains(string(configs[0]), "{{appName}}")
+}
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_EnvVarAndNonGoTemplateInSameFile() {
+	// Application doc has {{.Var}} substitution; flow doc in the same file has {{ t(...) }}.
+	// Each is processed independently — the flow doc must never cause a parse error.
+	s.setEnvVar("TEST_CLIENT_ID", "app-client-id")
+
+	content := `# resource_type: application
+name: My App
+client_id: {{.TEST_CLIENT_ID}}
+---
+# resource_type: flow
+handle: signin
+meta: '{"label":"{{ t(signin:title) }}"}'
+`
+	filePath := s.writeResourcesFile(content)
+
+	appConfigs, err := GetConfigsFromFile(filePath, "application")
+	s.NoError(err)
+	s.Len(appConfigs, 1)
+	s.Contains(string(appConfigs[0]), "app-client-id")
+
+	flowConfigs, err := GetConfigsFromFile(filePath, "flow")
+	s.NoError(err)
+	s.Len(flowConfigs, 1)
+	s.Contains(string(flowConfigs[0]), `{{ t(signin:title) }}`)
+}
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_MissingEnvVar_ReturnsError() {
+	content := `# resource_type: identity_provider
+name: oauth-idp
+client_id: {{.MISSING_ENV_VAR_XYZ}}
+`
+	filePath := s.writeResourcesFile(content)
+
+	configs, err := GetConfigsFromFile(filePath, "identity_provider")
+
+	s.Error(err)
+	s.Nil(configs)
+	s.Contains(err.Error(), "MISSING_ENV_VAR_XYZ")
+}
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_FileNotFound_ReturnsError() {
+	configs, err := GetConfigsFromFile(filepath.Join(s.T().TempDir(), "does-not-exist.yaml"), "identity_provider")
+
+	s.Error(err)
+	s.Nil(configs)
+	s.Contains(err.Error(), "failed to read resources file")
+}
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_EmptyFile_ReturnsEmpty() {
+	filePath := s.writeResourcesFile("")
+
+	configs, err := GetConfigsFromFile(filePath, "identity_provider")
+
+	s.NoError(err)
+	s.Empty(configs)
+}
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_MultipleTypesInFile() {
+	content := `# resource_type: organization_unit
+handle: default
+name: Default OU
+---
+# resource_type: identity_provider
+name: google-idp
+type: GOOGLE
+---
+# resource_type: translation
+language: en-US
+translations:
+  title: Sign In
+---
+# resource_type: flow
+handle: signin
+name: Sign-in Flow
+`
+	filePath := s.writeResourcesFile(content)
+
+	ouConfigs, err := GetConfigsFromFile(filePath, "organization_unit")
+	s.NoError(err)
+	s.Len(ouConfigs, 1)
+
+	idpConfigs, err := GetConfigsFromFile(filePath, "identity_provider")
+	s.NoError(err)
+	s.Len(idpConfigs, 1)
+
+	translationConfigs, err := GetConfigsFromFile(filePath, "translation")
+	s.NoError(err)
+	s.Len(translationConfigs, 1)
+
+	flowConfigs, err := GetConfigsFromFile(filePath, "flow")
+	s.NoError(err)
+	s.Len(flowConfigs, 1)
+}
+
+func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_RelativePathResolvesFromCWD() {
+	tmpDir := s.T().TempDir()
+	s.Require().NoError(os.WriteFile(filepath.Join(tmpDir, "resources.yaml"),
+		[]byte("# resource_type: flow\nhandle: x\n"), 0600))
+
+	origDir, err := os.Getwd()
+	s.Require().NoError(err)
+	s.Require().NoError(os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Pass a relative path — the function must resolve it against the current working directory.
+	configs, err := GetConfigsFromFile("resources.yaml", "flow")
+	s.NoError(err)
+	s.Len(configs, 1)
+}

--- a/backend/internal/system/declarative_resource/manager_test.go
+++ b/backend/internal/system/declarative_resource/manager_test.go
@@ -540,3 +540,126 @@ func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigs_HiddenFiles() {
 	suite.NoError(err)
 	suite.Len(configs, 2) // Both files should be read
 }
+
+// ──────────────────────── GetConfigsFromRootDir tests ────────────────────────
+
+// createRootResourceFile creates a YAML file directly inside repository/resources/.
+func (suite *FileBasedRuntimeManagerTestSuite) createRootResourceFile(filename, content string) {
+	serverHome := config.GetServerRuntime().ServerHome
+	rootDir := filepath.Join(serverHome, "repository", "resources")
+	err := os.MkdirAll(rootDir, 0750)
+	suite.Require().NoError(err)
+	filePath := filepath.Join(rootDir, filename)
+	err = os.WriteFile(filePath, []byte(content), 0600)
+	suite.Require().NoError(err)
+}
+
+// removeRootResourceFile removes a file from repository/resources/ to restore test isolation.
+func (suite *FileBasedRuntimeManagerTestSuite) removeRootResourceFile(filename string) {
+	serverHome := config.GetServerRuntime().ServerHome
+	_ = os.Remove(filepath.Join(serverHome, "repository", "resources", filename))
+}
+
+func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_MatchingDocument() {
+	content := `# resource_type: widget
+id: w1
+name: Widget One
+`
+	suite.createRootResourceFile("root-test-match.yaml", content)
+	defer suite.removeRootResourceFile("root-test-match.yaml")
+
+	configs, err := GetConfigsFromRootDir("widget")
+
+	suite.NoError(err)
+	suite.Len(configs, 1)
+	suite.Contains(string(configs[0]), "id: w1")
+}
+
+func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_NoMatchingDocument() {
+	content := `# resource_type: other
+id: o1
+name: Other Resource
+`
+	suite.createRootResourceFile("root-test-nomatch.yaml", content)
+	defer suite.removeRootResourceFile("root-test-nomatch.yaml")
+
+	configs, err := GetConfigsFromRootDir("widget")
+
+	suite.NoError(err)
+	suite.Empty(configs)
+}
+
+func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_MultipleFilesAndDocuments() {
+	file1 := `# resource_type: widget
+id: w1
+name: Widget One
+---
+# resource_type: gadget
+id: g1
+name: Gadget One
+`
+	file2 := `# resource_type: widget
+id: w2
+name: Widget Two
+`
+	suite.createRootResourceFile("root-multi-1.yaml", file1)
+	suite.createRootResourceFile("root-multi-2.yaml", file2)
+	defer suite.removeRootResourceFile("root-multi-1.yaml")
+	defer suite.removeRootResourceFile("root-multi-2.yaml")
+
+	configs, err := GetConfigsFromRootDir("widget")
+
+	suite.NoError(err)
+	suite.Len(configs, 2)
+}
+
+func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_IgnoresSubdirectories() {
+	content := `# resource_type: widget
+id: w1
+name: In Subdir
+`
+	suite.createTestFile("subdir-ignored", "resource.yaml", content)
+
+	configs, err := GetConfigsFromRootDir("widget-subdir-test")
+
+	suite.NoError(err)
+	suite.Empty(configs)
+}
+
+func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_IgnoresNonYAMLFiles() {
+	serverHome := config.GetServerRuntime().ServerHome
+	rootDir := filepath.Join(serverHome, "repository", "resources")
+	err := os.MkdirAll(rootDir, 0750)
+	suite.Require().NoError(err)
+	txtPath := filepath.Join(rootDir, "root-ignored.txt")
+	err = os.WriteFile(txtPath, []byte("# resource_type: widget\nid: w1\n"), 0600)
+	suite.Require().NoError(err)
+	defer func() { _ = os.Remove(txtPath) }()
+
+	configs, err := GetConfigsFromRootDir("widget-txt-test")
+
+	suite.NoError(err)
+	suite.Empty(configs)
+}
+
+func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_EmptyOnNoYAMLFiles() {
+	configs, err := GetConfigsFromRootDir("resource-type-no-root-yaml")
+
+	suite.NoError(err)
+	suite.Empty(configs)
+}
+
+func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_YmlExtension() {
+	content := `# resource_type: thing
+id: t1
+name: Thing One
+`
+	suite.createRootResourceFile("root-test.yml", content)
+	defer suite.removeRootResourceFile("root-test.yml")
+
+	configs, err := GetConfigsFromRootDir("thing")
+
+	suite.NoError(err)
+	suite.Len(configs, 1)
+	suite.Contains(string(configs[0]), "id: t1")
+}

--- a/backend/internal/system/utils/configutil.go
+++ b/backend/internal/system/utils/configutil.go
@@ -25,10 +25,13 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"text/template"
 
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
+
+const tplLiteralPlaceholderFmt = "__TPL_LITERAL_%d__"
 
 var (
 	// Pattern to match Go template variables like {{.Variable}}
@@ -39,6 +42,23 @@ var (
 
 	// Pattern to match Go template file path patterns
 	filePattern = regexp.MustCompile(`file://(?:"([^"]*)"|([^\s"]+))`)
+
+	// anyBracesPattern matches any single-line {{ ... }} expression (no nested braces).
+	anyBracesPattern = regexp.MustCompile(`\{\{[^}]*\}\}`)
+
+	// goTemplateExprPattern matches only the Go template expressions that Thunder config
+	// files intentionally use: {{.Var}}, {{.}} (range element), {{- range .Var}}, {{- end}}.
+	// Anything not matching this is a non-Go-template literal (e.g. {{ t(key) }}, {{appName}}).
+	goTemplateExprPattern = regexp.MustCompile(
+		`\{\{` +
+			`(?:` +
+			`\s*\.\s*[A-Za-z_][A-Za-z0-9_]*\s*` + // {{.Variable}}
+			`|\s*\.\s*` + // {{.}}
+			`|-\s*range\s+\.\s*[A-Za-z_][A-Za-z0-9_]*\s*` + // {{- range .Var}}
+			`|-\s*end\s*` + // {{- end}}
+			`)` +
+			`\}\}`,
+	)
 )
 
 // SubstituteFilePaths replaces file path placeholders in the given content with the actual file contents.
@@ -143,19 +163,48 @@ func SubstituteEnvironmentVariables(content []byte) ([]byte, error) {
 		return content, nil
 	}
 
+	// Shield non-Go-template {{ ... }} expressions (e.g. {{ t(key) }}, {{appName}},
+	// {{meta(prop)}}) so the Go template parser does not mistake them for function calls.
+	shielded, restore := shieldNonGoTemplateExpressions(contentStr)
+
 	// Create and execute the template
-	tmpl, err := template.New("config").Parse(contentStr)
+	tmpl, err := template.New("config").Parse(shielded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template: %w", err)
 	}
 
 	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, templateVars)
-	if err != nil {
+	if err = tmpl.Execute(&buf, templateVars); err != nil {
 		return nil, fmt.Errorf("failed to execute template: %w", err)
 	}
 
-	return buf.Bytes(), nil
+	// Restore shielded expressions to their original form
+	result := buf.String()
+	for placeholder, original := range restore {
+		result = strings.ReplaceAll(result, placeholder, original)
+	}
+
+	return []byte(result), nil
+}
+
+// shieldNonGoTemplateExpressions replaces any {{ ... }} pattern that is not a valid
+// Go template expression with a unique placeholder string, returning the modified
+// content and a map to restore the originals after template execution.
+func shieldNonGoTemplateExpressions(content string) (string, map[string]string) {
+	restore := make(map[string]string)
+	idx := 0
+
+	result := anyBracesPattern.ReplaceAllStringFunc(content, func(match string) string {
+		if goTemplateExprPattern.MatchString(match) {
+			return match
+		}
+		placeholder := fmt.Sprintf(tplLiteralPlaceholderFmt, idx)
+		idx++
+		restore[placeholder] = match
+		return placeholder
+	})
+
+	return result, restore
 }
 
 // buildArrayFromEnvVars builds an array by reading environment variables with indexed suffixes

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -360,16 +360,118 @@ Controls declarative configuration support.
 |---------|---------|-------------|
 | `declarative_resources.enabled` | `false` | If `true`, enables declarative resource configuration |
 
-For Helm deployments, this setting is managed through `declarativeResources.enabled` in the Helm values. When enabled, the chart also mounts declarative resource files from either a ConfigMap or Secret into the <ProductName /> `repository/resources` directory.
+### Resource Loading Precedence
 
-Example Helm values:
+At startup, <ProductName /> resolves declarative resources using the following precedence. Only the first matching source is used — sources are not merged.
+
+| Priority | Source | When active |
+|----------|--------|-------------|
+| 1 | Single file passed via `./start.sh <file>` | `--resources` flag is set |
+| 2 | `*.yaml`/`*.yml` files placed directly in `repository/resources/` (not in subdirectories) | Flag not set; at least one root-level YAML file exists |
+| 3 | Per-type subdirectories under `repository/resources/` (e.g. `repository/resources/groups/`) | Flag not set; no root-level YAML files found |
+
+If `--resources` is set, `repository/resources/` is not read at all, regardless of what files it contains. The two sources never merge.
+
+### Start <ProductName/> With a Resources File
+
+Pass a single multi-document YAML file to the server at startup as a positional argument to `start.sh`. The file is forwarded to the server binary as the `-resources` flag and read directly at startup.
+
+```bash
+./start.sh resources.yml
+```
+
+With environment variable substitution:
+
+```bash
+./start.sh resources.yml --env my.env
+```
+
+Each document in the file must declare its type with a `# resource_type: <type>` comment at the top. Supported types:
+
+```
+application, flow, group, identity_provider, layout, notification_sender,
+organization_unit, resource_server, role, theme, translation, user, user_schema
+```
+
+Example single file:
+
+```yaml
+# resource_type: application
+name: My App
+ou_handle: default
+auth_flow_handle: default-basic-flow
+---
+# resource_type: group
+name: admins
+description: Administrators
+```
+
+:::warning
+When `--resources` is active, any files in `repository/resources/` — including per-type subdirectories — are silently ignored. If you need files from the directory to be loaded, do not pass a `--resources` argument.
+:::
+
+### Resources Directory (No Startup Flag)
+
+If you do not pass a `--resources` argument, <ProductName /> automatically picks up multi-document YAML files placed directly in the `repository/resources/` directory (not in subdirectories). This is priority 2 in the loading precedence and requires no configuration change or restart argument.
+
+Place a multi-document YAML file in `repository/resources/`:
+
+```
+repository/
+  resources/
+    my-resources.yaml   ← loaded automatically at startup
+    groups/             ← used only when no root-level YAML files exist
+      admins.yaml
+```
+
+The file must use the same `# resource_type: <type>` document headers as the single-file startup format. On startup, <ProductName /> scans all `*.yaml` and `*.yml` files at that root level and loads every document whose `resource_type` matches a configured declarative resource type.
+
+:::note
+If any `*.yaml` or `*.yml` file is found at the `repository/resources/` root, per-type subdirectories (priority 3) are skipped entirely for that resource type.
+:::
+
+### Helm Deployment
+
+For Helm deployments, this setting is managed through `declarativeResources.enabled` in the Helm values. When enabled, the chart mounts declarative resource files from either a ConfigMap or Secret into the <ProductName /> `repository/resources` directory.
+
+Two mounting modes are available — use the one that fits your resource layout.
+
+#### Combined File Mode
+
+Use `singleFile.keys` to mount one or more combined YAML files (multi-document format with `# resource_type: <type>` headers) directly under `repository/resources`. Each key in your ConfigMap or Secret is mounted as `<key>.yaml` at that path. <ProductName /> scans the directory at startup and loads every document whose `resource_type` matches a configured declarative resource type.
 
 ```yaml
 declarativeResources:
   enabled: true
-  # Base mount path inside the {{ProductName}} container (default: /opt/thunder/repository/resources)
-  mountPath: /opt/thunder/repository/resources
-  # Mount as read-only (recommended)
+  readOnly: true
+  singleFile:
+    keys:
+      - resources          # mounted as repository/resources/resources.yaml
+      - extra-resources    # mounted as repository/resources/extra-resources.yaml
+  configMap:
+    name: declarative-resources
+```
+
+The same works with a Secret source (for files containing sensitive values):
+
+```yaml
+declarativeResources:
+  enabled: true
+  readOnly: true
+  singleFile:
+    keys:
+      - resources
+  secret:
+    name: declarative-resources-secret
+```
+
+#### Individual Files Mode
+
+Use `configMap.items` (or `secret.items`) to mount individual files into typed subdirectories under `repository/resources`. Each item maps a ConfigMap/Secret key to a specific path.
+
+```yaml
+declarativeResources:
+  enabled: true
   readOnly: true
   configMap:
     name: declarative-resources
@@ -382,22 +484,12 @@ declarativeResources:
       # Format 3 — per-item mountPath override (absolute path)
       - key: org-default
         path: organization_units/default.yaml
-        mountPath: /opt/thunder/repository/resources/organization_units/default.yaml
+        mountPath: /opt/thunderid/repository/resources/organization_units/default.yaml
 ```
 
-To source files from a Kubernetes Secret instead (for resources containing sensitive values):
-
-```yaml
-declarativeResources:
-  enabled: true
-  mountPath: /opt/thunder/repository/resources
-  readOnly: true
-  secret:
-    name: declarative-resources-secret
-    items:
-      - key: my-app-with-secrets
-        path: applications/my-app.yaml
-```
+:::note
+`singleFile.keys` and `configMap.items` / `secret.items` are mutually exclusive.
+:::
 
 Templates (email and other templated content) are now supported as a declarative resource. See the templates guide for schema, examples, and the configured directory location: [Template declarative resources](../declarative-configurations/templates.mdx).
 

--- a/install/helm/templates/_helpers.tpl
+++ b/install/helm/templates/_helpers.tpl
@@ -266,3 +266,19 @@ Each item may optionally specify a mountPath to override the global base path.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Render volumeMount entries for singleFile.keys mode.
+Each key is mounted as <key>.yaml directly under the given mountPath.
+*/}}
+{{- define "thunderid.singleFileVolumeMounts" -}}
+{{- $keys := default (list) .keys -}}
+{{- $mountPath := .mountPath -}}
+{{- $readOnly := .readOnly -}}
+{{- range $keys }}
+- name: declarative-resources
+  mountPath: {{ printf "%s/%s.yaml" $mountPath . }}
+  subPath: {{ . }}
+  readOnly: {{ $readOnly }}
+{{- end }}
+{{- end }}

--- a/install/helm/templates/thunderid-deployment.yaml
+++ b/install/helm/templates/thunderid-deployment.yaml
@@ -21,6 +21,9 @@
 {{- if and .Values.declarativeResources.enabled (not .Values.declarativeResources.configMap.name) (not .Values.declarativeResources.secret.name) }}
 {{- fail "Invalid declarativeResources configuration: set declarativeResources.configMap.name or declarativeResources.secret.name when declarativeResources.enabled=true." }}
 {{- end }}
+{{- if and .Values.declarativeResources.enabled .Values.declarativeResources.singleFile.keys (or .Values.declarativeResources.configMap.items .Values.declarativeResources.secret.items) }}
+{{- fail "Invalid declarativeResources configuration: declarativeResources.singleFile.keys is mutually exclusive with configMap.items / secret.items." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -170,7 +173,9 @@ spec:
               mountPath: /opt/thunderid/apps/console/config.js
               subPath: console-config.js
             {{- if .Values.declarativeResources.enabled }}
-            {{- if and .Values.declarativeResources.configMap.name .Values.declarativeResources.configMap.items }}
+            {{- if .Values.declarativeResources.singleFile.keys }}
+{{ include "thunderid.singleFileVolumeMounts" (dict "keys" .Values.declarativeResources.singleFile.keys "mountPath" .Values.declarativeResources.mountPath "readOnly" .Values.declarativeResources.readOnly) | nindent 12 }}
+            {{- else if and .Values.declarativeResources.configMap.name .Values.declarativeResources.configMap.items }}
 {{ include "thunderid.declarativeResourceVolumeMounts" (dict "items" .Values.declarativeResources.configMap.items "field" "declarativeResources.configMap.items" "mountPath" .Values.declarativeResources.mountPath "readOnly" .Values.declarativeResources.readOnly) | nindent 12 }}
             {{- else if and .Values.declarativeResources.secret.name .Values.declarativeResources.secret.items }}
 {{ include "thunderid.declarativeResourceVolumeMounts" (dict "items" .Values.declarativeResources.secret.items "field" "declarativeResources.secret.items" "mountPath" .Values.declarativeResources.mountPath "readOnly" .Values.declarativeResources.readOnly) | nindent 12 }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -434,6 +434,18 @@ declarativeResources:
   mountPath: /opt/thunderid/repository/resources
   # Mount resources as read-only.
   readOnly: true
+  # Combined file mode.
+  # Each key listed here is mounted as <key>.yaml directly under mountPath.
+  # Files must use the # resource_type: <type> header format so the directory
+  # scanner can identify each document.
+  # Mutually exclusive with configMap.items / secret.items.
+  singleFile:
+    # Keys in the ConfigMap or Secret to mount as combined resource YAML files.
+    # Example:
+    # keys:
+    #   - resources
+    #   - extra-resources
+    keys: []
   # Source from an existing ConfigMap.
   # When 'items' is empty, all keys are mounted.
   # Each item supports either:

--- a/start.ps1
+++ b/start.ps1
@@ -149,113 +149,43 @@ if ($ENV_FILE -ne "" -and -not [System.IO.Path]::IsPathRooted($ENV_FILE)) {
 # Exit on any error
 $ErrorActionPreference = 'Stop'
 
-function Setup-DeclarativeResources {
-    $scriptDir = Split-Path -Parent $MyInvocation.ScriptName
-    $resourcesBase = Join-Path $scriptDir "repository\resources"
-
-    # Load and export env vars from the env file.
-    if ($ENV_FILE -ne "") {
-        if (-not (Test-Path $ENV_FILE)) {
-            Write-Host "Error: env file not found: $ENV_FILE" -ForegroundColor Red
-            exit 1
-        }
-        Write-Host "Loading environment from $ENV_FILE ..."
-        Get-Content $ENV_FILE | ForEach-Object {
-            $line = $_.TrimEnd()
-            if ($line -eq "" -or $line.StartsWith('#')) { return }
-            if ($line -match '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
-                $key = $Matches[1]
-                $value = $Matches[2]
-                if ($value -match '^\[') {
-                    # JSON array — expand into KEY_0, KEY_1, ...
-                    try {
-                        $arr = $value | ConvertFrom-Json
-                        $idx = 0
-                        foreach ($elem in $arr) {
-                            [System.Environment]::SetEnvironmentVariable("${key}_${idx}", $elem, 'Process')
-                            $idx++
-                        }
-                    } catch {
-                        Write-Warning "Failed to parse JSON array for key '$key': $_"
-                        [System.Environment]::SetEnvironmentVariable($key, $value, 'Process')
-                    }
-                } else {
-                    [System.Environment]::SetEnvironmentVariable($key, $value, 'Process')
-                }
-            }
-        }
+# Load and export env vars from the env file.
+function Load-EnvFile {
+    if ($ENV_FILE -eq "") { return }
+    if (-not (Test-Path $ENV_FILE)) {
+        Write-Host "Error: env file not found: $ENV_FILE" -ForegroundColor Red
+        exit 1
     }
-
-    # Split the combined resources YAML and place each document in its type directory.
-    if ($RESOURCES_FILE -ne "") {
-        if (-not (Test-Path $RESOURCES_FILE)) {
-            Write-Host "Error: resources file not found: $RESOURCES_FILE" -ForegroundColor Red
-            exit 1
-        }
-        Write-Host "Setting up declarative resources from $RESOURCES_FILE ..."
-
-        $typeMap = @{
-            'application'         = 'applications'
-            'flow'                = 'flows'
-            'group'               = 'groups'
-            'identity_provider'   = 'identity_providers'
-            'layout'              = 'layouts'
-            'notification_sender' = 'notification_senders'
-            'organization_unit'   = 'organization_units'
-            'resource_server'     = 'resource_servers'
-            'role'                = 'roles'
-            'theme'               = 'themes'
-            'translation'         = 'translations'
-            'user'                = 'users'
-            'user_schema'         = 'user_schemas'
-        }
-
-        $lines = Get-Content $RESOURCES_FILE
-        $docLines = [System.Collections.Generic.List[string]]::new()
-        $currentFile = ""
-        $currentType = ""
-
-        $flushDoc = {
-            if ($docLines.Count -eq 0 -or $currentType -eq "") {
-                $docLines.Clear()
-                $script:currentFile = ""
-                $script:currentType = ""
-                return
-            }
-            $dir = if ($typeMap.ContainsKey($currentType)) { $typeMap[$currentType] } else { "${currentType}s" }
-            $targetDir = Join-Path $resourcesBase $dir
-            if (-not (Test-Path $targetDir)) { New-Item -ItemType Directory -Path $targetDir -Force | Out-Null }
-            $fname = if ($currentFile -ne "") { $currentFile } else { "resource.yaml" }
-            $outPath = Join-Path $targetDir $fname
-            $docLines | Set-Content -Path $outPath -Encoding UTF8
-            Write-Host "  Placed: $dir\$fname"
-            $docLines.Clear()
-            $script:currentFile = ""
-            $script:currentType = ""
-        }
-
-        foreach ($line in $lines) {
-            if ($line -match '^---\s*$') {
-                & $flushDoc
-            }
-            elseif ($line -match '^# File:\s*(.+)$') {
-                $currentFile = $Matches[1].Trim()
-            }
-            elseif ($line -match '^# resource_type:\s*(.+)$') {
-                $currentType = $Matches[1].Trim()
-            }
-            else {
-                $docLines.Add($line)
+    Write-Host "Loading environment from $ENV_FILE ..."
+    Get-Content $ENV_FILE | ForEach-Object {
+        $line = $_.TrimEnd()
+        if ($line -eq "" -or $line.StartsWith('#')) { return }
+        if ($line -match '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
+            $key = $Matches[1]
+            $value = $Matches[2]
+            if ($value -match '^\[') {
+                # JSON array — expand into KEY_0, KEY_1, ...
+                try {
+                    $arr = $value | ConvertFrom-Json
+                    $idx = 0
+                    foreach ($elem in $arr) {
+                        [System.Environment]::SetEnvironmentVariable("${key}_${idx}", $elem, 'Process')
+                        $idx++
+                    }
+                } catch {
+                    Write-Error "Failed to parse JSON array for key '$key': $_"
+                    exit 1
+                }
+            } else {
+                [System.Environment]::SetEnvironmentVariable($key, $value, 'Process')
             }
         }
-        & $flushDoc
-        Write-Host "Declarative resources ready."
     }
 }
 
-# Set up declarative resources if a resources file or env file was provided.
-if ($RESOURCES_FILE -ne "" -or $ENV_FILE -ne "") {
-    Setup-DeclarativeResources
+# Load env vars before starting the binary so substitution works in resource files.
+if ($ENV_FILE -ne "") {
+    Load-EnvFile
 }
 
 function Stop-PortListener {
@@ -371,6 +301,9 @@ try {
         }
     }
 
+    $resourcesArgs = @()
+    if ($RESOURCES_FILE -ne "") { $resourcesArgs = @('-resources', $RESOURCES_FILE) }
+
     if ($DEBUG_MODE) {
         Write-Host "[INFO] Starting $PRODUCT_NAME Server in DEBUG mode..."
         Write-Host "[INFO] Application will run on: https://localhost:$BACKEND_PORT"
@@ -380,8 +313,11 @@ try {
         Write-Host "   Host: 127.0.0.1, Port: $DEBUG_PORT" -ForegroundColor Gray
         Write-Host ""
 
+        # Export BACKEND_PORT for the child process (mirrors the non-debug branch)
+        $env:BACKEND_PORT = $BACKEND_PORT
+
         # Start Delve in headless mode
-        $dlvArgs =  @(
+        $dlvArgs = @(
             'exec'
             "--listen=:$DEBUG_PORT"
             '--headless=true'
@@ -389,7 +325,8 @@ try {
             '--accept-multiclient'
             '--continue'
             $serverExecPath
-        )
+            '--'
+        ) + $resourcesArgs
         $proc = Start-Process -FilePath dlv -ArgumentList $dlvArgs -WorkingDirectory $scriptDir -NoNewWindow -PassThru
     }
     else {
@@ -397,7 +334,7 @@ try {
 
         # Export BACKEND_PORT for the child process
         $env:BACKEND_PORT = $BACKEND_PORT
-        $proc = Start-Process -FilePath $serverExecPath -WorkingDirectory $scriptDir -NoNewWindow -PassThru
+        $proc = Start-Process -FilePath $serverExecPath -ArgumentList $resourcesArgs -WorkingDirectory $scriptDir -NoNewWindow -PassThru
     }
 
     Write-Host ""

--- a/start.sh
+++ b/start.sh
@@ -128,103 +128,41 @@ check_port() {
     fi
 }
 
-# Set up declarative resources from an exported resources file and optional env file.
-# Reads a multi-document YAML file and places each document into the appropriate
-# repository/resources/<type>/ directory, then exports variables from the env file.
-setup_declarative_resources() {
-    local script_dir
-    script_dir="$(cd "$(dirname "$0")" && pwd)"
-    local resources_base="$script_dir/repository/resources"
-
-    # Load and export env vars from the env file.
-    if [[ -n "$ENV_FILE" ]]; then
-        if [[ ! -f "$ENV_FILE" ]]; then
-            echo "Error: env file not found: $ENV_FILE"
-            exit 1
-        fi
-        echo "Loading environment from $ENV_FILE ..."
-        while IFS= read -r line || [[ -n "$line" ]]; do
-            [[ -z "$line" || "$line" == \#* ]] && continue
-            line="${line%$'\r'}"
-            if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
-                key="${BASH_REMATCH[1]}"
-                value="${BASH_REMATCH[2]}"
-                if [[ "$value" == \[* ]]; then
-                    # JSON array — expand into KEY_0, KEY_1, ...
-                    idx=0
-                    _json_tmp=$(mktemp)
-                    if ! python3 -c "import json,sys; [print(x) for x in json.loads(sys.argv[1])]" "$value" > "$_json_tmp" 2>&1; then
-                        echo "Error: failed to parse JSON array for key '$key': $(cat "$_json_tmp")" >&2
-                        rm -f "$_json_tmp"
-                        exit 1
-                    fi
-                    while IFS= read -r elem; do
-                        export "${key}_${idx}=${elem}"
-                        ((idx++))
-                    done < "$_json_tmp"
-                    rm -f "$_json_tmp"
-                else
-                    export "${key}=${value}"
-                fi
-            fi
-        done < "$ENV_FILE"
-    fi
-
-    # Split the combined resources YAML and place each document in its type directory.
-    if [[ -n "$RESOURCES_FILE" ]]; then
-        if [[ ! -f "$RESOURCES_FILE" ]]; then
-            echo "Error: resources file not found: $RESOURCES_FILE"
-            exit 1
-        fi
-        echo "Setting up declarative resources from $RESOURCES_FILE ..."
-        DEC_BASE="$resources_base" awk '
-BEGIN {
-    doc = ""; filename = ""; resource_type = ""
-    base = ENVIRON["DEC_BASE"]
-    type_dir["application"]         = "applications"
-    type_dir["flow"]                = "flows"
-    type_dir["group"]               = "groups"
-    type_dir["identity_provider"]   = "identity_providers"
-    type_dir["layout"]              = "layouts"
-    type_dir["notification_sender"] = "notification_senders"
-    type_dir["organization_unit"]   = "organization_units"
-    type_dir["resource_server"]     = "resource_servers"
-    type_dir["role"]                = "roles"
-    type_dir["theme"]               = "themes"
-    type_dir["translation"]         = "translations"
-    type_dir["user"]                = "users"
-    type_dir["user_schema"]         = "user_schemas"
-}
-function flush(    dir, target, outfile) {
-    if (doc == "" || resource_type == "") {
-        doc = ""; filename = ""; resource_type = ""
+# Load and export env vars from the env file.
+load_env_file() {
+    if [[ -z "$ENV_FILE" ]]; then
         return
-    }
-    dir = (resource_type in type_dir) ? type_dir[resource_type] : resource_type "s"
-    target = base "/" dir
-    system("mkdir -p " target)
-    if (filename == "") filename = "resource.yaml"
-    outfile = target "/" filename
-    printf "%s", doc > outfile
-    close(outfile)
-    print "  Placed: " dir "/" filename > "/dev/stderr"
-    doc = ""; filename = ""; resource_type = ""
-}
-/^---[[:space:]]*$/ { flush(); next }
-/^# File:[[:space:]]*/ {
-    sub(/^# File:[[:space:]]*/, "")
-    filename = $0
-    next
-}
-/^# resource_type:[[:space:]]*/ {
-    sub(/^# resource_type:[[:space:]]*/, "")
-    resource_type = $0
-    next
-}
-{ doc = doc $0 "\n" }
-END { flush() }' "$RESOURCES_FILE"
-        echo "Declarative resources ready."
     fi
+    if [[ ! -f "$ENV_FILE" ]]; then
+        echo "Error: env file not found: $ENV_FILE"
+        exit 1
+    fi
+    echo "Loading environment from $ENV_FILE ..."
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        line="${line%$'\r'}"
+        if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+            key="${BASH_REMATCH[1]}"
+            value="${BASH_REMATCH[2]}"
+            if [[ "$value" == \[* ]]; then
+                # JSON array — expand into KEY_0, KEY_1, ...
+                idx=0
+                _json_tmp=$(mktemp)
+                if ! python3 -c "import json,sys; [print(x) for x in json.loads(sys.argv[1])]" "$value" > "$_json_tmp" 2>&1; then
+                    echo "Error: failed to parse JSON array for key '$key': $(cat "$_json_tmp")" >&2
+                    rm -f "$_json_tmp"
+                    exit 1
+                fi
+                while IFS= read -r elem; do
+                    export "${key}_${idx}=${elem}"
+                    ((idx++))
+                done < "$_json_tmp"
+                rm -f "$_json_tmp"
+            else
+                export "${key}=${value}"
+            fi
+        fi
+    done < "$ENV_FILE"
 }
 
 # Check if ports are available
@@ -249,9 +187,9 @@ if [ "$DEBUG_MODE" = "true" ]; then
     fi
 fi
 
-# Set up declarative resources if a resources file or env file was provided.
-if [[ -n "$RESOURCES_FILE" || -n "$ENV_FILE" ]]; then
-    setup_declarative_resources
+# Load env vars before starting the binary so substitution works in resource files.
+if [[ -n "$ENV_FILE" ]]; then
+    load_env_file
 fi
 
 # Cleanup function
@@ -311,12 +249,17 @@ if [ "$DEBUG_MODE" = "true" ]; then
     echo ""
 
     # Run debugger
-    dlv exec --listen=:$DEBUG_PORT --headless=true --api-version=2 --accept-multiclient --continue ./${BINARY_NAME} &
+    RESOURCES_ARGS=()
+    [[ -n "$RESOURCES_FILE" ]] && RESOURCES_ARGS=(-resources "$RESOURCES_FILE")
+    BACKEND_PORT=$BACKEND_PORT dlv exec "--listen=:${DEBUG_PORT}" --headless=true --api-version=2 --accept-multiclient --continue \
+        "./${BINARY_NAME}" -- "${RESOURCES_ARGS[@]}" &
     SERVER_PID=$!
 else
     echo "⚡ Starting ${PRODUCT_NAME} Server ..."
 
-    BACKEND_PORT=$BACKEND_PORT ./${BINARY_NAME} &
+    RESOURCES_ARGS=()
+    [[ -n "$RESOURCES_FILE" ]] && RESOURCES_ARGS=(-resources "$RESOURCES_FILE")
+    BACKEND_PORT=$BACKEND_PORT "./${BINARY_NAME}" "${RESOURCES_ARGS[@]}" &
     SERVER_PID=$!
 fi
 

--- a/tests/integration/declarativesinglefile/single_file_mode_test.go
+++ b/tests/integration/declarativesinglefile/single_file_mode_test.go
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+Single-File Declarative Resource Integration Tests
+
+This suite validates that Thunder correctly loads resources from a single
+multi-document YAML file passed via the -resources flag on startup.
+
+Setup:
+  - The running server is stopped.
+  - A temporary resources.yaml (with env var placeholders) is written to disk.
+  - The required env vars are injected into the test process before the server
+    is started, so the server inherits them via os.Environ().
+  - The server is started with -resources=<path>.
+  - The admin token is re-obtained against the fresh server.
+
+Teardown:
+  - The server is stopped and restarted without a resources file so subsequent
+    test packages see the original server state.
+  - The admin token is re-obtained.
+*/
+package declarativesinglefile
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// resourcesYAML is the fixture loaded by the server under test. It contains:
+//   - Two identity_provider documents (one references an env var)
+//   - One organization_unit document
+//
+// The {{ t(...) }} expression in the GitHub IDP description verifies that
+// non-Go-template expressions inside the file are preserved as-is and do not
+// cause parse errors during env-var substitution.
+const resourcesYAML = `# resource_type: organization_unit
+id: sf-decl-ou-1
+handle: sf-decl-ou-1
+name: Single File Declarative OU
+description: Organization unit loaded via single-file mode
+---
+# resource_type: identity_provider
+id: sf-decl-idp-1
+name: Single File GitHub IDP
+description: "{{ t(idp.github.description) }}"
+type: GITHUB
+properties:
+  - name: client_id
+    value: {{.SF_TEST_GITHUB_CLIENT_ID}}
+    is_secret: false
+  - name: client_secret
+    value: sf-test-github-secret
+    is_secret: true
+  - name: redirect_uri
+    value: https://localhost:8095/callback
+    is_secret: false
+---
+# resource_type: identity_provider
+id: sf-decl-idp-2
+name: Single File Google IDP
+description: IDP loaded via single-file mode
+type: GOOGLE
+properties:
+  - name: client_id
+    value: sf-test-google-client
+    is_secret: false
+  - name: client_secret
+    value: sf-test-google-secret
+    is_secret: true
+  - name: redirect_uri
+    value: https://localhost:8095/callback
+    is_secret: false
+`
+
+// envVars are set in the test process before the server starts so they are inherited
+// via os.Environ() when the server binary is exec'd.
+var envVars = map[string]string{
+	"SF_TEST_GITHUB_CLIENT_ID": "sf-github-client-id-substituted",
+}
+
+type SingleFileModeSuite struct {
+	suite.Suite
+	resourcesFile string
+	originalEnv   map[string]*string // nil pointer means the key was absent before the test
+}
+
+func TestSingleFileModeSuite(t *testing.T) {
+	suite.Run(t, new(SingleFileModeSuite))
+}
+
+func (s *SingleFileModeSuite) SetupSuite() {
+	// Snapshot original env values so TearDownSuite can restore them exactly.
+	s.originalEnv = make(map[string]*string, len(envVars))
+	for k := range envVars {
+		if v, exists := os.LookupEnv(k); exists {
+			val := v
+			s.originalEnv[k] = &val
+		} else {
+			s.originalEnv[k] = nil
+		}
+	}
+
+	// Write the fixture YAML to a temp file in the OS temp dir.
+	tmpDir, err := os.MkdirTemp("", "thunder-sf-test-*")
+	s.Require().NoError(err, "failed to create temp dir for resources fixture")
+
+	s.resourcesFile = filepath.Join(tmpDir, "resources.yaml")
+	s.Require().NoError(
+		os.WriteFile(s.resourcesFile, []byte(resourcesYAML), 0600),
+		"failed to write resources fixture",
+	)
+
+	// Inject env vars so the server process inherits them.
+	for k, v := range envVars {
+		s.Require().NoError(os.Setenv(k, v), "failed to set env var %s", k)
+	}
+
+	// Restart the server with the -resources flag.
+	s.Require().NoError(
+		testutils.RestartServerWithResourcesFile(s.resourcesFile),
+		"failed to restart server with resources file",
+	)
+
+	// Re-obtain admin token since the server process was replaced.
+	s.Require().NoError(
+		testutils.ObtainAdminAccessToken(),
+		"failed to obtain admin access token after server restart",
+	)
+}
+
+func (s *SingleFileModeSuite) TearDownSuite() {
+	// Restore env vars to their original values (unset those that were absent before the test).
+	for k, orig := range s.originalEnv {
+		if orig == nil {
+			_ = os.Unsetenv(k)
+		} else {
+			_ = os.Setenv(k, *orig)
+		}
+	}
+
+	// Restore the server to its original state (no resources file).
+	s.Require().NoError(
+		testutils.RestartServer(),
+		"failed to restore server after single-file mode test",
+	)
+
+	// Re-obtain admin token for subsequent test packages.
+	s.Require().NoError(
+		testutils.ObtainAdminAccessToken(),
+		"failed to re-obtain admin token after server restore",
+	)
+
+	// Best-effort: remove the temp resources file.
+	if s.resourcesFile != "" {
+		_ = os.RemoveAll(filepath.Dir(s.resourcesFile))
+	}
+}
+
+// TestOrganizationUnitLoadedFromFile verifies that the organization_unit declared in the
+// single resources.yaml is visible via the REST API.
+func (s *SingleFileModeSuite) TestOrganizationUnitLoadedFromFile() {
+	client := testutils.GetHTTPClient()
+	resp, err := client.Get(fmt.Sprintf("%s/organization-units/sf-decl-ou-1", testutils.TestServerURL))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.Equal(http.StatusOK, resp.StatusCode, "declarative OU from single-file should be visible")
+
+	var ou map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&ou))
+	s.Equal("sf-decl-ou-1", ou["id"], "OU id should match")
+	s.Equal("Single File Declarative OU", ou["name"], "OU name should match")
+}
+
+// TestIdentityProviderWithEnvVarLoadedFromFile verifies that the IDP whose client_id
+// uses {{.SF_TEST_GITHUB_CLIENT_ID}} had the env var substituted correctly.
+func (s *SingleFileModeSuite) TestIdentityProviderWithEnvVarLoadedFromFile() {
+	client := testutils.GetHTTPClient()
+	resp, err := client.Get(fmt.Sprintf("%s/identity-providers/sf-decl-idp-1", testutils.TestServerURL))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.Equal(http.StatusOK, resp.StatusCode, "GitHub IDP from single-file should be visible")
+
+	var idp map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&idp))
+	s.Equal("sf-decl-idp-1", idp["id"])
+	s.Equal("Single File GitHub IDP", idp["name"])
+	s.Equal("GITHUB", idp["type"])
+
+	// Verify the env var was substituted in the client_id property.
+	properties, ok := idp["properties"].([]interface{})
+	s.Require().True(ok, "IDP should have properties")
+
+	clientIDFound := false
+	for _, raw := range properties {
+		prop, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if prop["name"] == "client_id" {
+			clientIDFound = true
+			s.Equal(
+				envVars["SF_TEST_GITHUB_CLIENT_ID"],
+				prop["value"],
+				"client_id should contain the substituted env var value",
+			)
+		}
+	}
+	s.True(clientIDFound, "client_id property should be present in IDP")
+}
+
+// TestSecondIdentityProviderLoadedFromFile verifies that a second IDP in the same file
+// is also correctly loaded.
+func (s *SingleFileModeSuite) TestSecondIdentityProviderLoadedFromFile() {
+	client := testutils.GetHTTPClient()
+	resp, err := client.Get(fmt.Sprintf("%s/identity-providers/sf-decl-idp-2", testutils.TestServerURL))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.Equal(http.StatusOK, resp.StatusCode, "Google IDP from single-file should be visible")
+
+	var idp map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&idp))
+	s.Equal("sf-decl-idp-2", idp["id"])
+	s.Equal("GOOGLE", idp["type"])
+}
+
+// TestAllIDPsFromFileAppearInListing verifies that both declarative IDPs appear in the
+// collection endpoint.
+func (s *SingleFileModeSuite) TestAllIDPsFromFileAppearInListing() {
+	client := testutils.GetHTTPClient()
+	resp, err := client.Get(fmt.Sprintf("%s/identity-providers", testutils.TestServerURL))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.Equal(http.StatusOK, resp.StatusCode)
+
+	var idps []map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&idps))
+
+	idpIDs := make([]string, 0, len(idps))
+	for _, idp := range idps {
+		if id, ok := idp["id"].(string); ok {
+			idpIDs = append(idpIDs, id)
+		}
+	}
+
+	s.Contains(idpIDs, "sf-decl-idp-1", "listing should include sf-decl-idp-1")
+	s.Contains(idpIDs, "sf-decl-idp-2", "listing should include sf-decl-idp-2")
+}
+
+// TestDeclarativeResourcesAreImmutable verifies that a resource loaded from the single
+// file cannot be deleted (declarative resources are read-only).
+func (s *SingleFileModeSuite) TestDeclarativeResourcesAreImmutable() {
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest(http.MethodDelete,
+		fmt.Sprintf("%s/identity-providers/sf-decl-idp-1", testutils.TestServerURL), nil)
+	s.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.Equal(http.StatusBadRequest, resp.StatusCode,
+		"deleting a declarative IDP should return 400 Bad Request")
+}

--- a/tests/integration/testutils/test_utils.go
+++ b/tests/integration/testutils/test_utils.go
@@ -645,11 +645,17 @@ func removePidFile() {
 	os.Remove(path)
 }
 
-func StartServer(port string, zipFilePattern string) error {
+func StartServer(port string, _ string) error {
 	log.Println("Starting server...")
+	return startServerInternal(port)
+}
 
+// startServerInternal launches the server binary with the standard args plus any extra args supplied.
+// All callers share this implementation so logging and env-var setup stay consistent.
+func startServerInternal(port string, extraArgs ...string) error {
 	serverPath := filepath.Join(extractedProductHome, ServerBinary)
-	cmd := exec.Command(serverPath, "-serverHome="+extractedProductHome)
+	args := append([]string{"-serverHome=" + extractedProductHome}, extraArgs...)
+	cmd := exec.Command(serverPath, args...)
 
 	// logFile is non-nil only when subprocessMode opens a log file. The parent
 	// must close its copy after cmd.Start() so it does not leak the FD.
@@ -701,6 +707,27 @@ func StartServer(port string, zipFilePattern string) error {
 	serverCmd = cmd
 	serverPid = cmd.Process.Pid
 	writePidFile(serverPid)
+
+	return nil
+}
+
+// RestartServerWithResourcesFile stops the running server and restarts it with the -resources flag
+// pointing to the given single-file declarative resources YAML. Call RestartServer to return to
+// normal mode afterwards.
+func RestartServerWithResourcesFile(resourcesFilePath string) error {
+	ensureInitialized()
+	log.Printf("Restarting server with resources file: %s", resourcesFilePath)
+
+	StopServer()
+	time.Sleep(3 * time.Second)
+
+	if err := startServerInternal(serverPort, "-resources="+resourcesFilePath); err != nil {
+		return fmt.Errorf("failed to start server with resources file: %w", err)
+	}
+
+	if err := waitForServerReady(30 * time.Second); err != nil {
+		return fmt.Errorf("server did not become ready after restart: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Purpose

Removes the bash-level YAML document-splitting logic from `start.sh`/`start.ps1` and moves the responsibility into the server binary. Thunder now accepts a `-resources <file>` startup flag and reads all declarative resources from a single multi-document YAML file, eliminating the need for separate per-type directories.

### Approach

**Binary flag (`-resources`)** — `main.go` registers a `-resources` flag, resolves it to an absolute path, and stores it via `config.SetResourcesFile()`. `ServerRuntime` gains a `ResourcesFile` field (added via a separate setter to keep `InitializeServerRuntime`'s signature unchanged).

**Per-type loading** — `ResourceLoader.LoadResources()` checks `ResourcesFile`; when set, it calls the new `GetConfigsFromFile(filePath, resourceType)` instead of `GetConfigs(dir)`. Resource type is derived from the loader's directory name with `strings.TrimSuffix(dir, "s")`, which covers all 14 built-in types.

**Multi-document YAML parsing** — `splitYAMLDocuments` splits on `---` separators. `documentMatchesResourceType` matches a `# resource_type: <type>` comment header (supports `resource_type:`, `resource type:`, and `resourcetype:` prefixes, quoted values). Env-var substitution (`{{.Var}}`) is applied per-document so that non-Go-template expressions in other documents (e.g., `{{ t(signin:title) }}` in flow pages) do not trigger parse errors.

**Non-Go-template expression shielding** — `SubstituteEnvironmentVariables` in `configutil.go` now calls `shieldNonGoTemplateExpressions` before parsing, replacing unknown `{{ ... }}` patterns (UI expressions, bare identifiers like `{{appName}}`) with unique placeholders that are restored after template execution. This fixes the pre-existing `function "t" not defined` error when flow YAML and env-var-using YAML coexisted in the same file.

**Start scripts** — `start.sh` and `start.ps1` are simplified: the old document-splitting logic (~100 lines each) is replaced by a lean env-file loader, and `-resources "$RESOURCES_FILE"` is forwarded to the binary.

**Tests:**
- `manager_file_test.go` — unit tests for `splitYAMLDocuments`, `documentMatchesResourceType`, and `GetConfigsFromFile` (21 cases covering env-var substitution, non-Go-template pass-through, error paths, multi-type files)
- `tests/integration/declarativesinglefile/` — integration test suite that restarts the server with `-resources`, verifies resources are loaded (OU, two IDPs including env-var substitution), checks collection listing, and confirms declarative resources are immutable

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load declarative resources from a single YAML file via a new -resources startup flag
  * Pass resource file to server startup in both debug and normal modes
  * Load env files into process env (supports JSON-array expansion into indexed vars)

* **Bug Fixes**
  * Prevent accidental interpretation of non-template {{...}} literals during substitution
  * Required env-var placeholders now surface errors if missing

* **Tests**
  * Added unit and integration tests for single-file loading, type filtering, env-var substitution, immutability and startup handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->