### PR TITLE
Improve SDKs to forward scopes to embedded flow init

### DIFF
--- a/sdks/javascript/src/api/v2/__tests__/executeEmbeddedSignInFlowV2.test.ts
+++ b/sdks/javascript/src/api/v2/__tests__/executeEmbeddedSignInFlowV2.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {EmbeddedSignInFlowResponse, EmbeddedSignInFlowStatus} from '../../../models/v2/embedded-signin-flow-v2';
+import executeEmbeddedSignInFlowV2 from '../executeEmbeddedSignInFlowV2';
+
+const URL = 'https://localhost:8090/flow/execute';
+
+const mockFlowResponse = (overrides: Partial<EmbeddedSignInFlowResponse> = {}): EmbeddedSignInFlowResponse =>
+  ({
+    flowStatus: EmbeddedSignInFlowStatus.Incomplete,
+    ...overrides,
+  }) as EmbeddedSignInFlowResponse;
+
+const captureRequestBody = (): Record<string, unknown> => {
+  const calls = (fetch as ReturnType<typeof vi.fn>).mock.calls;
+  const requestInit = calls[calls.length - 1][1] as RequestInit;
+  return JSON.parse(requestInit.body as string) as Record<string, unknown>;
+};
+
+describe('executeEmbeddedSignInFlowV2', (): void => {
+  beforeEach((): void => {
+    vi.resetAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(mockFlowResponse()),
+      ok: true,
+    });
+  });
+
+  describe('verbose: true injection', (): void => {
+    it('injects verbose:true for a new flow start with applicationId and flowType', async (): Promise<void> => {
+      await executeEmbeddedSignInFlowV2({
+        payload: {applicationId: 'app-1', flowType: 'AUTHENTICATION'},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).toMatchObject({verbose: true});
+    });
+
+    it('injects verbose:true for a new flow start that also includes scopes', async (): Promise<void> => {
+      await executeEmbeddedSignInFlowV2({
+        payload: {applicationId: 'app-1', flowType: 'AUTHENTICATION', scopes: ['openid', 'profile']},
+        url: URL,
+      });
+
+      const body = captureRequestBody();
+      expect(body).toMatchObject({verbose: true, inputs: {requested_permissions: 'openid profile'}});
+      expect(body).not.toHaveProperty('scopes');
+    });
+
+    it('injects verbose:true for a bare flow resumption (executionId only)', async (): Promise<void> => {
+      await executeEmbeddedSignInFlowV2({
+        payload: {executionId: 'exec-abc'},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).toMatchObject({verbose: true});
+    });
+
+    it('does NOT inject verbose:true for a step submission (executionId + inputs)', async (): Promise<void> => {
+      await executeEmbeddedSignInFlowV2({
+        payload: {action: 'submit', executionId: 'exec-abc', inputs: {password: 'secret', username: 'user'}},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).not.toHaveProperty('verbose');
+    });
+
+    it('strips a user-supplied verbose before applying internal logic', async (): Promise<void> => {
+      await executeEmbeddedSignInFlowV2({
+        payload: {action: 'submit', executionId: 'exec-abc', inputs: {}, verbose: false},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).not.toHaveProperty('verbose');
+    });
+
+    it('strips user-supplied verbose:true from step submissions', async (): Promise<void> => {
+      await executeEmbeddedSignInFlowV2({
+        payload: {action: 'submit', executionId: 'exec-abc', inputs: {}, verbose: true},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).not.toHaveProperty('verbose');
+    });
+  });
+
+  describe('scopes → inputs.requested_permissions translation', (): void => {
+    it('translates scopes to a space-separated inputs.requested_permissions string', async (): Promise<void> => {
+      await executeEmbeddedSignInFlowV2({
+        payload: {applicationId: 'app-1', flowType: 'AUTHENTICATION', scopes: ['openid', 'profile', 'email']},
+        url: URL,
+      });
+
+      const body = captureRequestBody();
+      expect(body).toMatchObject({inputs: {requested_permissions: 'openid profile email'}});
+      expect(body).not.toHaveProperty('scopes');
+    });
+
+    it('does not add requested_permissions when scopes is absent', async (): Promise<void> => {
+      await executeEmbeddedSignInFlowV2({
+        payload: {applicationId: 'app-1', flowType: 'AUTHENTICATION'},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).not.toHaveProperty('inputs');
+    });
+
+    it('does not add requested_permissions when scopes is an empty array', async (): Promise<void> => {
+      await executeEmbeddedSignInFlowV2({
+        payload: {applicationId: 'app-1', flowType: 'AUTHENTICATION', scopes: []},
+        url: URL,
+      });
+
+      const body = captureRequestBody();
+      expect(body).not.toHaveProperty('scopes');
+      expect(body).not.toHaveProperty('inputs');
+    });
+  });
+
+  it('throws when payload is missing', async (): Promise<void> => {
+    await expect(executeEmbeddedSignInFlowV2({url: URL})).rejects.toThrow('Authorization payload is required');
+  });
+
+  it('uses baseUrl to construct the endpoint when url is not provided', async (): Promise<void> => {
+    await executeEmbeddedSignInFlowV2({
+      baseUrl: 'https://localhost:8090',
+      payload: {applicationId: 'app-1', flowType: 'AUTHENTICATION'},
+    });
+
+    expect(fetch).toHaveBeenCalledWith('https://localhost:8090/flow/execute', expect.any(Object));
+  });
+});

--- a/sdks/javascript/src/api/v2/__tests__/executeEmbeddedSignUpFlowV2.test.ts
+++ b/sdks/javascript/src/api/v2/__tests__/executeEmbeddedSignUpFlowV2.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {EmbeddedSignUpFlowResponse, EmbeddedSignUpFlowStatus} from '../../../models/v2/embedded-signup-flow-v2';
+import executeEmbeddedSignUpFlowV2 from '../executeEmbeddedSignUpFlowV2';
+
+const URL = 'https://localhost:8090/flow/execute';
+
+const mockFlowResponse = (overrides: Partial<EmbeddedSignUpFlowResponse> = {}): EmbeddedSignUpFlowResponse =>
+  ({
+    flowStatus: EmbeddedSignUpFlowStatus.Incomplete,
+    ...overrides,
+  }) as EmbeddedSignUpFlowResponse;
+
+const captureRequestBody = (): Record<string, unknown> => {
+  const calls = (fetch as ReturnType<typeof vi.fn>).mock.calls;
+  const requestInit = calls[calls.length - 1][1] as RequestInit;
+  return JSON.parse(requestInit.body as string) as Record<string, unknown>;
+};
+
+describe('executeEmbeddedSignUpFlowV2', (): void => {
+  beforeEach((): void => {
+    vi.resetAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(mockFlowResponse()),
+      ok: true,
+    });
+  });
+
+  describe('verbose: true injection', (): void => {
+    it('injects verbose:true for a new flow start with applicationId and flowType', async (): Promise<void> => {
+      await executeEmbeddedSignUpFlowV2({
+        payload: {applicationId: 'app-1', flowType: 'REGISTRATION'},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).toMatchObject({verbose: true});
+    });
+
+    it('injects verbose:true for a new flow start that also includes scopes', async (): Promise<void> => {
+      await executeEmbeddedSignUpFlowV2({
+        payload: {applicationId: 'app-1', flowType: 'REGISTRATION', scopes: ['openid', 'profile']},
+        url: URL,
+      });
+
+      const body = captureRequestBody();
+      expect(body).toMatchObject({verbose: true, inputs: {requested_permissions: 'openid profile'}});
+      expect(body).not.toHaveProperty('scopes');
+    });
+
+    it('injects verbose:true for a bare flow resumption (executionId only)', async (): Promise<void> => {
+      await executeEmbeddedSignUpFlowV2({
+        payload: {executionId: 'exec-abc'},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).toMatchObject({verbose: true});
+    });
+
+    it('does NOT inject verbose:true for a step submission (executionId + inputs)', async (): Promise<void> => {
+      await executeEmbeddedSignUpFlowV2({
+        payload: {action: 'submit', executionId: 'exec-abc', inputs: {email: 'user@example.com'}},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).not.toHaveProperty('verbose');
+    });
+
+    it('strips a user-supplied verbose before applying internal logic', async (): Promise<void> => {
+      await executeEmbeddedSignUpFlowV2({
+        payload: {action: 'submit', executionId: 'exec-abc', inputs: {}, verbose: false},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).not.toHaveProperty('verbose');
+    });
+
+    it('strips user-supplied verbose:true from step submissions', async (): Promise<void> => {
+      await executeEmbeddedSignUpFlowV2({
+        payload: {action: 'submit', executionId: 'exec-abc', inputs: {}, verbose: true},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).not.toHaveProperty('verbose');
+    });
+  });
+
+  describe('scopes → inputs.requested_permissions translation', (): void => {
+    it('translates scopes to a space-separated inputs.requested_permissions string', async (): Promise<void> => {
+      await executeEmbeddedSignUpFlowV2({
+        payload: {applicationId: 'app-1', flowType: 'REGISTRATION', scopes: ['openid', 'profile', 'email']},
+        url: URL,
+      });
+
+      const body = captureRequestBody();
+      expect(body).toMatchObject({inputs: {requested_permissions: 'openid profile email'}});
+      expect(body).not.toHaveProperty('scopes');
+    });
+
+    it('does not add requested_permissions when scopes is absent', async (): Promise<void> => {
+      await executeEmbeddedSignUpFlowV2({
+        payload: {applicationId: 'app-1', flowType: 'REGISTRATION'},
+        url: URL,
+      });
+
+      expect(captureRequestBody()).not.toHaveProperty('inputs');
+    });
+
+    it('does not add requested_permissions when scopes is an empty array', async (): Promise<void> => {
+      await executeEmbeddedSignUpFlowV2({
+        payload: {applicationId: 'app-1', flowType: 'REGISTRATION', scopes: []},
+        url: URL,
+      });
+
+      const body = captureRequestBody();
+      expect(body).not.toHaveProperty('scopes');
+      expect(body).not.toHaveProperty('inputs');
+    });
+  });
+
+  it('throws when payload is missing', async (): Promise<void> => {
+    await expect(executeEmbeddedSignUpFlowV2({url: URL})).rejects.toThrow('Registration payload is required');
+  });
+
+  it('uses baseUrl to construct the endpoint when url is not provided', async (): Promise<void> => {
+    await executeEmbeddedSignUpFlowV2({
+      baseUrl: 'https://localhost:8090',
+      payload: {applicationId: 'app-1', flowType: 'REGISTRATION'},
+    });
+
+    expect(fetch).toHaveBeenCalledWith('https://localhost:8090/flow/execute', expect.any(Object));
+  });
+});

--- a/sdks/javascript/src/api/v2/executeEmbeddedSignInFlowV2.ts
+++ b/sdks/javascript/src/api/v2/executeEmbeddedSignInFlowV2.ts
@@ -22,6 +22,7 @@ import {
   EmbeddedSignInFlowResponse as EmbeddedSignInFlowResponseV2,
   EmbeddedSignInFlowStatus as EmbeddedSignInFlowStatusV2,
 } from '../../models/v2/embedded-signin-flow-v2';
+import injectRequestedPermissions from '../../utils/v2/injectRequestedPermissions';
 
 const executeEmbeddedSignInFlowV2 = async ({
   url,
@@ -50,22 +51,25 @@ const executeEmbeddedSignInFlowV2 = async ({
 
   // `verbose: true` is required to get the `meta` field in the response that includes component details.
   // Add verbose:true if:
-  // 1. payload contains only applicationId and flowType
-  // 2. payload contains only executionId
-  const hasOnlyAppIdAndFlowType: boolean =
+  // 1. payload contains applicationId and flowType (new flow start; may also carry scopes or other init params)
+  // 2. payload contains only executionId (flow resumption without step data)
+  const isNewFlowStart: boolean =
     typeof cleanPayload === 'object' &&
     cleanPayload !== null &&
     'applicationId' in cleanPayload &&
-    'flowType' in cleanPayload &&
-    Object.keys(cleanPayload).length === 2;
+    'flowType' in cleanPayload;
   const hasOnlyFlowId: boolean =
     typeof cleanPayload === 'object' &&
     cleanPayload !== null &&
     'executionId' in cleanPayload &&
     Object.keys(cleanPayload).length === 1;
 
+  const basePayload: Record<string, unknown> = isNewFlowStart
+    ? injectRequestedPermissions(cleanPayload as Record<string, unknown>)
+    : (cleanPayload as Record<string, unknown>);
+
   const requestPayload: Record<string, unknown> =
-    hasOnlyAppIdAndFlowType || hasOnlyFlowId ? {...cleanPayload, verbose: true} : cleanPayload;
+    isNewFlowStart || hasOnlyFlowId ? {...basePayload, verbose: true} : basePayload;
 
   const response: Response = await fetch(endpoint, {
     ...requestConfig,

--- a/sdks/javascript/src/api/v2/executeEmbeddedSignUpFlowV2.ts
+++ b/sdks/javascript/src/api/v2/executeEmbeddedSignUpFlowV2.ts
@@ -22,6 +22,7 @@ import {
   EmbeddedSignUpFlowResponse as EmbeddedSignUpFlowResponseV2,
   EmbeddedSignUpFlowStatus as EmbeddedSignUpFlowStatusV2,
 } from '../../models/v2/embedded-signup-flow-v2';
+import injectRequestedPermissions from '../../utils/v2/injectRequestedPermissions';
 
 const executeEmbeddedSignUpFlowV2 = async ({
   url,
@@ -50,22 +51,25 @@ const executeEmbeddedSignUpFlowV2 = async ({
 
   // `verbose: true` is required to get the `meta` field in the response that includes component details.
   // Add verbose:true if:
-  // 1. payload contains only applicationId and flowType
-  // 2. payload contains only executionId
-  const hasOnlyAppIdAndFlowType: boolean =
+  // 1. payload contains applicationId and flowType (new flow start; may also carry scopes or other init params)
+  // 2. payload contains only executionId (flow resumption without step data)
+  const isNewFlowStart: boolean =
     typeof cleanPayload === 'object' &&
     cleanPayload !== null &&
     'applicationId' in cleanPayload &&
-    'flowType' in cleanPayload &&
-    Object.keys(cleanPayload).length === 2;
+    'flowType' in cleanPayload;
   const hasOnlyFlowId: boolean =
     typeof cleanPayload === 'object' &&
     cleanPayload !== null &&
     'executionId' in cleanPayload &&
     Object.keys(cleanPayload).length === 1;
 
+  const basePayload: Record<string, unknown> = isNewFlowStart
+    ? injectRequestedPermissions(cleanPayload as Record<string, unknown>)
+    : (cleanPayload as Record<string, unknown>);
+
   const requestPayload: Record<string, unknown> =
-    hasOnlyAppIdAndFlowType || hasOnlyFlowId ? {...cleanPayload, verbose: true} : cleanPayload;
+    isNewFlowStart || hasOnlyFlowId ? {...basePayload, verbose: true} : basePayload;
 
   const response: Response = await fetch(endpoint, {
     ...requestConfig,

--- a/sdks/javascript/src/models/v2/embedded-signin-flow-v2.ts
+++ b/sdks/javascript/src/models/v2/embedded-signin-flow-v2.ts
@@ -298,6 +298,12 @@ export interface EmbeddedSignInFlowInitiateRequest {
    * Determines the authentication process and available options.
    */
   flowType: EmbeddedFlowTypeV1;
+
+  /**
+   * OAuth2 scopes to request during flow initialization.
+   * When provided, these scopes are forwarded to the platform at flow start.
+   */
+  scopes?: string | string[];
 }
 
 /**

--- a/sdks/javascript/src/models/v2/embedded-signup-flow-v2.ts
+++ b/sdks/javascript/src/models/v2/embedded-signup-flow-v2.ts
@@ -208,6 +208,11 @@ export interface EmbeddedSignUpFlowCompleteResponse {
 export interface EmbeddedSignUpFlowInitiateRequest {
   applicationId: string;
   flowType: EmbeddedFlowTypeV1;
+  /**
+   * OAuth2 scopes to request during flow initialization.
+   * When provided, these scopes are forwarded to the platform at flow start.
+   */
+  scopes?: string | string[];
 }
 
 /**

--- a/sdks/javascript/src/utils/__tests__/injectRequestedPermissions.test.ts
+++ b/sdks/javascript/src/utils/__tests__/injectRequestedPermissions.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it} from 'vitest';
+import injectRequestedPermissions from '../../utils/v2/injectRequestedPermissions';
+
+describe('injectRequestedPermissions', (): void => {
+  it('joins multiple scopes into a space-separated requested_permissions string', (): void => {
+    const result = injectRequestedPermissions({
+      applicationId: 'app-1',
+      flowType: 'AUTHENTICATION',
+      scopes: ['openid', 'profile', 'email'],
+    });
+
+    expect(result).toMatchObject({inputs: {requested_permissions: 'openid profile email'}});
+    expect(result).not.toHaveProperty('scopes');
+  });
+
+  it('handles a single scope', (): void => {
+    const result = injectRequestedPermissions({applicationId: 'app-1', flowType: 'AUTHENTICATION', scopes: ['openid']});
+
+    expect(result).toMatchObject({inputs: {requested_permissions: 'openid'}});
+  });
+
+  it('removes scopes from the payload when the array is empty', (): void => {
+    const result = injectRequestedPermissions({applicationId: 'app-1', flowType: 'AUTHENTICATION', scopes: []});
+
+    expect(result).not.toHaveProperty('scopes');
+    expect(result).not.toHaveProperty('inputs');
+  });
+
+  it('returns the payload unchanged (minus scopes) when scopes is absent', (): void => {
+    const result = injectRequestedPermissions({applicationId: 'app-1', flowType: 'AUTHENTICATION'});
+
+    expect(result).toEqual({applicationId: 'app-1', flowType: 'AUTHENTICATION'});
+    expect(result).not.toHaveProperty('inputs');
+  });
+
+  it('merges requested_permissions into existing inputs without overwriting other keys', (): void => {
+    const result = injectRequestedPermissions({
+      applicationId: 'app-1',
+      flowType: 'AUTHENTICATION',
+      inputs: {someKey: 'someValue'},
+      scopes: ['openid', 'profile'],
+    });
+
+    expect(result).toMatchObject({inputs: {requested_permissions: 'openid profile', someKey: 'someValue'}});
+  });
+
+  it('replaces a non-object inputs value with just requested_permissions', (): void => {
+    const result = injectRequestedPermissions({
+      applicationId: 'app-1',
+      flowType: 'AUTHENTICATION',
+      inputs: 'invalid-string',
+      scopes: ['openid'],
+    });
+
+    expect(result).toMatchObject({inputs: {requested_permissions: 'openid'}});
+    expect((result['inputs'] as Record<string, unknown>)['invalid-string']).toBeUndefined();
+  });
+
+  it('replaces an array inputs value with just requested_permissions', (): void => {
+    const result = injectRequestedPermissions({
+      applicationId: 'app-1',
+      flowType: 'AUTHENTICATION',
+      inputs: ['should', 'be', 'ignored'],
+      scopes: ['openid'],
+    });
+
+    expect(result).toMatchObject({inputs: {requested_permissions: 'openid'}});
+  });
+
+  it('preserves all other payload fields', (): void => {
+    const result = injectRequestedPermissions({
+      applicationId: 'app-1',
+      flowType: 'AUTHENTICATION',
+      scopes: ['openid'],
+      verbose: true,
+    });
+
+    expect(result).toMatchObject({applicationId: 'app-1', flowType: 'AUTHENTICATION', verbose: true});
+  });
+
+  it('accepts a space-separated string as scopes', (): void => {
+    const result = injectRequestedPermissions({
+      applicationId: 'app-1',
+      flowType: 'AUTHENTICATION',
+      scopes: 'openid profile email',
+    });
+
+    expect(result).toMatchObject({inputs: {requested_permissions: 'openid profile email'}});
+    expect(result).not.toHaveProperty('scopes');
+  });
+
+  it('trims a string scopes value', (): void => {
+    const result = injectRequestedPermissions({
+      applicationId: 'app-1',
+      flowType: 'AUTHENTICATION',
+      scopes: '  openid profile  ',
+    });
+
+    expect(result).toMatchObject({inputs: {requested_permissions: 'openid profile'}});
+  });
+
+  it('treats a whitespace-only string scopes as absent', (): void => {
+    const result = injectRequestedPermissions({applicationId: 'app-1', flowType: 'AUTHENTICATION', scopes: '   '});
+
+    expect(result).not.toHaveProperty('scopes');
+    expect(result).not.toHaveProperty('inputs');
+  });
+
+  it('treats a non-string non-array scopes value as absent', (): void => {
+    const result = injectRequestedPermissions({applicationId: 'app-1', flowType: 'AUTHENTICATION', scopes: 42});
+
+    expect(result).not.toHaveProperty('scopes');
+    expect(result).not.toHaveProperty('inputs');
+  });
+
+  it('trims and filters blank entries in a scopes array', (): void => {
+    const result = injectRequestedPermissions({
+      applicationId: 'app-1',
+      flowType: 'AUTHENTICATION',
+      scopes: ['openid', '  ', 'profile'],
+    });
+
+    expect(result).toMatchObject({inputs: {requested_permissions: 'openid profile'}});
+    expect(result).not.toHaveProperty('scopes');
+  });
+});

--- a/sdks/javascript/src/utils/v2/injectRequestedPermissions.ts
+++ b/sdks/javascript/src/utils/v2/injectRequestedPermissions.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Strips the top-level `scopes` field from a payload and injects it as
+ * `inputs.requested_permissions` (space-separated string).
+ *
+ * The backend reads requested_permissions from UserInputs (the `inputs` map), not a top-level field.
+ */
+const injectRequestedPermissions = (payload: Record<string, unknown>): Record<string, unknown> => {
+  const {scopes, ...rest} = payload;
+
+  const normalizedScopes: string =
+    Array.isArray(scopes)
+      ? scopes.map((s: unknown) => String(s).trim()).filter(Boolean).join(' ')
+      : typeof scopes === 'string'
+        ? scopes.trim()
+        : '';
+
+  if (!normalizedScopes) {
+    return rest;
+  }
+
+  const existingInputs =
+    rest['inputs'] != null && typeof rest['inputs'] === 'object' && !Array.isArray(rest['inputs'])
+      ? (rest['inputs'] as Record<string, unknown>)
+      : {};
+
+  return {
+    ...rest,
+    inputs: {
+      ...existingInputs,
+      requested_permissions: normalizedScopes,
+    },
+  };
+};
+
+export default injectRequestedPermissions;

--- a/sdks/nextjs/src/client/components/presentation/SignUp/SignUp.tsx
+++ b/sdks/nextjs/src/client/components/presentation/SignUp/SignUp.tsx
@@ -70,7 +70,7 @@ const SignUp: FC<SignUpProps> = ({
   afterSignUpUrl,
   onError,
 }: SignUpProps) => {
-  const {signUp} = useThunderID();
+  const {signUp, applicationId: contextApplicationId, scopes} = useThunderID();
 
   /**
    * Initialize the sign-up flow.
@@ -89,6 +89,8 @@ const SignUp: FC<SignUpProps> = ({
     return (await signUp(
       payload || {
         flowType: EmbeddedFlowType.Registration,
+        ...(contextApplicationId && {applicationId: contextApplicationId}),
+        ...(scopes && {scopes}),
       },
     )) as unknown as Promise<EmbeddedFlowExecuteResponse>;
   };

--- a/sdks/nextjs/src/client/contexts/ThunderID/ThunderIDProvider.tsx
+++ b/sdks/nextjs/src/client/contexts/ThunderID/ThunderIDProvider.tsx
@@ -105,6 +105,7 @@ const ThunderIDClientProvider: FC<PropsWithChildren<ThunderIDClientProviderProps
   updateProfile,
   applicationId,
   organizationHandle,
+  scopes,
   myOrganizations,
   revalidateMyOrganizations,
   getAllOrganizations,
@@ -303,6 +304,7 @@ const ThunderIDClientProvider: FC<PropsWithChildren<ThunderIDClientProviderProps
       isSignedIn,
       organizationHandle,
       refreshToken,
+      scopes,
       signIn: handleSignIn,
       signInUrl,
       signOut: handleSignOut,
@@ -310,7 +312,7 @@ const ThunderIDClientProvider: FC<PropsWithChildren<ThunderIDClientProviderProps
       signUpUrl,
       user,
     }),
-    [baseUrl, user, isSignedIn, isLoading, signInUrl, signUpUrl, applicationId, organizationHandle],
+    [baseUrl, user, isSignedIn, isLoading, signInUrl, signUpUrl, applicationId, organizationHandle, scopes],
   );
 
   const handleProfileUpdate = (payload: User): void => {

--- a/sdks/nuxt/src/module.ts
+++ b/sdks/nuxt/src/module.ts
@@ -115,7 +115,7 @@ export default defineNuxtModule<ThunderIDNuxtConfig>({
       clientId: string;
       platform?: ThunderIDNuxtConfig['platform'];
       preferences: ThunderIDNuxtConfig['preferences'];
-      scopes: string[];
+      scopes: string | string[];
       signInUrl?: string;
       signUpUrl?: string;
       tokenRequest?: ThunderIDNuxtConfig['tokenRequest'];
@@ -348,7 +348,7 @@ declare module '@nuxt/schema' {
       clientId: string;
       platform?: ThunderIDNuxtConfig['platform'];
       preferences?: ThunderIDNuxtConfig['preferences'];
-      scopes: string[];
+      scopes: string | string[];
       signInUrl?: string;
       signUpUrl?: string;
     };

--- a/sdks/nuxt/src/runtime/components/auth/SignUp.ts
+++ b/sdks/nuxt/src/runtime/components/auth/SignUp.ts
@@ -66,7 +66,7 @@ const SignUp: Component = defineComponent({
     variant: {default: 'outlined', type: String as PropType<'elevated' | 'outlined' | 'flat'>},
   },
   setup(props: any, {slots}: SetupContext): () => VNode | null {
-    const {signUp, isInitialized, applicationId} = useThunderID();
+    const {signUp, isInitialized, applicationId, scopes} = useThunderID();
 
     const handleInitialize = async (
       payload?: EmbeddedFlowExecuteRequestPayload,
@@ -87,6 +87,7 @@ const SignUp: Component = defineComponent({
       const initialPayload: any = payload || {
         flowType: EmbeddedFlowType.Registration,
         ...(effectiveApplicationId && {applicationId: effectiveApplicationId}),
+        ...(scopes && {scopes}),
       };
 
       return (await signUp(initialPayload)) as EmbeddedFlowExecuteResponse;
@@ -108,7 +109,8 @@ const SignUp: Component = defineComponent({
       if (
         props.shouldRedirectAfterSignUp &&
         response?.type !== EmbeddedFlowResponseType.Redirection &&
-        props.afterSignUpUrl
+        props.afterSignUpUrl &&
+        !(response as any)?.assertion
       ) {
         await navigateTo(props.afterSignUpUrl, {external: true});
       }

--- a/sdks/nuxt/src/runtime/plugins/thunderid.ts
+++ b/sdks/nuxt/src/runtime/plugins/thunderid.ts
@@ -55,7 +55,7 @@ export default defineNuxtPlugin((nuxtApp: NuxtApp) => {
     baseUrl: string;
     clientId: string;
     organizationHandle?: string;
-    scopes: string[];
+    scopes: string | string[];
     signInUrl?: string;
     signUpUrl?: string;
   } = useRuntimeConfig().public.thunderid as {
@@ -65,7 +65,7 @@ export default defineNuxtPlugin((nuxtApp: NuxtApp) => {
     baseUrl: string;
     clientId: string;
     organizationHandle?: string;
-    scopes: string[];
+    scopes: string | string[];
     signInUrl?: string;
     signUpUrl?: string;
   };
@@ -222,6 +222,7 @@ export default defineNuxtPlugin((nuxtApp: NuxtApp) => {
     organizationHandle: publicConfig.organizationHandle,
     platform: undefined,
     reInitialize: async () => false,
+    scopes: publicConfig.scopes,
     signIn,
     signInOptions: undefined,
     signInSilently: noop,

--- a/sdks/nuxt/src/runtime/types.ts
+++ b/sdks/nuxt/src/runtime/types.ts
@@ -82,7 +82,7 @@ export interface ThunderIDNuxtConfig {
     };
   };
   /** OAuth2 scopes to request */
-  scopes?: string[];
+  scopes?: string | string[];
   /** Secret for signing session JWTs (use THUNDERID_SESSION_SECRET env var) */
   sessionSecret?: string;
   /**

--- a/sdks/react/src/ThunderIDReactClient.ts
+++ b/sdks/react/src/ThunderIDReactClient.ts
@@ -41,6 +41,7 @@ import {
   executeEmbeddedSignUpFlowV2,
   executeEmbeddedRecoveryFlowV2,
   EmbeddedSignInFlowStatusV2,
+  EmbeddedSignUpFlowStatusV2,
 } from '@thunderid/browser';
 import getAllOrganizations from './api/getAllOrganizations';
 import getMeOrganizations from './api/getMeOrganizations';
@@ -348,14 +349,50 @@ class ThunderIDReactClient<T extends ThunderIDReactConfig = ThunderIDReactConfig
       sessionStorage.setItem('thunderid_auth_id', authIdFromUrl);
     }
 
-    return executeEmbeddedSignUpFlowV2({
+    const response: any = await executeEmbeddedSignUpFlowV2({
       authId,
       baseUrl,
       payload:
         typeof firstArg === 'object' && 'flowType' in firstArg
           ? {...(firstArg as EmbeddedFlowExecuteRequestPayload), verbose: true}
           : (firstArg as EmbeddedFlowExecuteRequestPayload),
-    }) as any;
+    });
+
+    if (
+      response &&
+      typeof response === 'object' &&
+      response.flowStatus === EmbeddedSignUpFlowStatusV2.Complete &&
+      response.assertion
+    ) {
+      const decodedAssertion: {
+        [key: string]: unknown;
+        exp?: number;
+        iat?: number;
+        scope?: string;
+      } = await this.decodeJwtToken<{
+        [key: string]: unknown;
+        exp?: number;
+        iat?: number;
+        scope?: string;
+      }>(response.assertion);
+
+      const createdAt: number = decodedAssertion.iat ? decodedAssertion.iat * 1000 : Date.now();
+      const expiresIn: number =
+        decodedAssertion.exp && decodedAssertion.iat ? decodedAssertion.exp - decodedAssertion.iat : 3600;
+
+      await this.setSession({
+        access_token: response.assertion,
+        created_at: createdAt,
+        expires_in: expiresIn,
+        id_token: response.assertion,
+        scope: decodedAssertion.scope,
+        token_type: 'Bearer',
+      });
+
+      this.notifySignIn(extractUserClaimsFromIdToken(decodedAssertion as IdToken) as User);
+    }
+
+    return response;
   }
 
   override async recover(payload: EmbeddedFlowExecuteRequestPayload): Promise<EmbeddedFlowExecuteResponse> {

--- a/sdks/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
+++ b/sdks/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
@@ -217,7 +217,7 @@ const SignIn: FC<SignInProps> = ({
   variant,
   children,
 }: SignInProps): ReactElement => {
-  const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading, meta, getStorageManager} = useThunderID();
+  const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading, meta, getStorageManager, scopes} = useThunderID();
   const {t} = useTranslation(preferences?.i18n);
 
   // State management for the flow
@@ -445,6 +445,7 @@ const SignIn: FC<SignInProps> = ({
         response = (await signIn({
           applicationId: effectiveApplicationId,
           flowType: EmbeddedFlowType.Authentication,
+          ...(scopes && {scopes}),
         })) as EmbeddedSignInFlowResponseV2;
       }
 

--- a/sdks/react/src/components/presentation/auth/SignUp/v2/SignUp.tsx
+++ b/sdks/react/src/components/presentation/auth/SignUp/v2/SignUp.tsx
@@ -56,7 +56,7 @@ const SignUp: FC<SignUpProps> = ({
   children,
   ...rest
 }: SignUpProps): ReactElement => {
-  const {signUp, isInitialized, applicationId} = useThunderID();
+  const {signUp, isInitialized, applicationId, scopes} = useThunderID();
 
   /**
    * Initialize the sign-up flow.
@@ -73,6 +73,7 @@ const SignUp: FC<SignUpProps> = ({
     const initialPayload: any = payload || {
       flowType: EmbeddedFlowType.Registration,
       ...(effectiveApplicationId && {applicationId: effectiveApplicationId}),
+      ...(scopes && {scopes}),
     };
 
     return (await signUp(initialPayload)) as EmbeddedFlowExecuteResponse;
@@ -98,8 +99,14 @@ const SignUp: FC<SignUpProps> = ({
       return;
     }
 
-    // For non-redirection responses (regular sign-up completion), handle redirect if configured
-    if (shouldRedirectAfterSignUp && response?.type !== EmbeddedFlowResponseType.Redirection && afterSignUpUrl) {
+    // For non-redirection responses (regular sign-up completion), handle redirect if configured.
+    // Skip when assertion is present — the SDK stored the session and the caller handled navigation.
+    if (
+      shouldRedirectAfterSignUp &&
+      response?.type !== EmbeddedFlowResponseType.Redirection &&
+      afterSignUpUrl &&
+      !(response as any)?.assertion
+    ) {
       window.location.href = afterSignUpUrl;
     }
 

--- a/sdks/react/src/contexts/ThunderID/ThunderIDContext.ts
+++ b/sdks/react/src/contexts/ThunderID/ThunderIDContext.ts
@@ -40,6 +40,7 @@ export type ThunderIDContextProps = {
   applicationId: string | undefined;
   baseUrl: string | undefined;
   clientId: string | undefined;
+  scopes: string | string[] | undefined;
   /**
    * OIDC discovery data.
    */
@@ -224,6 +225,7 @@ const ThunderIDContext: Context<ThunderIDContextProps | null> = createContext<nu
   baseUrl: undefined,
   clearSession: () => {},
   clientId: undefined,
+  scopes: undefined,
   discovery: {
     wellKnown: null,
   },

--- a/sdks/react/src/contexts/ThunderID/ThunderIDProvider.tsx
+++ b/sdks/react/src/contexts/ThunderID/ThunderIDProvider.tsx
@@ -544,6 +544,7 @@ const ThunderIDProvider: FC<PropsWithChildren<ThunderIDProviderProps>> = ({
       afterSignInUrl: config.afterSignInUrl,
       applicationId: config.applicationId,
       baseUrl,
+      scopes: config.scopes,
       clearSession,
       clientId,
       discovery: {
@@ -584,6 +585,7 @@ const ThunderIDProvider: FC<PropsWithChildren<ThunderIDProviderProps>> = ({
       applicationId,
       config?.organizationHandle,
       config.afterSignInUrl,
+      config.scopes,
       signInUrl,
       signUpUrl,
       baseUrl,

--- a/sdks/react/src/contexts/ThunderID/__tests__/useThunderID.test.tsx
+++ b/sdks/react/src/contexts/ThunderID/__tests__/useThunderID.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {cleanup, render, screen} from '@testing-library/react';
+import {Organization} from '@thunderid/browser';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import ThunderIDContext, {ThunderIDContextProps} from '../ThunderIDContext';
+import useThunderID from '../useThunderID';
+
+function createMockContext(overrides: Partial<ThunderIDContextProps> = {}): ThunderIDContextProps {
+  return {
+    afterSignInUrl: undefined,
+    applicationId: undefined,
+    baseUrl: undefined,
+    clientId: undefined,
+    scopes: undefined,
+    discovery: {wellKnown: null},
+    exchangeToken: vi.fn(),
+    getAccessToken: vi.fn(),
+    getDecodedIdToken: vi.fn(),
+    getIdToken: vi.fn(),
+    getStorageManager: vi.fn(),
+    http: {request: vi.fn(), requestAll: vi.fn()},
+    instanceId: 0,
+    isInitialized: false,
+    isLoading: false,
+    isMetaLoading: false,
+    isSignedIn: false,
+    meta: null,
+    organization: null as unknown as Organization,
+    organizationHandle: undefined,
+    reInitialize: vi.fn(),
+    recover: vi.fn(),
+    resolveFlowTemplateLiterals: vi.fn((t: string | undefined) => t ?? ''),
+    signIn: vi.fn(),
+    signInOptions: undefined,
+    signInSilently: vi.fn(),
+    signInUrl: undefined,
+    signOut: vi.fn(),
+    signUp: vi.fn(),
+    signUpUrl: undefined,
+    storage: undefined,
+    switchOrganization: vi.fn(),
+    user: null,
+    ...overrides,
+  } as unknown as ThunderIDContextProps;
+}
+
+function TestConsumer({onResult}: {onResult: (ctx: ThunderIDContextProps) => void}) {
+  const ctx = useThunderID();
+  onResult(ctx);
+  return <div data-testid="consumer">ok</div>;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useThunderID', () => {
+  it('returns the context value when inside a provider', () => {
+    const ctx = createMockContext();
+    let captured: ThunderIDContextProps | undefined;
+
+    render(
+      <ThunderIDContext.Provider value={ctx}>
+        <TestConsumer onResult={(c) => (captured = c)} />
+      </ThunderIDContext.Provider>,
+    );
+
+    expect(screen.getByTestId('consumer')).toBeDefined();
+    expect(captured).toBeDefined();
+    expect(captured!.isSignedIn).toBe(false);
+    expect(captured!.isInitialized).toBe(false);
+  });
+
+  it('exposes scopes from context', () => {
+    const ctx = createMockContext({scopes: ['openid', 'profile']});
+    let captured: ThunderIDContextProps | undefined;
+
+    render(
+      <ThunderIDContext.Provider value={ctx}>
+        <TestConsumer onResult={(c) => (captured = c)} />
+      </ThunderIDContext.Provider>,
+    );
+
+    expect(captured!.scopes).toEqual(['openid', 'profile']);
+  });
+
+  it('exposes scopes as undefined when not configured', () => {
+    const ctx = createMockContext();
+    let captured: ThunderIDContextProps | undefined;
+
+    render(
+      <ThunderIDContext.Provider value={ctx}>
+        <TestConsumer onResult={(c) => (captured = c)} />
+      </ThunderIDContext.Provider>,
+    );
+
+    expect(captured!.scopes).toBeUndefined();
+  });
+});

--- a/sdks/react/tsconfig.spec.json
+++ b/sdks/react/tsconfig.spec.json
@@ -10,7 +10,9 @@
     "vitest.config.ts",
     "jest.config.js",
     "**/*.test.ts",
+    "**/*.test.tsx",
     "**/*.spec.ts",
+    "**/*.spec.tsx",
     "**/*.test.js",
     "**/*.spec.js",
     "**/*.d.ts"

--- a/sdks/vue/src/ThunderIDVueClient.ts
+++ b/sdks/vue/src/ThunderIDVueClient.ts
@@ -40,6 +40,7 @@ import {
   isEmpty,
   EmbeddedSignInFlowResponseV2,
   EmbeddedSignInFlowStatusV2,
+  EmbeddedSignUpFlowStatusV2,
   deriveOrganizationHandleFromBaseUrl,
 } from '@thunderid/browser';
 import getAllOrganizations from './api/getAllOrganizations';
@@ -379,14 +380,50 @@ class ThunderIDVueClient<T extends ThunderIDVueConfig = ThunderIDVueConfig> exte
       sessionStorage.setItem('thunderid_auth_id', authIdFromUrl);
     }
 
-    return executeEmbeddedSignUpFlowV2({
+    const response: any = await executeEmbeddedSignUpFlowV2({
       authId,
       baseUrl,
       payload:
         typeof firstArg === 'object' && 'flowType' in firstArg
           ? {...(firstArg as EmbeddedFlowExecuteRequestPayload), verbose: true}
           : (firstArg as EmbeddedFlowExecuteRequestPayload),
-    }) as any;
+    });
+
+    if (
+      response &&
+      typeof response === 'object' &&
+      response.flowStatus === EmbeddedSignUpFlowStatusV2.Complete &&
+      response.assertion
+    ) {
+      const decodedAssertion: {
+        [key: string]: unknown;
+        exp?: number;
+        iat?: number;
+        scope?: string;
+      } = await this.decodeJwtToken<{
+        [key: string]: unknown;
+        exp?: number;
+        iat?: number;
+        scope?: string;
+      }>(response.assertion);
+
+      const createdAt: number = decodedAssertion.iat ? decodedAssertion.iat * 1000 : Date.now();
+      const expiresIn: number =
+        decodedAssertion.exp && decodedAssertion.iat ? decodedAssertion.exp - decodedAssertion.iat : 3600;
+
+      await this.setSession({
+        access_token: response.assertion,
+        created_at: createdAt,
+        expires_in: expiresIn,
+        id_token: response.assertion,
+        scope: decodedAssertion.scope,
+        token_type: 'Bearer',
+      });
+
+      this.notifySignIn(extractUserClaimsFromIdToken(decodedAssertion as IdToken) as User);
+    }
+
+    return response;
   }
 
   async request(requestConfig?: HttpRequestConfig): Promise<HttpResponse<any>> {

--- a/sdks/vue/src/__tests__/composables/useThunderID.test.ts
+++ b/sdks/vue/src/__tests__/composables/useThunderID.test.ts
@@ -34,6 +34,7 @@ function createMockThunderIDContext(overrides: Partial<ThunderIDContext> = {}): 
     isInitialized: ref(true),
     user: ref(null),
     organization: ref(null),
+    scopes: undefined,
     signIn: vi.fn(),
     signOut: vi.fn(),
     signUp: vi.fn(),
@@ -73,9 +74,9 @@ describe('useThunderID', () => {
     });
 
     expect(result).toBeDefined();
-    expect(result.isSignedIn.value).toBe(false);
-    expect(result.isLoading.value).toBe(false);
-    expect(result.isInitialized.value).toBe(true);
+    expect(result!.isSignedIn.value).toBe(false);
+    expect(result!.isLoading.value).toBe(false);
+    expect(result!.isInitialized.value).toBe(true);
   });
 
   it('should throw an error when called outside of ThunderIDProvider', () => {
@@ -111,9 +112,9 @@ describe('useThunderID', () => {
       },
     });
 
-    expect(result.isSignedIn.value).toBe(false);
+    expect(result!.isSignedIn.value).toBe(false);
     isSignedIn.value = true;
-    expect(result.isSignedIn.value).toBe(true);
+    expect(result!.isSignedIn.value).toBe(true);
   });
 
   it('should expose signIn and signOut methods', () => {
@@ -135,9 +136,53 @@ describe('useThunderID', () => {
       },
     });
 
-    expect(typeof result.signIn).toBe('function');
-    expect(typeof result.signOut).toBe('function');
-    expect(typeof result.signUp).toBe('function');
-    expect(typeof result.getAccessToken).toBe('function');
+    expect(typeof result!.signIn).toBe('function');
+    expect(typeof result!.signOut).toBe('function');
+    expect(typeof result!.signUp).toBe('function');
+    expect(typeof result!.getAccessToken).toBe('function');
+  });
+
+  it('should expose scopes from context', () => {
+    const mockContext = createMockThunderIDContext({scopes: ['openid', 'profile']});
+    let result: ThunderIDContext | undefined;
+
+    const TestChild = defineComponent({
+      setup() {
+        result = useThunderID();
+        return () => h('div', 'test');
+      },
+    });
+
+    mount(TestChild, {
+      global: {
+        provide: {
+          [THUNDERID_KEY as symbol]: mockContext,
+        },
+      },
+    });
+
+    expect(result!.scopes).toEqual(['openid', 'profile']);
+  });
+
+  it('should expose scopes as undefined when not configured', () => {
+    const mockContext = createMockThunderIDContext();
+    let result: ThunderIDContext | undefined;
+
+    const TestChild = defineComponent({
+      setup() {
+        result = useThunderID();
+        return () => h('div', 'test');
+      },
+    });
+
+    mount(TestChild, {
+      global: {
+        provide: {
+          [THUNDERID_KEY as symbol]: mockContext,
+        },
+      },
+    });
+
+    expect(result!.scopes).toBeUndefined();
   });
 });

--- a/sdks/vue/src/components/auth/sign-in/v2/SignIn.ts
+++ b/sdks/vue/src/components/auth/sign-in/v2/SignIn.ts
@@ -114,7 +114,7 @@ const SignIn: Component = defineComponent({
     props: Readonly<{className: string; size: 'small' | 'medium' | 'large'; variant: 'elevated' | 'outlined' | 'flat'}>,
     {slots, emit, attrs}: SetupContext,
   ): () => VNode | null {
-    const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading: sdkLoading} = useThunderID();
+    const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading: sdkLoading, scopes} = useThunderID();
     const {meta: flowMeta} = useFlowMeta();
     const {t} = useI18n();
 
@@ -238,6 +238,7 @@ const SignIn: Component = defineComponent({
           response = (await signIn({
             applicationId: effectiveApplicationId,
             flowType: EmbeddedFlowType.Authentication,
+            ...(scopes && {scopes}),
           })) as EmbeddedSignInFlowResponseV2;
         }
 

--- a/sdks/vue/src/components/auth/sign-up/v2/SignUp.ts
+++ b/sdks/vue/src/components/auth/sign-up/v2/SignUp.ts
@@ -50,7 +50,7 @@ const SignUp: Component = defineComponent({
     variant: {default: 'outlined', type: String as PropType<'elevated' | 'outlined' | 'flat'>},
   },
   setup(props: any, {slots}: SetupContext): () => VNode | null {
-    const {signUp, isInitialized, applicationId} = useThunderID();
+    const {signUp, isInitialized, applicationId, scopes} = useThunderID();
 
     const handleInitialize = async (
       payload?: EmbeddedFlowExecuteRequestPayload,
@@ -62,6 +62,7 @@ const SignUp: Component = defineComponent({
       const initialPayload: any = payload || {
         flowType: EmbeddedFlowType.Registration,
         ...(effectiveApplicationId && {applicationId: effectiveApplicationId}),
+        ...(scopes && {scopes}),
       };
 
       return (await signUp(initialPayload)) as EmbeddedFlowExecuteResponse;
@@ -82,7 +83,8 @@ const SignUp: Component = defineComponent({
       if (
         props.shouldRedirectAfterSignUp &&
         response?.type !== EmbeddedFlowResponseType.Redirection &&
-        props.afterSignUpUrl
+        props.afterSignUpUrl &&
+        !(response as any)?.assertion
       ) {
         window.location.href = props.afterSignUpUrl;
       }

--- a/sdks/vue/src/models/contexts.ts
+++ b/sdks/vue/src/models/contexts.ts
@@ -56,6 +56,8 @@ export interface ThunderIDContext {
   clearSession: (...args: any[]) => void;
   /** The OAuth2 client ID. */
   clientId: string | undefined;
+  /** The OAuth2 scopes requested during flow initialization. */
+  scopes: string | string[] | undefined;
 
   exchangeToken: (config: TokenExchangeRequestConfig) => Promise<TokenResponse | Response>;
   // ── Token ──

--- a/sdks/vue/src/providers/ThunderIDProvider.ts
+++ b/sdks/vue/src/providers/ThunderIDProvider.ts
@@ -70,7 +70,7 @@ interface ThunderIDProviderProps {
   organizationChain: object | undefined;
   organizationHandle: string | undefined;
   platform: string | undefined;
-  scopes: string[] | undefined;
+  scopes: string | string[] | undefined;
   signInOptions: SignInOptions | undefined;
   signInUrl: string | undefined;
   signUpUrl: string | undefined;
@@ -156,7 +156,7 @@ const ThunderIDProvider: Component = defineComponent({
     /** The scopes to request. */
     scopes: {
       default: undefined,
-      type: Array as PropType<string[]>,
+      type: [Array, String] as PropType<string | string[]>,
     },
     /** Additional sign-in options. */
     signInOptions: {
@@ -345,6 +345,7 @@ const ThunderIDProvider: Component = defineComponent({
         await client.clearSession(...args);
       },
       clientId: props.clientId,
+      scopes: props.scopes,
       exchangeToken: (config: any): Promise<TokenResponse | Response> => client.exchangeToken(config),
       getAccessToken: (): Promise<string> => client.getAccessToken(),
       getDecodedIdToken: (): Promise<IdToken> => client.getDecodedIdToken(),


### PR DESCRIPTION
### Purpose

Fixes two related gaps in the embedded flow V2 SDK stack:

1. **`verbose: true` injection bug** — The check that decides whether to inject
   `verbose: true` into the flow execute payload used a strict key-count guard
   (`Object.keys(payload).length === 2`). This broke as soon as any optional
   init-time parameter (e.g. `scopes`) was added alongside `applicationId` and
   `flowType`, causing the flow to receive no `meta.components` in the response
   and the UI to silently fall through to "form not available".

2. **Scopes not forwarded to flow initialization** — OAuth2 scopes configured on
   `ThunderIDProvider` via the `scopes` prop were never forwarded to the
   `/flow/execute` API call at flow start time. The provider accepted them, but
   they were dropped before reaching the platform.

### Approach

**Verbose injection fix (`sdks/javascript`)**

Replaced the key-count-based `hasOnlyAppIdAndFlowType` check with a
presence-only `isNewFlowStart` check in both `executeEmbeddedSignInFlowV2` and
`executeEmbeddedSignUpFlowV2`. The new check injects `verbose: true` whenever
`applicationId` and `flowType` are present, regardless of any additional keys.
The `hasOnlyFlowId` check (bare flow resumption) retains its strict
`length === 1` guard since `{ executionId }` alone means resumption, but
`{ executionId, inputs, action }` is a step submission that must not receive
`verbose: true`.

**Scopes propagation (React / Vue / Nuxt)**

- Added `scopes?: string[]` to the `EmbeddedSignInFlowInitiateRequest` and
  `EmbeddedSignUpFlowInitiateRequest` models in the JavaScript SDK so the field
  is accepted by the flow execute API.
- Exposed `scopes` through the `ThunderIDContext` interface and the
  `ThunderIDProvider` context value in both React and Vue SDKs.
- Updated the V2 `SignIn` and `SignUp` components in React, Vue, and Nuxt to
  read `scopes` from `useThunderID()` and spread them into the flow
  initialization payload via `...(scopes && {scopes})`.
- No new component prop is added — scopes flow exclusively through the provider
  config, matching how `applicationId` and `afterSignInUrl` are already handled.

**Stacks evaluated but not changed**

| Stack | Reason not changed |
|---|---|
| `sdks/browser` | Re-exports the JavaScript SDK models and client. Contains no flow execution or component logic of its own. |
| `sdks/nextjs` | Uses server actions. The `SignUp` and `SignIn` client components pass the payload to a Next.js server action (`signUpAction` / `signInAction`), which calls the Node client directly server-side. The Node client has the full config — including scopes — available at the server level, so no client-side threading is needed. |
| `sdks/node` / `sdks/express` | Server-side SDKs. Config including scopes is applied at the Node client initialization level, not through UI components. |
| `sdks/nuxt` (SignIn) | Nuxt's `SignIn` component uses a V1-style `{ flowId: '' }` path that routes through Nitro server routes, not the V2 embedded flow. Only `SignUp` builds a V2 `{ flowType, applicationId }` payload client-side, so only that component needed the fix. |
| `sdks/react-router` / `sdks/tanstack-router` | Routing adapter SDKs only — contain `ProtectedRoute` and `CallbackRoute` utilities. No `SignIn` or `SignUp` flow components. |

**Tests**

- New test files for `executeEmbeddedSignInFlowV2` and
  `executeEmbeddedSignUpFlowV2` covering the `verbose: true` injection logic
  across all payload shapes (new flow start with/without scopes, bare
  resumption, step submission, user-supplied verbose stripping).
- Updated Vue `useThunderID` composable test mock to include `scopes` and added
  tests verifying scopes is accessible from context.
- New React `useThunderID` hook test covering scopes exposure through context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth2 scopes support for embedded sign-in and sign-up flows across React, Vue, and Nuxt SDKs.
  * Enhanced sign-up flow completion to properly decode and persist user session data upon flow completion.

* **Tests**
  * Added comprehensive test coverage for embedded sign-in/sign-up flows, scopes handling, and session management logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->