### PR TITLE
Add GetTLSMaterial impl in RuntimeCryptoProvider

### DIFF
--- a/backend/.mockery.public.yml
+++ b/backend/.mockery.public.yml
@@ -458,7 +458,7 @@ packages:
       pkgname: hashmock
       filename: "{{.InterfaceName}}_mock.go"
 
-  github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pkiservice:
+  github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki:
     config:
       all: true
       dir: tests/mocks/crypto/pki/pkimock

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -39,7 +39,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/cors"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
-	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
 	"github.com/thunder-id/thunderid/internal/system/security"
@@ -84,7 +84,7 @@ func main() {
 	}
 
 	// Register the services.
-	jwtService := registerServices(mux, cacheManager)
+	jwtService, runtimeCryptoSvc := registerServices(mux, cacheManager)
 
 	// Register static file handlers for frontend applications.
 	registerStaticFileHandlers(logger, mux, serverHome)
@@ -100,7 +100,7 @@ func main() {
 		logger.Info("TLS is not enabled, starting server without TLS")
 		ln = createListener(logger, server)
 	} else {
-		tlsConfig := loadCertConfig(logger, cfg, serverHome)
+		tlsConfig := loadCertConfig(logger, runtimeCryptoSvc)
 		ln = createTLSListener(logger, server, tlsConfig)
 	}
 
@@ -164,18 +164,17 @@ func initThunderConfigurations(logger *log.Logger, serverHome string) *config.Co
 	return cfg
 }
 
