### PR TITLE
Remove playwright cache

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -18,22 +18,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: 🎭 Restore Playwright Cache
-      id: playwright-cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        path: ~/.cache/ms-playwright
-        key: playwright-${{ runner.os }}-${{ inputs.scope }}-${{ hashFiles('pnpm-lock.yaml') }}
-
     - name: 🎭 Install Playwright Browsers
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: pnpm exec playwright install --with-deps ${{ inputs.browsers }}
 
-    - name: 🎭 Save Playwright Cache
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        path: ~/.cache/ms-playwright
-        key: playwright-${{ runner.os }}-${{ inputs.scope }}-${{ hashFiles('pnpm-lock.yaml') }}


### PR DESCRIPTION
### Purpose
Comment out playwright cache

### Approach
This pull request comments out the Playwright cache restore and save steps in the `.github/actions/setup-playwright/action.yml` file, effectively disabling Playwright cache usage in this GitHub Action. The installation of Playwright browsers will now always run without attempting to restore or save a cache.

- **GitHub Actions workflow update:**
  - Commented out both the restore and save cache steps for Playwright in the `setup-playwright` action, so Playwright browsers are always installed fresh rather than using a cache.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Playwright browser installation in CI now runs unconditionally on every run.
  * Browser caching for Playwright has been removed (no restore/save steps), simplifying and slightly increasing runtime for automated test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->