### PR TITLE
Fix status reporting for docs-only PRs in merge queue

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -657,6 +657,21 @@ jobs:
       #     name: Backend-combined Coverage (${{ matrix.database }})
       #     fail_ci_if_error: false
 
+  test-integration-status:
+    name: ✅ Integration Tests Status
+    needs: [test-integration]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check integration test results
+        run: |
+          if [[ "${{ needs.test-integration.result }}" == "failure" || "${{ needs.test-integration.result }}" == "cancelled" ]]; then
+            echo "❌ Integration tests failed or were cancelled"
+            exit 1
+          fi
+          echo "✅ Integration tests passed or were not required"
+
   test-e2e:
     name: 🎭 Playwright E2E Tests
     needs: [build, build_samples, detect-code-changes]

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,40 +20,30 @@ codecov:
   require_ci_to_pass: true
   notify:
     wait_for_ci: true
-    # Wait for exactly 5 coverage uploads before reporting status:
-    #   1. backend-unit (from build job)
-    #   2. backend-integration-sqlite (from test-integration matrix)
-    #   3. backend-integration-postgres (from test-integration matrix)
-    #   4. frontend-apps-console-unit (from upload-frontend-coverage)
-    #   5. frontend-apps-gate-unit (from upload-frontend-coverage)
-    # Without this, Codecov status checks can intermittently hang at
-    # "Expected — Waiting for status to be reported" when CI signal is delayed.
-    # See: https://about.codecov.io/blog/delay-notifications-for-flags-with-after_n_builds/
-    after_n_builds: 6
 
 flags:
   backend-unit:
-    carryforward: false
+    carryforward: true
     paths:
       - backend/
   backend-integration-sqlite:
-    carryforward: false
+    carryforward: true
     paths:
       - backend/
   backend-integration-postgres:
-    carryforward: false
+    carryforward: true
     paths:
       - backend/
   backend-integration-redis:
-    carryforward: false
+    carryforward: true
     paths:
       - backend/
   frontend-apps-console-unit:
-    carryforward: false
+    carryforward: true
     paths:
       - frontend/apps/console/
   frontend-apps-gate-unit:
-    carryforward: false
+    carryforward: true
     paths:
       - frontend/apps/gate/
 


### PR DESCRIPTION
### Purpose
Docs-only PRs were getting stuck in the merge queue with required checks showing \"Expected — Waiting for status to be reported\" indefinitely. Two separate issues caused this:

1. **Integration test matrix checks never reported** — When `build` is skipped (docs-only PR), the `test-integration` matrix job is also skipped at the job level. GitHub does not expand the matrix before skipping, so individual check runs for `🧪 Integration Tests (sqlite)` and `🧪 Integration Tests (postgres)` are never created, leaving required checks permanently pending.

2. **Codecov/patch never reported** — With `after_n_builds: 6` and `carryforward: false`, Codecov waited for 6 new coverage uploads that never arrive on docs-only PRs, causing `codecov/patch` to hang as pending indefinitely.

Here is the example for waiting in PR builder: https://github.com/thunder-id/thunderid/pull/3009

### Approach

**PR builder (`pr-builder.yml`):** Added a `test-integration-status` fan-in job that always runs after the matrix job. It reports a concrete `success` or `failure` to the merge queue — never a neutral/skipped status — regardless of whether the matrix job ran or was skipped. The required branch protection check should be updated to use `✅ Integration Tests Status` instead of the individual matrix job names.

**Codecov (`codecov.yml`):** Enabled `carryforward: true` on all coverage flags so Codecov reuses base commit coverage data when no new uploads arrive (docs-only PRs). Removed `after_n_builds: 6` since it counted actual new uploads (0 on docs-only PRs) and blocked reporting — `wait_for_ci: true` already ensures ordering for code PRs.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved CI/CD infrastructure with enhanced integration test status reporting and updated coverage tracking configuration for better consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->