-// loadCertConfig loads the certificate configuration and extracts the Key ID (kid).
-func loadCertConfig(logger *log.Logger, cfg *config.Config, serverHome string) *tls.Config {
-	// Build full paths for certificate and key files
-	certFilePath := path.Join(serverHome, cfg.TLS.CertFile)
-	keyFilePath := path.Join(serverHome, cfg.TLS.KeyFile)
-
-	// Load TLS configuration
-	tlsConfig, err := pki.LoadTLSConfig(cfg, certFilePath, keyFilePath)
+// loadCertConfig loads the TLS material via the runtime crypto provider.
+func loadCertConfig(logger *log.Logger, runtimeSvc kmprovider.RuntimeCryptoProvider) *tls.Config {
+	mat, err := runtimeSvc.GetTLSMaterial(context.Background())
 	if err != nil {
-		logger.Fatal("Failed to load TLS configuration", log.Error(err))
+		logger.Fatal("Failed to load TLS material", log.Error(err))
 	}
-	return tlsConfig
+	// #nosec G402 -- MinVersion is set to TLS 1.2 or higher by GetTLSMaterial
+	return &tls.Config{
+		Certificates: []tls.Certificate{mat.Certificate},
+		MinVersion:   mat.MinVersion,
+	}
 }
 
 // createHTTPServer creates and configures an HTTP server with common settings.

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -89,7 +89,8 @@ import (
 var observabilitySvc observability.ObservabilityServiceInterface
 
 // registerServices registers all the services with the provided HTTP multiplexer.
-func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterface) jwt.JWTServiceInterface {
+func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterface) (
+	jwt.JWTServiceInterface, kmprovider.RuntimeCryptoProvider) {
 	logger := log.GetLogger()
 
 	// Load the server's private key for signing JWTs.
@@ -368,7 +369,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	healthSvc := healthcheckservice.Initialize(dbprovider.GetDBProvider(), dbprovider.GetRedisProvider())
 	services.NewHealthCheckService(mux, healthSvc)
 
-	return jwtService
+	return jwtService, runtimeCryptoSvc
 }
 
 // unregisterServices unregisters all services that require cleanup during shutdown.

--- a/backend/internal/system/kmprovider/common/interface.go
+++ b/backend/internal/system/kmprovider/common/interface.go
@@ -43,7 +43,7 @@ type RuntimeCryptoProvider interface {
 	Decrypt(ctx context.Context, keyRef *KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, error)
 	Sign(ctx context.Context, keyRef KeyRef, algorithm cryptolib.SignAlgorithm, content []byte) ([]byte, error)
 	GetPublicKeys(ctx context.Context, filter PublicKeyFilter) ([]PublicKeyInfo, error)
-	GetTLSMaterial(ctx context.Context, keyRef *KeyRef) (*TLSMaterial, error)
+	GetTLSMaterial(ctx context.Context) (*TLSMaterial, error)
 }
 
 // KeyRef identifies a cryptographic key by its ID.
@@ -69,4 +69,5 @@ type PublicKeyInfo struct {
 // TLSMaterial holds the TLS certificate material for a key reference.
 type TLSMaterial struct {
 	Certificate tls.Certificate
+	MinVersion  uint16
 }

--- a/backend/internal/system/kmprovider/defaultkm/pki/service.go
+++ b/backend/internal/system/kmprovider/defaultkm/pki/service.go
@@ -46,6 +46,7 @@ type PKIServiceInterface interface {
 	GetX509Certificate(id string) (*x509.Certificate, *serviceerror.ServiceError)
 	GetAllX509Certificates() (map[string]*x509.Certificate, *serviceerror.ServiceError)
 	GetSupportedSigningAlgorithms() []string
+	GetTLSConfig() (*tls.Config, error)
 }
 
 // pkiService stores loaded certificates indexed by their ID.
@@ -177,6 +178,14 @@ func (s *pkiService) GetSupportedSigningAlgorithms() []string {
 		}
 	}
 	return result
+}
+
+// GetTLSConfig loads and returns the TLS configuration from the server's TLS cert and key files.
+func (s *pkiService) GetTLSConfig() (*tls.Config, error) {
+	serverRuntime := config.GetServerRuntime()
+	certFilePath := path.Join(serverRuntime.ServerHome, serverRuntime.Config.TLS.CertFile)
+	keyFilePath := path.Join(serverRuntime.ServerHome, serverRuntime.Config.TLS.KeyFile)
+	return LoadTLSConfig(&serverRuntime.Config, certFilePath, keyFilePath)
 }
 
 // pkiAlgorithmToJWSAlgorithms returns the JWS algorithm strings supported for the given PKI algorithm.

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
@@ -192,9 +192,19 @@ func (s *runtimeCryptoService) GetPublicKeys(
 }
 
 func (s *runtimeCryptoService) GetTLSMaterial(
-	_ context.Context, _ *kmprovider.KeyRef,
+	_ context.Context,
 ) (*kmprovider.TLSMaterial, error) {
-	return nil, errors.New("not implemented")
+	if s.pkiService == nil {
+		return nil, errors.New("PKI service not initialized")
+	}
+	tlsCfg, err := s.pkiService.GetTLSConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load TLS config: %w", err)
+	}
+	return &kmprovider.TLSMaterial{
+		Certificate: tlsCfg.Certificates[0],
+		MinVersion:  tlsCfg.MinVersion,
+	}, nil
 }
 
 func (s *runtimeCryptoService) getRSAPublicKey(keyRef kmprovider.KeyRef) (*rsa.PublicKey, error) {

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider_test.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider_test.go
@@ -25,7 +25,9 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -637,4 +639,46 @@ func TestGetPublicKeys_FilterByAlgorithm(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
 	assert.Equal(t, "ec-key", keys[0].KeyID)
+}
+
+// GetTLSMaterial
+
+func TestGetTLSMaterial_NilPKIService(t *testing.T) {
+	svc := &runtimeCryptoService{pkiService: nil}
+	material, err := svc.GetTLSMaterial(context.Background())
+	assert.Nil(t, material)
+	assert.EqualError(t, err, "PKI service not initialized")
+}
+
+func TestGetTLSMaterial_GetTLSConfigFailure(t *testing.T) {
+	pkiMock := pkimock.NewPKIServiceInterfaceMock(t)
+	pkiMock.EXPECT().GetTLSConfig().Return(nil, errors.New("cert file not found"))
+
+	svc := &runtimeCryptoService{pkiService: pkiMock}
+	material, err := svc.GetTLSMaterial(context.Background())
+	assert.Nil(t, material)
+	assert.ErrorContains(t, err, "cert file not found")
+}
+
+func TestGetTLSMaterial_Success(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tlsCert := tls.Certificate{
+		PrivateKey: rsaKey,
+	}
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	pkiMock := pkimock.NewPKIServiceInterfaceMock(t)
+	pkiMock.EXPECT().GetTLSConfig().Return(tlsCfg, nil)
+
+	svc := &runtimeCryptoService{pkiService: pkiMock}
+	material, err := svc.GetTLSMaterial(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, material)
+	assert.Equal(t, tlsCert, material.Certificate)
+	assert.Equal(t, uint16(tls.VersionTLS12), material.MinVersion)
 }

--- a/backend/internal/system/kmprovider/init.go
+++ b/backend/internal/system/kmprovider/init.go
@@ -25,6 +25,9 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
 )
 
