### PR TITLE
Redirect to application URL after sign-up instead of bare sign-in page

### DIFF
--- a/frontend/apps/gate/src/components/SignUp/SignUpBox.tsx
+++ b/frontend/apps/gate/src/components/SignUp/SignUpBox.tsx
@@ -32,7 +32,7 @@ import ROUTES from '../../constants/routes';
 
 export default function SignUpBox(): JSX.Element {
   const navigate = useNavigate();
-  const {resolveFlowTemplateLiterals: resolve} = useThunderID();
+  const {resolveFlowTemplateLiterals: resolve, meta} = useThunderID();
   const {t} = useTranslation();
   const {isDesignEnabled} = useDesign();
   const [flowError, setFlowError] = useState<string | null>(null);
@@ -42,7 +42,12 @@ export default function SignUpBox(): JSX.Element {
   // For window.location.href and new URL() (via afterSignUpUrl) — React Router basename is
   // bypassed, so an absolute URL with origin + base path must be constructed explicitly.
   // Vite appends a trailing slash to BASE_URL.
-  const afterSignUpUrl = `${window.location.origin}${import.meta.env.BASE_URL.replace(/\/$/, '')}${signInPath}`;
+  const signInUrl = `${window.location.origin}${import.meta.env.BASE_URL.replace(/\/$/, '')}${signInPath}`;
+  // Prefer the application's home URL from flow metadata so the user is returned to the
+  // app after sign-up instead of the gate sign-in page. Fall back to the sign-in page if
+  // the application URL is not available in the flow metadata.
+  const appUrl = meta?.application?.url;
+  const afterSignUpUrl = appUrl != null && appUrl !== '' ? appUrl : signInUrl;
 
   const renderFlowContent = (
     components: EmbeddedFlowComponent[],

--- a/frontend/apps/gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
@@ -99,11 +99,16 @@ const createMockSignUpRenderProps = (overrides: Partial<MockSignUpRenderProps> =
 let mockSignUpRenderProps: MockSignUpRenderProps = createMockSignUpRenderProps();
 let capturedOnFlowChange: ((response: unknown) => void) | undefined;
 let capturedAfterSignUpUrl: string | undefined;
+let mockMeta: {application?: {url?: string}} | null = null;
 
 vi.mock('@thunderid/react', async () => {
   const actual = await vi.importActual('@thunderid/react');
   return {
     ...actual,
+    useThunderID: () => ({
+      resolveFlowTemplateLiterals: (t: string) => t,
+      meta: mockMeta,
+    }),
     SignUp: ({
       children,
       onFlowChange = undefined,
@@ -140,6 +145,7 @@ describe('SignUpBox', () => {
     mockSignUpRenderProps = createMockSignUpRenderProps();
     capturedOnFlowChange = undefined;
     capturedAfterSignUpUrl = undefined;
+    mockMeta = null;
   });
 
   it('renders without crashing', () => {
@@ -550,10 +556,17 @@ describe('SignUpBox', () => {
     expect(screen.getByText('Sign in')).toBeInTheDocument();
   });
 
-  it('passes afterSignUpUrl as an absolute URL with origin and BASE_URL prefix to SignUp component', () => {
+  it('falls back to sign-in URL as afterSignUpUrl when meta has no application URL', () => {
+    mockMeta = null;
     render(<SignUpBox />);
     const expectedUrl = `${window.location.origin}${import.meta.env.BASE_URL.replace(/\/$/, '')}/signin`;
     expect(capturedAfterSignUpUrl).toBe(expectedUrl);
+  });
+
+  it('uses application URL from flow meta as afterSignUpUrl when available', () => {
+    mockMeta = {application: {url: 'https://myapp.example.com/home'}};
+    render(<SignUpBox />);
+    expect(capturedAfterSignUpUrl).toBe('https://myapp.example.com/home');
   });
 
   it('navigates to sign in page when clicking sign in link', async () => {


### PR DESCRIPTION
### Purpose
After sign-up completes via the ThunderID gate (redirect-based OAuth flow) without auto-login, the gate was unconditionally redirecting users to its own sign-in page. This was incorrect — the application may have configured a destination URL, and even without one, sending users to a bare gate sign-in page loses the original OAuth session context (authId + requested_permissions), causing the subsequent sign-in token to be missing application-specific permission scopes.

### Approach
The SignUpBox component already had access to flow metadata via useThunderID(). The FlowMetadataResponse exposes an application.url field representing the application's home URL registered in ThunderID.

The fix reads meta?.application?.url at render time and uses it as the afterSignUpUrl passed to the <SignUp> component. If the application URL is not present in the flow metadata, it falls back to the existing gate sign-in path — preserving backward compatibility.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3100

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3063


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-up now redirects after registration by preferring the application's configured URL when available and falling back to the default sign-in page.

* **Tests**
  * Tests updated to cover both the application-configured redirect and the fallback absolute sign-in redirect, ensuring behavior varies correctly with flow metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->