### PR TITLE
Add read-only indicators and access guards for declarative resources

### DIFF
--- a/frontend/apps/console/src/features/agents/components/AgentsList.tsx
+++ b/frontend/apps/console/src/features/agents/components/AgentsList.tsx
@@ -19,7 +19,7 @@
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
 import {Box, IconButton, Tooltip, Typography, ListingTable, DataGrid} from '@wso2/oxygen-ui';
-import {Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useCallback, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -66,27 +66,29 @@ export default function AgentsList(): JSX.Element {
         flex: 1,
         minWidth: 200,
         renderCell: (params: DataGrid.GridRenderCellParams<BasicAgent>): JSX.Element => (
-          <ListingTable.CellIcon
-            sx={{width: '100%'}}
-            icon={
-              <Box
-                sx={{
-                  width: 30,
-                  height: 30,
-                  borderRadius: '50%',
-                  bgcolor: 'primary.light',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontSize: '1rem',
-                }}
-              >
-                🤖
-              </Box>
-            }
-            primary={params.row.name}
-            secondary={params.row.description}
-          />
+          <Box sx={{display: 'flex', alignItems: 'center', gap: 1, width: '100%', overflow: 'hidden'}}>
+            <ListingTable.CellIcon
+              sx={{flex: 1, minWidth: 0}}
+              icon={
+                <Box
+                  sx={{
+                    width: 30,
+                    height: 30,
+                    borderRadius: '50%',
+                    bgcolor: 'primary.light',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: '1rem',
+                  }}
+                >
+                  🤖
+                </Box>
+              }
+              primary={params.row.name}
+              secondary={params.row.description}
+            />
+          </Box>
         ),
       },
       {
@@ -122,29 +124,39 @@ export default function AgentsList(): JSX.Element {
         hideable: false,
         renderCell: (params: DataGrid.GridRenderCellParams<BasicAgent>): JSX.Element => (
           <ListingTable.RowActions>
-            <Tooltip title={t('common:actions.edit')}>
-              <IconButton
-                size="small"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleEditClick(params.row.id);
-                }}
-              >
-                <Pencil size={16} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('common:actions.delete')}>
-              <IconButton
-                size="small"
-                color="error"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleDeleteClick(params.row.id);
-                }}
-              >
-                <Trash2 size={16} />
-              </IconButton>
-            </Tooltip>
+            {params.row.isReadOnly ? (
+              <Tooltip title={t('common:status.readOnly', 'Read Only')}>
+                <IconButton size="small" disableRipple sx={{cursor: 'default'}}>
+                  <Eye size={16} />
+                </IconButton>
+              </Tooltip>
+            ) : (
+              <>
+                <Tooltip title={t('common:actions.edit')}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleEditClick(params.row.id);
+                    }}
+                  >
+                    <Pencil size={16} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title={t('common:actions.delete')}>
+                  <IconButton
+                    size="small"
+                    color="error"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteClick(params.row.id);
+                    }}
+                  >
+                    <Trash2 size={16} />
+                  </IconButton>
+                </Tooltip>
+              </>
+            )}
           </ListingTable.RowActions>
         ),
       },

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/CertificateSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/CertificateSection.tsx
@@ -26,9 +26,15 @@ interface CertificateSectionProps {
   agent: Agent;
   editedAgent: Partial<Agent>;
   onFieldChange: (field: keyof Agent, value: unknown) => void;
+  disabled?: boolean;
 }
 
