### PR TITLE
Integrate rollup-plugin-visualizer for bundle analysis

### DIFF
--- a/frontend/apps/console/package.json
+++ b/frontend/apps/console/package.json
@@ -22,6 +22,7 @@
     "directory": "frontend/apps/console"
   },
   "scripts": {
+    "analyze": "ANALYZE=true vite build",
     "build": "tsc -b && vite build",
     "clean": "pnpm clean:dist && pnpm clean:node_modules",
     "clean:dist": "rimraf dist",

--- a/frontend/apps/gate/package.json
+++ b/frontend/apps/gate/package.json
@@ -22,6 +22,7 @@
     "directory": "frontend/apps/gate"
   },
   "scripts": {
+    "analyze": "ANALYZE=true vite build",
     "build": "tsc -b && vite build",
     "clean": "pnpm clean:dist && pnpm clean:node_modules",
     "clean:dist": "rimraf dist",
@@ -74,6 +75,7 @@
     "eslint": "catalog:",
     "jsdom": "catalog:",
     "rimraf": "catalog:",
+    "rollup-plugin-visualizer": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plugin-svgr": "catalog:",

--- a/frontend/apps/gate/vite.config.ts
+++ b/frontend/apps/gate/vite.config.ts
@@ -20,6 +20,7 @@ import {resolve, dirname} from 'path';
 import {fileURLToPath} from 'url';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import react from '@vitejs/plugin-react';
+import {visualizer} from 'rollup-plugin-visualizer';
 import svgr from 'vite-plugin-svgr';
 import {defineConfig} from 'vitest/config';
 
@@ -51,6 +52,16 @@ export default defineConfig({
         plugins: [['babel-plugin-react-compiler']],
       },
     }),
+    ...(process.env.ANALYZE === 'true'
+      ? [
+          visualizer({
+            filename: resolve(currentDir, 'dist', 'stats.html'),
+            open: true,
+            gzipSize: true,
+            brotliSize: true,
+          }),
+        ]
+      : []),
   ],
   test: {
     globals: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,9 @@ importers:
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
+      rollup-plugin-visualizer:
+        specifier: 'catalog:'
+        version: 6.0.5(rolldown@1.0.0)(rollup@4.60.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
### Purpose

Adds bundle analysis tooling as the measurement baseline for the staged bundle-size improvements tracked in #3025.

- Wires `rollup-plugin-visualizer` into Gate's `vite.config.ts` (same conditional `ANALYZE=true` block already used by Console)
- Adds `rollup-plugin-visualizer` to Gate's `package.json` devDependencies (catalog ref — no new workspace dep)
- Adds an `analyze` convenience script to both Console and Gate `package.json`

**Baseline recorded from this build:**

| Chunk | Disk size |
|---|---|
| `index-KSqY7b6N.js` (initial load) | 6.8 MB |
| `dist-DlzFTWxn.js` | 603 KB |
| `dist-CZxUHfz4.js` | 126 KB |
| **Total** | ~7.5 MB |

### Approach

No code changes — tooling only. `ANALYZE=true vite build` activates the plugin and writes `dist/stats.html`. Without the flag, builds are unaffected.

Usage:
```sh
pnpm --filter console analyze   # opens dist/stats.html
pnpm --filter gate analyze      # opens dist/stats.html
```

### Related Issues
- #3025

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an "analyze" npm script in two frontend apps to run a build with analysis enabled.
  * Introduced bundle-visualizer tooling as a dev dependency and wiring to produce an interactive build report (HTML) with gzip/brotli and total-size metrics and automatic opening after builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->