### PR TITLE
Pass TranslationConfig as argument to Initializer

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -118,7 +118,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	var exporters []declarativeresource.ResourceExporter
 
 	// Initialize i18n service for internationalization support.
-	i18nService, i18nExporter, err := i18nmgt.Initialize(mux)
+	i18nService, i18nExporter, err := i18nmgt.Initialize(mux, config.GetServerRuntime().Config.Translation)
 	if err != nil {
 		logger.Fatal("Failed to initialize i18n service", log.Error(err))
 	}

--- a/backend/internal/system/i18n/mgt/config.go
+++ b/backend/internal/system/i18n/mgt/config.go
@@ -21,7 +21,7 @@ package mgt
 import (
 	"strings"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
+	sysconfig "github.com/thunder-id/thunderid/internal/system/config"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 )
@@ -35,10 +35,9 @@ import (
 //     - If disabled: return "mutable"
 //
 // Returns normalized store mode: "mutable", "declarative", or "composite"
-func getI18nStoreMode() serverconst.StoreMode {
-	cfg := config.GetServerRuntime().Config
-	if cfg.Translation.Store != "" {
-		mode := serverconst.StoreMode(strings.ToLower(strings.TrimSpace(cfg.Translation.Store)))
+func getI18nStoreMode(translationConfig sysconfig.TranslationConfig) serverconst.StoreMode {
+	if translationConfig.Store != "" {
+		mode := serverconst.StoreMode(strings.ToLower(strings.TrimSpace(translationConfig.Store)))
 		switch mode {
 		case serverconst.StoreModeMutable, serverconst.StoreModeDeclarative, serverconst.StoreModeComposite:
 			return mode

--- a/backend/internal/system/i18n/mgt/config_test.go
+++ b/backend/internal/system/i18n/mgt/config_test.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package mgt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func TestConfigSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}
+
+func (suite *ConfigTestSuite) TestGetI18nStoreMode() {
+	t := suite.T()
+
+	tests := []struct {
+		name                      string
+		translationStore          string
+		declarativeModeEnabled    bool
+		expectedResolvedStoreMode serverconst.StoreMode
+	}{
+		{
+			name:                      "returns mutable when explicitly configured",
+			translationStore:          "mutable",
+			declarativeModeEnabled:    true,
+			expectedResolvedStoreMode: serverconst.StoreModeMutable,
+		},
+		{
+			name:                      "returns declarative when explicitly configured",
+			translationStore:          "declarative",
+			declarativeModeEnabled:    false,
+			expectedResolvedStoreMode: serverconst.StoreModeDeclarative,
+		},
+		{
+			name:                      "returns composite when explicitly configured",
+			translationStore:          "composite",
+			declarativeModeEnabled:    false,
+			expectedResolvedStoreMode: serverconst.StoreModeComposite,
+		},
+		{
+			name:                      "normalizes casing and spaces of explicit store mode",
+			translationStore:          "  CoMpOsItE  ",
+			declarativeModeEnabled:    false,
+			expectedResolvedStoreMode: serverconst.StoreModeComposite,
+		},
+		{
+			name:                      "falls back to declarative mode when explicit store is invalid",
+			translationStore:          "invalid",
+			declarativeModeEnabled:    true,
+			expectedResolvedStoreMode: serverconst.StoreModeDeclarative,
+		},
+		{
+			name:                      "falls back to mutable when store is empty and declarative mode is disabled",
+			translationStore:          "",
+			declarativeModeEnabled:    false,
+			expectedResolvedStoreMode: serverconst.StoreModeMutable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.ResetServerRuntime()
+			t.Cleanup(config.ResetServerRuntime)
+
+			testConfig := &config.Config{
+				DeclarativeResources: config.DeclarativeResources{
+					Enabled: tt.declarativeModeEnabled,
+				},
+			}
+			err := config.InitializeServerRuntime("/tmp/test", testConfig)
+			assert.NoError(t, err)
+
+			resolvedStoreMode := getI18nStoreMode(config.TranslationConfig{
+				Store: tt.translationStore,
+			})
+
+			assert.Equal(t, tt.expectedResolvedStoreMode, resolvedStoreMode)
+		})
+	}
+}

--- a/backend/internal/system/i18n/mgt/init.go
+++ b/backend/internal/system/i18n/mgt/init.go
@@ -21,16 +21,19 @@ package mgt
 import (
 	"net/http"
 
+	"github.com/thunder-id/thunderid/internal/system/config"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
 )
 
 // Initialize initializes the i18n service and registers its routes.
-func Initialize(mux *http.ServeMux) (I18nServiceInterface, declarativeresource.ResourceExporter, error) {
+func Initialize(mux *http.ServeMux,
+	translationConfig config.TranslationConfig,
+) (I18nServiceInterface, declarativeresource.ResourceExporter, error) {
 	var store i18nStoreInterface
 
-	storeMode := getI18nStoreMode()
+	storeMode := getI18nStoreMode(translationConfig)
 	switch storeMode {
 	case serverconst.StoreModeDeclarative:
 		fileStore := newFileBasedStore()

--- a/backend/internal/system/i18n/mgt/init_test.go
+++ b/backend/internal/system/i18n/mgt/init_test.go
@@ -62,7 +62,7 @@ func (suite *InitTestSuite) TestInitialize_MutableMode() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, exporter, err := Initialize(mux)
+	service, exporter, err := Initialize(mux, runtime.Config.Translation)
 
 	// Verify
 	assert.NoError(suite.T(), err)
@@ -82,7 +82,7 @@ func (suite *InitTestSuite) TestInitialize_DeclarativeMode() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, exporter, err := Initialize(mux)
+	service, exporter, err := Initialize(mux, runtime.Config.Translation)
 
 	// Verify
 	assert.NoError(suite.T(), err)
@@ -124,7 +124,7 @@ func (suite *InitTestSuite) TestInitialize_DeclarativeMode_LoadError() {
 	mux := http.NewServeMux()
 
 	// Execute
-	service, exporter, err := Initialize(mux)
+	service, exporter, err := Initialize(mux, config.GetServerRuntime().Config.Translation)
 
 	// Verify
 	assert.Error(suite.T(), err)


### PR DESCRIPTION
### Purpose

Instead of directly depending on serverConfig, i18n initialize method is provided with required Translation configuration. Making it easier for embedding applications to integrate.

### Approach

Directly passing TranslationConfig to initialize method.

### Related Issues
- #3037 

### Related PRs
- Closed PR #3046

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for internationalization configuration and store mode resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->