### PR TITLE
Improve agent model selection with provider-grouped dropdown

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -225,7 +225,7 @@ $agentTypeData = ([ordered]@{
             type = "string"
             displayName = "Model"
             required = $false
-            enum = @("GPT-5", "Claude", "Gemini", "Llama", "Mistral", "Other")
+            enum = @("claude-opus-4.7", "claude-opus-4.6", "claude-sonnet-4.6", "claude-sonnet-4.5", "claude-haiku-4.5", "openai-gpt-5.4-pro", "openai-gpt-5.4-thinking", "openai-gpt-5.4-mini", "openai-gpt-5.4-nano", "openai-gpt-5.3-instant", "gemini-3.5-flash", "gemini-3.1-pro", "gemini-3-pro", "gemini-3-flash", "llama-4-scout", "llama-4-maverick", "llama-3.3-70b", "mistral-large-3", "mistral-small-4", "mistral-medium-3.5", "mistral-devstral-2", "other")
         }
         department = @{
             type = "string"

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -211,7 +211,7 @@ RESPONSE=$(api_call POST "/agent-types" '{
       "type": "string",
       "displayName": "Model",
       "required": false,
-      "enum": ["GPT-5", "Claude", "Gemini", "Llama", "Mistral", "Other"]
+      "enum": ["claude-opus-4.7", "claude-opus-4.6", "claude-sonnet-4.6", "claude-sonnet-4.5", "claude-haiku-4.5", "openai-gpt-5.4-pro", "openai-gpt-5.4-thinking", "openai-gpt-5.4-mini", "openai-gpt-5.4-nano", "openai-gpt-5.3-instant", "gemini-3.5-flash", "gemini-3.1-pro", "gemini-3-pro", "gemini-3-flash", "llama-4-scout", "llama-4-maverick", "llama-3.3-70b", "mistral-large-3", "mistral-small-4", "mistral-medium-3.5", "mistral-devstral-2", "other"]
     },
     "department": {
       "type": "string",

--- a/frontend/packages/configure-users/src/utils/__tests__/groupEnumOptions.test.ts
+++ b/frontend/packages/configure-users/src/utils/__tests__/groupEnumOptions.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {groupEnumOptions, getModelDisplayName} from '../groupEnumOptions';
+
+describe('groupEnumOptions', () => {
+  it('groups enum values by provider prefix', () => {
+    const enums = [
+      'claude-opus-4.7',
+      'claude-sonnet-4.6',
+      'claude-haiku-4.5',
+      'openai-gpt-5.4-pro',
+      'openai-gpt-5.4-mini',
+    ];
+    const result = groupEnumOptions(enums);
+
+    expect(result.size).toBe(2);
+    expect(result.get('claude')).toEqual(['claude-opus-4.7', 'claude-sonnet-4.6', 'claude-haiku-4.5']);
+    expect(result.get('openai')).toEqual(['openai-gpt-5.4-pro', 'openai-gpt-5.4-mini']);
+  });
+
+  it('puts values without dashes into an "other" group', () => {
+    const enums = ['claude-sonnet-4.6', 'other'];
+    const result = groupEnumOptions(enums);
+
+    expect(result.get('claude')).toEqual(['claude-sonnet-4.6']);
+    expect(result.get('other')).toEqual(['other']);
+  });
+
+  it('returns empty map for empty array', () => {
+    const result = groupEnumOptions([]);
+    expect(result.size).toBe(0);
+  });
+
+  it('preserves insertion order of groups', () => {
+    const enums = ['gemini-3.5-flash', 'claude-sonnet-4.6', 'gemini-3.1-pro'];
+    const result = groupEnumOptions(enums);
+    const keys = [...result.keys()];
+
+    expect(keys).toEqual(['gemini', 'claude']);
+  });
+
+  it('handles single-provider list', () => {
+    const enums = ['claude-opus-4.7', 'claude-opus-4.6'];
+    const result = groupEnumOptions(enums);
+
+    expect(result.size).toBe(1);
+    expect(result.get('claude')).toEqual(['claude-opus-4.7', 'claude-opus-4.6']);
+  });
+});
+
+describe('getModelDisplayName', () => {
+  it('returns human-readable name for known models', () => {
+    expect(getModelDisplayName('claude-sonnet-4.6')).toBe('Sonnet 4.6');
+  });
+
+  it('returns human-readable name for provider keys', () => {
+    expect(getModelDisplayName('claude')).toBe('Claude');
+    expect(getModelDisplayName('openai')).toBe('OpenAI');
+  });
+
+  it('returns capitalized fallback for unknown values', () => {
+    expect(getModelDisplayName('unknown-model-x')).toBe('Model-x');
+  });
+
+  it('returns capitalized value for unknown single-word values', () => {
+    expect(getModelDisplayName('custom')).toBe('Custom');
+  });
+});

--- a/frontend/packages/configure-users/src/utils/__tests__/renderSchemaField.test.tsx
+++ b/frontend/packages/configure-users/src/utils/__tests__/renderSchemaField.test.tsx
@@ -112,6 +112,97 @@ describe('renderSchemaField', () => {
       });
     });
 
+    it('renders grouped enum options with provider headers', async () => {
+      const user = userEvent.setup();
+      const fieldDef: PropertyDefinition = {
+        type: 'string',
+        enum: ['claude-sonnet-4.6', 'claude-opus-4.6', 'openai-gpt-5.4-pro'],
+      };
+      render(<TestForm fieldName="model" fieldDef={fieldDef} />);
+
+      const select = screen.getByRole('combobox');
+      await user.click(select);
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude')).toBeInTheDocument();
+        expect(screen.getByText('OpenAI')).toBeInTheDocument();
+        expect(screen.getByText('Sonnet 4.6')).toBeInTheDocument();
+        expect(screen.getByText('Opus 4.6')).toBeInTheDocument();
+        expect(screen.getByText('GPT-5.4 Pro')).toBeInTheDocument();
+      });
+    });
+
+    it('keeps flat rendering for simple enums without dashes', async () => {
+      const user = userEvent.setup();
+      const fieldDef: PropertyDefinition = {
+        type: 'string',
+        enum: ['admin', 'user', 'guest'],
+      };
+      render(<TestForm fieldName="role" fieldDef={fieldDef} />);
+
+      const select = screen.getByRole('combobox');
+      await user.click(select);
+
+      await waitFor(() => {
+        expect(screen.getByText('Admin')).toBeInTheDocument();
+        expect(screen.getByText('User')).toBeInTheDocument();
+        expect(screen.getByText('Guest')).toBeInTheDocument();
+      });
+    });
+
+    it('renders selected grouped enum value with display name', () => {
+      const fieldDef: PropertyDefinition = {
+        type: 'string',
+        enum: ['claude-sonnet-4.6', 'claude-opus-4.6'],
+      };
+      render(<TestForm fieldName="model" fieldDef={fieldDef} defaultValues={{model: 'claude-sonnet-4.6'}} />);
+
+      const select = screen.getByRole('combobox');
+      expect(select).toHaveTextContent('Sonnet 4.6');
+    });
+
+    it('does not group enums where no provider has multiple values', async () => {
+      const user = userEvent.setup();
+      const fieldDef: PropertyDefinition = {
+        type: 'string',
+        enum: ['north-america', 'south-america', 'europe'],
+      };
+      render(<TestForm fieldName="region" fieldDef={fieldDef} />);
+
+      const select = screen.getByRole('combobox');
+      await user.click(select);
+
+      await waitFor(() => {
+        expect(screen.getByText('North-america')).toBeInTheDocument();
+        expect(screen.getByText('South-america')).toBeInTheDocument();
+        expect(screen.getByText('Europe')).toBeInTheDocument();
+        // Should NOT have group headers
+        expect(screen.queryByText('North')).not.toBeInTheDocument();
+        expect(screen.queryByText('South')).not.toBeInTheDocument();
+      });
+    });
+
+    it('renders ungrouped single items without redundant headers', async () => {
+      const user = userEvent.setup();
+      const fieldDef: PropertyDefinition = {
+        type: 'string',
+        enum: ['claude-sonnet-4.6', 'claude-opus-4.6', 'other'],
+      };
+      render(<TestForm fieldName="model" fieldDef={fieldDef} />);
+
+      const select = screen.getByRole('combobox');
+      await user.click(select);
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude')).toBeInTheDocument();
+        expect(screen.getByText('Sonnet 4.6')).toBeInTheDocument();
+        expect(screen.getByText('Opus 4.6')).toBeInTheDocument();
+        // "Other" should appear once as a MenuItem, NOT with a ListSubheader
+        const otherElements = screen.getAllByText('Other');
+        expect(otherElements).toHaveLength(1);
+      });
+    });
+
     it('renders with default value for string field', () => {
       const fieldDef: PropertyDefinition = {type: 'string'};
       render(<TestForm fieldName="username" fieldDef={fieldDef} defaultValues={{username: 'john'}} />);

--- a/frontend/packages/configure-users/src/utils/groupEnumOptions.ts
+++ b/frontend/packages/configure-users/src/utils/groupEnumOptions.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const DISPLAY_NAMES: Record<string, string> = {
+  claude: 'Claude',
+  'claude-opus-4.7': 'Opus 4.7',
+  'claude-opus-4.6': 'Opus 4.6',
+  'claude-sonnet-4.6': 'Sonnet 4.6',
+  'claude-sonnet-4.5': 'Sonnet 4.5',
+  'claude-haiku-4.5': 'Haiku 4.5',
+  openai: 'OpenAI',
+  'openai-gpt-5.4-pro': 'GPT-5.4 Pro',
+  'openai-gpt-5.4-thinking': 'GPT-5.4 Thinking',
+  'openai-gpt-5.4-mini': 'GPT-5.4 Mini',
+  'openai-gpt-5.4-nano': 'GPT-5.4 Nano',
+  'openai-gpt-5.3-instant': 'GPT-5.3 Instant',
+  gemini: 'Gemini',
+  'gemini-3.5-flash': '3.5 Flash',
+  'gemini-3.1-pro': '3.1 Pro',
+  'gemini-3-pro': '3 Pro',
+  'gemini-3-flash': '3 Flash',
+  llama: 'Llama',
+  'llama-4-scout': '4 Scout',
+  'llama-4-maverick': '4 Maverick',
+  'llama-3.3-70b': '3.3 70B',
+  mistral: 'Mistral',
+  'mistral-large-3': 'Large 3',
+  'mistral-small-4': 'Small 4',
+  'mistral-medium-3.5': 'Medium 3.5',
+  'mistral-devstral-2': 'Devstral 2',
+  other: 'Other',
+};
+
+export const groupEnumOptions = (enumValues: string[]): Map<string, string[]> => {
+  const groups = new Map<string, string[]>();
+
+  for (const value of enumValues) {
+    const dashIndex = value.indexOf('-');
+    const provider = dashIndex > 0 ? value.substring(0, dashIndex) : value;
+
+    const existing = groups.get(provider);
+    if (existing) {
+      existing.push(value);
+    } else {
+      groups.set(provider, [value]);
+    }
+  }
+
+  return groups;
+};
+
+export const getModelDisplayName = (value: string): string => {
+  if (DISPLAY_NAMES[value]) {
+    return DISPLAY_NAMES[value];
+  }
+
+  const dashIndex = value.indexOf('-');
+  if (dashIndex > 0) {
+    const afterPrefix = value.substring(dashIndex + 1);
+    return afterPrefix.charAt(0).toUpperCase() + afterPrefix.slice(1);
+  }
+
+  return value.charAt(0).toUpperCase() + value.slice(1);
+};

--- a/frontend/packages/configure-users/src/utils/renderSchemaField.tsx
+++ b/frontend/packages/configure-users/src/utils/renderSchemaField.tsx
@@ -26,11 +26,14 @@ import {
   MenuItem,
   Checkbox,
   FormControlLabel,
+  ListSubheader,
 } from '@wso2/oxygen-ui';
+import type {ReactNode} from 'react';
 import {Controller} from 'react-hook-form';
 import type {Control, FieldErrors, Path} from 'react-hook-form';
 import ArrayFieldInput from '../components/ArrayFieldInput';
 import CredentialFieldInput from '../components/CredentialFieldInput';
+import {groupEnumOptions, getModelDisplayName} from './groupEnumOptions';
 import type {PropertyDefinition} from '../models/users';
 
 /**
@@ -65,6 +68,44 @@ const renderSchemaField = <T extends Record<string, unknown>>(
     // Render as Select dropdown if enum values are provided
     if (stringDef.enum && stringDef.enum.length > 0) {
       const enumOptions = stringDef.enum;
+      const groups = groupEnumOptions(enumOptions);
+      const hasGroupedValues = [...groups.values()].some((v) => v.length >= 2);
+
+      const renderEnumItems = () => {
+        if (!hasGroupedValues) {
+          return enumOptions.map((option) => (
+            <MenuItem key={option} value={option}>
+              {option.charAt(0).toUpperCase() + option.slice(1)}
+            </MenuItem>
+          ));
+        }
+
+        const items: ReactNode[] = [];
+
+        groups.forEach((values, provider) => {
+          const isSingleUngrouped = values.length === 1 && values[0] === provider;
+          if (!isSingleUngrouped) {
+            items.push(<ListSubheader key={`header-${provider}`}>{getModelDisplayName(provider)}</ListSubheader>);
+          }
+          for (const value of values) {
+            items.push(
+              <MenuItem key={value} value={value} sx={isSingleUngrouped ? {} : {pl: 4}}>
+                {getModelDisplayName(value)}
+              </MenuItem>,
+            );
+          }
+        });
+
+        return items;
+      };
+
+      const renderSelectedValue = (selected: unknown) => {
+        if (!selected || selected === '') return <em>Select {fieldLabel}</em>;
+        if (hasGroupedValues) return getModelDisplayName(selected as string);
+        const s = selected as string;
+        return s.charAt(0).toUpperCase() + s.slice(1);
+      };
+
       return (
         <FormControl key={fieldName}>
           <FormLabel htmlFor={fieldName}>
@@ -86,15 +127,12 @@ const renderSchemaField = <T extends Record<string, unknown>>(
                 required={isRequired}
                 error={!!errors[fieldName]}
                 displayEmpty
+                renderValue={renderSelectedValue}
               >
                 <MenuItem value="">
                   <em>Select {fieldLabel}</em>
                 </MenuItem>
-                {enumOptions.map((option) => (
-                  <MenuItem key={option} value={option}>
-                    {option.charAt(0).toUpperCase() + option.slice(1)}
-                  </MenuItem>
-                ))}
+                {renderEnumItems()}
               </Select>
             )}
           />


### PR DESCRIPTION
## Summary

- Replace the flat model provider dropdown (Claude, GPT-5, etc.) with a grouped dropdown showing specific models organized by provider
- Each provider (Claude, OpenAI, Gemini, Llama, Mistral) appears as a section header with its models listed beneath
- Add `groupEnumOptions` utility for prefix-based grouping and `getModelDisplayName` for human-readable labels
- Update `renderSchemaField` to render `ListSubheader` group headers for grouped enums while preserving flat rendering for simple enums
- Smart grouping heuristic: only triggers when a provider prefix has 2+ values (avoids false positives like `north-america`)
- Skip redundant headers for standalone items like "other"
- Update bootstrap scripts with current model identifiers (May 2026)

### Updated model list

| Provider | Models |
|----------|--------|
| Claude | Opus 4.7, Opus 4.6, Sonnet 4.6, Sonnet 4.5, Haiku 4.5 |
| OpenAI | GPT-5.4 Pro, GPT-5.4 Thinking, GPT-5.4 Mini, GPT-5.4 Nano, GPT-5.3 Instant |
| Gemini | 3.5 Flash, 3.1 Pro, 3 Pro, 3 Flash |
| Llama | 4 Scout, 4 Maverick, 3.3 70B |
| Mistral | Large 3, Small 4, Medium 3.5, Devstral 2 |

## Test plan

- [x] `groupEnumOptions` groups enum values by provider prefix correctly (9 tests)
- [x] Grouped dropdown renders `ListSubheader` headers with indented model items (3 tests)
- [x] Simple enums without dashes (e.g. `admin`, `user`) render flat as before
- [x] Enums where no provider has multiple values render flat (no false positive grouping)
- [x] "Other" renders as a standalone MenuItem without a redundant ListSubheader
- [x] Selected grouped value displays human-readable name via `renderValue`
- [x] All 395 existing tests pass

Closes thunder-id/thunderid#3059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model selection now organizes available AI models by provider (Claude, OpenAI, Gemini, Llama, Mistral) for improved discoverability.
  * Models display with human-friendly names instead of technical identifiers.

* **Improved UI**
  * Enhanced model selection interface with provider grouping and clearer visual organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3065?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->