### PR TITLE
passing CacheConfig as argument to Initialize

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	// Initialize the cache manager.
-	cacheManager := cache.Initialize()
+	cacheManager := cache.Initialize(cfg.Cache, cfg.Server.Identifier)
 
 	// Initialize system permission strings before any service or middleware uses them.
 	security.InitSystemPermissions(cfg.Server.SecurityConfig.SystemPermissionPrefix)

--- a/backend/internal/entitytype/init_test.go
+++ b/backend/internal/entitytype/init_test.go
@@ -49,6 +49,42 @@ func (m *mockTransactioner) Transact(ctx context.Context, txFunc func(context.Co
 	return txFunc(ctx)
 }
 
+func testCacheManager() cache.CacheManagerInterface {
+	return cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment")
+}
+
+func setupEntityTypeStoreRuntime(t *testing.T, entityTypeStore string, declarativeEnabled bool) {
+	t.Helper()
+
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: declarativeEnabled,
+		},
+		EntityType: config.EntityTypeConfig{
+			Store: entityTypeStore,
+		},
+		Database: config.DatabaseConfig{
+			Config: config.DataSource{
+				Type:   "sqlite",
+				SQLite: config.SQLiteDataSource{Path: ":memory:"},
+			},
+		},
+	}
+
+	config.ResetServerRuntime()
+	err := config.InitializeServerRuntime("", testConfig)
+	assert.NoError(t, err)
+}
+
+func assertMutableEntityTypeStore(t *testing.T, store entityTypeStoreInterface) {
+	t.Helper()
+
+	_, isComposite := store.(*compositeEntityTypeStore)
+	assert.False(t, isComposite, "Store should not be composite in mutable mode")
+	_, isFileBased := store.(*entityTypeFileBasedStore)
+	assert.False(t, isFileBased, "Store should not be file-based in mutable mode")
+}
+
 // InitTestSuite contains comprehensive tests for the init.go file.
 type InitTestSuite struct {
 	suite.Suite
@@ -89,7 +125,7 @@ func (suite *InitTestSuite) TestInitialize() {
 	assert.NoError(suite.T(), err)
 
 	service, _, err := Initialize(
-		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, testCacheManager(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	suite.NotNil(service)
@@ -113,7 +149,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_ListEndpoint() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, testCacheManager(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodGet, "/user-types", nil)
@@ -141,7 +177,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CreateEndpoint() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, testCacheManager(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodPost, "/user-types", nil)
@@ -177,7 +213,7 @@ func (suite *InitTestSuite) TestInitialize_DBTransactionerError() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, testCacheManager(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.Error(suite.T(), err)
 	if err != nil {
 		assert.Contains(suite.T(), err.Error(), "failed to get config database client")
@@ -201,7 +237,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_GetByIDEndpoint() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, testCacheManager(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodGet, "/user-types/test-id", nil)
@@ -229,7 +265,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_UpdateEndpoint() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, testCacheManager(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodPut, "/user-types/test-id", nil)
@@ -257,7 +293,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_DeleteEndpoint() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, testCacheManager(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodDelete, "/user-types/test-id", nil)
@@ -285,7 +321,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSPreflight() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, testCacheManager(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodOptions, "/user-types", nil)
@@ -313,7 +349,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSPreflightByID() {
 	assert.NoError(suite.T(), err)
 
 	_, _, err = Initialize(
-		suite.mux, nil, cache.Initialize(), suite.mockOUService, nil, suite.mockConsentService)
+		suite.mux, nil, testCacheManager(), suite.mockOUService, nil, suite.mockConsentService)
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodOptions, "/user-types/test-id", nil)
@@ -521,7 +557,7 @@ func TestInitialize_Standalone(t *testing.T) {
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
-	service, exporter, err := Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
+	service, exporter, err := Initialize(mux, nil, testCacheManager(), mockOUService, nil, mockConsentService)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
@@ -530,35 +566,14 @@ func TestInitialize_Standalone(t *testing.T) {
 
 // TestInitializeStore_MutableMode tests initializeStore with mutable mode (database only).
 func TestInitializeStore_MutableMode(t *testing.T) {
-	testConfig := &config.Config{
-		DeclarativeResources: config.DeclarativeResources{
-			Enabled: false,
-		},
-		EntityType: config.EntityTypeConfig{
-			Store: "mutable",
-		},
-		Database: config.DatabaseConfig{
-			Config: config.DataSource{
-				Type:   "sqlite",
-				SQLite: config.SQLiteDataSource{Path: ":memory:"},
-			},
-		},
-	}
+	setupEntityTypeStoreRuntime(t, "mutable", false)
 
-	config.ResetServerRuntime()
-	err := config.InitializeServerRuntime("", testConfig)
-	assert.NoError(t, err)
-
-	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), cache.Initialize())
+	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), testCacheManager())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
 	assert.NotNil(t, transactioner)
-	// In mutable mode, should return entityTypeStore (not composite or file-based)
-	_, isComposite := store.(*compositeEntityTypeStore)
-	assert.False(t, isComposite, "Store should not be composite in mutable mode")
-	_, isFileBased := store.(*entityTypeFileBasedStore)
-	assert.False(t, isFileBased, "Store should not be file-based in mutable mode")
+	assertMutableEntityTypeStore(t, store)
 }
 
 // TestInitializeStore_DeclarativeMode tests initializeStore with declarative mode (file-based only).
@@ -582,7 +597,7 @@ func TestInitializeStore_DeclarativeMode(t *testing.T) {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(t, err)
 
-	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), cache.Initialize())
+	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), testCacheManager())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
@@ -613,7 +628,7 @@ func TestInitializeStore_CompositeMode(t *testing.T) {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(t, err)
 
-	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), cache.Initialize())
+	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), testCacheManager())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
@@ -627,35 +642,14 @@ func TestInitializeStore_CompositeMode(t *testing.T) {
 
 // TestInitializeStore_DefaultFallbackToMutable tests that default config falls back to mutable mode.
 func TestInitializeStore_DefaultFallbackToMutable(t *testing.T) {
-	testConfig := &config.Config{
-		DeclarativeResources: config.DeclarativeResources{
-			Enabled: false, // Disabled, should default to mutable
-		},
-		EntityType: config.EntityTypeConfig{
-			Store: "", // Not specified
-		},
-		Database: config.DatabaseConfig{
-			Config: config.DataSource{
-				Type:   "sqlite",
-				SQLite: config.SQLiteDataSource{Path: ":memory:"},
-			},
-		},
-	}
+	setupEntityTypeStoreRuntime(t, "", false)
 
-	config.ResetServerRuntime()
-	err := config.InitializeServerRuntime("", testConfig)
-	assert.NoError(t, err)
-
-	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), cache.Initialize())
+	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), testCacheManager())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
 	assert.NotNil(t, transactioner)
