### PR TITLE
Remove the cron job from release actions.

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -6,9 +6,9 @@
 name: 🚀 Release Builder
 
 on:
-  schedule:
-    # Runs every Friday at 12:00 PM IST (6:30 AM UTC)
-    - cron: '30 6 * * 5'
+  # schedule:
+  #   # Runs every Friday at 12:00 PM IST (6:30 AM UTC)
+  #   - cron: '30 6 * * 5'
   workflow_dispatch:
     inputs:
       bump_type:
@@ -59,7 +59,7 @@ jobs:
       prerelease: ${{ steps.get_version.outputs.prerelease }}
       run_performance_test: ${{ steps.get_version.outputs.run_performance_test }}
       use_existing_version: ${{ steps.get_version.outputs.use_existing_version }}
-    steps:  
+    steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -88,18 +88,10 @@ jobs:
             exit 1
           fi
 
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            PRERELEASE="${{ github.event.inputs.prerelease }}"
-            RUN_PERF_TEST="${{ github.event.inputs.run_performance_test }}"
-            BUMP_TYPE="${{ github.event.inputs.bump_type }}"
-            USE_EXISTING_VERSION="${{ github.event.inputs.use_existing_version }}"
-          else
-            # Scheduled run — default to minor bump
-            PRERELEASE="false"
-            RUN_PERF_TEST="true"
-            BUMP_TYPE="minor"
-            USE_EXISTING_VERSION="false"
-          fi
+          PRERELEASE="${{ github.event.inputs.prerelease }}"
+          RUN_PERF_TEST="${{ github.event.inputs.run_performance_test }}"
+          BUMP_TYPE="${{ github.event.inputs.bump_type }}"
+          USE_EXISTING_VERSION="${{ github.event.inputs.use_existing_version }}"
 
           if [ "$USE_EXISTING_VERSION" == "true" ]; then
             VERSION="$CURRENT_VERSION"

--- a/docs/content/community/release-operations.mdx
+++ b/docs/content/community/release-operations.mdx
@@ -91,5 +91,5 @@ The weekly release process uses these GitHub Actions workflows:
 | --- | --- | --- |
 | [Pre-Release Sync](https://github.com/thunder-id/thunderid/blob/main/.github/workflows/pre-release-sync.yml) | Thursday 9:30 PM UTC and manual dispatch | Merges main into release branch; commits directly if no conflicts, opens a PR otherwise |
 | [Release Milestone Reminder](https://github.com/thunder-id/thunderid/blob/main/.github/workflows/release-milestone-reminder.yaml) | Thursday 6:00 AM IST and manual dispatch | Sends release-readiness reminder based on open milestone items |
-| [Release Builder](https://github.com/thunder-id/thunderid/blob/main/.github/workflows/release-builder.yml) | Scheduled on Friday and manual dispatch | Builds, tags, packages, and publishes the release |
+| [Release Builder](https://github.com/thunder-id/thunderid/blob/main/.github/workflows/release-builder.yml) | Manual dispatch | Builds, tags, packages, and publishes the release |
 | [Post-Release Sync](https://github.com/thunder-id/thunderid/blob/main/.github/workflows/post-release-sync.yml) | After successful release workflow run and manual dispatch | Merges release into main directly if no conflicts; opens a conflict-resolution PR otherwise |


### PR DESCRIPTION
### Purpose
Remove the automated cron schedules from the release builder and pre-release sync workflows. Both workflows are now triggered exclusively on demand via `workflow_dispatch`.

### Approach
- Removed the weekly cron trigger (`30 6 * * 5`) from `release-builder.yml`.
- Removed the dead `else` branch in the version determination step that only applied to scheduled runs.

### Test run
- https://github.com/Malith-19/thunder/actions/runs/26868246076

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided.
- [ ] Tests provided.
- [ ] Breaking changes.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now uses manual dispatch only; scheduled automatic releases removed.
  * Streamlined release logic by removing conditional branching tied to trigger type.
  * Documentation updated to reflect the manual-only release trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->