### PR TITLE
Added structured error logs in dbTransactioner.Transact for two failure paths

### DIFF
--- a/backend/internal/system/transaction/transactioner.go
+++ b/backend/internal/system/transaction/transactioner.go
@@ -68,6 +68,10 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 	// 1. Begin transaction
 	tx, err := t.db.BeginTx(ctx, nil)
 	if err != nil {
+		log.GetLogger().Error("failed to begin transaction",
+			log.String("dbName", t.dbName),
+			log.Error(err),
+		)
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
@@ -116,6 +120,12 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 		} else {
 			// Success - commit
 			err = tx.Commit()
+			if err != nil {
+				log.GetLogger().Error("failed to commit transaction",
+					log.String("dbName", t.dbName),
+					log.Error(err),
+				)
+			}
 		}
 	}()
 


### PR DESCRIPTION
### Purpose
Previously, transaction begin and commit failures in the database-backed `Transactioner` were silently propagated as errors without any log output. This made it difficult to diagnose transaction-layer failures in production, since the error would surface at the caller with no infrastructure-level context.

### Approach
Added structured error logs in `dbTransactioner.Transact` for two failure paths:
- **Begin failure** — logged before returning the wrapped error when `BeginTx` fails.
- **Commit failure** — logged inside the deferred handler when `tx.Commit` returns an error.

The existing rollback failure log (already present) follows the same pattern. No behavior changes — errors are still propagated as before; logs are additive only.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/1868



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for transaction operations: startup and commit failures now record clearer details (including database identifier and commit error), yielding better diagnostics and more actionable logs for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->