-	// Should default to mutable mode (database store)
-	_, isComposite := store.(*compositeEntityTypeStore)
-	assert.False(t, isComposite, "Store should not be composite when not specified")
-	_, isFileBased := store.(*entityTypeFileBasedStore)
-	assert.False(t, isFileBased, "Store should not be file-based when declarative disabled")
+	assertMutableEntityTypeStore(t, store)
 }
 
 // TestInitializeStore_GlobalDeclarativeEnabled tests fallback to global declarative setting.
@@ -679,7 +673,7 @@ func TestInitializeStore_GlobalDeclarativeEnabled(t *testing.T) {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(t, err)
 
-	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), cache.Initialize())
+	store, transactioner, err := initializeStore(getEntityTypeStoreMode(), testCacheManager())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
@@ -714,7 +708,7 @@ func TestInitialize_MutableMode(t *testing.T) {
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
-	service, exporter, err := Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
+	service, exporter, err := Initialize(mux, nil, testCacheManager(), mockOUService, nil, mockConsentService)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
@@ -757,7 +751,7 @@ func TestInitialize_StoreModes(t *testing.T) {
 				Maybe()
 			mockConsentService := mockConsentServiceWithDisabled(t)
 
-			service, exporter, err := Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
+			service, exporter, err := Initialize(mux, nil, testCacheManager(), mockOUService, nil, mockConsentService)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, service)
@@ -1148,7 +1142,7 @@ func TestInitialize_WithDeclarativeResourcesEnabled_InvalidYAML(t *testing.T) {
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
 	// Initialize should return an error due to invalid YAML
-	_, _, err = Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }
@@ -1208,7 +1202,7 @@ schema: |
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
 	// Initialize should return an error due to validation failure
-	_, _, err = Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }
@@ -1282,7 +1276,7 @@ schema: |
 		}).Once()
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
-	_, _, err = Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 
@@ -1342,7 +1336,7 @@ schema: |
 	mockConsentService := mockConsentServiceWithDisabled(t)
 
 	// Initialize should return an error due to invalid JSON
-	_, _, err = Initialize(mux, nil, cache.Initialize(), mockOUService, nil, mockConsentService)
+	_, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil, mockConsentService)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -136,7 +136,7 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 	testConfig := &config.Config{}
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
 
 	// Mock inbound client + entity for the flow's owning entity (shared across test cases).
