### PR TITLE
Fix afterSignUpUrl base path in SignUpBox to include BASE_URL prefix

### DIFF
--- a/frontend/apps/gate/src/components/SignUp/SignUpBox.tsx
+++ b/frontend/apps/gate/src/components/SignUp/SignUpBox.tsx
@@ -37,7 +37,12 @@ export default function SignUpBox(): JSX.Element {
   const {isDesignEnabled} = useDesign();
   const [flowError, setFlowError] = useState<string | null>(null);
 
-  const signInUrl = ROUTES.AUTH.SIGN_IN;
+  // For React Router navigate() — basename is handled by the router.
+  const signInPath = ROUTES.AUTH.SIGN_IN;
+  // For window.location.href and new URL() (via afterSignUpUrl) — React Router basename is
+  // bypassed, so an absolute URL with origin + base path must be constructed explicitly.
+  // Vite appends a trailing slash to BASE_URL.
+  const afterSignUpUrl = `${window.location.origin}${import.meta.env.BASE_URL.replace(/\/$/, '')}${signInPath}`;
 
   const renderFlowContent = (
     components: EmbeddedFlowComponent[],
@@ -103,7 +108,7 @@ export default function SignUpBox(): JSX.Element {
       logoDisplay={!isDesignEnabled ? {xs: 'flex', md: 'none'} : {display: 'none'}}
     >
       <SignUp
-        afterSignUpUrl={signInUrl}
+        afterSignUpUrl={afterSignUpUrl}
         onFlowChange={(response: any) => {
           if (response?.failureReason) {
             setFlowError(response.failureReason as string);
@@ -151,7 +156,7 @@ export default function SignUpBox(): JSX.Element {
                 <Button
                   variant="text"
                   onClick={() => {
-                    void navigate(signInUrl);
+                    void navigate(signInPath);
                   }}
                   sx={{
                     p: 0,

--- a/frontend/apps/gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
@@ -98,6 +98,7 @@ const createMockSignUpRenderProps = (overrides: Partial<MockSignUpRenderProps> =
 
 let mockSignUpRenderProps: MockSignUpRenderProps = createMockSignUpRenderProps();
 let capturedOnFlowChange: ((response: unknown) => void) | undefined;
+let capturedAfterSignUpUrl: string | undefined;
 
 vi.mock('@thunderid/react', async () => {
   const actual = await vi.importActual('@thunderid/react');
@@ -106,11 +107,14 @@ vi.mock('@thunderid/react', async () => {
     SignUp: ({
       children,
       onFlowChange = undefined,
+      afterSignUpUrl = undefined,
     }: {
       children: (props: typeof mockSignUpRenderProps) => React.ReactNode;
       onFlowChange?: (response: unknown) => void;
+      afterSignUpUrl?: string;
     }) => {
       capturedOnFlowChange = onFlowChange;
+      capturedAfterSignUpUrl = afterSignUpUrl;
       return <div data-testid="thunderid-signup">{children(mockSignUpRenderProps)}</div>;
     },
     EmbeddedFlowComponentType: {
@@ -135,6 +139,7 @@ describe('SignUpBox', () => {
     });
     mockSignUpRenderProps = createMockSignUpRenderProps();
     capturedOnFlowChange = undefined;
+    capturedAfterSignUpUrl = undefined;
   });
 
   it('renders without crashing', () => {
@@ -543,6 +548,12 @@ describe('SignUpBox', () => {
     });
     render(<SignUpBox />);
     expect(screen.getByText('Sign in')).toBeInTheDocument();
+  });
+
+  it('passes afterSignUpUrl as an absolute URL with origin and BASE_URL prefix to SignUp component', () => {
+    render(<SignUpBox />);
+    const expectedUrl = `${window.location.origin}${import.meta.env.BASE_URL.replace(/\/$/, '')}/signin`;
+    expect(capturedAfterSignUpUrl).toBe(expectedUrl);
   });
 
   it('navigates to sign in page when clicking sign in link', async () => {


### PR DESCRIPTION
### Purpose

The sign-up flow was redirecting users to `<origin>/signin` instead of `<origin>/gate/signin`
after successful registration. The `afterSignUpUrl` prop passed to the `<SignUp>` component was
set to `ROUTES.AUTH.SIGN_IN` (`/signin`) — a React Router-relative path. When `window.location.href`
is assigned that value inside the SDK, it resolves against the origin directly, bypassing React
Router's `basename` configuration entirely.

### Approach

`SignUpBox` uses two different navigation mechanisms with different semantics:

- `navigate(path)` — goes through React Router, which automatically prepends the configured
  `basename` (`/gate/`). The raw route constant (`/signin`) is correct here.
- `window.location.href = url` (used internally by the SDK via `afterSignUpUrl`) — resolves
  against the origin with no knowledge of React Router's `basename`. The full path including
  the base must be provided explicitly.

The fix separates the single `signInUrl` variable into two:

- `signInPath` — the raw Router path (`/signin`), used for `navigate()`
- `afterSignUpUrl` — the full origin-relative URL constructed as `BASE_URL + signInPath`
  (stripping Vite's trailing slash from `BASE_URL`), passed as the `afterSignUpUrl` prop

This follows the existing `generateFallbackSignUpUrl` pattern already established in the
gate app for the same reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized signup navigation and post-signup redirect URL to derive from app routes and the current site origin, ensuring consistent in-app navigation and redirects.

* **Tests**
  * Added test coverage to verify the post-signup redirect is an absolute URL with the base path normalized and the expected sign-in path appended.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->