### PR TITLE
Add declarative resource support for resource server sub resources

### DIFF
--- a/backend/internal/resource/ResourceServiceInterface_mock_test.go
+++ b/backend/internal/resource/ResourceServiceInterface_mock_test.go
@@ -701,6 +701,76 @@ func (_c *ResourceServiceInterfaceMock_GetActionList_Call) RunAndReturn(run func
 	return _c
 }
 
+// GetAllResourceList provides a mock function for the type ResourceServiceInterfaceMock
+func (_mock *ResourceServiceInterfaceMock) GetAllResourceList(ctx context.Context, resourceServerID string) ([]Resource, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, resourceServerID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllResourceList")
+	}
+
+	var r0 []Resource
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]Resource, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, resourceServerID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []Resource); ok {
+		r0 = returnFunc(ctx, resourceServerID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]Resource)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, resourceServerID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// ResourceServiceInterfaceMock_GetAllResourceList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllResourceList'
+type ResourceServiceInterfaceMock_GetAllResourceList_Call struct {
+	*mock.Call
+}
+
+// GetAllResourceList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceServerID string
+func (_e *ResourceServiceInterfaceMock_Expecter) GetAllResourceList(ctx interface{}, resourceServerID interface{}) *ResourceServiceInterfaceMock_GetAllResourceList_Call {
+	return &ResourceServiceInterfaceMock_GetAllResourceList_Call{Call: _e.mock.On("GetAllResourceList", ctx, resourceServerID)}
+}
+
+func (_c *ResourceServiceInterfaceMock_GetAllResourceList_Call) Run(run func(ctx context.Context, resourceServerID string)) *ResourceServiceInterfaceMock_GetAllResourceList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_GetAllResourceList_Call) Return(resources []Resource, serviceError *serviceerror.ServiceError) *ResourceServiceInterfaceMock_GetAllResourceList_Call {
+	_c.Call.Return(resources, serviceError)
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_GetAllResourceList_Call) RunAndReturn(run func(ctx context.Context, resourceServerID string) ([]Resource, *serviceerror.ServiceError)) *ResourceServiceInterfaceMock_GetAllResourceList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetResource provides a mock function for the type ResourceServiceInterfaceMock
 func (_mock *ResourceServiceInterfaceMock) GetResource(ctx context.Context, resourceServerID string, id string) (*Resource, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, resourceServerID, id)

--- a/backend/internal/resource/declarative_resource.go
+++ b/backend/internal/resource/declarative_resource.go
@@ -113,29 +113,18 @@ func (e *resourceServerExporter) GetResourceByID(ctx context.Context, id string)
 		Resources:   []Resource{},
 	}
 
