### PR TITLE
Replace lodash-es merge with @thunderid/utils and fix initialize() deep merge

### DIFF
--- a/frontend/apps/console/src/hocs/withConfig.tsx
+++ b/frontend/apps/console/src/hocs/withConfig.tsx
@@ -19,7 +19,7 @@
 import {useConfig} from '@thunderid/contexts';
 import {ThunderIDProvider} from '@thunderid/react';
 import type {ThunderIDProviderProps} from '@thunderid/react';
-import {merge} from 'lodash-es';
+import {merge} from '@thunderid/utils';
 import type {JSX, ComponentType} from 'react';
 
 export default function withConfig<P extends object>(WrappedComponent: ComponentType<P>) {

--- a/sdks/javascript/src/ThunderIDJavaScriptClient.ts
+++ b/sdks/javascript/src/ThunderIDJavaScriptClient.ts
@@ -131,13 +131,18 @@ class ThunderIDJavaScriptClient<T = Config> implements ThunderIDClient<T> {
 
     const resolvedEndpoints = endpoints ? {...endpoints} : {};
 
-    await this.storageManager.setConfigData({
-      ...DEFAULT_CONFIG,
-      ...fullConfig,
-      applicationId: resolvedApplicationId,
-      endpoints: resolvedEndpoints,
-      scope: processOpenIDScopes((fullConfig as any).scopes),
-    } as any);
+    await this.storageManager.setConfigData(
+      deepMerge(
+        {} as Record<string, any>,
+        DEFAULT_CONFIG,
+        fullConfig as Record<string, any>,
+        {
+          applicationId: resolvedApplicationId,
+          endpoints: resolvedEndpoints,
+          scope: processOpenIDScopes((fullConfig as any).scopes),
+        }
+      ) as any
+    );
 
     this.baseURL = (fullConfig as any).baseUrl ?? '';
 

--- a/sdks/javascript/src/__tests__/ThunderIDJavaScriptClient.test.ts
+++ b/sdks/javascript/src/__tests__/ThunderIDJavaScriptClient.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+import ThunderIDJavaScriptClient from '../ThunderIDJavaScriptClient';
+import type {Storage} from '../models/store';
+
+vi.mock('../IsomorphicCrypto', () => ({
+  IsomorphicCrypto: class MockIsomorphicCrypto {
+    constructor(_cryptoUtils: unknown) {}
+  },
+}));
+
+vi.mock('../utils/AuthenticationHelper', () => ({
+  default: class MockAuthenticationHelper {
+    constructor(_storage: unknown, _crypto: unknown) {}
+  },
+}));
+
+class MemoryStore implements Storage {
+  private store = new Map<string, string>();
+
+  async getData(key: string): Promise<string> {
+    return this.store.get(key) ?? null!;
+  }
+
+  async setData(key: string, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async removeData(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+async function getStoredConfig(client: ThunderIDJavaScriptClient): Promise<Record<string, any>> {
+  return (client as any).storageManager.getConfigData();
+}
+
+describe('ThunderIDJavaScriptClient', () => {
+  let store: MemoryStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = new MemoryStore();
+  });
+
+  describe('initialize()', () => {
+    it('should apply DEFAULT_CONFIG baseline when no overrides are provided', async () => {
+      const client = new ThunderIDJavaScriptClient(store, {} as any);
+
+      await client.initialize({baseUrl: 'https://example.com', clientId: 'test-client'} as any);
+
+      const config = await getStoredConfig(client);
+
+      expect(config['enablePKCE']).toBe(true);
+      expect(config['sendCookiesInRequests']).toBe(true);
+      expect(config['tokenValidation']['idToken']['clockTolerance']).toBe(300);
+      expect(config['tokenValidation']['idToken']['validate']).toBe(true);
+      expect(config['tokenValidation']['idToken']['validateIssuer']).toBe(true);
+    });
+
+    it('should deep-merge partial tokenValidation, preserving sibling defaults', async () => {
+      const client = new ThunderIDJavaScriptClient(store, {} as any);
+
+      await client.initialize({
+        baseUrl: 'https://example.com',
+        clientId: 'test-client',
+        tokenValidation: {idToken: {validate: false}},
+      } as any);
+
+      const config = await getStoredConfig(client);
+
+      expect(config['tokenValidation']['idToken']['validate']).toBe(false);
+      expect(config['tokenValidation']['idToken']['clockTolerance']).toBe(300);
+      expect(config['tokenValidation']['idToken']['validateIssuer']).toBe(true);
+    });
+
+    it('should allow individual tokenValidation fields to be overridden independently', async () => {
+      const client = new ThunderIDJavaScriptClient(store, {} as any);
+
+      await client.initialize({
+        baseUrl: 'https://example.com',
+        clientId: 'test-client',
+        tokenValidation: {idToken: {clockTolerance: 60}},
+      } as any);
+
+      const config = await getStoredConfig(client);
+
+      expect(config['tokenValidation']['idToken']['clockTolerance']).toBe(60);
+      expect(config['tokenValidation']['idToken']['validate']).toBe(true);
+      expect(config['tokenValidation']['idToken']['validateIssuer']).toBe(true);
+    });
+
+    it('should set explicit fields (applicationId, scope) at highest precedence', async () => {
+      const client = new ThunderIDJavaScriptClient(store, {} as any);
+
+      await client.initialize({
+        applicationId: 'app-123',
+        baseUrl: 'https://example.com',
+        clientId: 'test-client',
+        scopes: ['openid', 'profile'],
+      } as any);
+
+      const config = await getStoredConfig(client);
+
+      expect(config['applicationId']).toBe('app-123');
+      expect(config['scope']).toContain('openid');
+    });
+  });
+});


### PR DESCRIPTION
### Purpose

Follow-up to #2991. Two issues are fixed together:

1. **Remove lodash-es import** — The console `withConfig` HOC introduced `import {merge} from 'lodash-es'` in #2991, but an in-house drop-in replacement (`merge` from `@thunderid/utils`) already exists in the codebase and is already a declared dependency of the console app. Using the internal utility is preferred.

2. **Fix shallow spread in `ThunderIDJavaScriptClient.initialize()`** — The SDK's `initialize()` method merged `DEFAULT_CONFIG` with user-supplied config using a shallow object spread (`{...DEFAULT_CONFIG, ...fullConfig}`). This silently drops nested sibling defaults when a partial nested object is supplied. For example:
   ```js
   // config.js
   sdk: { tokenValidation: { idToken: { validate: false } } }
   ```
   Previously caused `clockTolerance: 300` and `validateIssuer: true` to be lost from the stored config entirely. `initialize()` now uses the existing `deepMerge` utility, consistent with `reInitialize()` in the same file which was already correct.

### Approach

- **`frontend/apps/console/src/hocs/withConfig.tsx`** — one-line import swap: `lodash-es` → `@thunderid/utils`. Call site and behaviour are unchanged; `@thunderid/utils merge` has the identical variadic API and semantics.
- **`sdks/javascript/src/ThunderIDJavaScriptClient.ts`** — replaced the shallow spread in `initialize()` with `deepMerge({}, DEFAULT_CONFIG, fullConfig, { applicationId, endpoints, scope })`. The four-source pattern preserves the original precedence: explicit computed fields always win, user config overrides only the keys it specifies, and sibling defaults in `DEFAULT_CONFIG` are preserved.
- **`sdks/javascript/src/__tests__/ThunderIDJavaScriptClient.test.ts`** — new test file covering baseline defaults, partial `tokenValidation` deep merge (the specific loophole), individual field overrides, and explicit field precedence.

### Related Issues
- N/A

### Related PRs
- #2991

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JavaScript SDK configuration initialization now properly merges nested configuration options, including token validation settings, application identifiers, and endpoint configurations.

* **Tests**
  * Added comprehensive test suite for SDK configuration initialization, validating default settings behavior, partial configuration override merging, and proper configuration data persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thunder-id/thunderid/pull/3073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->