@@ -289,7 +289,7 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 	testConfig := &config.Config{}
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 
 	tests := []struct {
 		name       string
@@ -466,7 +466,7 @@ func TestEncryptedPayloadStoredBeforeWrite(t *testing.T) {
 	testConfig := &config.Config{}
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
 
 	mockStore := newFlowStoreInterfaceMock(t)
@@ -511,7 +511,7 @@ func TestEncryptedPayloadStoredBeforeWrite(t *testing.T) {
 func TestDecryptCalledForEncryptedStoredContext(t *testing.T) {
 	// Verifies that when GetFlowContext returns an encrypted context (has "alg" field),
 	// Decrypt is called and the engine receives the properly restored EngineContext.
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	engineCtx := EngineContext{
@@ -621,7 +621,7 @@ func TestEncryptedContext_SensitiveFieldsHidden(t *testing.T) {
 				return encrypted, nil, encErr
 			})
 
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	sensitiveAppID := "app-sensitive-99999"
@@ -723,7 +723,7 @@ func TestEncryptDecryptRoundTrip_AllFieldsPreserved(t *testing.T) {
 			return mockConfigCryptoService.Decrypt(ctx, content)
 		})
 
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	originalToken := "original-secret-token-value-xyz789"
@@ -812,7 +812,7 @@ func TestExecute_ContextDecryptionFailure(t *testing.T) {
 func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 	// Tests that a plain-text stored context (decryption already handled by service before store)
 	// is loaded and used to continue flow execution without error.
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	engineCtx := EngineContext{
@@ -873,7 +873,7 @@ func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 }
 
 func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	engineCtx := EngineContext{
@@ -936,7 +936,7 @@ func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
 }
 
 func TestExecute_ExistingFlowWithDifferentChallengeTokens(t *testing.T) {
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	tests := []struct {
@@ -1027,7 +1027,7 @@ func TestExecute_ExistingFlowWithDifferentChallengeTokens(t *testing.T) {
 }
 
 func TestExecute_EngineError_InvalidChallengeToken_PreservesContext(t *testing.T) {
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	engineCtx := EngineContext{
@@ -1081,7 +1081,7 @@ func TestExecute_EngineError_InvalidChallengeToken_PreservesContext(t *testing.T
 }
 
 func TestExecute_EngineError_NonChallengeToken_RemovesContext(t *testing.T) {
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	engineCtx := EngineContext{
@@ -1153,7 +1153,7 @@ func TestExecute_EngineError_NewFlow_ContextNeverRemoved(t *testing.T) {
 	config.ResetServerRuntime()
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
 
 	mockStore := newFlowStoreInterfaceMock(t)
@@ -1334,7 +1334,7 @@ func TestEncryptEngineContext_EncryptError(t *testing.T) {
 	testConfig := &config.Config{}
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
-	flowFactory, _ := core.Initialize(cache.Initialize())
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
 	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
 
 	engineCtx := &EngineContext{

--- a/backend/internal/flow/mgt/init_test.go
+++ b/backend/internal/flow/mgt/init_test.go
@@ -756,7 +756,9 @@ func (s *InitTestSuite) TestInitializeStore_MutableMode() {
 	cleanup := setupMockDBProvider()
 	defer cleanup()
 
-	store, compositeStore, _, err := initializeStore(cache.Initialize())
+	store, compositeStore, _, err := initializeStore(
+		cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"),
+	)
 
 	s.NoError(err)
 	s.NotNil(store)
@@ -793,7 +795,9 @@ func (s *InitTestSuite) TestInitializeStore_DeclarativeMode() {
 	_ = config.InitializeServerRuntime("test", testConfig)
 	defer config.ResetServerRuntime()
 
-	store, compositeStore, _, err := initializeStore(cache.Initialize())
+	store, compositeStore, _, err := initializeStore(
+		cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"),
+	)
 
 	// Note: err might occur if declarative resources path doesn't exist, but that's expected
 	// We're testing store type initialization, not resource loading
@@ -835,7 +839,9 @@ func (s *InitTestSuite) TestInitializeStore_CompositeMode() {
 	cleanup := setupMockDBProvider()
 	defer cleanup()
 
-	store, compositeStore, _, err := initializeStore(cache.Initialize())
+	store, compositeStore, _, err := initializeStore(
+		cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"),
+	)
 
 	// Note: err might occur if declarative resources path doesn't exist, but that's expected
 	// We're testing store type initialization, not resource loading
@@ -876,7 +882,9 @@ func (s *InitTestSuite) TestInitializeStore_DeclarativeMode_ResourceLoadingError
 	_ = config.InitializeServerRuntime("test", testConfig)
 	defer config.ResetServerRuntime()
 
-	store, compositeStore, _, err := initializeStore(cache.Initialize())
+	store, compositeStore, _, err := initializeStore(
+		cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"),
+	)
 
 	// When declarative resources path doesn't exist or has issues, error is returned
 	// The store and compositeStore should be nil when error occurs
@@ -920,7 +928,9 @@ func (s *InitTestSuite) TestInitializeStore_CompositeMode_ResourceLoadingError()
 	cleanup := setupMockDBProvider()
 	defer cleanup()
 
-	store, compositeStore, _, err := initializeStore(cache.Initialize())
+	store, compositeStore, _, err := initializeStore(
+		cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"),
+	)
 
 	// When declarative resources path doesn't exist or has issues, error is returned
 	// The store and compositeStore should be nil when error occurs
@@ -964,7 +974,9 @@ func (s *InitTestSuite) TestInitializeStore_DefaultMode() {
 	cleanup := setupMockDBProvider()
 	defer cleanup()
 
-	store, compositeStore, _, err := initializeStore(cache.Initialize())
+	store, compositeStore, _, err := initializeStore(
+		cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"),
+	)
 
 	s.NoError(err)
 	s.NotNil(store)
@@ -1004,7 +1016,9 @@ func (s *InitTestSuite) TestInitializeStore_ModeNormalization() {
 	cleanup := setupMockDBProvider()
 	defer cleanup()
 
-	store, compositeStore, _, err := initializeStore(cache.Initialize())
+	store, compositeStore, _, err := initializeStore(
+		cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"),
+	)
 
 	// Note: err might occur if declarative resources path doesn't exist, but that's expected
 	// We're testing store type initialization and mode normalization

--- a/backend/internal/idp/init_test.go
+++ b/backend/internal/idp/init_test.go
@@ -86,7 +86,7 @@ func (s *IDPInitTestSuite) TestInitialize() {
 	_ = config.InitializeServerRuntime("", testConfig)
 	mux := http.NewServeMux()
 
-	service, _, err := Initialize(cache.Initialize(), mux)
+	service, _, err := Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"), mux)
 	s.NoError(err)
 	s.NotNil(service)
 	s.Implements((*IDPServiceInterface)(nil), service)
@@ -317,7 +317,7 @@ func (suite *IDPInitTestSuite) TestInitialize_WithDeclarativeResourcesDisabled()
 	mux := http.NewServeMux()
 
 	// Execute
-	service, _, err := Initialize(cache.Initialize(), mux)
+	service, _, err := Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"), mux)
 
 	// Assert
 	suite.NoError(err)
@@ -368,7 +368,7 @@ func TestInitialize_WithDeclarativeResourcesEnabled_EmptyDirectory(t *testing.T)
 	mux := http.NewServeMux()
 
 	// Execute
-	service, _, err := Initialize(cache.Initialize(), mux)
+	service, _, err := Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"), mux)
 
 	// Assert
 	assert.NoError(t, err)
@@ -467,7 +467,7 @@ properties:
 	mux := http.NewServeMux()
 
 	// Execute
-	service, _, err := Initialize(cache.Initialize(), mux)
+	service, _, err := Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"), mux)
 
 	// Assert
 	assert.NoError(t, err)
@@ -557,7 +557,7 @@ func TestInitialize_WithDeclarativeResourcesEnabled_InvalidYAML(t *testing.T) {
 	mux := http.NewServeMux()
 
 	// Initialize should return an error due to invalid YAML
-	_, _, err = Initialize(cache.Initialize(), mux)
+	_, _, err = Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"), mux)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load identity provider resources")
 }
@@ -618,7 +618,7 @@ properties:
 	mux := http.NewServeMux()
 
 	// Initialize should return an error due to validation failure
-	_, _, err = Initialize(cache.Initialize(), mux)
+	_, _, err = Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"), mux)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load identity provider resources")
 }
@@ -679,7 +679,7 @@ properties:
 	mux := http.NewServeMux()
 
 	// Initialize should return an error due to invalid IDP type
-	_, _, err = Initialize(cache.Initialize(), mux)
+	_, _, err = Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"), mux)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load identity provider resources")
 }
@@ -818,7 +818,7 @@ func (s *IDPInitTestSuite) TestInitialize_DBClientError() {
 	}()
 
 	mux := http.NewServeMux()
-	_, _, err := Initialize(cache.Initialize(), mux)
+	_, _, err := Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"), mux)
 
 	s.Error(err)
 	s.Equal("mock db client error", err.Error())
@@ -842,7 +842,7 @@ func (s *IDPInitTestSuite) TestInitialize_TransactionerError() {
 	}()
 
 	mux := http.NewServeMux()
-	_, _, err := Initialize(cache.Initialize(), mux)
+	_, _, err := Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"), mux)
 
 	s.Error(err)
 	s.Equal("mock transactioner error", err.Error())

--- a/backend/internal/ou/cache_backed_store_test.go
+++ b/backend/internal/ou/cache_backed_store_test.go
@@ -609,7 +609,7 @@ func (s *CacheBackedOUStoreTestSuite) TestWrapWithCache_WithCacheManager() {
 	err := config.InitializeServerRuntime(tmpDir, &config.Config{})
 	s.Require().NoError(err)
 
-	cm := cache.Initialize()
+	cm := cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment")
 	defer cm.Close()
 
 	result := wrapWithCache(s.mockStore, cm)

--- a/backend/internal/system/cache/CacheManagerInterface_mock_test.go
+++ b/backend/internal/system/cache/CacheManagerInterface_mock_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/system/config"
 )
 
 // NewCacheManagerInterfaceMock creates a new instance of CacheManagerInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -252,6 +253,94 @@ func (_c *CacheManagerInterfaceMock_getCache_Call) Return(ifaceVal interface{}, 
 }
 
 func (_c *CacheManagerInterfaceMock_getCache_Call) RunAndReturn(run func(cacheKey string) (interface{}, bool)) *CacheManagerInterfaceMock_getCache_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// getCacheConfig provides a mock function for the type CacheManagerInterfaceMock
+func (_mock *CacheManagerInterfaceMock) getCacheConfig() config.CacheConfig {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for getCacheConfig")
+	}
+
+	var r0 config.CacheConfig
+	if returnFunc, ok := ret.Get(0).(func() config.CacheConfig); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(config.CacheConfig)
+	}
+	return r0
+}
+
+// CacheManagerInterfaceMock_getCacheConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getCacheConfig'
+type CacheManagerInterfaceMock_getCacheConfig_Call struct {
+	*mock.Call
+}
+
+// getCacheConfig is a helper method to define mock.On call
+func (_e *CacheManagerInterfaceMock_Expecter) getCacheConfig() *CacheManagerInterfaceMock_getCacheConfig_Call {
+	return &CacheManagerInterfaceMock_getCacheConfig_Call{Call: _e.mock.On("getCacheConfig")}
+}
+
+func (_c *CacheManagerInterfaceMock_getCacheConfig_Call) Run(run func()) *CacheManagerInterfaceMock_getCacheConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *CacheManagerInterfaceMock_getCacheConfig_Call) Return(cacheConfig config.CacheConfig) *CacheManagerInterfaceMock_getCacheConfig_Call {
+	_c.Call.Return(cacheConfig)
+	return _c
+}
+
+func (_c *CacheManagerInterfaceMock_getCacheConfig_Call) RunAndReturn(run func() config.CacheConfig) *CacheManagerInterfaceMock_getCacheConfig_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// getDeploymentID provides a mock function for the type CacheManagerInterfaceMock
+func (_mock *CacheManagerInterfaceMock) getDeploymentID() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for getDeploymentID")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// CacheManagerInterfaceMock_getDeploymentID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getDeploymentID'
+type CacheManagerInterfaceMock_getDeploymentID_Call struct {
+	*mock.Call
+}
+
+// getDeploymentID is a helper method to define mock.On call
+func (_e *CacheManagerInterfaceMock_Expecter) getDeploymentID() *CacheManagerInterfaceMock_getDeploymentID_Call {
+	return &CacheManagerInterfaceMock_getDeploymentID_Call{Call: _e.mock.On("getDeploymentID")}
+}
+
+func (_c *CacheManagerInterfaceMock_getDeploymentID_Call) Run(run func()) *CacheManagerInterfaceMock_getDeploymentID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *CacheManagerInterfaceMock_getDeploymentID_Call) Return(s string) *CacheManagerInterfaceMock_getDeploymentID_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *CacheManagerInterfaceMock_getDeploymentID_Call) RunAndReturn(run func() string) *CacheManagerInterfaceMock_getDeploymentID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/system/cache/manager.go
+++ b/backend/internal/system/cache/manager.go
@@ -37,6 +37,8 @@ type CacheManagerInterface interface {
 	getMutex() *sync.RWMutex
 	getCache(cacheKey string) (interface{}, bool)
 	addCache(cacheKey string, cacheInstance interface{})
+	getCacheConfig() config.CacheConfig
+	getDeploymentID() string
 	getRedisClient() *redis.Client
 	startCleanupRoutine()
 	cleanupAllCaches()
@@ -50,19 +52,21 @@ type CacheManager struct {
 	enabled         bool
 	cleanupInterval time.Duration
 	redisClient     *redis.Client
+	cacheConfig     config.CacheConfig
+	deploymentID    string
 }
 
-// Initialize creates and returns a new CacheManagerInterface instance.
 // Initialize creates, configures, and returns a ready-to-use CacheManagerInterface.
-func Initialize() CacheManagerInterface {
+func Initialize(cacheConfig config.CacheConfig, deploymentID string) CacheManagerInterface {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
 	logger.Debug("Initializing Cache Manager")
 
 	cm := &CacheManager{
-		caches: make(map[string]interface{}),
+		cacheConfig:  cacheConfig,
+		deploymentID: deploymentID,
+		caches:       make(map[string]interface{}),
 	}
 
-	cacheConfig := config.GetServerRuntime().Config.Cache
 	if cacheConfig.Disabled {
 		logger.Debug("Caching is disabled. Skipping initialization")
 		return cm
@@ -147,6 +151,16 @@ func (cm *CacheManager) addCache(cacheKey string, cacheInstance interface{}) {
 	}
 }
 
+// getCacheConfig returns the cache configuration used by the manager.
+func (cm *CacheManager) getCacheConfig() config.CacheConfig {
+	return cm.cacheConfig
+}
+
+// getDeploymentID returns the deployment identifier used for Redis key isolation.
+func (cm *CacheManager) getDeploymentID() string {
+	return cm.deploymentID
+}
+
 // getRedisClient returns the shared Redis client, or nil if Redis is not configured.
 func (cm *CacheManager) getRedisClient() *redis.Client {
 	return cm.redisClient
@@ -206,8 +220,7 @@ func (cm *CacheManager) reset() {
 }
 
 // buildRedisKeyPrefix composes the Redis key prefix with deployment ID for per-deployment isolation.
-func buildRedisKeyPrefix(basePrefix string) string {
-	deploymentID := config.GetServerRuntime().Config.Server.Identifier
+func buildRedisKeyPrefix(basePrefix, deploymentID string) string {
 	if deploymentID == "" {
 		return basePrefix
 	}
@@ -224,7 +237,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"),
 		log.String("cacheName", cacheName))
 
-	cacheConfig := config.GetServerRuntime().Config.Cache
+	cacheConfig := cm.getCacheConfig()
 	if cacheConfig.Disabled {
 		logger.Debug("Caching is disabled, returning empty")
 		return &Cache[T]{
@@ -266,7 +279,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 				cacheImpl: nil,
 			}
 		} else {
-			keyPrefix := buildRedisKeyPrefix(cacheConfig.Redis.KeyPrefix)
+			keyPrefix := buildRedisKeyPrefix(cacheConfig.Redis.KeyPrefix, cm.getDeploymentID())
 			internalCache = newRedisCache[T](
 				cacheName,
 				!cacheProperty.Disabled,
@@ -324,7 +337,7 @@ func GetInMemoryCache[T any](cm CacheManagerInterface, cacheName string) CacheIn
 
 	logger.Debug("Creating new in-memory cache", log.String("cacheName", cacheName), log.String("type", typeName))
 
-	cacheConfig := config.GetServerRuntime().Config.Cache
+	cacheConfig := cm.getCacheConfig()
 	cacheProperty := getCacheProperty(cacheConfig, cacheName)
 
 	var internalCache CacheInterface[T]

--- a/backend/internal/system/cache/manager_test.go
+++ b/backend/internal/system/cache/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -60,33 +61,90 @@ func (suite *CacheManagerTestSuite) TearDownSuite() {
 func (suite *CacheManagerTestSuite) TestInitialize() {
 	t := suite.T()
 
-	manager := Initialize()
+	manager := Initialize(config.CacheConfig{Disabled: true}, "test-deployment")
 	assert.NotNil(t, manager, "Cache manager should not be nil")
 	assert.IsType(t, &CacheManager{}, manager, "Cache manager should be of type *CacheManager")
+}
+
+func (suite *CacheManagerTestSuite) TestInitializeWithCacheConfig() {
+	t := suite.T()
+
+	tests := []struct {
+		name              string
+		cacheConfig       config.CacheConfig
+		expectEnabled     bool
+		expectCleanupSecs int
+	}{
+		{
+			name:          "returns disabled manager when cache is disabled",
+			cacheConfig:   config.CacheConfig{Disabled: true},
+			expectEnabled: false,
+		},
+		{
+			name: "enables in-memory manager with configured cleanup interval",
+			cacheConfig: config.CacheConfig{
+				Disabled:        false,
+				Type:            "inmemory",
+				CleanupInterval: 60,
+			},
+			expectEnabled:     true,
+			expectCleanupSecs: 60,
+		},
+		{
+			name: "defaults to in-memory when cache type is empty",
+			cacheConfig: config.CacheConfig{
+				Disabled:        false,
+				CleanupInterval: 30,
+			},
+			expectEnabled:     true,
+			expectCleanupSecs: 30,
+		},
+		{
+			name: "disables manager when redis connection fails",
+			cacheConfig: config.CacheConfig{
+				Disabled: false,
+				Type:     "redis",
+				Redis: config.RedisConfig{
+					Address:        "127.0.0.1:1",
+					DialTimeoutMS:  100,
+					ReadTimeoutMS:  100,
+					WriteTimeoutMS: 100,
+				},
+			},
+			expectEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := Initialize(tt.cacheConfig, "test-deployment").(*CacheManager)
+
+			assert.Equal(t, tt.expectEnabled, manager.IsEnabled())
+			if tt.expectEnabled {
+				assert.Equal(t, time.Duration(tt.expectCleanupSecs)*time.Second, manager.cleanupInterval)
+				assert.Nil(t, manager.redisClient)
+			} else {
+				assert.Nil(t, manager.redisClient)
+			}
+		})
+	}
 }
 
 func (suite *CacheManagerTestSuite) TestCacheManagerInit() {
 	t := suite.T()
 
-	// Test with cache disabled (default config has cache disabled)
-	manager := Initialize()
+	manager := Initialize(config.CacheConfig{Disabled: true}, "test-deployment")
 	assert.False(t, manager.IsEnabled(), "Cache should be disabled")
 
-	// Test with cache enabled
-	enabledConfig := &config.Config{
-		Cache: config.CacheConfig{
-			Disabled:        false,
-			Size:            1000,
-			TTL:             3600,
-			EvictionPolicy:  "LRU",
-			CleanupInterval: 60,
-		},
+	enabledCacheConfig := config.CacheConfig{
+		Disabled:        false,
+		Size:            1000,
+		TTL:             3600,
+		EvictionPolicy:  "LRU",
+		CleanupInterval: 60,
 	}
-	config.ResetServerRuntime()
-	err := config.InitializeServerRuntime("/test/thunderid/home", enabledConfig)
-	assert.NoError(t, err)
 
-	manager = Initialize()
+	manager = Initialize(enabledCacheConfig, "test-deployment")
 	assert.True(t, manager.IsEnabled(), "Cache should be enabled")
 	assert.Equal(t, time.Duration(60)*time.Second, manager.(*CacheManager).cleanupInterval,
 		"Cleanup interval should be set")
@@ -134,7 +192,7 @@ func (suite *CacheManagerTestSuite) TestAddAndGetCache() {
 func (suite *CacheManagerTestSuite) TestGetCache() {
 	t := suite.T()
 
-	manager := Initialize()
+	manager := Initialize(config.GetServerRuntime().Config.Cache, "test-deployment")
 	cacheName := "testCache"
 	cache1 := GetCache[string](manager, cacheName)
 	assert.NotNil(t, cache1, "Cache should not be nil")
@@ -151,7 +209,7 @@ func (suite *CacheManagerTestSuite) TestGetCache() {
 func (suite *CacheManagerTestSuite) TestGetCacheMultipleTypes() {
 	t := suite.T()
 
-	manager := Initialize()
+	manager := Initialize(config.GetServerRuntime().Config.Cache, "test-deployment")
 	cacheName := "testMultiTypeCache"
 
 	cacheString := GetCache[string](manager, cacheName)
@@ -176,7 +234,7 @@ func (suite *CacheManagerTestSuite) TestGetCacheMultipleTypes() {
 func (suite *CacheManagerTestSuite) TestResetCacheManager() {
 	t := suite.T()
 
-	manager := Initialize().(*CacheManager)
+	manager := Initialize(config.GetServerRuntime().Config.Cache, "test-deployment").(*CacheManager)
 	cacheName := "testResetCache"
 	cm := GetCache[string](manager, cacheName)
 	assert.NotNil(t, cm, "Cache should not be nil")
@@ -233,7 +291,7 @@ func (suite *CacheManagerTestSuite) TestConcurrentAccess() {
 	err := config.InitializeServerRuntime("/test/thunderid/home", enabledConfig)
 	assert.NoError(t, err)
 
-	cm := Initialize()
+	cm := Initialize(config.GetServerRuntime().Config.Cache, "test-deployment")
 
 	// Number of goroutines to use
 	numGoroutines := 10
@@ -274,7 +332,7 @@ func (suite *CacheManagerTestSuite) TestTypeMismatch() {
 	t := suite.T()
 
 	cacheName := "typeMismatchCache"
-	manager := Initialize().(*CacheManager)
+	manager := Initialize(config.GetServerRuntime().Config.Cache, "test-deployment").(*CacheManager)
 
 	var mockCache interface{} = &Cache[int]{} // Int type
 	typeName := "string"
@@ -310,7 +368,10 @@ func (suite *CacheManagerTestSuite) TestNewCache() {
 	err := config.InitializeServerRuntime("/test/thunderid/home", &disabledConfig)
 	assert.NoError(t, err)
 
-	cache1 := newCache[string](Initialize(), "testDisabledCache")
+	cache1 := newCache[string](
+		Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"),
+		"testDisabledCache",
+	)
 	assert.NotNil(t, cache1)
 	assert.False(t, cache1.IsEnabled())
 
@@ -330,7 +391,10 @@ func (suite *CacheManagerTestSuite) TestNewCache() {
 	err = config.InitializeServerRuntime("/test/thunderid/home", &enabledConfig)
 	assert.NoError(t, err)
 
-	cache2 := newCache[string](Initialize(), "testSpecificDisabledCache")
+	cache2 := newCache[string](
+		Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"),
+		"testSpecificDisabledCache",
+	)
 	assert.NotNil(t, cache2)
 	assert.False(t, cache2.IsEnabled())
 
@@ -352,7 +416,7 @@ func (suite *CacheManagerTestSuite) TestNewCache() {
 	err = config.InitializeServerRuntime("/test/thunderid/home", &inMemConfig)
 	assert.NoError(t, err)
 
-	cache3 := newCache[string](Initialize(), "testInMemCache")
+	cache3 := newCache[string](Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"), "testInMemCache")
 	assert.NotNil(t, cache3)
 	assert.True(t, cache3.IsEnabled())
 
@@ -367,7 +431,10 @@ func (suite *CacheManagerTestSuite) TestNewCache() {
 	err = config.InitializeServerRuntime("/test/thunderid/home", &unknownTypeConfig)
 	assert.NoError(t, err)
 
-	cache4 := newCache[string](Initialize(), "testUnknownTypeCache")
+	cache4 := newCache[string](
+		Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"),
+		"testUnknownTypeCache",
+	)
 	assert.NotNil(t, cache4)
 	assert.True(t, cache4.IsEnabled())
 }
@@ -380,6 +447,22 @@ func (suite *CacheManagerTestSuite) TestGetCleanupInterval() {
 	interval := getCleanupInterval(config)
 	assert.Equal(t, time.Duration(120)*time.Second, interval, "Should use configured cleanup interval")
 }
+
+func (suite *CacheManagerTestSuite) TestCacheManagerAccessors() {
+	t := suite.T()
+
+	client := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
+	manager := &CacheManager{
+		caches:       make(map[string]interface{}),
+		cacheConfig:  config.CacheConfig{Disabled: false},
+		deploymentID: "deployment-test",
+		redisClient:  client,
+	}
+
+	assert.Equal(t, "deployment-test", manager.getDeploymentID())
+	assert.Same(t, client, manager.getRedisClient())
+}
+
 func (suite *CacheManagerTestSuite) TestBuildRedisKeyPrefix() {
 	t := suite.T()
 
@@ -431,7 +514,7 @@ func (suite *CacheManagerTestSuite) TestBuildRedisKeyPrefix() {
 			err := config.InitializeServerRuntime("/test/thunderid/home", &cfg)
 			assert.NoError(t, err)
 
-			result := buildRedisKeyPrefix(tc.basePrefix)
+			result := buildRedisKeyPrefix(tc.basePrefix, tc.deploymentID)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/backend/tests/mocks/cachemock/CacheManagerInterface_mock.go
+++ b/backend/tests/mocks/cachemock/CacheManagerInterface_mock.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/system/config"
 )
 
 // NewCacheManagerInterfaceMock creates a new instance of CacheManagerInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -252,6 +253,94 @@ func (_c *CacheManagerInterfaceMock_getCache_Call) Return(ifaceVal interface{}, 
 }
 
 func (_c *CacheManagerInterfaceMock_getCache_Call) RunAndReturn(run func(cacheKey string) (interface{}, bool)) *CacheManagerInterfaceMock_getCache_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// getCacheConfig provides a mock function for the type CacheManagerInterfaceMock
+func (_mock *CacheManagerInterfaceMock) getCacheConfig() config.CacheConfig {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for getCacheConfig")
+	}
+
+	var r0 config.CacheConfig
+	if returnFunc, ok := ret.Get(0).(func() config.CacheConfig); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(config.CacheConfig)
+	}
+	return r0
+}
+
+// CacheManagerInterfaceMock_getCacheConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getCacheConfig'
+type CacheManagerInterfaceMock_getCacheConfig_Call struct {
+	*mock.Call
+}
+
+// getCacheConfig is a helper method to define mock.On call
+func (_e *CacheManagerInterfaceMock_Expecter) getCacheConfig() *CacheManagerInterfaceMock_getCacheConfig_Call {
+	return &CacheManagerInterfaceMock_getCacheConfig_Call{Call: _e.mock.On("getCacheConfig")}
+}
+
+func (_c *CacheManagerInterfaceMock_getCacheConfig_Call) Run(run func()) *CacheManagerInterfaceMock_getCacheConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *CacheManagerInterfaceMock_getCacheConfig_Call) Return(cacheConfig config.CacheConfig) *CacheManagerInterfaceMock_getCacheConfig_Call {
+	_c.Call.Return(cacheConfig)
+	return _c
+}
+
+func (_c *CacheManagerInterfaceMock_getCacheConfig_Call) RunAndReturn(run func() config.CacheConfig) *CacheManagerInterfaceMock_getCacheConfig_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// getDeploymentID provides a mock function for the type CacheManagerInterfaceMock
+func (_mock *CacheManagerInterfaceMock) getDeploymentID() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for getDeploymentID")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// CacheManagerInterfaceMock_getDeploymentID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'getDeploymentID'
+type CacheManagerInterfaceMock_getDeploymentID_Call struct {
+	*mock.Call
+}
+
+// getDeploymentID is a helper method to define mock.On call
+func (_e *CacheManagerInterfaceMock_Expecter) getDeploymentID() *CacheManagerInterfaceMock_getDeploymentID_Call {
+	return &CacheManagerInterfaceMock_getDeploymentID_Call{Call: _e.mock.On("getDeploymentID")}
+}
+
+func (_c *CacheManagerInterfaceMock_getDeploymentID_Call) Run(run func()) *CacheManagerInterfaceMock_getDeploymentID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *CacheManagerInterfaceMock_getDeploymentID_Call) Return(s string) *CacheManagerInterfaceMock_getDeploymentID_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *CacheManagerInterfaceMock_getDeploymentID_Call) RunAndReturn(run func() string) *CacheManagerInterfaceMock_getDeploymentID_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- #3037 

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache initialization now uses the active runtime cache configuration and an explicit deployment identifier, improving cache isolation, key namespacing, and disabled-cache behavior.

* **Tests**
  * Tests updated and expanded to validate runtime-backed cache scenarios (disabled, in-memory, Redis, error paths) and ensure consistent behavior across suites.
  * Mocks and new table-driven tests added to cover cache manager accessors and initialization variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->