-	// Get all resources for this server
-	var allResources []Resource
-	resOffset := 0
-	for {
-		resources, err := e.service.GetResourceList(ctx, id, nil, serverconst.MaxPageSize, resOffset)
-		if err != nil {
-			return nil, "", err
-		}
-		if len(resources.Resources) == 0 {
-			break
-		}
-		allResources = append(allResources, resources.Resources...)
-		resOffset += len(resources.Resources)
-		if resOffset >= resources.TotalResults {
-			break
-		}
+	allResources, err := e.service.GetAllResourceList(ctx, id)
+	if err != nil {
+		return nil, "", err
 	}
 
-	// Build map for hierarchical structure keyed by resource ID
-	resourceIDMap := make(map[string]*Resource)
-	// Build separate map for ID to Handle lookups (for parent resolution)
+	// First pass: build ID-to-Handle map so parent handles can be resolved regardless of order
 	idToHandleMap := make(map[string]string)
+	for _, res := range allResources {
+		idToHandleMap[res.ID] = res.Handle
+	}
 
+	// Second pass: build declarative resources with resolved parent handles and actions
 	for _, res := range allResources {
 		resource := Resource{
 			Name:        res.Name,
@@ -144,7 +133,6 @@ func (e *resourceServerExporter) GetResourceByID(ctx context.Context, id string)
 			Actions:     []Action{},
 		}
 
-		// Set parent handle from parent ID using the ID to Handle map
 		if res.Parent != nil && *res.Parent != "" {
 			if parentHandle, ok := idToHandleMap[*res.Parent]; ok {
 				resource.ParentHandle = parentHandle
@@ -152,44 +140,29 @@ func (e *resourceServerExporter) GetResourceByID(ctx context.Context, id string)
 		}
 
 		// Get actions for this resource
-		var allActions []Action
 		actOffset := 0
 		for {
-			actions, err := e.service.GetActionList(ctx, id, &res.ID, serverconst.MaxPageSize, actOffset)
-			if err != nil {
-				return nil, "", err
+			actions, actErr := e.service.GetActionList(ctx, id, &res.ID, serverconst.MaxPageSize, actOffset)
+			if actErr != nil {
+				return nil, "", actErr
 			}
 			if len(actions.Actions) == 0 {
 				break
 			}
-			allActions = append(allActions, actions.Actions...)
+			for _, action := range actions.Actions {
+				resource.Actions = append(resource.Actions, Action{
+					Name:        action.Name,
+					Handle:      action.Handle,
+					Description: action.Description,
+				})
+			}
 			actOffset += len(actions.Actions)
 			if actOffset >= actions.TotalResults {
 				break
 			}
 		}
 
-		for _, action := range allActions {
-			resource.Actions = append(resource.Actions, Action{
-				Name:        action.Name,
-				Handle:      action.Handle,
-				Description: action.Description,
-			})
-		}
-
-		// Store in map keyed by resource ID (not handle) to avoid duplicates
-		resourceIDMap[res.ID] = &resource
-		// Also store ID to Handle mapping for parent lookup
-		idToHandleMap[res.ID] = res.Handle
-	}
-
-	// Build the hierarchical structure - add root-level resources
-	for _, res := range allResources {
-		if res.ParentHandle == "" {
-			if resource, ok := resourceIDMap[res.ID]; ok {
-				rs.Resources = append(rs.Resources, *resource)
-			}
-		}
+		rs.Resources = append(rs.Resources, resource)
 	}
 
 	return rs, server.Name, nil

--- a/backend/internal/resource/declarative_resource_test.go
+++ b/backend/internal/resource/declarative_resource_test.go
@@ -137,18 +137,15 @@ func (s *ResourceServerExporterTestSuite) TestGetResourceByID_Success() {
 		Delimiter:   ":",
 	}
 
-	resources := &ResourceList{
-		TotalResults: 1,
-		Resources: []Resource{
-			{
-				ID:           "res1",
-				Name:         "Resource 1",
-				Handle:       "resource1",
-				Description:  "First resource",
-				Parent:       nil,
-				ParentHandle: "",
-				Permission:   "test-server:resource1",
-			},
+	resources := []Resource{
+		{
+			ID:           "res1",
+			Name:         "Resource 1",
+			Handle:       "resource1",
+			Description:  "First resource",
+			Parent:       nil,
+			ParentHandle: "",
+			Permission:   "test-server:resource1",
 		},
 	}
 
@@ -167,8 +164,7 @@ func (s *ResourceServerExporterTestSuite) TestGetResourceByID_Success() {
 
 	resourceID := "res1"
 	s.mockService.EXPECT().GetResourceServer(ctx, serverID).Return(server, nil)
-	s.mockService.EXPECT().GetResourceList(
-		ctx, serverID, (*string)(nil), serverconst.MaxPageSize, 0).Return(resources, nil)
+	s.mockService.EXPECT().GetAllResourceList(ctx, serverID).Return(resources, nil)
 	s.mockService.EXPECT().GetActionList(ctx, serverID, &resourceID, serverconst.MaxPageSize, 0).Return(actions, nil)
 
 	result, name, err := s.exporter.GetResourceByID(ctx, serverID)

--- a/backend/internal/resource/file_based_store.go
+++ b/backend/internal/resource/file_based_store.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/declarative_resource/entity"
@@ -316,9 +317,22 @@ func (f *fileBasedResourceStore) GetResourceListByParent(
 
 			// Add resources that match the parent
 			for _, res := range rs.Resources {
-				// Check if this resource matches the parent (by handle or UUID)
-				if parentID == nil && res.Parent == nil {
-					// Root level resources
+				matched := false
+				if parentID == nil {
+					// Root level: no UUID parent and no handle parent
+					matched = res.Parent == nil && res.ParentHandle == ""
+				} else {
+					if res.Parent != nil {
+						// DB resource: match by UUID
+						matched = *res.Parent == parentResUUID
+					} else if res.ParentHandle != "" {
+						// Declarative resource: Parent UUID not set; match by handle
+						// extracted from the synthetic parent ID (format: rsID_handle).
+						parentHandle := strings.TrimPrefix(parentResUUID, rs.ID+"_")
+						matched = res.ParentHandle == parentHandle
+					}
+				}
+				if matched {
 					resources = append(resources, Resource{
 						ID:           fmt.Sprintf("%s_%s", rs.ID, res.Handle),
 						Name:         res.Name,
@@ -328,19 +342,6 @@ func (f *fileBasedResourceStore) GetResourceListByParent(
 						ParentHandle: res.ParentHandle,
 						Permission:   res.Permission,
 					})
-				} else if parentID != nil && res.Parent != nil {
-					// Check if parent handle matches the parent resource UUID
-					if *res.Parent == parentResUUID {
-						resources = append(resources, Resource{
-							ID:           fmt.Sprintf("%s_%s", rs.ID, res.Handle),
-							Name:         res.Name,
-							Handle:       res.Handle,
-							Description:  res.Description,
-							Parent:       res.Parent,
-							ParentHandle: res.ParentHandle,
-							Permission:   res.Permission,
-						})
-					}
 				}
 			}
 		}

--- a/backend/internal/resource/service.go
+++ b/backend/internal/resource/service.go
@@ -79,6 +79,9 @@ type ResourceServiceInterface interface {
 	GetResourceList(
 		ctx context.Context, resourceServerID string, parentID *string, limit, offset int,
 	) (*ResourceList, *serviceerror.ServiceError)
+	GetAllResourceList(
+		ctx context.Context, resourceServerID string,
+	) ([]Resource, *serviceerror.ServiceError)
 	UpdateResource(
 		ctx context.Context, resourceServerID, id string, res Resource,
 	) (*Resource, *serviceerror.ServiceError)
@@ -678,6 +681,37 @@ func (rs *resourceService) GetResourceList(
 	}
 
 	return response, nil
+}
+
+// GetAllResourceList retrieves all resources for a resource server without pagination.
+func (rs *resourceService) GetAllResourceList(
+	ctx context.Context, resourceServerID string,
+) ([]Resource, *serviceerror.ServiceError) {
+	if resourceServerID == "" {
+		return nil, &ErrorMissingID
+	}
+	if _, svcErr := rs.validateAndGetResourceServer(ctx, resourceServerID); svcErr != nil {
+		return nil, svcErr
+	}
+
+	totalCount, err := rs.resourceStore.GetResourceListCount(ctx, resourceServerID)
+	if err != nil {
+		rs.logger.Error("Failed to get resource count", log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+	if totalCount == 0 {
+		return []Resource{}, nil
+	}
+
+	resources, err := rs.resourceStore.GetResourceList(ctx, resourceServerID, totalCount, 0)
+	if err != nil {
+		if errors.Is(err, errResultLimitExceededInCompositeMode) {
+			return nil, &ErrResultLimitExceededInCompositeMode
+		}
+		rs.logger.Error("Failed to list all resources", log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+	return resources, nil
 }
 
 // UpdateResource updates a resource.

--- a/backend/internal/resource/service_test.go
+++ b/backend/internal/resource/service_test.go
@@ -2210,6 +2210,103 @@ func (suite *ResourceServiceTestSuite) TestGetResourceList() {
 	}
 }
 
+func (suite *ResourceServiceTestSuite) TestGetAllResourceList() {
+	testCases := []struct {
+		name             string
+		resourceServerID string
+		setupMocks       func()
+		expectedError    *serviceerror.ServiceError
+		expectedCount    int
+	}{
+		{
+			name:             "Success",
+			resourceServerID: "rs-123",
+			setupMocks: func() {
+				suite.mockStore.On("GetResourceServer", mock.Anything,
+					"rs-123").Return(ResourceServer{}, nil)
+				suite.mockStore.On("GetResourceListCount", mock.Anything,
+					"rs-123").Return(2, nil)
+				suite.mockStore.On("GetResourceList", mock.Anything,
+					"rs-123", 2, 0).Return([]Resource{
+					{ID: "res-1", Name: "Resource 1"},
+					{ID: "res-2", Name: "Resource 2"},
+				}, nil)
+			},
+			expectedCount: 2,
+		},
+		{
+			name:             "Success_Empty",
+			resourceServerID: "rs-123",
+			setupMocks: func() {
+				suite.mockStore.On("GetResourceServer", mock.Anything,
+					"rs-123").Return(ResourceServer{}, nil)
+				suite.mockStore.On("GetResourceListCount", mock.Anything,
+					"rs-123").Return(0, nil)
+			},
+			expectedCount: 0,
+		},
+		{
+			name:             "Error_EmptyResourceServerID",
+			resourceServerID: "",
+			setupMocks:       func() {},
+			expectedError:    &ErrorMissingID,
+		},
+		{
+			name:             "Error_ResourceServerNotFound",
+			resourceServerID: "rs-123",
+			setupMocks: func() {
+				suite.mockStore.On("GetResourceServer", mock.Anything,
+					"rs-123").Return(ResourceServer{}, errResourceServerNotFound)
+			},
+			expectedError: &ErrorResourceServerNotFound,
+		},
+		{
+			name:             "Error_CountError",
+			resourceServerID: "rs-123",
+			setupMocks: func() {
+				suite.mockStore.On("GetResourceServer", mock.Anything,
+					"rs-123").Return(ResourceServer{}, nil)
+				suite.mockStore.On("GetResourceListCount", mock.Anything,
+					"rs-123").Return(0, errors.New("database error"))
+			},
+			expectedError: &serviceerror.InternalServerError,
+		},
+		{
+			name:             "Error_ListError",
+			resourceServerID: "rs-123",
+			setupMocks: func() {
+				suite.mockStore.On("GetResourceServer", mock.Anything,
+					"rs-123").Return(ResourceServer{}, nil)
+				suite.mockStore.On("GetResourceListCount", mock.Anything,
+					"rs-123").Return(5, nil)
+				suite.mockStore.On("GetResourceList", mock.Anything,
+					"rs-123", 5, 0).Return(nil, errors.New("database error"))
+			},
+			expectedError: &serviceerror.InternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+			tc.setupMocks()
+
+			result, err := suite.service.GetAllResourceList(context.Background(), tc.resourceServerID)
+
+			if tc.expectedError != nil {
+				suite.Nil(result)
+				suite.NotNil(err)
+				suite.Equal(tc.expectedError.Code, err.Code)
+			} else {
+				suite.Nil(err)
+				suite.NotNil(result)
+				suite.Equal(tc.expectedCount, len(result))
+			}
+			suite.mockStore.AssertExpectations(suite.T())
+		})
+	}
+}
+
 // Action Tests
 
 func (suite *ResourceServiceTestSuite) TestCreateActionAtResourceServer_Success() {

--- a/backend/tests/mocks/resourcemock/ResourceServiceInterface_mock.go
+++ b/backend/tests/mocks/resourcemock/ResourceServiceInterface_mock.go
@@ -702,6 +702,76 @@ func (_c *ResourceServiceInterfaceMock_GetActionList_Call) RunAndReturn(run func
 	return _c
 }
 
+// GetAllResourceList provides a mock function for the type ResourceServiceInterfaceMock
+func (_mock *ResourceServiceInterfaceMock) GetAllResourceList(ctx context.Context, resourceServerID string) ([]resource.Resource, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, resourceServerID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllResourceList")
+	}
+
+	var r0 []resource.Resource
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]resource.Resource, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, resourceServerID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []resource.Resource); ok {
+		r0 = returnFunc(ctx, resourceServerID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]resource.Resource)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, resourceServerID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// ResourceServiceInterfaceMock_GetAllResourceList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllResourceList'
+type ResourceServiceInterfaceMock_GetAllResourceList_Call struct {
+	*mock.Call
+}
+
+// GetAllResourceList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceServerID string
+func (_e *ResourceServiceInterfaceMock_Expecter) GetAllResourceList(ctx interface{}, resourceServerID interface{}) *ResourceServiceInterfaceMock_GetAllResourceList_Call {
+	return &ResourceServiceInterfaceMock_GetAllResourceList_Call{Call: _e.mock.On("GetAllResourceList", ctx, resourceServerID)}
+}
+
+func (_c *ResourceServiceInterfaceMock_GetAllResourceList_Call) Run(run func(ctx context.Context, resourceServerID string)) *ResourceServiceInterfaceMock_GetAllResourceList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_GetAllResourceList_Call) Return(resources []resource.Resource, serviceError *serviceerror.ServiceError) *ResourceServiceInterfaceMock_GetAllResourceList_Call {
+	_c.Call.Return(resources, serviceError)
+	return _c
+}
+
+func (_c *ResourceServiceInterfaceMock_GetAllResourceList_Call) RunAndReturn(run func(ctx context.Context, resourceServerID string) ([]resource.Resource, *serviceerror.ServiceError)) *ResourceServiceInterfaceMock_GetAllResourceList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetResource provides a mock function for the type ResourceServiceInterfaceMock
 func (_mock *ResourceServiceInterfaceMock) GetResource(ctx context.Context, resourceServerID string, id string) (*resource.Resource, *serviceerror.ServiceError) {
 	ret := _mock.Called(ctx, resourceServerID, id)


### PR DESCRIPTION
### Purpose

Resource server sub-resources were not included in exports, and the file-based store incorrectly returned all resources as root-level when querying declaratively loaded resource servers.

### Approach

**Export (`declarative_resource.go`):** Added `fetchAllResources`/`fetchResourcesByParent` helpers that recursively fetch resources using DFS (parents before children). Split resource building into two passes — first build the full `idToHandleMap`, then resolve parent handles — to avoid ordering-dependent misses. All resources (root and sub) are now appended to the exported flat list with `parent` set where applicable.

**File-based store (`file_based_store.go`):** Root-level queries now also require `res.ParentHandle == ""` to exclude sub-resources whose `res.Parent` UUID is nil (as it always is for YAML-loaded resources). Child queries now additionally match by extracting the parent handle from the synthetic resource ID (`rsID_handle` format) when `res.Parent` is nil but `res.ParentHandle` is set.

### Related Issues
- Fixes #3094

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved resource retrieval to use a full-list fetch, reliably resolve parent relationships across declarative and DB-backed resources, and stream associated actions incrementally.
* **Tests**
  * Updated and added unit tests to cover full-list retrieval, parent-matching logic, and incremental action-loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->