+// RuntimeCryptoProvider is a type alias for convenience.
+type RuntimeCryptoProvider = common.RuntimeCryptoProvider
+
 // Initialize initializes and returns both RuntimeCryptoProvider and ConfigCryptoProvider.
 // The pkiService is injected as a dependency.
 // Currently hardcoded to use the default KM provider, but structured to support

--- a/backend/tests/mocks/crypto/cryptomock/RuntimeCryptoProvider_mock.go
+++ b/backend/tests/mocks/crypto/cryptomock/RuntimeCryptoProvider_mock.go
@@ -9,7 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
-	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 )
 
 // NewRuntimeCryptoProviderMock creates a new instance of RuntimeCryptoProviderMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -40,7 +40,7 @@ func (_m *RuntimeCryptoProviderMock) EXPECT() *RuntimeCryptoProviderMock_Expecte
 }
 
 // Decrypt provides a mock function for the type RuntimeCryptoProviderMock
-func (_mock *RuntimeCryptoProviderMock) Decrypt(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, error) {
+func (_mock *RuntimeCryptoProviderMock) Decrypt(ctx context.Context, keyRef *common.KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, error) {
 	ret := _mock.Called(ctx, keyRef, params, content)
 
 	if len(ret) == 0 {
@@ -49,17 +49,17 @@ func (_mock *RuntimeCryptoProviderMock) Decrypt(ctx context.Context, keyRef *kmp
 
 	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef, cryptolib.AlgorithmParams, []byte) ([]byte, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *common.KeyRef, cryptolib.AlgorithmParams, []byte) ([]byte, error)); ok {
 		return returnFunc(ctx, keyRef, params, content)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef, cryptolib.AlgorithmParams, []byte) []byte); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *common.KeyRef, cryptolib.AlgorithmParams, []byte) []byte); ok {
 		r0 = returnFunc(ctx, keyRef, params, content)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *kmprovider.KeyRef, cryptolib.AlgorithmParams, []byte) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *common.KeyRef, cryptolib.AlgorithmParams, []byte) error); ok {
 		r1 = returnFunc(ctx, keyRef, params, content)
 	} else {
 		r1 = ret.Error(1)
@@ -74,22 +74,22 @@ type RuntimeCryptoProviderMock_Decrypt_Call struct {
 
 // Decrypt is a helper method to define mock.On call
 //   - ctx context.Context
-//   - keyRef *kmprovider.KeyRef
+//   - keyRef *common.KeyRef
 //   - params cryptolib.AlgorithmParams
 //   - content []byte
 func (_e *RuntimeCryptoProviderMock_Expecter) Decrypt(ctx interface{}, keyRef interface{}, params interface{}, content interface{}) *RuntimeCryptoProviderMock_Decrypt_Call {
 	return &RuntimeCryptoProviderMock_Decrypt_Call{Call: _e.mock.On("Decrypt", ctx, keyRef, params, content)}
 }
 
-func (_c *RuntimeCryptoProviderMock_Decrypt_Call) Run(run func(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolib.AlgorithmParams, content []byte)) *RuntimeCryptoProviderMock_Decrypt_Call {
+func (_c *RuntimeCryptoProviderMock_Decrypt_Call) Run(run func(ctx context.Context, keyRef *common.KeyRef, params cryptolib.AlgorithmParams, content []byte)) *RuntimeCryptoProviderMock_Decrypt_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *kmprovider.KeyRef
+		var arg1 *common.KeyRef
 		if args[1] != nil {
-			arg1 = args[1].(*kmprovider.KeyRef)
+			arg1 = args[1].(*common.KeyRef)
 		}
 		var arg2 cryptolib.AlgorithmParams
 		if args[2] != nil {
@@ -114,13 +114,13 @@ func (_c *RuntimeCryptoProviderMock_Decrypt_Call) Return(bytes []byte, err error
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_Decrypt_Call) RunAndReturn(run func(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, error)) *RuntimeCryptoProviderMock_Decrypt_Call {
+func (_c *RuntimeCryptoProviderMock_Decrypt_Call) RunAndReturn(run func(ctx context.Context, keyRef *common.KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, error)) *RuntimeCryptoProviderMock_Decrypt_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Encrypt provides a mock function for the type RuntimeCryptoProviderMock
-func (_mock *RuntimeCryptoProviderMock) Encrypt(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, *cryptolib.CryptoDetails, error) {
+func (_mock *RuntimeCryptoProviderMock) Encrypt(ctx context.Context, keyRef *common.KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, *cryptolib.CryptoDetails, error) {
 	ret := _mock.Called(ctx, keyRef, params, content)
 
 	if len(ret) == 0 {
@@ -130,24 +130,24 @@ func (_mock *RuntimeCryptoProviderMock) Encrypt(ctx context.Context, keyRef *kmp
 	var r0 []byte
 	var r1 *cryptolib.CryptoDetails
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef, cryptolib.AlgorithmParams, []byte) ([]byte, *cryptolib.CryptoDetails, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *common.KeyRef, cryptolib.AlgorithmParams, []byte) ([]byte, *cryptolib.CryptoDetails, error)); ok {
 		return returnFunc(ctx, keyRef, params, content)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef, cryptolib.AlgorithmParams, []byte) []byte); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *common.KeyRef, cryptolib.AlgorithmParams, []byte) []byte); ok {
 		r0 = returnFunc(ctx, keyRef, params, content)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *kmprovider.KeyRef, cryptolib.AlgorithmParams, []byte) *cryptolib.CryptoDetails); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *common.KeyRef, cryptolib.AlgorithmParams, []byte) *cryptolib.CryptoDetails); ok {
 		r1 = returnFunc(ctx, keyRef, params, content)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*cryptolib.CryptoDetails)
 		}
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, *kmprovider.KeyRef, cryptolib.AlgorithmParams, []byte) error); ok {
+	if returnFunc, ok := ret.Get(2).(func(context.Context, *common.KeyRef, cryptolib.AlgorithmParams, []byte) error); ok {
 		r2 = returnFunc(ctx, keyRef, params, content)
 	} else {
 		r2 = ret.Error(2)
@@ -162,22 +162,22 @@ type RuntimeCryptoProviderMock_Encrypt_Call struct {
 
 // Encrypt is a helper method to define mock.On call
 //   - ctx context.Context
-//   - keyRef *kmprovider.KeyRef
+//   - keyRef *common.KeyRef
 //   - params cryptolib.AlgorithmParams
 //   - content []byte
 func (_e *RuntimeCryptoProviderMock_Expecter) Encrypt(ctx interface{}, keyRef interface{}, params interface{}, content interface{}) *RuntimeCryptoProviderMock_Encrypt_Call {
 	return &RuntimeCryptoProviderMock_Encrypt_Call{Call: _e.mock.On("Encrypt", ctx, keyRef, params, content)}
 }
 
-func (_c *RuntimeCryptoProviderMock_Encrypt_Call) Run(run func(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolib.AlgorithmParams, content []byte)) *RuntimeCryptoProviderMock_Encrypt_Call {
+func (_c *RuntimeCryptoProviderMock_Encrypt_Call) Run(run func(ctx context.Context, keyRef *common.KeyRef, params cryptolib.AlgorithmParams, content []byte)) *RuntimeCryptoProviderMock_Encrypt_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *kmprovider.KeyRef
+		var arg1 *common.KeyRef
 		if args[1] != nil {
-			arg1 = args[1].(*kmprovider.KeyRef)
+			arg1 = args[1].(*common.KeyRef)
 		}
 		var arg2 cryptolib.AlgorithmParams
 		if args[2] != nil {
@@ -202,32 +202,32 @@ func (_c *RuntimeCryptoProviderMock_Encrypt_Call) Return(bytes []byte, cryptoDet
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_Encrypt_Call) RunAndReturn(run func(ctx context.Context, keyRef *kmprovider.KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, *cryptolib.CryptoDetails, error)) *RuntimeCryptoProviderMock_Encrypt_Call {
+func (_c *RuntimeCryptoProviderMock_Encrypt_Call) RunAndReturn(run func(ctx context.Context, keyRef *common.KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, *cryptolib.CryptoDetails, error)) *RuntimeCryptoProviderMock_Encrypt_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetPublicKeys provides a mock function for the type RuntimeCryptoProviderMock
-func (_mock *RuntimeCryptoProviderMock) GetPublicKeys(ctx context.Context, filter kmprovider.PublicKeyFilter) ([]kmprovider.PublicKeyInfo, error) {
+func (_mock *RuntimeCryptoProviderMock) GetPublicKeys(ctx context.Context, filter common.PublicKeyFilter) ([]common.PublicKeyInfo, error) {
 	ret := _mock.Called(ctx, filter)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPublicKeys")
 	}
 
-	var r0 []kmprovider.PublicKeyInfo
+	var r0 []common.PublicKeyInfo
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, kmprovider.PublicKeyFilter) ([]kmprovider.PublicKeyInfo, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.PublicKeyFilter) ([]common.PublicKeyInfo, error)); ok {
 		return returnFunc(ctx, filter)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, kmprovider.PublicKeyFilter) []kmprovider.PublicKeyInfo); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.PublicKeyFilter) []common.PublicKeyInfo); ok {
 		r0 = returnFunc(ctx, filter)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]kmprovider.PublicKeyInfo)
+			r0 = ret.Get(0).([]common.PublicKeyInfo)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, kmprovider.PublicKeyFilter) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.PublicKeyFilter) error); ok {
 		r1 = returnFunc(ctx, filter)
 	} else {
 		r1 = ret.Error(1)
@@ -242,20 +242,20 @@ type RuntimeCryptoProviderMock_GetPublicKeys_Call struct {
 
 // GetPublicKeys is a helper method to define mock.On call
 //   - ctx context.Context
-//   - filter kmprovider.PublicKeyFilter
+//   - filter common.PublicKeyFilter
 func (_e *RuntimeCryptoProviderMock_Expecter) GetPublicKeys(ctx interface{}, filter interface{}) *RuntimeCryptoProviderMock_GetPublicKeys_Call {
 	return &RuntimeCryptoProviderMock_GetPublicKeys_Call{Call: _e.mock.On("GetPublicKeys", ctx, filter)}
 }
 
-func (_c *RuntimeCryptoProviderMock_GetPublicKeys_Call) Run(run func(ctx context.Context, filter kmprovider.PublicKeyFilter)) *RuntimeCryptoProviderMock_GetPublicKeys_Call {
+func (_c *RuntimeCryptoProviderMock_GetPublicKeys_Call) Run(run func(ctx context.Context, filter common.PublicKeyFilter)) *RuntimeCryptoProviderMock_GetPublicKeys_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 kmprovider.PublicKeyFilter
+		var arg1 common.PublicKeyFilter
 		if args[1] != nil {
-			arg1 = args[1].(kmprovider.PublicKeyFilter)
+			arg1 = args[1].(common.PublicKeyFilter)
 		}
 		run(
 			arg0,
@@ -265,38 +265,38 @@ func (_c *RuntimeCryptoProviderMock_GetPublicKeys_Call) Run(run func(ctx context
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_GetPublicKeys_Call) Return(publicKeyInfos []kmprovider.PublicKeyInfo, err error) *RuntimeCryptoProviderMock_GetPublicKeys_Call {
+func (_c *RuntimeCryptoProviderMock_GetPublicKeys_Call) Return(publicKeyInfos []common.PublicKeyInfo, err error) *RuntimeCryptoProviderMock_GetPublicKeys_Call {
 	_c.Call.Return(publicKeyInfos, err)
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_GetPublicKeys_Call) RunAndReturn(run func(ctx context.Context, filter kmprovider.PublicKeyFilter) ([]kmprovider.PublicKeyInfo, error)) *RuntimeCryptoProviderMock_GetPublicKeys_Call {
+func (_c *RuntimeCryptoProviderMock_GetPublicKeys_Call) RunAndReturn(run func(ctx context.Context, filter common.PublicKeyFilter) ([]common.PublicKeyInfo, error)) *RuntimeCryptoProviderMock_GetPublicKeys_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetTLSMaterial provides a mock function for the type RuntimeCryptoProviderMock
-func (_mock *RuntimeCryptoProviderMock) GetTLSMaterial(ctx context.Context, keyRef *kmprovider.KeyRef) (*kmprovider.TLSMaterial, error) {
-	ret := _mock.Called(ctx, keyRef)
+func (_mock *RuntimeCryptoProviderMock) GetTLSMaterial(ctx context.Context) (*common.TLSMaterial, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTLSMaterial")
 	}
 
-	var r0 *kmprovider.TLSMaterial
+	var r0 *common.TLSMaterial
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef) (*kmprovider.TLSMaterial, error)); ok {
-		return returnFunc(ctx, keyRef)
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (*common.TLSMaterial, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *kmprovider.KeyRef) *kmprovider.TLSMaterial); ok {
-		r0 = returnFunc(ctx, keyRef)
+	if returnFunc, ok := ret.Get(0).(func(context.Context) *common.TLSMaterial); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*kmprovider.TLSMaterial)
+			r0 = ret.Get(0).(*common.TLSMaterial)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *kmprovider.KeyRef) error); ok {
-		r1 = returnFunc(ctx, keyRef)
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -310,41 +310,35 @@ type RuntimeCryptoProviderMock_GetTLSMaterial_Call struct {
 
 // GetTLSMaterial is a helper method to define mock.On call
 //   - ctx context.Context
-//   - keyRef *kmprovider.KeyRef
-func (_e *RuntimeCryptoProviderMock_Expecter) GetTLSMaterial(ctx interface{}, keyRef interface{}) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
-	return &RuntimeCryptoProviderMock_GetTLSMaterial_Call{Call: _e.mock.On("GetTLSMaterial", ctx, keyRef)}
+func (_e *RuntimeCryptoProviderMock_Expecter) GetTLSMaterial(ctx interface{}) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
+	return &RuntimeCryptoProviderMock_GetTLSMaterial_Call{Call: _e.mock.On("GetTLSMaterial", ctx)}
 }
 
-func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) Run(run func(ctx context.Context, keyRef *kmprovider.KeyRef)) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
+func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) Run(run func(ctx context.Context)) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *kmprovider.KeyRef
-		if args[1] != nil {
-			arg1 = args[1].(*kmprovider.KeyRef)
-		}
 		run(
 			arg0,
-			arg1,
 		)
 	})
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) Return(tLSMaterial *kmprovider.TLSMaterial, err error) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
+func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) Return(tLSMaterial *common.TLSMaterial, err error) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
 	_c.Call.Return(tLSMaterial, err)
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) RunAndReturn(run func(ctx context.Context, keyRef *kmprovider.KeyRef) (*kmprovider.TLSMaterial, error)) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
+func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) RunAndReturn(run func(ctx context.Context) (*common.TLSMaterial, error)) *RuntimeCryptoProviderMock_GetTLSMaterial_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Sign provides a mock function for the type RuntimeCryptoProviderMock
-func (_mock *RuntimeCryptoProviderMock) Sign(ctx context.Context, keyRef kmprovider.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte) ([]byte, error) {
+func (_mock *RuntimeCryptoProviderMock) Sign(ctx context.Context, keyRef common.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte) ([]byte, error) {
 	ret := _mock.Called(ctx, keyRef, algorithm, content)
 
 	if len(ret) == 0 {
@@ -353,17 +347,17 @@ func (_mock *RuntimeCryptoProviderMock) Sign(ctx context.Context, keyRef kmprovi
 
 	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, kmprovider.KeyRef, cryptolib.SignAlgorithm, []byte) ([]byte, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.KeyRef, cryptolib.SignAlgorithm, []byte) ([]byte, error)); ok {
 		return returnFunc(ctx, keyRef, algorithm, content)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, kmprovider.KeyRef, cryptolib.SignAlgorithm, []byte) []byte); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.KeyRef, cryptolib.SignAlgorithm, []byte) []byte); ok {
 		r0 = returnFunc(ctx, keyRef, algorithm, content)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, kmprovider.KeyRef, cryptolib.SignAlgorithm, []byte) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.KeyRef, cryptolib.SignAlgorithm, []byte) error); ok {
 		r1 = returnFunc(ctx, keyRef, algorithm, content)
 	} else {
 		r1 = ret.Error(1)
@@ -378,22 +372,22 @@ type RuntimeCryptoProviderMock_Sign_Call struct {
 
 // Sign is a helper method to define mock.On call
 //   - ctx context.Context
-//   - keyRef kmprovider.KeyRef
+//   - keyRef common.KeyRef
 //   - algorithm cryptolib.SignAlgorithm
 //   - content []byte
 func (_e *RuntimeCryptoProviderMock_Expecter) Sign(ctx interface{}, keyRef interface{}, algorithm interface{}, content interface{}) *RuntimeCryptoProviderMock_Sign_Call {
 	return &RuntimeCryptoProviderMock_Sign_Call{Call: _e.mock.On("Sign", ctx, keyRef, algorithm, content)}
 }
 
-func (_c *RuntimeCryptoProviderMock_Sign_Call) Run(run func(ctx context.Context, keyRef kmprovider.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte)) *RuntimeCryptoProviderMock_Sign_Call {
+func (_c *RuntimeCryptoProviderMock_Sign_Call) Run(run func(ctx context.Context, keyRef common.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte)) *RuntimeCryptoProviderMock_Sign_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 kmprovider.KeyRef
+		var arg1 common.KeyRef
 		if args[1] != nil {
-			arg1 = args[1].(kmprovider.KeyRef)
+			arg1 = args[1].(common.KeyRef)
 		}
 		var arg2 cryptolib.SignAlgorithm
 		if args[2] != nil {
@@ -418,7 +412,7 @@ func (_c *RuntimeCryptoProviderMock_Sign_Call) Return(bytes []byte, err error) *
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_Sign_Call) RunAndReturn(run func(ctx context.Context, keyRef kmprovider.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte) ([]byte, error)) *RuntimeCryptoProviderMock_Sign_Call {
+func (_c *RuntimeCryptoProviderMock_Sign_Call) RunAndReturn(run func(ctx context.Context, keyRef common.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte) ([]byte, error)) *RuntimeCryptoProviderMock_Sign_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/crypto/pki/pkimock/PKIServiceInterface_mock.go
+++ b/backend/tests/mocks/crypto/pki/pkimock/PKIServiceInterface_mock.go
@@ -6,6 +6,7 @@ package pkimock
 
 import (
 	"crypto"
+	"crypto/tls"
 	"crypto/x509"
 
 	mock "github.com/stretchr/testify/mock"
@@ -253,6 +254,61 @@ func (_c *PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call) Return(str
 }
 
 func (_c *PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call) RunAndReturn(run func() []string) *PKIServiceInterfaceMock_GetSupportedSigningAlgorithms_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTLSConfig provides a mock function for the type PKIServiceInterfaceMock
+func (_mock *PKIServiceInterfaceMock) GetTLSConfig() (*tls.Config, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTLSConfig")
+	}
+
+	var r0 *tls.Config
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (*tls.Config, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() *tls.Config); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*tls.Config)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// PKIServiceInterfaceMock_GetTLSConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTLSConfig'
+type PKIServiceInterfaceMock_GetTLSConfig_Call struct {
+	*mock.Call
+}
+
+// GetTLSConfig is a helper method to define mock.On call
+func (_e *PKIServiceInterfaceMock_Expecter) GetTLSConfig() *PKIServiceInterfaceMock_GetTLSConfig_Call {
+	return &PKIServiceInterfaceMock_GetTLSConfig_Call{Call: _e.mock.On("GetTLSConfig")}
+}
+
+func (_c *PKIServiceInterfaceMock_GetTLSConfig_Call) Run(run func()) *PKIServiceInterfaceMock_GetTLSConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *PKIServiceInterfaceMock_GetTLSConfig_Call) Return(config *tls.Config, err error) *PKIServiceInterfaceMock_GetTLSConfig_Call {
+	_c.Call.Return(config, err)
+	return _c
+}
+
+func (_c *PKIServiceInterfaceMock_GetTLSConfig_Call) RunAndReturn(run func() (*tls.Config, error)) *PKIServiceInterfaceMock_GetTLSConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose

Implements `GetTLSMaterial` in the default key manager.

The implementation wires through the existing `LoadTLSConfig` utility and exposes the result via the `RuntimeCryptoProvider` interface so that main.go no longer calls PKI internals directly.

### Approach

- Extended `TLSMaterial` with a `MinVersion uint16` field so callers receive a ready-to-use TLS config without needing to know the minimum version policy.
- Dropped the unused `*KeyRef` parameter from `GetTLSMaterial` — TLS cert identity is not key-ref-based; it comes from server config paths.
- Added `GetTLSConfig() (*tls.Config, error)` to `PKIServiceInterface`, implemented by delegating to `LoadTLSConfig` with the server's `cfg.TLS` paths.
- `runtimeCryptoService.GetTLSMaterial` now calls `pkiService.GetTLSConfig()` and maps the result to `TLSMaterial`.
- `loadCertConfig` in main.go updated to accept a `RuntimeCryptoProvider` instead of calling PKI internals directly; `registerServices` now returns the provider alongside `JWTServiceInterface`.
- Regenerated mocks (`PKIServiceInterfaceMock`, `RuntimeCryptoProviderMock`) to reflect interface changes.

### Related Issues
- Fixes #2350 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * TLS/HTTPS certificate loading now uses the runtime crypto provider instead of disk-based loading
  * Streamlined certificate retrieval API with fewer parameters
  * Support for configurable minimum TLS version included
  * Cleaner separation in the crypto provider architecture

* **Tests**
  * Added unit tests validating TLS material retrieval behavior and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->