### PR TITLE
Fix theme flashing in docs page.

### DIFF
--- a/docs/src/theme/ColorModeToggle/index.tsx
+++ b/docs/src/theme/ColorModeToggle/index.tsx
@@ -20,7 +20,12 @@ import type {WrapperProps} from '@docusaurus/types';
 import type ColorModeToggleType from '@theme/ColorModeToggle';
 import ColorModeToggle from '@theme-original/ColorModeToggle';
 import {useColorScheme} from '@wso2/oxygen-ui';
-import {useEffect, type ReactNode} from 'react';
+import {useEffect, useLayoutEffect, type ReactNode} from 'react';
+
+// useLayoutEffect runs synchronously before the browser paints, which ensures the
+// dark-mode / light-mode class is on document.body before Scalar (BrowserOnly) reads it.
+// Falls back to useEffect in SSR where window is not available to avoid React warnings.
+const useSyncLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 type Props = WrapperProps<typeof ColorModeToggleType>;
 
@@ -33,7 +38,7 @@ export default function ColorModeToggleWrapper(props: Props): ReactNode {
 
   // change mode based on "value" prop
   // "dark" or "light" are also used for MUI
-  useEffect(() => {
+  useSyncLayoutEffect(() => {
     setMode(value);
 
     // Set CSS class on body tag to sync Scalar API Reference theme with the main Docusaurus theme.


### PR DESCRIPTION

### Purpose

Fixes an intermittent color scheme flashing bug in the docs site where Scalar API Reference would briefly render in the wrong theme. There were two distinct causes:

1. **Initial load flash** — The `dark-mode`/`light-mode` body classes were applied inside a `useEffect`, which runs *after* the browser has already painted. Because Scalar renders inside `BrowserOnly` (also a `useEffect`), Scalar could read `document.body.classList` before the class was written, causing it to initialize in the wrong theme.

2. **Theme toggle flash** — `applyModeClass` called `classList.remove('dark-mode', 'light-mode')` before adding the new class, creating a brief window where the body had neither class, which Scalar interpreted as light mode.

### Approach

**Fix 1 — `useLayoutEffect` instead of `useEffect`:**
React guarantees that all `useLayoutEffect` hooks run synchronously before the browser paints, and before any `useEffect` runs. Switching to `useLayoutEffect` means the body class is always written before Scalar (triggered via `BrowserOnly`'s `useEffect`) ever reads it.

A module-level SSR guard (`typeof window !== 'undefined' ? useLayoutEffect : useEffect`) is used to avoid the React "useLayoutEffect in SSR" warning that would otherwise fire during Docusaurus's static site generation.

**Fix 2 — Add before remove in `applyModeClass`:**
Changed the class update order so the correct mode class is added first, then the opposite is removed. This ensures `document.body` always carries a valid mode class when `effectiveMode` is known, eliminating the intermediate state that caused the flash on toggle.


### Preview
https://github.com/user-attachments/assets/db990e6f-a055-4a90-b254-7225e2406655


### Related Issues
- Fixes #3020

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [[WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Theme mode is now applied synchronously during page load, eliminating color flashing.
  * Resolved server-side rendering compatibility issues with theme functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->