-export default function CertificateSection({agent, editedAgent, onFieldChange}: CertificateSectionProps) {
+export default function CertificateSection({
+  agent,
+  editedAgent,
+  onFieldChange,
+  disabled = false,
+}: CertificateSectionProps) {
   const {t} = useTranslation();
 
   const certificateTypeOptions = [
@@ -60,6 +66,7 @@ export default function CertificateSection({agent, editedAgent, onFieldChange}: 
             isOptionEqualToValue={(option, value) => option.value === value.value}
             renderInput={(params) => <TextField {...params} fullWidth />}
             disableClearable
+            disabled={disabled}
           />
         </FormControl>
 
@@ -74,6 +81,7 @@ export default function CertificateSection({agent, editedAgent, onFieldChange}: 
                 agent.certificate ?? {type: CertificateTypes.NONE, value: ''};
               onFieldChange('certificate', {...currentCert, value: e.target.value});
             }}
+            disabled={disabled}
             placeholder={
               currentCertType === CertificateTypes.JWKS_URI
                 ? t('applications:edit.advanced.certificate.placeholder.jwksUri')

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/EditAdvancedSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/EditAdvancedSettings.tsx
@@ -51,13 +51,23 @@ export default function EditAdvancedSettings({
 
   return (
     <Stack spacing={3}>
-      <OAuth2ConfigSection oauth2Config={oauth2Config} onOAuth2ConfigChange={handleOAuth2ConfigChange} />
+      <OAuth2ConfigSection
+        oauth2Config={oauth2Config}
+        onOAuth2ConfigChange={handleOAuth2ConfigChange}
+        disabled={agent.isReadOnly}
+      />
       <RedirectURIsSection
         oauth2Config={oauth2Config}
         onOAuth2ConfigChange={handleOAuth2ConfigChange}
         onValidationChange={onValidationChange}
+        disabled={agent.isReadOnly}
       />
-      <CertificateSection agent={agent} editedAgent={editedAgent} onFieldChange={onFieldChange} />
+      <CertificateSection
+        agent={agent}
+        editedAgent={editedAgent}
+        onFieldChange={onFieldChange}
+        disabled={agent.isReadOnly}
+      />
     </Stack>
   );
 }

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/OAuth2ConfigSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/OAuth2ConfigSection.tsx
@@ -54,6 +54,7 @@ interface OidcDiscovery {
 interface OAuth2ConfigSectionProps {
   oauth2Config?: OAuth2Config;
   onOAuth2ConfigChange?: (updates: Partial<OAuth2Config>) => void;
+  disabled?: boolean;
 }
 
 function OAuth2Logo() {
@@ -110,6 +111,7 @@ function OAuth2Logo() {
 export default function OAuth2ConfigSection({
   oauth2Config = undefined,
   onOAuth2ConfigChange = undefined,
+  disabled = false,
 }: OAuth2ConfigSectionProps) {
   const {t} = useTranslation();
   const {discovery} = useThunderID();
@@ -120,7 +122,7 @@ export default function OAuth2ConfigSection({
   const availableGrantTypes = wellKnown?.grant_types_supported ?? [];
   const availableResponseTypes = wellKnown?.response_types_supported ?? [];
   const availableTokenEndpointAuthMethods: string[] = wellKnown?.token_endpoint_auth_methods_supported ?? [];
-  const isEditable = Boolean(onOAuth2ConfigChange);
+  const isEditable = Boolean(onOAuth2ConfigChange) && !disabled;
 
   const grantTypes = oauth2Config.grantTypes ?? [];
   const flags = deriveOAuth2Flags(oauth2Config);

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/RedirectURIsSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/RedirectURIsSection.tsx
@@ -35,6 +35,10 @@ interface RedirectURIsSectionProps {
    * is configured.
    */
   onValidationChange?: (hasErrors: boolean) => void;
+  /**
+   * Whether inputs should be disabled (e.g. read-only resource).
+   */
+  disabled?: boolean;
 }
 
 const isValidURL = (value: string): boolean => {
@@ -49,6 +53,7 @@ export default function RedirectURIsSection({
   oauth2Config = undefined,
   onOAuth2ConfigChange = undefined,
   onValidationChange = undefined,
+  disabled = false,
 }: RedirectURIsSectionProps): JSX.Element | null {
   const {t} = useTranslation();
   const [errors, setErrors] = useState<Record<number, string>>({});
@@ -90,7 +95,7 @@ export default function RedirectURIsSection({
   // Hide entirely when no redirect-using grant is selected — redirect URIs are meaningless then.
   if (!oauth2Config || !usesRedirect) return null;
 
-  const isEditable = Boolean(onOAuth2ConfigChange);
+  const isEditable = Boolean(onOAuth2ConfigChange) && !disabled;
 
   const commit = (next: string[]): void => {
     if (!isEditable) return;

--- a/frontend/apps/console/src/features/agents/components/edit-agent/attributes/EditAgentAttributes.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/attributes/EditAgentAttributes.tsx
@@ -122,7 +122,7 @@ export default function EditAgentAttributes({agent, onSaved = undefined}: EditAg
       title={t('agents:edit.attributes.title', 'Attributes')}
       description={t('agents:edit.attributes.description', 'View and manage agent attribute values.')}
       headerAction={
-        !isEditMode && hasEditableFields ? (
+        !isEditMode && hasEditableFields && !agent.isReadOnly ? (
           <Button variant="outlined" size="small" onClick={() => setIsEditMode(true)}>
             {t('common:actions.edit', 'Edit')}
           </Button>

--- a/frontend/apps/console/src/features/agents/components/edit-agent/flows-settings/AllowedUserTypesSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/flows-settings/AllowedUserTypesSection.tsx
@@ -60,6 +60,7 @@ export default function AllowedUserTypesSection({
           options={userTypeOptions}
           value={value}
           onChange={(_event, newValue) => onFieldChange('allowedUserTypes', newValue)}
+          disabled={agent.isReadOnly}
           renderInput={(params) => (
             <TextField
               {...params}

--- a/frontend/apps/console/src/features/agents/components/edit-agent/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/general-settings/EditGeneralSettings.tsx
@@ -72,11 +72,13 @@ export default function EditGeneralSettings({
           onCopyToClipboard={onCopyToClipboard}
         />
         <OrganizationUnitSection agent={agent} copiedField={copiedField} onCopyToClipboard={onCopyToClipboard} />
-        <DangerZoneSection
-          showRegenerateSecret={isConfidentialClient}
-          onRegenerateClick={() => setRegenerateDialogOpen(true)}
-          onDeleteClick={() => setDeleteDialogOpen(true)}
-        />
+        {!agent.isReadOnly && (
+          <DangerZoneSection
+            showRegenerateSecret={isConfidentialClient}
+            onRegenerateClick={() => setRegenerateDialogOpen(true)}
+            onDeleteClick={() => setDeleteDialogOpen(true)}
+          />
+        )}
       </Stack>
 
       <RegenerateSecretDialog

--- a/frontend/apps/console/src/features/agents/models/agent.ts
+++ b/frontend/apps/console/src/features/agents/models/agent.ts
@@ -61,6 +61,7 @@ export interface Agent {
   assertion?: AssertionConfig;
   loginConsent?: AgentLoginConsentConfig;
   certificate?: AgentCertificate;
+  isReadOnly?: boolean;
 }
 
 export interface BasicAgent {
@@ -71,6 +72,7 @@ export interface BasicAgent {
   name: string;
   description?: string;
   clientId?: string;
+  isReadOnly?: boolean;
 }
 
 export interface AgentListResponse {

--- a/frontend/apps/console/src/features/agents/pages/AgentEditPage.tsx
+++ b/frontend/apps/console/src/features/agents/pages/AgentEditPage.tsx
@@ -264,6 +264,11 @@ export default function AgentEditPage(): JSX.Element {
 
   return (
     <PageContent>
+      {agent.isReadOnly && (
+        <Alert severity="info" sx={{mb: 2}}>
+          {t('common:messages.readOnlyResource', 'This resource is read-only and cannot be modified.')}
+        </Alert>
+      )}
       <PageTitle>
         <PageTitle.BackButton component={<Link to="/agents" />}>
           {t('agents:edit.page.back', 'Back to agents')}
@@ -307,16 +312,18 @@ export default function AgentEditPage(): JSX.Element {
             ) : (
               <>
                 <Typography variant="h3">{editedAgent.name ?? agent.name}</Typography>
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setTempName(editedAgent.name ?? agent.name);
-                    setIsEditingName(true);
-                  }}
-                  sx={{opacity: 0.6, '&:hover': {opacity: 1}}}
-                >
-                  <Edit size={16} />
-                </IconButton>
+                {!agent.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setTempName(editedAgent.name ?? agent.name);
+                      setIsEditingName(true);
+                    }}
+                    sx={{opacity: 0.6, '&:hover': {opacity: 1}}}
+                  >
+                    <Edit size={16} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -352,16 +359,18 @@ export default function AgentEditPage(): JSX.Element {
                     agent.description ??
                     t('agents:edit.page.description.empty', 'No description')}
                 </Typography>
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setTempDescription(editedAgent.description ?? agent.description ?? '');
-                    setIsEditingDescription(true);
-                  }}
-                  sx={{opacity: 0.6, '&:hover': {opacity: 1}, mt: -0.5}}
-                >
-                  <Edit size={14} />
-                </IconButton>
+                {!agent.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setTempDescription(editedAgent.description ?? agent.description ?? '');
+                      setIsEditingDescription(true);
+                    }}
+                    sx={{opacity: 0.6, '&:hover': {opacity: 1}, mt: -0.5}}
+                  >
+                    <Edit size={14} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -393,7 +402,7 @@ export default function AgentEditPage(): JSX.Element {
           saveLabel={t('agents:edit.page.save', 'Save')}
           savingLabel={t('agents:edit.page.saving', 'Saving…')}
           isSaving={updateAgent.isPending}
-          saveDisabled={hasAnyValidationError}
+          saveDisabled={hasAnyValidationError || agent.isReadOnly === true}
           onReset={() => setEditedAgent({})}
           onSave={() => {
             void handleSave();

--- a/frontend/apps/console/src/features/applications/components/ApplicationsList.tsx
+++ b/frontend/apps/console/src/features/applications/components/ApplicationsList.tsx
@@ -21,7 +21,7 @@ import {useConfig} from '@thunderid/contexts';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
 import {Box, Chip, IconButton, Tooltip, Typography, ListingTable, DataGrid, useTheme} from '@wso2/oxygen-ui';
-import {Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useCallback, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -132,30 +132,40 @@ export default function ApplicationsList(): JSX.Element {
         hideable: false,
         renderCell: (params: DataGrid.GridRenderCellParams<BasicApplication>): JSX.Element => (
           <ListingTable.RowActions>
-            <Tooltip title={t('common:actions.edit')}>
-              <IconButton
-                size="small"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleEditClick(params.row.id);
-                }}
-              >
-                <Pencil size={16} />
-              </IconButton>
-            </Tooltip>
-            {params.row.clientId?.toUpperCase() !== systemConsoleClientId && (
-              <Tooltip title={t('common:actions.delete')}>
-                <IconButton
-                  size="small"
-                  color="error"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDeleteClick(params.row.id);
-                  }}
-                >
-                  <Trash2 size={16} />
+            {params.row.isReadOnly ? (
+              <Tooltip title={t('common:status.readOnly', 'Read Only')}>
+                <IconButton size="small" disableRipple sx={{cursor: 'default'}}>
+                  <Eye size={16} />
                 </IconButton>
               </Tooltip>
+            ) : (
+              <>
+                <Tooltip title={t('common:actions.edit')}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleEditClick(params.row.id);
+                    }}
+                  >
+                    <Pencil size={16} />
+                  </IconButton>
+                </Tooltip>
+                {params.row.clientId?.toUpperCase() !== systemConsoleClientId && (
+                  <Tooltip title={t('common:actions.delete')}>
+                    <IconButton
+                      size="small"
+                      color="error"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDeleteClick(params.row.id);
+                      }}
+                    >
+                      <Trash2 size={16} />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </>
             )}
           </ListingTable.RowActions>
         ),

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/CertificateSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/CertificateSection.tsx
@@ -40,6 +40,10 @@ interface CertificateSectionProps {
    * @param value - The new value for the field
    */
   onFieldChange: (field: keyof Application, value: unknown) => void;
+  /**
+   * Whether inputs should be disabled (e.g. read-only resource).
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -55,7 +59,12 @@ interface CertificateSectionProps {
  * @param props - Component props
  * @returns Certificate configuration UI within a SettingsCard
  */
-export default function CertificateSection({application, editedApp, onFieldChange}: CertificateSectionProps) {
+export default function CertificateSection({
+  application,
+  editedApp,
+  onFieldChange,
+  disabled = false,
+}: CertificateSectionProps) {
   const {t} = useTranslation();
 
   const certificateTypeOptions = [
@@ -96,6 +105,7 @@ export default function CertificateSection({application, editedApp, onFieldChang
             isOptionEqualToValue={(option, value) => option.value === value.value}
             renderInput={(params) => <TextField {...params} fullWidth />}
             disableClearable
+            disabled={disabled}
           />
         </FormControl>
 
@@ -121,6 +131,7 @@ export default function CertificateSection({application, editedApp, onFieldChang
               };
               onFieldChange('certificate', {...currentCert, value: e.target.value});
             }}
+            disabled={disabled}
             placeholder={
               ((editedApp.certificate as {type?: string})?.type ??
                 (application.certificate as {type?: string})?.type) === CertificateTypes.JWKS_URI

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/EditAdvancedSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/EditAdvancedSettings.tsx
@@ -85,8 +85,14 @@ export default function EditAdvancedSettings({
         oauth2Config={oauth2Config}
         oauth2Constraints={oauth2Constraints}
         onOAuth2ConfigChange={handleOAuth2ConfigChange}
+        disabled={application.isReadOnly}
       />
-      <CertificateSection application={application} editedApp={editedApp} onFieldChange={onFieldChange} />
+      <CertificateSection
+        application={application}
+        editedApp={editedApp}
+        onFieldChange={onFieldChange}
+        disabled={application.isReadOnly}
+      />
       <MetadataSection application={application} />
     </Stack>
   );

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/OAuth2ConfigSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/OAuth2ConfigSection.tsx
@@ -70,6 +70,10 @@ interface OAuth2ConfigSectionProps {
    * Callback to handle OAuth2 config field changes. When omitted the section is read-only.
    */
   onOAuth2ConfigChange?: (updates: Partial<OAuth2Config>) => void;
+  /**
+   * Whether inputs should be disabled (e.g. read-only resource).
+   */
+  disabled?: boolean;
 }
 
 function OAuth2Logo() {
@@ -146,6 +150,7 @@ export default function OAuth2ConfigSection({
   oauth2Config = undefined,
   oauth2Constraints = undefined,
   onOAuth2ConfigChange = undefined,
+  disabled = false,
 }: OAuth2ConfigSectionProps) {
   const {t} = useTranslation();
   const {discovery} = useThunderID();
@@ -156,7 +161,7 @@ export default function OAuth2ConfigSection({
   const availableResponseTypes = discovery?.wellKnown?.response_types_supported ?? [];
   const availableTokenEndpointAuthMethods: string[] =
     (discovery as {wellKnown?: OidcDiscovery} | undefined)?.wellKnown?.token_endpoint_auth_methods_supported ?? [];
-  const isEditable = Boolean(onOAuth2ConfigChange);
+  const isEditable = Boolean(onOAuth2ConfigChange) && !disabled;
 
   // Constraint helpers
   const constraint = <K extends keyof OAuth2Config>(field: K) => oauth2Constraints?.[field];

--- a/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/AppearanceSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/AppearanceSection.tsx
@@ -88,6 +88,7 @@ export default function AppearanceSection({
           value={themeOptions.find((theme) => theme.id === (editedApp.themeId! ?? application.themeId!)) ?? null}
           onChange={(_event, newValue) => onFieldChange('themeId' as keyof Application, newValue?.id ?? '')}
           loading={loadingThemes}
+          disabled={application.isReadOnly}
           renderInput={(params) => (
             <TextField
               {...params}
@@ -117,6 +118,7 @@ export default function AppearanceSection({
           value={layoutOptions.find((layout) => layout.id === (editedApp.layoutId ?? application.layoutId)) ?? null}
           onChange={(_event, newValue) => onFieldChange('layoutId', newValue?.id ?? '')}
           loading={loadingLayouts}
+          disabled={application.isReadOnly}
           renderInput={(params) => (
             <TextField
               {...params}

--- a/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/ContactsSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/ContactsSection.tsx
@@ -104,6 +104,7 @@ export default function ContactsSection({
         onInputChange={() => {
           if (inputError) setInputError('');
         }}
+        disabled={application.isReadOnly}
         renderTags={(value, getTagProps) =>
           value.map((option, index) => <Chip label={option} {...getTagProps({index})} key={option} />)
         }

--- a/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/UrlsSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/UrlsSection.tsx
@@ -116,6 +116,7 @@ export default function UrlsSection({
                 placeholder={t('applications:edit.customization.tosUri.placeholder')}
                 error={!!errors.tosUri}
                 helperText={errors.tosUri?.message ?? t('applications:edit.customization.tosUri.hint')}
+                disabled={application.isReadOnly}
               />
             )}
           />
@@ -139,6 +140,7 @@ export default function UrlsSection({
                 placeholder={t('applications:edit.customization.policyUri.placeholder')}
                 error={!!errors.policyUri}
                 helperText={errors.policyUri?.message ?? t('applications:edit.customization.policyUri.hint')}
+                disabled={application.isReadOnly}
               />
             )}
           />

--- a/frontend/apps/console/src/features/applications/components/edit-application/flows-settings/AuthenticationFlowSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/flows-settings/AuthenticationFlowSection.tsx
@@ -102,6 +102,7 @@ export default function AuthenticationFlowSection({
         value={authFlowOptions.find((flow) => flow.id === (editedApp.authFlowId ?? application.authFlowId)) ?? null}
         onChange={(_event, newValue) => onFieldChange('authFlowId', newValue?.id ?? '')}
         loading={loadingAuthFlows}
+        disabled={application.isReadOnly}
         renderInput={(params) => (
           <TextField
             {...params}

--- a/frontend/apps/console/src/features/applications/components/edit-application/flows-settings/RecoveryFlowSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/flows-settings/RecoveryFlowSection.tsx
@@ -75,7 +75,7 @@ export default function RecoveryFlowSection({
       title={t('applications:edit.flows.labels.recoveryFlow')}
       description={t('applications:edit.flows.labels.recoveryFlow.description')}
       enabled={editedApp.isRecoveryFlowEnabled ?? application.isRecoveryFlowEnabled ?? false}
-      onToggle={(enabled) => onFieldChange('isRecoveryFlowEnabled', enabled)}
+      onToggle={application.isReadOnly ? undefined : (enabled) => onFieldChange('isRecoveryFlowEnabled', enabled)}
     >
       {(editedApp.recoveryFlowId ?? application.recoveryFlowId) && (
         <Alert severity="info" sx={{mb: 2}}>
@@ -106,6 +106,7 @@ export default function RecoveryFlowSection({
         }
         onChange={(_event, newValue) => onFieldChange('recoveryFlowId', newValue?.id ?? '')}
         loading={loadingRecoveryFlows}
+        disabled={application.isReadOnly}
         renderInput={(params) => (
           <TextField
             {...params}

--- a/frontend/apps/console/src/features/applications/components/edit-application/flows-settings/RegistrationFlowSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/flows-settings/RegistrationFlowSection.tsx
@@ -77,7 +77,7 @@ export default function RegistrationFlowSection({
       title={t('applications:edit.flows.labels.registrationFlow')}
       description={t('applications:edit.flows.labels.registrationFlow.description')}
       enabled={editedApp.isRegistrationFlowEnabled ?? application.isRegistrationFlowEnabled ?? false}
-      onToggle={(enabled) => onFieldChange('isRegistrationFlowEnabled', enabled)}
+      onToggle={application.isReadOnly ? undefined : (enabled) => onFieldChange('isRegistrationFlowEnabled', enabled)}
     >
       {(editedApp.registrationFlowId ?? application.registrationFlowId) && (
         <Alert severity="info" sx={{mb: 2}}>
@@ -108,6 +108,7 @@ export default function RegistrationFlowSection({
         }
         onChange={(_event, newValue) => onFieldChange('registrationFlowId', newValue?.id ?? '')}
         loading={loadingRegFlows}
+        disabled={application.isReadOnly}
         renderInput={(params) => (
           <TextField
             {...params}

--- a/frontend/apps/console/src/features/applications/components/edit-application/general-settings/AccessSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/general-settings/AccessSection.tsx
@@ -233,6 +233,7 @@ export default function AccessSection({
             value={editedApp.allowedUserTypes ?? application.allowedUserTypes ?? []}
             onChange={(_event, newValue) => onFieldChange('allowedUserTypes', newValue)}
             loading={loadingUserTypes}
+            disabled={application.isReadOnly}
             renderInput={(params) => (
               <TextField
                 {...params}
@@ -274,6 +275,7 @@ export default function AccessSection({
                 placeholder="https://example.com"
                 error={!!errors.url}
                 helperText={errors.url?.message ?? t('applications:edit.general.applicationUrl.hint')}
+                disabled={application.isReadOnly}
               />
             )}
           />
@@ -301,10 +303,16 @@ export default function AccessSection({
                       error={!!uriErrors[index]}
                       helperText={uriErrors[index]}
                       placeholder="https://example.com/callback"
+                      disabled={application.isReadOnly}
                     />
                   </FormControl>
                   <Tooltip title={t('common:actions.delete')}>
-                    <IconButton onClick={() => handleRemoveUri(index)} color="error" sx={{mt: 1}}>
+                    <IconButton
+                      onClick={() => handleRemoveUri(index)}
+                      color="error"
+                      sx={{mt: 1}}
+                      disabled={application.isReadOnly}
+                    >
                       <Trash size={20} />
                     </IconButton>
                   </Tooltip>
@@ -312,7 +320,13 @@ export default function AccessSection({
               ))}
 
               <Box>
-                <Button variant="outlined" startIcon={<Plus />} onClick={handleAddUri} size="small">
+                <Button
+                  variant="outlined"
+                  startIcon={<Plus />}
+                  onClick={handleAddUri}
+                  size="small"
+                  disabled={application.isReadOnly}
+                >
                   {t('applications:edit.general.redirectUris.addUri')}
                 </Button>
               </Box>

--- a/frontend/apps/console/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
@@ -128,7 +128,7 @@ export default function EditGeneralSettings({
           oauth2Config={oauth2Config}
           onFieldChange={onFieldChange}
         />
-        {oauth2Config?.clientId?.toUpperCase() !== systemConsoleClientId && (
+        {!application.isReadOnly && oauth2Config?.clientId?.toUpperCase() !== systemConsoleClientId && (
           <DangerZoneSection
             showRegenerateSecret={isConfidentialClient}
             onRegenerateClick={handleRegenerateClick}

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
@@ -627,6 +627,7 @@ export default function EditTokenSettings({
             highlightedAttributes={visibleHighlightedAttributes}
             onAttributeClick={handleAttributeClick}
             entityLabel={entityLabel}
+            disabled={application.isReadOnly}
           />
 
           {/* Scopes & Attribute Mapping */}
@@ -638,10 +639,16 @@ export default function EditTokenSettings({
             onScopesChange={handleScopesChange}
             onScopeClaimsChange={handleScopeClaimsChange}
             entityLabel={entityLabel}
+            disabled={application.isReadOnly}
           />
 
           {/* Merged Token Validation (Access Token / ID Token tabs) */}
-          <TokenValidationSection control={control} errors={errors} tokenType="oauth" />
+          <TokenValidationSection
+            control={control}
+            errors={errors}
+            tokenType="oauth"
+            disabled={application.isReadOnly}
+          />
         </>
       ) : (
         <>
@@ -655,10 +662,16 @@ export default function EditTokenSettings({
             highlightedAttributes={visibleHighlightedAttributes}
             onAttributeClick={handleAttributeClick}
             entityLabel={entityLabel}
+            disabled={application.isReadOnly}
           />
 
           {/* Token Validation */}
-          <TokenValidationSection control={control} errors={errors} tokenType="shared" />
+          <TokenValidationSection
+            control={control}
+            errors={errors}
+            tokenType="shared"
+            disabled={application.isReadOnly}
+          />
         </>
       )}
     </Stack>

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ScopeMapper.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ScopeMapper.tsx
@@ -46,6 +46,10 @@ interface ScopeMapperProps {
    * Callback fired when the scope → attributes mapping changes.
    */
   onScopeClaimsChange: (scopeClaims: ScopeClaims) => void;
+  /**
+   * Whether inputs should be disabled (e.g. read-only resource).
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -64,6 +68,7 @@ export default function ScopeMapper({
   userAttributes,
   isLoadingUserAttributes,
   onScopeClaimsChange,
+  disabled = false,
 }: ScopeMapperProps) {
   const {t} = useTranslation();
   const [selectedScope, setSelectedScope] = useState<string | null>(null);
@@ -205,7 +210,13 @@ export default function ScopeMapper({
               ) : (
                 <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
                   {mappedAttributes.map((attr) => (
-                    <Chip key={attr} label={attr} size="small" color="primary" onDelete={() => handleRemove(attr)} />
+                    <Chip
+                      key={attr}
+                      label={attr}
+                      size="small"
+                      color="primary"
+                      onDelete={disabled ? undefined : () => handleRemove(attr)}
+                    />
                   ))}
                 </Stack>
               )}
@@ -252,13 +263,13 @@ export default function ScopeMapper({
                       label={attr}
                       size="small"
                       variant="outlined"
-                      onClick={() => handleAdd(attr)}
+                      onClick={disabled ? undefined : () => handleAdd(attr)}
                       sx={{
-                        cursor: 'pointer',
+                        cursor: disabled ? 'default' : 'pointer',
                         borderStyle: 'dashed',
                         '&:hover': {
                           borderStyle: 'solid',
-                          bgcolor: 'action.hover',
+                          bgcolor: disabled ? 'transparent' : 'action.hover',
                         },
                         transition: 'all 0.15s ease',
                       }}

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ScopeSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ScopeSection.tsx
@@ -55,6 +55,10 @@ interface ScopeSectionProps {
    * Singular noun used to refer to the entity in user-visible copy (default: 'application').
    */
   entityLabel?: string;
+  /**
+   * Whether inputs should be disabled (e.g. read-only resource).
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -76,6 +80,7 @@ export default function ScopeSection({
   onScopesChange,
   onScopeClaimsChange,
   entityLabel = 'application',
+  disabled = false,
 }: ScopeSectionProps) {
   const {t} = useTranslation();
 
@@ -100,7 +105,12 @@ export default function ScopeSection({
     >
       <Stack spacing={3}>
         {/* ── Scopes ─────────────────────────────────────────────────── */}
-        <ScopeSelector scopes={scopes} onScopesChange={handleScopesChange} entityLabel={entityLabel} />
+        <ScopeSelector
+          scopes={scopes}
+          onScopesChange={handleScopesChange}
+          entityLabel={entityLabel}
+          disabled={disabled}
+        />
 
         <Divider />
 
@@ -122,6 +132,7 @@ export default function ScopeSection({
             userAttributes={userAttributes}
             isLoadingUserAttributes={isLoadingUserAttributes}
             onScopeClaimsChange={onScopeClaimsChange}
+            disabled={disabled}
           />
         </Box>
       </Stack>

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ScopeSelector.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ScopeSelector.tsx
@@ -41,6 +41,10 @@ interface ScopeSelectorProps {
    * Singular noun used to refer to the entity in user-visible copy (default: 'application').
    */
   entityLabel?: string;
+  /**
+   * Whether inputs should be disabled (e.g. read-only resource).
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -51,7 +55,12 @@ interface ScopeSelectorProps {
  * - An input + Add button lets users add any custom scope name.
  * All changes are reflected immediately via `onScopesChange`.
  */
-export default function ScopeSelector({scopes, onScopesChange, entityLabel = 'application'}: ScopeSelectorProps) {
+export default function ScopeSelector({
+  scopes,
+  onScopesChange,
+  entityLabel = 'application',
+  disabled = false,
+}: ScopeSelectorProps) {
   const {t} = useTranslation();
   const [customScopeInput, setCustomScopeInput] = useState('');
   const [customScopeError, setCustomScopeError] = useState<string | null>(null);
@@ -175,7 +184,7 @@ export default function ScopeSelector({scopes, onScopesChange, entityLabel = 'ap
                     size="small"
                     variant={isPendingRemoval ? 'outlined' : 'filled'}
                     color="default"
-                    onDelete={() => handleRemove(scope)}
+                    onDelete={disabled ? undefined : () => handleRemove(scope)}
                     sx={{transition: 'all 0.2s ease'}}
                   />
                 );
@@ -187,16 +196,20 @@ export default function ScopeSelector({scopes, onScopesChange, entityLabel = 'ap
                   size="small"
                   variant="outlined"
                   color="primary"
-                  onDelete={() => {
-                    const timer = additionTimers.current.get(scope);
-                    if (timer) clearTimeout(timer);
-                    additionTimers.current.delete(scope);
-                    setPendingAdditions((prev) => {
-                      const next = new Set(prev);
-                      next.delete(scope);
-                      return next;
-                    });
-                  }}
+                  onDelete={
+                    disabled
+                      ? undefined
+                      : () => {
+                          const timer = additionTimers.current.get(scope);
+                          if (timer) clearTimeout(timer);
+                          additionTimers.current.delete(scope);
+                          setPendingAdditions((prev) => {
+                            const next = new Set(prev);
+                            next.delete(scope);
+                            return next;
+                          });
+                        }
+                  }
                   sx={{transition: 'all 0.2s ease'}}
                 />
               ))}
@@ -221,8 +234,8 @@ export default function ScopeSelector({scopes, onScopesChange, entityLabel = 'ap
                     label={scope}
                     size="small"
                     variant="outlined"
-                    onClick={() => handleAdd(scope)}
-                    sx={{cursor: 'pointer', borderStyle: 'dashed'}}
+                    onClick={disabled ? undefined : () => handleAdd(scope)}
+                    sx={{cursor: disabled ? 'default' : 'pointer', borderStyle: 'dashed'}}
                   />
                 </Tooltip>
               ))}
@@ -257,8 +270,9 @@ export default function ScopeSelector({scopes, onScopesChange, entityLabel = 'ap
               error={!!customScopeError}
               helperText={customScopeError ?? ''}
               sx={{width: 240}}
+              disabled={disabled}
             />
-            <Button variant="outlined" size="small" onClick={handleAddCustom} sx={{mt: '1px'}}>
+            <Button variant="outlined" size="small" onClick={handleAddCustom} sx={{mt: '1px'}} disabled={disabled}>
               {t('applications:edit.token.scopes.add_custom.button', 'Add')}
             </Button>
           </Stack>

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/TokenUserAttributesSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/TokenUserAttributesSection.tsx
@@ -105,6 +105,10 @@ interface TokenUserAttributesSectionProps {
    * Singular noun used to refer to the entity in user-visible copy (default: 'application').
    */
   entityLabel?: string;
+  /**
+   * Whether inputs should be disabled (e.g. read-only resource).
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -138,6 +142,7 @@ export default function TokenUserAttributesSection({
   onToggleUserInfo = undefined,
   sharedAttributes = undefined,
   entityLabel = 'application',
+  disabled = false,
 }: TokenUserAttributesSectionProps) {
   const {t} = useTranslation();
 
@@ -239,7 +244,7 @@ export default function TokenUserAttributesSection({
                               size="small"
                               variant={isActive ? 'filled' : 'outlined'}
                               color={isActive ? 'primary' : 'default'}
-                              onClick={() => onAttributeClick(attr, tokenType)}
+                              onClick={disabled ? undefined : () => onAttributeClick(attr, tokenType)}
                               sx={{
                                 cursor: 'pointer',
                                 transition: 'all 0.3s ease',
@@ -327,6 +332,7 @@ export default function TokenUserAttributesSection({
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => onToggleUserInfo?.(!e.target.checked)}
                       name="userinfo-inherit"
                       size="small"
+                      disabled={disabled}
                     />
                   }
                   label={

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/TokenValidationSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/TokenValidationSection.tsx
@@ -49,6 +49,10 @@ interface TokenValidationSectionProps {
    * - 'oauth': Tabbed layout with separate Access Token and ID Token validity inputs
    */
   tokenType: 'shared' | 'oauth';
+  /**
+   * Whether inputs should be disabled (e.g. read-only resource).
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -62,7 +66,12 @@ interface TokenValidationSectionProps {
  * @param props - Component props
  * @returns Token validity configuration UI within a SettingsCard
  */
-export default function TokenValidationSection({control, errors, tokenType}: TokenValidationSectionProps) {
+export default function TokenValidationSection({
+  control,
+  errors,
+  tokenType,
+  disabled = false,
+}: TokenValidationSectionProps) {
   const {t} = useTranslation();
   const [activeValidationTab, setActiveValidationTab] = useState<'access' | 'id'>('access');
 
@@ -90,6 +99,7 @@ export default function TokenValidationSection({control, errors, tokenType}: Tok
             error={!!errors[fieldName]}
             helperText={errors[fieldName]?.message ?? hint}
             inputProps={{min: 1}}
+            disabled={disabled}
           />
         )}
       />

--- a/frontend/apps/console/src/features/applications/models/application.ts
+++ b/frontend/apps/console/src/features/applications/models/application.ts
@@ -60,6 +60,7 @@ export type BasicApplication = Pick<
   | 'registrationFlowId'
   | 'isRegistrationFlowEnabled'
   | 'template'
+  | 'isReadOnly'
 > & {
   /**
    * OAuth2 client identifier
@@ -288,4 +289,9 @@ export interface Application {
    * Defines how assertions are generated for this application.
    */
   assertion?: AssertionConfig;
+
+  /**
+   * Whether this application is read-only (declarative/immutable)
+   */
+  isReadOnly?: boolean;
 }

--- a/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
@@ -191,6 +191,11 @@ export default function ApplicationEditPage() {
 
   return (
     <PageContent>
+      {application.isReadOnly && (
+        <Alert severity="info" sx={{mb: 2}}>
+          {t('common:messages.readOnlyResource', 'This resource is read-only and cannot be modified.')}
+        </Alert>
+      )}
       {/* Header */}
       <PageTitle>
         <PageTitle.BackButton component={<Link to="/applications" />}>
@@ -198,7 +203,7 @@ export default function ApplicationEditPage() {
         </PageTitle.BackButton>
         <PageTitle.Avatar sx={{overflow: 'visible'}}>
           <ResourceAvatar
-            editable
+            editable={!application.isReadOnly}
             value={editedApp.logoUrl ?? application.logoUrl}
             fallback="emoji:🖥️"
             editAriaLabel={t('applications:edit.page.logoUpdate.label')}
@@ -233,19 +238,21 @@ export default function ApplicationEditPage() {
             ) : (
               <>
                 <Typography variant="h3">{editedApp.name ?? application.name}</Typography>
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setTempName(editedApp.name ?? application.name);
-                    setIsEditingName(true);
-                  }}
-                  sx={{
-                    opacity: 0.6,
-                    '&:hover': {opacity: 1},
-                  }}
-                >
-                  <Edit size={16} />
-                </IconButton>
+                {!application.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setTempName(editedApp.name ?? application.name);
+                      setIsEditingName(true);
+                    }}
+                    sx={{
+                      opacity: 0.6,
+                      '&:hover': {opacity: 1},
+                    }}
+                  >
+                    <Edit size={16} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -293,20 +300,22 @@ export default function ApplicationEditPage() {
                 <Typography variant="body2" color="text.secondary">
                   {editedApp.description ?? application.description ?? t('applications:edit.page.description.empty')}
                 </Typography>
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setTempDescription(editedApp.description ?? application.description ?? '');
-                    setIsEditingDescription(true);
-                  }}
-                  sx={{
-                    opacity: 0.6,
-                    '&:hover': {opacity: 1},
-                    mt: -0.5,
-                  }}
-                >
-                  <Edit size={14} />
-                </IconButton>
+                {!application.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setTempDescription(editedApp.description ?? application.description ?? '');
+                      setIsEditingDescription(true);
+                    }}
+                    sx={{
+                      opacity: 0.6,
+                      '&:hover': {opacity: 1},
+                      mt: -0.5,
+                    }}
+                  >
+                    <Edit size={14} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -441,7 +450,7 @@ export default function ApplicationEditPage() {
           saveLabel={t('applications:edit.page.save')}
           savingLabel={t('applications:edit.page.saving')}
           isSaving={updateApplication.isPending}
-          saveDisabled={hasValidationErrors}
+          saveDisabled={hasValidationErrors || application.isReadOnly === true}
           onReset={() => setEditedApp({})}
           onSave={() => {
             handleSave().catch(() => null);

--- a/frontend/apps/console/src/features/design/components/common/ItemCard.tsx
+++ b/frontend/apps/console/src/features/design/components/common/ItemCard.tsx
@@ -16,8 +16,8 @@
  * under the License.
  */
 
-import {Box, Card, Typography} from '@wso2/oxygen-ui';
-import {ArrowUpRight} from '@wso2/oxygen-ui-icons-react';
+import {Box, Card, Tooltip, Typography} from '@wso2/oxygen-ui';
+import {ArrowUpRight, Eye} from '@wso2/oxygen-ui-icons-react';
 import type {JSX, ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
 
@@ -25,57 +25,81 @@ export interface ItemCardProps {
   thumbnail: ReactNode;
   name: string;
   onClick: () => void;
+  isReadOnly?: boolean;
 }
 
-export default function ItemCard({thumbnail, name, onClick}: ItemCardProps): JSX.Element {
+export default function ItemCard({thumbnail, name, onClick, isReadOnly = false}: ItemCardProps): JSX.Element {
   const {t} = useTranslation('design');
   return (
     <Card
-      onClick={onClick}
+      onClick={isReadOnly ? undefined : onClick}
       sx={{
-        cursor: 'pointer',
-        '&:hover': {
-          borderColor: 'primary.main',
-          boxShadow: '0 4px 20px rgba(0,0,0,0.1)',
-          transform: 'translateY(-2px)',
-          '& .card-overlay': {opacity: 1},
-        },
+        cursor: isReadOnly ? 'default' : 'pointer',
+        ...(!isReadOnly && {
+          '&:hover': {
+            borderColor: 'primary.main',
+            boxShadow: '0 4px 20px rgba(0,0,0,0.1)',
+            transform: 'translateY(-2px)',
+            '& .card-overlay': {opacity: 1},
+          },
+        }),
       }}
     >
       <Box sx={{aspectRatio: '4/3', overflow: 'hidden', position: 'relative'}}>
         {thumbnail}
-        {/* Hover overlay */}
-        <Box
-          className="card-overlay"
-          sx={{
-            position: 'absolute',
-            inset: 0,
-            bgcolor: 'rgba(0,0,0,0.35)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            opacity: 0,
-            transition: 'opacity 0.18s ease',
-            backdropFilter: 'blur(2px)',
-          }}
-        >
+        {isReadOnly ? (
+          <Tooltip title={t('common:status.readOnly', 'Read Only')}>
+            <Box
+              sx={{
+                position: 'absolute',
+                top: 8,
+                right: 8,
+                bgcolor: 'background.paper',
+                borderRadius: '50%',
+                width: 28,
+                height: 28,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                boxShadow: 1,
+              }}
+            >
+              <Eye size={14} />
+            </Box>
+          </Tooltip>
+        ) : (
           <Box
+            className="card-overlay"
             sx={{
+              position: 'absolute',
+              inset: 0,
+              bgcolor: 'rgba(0,0,0,0.35)',
               display: 'flex',
               alignItems: 'center',
-              gap: 0.5,
-              bgcolor: 'common.background',
-              borderRadius: 2,
-              px: 1.5,
-              py: 0.75,
+              justifyContent: 'center',
+              opacity: 0,
+              transition: 'opacity 0.18s ease',
+              backdropFilter: 'blur(2px)',
             }}
           >
-            <ArrowUpRight size={13} />
-            <Typography variant="caption" sx={{fontWeight: 600, fontSize: '0.75rem'}}>
-              {t('common.item_card.actions.open_in_builder.label', 'Open in builder')}
-            </Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                bgcolor: 'common.background',
+                borderRadius: 2,
+                px: 1.5,
+                py: 0.75,
+              }}
+            >
+              <ArrowUpRight size={13} />
+              <Typography variant="caption" sx={{fontWeight: 600, fontSize: '0.75rem'}}>
+                {t('common.item_card.actions.open_in_builder.label', 'Open in builder')}
+              </Typography>
+            </Box>
           </Box>
-        </Box>
+        )}
       </Box>
       <Box sx={{px: 1.5, py: 1, borderTop: '1px solid', borderColor: 'divider'}}>
         <Typography

--- a/frontend/apps/console/src/features/design/pages/DesignPage.tsx
+++ b/frontend/apps/console/src/features/design/pages/DesignPage.tsx
@@ -125,6 +125,7 @@ export default function DesignPage(): JSX.Element {
                     <ItemCard
                       thumbnail={<ThemeThumbnail theme={theme} />}
                       name={theme.displayName}
+                      isReadOnly={theme.isReadOnly}
                       onClick={() => {
                         (async () => {
                           await navigate(`/design/themes/${theme.id}`);

--- a/frontend/apps/console/src/features/flows/components/FlowsList.tsx
+++ b/frontend/apps/console/src/features/flows/components/FlowsList.tsx
@@ -19,7 +19,7 @@
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
 import {Box, Chip, IconButton, Tooltip, Typography, ListingTable, DataGrid} from '@wso2/oxygen-ui';
-import {Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useCallback, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -125,29 +125,39 @@ export default function FlowsList(): JSX.Element {
         renderCell: (params: DataGrid.GridRenderCellParams<BasicFlowDefinition>): JSX.Element | null => {
           return (
             <ListingTable.RowActions>
-              <Tooltip title={t('common:actions.edit')}>
-                <IconButton
-                  size="small"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleEditClick(params.row);
-                  }}
-                >
-                  <Pencil size={16} />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title={t('common:actions.delete')}>
-                <IconButton
-                  size="small"
-                  color="error"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDeleteClick(params.row);
-                  }}
-                >
-                  <Trash2 size={16} />
-                </IconButton>
-              </Tooltip>
+              {params.row.isReadOnly ? (
+                <Tooltip title={t('common:status.readOnly', 'Read Only')}>
+                  <IconButton size="small" disableRipple sx={{cursor: 'default'}}>
+                    <Eye size={16} />
+                  </IconButton>
+                </Tooltip>
+              ) : (
+                <>
+                  <Tooltip title={t('common:actions.edit')}>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleEditClick(params.row);
+                      }}
+                    >
+                      <Pencil size={16} />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title={t('common:actions.delete')}>
+                    <IconButton
+                      size="small"
+                      color="error"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDeleteClick(params.row);
+                      }}
+                    >
+                      <Trash2 size={16} />
+                    </IconButton>
+                  </Tooltip>
+                </>
+              )}
             </ListingTable.RowActions>
           );
         },
@@ -178,7 +188,9 @@ export default function FlowsList(): JSX.Element {
             columns={columns}
             getRowId={(row): string => (row as BasicFlowDefinition).id}
             onRowClick={(params) => {
-              handleEditClick(params.row as BasicFlowDefinition);
+              if (!(params.row as BasicFlowDefinition).isReadOnly) {
+                handleEditClick(params.row as BasicFlowDefinition);
+              }
             }}
             initialState={{
               pagination: {

--- a/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
@@ -628,7 +628,12 @@ function DecoratedVisualFlow({
             }
           >
             <span>
-              <Button variant="contained" disabled={hasErrors} startIcon={<Save size={18} />} onClick={handleSave}>
+              <Button
+                variant="contained"
+                disabled={hasErrors || !onSave}
+                startIcon={<Save size={18} />}
+                onClick={handleSave}
+              >
                 {t('flows:core.headerPanel.save')}
               </Button>
             </span>

--- a/frontend/apps/console/src/features/flows/models/responses.ts
+++ b/frontend/apps/console/src/features/flows/models/responses.ts
@@ -51,6 +51,11 @@ export interface BasicFlowDefinition {
    * Timestamp when the flow was last modified
    */
   updatedAt: string;
+
+  /**
+   * Whether the flow is read-only and cannot be modified or deleted.
+   */
+  isReadOnly?: boolean;
 }
 
 /**
@@ -336,4 +341,9 @@ export interface FlowDefinitionResponse {
    * Timestamp when the flow was last modified
    */
   updatedAt: string;
+
+  /**
+   * Whether the flow is read-only and cannot be modified or deleted.
+   */
+  isReadOnly?: boolean;
 }

--- a/frontend/apps/console/src/features/groups/components/GroupsList.tsx
+++ b/frontend/apps/console/src/features/groups/components/GroupsList.tsx
@@ -19,7 +19,7 @@
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
 import {IconButton, Typography, Tooltip, DataGrid, ListingTable, Box} from '@wso2/oxygen-ui';
-import {Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useCallback, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -77,6 +77,9 @@ export default function GroupsList(): JSX.Element {
         headerName: t('groups:listing.columns.name', 'Name'),
         flex: 1,
         minWidth: 200,
+        renderCell: (params: DataGrid.GridRenderCellParams<GroupBasic>): JSX.Element => (
+          <Typography variant="body2">{params.row.name}</Typography>
+        ),
       },
       {
         field: 'description',
@@ -107,29 +110,39 @@ export default function GroupsList(): JSX.Element {
         hideable: false,
         renderCell: (params: DataGrid.GridRenderCellParams<GroupBasic>): JSX.Element => (
           <ListingTable.RowActions>
-            <Tooltip title={t('common:actions.edit')}>
-              <IconButton
-                size="small"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleViewClick(params.row.id);
-                }}
-              >
-                <Pencil size={16} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('common:actions.delete')}>
-              <IconButton
-                size="small"
-                color="error"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleDeleteClick(params.row.id);
-                }}
-              >
-                <Trash2 size={16} />
-              </IconButton>
-            </Tooltip>
+            {params.row.isReadOnly ? (
+              <Tooltip title={t('common:status.readOnly', 'Read Only')}>
+                <IconButton size="small" disableRipple sx={{cursor: 'default'}}>
+                  <Eye size={16} />
+                </IconButton>
+              </Tooltip>
+            ) : (
+              <>
+                <Tooltip title={t('common:actions.edit')}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleViewClick(params.row.id);
+                    }}
+                  >
+                    <Pencil size={16} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title={t('common:actions.delete')}>
+                  <IconButton
+                    size="small"
+                    color="error"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteClick(params.row.id);
+                    }}
+                  >
+                    <Trash2 size={16} />
+                  </IconButton>
+                </Tooltip>
+              </>
+            )}
           </ListingTable.RowActions>
         ),
       },

--- a/frontend/apps/console/src/features/groups/components/edit-group/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/console/src/features/groups/components/edit-group/general-settings/EditGeneralSettings.tsx
@@ -36,14 +36,14 @@ import type {Group} from '../../../models/group';
 
 interface EditGeneralSettingsProps {
   group: Group;
-  onDeleteClick: () => void;
+  onDeleteClick?: () => void;
 }
 
 /**
  * General settings tab content for the Group edit page.
  * Displays Organization Unit and Danger Zone sections.
  */
-export default function EditGeneralSettings({group, onDeleteClick}: EditGeneralSettingsProps): JSX.Element {
+export default function EditGeneralSettings({group, onDeleteClick = undefined}: EditGeneralSettingsProps): JSX.Element {
   const {t} = useTranslation();
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -164,20 +164,22 @@ export default function EditGeneralSettings({group, onDeleteClick}: EditGeneralS
       </SettingsCard>
 
       {/* Danger Zone */}
-      <SettingsCard
-        title={t('groups:edit.general.sections.dangerZone.title')}
-        description={t('groups:edit.general.sections.dangerZone.description')}
-      >
-        <Typography variant="h6" gutterBottom color="error">
-          {t('groups:edit.general.sections.dangerZone.deleteGroup')}
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
-          {t('groups:edit.general.sections.dangerZone.deleteGroupDescription')}
-        </Typography>
-        <Button variant="contained" color="error" onClick={onDeleteClick}>
-          {t('common:actions.delete')}
-        </Button>
-      </SettingsCard>
+      {onDeleteClick && (
+        <SettingsCard
+          title={t('groups:edit.general.sections.dangerZone.title')}
+          description={t('groups:edit.general.sections.dangerZone.description')}
+        >
+          <Typography variant="h6" gutterBottom color="error">
+            {t('groups:edit.general.sections.dangerZone.deleteGroup')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
+            {t('groups:edit.general.sections.dangerZone.deleteGroupDescription')}
+          </Typography>
+          <Button variant="contained" color="error" onClick={onDeleteClick}>
+            {t('common:actions.delete')}
+          </Button>
+        </SettingsCard>
+      )}
     </Stack>
   );
 }

--- a/frontend/apps/console/src/features/groups/components/edit-group/members-settings/EditMembersSettings.tsx
+++ b/frontend/apps/console/src/features/groups/components/edit-group/members-settings/EditMembersSettings.tsx
@@ -93,19 +93,22 @@ export default function EditMembersSettings({group}: EditMembersSettingsProps): 
       <ManageMembersSection
         groupId={group.id}
         onRemoveMember={handleRemoveMember}
+        isReadOnly={group.isReadOnly}
         headerAction={
-          <Button
-            variant="contained"
-            size="small"
-            startIcon={<Plus size={16} />}
-            onClick={() => setAddDialogOpen(true)}
-          >
-            {t('groups:edit.members.sections.manage.addMember')}
-          </Button>
+          !group.isReadOnly ? (
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={<Plus size={16} />}
+              onClick={() => setAddDialogOpen(true)}
+            >
+              {t('groups:edit.members.sections.manage.addMember')}
+            </Button>
+          ) : undefined
         }
       />
 
-      {addDialogOpen && (
+      {addDialogOpen && !group.isReadOnly && (
         <AddMemberDialog open={addDialogOpen} onClose={() => setAddDialogOpen(false)} onAdd={handleAddMembers} />
       )}
     </Stack>

--- a/frontend/apps/console/src/features/groups/components/edit-group/members-settings/ManageMembersSection.tsx
+++ b/frontend/apps/console/src/features/groups/components/edit-group/members-settings/ManageMembersSection.tsx
@@ -29,6 +29,7 @@ interface ManageMembersSectionProps {
   groupId: string;
   onRemoveMember: (member: Member) => void;
   headerAction?: ReactNode;
+  isReadOnly?: boolean;
 }
 
 /**
@@ -38,6 +39,7 @@ export default function ManageMembersSection({
   groupId,
   onRemoveMember,
   headerAction = undefined,
+  isReadOnly = false,
 }: ManageMembersSectionProps): JSX.Element {
   const {t} = useTranslation();
   const dataGridLocaleText = useDataGridLocaleText();
@@ -52,7 +54,7 @@ export default function ManageMembersSection({
   );
   const {data: membersData, isLoading} = useGetGroupMembers(groupId, membersParams);
 
-  const columns: DataGrid.GridColDef<Member>[] = useMemo(
+  const baseColumns: DataGrid.GridColDef<Member>[] = useMemo(
     () => [
       {
         field: 'avatar',
@@ -128,6 +130,11 @@ export default function ManageMembersSection({
       },
     ],
     [t, onRemoveMember],
+  );
+
+  const columns = useMemo(
+    () => (isReadOnly ? baseColumns.filter((col) => col.field !== 'actions') : baseColumns),
+    [isReadOnly, baseColumns],
   );
 
   return (

--- a/frontend/apps/console/src/features/groups/models/group.ts
+++ b/frontend/apps/console/src/features/groups/models/group.ts
@@ -42,6 +42,8 @@ export interface GroupBasic {
   ouId: string;
   /** Handle of the organization unit, populated when include=display is used */
   ouHandle?: string;
+  /** Whether this group is read-only (declarative/immutable) */
+  isReadOnly?: boolean;
 }
 
 /**

--- a/frontend/apps/console/src/features/groups/pages/GroupEditPage.tsx
+++ b/frontend/apps/console/src/features/groups/pages/GroupEditPage.tsx
@@ -180,6 +180,11 @@ export default function GroupEditPage(): JSX.Element {
 
   return (
     <PageContent>
+      {group.isReadOnly && (
+        <Alert severity="info" sx={{mb: 2}}>
+          {t('common:messages.readOnlyResource', 'This resource is read-only and cannot be modified.')}
+        </Alert>
+      )}
       {/* Header */}
       <PageTitle>
         <PageTitle.BackButton component={<Link to={listUrl} />}>{t('groups:edit.page.back')}</PageTitle.BackButton>
@@ -215,20 +220,22 @@ export default function GroupEditPage(): JSX.Element {
             ) : (
               <>
                 <Typography variant="h3">{editedGroup.name ?? group.name}</Typography>
-                <IconButton
-                  size="small"
-                  aria-label="Edit group name"
-                  onClick={() => {
-                    setTempName(editedGroup.name ?? group.name);
-                    setIsEditingName(true);
-                  }}
-                  sx={{
-                    opacity: 0.6,
-                    '&:hover': {opacity: 1},
-                  }}
-                >
-                  <Edit size={16} />
-                </IconButton>
+                {!group.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    aria-label="Edit group name"
+                    onClick={() => {
+                      setTempName(editedGroup.name ?? group.name);
+                      setIsEditingName(true);
+                    }}
+                    sx={{
+                      opacity: 0.6,
+                      '&:hover': {opacity: 1},
+                    }}
+                  >
+                    <Edit size={16} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -275,21 +282,23 @@ export default function GroupEditPage(): JSX.Element {
                 <Typography variant="body2" color="text.secondary">
                   {effectiveDescription || t('groups:edit.page.description.empty')}
                 </Typography>
-                <IconButton
-                  size="small"
-                  aria-label="Edit group description"
-                  onClick={() => {
-                    setTempDescription(effectiveDescription);
-                    setIsEditingDescription(true);
-                  }}
-                  sx={{
-                    opacity: 0.6,
-                    '&:hover': {opacity: 1},
-                    mt: -0.5,
-                  }}
-                >
-                  <Edit size={14} />
-                </IconButton>
+                {!group.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    aria-label="Edit group description"
+                    onClick={() => {
+                      setTempDescription(effectiveDescription);
+                      setIsEditingDescription(true);
+                    }}
+                    sx={{
+                      opacity: 0.6,
+                      '&:hover': {opacity: 1},
+                      mt: -0.5,
+                    }}
+                  >
+                    <Edit size={14} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -315,7 +324,10 @@ export default function GroupEditPage(): JSX.Element {
       {/* Tab Panels */}
       <>
         <TabPanel value={activeTab} index={0}>
-          <EditGeneralSettings group={group} onDeleteClick={() => setDeleteDialogOpen(true)} />
+          <EditGeneralSettings
+            group={group}
+            onDeleteClick={group.isReadOnly ? undefined : () => setDeleteDialogOpen(true)}
+          />
         </TabPanel>
 
         <TabPanel value={activeTab} index={1}>
@@ -379,7 +391,7 @@ export default function GroupEditPage(): JSX.Element {
               onClick={() => {
                 handleSave().catch(() => null);
               }}
-              disabled={updateGroup.isPending}
+              disabled={updateGroup.isPending || group.isReadOnly === true}
             >
               {updateGroup.isPending ? t('groups:edit.page.saving') : t('groups:edit.page.save')}
             </Button>

--- a/frontend/apps/console/src/features/integrations/models/identity-provider.ts
+++ b/frontend/apps/console/src/features/integrations/models/identity-provider.ts
@@ -138,6 +138,11 @@ export interface BasicIdentityProvider {
    * The type of identity provider
    */
   type: IdentityProviderType;
+
+  /**
+   * Whether this identity provider is read-only (declarative/immutable)
+   */
+  isReadOnly?: boolean;
 }
 
 /**

--- a/frontend/apps/console/src/features/login-flow/components/LoginFlowBuilder.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/LoginFlowBuilder.tsx
@@ -280,6 +280,11 @@ function LoginFlowBuilder() {
         width: '100%',
       }}
     >
+      {existingFlowData?.isReadOnly && (
+        <Alert severity="info" sx={{mb: 2}}>
+          {t('common:messages.readOnlyResource', 'This resource is read-only and cannot be modified.')}
+        </Alert>
+      )}
       <FlowBuilder
         resources={resources}
         nodeTypes={nodeTypes}
@@ -289,7 +294,7 @@ function LoginFlowBuilder() {
         onWidgetLoad={handleWidgetLoad}
         onStepLoad={handleStepLoad}
         onResourceAdd={handleResourceAdd}
-        onSave={handleSave}
+        onSave={existingFlowData?.isReadOnly ? undefined : handleSave}
         nodes={filteredNodes}
         edges={filteredEdges}
         setNodes={setNodes}

--- a/frontend/apps/console/src/features/roles/components/RolesList.tsx
+++ b/frontend/apps/console/src/features/roles/components/RolesList.tsx
@@ -19,7 +19,7 @@
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
 import {Box, IconButton, Typography, Tooltip, DataGrid, ListingTable} from '@wso2/oxygen-ui';
-import {Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useCallback, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -77,6 +77,9 @@ export default function RolesList(): JSX.Element {
         headerName: t('roles:listing.columns.name'),
         flex: 1,
         minWidth: 200,
+        renderCell: (params: DataGrid.GridRenderCellParams<RoleSummary>): JSX.Element => (
+          <Typography variant="body2">{params.row.name}</Typography>
+        ),
       },
       {
         field: 'description',
@@ -107,29 +110,39 @@ export default function RolesList(): JSX.Element {
         hideable: false,
         renderCell: (params: DataGrid.GridRenderCellParams<RoleSummary>): JSX.Element => (
           <ListingTable.RowActions>
-            <Tooltip title={t('common:actions.edit')}>
-              <IconButton
-                size="small"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleViewClick(params.row.id);
-                }}
-              >
-                <Pencil size={16} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('common:actions.delete')}>
-              <IconButton
-                size="small"
-                color="error"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleDeleteClick(params.row.id);
-                }}
-              >
-                <Trash2 size={16} />
-              </IconButton>
-            </Tooltip>
+            {params.row.isReadOnly ? (
+              <Tooltip title={t('common:status.readOnly', 'Read Only')}>
+                <IconButton size="small" disableRipple sx={{cursor: 'default'}}>
+                  <Eye size={16} />
+                </IconButton>
+              </Tooltip>
+            ) : (
+              <>
+                <Tooltip title={t('common:actions.edit')}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleViewClick(params.row.id);
+                    }}
+                  >
+                    <Pencil size={16} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title={t('common:actions.delete')}>
+                  <IconButton
+                    size="small"
+                    color="error"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteClick(params.row.id);
+                    }}
+                  >
+                    <Trash2 size={16} />
+                  </IconButton>
+                </Tooltip>
+              </>
+            )}
           </ListingTable.RowActions>
         ),
       },

--- a/frontend/apps/console/src/features/roles/components/edit-role/assignments-settings/EditAssignmentsSettings.tsx
+++ b/frontend/apps/console/src/features/roles/components/edit-role/assignments-settings/EditAssignmentsSettings.tsx
@@ -28,13 +28,17 @@ import type {RoleAssignment} from '../../../models/role';
 
 interface EditAssignmentsSettingsProps {
   roleId: string;
+  isReadOnly?: boolean;
 }
 
 /**
  * Assignments tab content for the Role edit page.
  * Provides assignment listing, add, and remove functionality.
  */
-export default function EditAssignmentsSettings({roleId}: EditAssignmentsSettingsProps): JSX.Element {
+export default function EditAssignmentsSettings({
+  roleId,
+  isReadOnly = false,
+}: EditAssignmentsSettingsProps): JSX.Element {
   const {t} = useTranslation();
   const addRoleAssignments = useAddRoleAssignments();
   const removeRoleAssignments = useRemoveRoleAssignments();
@@ -91,19 +95,22 @@ export default function EditAssignmentsSettings({roleId}: EditAssignmentsSetting
         onRemoveAssignment={handleRemoveAssignment}
         activeAssignmentTab={activeAssignmentTab}
         onAssignmentTabChange={setActiveAssignmentTab}
+        isReadOnly={isReadOnly}
         headerAction={
-          <Button
-            variant="contained"
-            size="small"
-            startIcon={<Plus size={16} />}
-            onClick={() => setAddDialogOpen(true)}
-          >
-            {t('roles:edit.assignments.sections.manage.addAssignment')}
-          </Button>
+          !isReadOnly ? (
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={<Plus size={16} />}
+              onClick={() => setAddDialogOpen(true)}
+            >
+              {t('roles:edit.assignments.sections.manage.addAssignment')}
+            </Button>
+          ) : undefined
         }
       />
 
-      {addDialogOpen && (
+      {addDialogOpen && !isReadOnly && (
         <AddAssignmentDialog
           open={addDialogOpen}
           roleId={roleId}

--- a/frontend/apps/console/src/features/roles/components/edit-role/assignments-settings/ManageAssignmentsSection.tsx
+++ b/frontend/apps/console/src/features/roles/components/edit-role/assignments-settings/ManageAssignmentsSection.tsx
@@ -31,6 +31,7 @@ interface ManageAssignmentsSectionProps {
   headerAction?: ReactNode;
   activeAssignmentTab: number;
   onAssignmentTabChange: (tab: number) => void;
+  isReadOnly?: boolean;
 }
 
 /**
@@ -43,6 +44,7 @@ export default function ManageAssignmentsSection({
   headerAction = undefined,
   activeAssignmentTab,
   onAssignmentTabChange,
+  isReadOnly = false,
 }: ManageAssignmentsSectionProps): JSX.Element {
   const {t} = useTranslation();
   const dataGridLocaleText = useDataGridLocaleText();
@@ -147,6 +149,11 @@ export default function ManageAssignmentsSection({
     [t, onRemoveAssignment],
   );
 
+  const effectiveBaseColumns = useMemo(
+    () => (isReadOnly ? baseColumns.filter((col) => col.field !== 'actions') : baseColumns),
+    [isReadOnly, baseColumns],
+  );
+
   const userColumns: DataGrid.GridColDef<RoleAssignment>[] = useMemo(
     () => [
       {
@@ -163,9 +170,9 @@ export default function ManageAssignmentsSection({
           </Box>
         ),
       },
-      ...baseColumns,
+      ...effectiveBaseColumns,
     ],
-    [baseColumns],
+    [effectiveBaseColumns],
   );
 
   const groupColumns: DataGrid.GridColDef<RoleAssignment>[] = useMemo(
@@ -184,9 +191,9 @@ export default function ManageAssignmentsSection({
           </Box>
         ),
       },
-      ...baseColumns,
+      ...effectiveBaseColumns,
     ],
-    [baseColumns],
+    [effectiveBaseColumns],
   );
   const appColumns: DataGrid.GridColDef<RoleAssignment>[] = useMemo(
     () => [
@@ -204,9 +211,9 @@ export default function ManageAssignmentsSection({
           </Box>
         ),
       },
-      ...baseColumns,
+      ...effectiveBaseColumns,
     ],
-    [baseColumns],
+    [effectiveBaseColumns],
   );
   const agentColumns: DataGrid.GridColDef<RoleAssignment>[] = useMemo(
     () => [
@@ -224,9 +231,9 @@ export default function ManageAssignmentsSection({
           </Box>
         ),
       },
-      ...baseColumns,
+      ...effectiveBaseColumns,
     ],
-    [baseColumns],
+    [effectiveBaseColumns],
   );
 
   const handleTabChange = (_event: SyntheticEvent, newValue: number): void => {

--- a/frontend/apps/console/src/features/roles/components/edit-role/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/console/src/features/roles/components/edit-role/general-settings/EditGeneralSettings.tsx
@@ -36,14 +36,14 @@ import type {Role} from '../../../models/role';
 
 interface EditGeneralSettingsProps {
   role: Role;
-  onDeleteClick: () => void;
+  onDeleteClick?: () => void;
 }
 
 /**
  * General settings tab content for the Role edit page.
  * Displays Organization Unit info and Danger Zone sections.
  */
-export default function EditGeneralSettings({role, onDeleteClick}: EditGeneralSettingsProps): JSX.Element {
+export default function EditGeneralSettings({role, onDeleteClick = undefined}: EditGeneralSettingsProps): JSX.Element {
   const {t} = useTranslation();
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -158,20 +158,22 @@ export default function EditGeneralSettings({role, onDeleteClick}: EditGeneralSe
       </SettingsCard>
 
       {/* Danger Zone */}
-      <SettingsCard
-        title={t('roles:edit.general.sections.dangerZone.title')}
-        description={t('roles:edit.general.sections.dangerZone.description')}
-      >
-        <Typography variant="h6" gutterBottom color="error">
-          {t('roles:edit.general.sections.dangerZone.deleteRole')}
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
-          {t('roles:edit.general.sections.dangerZone.deleteRoleDescription')}
-        </Typography>
-        <Button variant="contained" color="error" onClick={onDeleteClick}>
-          {t('common:actions.delete')}
-        </Button>
-      </SettingsCard>
+      {onDeleteClick && (
+        <SettingsCard
+          title={t('roles:edit.general.sections.dangerZone.title')}
+          description={t('roles:edit.general.sections.dangerZone.description')}
+        >
+          <Typography variant="h6" gutterBottom color="error">
+            {t('roles:edit.general.sections.dangerZone.deleteRole')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
+            {t('roles:edit.general.sections.dangerZone.deleteRoleDescription')}
+          </Typography>
+          <Button variant="contained" color="error" onClick={onDeleteClick}>
+            {t('common:actions.delete')}
+          </Button>
+        </SettingsCard>
+      )}
     </Stack>
   );
 }

--- a/frontend/apps/console/src/features/roles/models/role.ts
+++ b/frontend/apps/console/src/features/roles/models/role.ts
@@ -52,6 +52,8 @@ export interface RoleSummary {
   ouId: string;
   /** Handle of the organization unit (resolved when include=display is used) */
   ouHandle?: string;
+  /** Whether this role is read-only (declarative/immutable) */
+  isReadOnly?: boolean;
 }
 
 /**

--- a/frontend/apps/console/src/features/roles/pages/RoleEditPage.tsx
+++ b/frontend/apps/console/src/features/roles/pages/RoleEditPage.tsx
@@ -176,6 +176,11 @@ export default function RoleEditPage(): JSX.Element {
 
   return (
     <PageContent>
+      {role.isReadOnly && (
+        <Alert severity="info" sx={{mb: 2}}>
+          {t('common:messages.readOnlyResource', 'This resource is read-only and cannot be modified.')}
+        </Alert>
+      )}
       {/* Header */}
       <PageTitle>
         <PageTitle.BackButton component={<Link to={listUrl} />}>{t('roles:edit.page.back')}</PageTitle.BackButton>
@@ -208,17 +213,19 @@ export default function RoleEditPage(): JSX.Element {
             ) : (
               <>
                 <Typography variant="h3">{editedRole.name ?? role.name}</Typography>
-                <IconButton
-                  size="small"
-                  aria-label={t('roles:edit.page.editName')}
-                  onClick={() => {
-                    setTempName(editedRole.name ?? role.name);
-                    setIsEditingName(true);
-                  }}
-                  sx={{opacity: 0.6, '&:hover': {opacity: 1}}}
-                >
-                  <Edit size={16} />
-                </IconButton>
+                {!role.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    aria-label={t('roles:edit.page.editName')}
+                    onClick={() => {
+                      setTempName(editedRole.name ?? role.name);
+                      setIsEditingName(true);
+                    }}
+                    sx={{opacity: 0.6, '&:hover': {opacity: 1}}}
+                  >
+                    <Edit size={16} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -258,17 +265,19 @@ export default function RoleEditPage(): JSX.Element {
                 <Typography component="span" variant="body2" color="text.secondary">
                   {effectiveDescription || t('roles:edit.page.description.empty')}
                 </Typography>
-                <IconButton
-                  size="small"
-                  aria-label={t('roles:edit.page.editDescription')}
-                  onClick={() => {
-                    setTempDescription(effectiveDescription);
-                    setIsEditingDescription(true);
-                  }}
-                  sx={{opacity: 0.6, '&:hover': {opacity: 1}, mt: -0.5}}
-                >
-                  <Edit size={14} />
-                </IconButton>
+                {!role.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    aria-label={t('roles:edit.page.editDescription')}
+                    onClick={() => {
+                      setTempDescription(effectiveDescription);
+                      setIsEditingDescription(true);
+                    }}
+                    sx={{opacity: 0.6, '&:hover': {opacity: 1}, mt: -0.5}}
+                  >
+                    <Edit size={14} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -294,11 +303,14 @@ export default function RoleEditPage(): JSX.Element {
       {/* Tab Panels */}
       <>
         <TabPanel value={activeTab} index={0}>
-          <EditGeneralSettings role={role} onDeleteClick={() => setDeleteDialogOpen(true)} />
+          <EditGeneralSettings
+            role={role}
+            onDeleteClick={role.isReadOnly ? undefined : () => setDeleteDialogOpen(true)}
+          />
         </TabPanel>
 
         <TabPanel value={activeTab} index={1}>
-          <EditAssignmentsSettings roleId={role.id} />
+          <EditAssignmentsSettings roleId={role.id} isReadOnly={role.isReadOnly} />
         </TabPanel>
       </>
 
@@ -366,7 +378,7 @@ export default function RoleEditPage(): JSX.Element {
                   /* noop */
                 });
               }}
-              disabled={updateRole.isPending}
+              disabled={updateRole.isPending || role.isReadOnly === true}
             >
               {updateRole.isPending ? t('roles:edit.page.saving') : t('roles:edit.page.save')}
             </Button>

--- a/frontend/apps/console/src/features/user-types/components/UserTypesList.tsx
+++ b/frontend/apps/console/src/features/user-types/components/UserTypesList.tsx
@@ -34,7 +34,7 @@ import {
   Button,
   DataGrid,
 } from '@wso2/oxygen-ui';
-import {Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useCallback, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -115,6 +115,9 @@ export default function UserTypesList() {
         headerName: t('userTypes:listing.columns.name', 'Name'),
         flex: 1.5,
         minWidth: 220,
+        renderCell: (params: DataGrid.GridRenderCellParams<UserTypeListItem>) => (
+          <Typography variant="body2">{params.row.name}</Typography>
+        ),
       },
       {
         field: 'id',
@@ -160,29 +163,39 @@ export default function UserTypesList() {
         hideable: false,
         renderCell: (params: GridRenderCellParams<UserTypeListItem>) => (
           <ListingTable.RowActions>
-            <Tooltip title={t('common:actions.edit')}>
-              <IconButton
-                size="small"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleViewClick(params.row.id);
-                }}
-              >
-                <Pencil size={16} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('common:actions.delete')}>
-              <IconButton
-                size="small"
-                color="error"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleDeleteClick(params.row.id);
-                }}
-              >
-                <Trash2 size={16} />
-              </IconButton>
-            </Tooltip>
+            {params.row.isReadOnly ? (
+              <Tooltip title={t('common:status.readOnly', 'Read Only')}>
+                <IconButton size="small" disableRipple sx={{cursor: 'default'}}>
+                  <Eye size={16} />
+                </IconButton>
+              </Tooltip>
+            ) : (
+              <>
+                <Tooltip title={t('common:actions.edit')}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleViewClick(params.row.id);
+                    }}
+                  >
+                    <Pencil size={16} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title={t('common:actions.delete')}>
+                  <IconButton
+                    size="small"
+                    color="error"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteClick(params.row.id);
+                    }}
+                  >
+                    <Trash2 size={16} />
+                  </IconButton>
+                </Tooltip>
+              </>
+            )}
           </ListingTable.RowActions>
         ),
       },

--- a/frontend/apps/console/src/features/user-types/components/edit-user-type/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/console/src/features/user-types/components/edit-user-type/general-settings/EditGeneralSettings.tsx
@@ -32,7 +32,7 @@ export interface EditGeneralSettingsProps {
   editedAllowSelfRegistration: boolean | undefined;
   editedDisplayAttribute: string | undefined;
   onFieldChange: (field: string, value: unknown) => void;
-  onDeleteClick: () => void;
+  onDeleteClick?: () => void;
   eligibleDisplayProperties: SchemaPropertyInput[];
 }
 
@@ -46,7 +46,7 @@ export default function EditGeneralSettings({
   editedAllowSelfRegistration,
   editedDisplayAttribute,
   onFieldChange,
-  onDeleteClick,
+  onDeleteClick = undefined,
   eligibleDisplayProperties,
 }: EditGeneralSettingsProps): JSX.Element {
   const {t} = useTranslation();
@@ -92,7 +92,7 @@ export default function EditGeneralSettings({
       >
         <OrganizationUnitTreePicker
           value={effectiveOuId}
-          onChange={(selectedOuId) => onFieldChange('ouId', selectedOuId)}
+          onChange={userType.isReadOnly ? () => undefined : (selectedOuId) => onFieldChange('ouId', selectedOuId)}
           maxHeight={400}
         />
       </SettingsCard>
@@ -105,7 +105,7 @@ export default function EditGeneralSettings({
           'Allow users to self-register with this user type.',
         )}
         enabled={effectiveAllowSelfRegistration}
-        onToggle={(enabled) => onFieldChange('allowSelfRegistration', enabled)}
+        onToggle={userType.isReadOnly ? undefined : (enabled) => onFieldChange('allowSelfRegistration', enabled)}
       >
         <Typography variant="body2" color="text.secondary">
           {t('userTypes:edit.general.selfRegistration.enabledHint', 'Users can register themselves as this user type.')}
@@ -123,6 +123,7 @@ export default function EditGeneralSettings({
         <Select
           value={effectiveDisplayAttribute}
           onChange={(event) => onFieldChange('displayAttribute', event.target.value)}
+          disabled={userType.isReadOnly}
           size="small"
           fullWidth
           displayEmpty
@@ -158,23 +159,25 @@ export default function EditGeneralSettings({
       </SettingsCard>
 
       {/* Danger Zone */}
-      <SettingsCard
-        title={t('userTypes:edit.general.dangerZone.title', 'Danger Zone')}
-        description={t('userTypes:edit.general.dangerZone.description', 'Irreversible actions for this user type.')}
-      >
-        <Typography variant="h6" gutterBottom color="error">
-          {t('userTypes:edit.general.dangerZone.deleteUserType', 'Delete User Type')}
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
-          {t(
-            'userTypes:edit.general.dangerZone.deleteUserTypeDescription',
-            'Permanently delete this user type and all associated schema definitions. This action cannot be undone.',
-          )}
-        </Typography>
-        <Button variant="contained" color="error" onClick={onDeleteClick}>
-          {t('common:actions.delete')}
-        </Button>
-      </SettingsCard>
+      {onDeleteClick && (
+        <SettingsCard
+          title={t('userTypes:edit.general.dangerZone.title', 'Danger Zone')}
+          description={t('userTypes:edit.general.dangerZone.description', 'Irreversible actions for this user type.')}
+        >
+          <Typography variant="h6" gutterBottom color="error">
+            {t('userTypes:edit.general.dangerZone.deleteUserType', 'Delete User Type')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
+            {t(
+              'userTypes:edit.general.dangerZone.deleteUserTypeDescription',
+              'Permanently delete this user type and all associated schema definitions. This action cannot be undone.',
+            )}
+          </Typography>
+          <Button variant="contained" color="error" onClick={onDeleteClick}>
+            {t('common:actions.delete')}
+          </Button>
+        </SettingsCard>
+      )}
     </Stack>
   );
 }

--- a/frontend/apps/console/src/features/user-types/components/edit-user-type/schema-settings/EditSchemaSettings.tsx
+++ b/frontend/apps/console/src/features/user-types/components/edit-user-type/schema-settings/EditSchemaSettings.tsx
@@ -49,6 +49,7 @@ export interface EditSchemaSettingsProps {
   properties: SchemaPropertyInput[];
   onPropertiesChange: (properties: SchemaPropertyInput[]) => void;
   userTypeName: string;
+  disabled?: boolean;
 }
 
 /**
@@ -59,6 +60,7 @@ export default function EditSchemaSettings({
   properties,
   onPropertiesChange,
   userTypeName,
+  disabled = false,
 }: EditSchemaSettingsProps): JSX.Element {
   const {t} = useTranslation();
   const [enumInput, setEnumInput] = useState<Record<string, string>>({});
@@ -152,7 +154,7 @@ export default function EditSchemaSettings({
           }}
         >
           {/* Remove button - visible on hover */}
-          {properties.length > 1 && (
+          {properties.length > 1 && !disabled && (
             <Tooltip title={t('userTypes:removeProperty', 'Remove property')}>
               <IconButton
                 className="property-delete-btn"
@@ -175,6 +177,7 @@ export default function EditSchemaSettings({
                   onChange={(e) => handlePropertyChange(property.id, 'name', e.target.value)}
                   placeholder={t('userTypes:propertyNamePlaceholder', 'e.g., email, age, address')}
                   size="small"
+                  disabled={disabled}
                 />
               </FormControl>
 
@@ -184,6 +187,7 @@ export default function EditSchemaSettings({
                   value={property.type}
                   onChange={(e) => handlePropertyChange(property.id, 'type', e.target.value as PropertyType)}
                   size="small"
+                  disabled={disabled}
                 >
                   <MenuItem value="string">{t('userTypes:types.string', 'String')}</MenuItem>
                   <MenuItem value="number">{t('userTypes:types.number', 'Number')}</MenuItem>
@@ -239,6 +243,7 @@ export default function EditSchemaSettings({
                     <Checkbox
                       checked={property.required}
                       onChange={(e) => handlePropertyChange(property.id, 'required', e.target.checked)}
+                      disabled={disabled}
                     />
                   }
                   label={
@@ -259,7 +264,7 @@ export default function EditSchemaSettings({
                     control={
                       <Checkbox
                         checked={property.unique}
-                        disabled={property.credential}
+                        disabled={property.credential || disabled}
                         onChange={(e) => handlePropertyChange(property.id, 'unique', e.target.checked)}
                       />
                     }
@@ -282,6 +287,7 @@ export default function EditSchemaSettings({
                     control={
                       <Checkbox
                         checked={property.credential}
+                        disabled={disabled}
                         onChange={({target: {checked}}) => {
                           if (!checked) {
                             setPendingCredentialRemoveId(property.id);
@@ -326,6 +332,7 @@ export default function EditSchemaSettings({
                   onChange={(e) => handlePropertyChange(property.id, 'regex', e.target.value)}
                   placeholder={t('userTypes:regexPlaceholder', 'e.g., ^[a-zA-Z0-9]+$')}
                   size="small"
+                  disabled={disabled}
                 />
               </FormControl>
             )}
@@ -347,8 +354,14 @@ export default function EditSchemaSettings({
                     placeholder={t('userTypes:enumPlaceholder', 'Add value and press Enter')}
                     size="small"
                     fullWidth
+                    disabled={disabled}
                   />
-                  <Button variant="outlined" size="small" onClick={() => handleAddEnumValue(property.id)}>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => handleAddEnumValue(property.id)}
+                    disabled={disabled}
+                  >
                     {t('common:actions.add', 'Add')}
                   </Button>
                 </Box>
@@ -358,7 +371,7 @@ export default function EditSchemaSettings({
                       <Chip
                         key={val}
                         label={val}
-                        onDelete={() => handleRemoveEnumValue(property.id, val)}
+                        onDelete={disabled ? undefined : () => handleRemoveEnumValue(property.id, val)}
                         size="small"
                       />
                     ))}
@@ -376,6 +389,7 @@ export default function EditSchemaSettings({
         startIcon={<Plus size={16} />}
         onClick={handleAddProperty}
         fullWidth
+        disabled={disabled}
         sx={{
           py: 1.5,
           mb: 2,

--- a/frontend/apps/console/src/features/user-types/pages/ViewUserTypePage.tsx
+++ b/frontend/apps/console/src/features/user-types/pages/ViewUserTypePage.tsx
@@ -322,6 +322,11 @@ export default function ViewUserTypePage(): JSX.Element {
 
   return (
     <PageContent>
+      {userType.isReadOnly && (
+        <Alert severity="info" sx={{mb: 2}}>
+          {t('common:messages.readOnlyResource', 'This resource is read-only and cannot be modified.')}
+        </Alert>
+      )}
       {/* Header */}
       <PageTitle>
         <PageTitle.BackButton component={<Link to={listUrl} />}>
@@ -358,20 +363,22 @@ export default function ViewUserTypePage(): JSX.Element {
             ) : (
               <>
                 <Typography variant="h3">{effectiveName}</Typography>
-                <IconButton
-                  size="small"
-                  aria-label={t('userTypes:edit.editName', 'Edit user type name')}
-                  onClick={() => {
-                    setTempName(effectiveName);
-                    setIsEditingName(true);
-                  }}
-                  sx={{
-                    opacity: 0.6,
-                    '&:hover': {opacity: 1},
-                  }}
-                >
-                  <Edit size={16} />
-                </IconButton>
+                {!userType.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    aria-label={t('userTypes:edit.editName', 'Edit user type name')}
+                    onClick={() => {
+                      setTempName(effectiveName);
+                      setIsEditingName(true);
+                    }}
+                    sx={{
+                      opacity: 0.6,
+                      '&:hover': {opacity: 1},
+                    }}
+                  >
+                    <Edit size={16} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -403,7 +410,7 @@ export default function ViewUserTypePage(): JSX.Element {
             editedAllowSelfRegistration={editedUserType.allowSelfRegistration}
             editedDisplayAttribute={editedUserType.displayAttribute}
             onFieldChange={handleFieldChange}
-            onDeleteClick={() => setDeleteDialogOpen(true)}
+            onDeleteClick={userType.isReadOnly ? undefined : () => setDeleteDialogOpen(true)}
             eligibleDisplayProperties={eligibleDisplayProperties}
           />
         </TabPanel>
@@ -413,6 +420,7 @@ export default function ViewUserTypePage(): JSX.Element {
             properties={effectiveProperties}
             onPropertiesChange={handlePropertiesChange}
             userTypeName={effectiveName}
+            disabled={userType.isReadOnly}
           />
         </TabPanel>
       </>
@@ -433,6 +441,7 @@ export default function ViewUserTypePage(): JSX.Element {
           saveLabel={t('common:actions.save', 'Save')}
           savingLabel={t('common:status.saving', 'Saving...')}
           isSaving={updateUserTypeMutation.isPending}
+          saveDisabled={userType.isReadOnly === true}
           onReset={handleReset}
           onSave={() => {
             handleSave().catch(() => null);

--- a/frontend/apps/console/src/features/user-types/types/user-types.ts
+++ b/frontend/apps/console/src/features/user-types/types/user-types.ts
@@ -119,6 +119,7 @@ export interface ApiUserType {
   allowSelfRegistration: boolean;
   systemAttributes?: SystemAttributes;
   schema: UserTypeDefinition;
+  isReadOnly?: boolean;
 }
 
 /**
@@ -131,6 +132,7 @@ export interface UserTypeListItem {
   ouHandle?: string;
   allowSelfRegistration: boolean;
   systemAttributes?: SystemAttributes;
+  isReadOnly?: boolean;
 }
 
 /**

--- a/frontend/packages/configure-organization-units/src/components/OrganizationUnitsTreeView.tsx
+++ b/frontend/packages/configure-organization-units/src/components/OrganizationUnitsTreeView.tsx
@@ -33,7 +33,7 @@ import {
   Avatar,
   Tooltip,
 } from '@wso2/oxygen-ui';
-import {Pencil, Plus, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Eye, Pencil, Plus, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, useEffect, useRef, useMemo} from 'react';
 import type {ReactNode, MouseEvent, KeyboardEvent, SyntheticEvent, JSX} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -312,47 +312,57 @@ function CustomTreeItem(allProps: CustomTreeItemProps): JSX.Element {
               </Typography>
             )}
           </Box>
-          <Tooltip title={addChildTooltip}>
-            <IconButton
-              size="small"
-              aria-label={addChildTooltip}
-              onClick={(e: MouseEvent<HTMLButtonElement>) => {
-                e.stopPropagation();
-                onAddChild?.(e as unknown as MouseEvent<HTMLElement>, {
-                  id: itemId,
-                  name: labelStr,
-                  handle: itemData?.handle ?? '',
-                });
-              }}
-            >
-              <Plus size={16} />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title={editTooltip}>
-            <IconButton
-              size="small"
-              aria-label={editTooltip}
-              onClick={(e: MouseEvent<HTMLButtonElement>) => {
-                e.stopPropagation();
-                onEdit?.(e as unknown as MouseEvent<HTMLElement>, {id: itemId, name: labelStr});
-              }}
-            >
-              <Pencil size={16} />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title={deleteTooltip}>
-            <IconButton
-              size="small"
-              color="error"
-              aria-label={deleteTooltip}
-              onClick={(e: MouseEvent<HTMLButtonElement>) => {
-                e.stopPropagation();
-                onDelete?.(e as unknown as MouseEvent<HTMLElement>, {id: itemId, name: labelStr});
-              }}
-            >
-              <Trash2 size={16} />
-            </IconButton>
-          </Tooltip>
+          {itemData?.isReadOnly ? (
+            <Tooltip title={t('common:status.readOnly', 'Read Only')}>
+              <IconButton size="small" disableRipple sx={{cursor: 'default'}}>
+                <Eye size={16} />
+              </IconButton>
+            </Tooltip>
+          ) : (
+            <>
+              <Tooltip title={addChildTooltip}>
+                <IconButton
+                  size="small"
+                  aria-label={addChildTooltip}
+                  onClick={(e: MouseEvent<HTMLButtonElement>) => {
+                    e.stopPropagation();
+                    onAddChild?.(e as unknown as MouseEvent<HTMLElement>, {
+                      id: itemId,
+                      name: labelStr,
+                      handle: itemData?.handle ?? '',
+                    });
+                  }}
+                >
+                  <Plus size={16} />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title={editTooltip}>
+                <IconButton
+                  size="small"
+                  aria-label={editTooltip}
+                  onClick={(e: MouseEvent<HTMLButtonElement>) => {
+                    e.stopPropagation();
+                    onEdit?.(e as unknown as MouseEvent<HTMLElement>, {id: itemId, name: labelStr});
+                  }}
+                >
+                  <Pencil size={16} />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title={deleteTooltip}>
+                <IconButton
+                  size="small"
+                  color="error"
+                  aria-label={deleteTooltip}
+                  onClick={(e: MouseEvent<HTMLButtonElement>) => {
+                    e.stopPropagation();
+                    onDelete?.(e as unknown as MouseEvent<HTMLElement>, {id: itemId, name: labelStr});
+                  }}
+                >
+                  <Trash2 size={16} />
+                </IconButton>
+              </Tooltip>
+            </>
+          )}
         </Box>
       }
     />

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/general-settings/EditGeneralSettings.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/general-settings/EditGeneralSettings.tsx
@@ -35,7 +35,7 @@ interface EditGeneralSettingsProps {
   /**
    * Callback function to open the delete confirmation dialog
    */
-  onDeleteClick: () => void;
+  onDeleteClick?: () => void;
 }
 
 /**
@@ -49,7 +49,10 @@ interface EditGeneralSettingsProps {
  * @param props - Component props
  * @returns General settings sections wrapped in a Stack
  */
-export default function EditGeneralSettings({organizationUnit, onDeleteClick}: EditGeneralSettingsProps): JSX.Element {
+export default function EditGeneralSettings({
+  organizationUnit,
+  onDeleteClick = undefined,
+}: EditGeneralSettingsProps): JSX.Element {
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -81,7 +84,7 @@ export default function EditGeneralSettings({organizationUnit, onDeleteClick}: E
         onCopyToClipboard={handleCopyToClipboard}
       />
       <ParentSettingsSection organizationUnit={organizationUnit} />
-      <DangerZoneSection onDeleteClick={onDeleteClick} />
+      {onDeleteClick && <DangerZoneSection onDeleteClick={onDeleteClick} />}
     </Stack>
   );
 }

--- a/frontend/packages/configure-organization-units/src/models/organization-unit-tree.ts
+++ b/frontend/packages/configure-organization-units/src/models/organization-unit-tree.ts
@@ -41,7 +41,8 @@ import type {OrganizationUnit} from './organization-unit';
  * };
  * ```
  */
-export interface OrganizationUnitTreeItem extends Pick<OrganizationUnit, 'id' | 'handle' | 'description' | 'logoUrl'> {
+export interface OrganizationUnitTreeItem
+  extends Pick<OrganizationUnit, 'id' | 'handle' | 'description' | 'logoUrl' | 'isReadOnly'> {
   /**
    * Display label shown in the tree view
    * @example 'Engineering'

--- a/frontend/packages/configure-organization-units/src/models/organization-unit.ts
+++ b/frontend/packages/configure-organization-units/src/models/organization-unit.ts
@@ -99,4 +99,9 @@ export interface OrganizationUnit {
    * @example 'https://example.com/logo.png'
    */
   logoUrl?: string;
+
+  /**
+   * Whether the organization unit is read-only and cannot be modified or deleted.
+   */
+  isReadOnly?: boolean;
 }

--- a/frontend/packages/configure-organization-units/src/pages/OrganizationUnitEditPage.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/OrganizationUnitEditPage.tsx
@@ -200,6 +200,11 @@ export default function OrganizationUnitEditPage(): JSX.Element {
 
   return (
     <PageContent>
+      {organizationUnit.isReadOnly && (
+        <Alert severity="info" sx={{mb: 2}}>
+          {t('common:messages.readOnlyResource', 'This resource is read-only and cannot be modified.')}
+        </Alert>
+      )}
       {/* Header */}
       <PageTitle>
         <PageTitle.BackButton component={<Link to={fromOU ? `/organization-units/${fromOU.id}` : listUrl} />}>
@@ -207,7 +212,7 @@ export default function OrganizationUnitEditPage(): JSX.Element {
         </PageTitle.BackButton>
         <PageTitle.Avatar sx={{overflow: 'visible'}}>
           <ResourceAvatar
-            editable
+            editable={!organizationUnit.isReadOnly}
             value={editedOU.logoUrl ?? organizationUnit.logoUrl ?? undefined}
             fallback="emoji:🏛️"
             editAriaLabel={t('organizationUnits:edit.page.logoUpdate.label')}
@@ -242,19 +247,21 @@ export default function OrganizationUnitEditPage(): JSX.Element {
             ) : (
               <>
                 <Typography variant="h3">{editedOU.name ?? organizationUnit.name}</Typography>
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setTempName(editedOU.name ?? organizationUnit.name);
-                    setIsEditingName(true);
-                  }}
-                  sx={{
-                    opacity: 0.6,
-                    '&:hover': {opacity: 1},
-                  }}
-                >
-                  <Edit size={16} />
-                </IconButton>
+                {!organizationUnit.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setTempName(editedOU.name ?? organizationUnit.name);
+                      setIsEditingName(true);
+                    }}
+                    sx={{
+                      opacity: 0.6,
+                      '&:hover': {opacity: 1},
+                    }}
+                  >
+                    <Edit size={16} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -304,22 +311,25 @@ export default function OrganizationUnitEditPage(): JSX.Element {
                   {(editedOU.description !== undefined ? editedOU.description : organizationUnit.description) ??
                     t('organizationUnits:edit.page.description.empty')}
                 </Typography>
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setTempDescription(
-                      (editedOU.description !== undefined ? editedOU.description : organizationUnit.description) ?? '',
-                    );
-                    setIsEditingDescription(true);
-                  }}
-                  sx={{
-                    opacity: 0.6,
-                    '&:hover': {opacity: 1},
-                    mt: -0.5,
-                  }}
-                >
-                  <Edit size={14} />
-                </IconButton>
+                {!organizationUnit.isReadOnly && (
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setTempDescription(
+                        (editedOU.description !== undefined ? editedOU.description : organizationUnit.description) ??
+                          '',
+                      );
+                      setIsEditingDescription(true);
+                    }}
+                    sx={{
+                      opacity: 0.6,
+                      '&:hover': {opacity: 1},
+                      mt: -0.5,
+                    }}
+                  >
+                    <Edit size={14} />
+                  </IconButton>
+                )}
               </>
             )}
           </Stack>
@@ -364,7 +374,10 @@ export default function OrganizationUnitEditPage(): JSX.Element {
       <>
         {/* General Settings Tab */}
         <TabPanel value={activeTab} index={0}>
-          <EditGeneralSettings organizationUnit={organizationUnit} onDeleteClick={() => setDeleteDialogOpen(true)} />
+          <EditGeneralSettings
+            organizationUnit={organizationUnit}
+            onDeleteClick={organizationUnit.isReadOnly ? undefined : () => setDeleteDialogOpen(true)}
+          />
         </TabPanel>
 
         {/* Child OUs Tab */}
@@ -420,6 +433,7 @@ export default function OrganizationUnitEditPage(): JSX.Element {
           saveLabel={t('organizationUnits:edit.actions.save.label')}
           savingLabel={t('organizationUnits:edit.actions.saving.label')}
           isSaving={updateOrganizationUnit.isPending}
+          saveDisabled={organizationUnit.isReadOnly === true}
           onReset={() => setEditedOU({})}
           onSave={() => {
             // Errors are handled in handleSave

--- a/frontend/packages/configure-organization-units/src/utils/buildTreeItems.ts
+++ b/frontend/packages/configure-organization-units/src/utils/buildTreeItems.ts
@@ -27,6 +27,7 @@ export default function buildTreeItems(ous: OrganizationUnit[]): OrganizationUni
     handle: ou.handle,
     description: ou.description,
     logoUrl: ou.logoUrl,
+    isReadOnly: ou.isReadOnly,
     children: [
       {
         id: `${ou.id}${OrganizationUnitTreeConstants.PLACEHOLDER_SUFFIX}`,

--- a/frontend/packages/configure-users/src/components/UsersList.tsx
+++ b/frontend/packages/configure-users/src/components/UsersList.tsx
@@ -35,7 +35,7 @@ import {
   DataGrid,
   useTheme,
 } from '@wso2/oxygen-ui';
-import {Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useState, useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -161,29 +161,39 @@ export default function UsersList() {
         hideable: false,
         renderCell: (params: DataGrid.GridRenderCellParams<UserWithDetails>) => (
           <ListingTable.RowActions>
-            <Tooltip title={t('common:actions.edit')}>
-              <IconButton
-                size="small"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleEditClick(params.row.id);
-                }}
-              >
-                <Pencil size={16} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('common:actions.delete')}>
-              <IconButton
-                size="small"
-                color="error"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleDeleteClick(params.row.id);
-                }}
-              >
-                <Trash2 size={16} />
-              </IconButton>
-            </Tooltip>
+            {params.row.isReadOnly ? (
+              <Tooltip title={t('common:status.readOnly', 'Read Only')}>
+                <IconButton size="small" disableRipple sx={{cursor: 'default'}}>
+                  <Eye size={16} />
+                </IconButton>
+              </Tooltip>
+            ) : (
+              <>
+                <Tooltip title={t('common:actions.edit')}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleEditClick(params.row.id);
+                    }}
+                  >
+                    <Pencil size={16} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title={t('common:actions.delete')}>
+                  <IconButton
+                    size="small"
+                    color="error"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteClick(params.row.id);
+                    }}
+                  >
+                    <Trash2 size={16} />
+                  </IconButton>
+                </Tooltip>
+              </>
+            )}
           </ListingTable.RowActions>
         ),
       },

--- a/frontend/packages/configure-users/src/pages/UserEditPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserEditPage.tsx
@@ -251,6 +251,11 @@ export default function UserEditPage() {
 
   return (
     <PageContent>
+      {user.isReadOnly && (
+        <Alert severity="info" sx={{mb: 2}}>
+          {t('common:messages.readOnlyResource', 'This resource is read-only and cannot be modified.')}
+        </Alert>
+      )}
       {/* Header */}
       <PageTitle>
         <PageTitle.BackButton component={<Link to="/users" />}>
@@ -294,7 +299,7 @@ export default function UserEditPage() {
                 'View and manage user attribute values.',
               )}
               headerAction={
-                !isEditMode && hasEditableFields ? (
+                !isEditMode && hasEditableFields && !user.isReadOnly ? (
                   <Button variant="outlined" size="small" onClick={() => setIsEditMode(true)}>
                     {t('common:actions.edit', 'Edit')}
                   </Button>
@@ -494,26 +499,28 @@ export default function UserEditPage() {
             </SettingsCard>
 
             {/* Danger Zone */}
-            <SettingsCard
-              title={t('users:manageUser.sections.dangerZone.title', 'Danger Zone')}
-              description={t(
-                'users:manageUser.sections.dangerZone.description',
-                'Irreversible and destructive actions.',
-              )}
-            >
-              <Typography variant="h6" gutterBottom color="error">
-                {t('users:manageUser.sections.dangerZone.deleteUser', 'Delete User')}
-              </Typography>
-              <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
-                {t(
-                  'users:manageUser.sections.dangerZone.deleteUserDescription',
-                  'Once deleted, this user cannot be recovered. All associated data will be permanently removed.',
+            {!user.isReadOnly && (
+              <SettingsCard
+                title={t('users:manageUser.sections.dangerZone.title', 'Danger Zone')}
+                description={t(
+                  'users:manageUser.sections.dangerZone.description',
+                  'Irreversible and destructive actions.',
                 )}
-              </Typography>
-              <Button variant="contained" color="error" onClick={() => setDeleteDialogOpen(true)}>
-                {t('common:actions.delete', 'Delete')}
-              </Button>
-            </SettingsCard>
+              >
+                <Typography variant="h6" gutterBottom color="error">
+                  {t('users:manageUser.sections.dangerZone.deleteUser', 'Delete User')}
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
+                  {t(
+                    'users:manageUser.sections.dangerZone.deleteUserDescription',
+                    'Once deleted, this user cannot be recovered. All associated data will be permanently removed.',
+                  )}
+                </Typography>
+                <Button variant="contained" color="error" onClick={() => setDeleteDialogOpen(true)}>
+                  {t('common:actions.delete', 'Delete')}
+                </Button>
+              </SettingsCard>
+            )}
           </Stack>
         </TabPanel>
       </>

--- a/frontend/packages/design/src/models/responses.ts
+++ b/frontend/packages/design/src/models/responses.ts
@@ -33,6 +33,7 @@ export interface ThemeListItem {
   primaryColor?: string;
   createdAt?: string;
   updatedAt?: string;
+  isReadOnly?: boolean;
 }
 
 /**

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -101,6 +101,7 @@ const translations = {
     'status.inactive': 'Inactive',
     'status.enabled': 'Enabled',
     'status.disabled': 'Disabled',
+    'status.readOnly': 'Read Only',
     'status.completed': 'Completed',
     'status.failed': 'Failed',
 

--- a/frontend/packages/types/src/concepts/user.ts
+++ b/frontend/packages/types/src/concepts/user.ts
@@ -54,4 +54,9 @@ export interface User {
    * Human-readable display name for the user.
    */
   display?: string;
+
+  /**
+   * Whether the user is read-only and cannot be modified or deleted.
+   */
+  isReadOnly?: boolean;
 }


### PR DESCRIPTION
### Purpose

Backend API list endpoints return an `isReadOnly` flag for declarative (file-based) resources. This PR wires up the frontend to visually indicate when a resource is read-only and prevent any mutation actions on those resources.

**Affected resources:** Applications, Agents, Groups, Roles, User Types, Users, Flows, Organization Units, Themes

Applications
<img width="1752" height="1108" alt="Screenshot 2026-05-27 at 18 40 22" src="https://github.com/user-attachments/assets/978446ae-80b3-400f-b941-fdafac9e6ae1" />

Users
<img width="1752" height="1108" alt="Screenshot 2026-05-27 at 18 40 19" src="https://github.com/user-attachments/assets/02e70e60-624d-4b38-8b31-eddef671d133" />

Roles
<img width="1752" height="1108" alt="Screenshot 2026-05-27 at 18 40 27" src="https://github.com/user-attachments/assets/9b8d141f-5cb0-4abf-a3af-55c5002cc9dd" />

Organization Units
<img width="1728" height="1080" alt="Screenshot 2026-05-27 at 18 40 39" src="https://github.com/user-attachments/assets/c12c9585-f40d-42fb-8c6e-f0957a1bba76" />

Flows
<img width="1752" height="1108" alt="Screenshot 2026-05-27 at 18 40 44" src="https://github.com/user-attachments/assets/8119de57-1942-4fbc-80ec-76c819c3912b" />

---

### Approach

#### List views
- Replaced the previous Chip-based "Read Only" label with a `Lock` icon button in the actions column (DataGrid lists) — clicking is disabled and hovering shows a "Read Only" tooltip.
- For read-only rows, the Edit and Delete action buttons are completely replaced by the single Lock icon.
- Row click navigation is blocked for read-only flows.

#### Organization Units (tree view)
- The OU list uses a `RichTreeView` rather than a DataGrid. For read-only items the Plus/Edit/Delete icon buttons in each tree node are replaced by a single Lock icon with a tooltip.
- `isReadOnly` is propagated through `buildTreeItems` → `OrganizationUnitTreeItem` → `buildItemMap` → `CustomTreeItem`.

#### Themes (card grid)
- The Themes page uses a card grid (`ItemCard`) instead of a table. For read-only themes:
  - A Lock badge is shown permanently in the top-right corner of the thumbnail.
  - Click is disabled and hover effects are suppressed.
- `isReadOnly` added to `ThemeListItem` model.

#### Edit pages
- An informational Alert banner is shown at the top of edit pages when the resource is read-only.
- Save, delete, and inline edit actions are disabled or hidden when `isReadOnly` is true.
- Organization Unit edit: `ResourceAvatar` made non-editable, inline name/description edit buttons hidden, delete section hidden, `UnsavedChangesBar` save button disabled.
- Flow builder: Save button disabled by passing `onSave={undefined}` when the flow is read-only.

#### Bug fixes
- Fixed missing `Box` and `Chip` imports in `FlowsList.tsx` and `RolesList.tsx` that caused render failures.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global read-only mode across console resources with informational banners and an eye icon indicator per read-only item.
  * Edit/delete controls, dangerous actions, avatar/logo edits, and Save buttons are disabled when a resource is read-only; many form inputs and list actions become non-interactive.
* **Chores**
  * Read-only state plumbing added across lists, detail pages, and settings to enforce consistent UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->