### PR TITLE
Default release-builder workflow_dispatch to release branch

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -10,8 +10,6 @@ on:
     # Runs every Friday at 12:00 PM IST (6:30 AM UTC)
     - cron: '30 6 * * 5'
   workflow_dispatch:
-    branches:
-      - release
     inputs:
       bump_type:
         description: 'Version bump type to apply to version.txt (major, minor, or patch)'
@@ -61,7 +59,13 @@ jobs:
       prerelease: ${{ steps.get_version.outputs.prerelease }}
       run_performance_test: ${{ steps.get_version.outputs.run_performance_test }}
       use_existing_version: ${{ steps.get_version.outputs.use_existing_version }}
-    steps:  
+    steps:
+      - name: 🔒 Enforce release branch
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name != 'release' }}
+        run: |
+          echo "❌ This workflow must be triggered from the 'release' branch, not '${{ github.ref_name }}'."
+          exit 1
+
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -10,6 +10,8 @@ on:
     # Runs every Friday at 12:00 PM IST (6:30 AM UTC)
     - cron: '30 6 * * 5'
   workflow_dispatch:
+    branches:
+      - release
     inputs:
       bump_type:
         description: 'Version bump type to apply to version.txt (major, minor, or patch)'


### PR DESCRIPTION
## Summary

- Adds a `branches: [release]` filter to the `workflow_dispatch` trigger in `release-builder.yml`
- GitHub's "Run workflow" UI will now pre-select the `release` branch instead of `main`, since the release builder is always triggered from the release branch

## Related Issues

Closes N/A

## Checklist

- [x] Code follows project conventions
- [ ] Tests added/updated (N/A — workflow change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened the release workflow so it only proceeds when manually triggered from the designated release branch; manual dispatches from other branches now fail with a clear error to prevent unintended releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->