### PR TITLE
Prefer direct dep bumps over overrides for qs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,7 +198,6 @@ overrides:
   js-yaml@>=4.0.0 <4.1.1: 4.1.1
   devalue: 5.8.1
   js-cookie: 3.0.7
-  qs: 6.15.2
   uuid: 11.1.1
 
 packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,9 +119,7 @@ overrides:
   devalue: 5.8.1
   # JUSTIFICATION: Transitive dep via js-beautify. Fixes CVE-2026-46625 (GHSA-qjx8-664m-686j) — prototype hijack in assign() allows cookie-attribute injection.
   js-cookie: 3.0.7
-  # JUSTIFICATION: Fixes GHSA-gg6b-4mfj-5v5c — ReDoS vulnerability in qs parsing.
-  qs: 6.15.2
-  # JUSTIFICATION: Transitive dep resolves to versions < 11.1.1 which contain a predictable RNG vulnerability.
+  # JUSTIFICATION: @langchain/langgraph requires uuid@^10.0.0 (not yet bumped upstream to v11). Fixes predictable RNG vulnerability in uuid < 11.1.1.
   uuid: 11.1.1
 
 packageExtensions:

--- a/samples/apps/react-vanilla-sample/server/package-lock.json
+++ b/samples/apps/react-vanilla-sample/server/package-lock.json
@@ -8,7 +8,7 @@
       "name": "server",
       "version": "0.40.0",
       "dependencies": {
-        "express": "4.22.1"
+        "express": "4.22.2"
       },
       "bin": {
         "server": "server.js"
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -322,7 +322,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -696,14 +696,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -722,7 +722,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",

--- a/samples/apps/react-vanilla-sample/server/package.json
+++ b/samples/apps/react-vanilla-sample/server/package.json
@@ -18,11 +18,10 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "4.22.1"
+    "express": "4.22.2"
   },
   "overrides": {
-    "path-to-regexp": "0.1.13",
-    "qs": "6.15.2"
+    "path-to-regexp": "0.1.13"
   },
   "devDependencies": {
     "pkg": "5.8.1"

--- a/samples/apps/wayfinder-sample/mcp/package.json
+++ b/samples/apps/wayfinder-sample/mcp/package.json
@@ -14,8 +14,5 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.19"
-  },
-  "overrides": {
-    "qs": "6.15.2"
   }
 }

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -52,7 +52,6 @@
     "dotenv": "17.2.3"
   },
   "overrides": {
-    "qs": "6.15.2",
     "flatted": ">=3.4.2",
     "path-to-regexp": ">=8.4.0"
   }


### PR DESCRIPTION
## Summary

Follows up on the previous security PRs by replacing the `qs: 6.15.2` overrides (added as a belt-and-suspenders fix) with proper direct dependency bumps. The overrides work but mask the root cause; bumping the packages that own the dep range is cleaner and more self-documenting.

### What changed

`qs` enters as a transitive dep through `express → body-parser → qs`. `express@4.22.2` updated its `body-parser` range to use `qs@~6.15.1`, which naturally resolves to `6.15.2` without any override.

| Location | Before | After |
|---|---|---|
| `pnpm-workspace.yaml` | `qs: 6.15.2` override | override removed — `webpack-dev-server` already uses `express@4.22.2` |
| `react-vanilla-sample/server` | `express@4.22.1` + qs override | `express@4.22.2`, no override — `~6.15.1` resolves to `6.15.2` |
| `tests/e2e` | `qs: "6.15.2"` override | override removed — `express@^5.2.1` resolves naturally |
| `wayfinder-sample/mcp` | `qs: "6.15.2"` override | override removed — MCP SDK → `express@^5.2.1` resolves naturally |

The `uuid: 11.1.1` override is **unchanged** — `@langchain/langgraph@1.3.2` (latest) still requires `uuid@^10.0.0`, so no direct dep bump is possible there.

## Test plan

- [ ] CI passes
- [ ] All lock files still resolve `qs` to `6.15.2` (verified locally)
- [ ] No `qs` overrides remain in any `package.json` or `pnpm-workspace.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Express dependency to the latest patch version in the sample server
  * Refined dependency override configurations across workspace packages to address security vulnerabilities and resolve upstream constraint compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->