### PR TITLE
Add "Try In Your Own App" B2C walkthroughs.

### DIFF
--- a/docs/content/use-cases/b2c/try-in-your-own-app.mdx
+++ b/docs/content/use-cases/b2c/try-in-your-own-app.mdx
@@ -1,0 +1,65 @@
+---
+title: Try In Your Own App
+description: Configure {{ProductName}} for each B2C use case and integrate it into your own application.
+sidebar_position: 4
+---
+
+import {NextSteps, NextStepsCard} from '../../../src/components/NextSteps';
+
+# Try In Your Own App
+
+Each walkthrough below configures <ProductName /> for one B2C use case and walks you through integrating it into your application.
+
+:::tip Already following Try It Out?
+This path is for integrating <ProductName /> into your own app. If you'd rather see the use cases running against a pre-built sample, see [Try It Out](../try-it-out).
+:::
+
+## Prerequisites
+
+- <ProductName /> running locally. Follow [Get <ProductName />](/docs/next/guides/getting-started/get-thunderid) if you haven't already.
+
+## Foundation
+
+All walkthroughs build on a shared consumer user type. Create it once here; each walkthrough then layers its own configuration on top.
+
+Navigate to **User Types** → **Create User Type**. Add at minimum:
+
+| Attribute  | Type   | Properties       |
+| ---------- | ------ | ---------------- |
+| `username` | string | Required, unique |
+| `email`    | string | Required, unique |
+| `password` | string | Credential       |
+
+See [User Types](/docs/next/guides/guides/users/user-types).
+
+Start with the [Login](./add-login) walkthrough — it registers your application and builds the sign-in flow that every other walkthrough depends on.
+
+## Walkthroughs
+
+<NextSteps>
+  <NextStepsCard
+    title="Login"
+    description="Configure sign-in and wire it into your app."
+    href="./add-login"
+  />
+  <NextStepsCard
+    title="Self Sign-Up"
+    description="Let new users register themselves with email and password."
+    href="./self-sign-up"
+  />
+  <NextStepsCard
+    title="View Profile"
+    description="Display and update a user's profile attributes and password."
+    href="./profile-section"
+  />
+  <NextStepsCard
+    title="Account Recovery"
+    description="Let users reset a forgotten password through an email link."
+    href="./account-recovery"
+  />
+  <NextStepsCard
+    title="Onboard Internal Users"
+    description="Invite staff by email and provision them with the right role on accept."
+    href="./onboard-internal-users"
+  />
+</NextSteps>

--- a/docs/content/use-cases/b2c/try-in-your-own-app/_category_.json
+++ b/docs/content/use-cases/b2c/try-in-your-own-app/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 4,
+  "label": "Try In Your Own App",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/content/use-cases/b2c/try-in-your-own-app/account-recovery.mdx
+++ b/docs/content/use-cases/b2c/try-in-your-own-app/account-recovery.mdx
@@ -1,0 +1,209 @@
+---
+title: Account Recovery
+description: Configure {{ProductName}} for password recovery and integrate it into your own application.
+sidebar_position: 5
+---
+
+# Account Recovery
+
+This walkthrough configures <ProductName /> to let users reset a forgotten password through an email link. <ProductName /> identifies the user, sends the recovery email, verifies the link, and lets the user set a new password — all on the hosted sign-in pages in the redirect-based pattern.
+
+:::info Background
+[Add Account Recovery](../../customer-identity#add-account-recovery) covers the requirements story behind this use case.
+:::
+
+:::note Prerequisites
+- Complete the [Login](../add-login) walkthrough first. The user type and application set up there are required here.
+- Configure SMTP so that <ProductName /> can send recovery emails. See [Email Configuration](/docs/next/guides/getting-started/configuration#email-configuration), then restart <ProductName /> for the changes to take effect.
+:::
+
+## Pick Your Pattern
+
+<details open>
+  <summary>Redirect-based</summary>
+
+In the redirect-based pattern, the entire recovery experience is hosted by <ProductName />. Your app provides a **Forgot password?** link that redirects the user to <ProductName />. After the user completes the recovery flow, they return to your app's sign-in page.
+
+### Configure <ProductName />
+
+**1. Build a recovery flow**
+
+Build a `RECOVERY` flow that identifies the user, generates a recovery token, sends the email, verifies the link, and lets the user set a new password. See [Build a Flow](/docs/next/guides/guides/flows/build-a-flow).
+
+<details>
+  <summary>Sample recovery flow</summary>
+
+```json
+{
+  "handle": "consumer-recovery-flow",
+  "name": "Consumer Password Recovery Flow",
+  "flowType": "RECOVERY",
+  "nodes": [
+    { "id": "start", "type": "START", "onSuccess": "prompt_username" },
+    {
+      "id": "prompt_username",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "text_header_username", "label": "Reset your password", "variant": "HEADING_1" },
+          { "type": "TEXT", "id": "text_subtitle_username", "label": "Enter your username and we'll email you a recovery link.", "variant": "HEADING_6" },
+          {
+            "type": "BLOCK",
+            "id": "block_username",
+            "components": [
+              { "id": "input_username", "ref": "username", "type": "TEXT_INPUT", "label": "Username", "required": true, "placeholder": "Your username" },
+              { "type": "ACTION", "id": "action_submit_username", "label": "Send recovery link", "variant": "PRIMARY", "eventType": "SUBMIT" }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [ { "ref": "input_username", "identifier": "username", "type": "TEXT_INPUT", "required": true } ],
+          "action": { "ref": "action_submit_username", "nextNode": "identify_user" }
+        }
+      ]
+    },
+    {
+      "id": "identify_user",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "IdentifyingExecutor",
+        "mode": "identify",
+        "inputs": [ { "ref": "input_username", "identifier": "username", "type": "TEXT_INPUT", "required": true } ]
+      },
+      "onSuccess": "generate_recovery_token",
+      "onFailure": "email_sent_status"
+    },
+    {
+      "id": "generate_recovery_token",
+      "type": "TASK_EXECUTION",
+      "executor": { "name": "InviteExecutor", "mode": "generate" },
+      "onSuccess": "send_recovery_email"
+    },
+    {
+      "id": "send_recovery_email",
+      "type": "TASK_EXECUTION",
+      "properties": { "emailTemplate": "PASSWORD_RECOVERY" },
+      "executor": { "name": "EmailExecutor", "mode": "send" },
+      "onSuccess": "email_sent_status",
+      "onFailure": "email_sent_status"
+    },
+    {
+      "id": "email_sent_status",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "email_sent_icon", "label": "✉️", "variant": "HEADING_1" },
+          { "align": "center", "type": "TEXT", "id": "email_sent_heading", "label": "Check your email", "variant": "HEADING_1" },
+          { "align": "center", "type": "TEXT", "id": "email_sent_message", "label": "If an account matches, we've sent a recovery link.", "variant": "HEADING_6" }
+        ]
+      },
+      "message": "Check Your Email",
+      "next": "verify_recovery_token"
+    },
+    {
+      "id": "verify_recovery_token",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "InviteExecutor",
+        "mode": "verify",
+        "inputs": [ { "ref": "input_recovery_token", "identifier": "inviteToken", "type": "HIDDEN", "required": true } ]
+      },
+      "onSuccess": "prompt_new_password"
+    },
+    {
+      "id": "prompt_new_password",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "text_header_password", "label": "Set a new password", "variant": "HEADING_1" },
+          {
+            "type": "BLOCK",
+            "id": "block_password",
+            "components": [
+              { "id": "input_new_password", "ref": "password", "type": "PASSWORD_INPUT", "label": "New password", "required": true, "placeholder": "New password" },
+              { "type": "ACTION", "id": "action_submit_password", "label": "Update password", "variant": "PRIMARY", "eventType": "SUBMIT" }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [ { "ref": "input_new_password", "identifier": "password", "type": "PASSWORD_INPUT", "required": true } ],
+          "action": { "ref": "action_submit_password", "nextNode": "set_credential" }
+        }
+      ]
+    },
+    {
+      "id": "set_credential",
+      "type": "TASK_EXECUTION",
+      "executor": { "name": "CredentialSetter" },
+      "onSuccess": "recovery_complete"
+    },
+    {
+      "id": "recovery_complete",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "recovery_complete_icon", "label": "✅", "variant": "HEADING_1" },
+          { "align": "center", "type": "TEXT", "id": "recovery_complete_heading", "label": "Password updated", "variant": "HEADING_1" },
+          { "align": "center", "type": "TEXT", "id": "recovery_complete_message", "label": "Return to your app and sign in with your new password.", "variant": "HEADING_6" }
+        ]
+      },
+      "message": "Password Reset Successful",
+      "next": "end"
+    },
+    { "id": "end", "type": "END" }
+  ]
+}
+```
+
+</details>
+
+**2. Attach the recovery flow to your application**
+
+Go to **Applications** → your app → **Flows** tab. Under **Recovery Flow**, select the flow you created. Save the application.
+
+See [Manage Applications](/docs/next/guides/guides/applications/manage-applications).
+
+### Integrate into Your App
+
+The recovery flow is hosted on <ProductName />. Your app only needs a **Forgot password?** entry point that your SDK routes to the hosted recovery experience:
+
+| Framework   | Where to integrate                                                                            |
+| ----------- | --------------------------------------------------------------------------------------------- |
+| React       | [React SDK Overview](/docs/next/sdks/react/overview) — use the SDK's recovery entry point    |
+| Next.js     | [Next.js Quickstart](/docs/next/guides/getting-started/connect-your-application/nextjs)       |
+| Vue         | [Vue Quickstart](/docs/next/guides/getting-started/connect-your-application/vue)              |
+| Browser SDK | [Browser SDK Overview](/docs/next/sdks/browser/overview)                                      |
+
+### Try It Out
+
+1. Start your app and navigate to the sign-in screen.
+2. Click **Forgot password?** (or your equivalent entry point). The browser navigates to <ProductName />.
+3. Enter your test user's username and submit.
+4. Check the inbox for the test user's email address and open the recovery link.
+5. <ProductName /> renders the **Set new password** screen. Enter a new password and submit.
+6. Return to your app and sign in with the new password.
+
+</details>
+
+<details>
+  <summary>App-native step-by-step</summary>
+
+Coming soon. See the [App-native pattern](../../solution-patterns#app-native) for what to expect.
+
+</details>
+
+<details>
+  <summary>App-native managed</summary>
+
+Coming soon. See the [App-native pattern](../../solution-patterns#app-native) for what to expect.
+
+</details>
+
+## Going Deeper
+
+- Want to understand how the recovery flow nodes work? See [Flows](../../identity-concepts#flows) in Identity Concepts.
+- Want to see this use case running against the Wayfinder sample? See [Account Recovery — Try It Out](../../try-it-out/account-recovery).

--- a/docs/content/use-cases/b2c/try-in-your-own-app/add-login.mdx
+++ b/docs/content/use-cases/b2c/try-in-your-own-app/add-login.mdx
@@ -1,0 +1,113 @@
+---
+title: Login
+description: Configure {{ProductName}} for sign-in and integrate it into your own application.
+sidebar_position: 2
+---
+
+# Login
+
+This walkthrough configures <ProductName /> for sign-in and walks you through integrating it into your application. By the end, a user who clicks your sign-in button is authenticated by <ProductName /> and lands back in your app with an access token.
+
+:::info Background
+[Add Login to Your Application](../../customer-identity#add-login-to-your-application) covers the requirements story behind this use case.
+:::
+
+## Pick Your Pattern
+
+<details open>
+  <summary>Redirect-based</summary>
+
+In the redirect-based pattern, your app redirects the user to <ProductName /> for the sign-in experience, and <ProductName /> returns them to your app with tokens. Your app never handles credentials.
+
+### Configure <ProductName />
+
+**1. Allow your app origin**
+
+Add your app's origin to `cors.allowed_origins` in `repository/conf/deployment.yaml`. Leave any existing entries in place.
+
+```yaml
+cors:
+  allowed_origins:
+    # ...existing entries...
+    - "http://localhost:5173"   # replace with your app's origin
+```
+
+Restart <ProductName /> after the change.
+
+**2. Register your application**
+
+Navigate to **Applications** → **Add Application** and choose **Browser App**. Configure:
+
+| Setting            | Value                              |
+| ------------------ | ---------------------------------- |
+| Redirect URI       | Your app's callback URL (e.g., `http://localhost:5173`) |
+| Allowed grants     | `authorization_code`               |
+| PKCE               | Required                           |
+| Allowed user types | Your consumer user type            |
+
+Copy the **Client ID** — your SDK configuration needs it.
+
+See [Register an Application](/docs/next/guides/getting-started/register-an-application) and [Manage Applications](/docs/next/guides/guides/applications/manage-applications).
+
+**3. Build a sign-in flow and attach it**
+
+Create a sign-in flow in the Flow Designer and assign it to your application.
+
+See [Build a Sign-In Flow](/docs/next/guides/getting-started/build-a-flow).
+
+**4. Create a test user**
+
+Navigate to **Users** → **Add User**. Select your consumer user type and fill in the attributes.
+
+See [Manage Users](/docs/next/guides/guides/users/manage-users).
+
+### Integrate into Your App
+
+Your app initiates the redirect and handles the callback. Use the SDK for your framework:
+
+| Framework   | Where to integrate                                                                                                                              |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| React       | [React Quickstart](/docs/next/guides/getting-started/connect-your-application/react) — `<SignInButton />`, `<SignedIn />`, `<SignedOut />`      |
+| Next.js     | [Next.js Quickstart](/docs/next/guides/getting-started/connect-your-application/nextjs)                                                         |
+| Vue         | [Vue Quickstart](/docs/next/guides/getting-started/connect-your-application/vue)                                                                |
+| Browser SDK | [Browser SDK Overview](/docs/next/sdks/browser/overview)                                                                                        |
+
+:::tip Using a different SDK?
+The redirect-based pattern is standard OAuth 2.0 authorization code flow with PKCE, so **any OIDC-compliant SDK works** — you are not limited to the <ProductName /> SDK. Point it at your <ProductName /> server's discovery endpoint (`http://localhost:8080/oauth2/token/.well-known/openid-configuration`) and use your **Client ID** from the registered application.
+:::
+
+### Try It Out
+
+1. Start your app and open it in the browser.
+2. Click your sign-in button. The browser navigates to <ProductName />.
+3. Sign in with your test user's credentials.
+4. <ProductName /> runs the sign-in flow and redirects back to your app.
+5. Verify that your app receives the tokens and the user is signed in.
+
+</details>
+
+<details>
+  <summary>App-native step-by-step</summary>
+
+Coming soon. See the [App-native pattern](../../solution-patterns#app-native) for what to expect.
+
+</details>
+
+<details>
+  <summary>App-native managed</summary>
+
+Coming soon. See the [App-native pattern](../../solution-patterns#app-native) for what to expect.
+
+</details>
+
+<details>
+  <summary>Direct API</summary>
+
+Coming soon. See the [Direct API pattern](../../solution-patterns#direct-api) for what to expect.
+
+</details>
+
+## Going Deeper
+
+- Curious how access tokens get their permissions? See [Resources and Permissions](../../identity-concepts#resources-and-permissions) and [Roles](../../identity-concepts#roles) in Identity Concepts.
+- Want to see this use case running against the Wayfinder sample? See [Login — Try It Out](../../try-it-out/add-login).

--- a/docs/content/use-cases/b2c/try-in-your-own-app/onboard-internal-users.mdx
+++ b/docs/content/use-cases/b2c/try-in-your-own-app/onboard-internal-users.mdx
@@ -1,0 +1,232 @@
+---
+title: Onboard Internal Users
+description: Configure {{ProductName}} to invite and onboard internal staff members in your own application.
+sidebar_position: 6
+---
+
+# Onboard Internal Users
+
+This walkthrough configures <ProductName /> so that an admin can invite staff members by email. When the invitee accepts, <ProductName /> provisions their account and attaches the right role automatically. The invitation and acceptance flow runs inside the <ProductName /> Console, so this walkthrough applies regardless of which solution pattern your consumer app uses.
+
+:::info Background
+[Onboard Internal Users](../../customer-identity#onboard-internal-users) covers the requirements story behind this use case.
+:::
+
+:::note Prerequisites
+Configure SMTP so that <ProductName /> can send invitation emails. See [Email Configuration](/docs/next/guides/getting-started/configuration#email-configuration), then restart <ProductName /> for the changes to take effect.
+:::
+
+## Configure <ProductName />
+
+**1. Create an internal user type**
+
+Navigate to **User Types** → **Create User Type**. Define the schema for your staff accounts. At minimum:
+
+| Attribute     | Type   | Notes                         |
+| ------------- | ------ | ----------------------------- |
+| `username`    | string | Required, unique              |
+| `email`       | string | Required, unique              |
+| `password`    | string | Credential                    |
+| `displayName` | string | Captured on invitation accept |
+
+See [User Types](/docs/next/guides/guides/users/user-types).
+
+**2. Create staff roles**
+
+Navigate to **Roles** → **Add Role** and create the roles your internal users need. Assign the permissions that match each role's access level in your application.
+
+See [Authorization](/docs/next/guides/key-concepts/authorization).
+
+**3. Build a user onboarding flow**
+
+Build a `USER_ONBOARDING` flow that sends the invitation email and provisions the invitee with the correct role on acceptance. See [Build a Flow](/docs/next/guides/guides/flows/build-a-flow).
+
+Set `properties.assignRole` on the `ProvisioningExecutor` node to the ID of the role from step 2. If you have multiple staff roles, duplicate the invite/provision branch for each.
+
+<details>
+  <summary>Sample user onboarding flow</summary>
+
+```json
+{
+  "handle": "staff-onboarding-flow",
+  "name": "Staff Onboarding Flow",
+  "flowType": "USER_ONBOARDING",
+  "nodes": [
+    { "id": "start", "type": "START", "onSuccess": "permission_validator" },
+    {
+      "id": "permission_validator",
+      "type": "TASK_EXECUTION",
+      "properties": { "requiredScopes": ["system"] },
+      "executor": { "name": "PermissionValidator" },
+      "onSuccess": "user_type_resolver"
+    },
+    {
+      "id": "user_type_resolver",
+      "type": "TASK_EXECUTION",
+      "executor": { "name": "UserTypeResolver" },
+      "onSuccess": "prompt_email",
+      "onIncomplete": "prompt_usertype"
+    },
+    {
+      "id": "prompt_usertype",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "heading_usertype", "label": "Who are you inviting?", "variant": "HEADING_1" },
+          {
+            "type": "BLOCK",
+            "id": "block_usertype",
+            "components": [
+              { "type": "SELECT", "id": "usertype_input", "ref": "userType", "label": "User type", "placeholder": "Select a user type", "required": true, "options": [] },
+              { "type": "ACTION", "id": "action_usertype", "label": "Continue", "variant": "PRIMARY", "eventType": "SUBMIT" }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [ { "ref": "usertype_input", "identifier": "userType", "type": "SELECT", "required": true } ],
+          "action": { "ref": "action_usertype", "nextNode": "user_type_resolver" }
+        }
+      ]
+    },
+    {
+      "id": "prompt_email",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "text_header_email", "label": "Invitee email", "variant": "HEADING_1" },
+          {
+            "type": "BLOCK",
+            "id": "block_email",
+            "components": [
+              { "id": "input_email", "ref": "email", "type": "EMAIL_INPUT", "label": "Email", "required": true, "placeholder": "name@example.com" },
+              { "type": "ACTION", "id": "action_submit_email", "label": "Send invitation", "variant": "PRIMARY", "eventType": "SUBMIT" }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [ { "ref": "input_email", "identifier": "email", "type": "EMAIL_INPUT", "required": true } ],
+          "action": { "ref": "action_submit_email", "nextNode": "check_email_uniqueness" }
+        }
+      ]
+    },
+    {
+      "id": "check_email_uniqueness",
+      "type": "TASK_EXECUTION",
+      "executor": { "name": "AttributeUniquenessValidator" },
+      "onSuccess": "invite_generate",
+      "onIncomplete": "prompt_email"
+    },
+    {
+      "id": "invite_generate",
+      "type": "TASK_EXECUTION",
+      "executor": { "name": "InviteExecutor", "mode": "generate" },
+      "onSuccess": "send_invite_email"
+    },
+    {
+      "id": "send_invite_email",
+      "type": "TASK_EXECUTION",
+      "properties": { "emailTemplate": "USER_INVITE" },
+      "executor": { "name": "EmailExecutor", "mode": "send" },
+      "onSuccess": "email_invite_status",
+      "onFailure": "email_invite_status"
+    },
+    {
+      "id": "email_invite_status",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "email_status_icon", "label": "✅", "variant": "HEADING_1" },
+          { "align": "center", "type": "TEXT", "id": "email_status_heading", "label": "Invitation sent", "variant": "HEADING_1" },
+          { "align": "center", "type": "TEXT", "id": "email_status_message", "label": "The invitee can accept from their email.", "variant": "HEADING_6" }
+        ]
+      },
+      "message": "Invitation sent",
+      "next": "invite_verify"
+    },
+    {
+      "id": "invite_verify",
+      "type": "TASK_EXECUTION",
+      "inputs": [ { "ref": "input_invite_token", "identifier": "inviteToken", "type": "HIDDEN", "required": true } ],
+      "executor": { "name": "InviteExecutor", "mode": "verify" },
+      "onSuccess": "provisioning"
+    },
+    {
+      "id": "provisioning",
+      "type": "TASK_EXECUTION",
+      "properties": { "includeOptional": true, "includeOptionalCredentials": true, "assignRole": "<your-role-id>" },
+      "executor": { "name": "ProvisioningExecutor" },
+      "onSuccess": "registration_complete",
+      "onIncomplete": "prompt_user_details"
+    },
+    {
+      "id": "prompt_user_details",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "text_header_user_details", "label": "Complete your profile", "variant": "HEADING_1" },
+          {
+            "type": "BLOCK",
+            "id": "block_user_details",
+            "components": [
+              { "type": "DYNAMIC_INPUT_PLACEHOLDER", "id": "dynamic_inputs_user_details" },
+              { "type": "ACTION", "id": "action_user_details", "label": "Finish", "variant": "PRIMARY", "eventType": "SUBMIT" }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        { "inputs": [], "action": { "ref": "action_user_details", "nextNode": "provisioning" } }
+      ]
+    },
+    {
+      "id": "registration_complete",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "registration_complete_icon", "label": "✅", "variant": "HEADING_1" },
+          { "align": "center", "type": "TEXT", "id": "registration_complete_heading", "label": "Account ready", "variant": "HEADING_1" },
+          { "align": "center", "type": "TEXT", "id": "registration_complete_message", "label": "Your staff account has been created.", "variant": "HEADING_6" }
+        ]
+      },
+      "message": "Registration complete",
+      "next": "end"
+    },
+    { "id": "end", "type": "END" }
+  ]
+}
+```
+
+</details>
+
+**4. Activate the onboarding flow**
+
+Point the `user_onboarding_flow_handle` at your flow handle in `repository/conf/deployment.yaml` and restart:
+
+```yaml
+flow:
+  user_onboarding_flow_handle: "staff-onboarding-flow"
+```
+
+**5. Create an admin user**
+
+Navigate to **Users** → **Add User**. Create a user with your internal user type and assign the role that grants admin permissions. This user will issue invitations from the <ProductName /> Console.
+
+See [Manage Users](/docs/next/guides/guides/users/manage-users).
+
+## Try It Out
+
+1. Sign in to the <ProductName /> Console at <ConsoleUrl /> as the admin user you created.
+2. Navigate to **Users** and select **Invite User**.
+3. Select your internal user type and enter the invitee's email address. Send the invitation.
+4. Open the invitation email in the invitee's inbox and click the link.
+5. Fill in the required attributes (username, display name, password) and submit.
+6. Verify that the new staff account appears in **Users** in the Console with the correct role attached.
+
+## Going Deeper
+
+- Want to understand how the staff user type and roles fit together? See [User Types](../../identity-concepts#user-types) and [Roles](../../identity-concepts#roles) in Identity Concepts.
+- Want to see this use case running against the Wayfinder sample? See [Onboard Internal Users — Try It Out](../../try-it-out/onboard-internal-users).

--- a/docs/content/use-cases/b2c/try-in-your-own-app/profile-section.mdx
+++ b/docs/content/use-cases/b2c/try-in-your-own-app/profile-section.mdx
@@ -1,0 +1,94 @@
+---
+title: View Profile
+description: Display and update a user's profile attributes and password in your own application.
+sidebar_position: 4
+---
+
+# View Profile
+
+This walkthrough configures <ProductName /> for self-service profile management. Users can view the attributes stored about them, update those attributes, and change their password — all without leaving your application.
+
+:::info Background
+[Add Self-Service Profile Management](../../customer-identity#add-self-service-profile-management) covers the requirements story behind this use case.
+:::
+
+:::note Prerequisites
+Complete the [Login](../add-login) walkthrough first. The user type and application set up there are required here.
+:::
+
+## Pick Your Pattern
+
+<details open>
+  <summary>Redirect-based</summary>
+
+In the redirect-based pattern, your application renders the profile UI itself. Profile attributes are read from the ID token on sign-in. Attribute updates and credential changes go to <ProductName />'s self-service endpoints, which act on the signed-in user's own record — no additional permissions are needed beyond the access token.
+
+### Configure <ProductName />
+
+**1. Ensure your user type has the attributes you want to expose**
+
+Navigate to **User Types** and open your consumer user type. Add any attributes you want users to view or update (for example, `given_name`, `family_name`). Mark attributes you want users to be able to update as non-credential, non-unique fields.
+
+See [User Types](/docs/next/guides/guides/users/user-types).
+
+**2. Ensure your application allows the required scopes**
+
+Navigate to **Applications** → your app. Under **Allowed Scopes**, confirm that `openid`, `profile`, and `email` are listed. These scopes allow the ID token to include the user's name and email attributes.
+
+See [Manage Applications](/docs/next/guides/guides/applications/manage-applications).
+
+### Integrate into Your App
+
+Your app reads profile attributes from the ID token and calls the self-service endpoints for updates. Use the SDK for your framework:
+
+| Framework   | Where to integrate                                                                                                                                          |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| React       | [React SDK Overview](/docs/next/sdks/react/overview) — [`<UserProfile />`](/docs/next/sdks/react/apis/components/user-profile) for the full profile UI, [`<User />`](/docs/next/sdks/react/apis/components/user) to read user attributes                               |
+| Next.js     | [Next.js Quickstart](/docs/next/guides/getting-started/connect-your-application/nextjs)                                                                     |
+| Vue         | [Vue Quickstart](/docs/next/guides/getting-started/connect-your-application/vue)                                                                            |
+| Browser SDK | [Browser SDK Overview](/docs/next/sdks/browser/overview)                                                                                                    |
+
+For direct API access, profile attributes are read and updated through the self-service endpoints:
+
+| Operation         | Endpoint                             | Method |
+| ----------------- | ------------------------------------ | ------ |
+| Read profile      | `/users/me`                          | GET    |
+| Update attributes | `/users/me`                          | PATCH  |
+| Change password   | `/users/me/update-credentials`       | POST   |
+
+See the [APIs reference](/docs/next/apis).
+
+### Try It Out
+
+1. Start your app and sign in as your test user.
+2. Navigate to the profile section. Verify that the user's attributes render from the ID token.
+3. Edit an attribute (for example, the user's last name) and save. Confirm the update is reflected.
+4. Change the password. Sign out, sign back in with the new password, and verify it works.
+
+</details>
+
+<details>
+  <summary>App-native step-by-step</summary>
+
+Coming soon. See the [App-native pattern](../../solution-patterns#app-native) for what to expect.
+
+</details>
+
+<details>
+  <summary>App-native managed</summary>
+
+Coming soon. See the [App-native pattern](../../solution-patterns#app-native) for what to expect.
+
+</details>
+
+<details>
+  <summary>Direct API</summary>
+
+Coming soon. See the [Direct API pattern](../../solution-patterns#direct-api) for what to expect.
+
+</details>
+
+## Going Deeper
+
+- Want to understand which attributes are stored on a user record? See [User Types](../../identity-concepts#user-types) in Identity Concepts.
+- Want to see this use case running against the Wayfinder sample? See [View Profile — Try It Out](../../try-it-out/profile-section).

--- a/docs/content/use-cases/b2c/try-in-your-own-app/self-sign-up.mdx
+++ b/docs/content/use-cases/b2c/try-in-your-own-app/self-sign-up.mdx
@@ -1,0 +1,211 @@
+---
+title: Self Sign-Up
+description: Configure {{ProductName}} for self-registration and integrate it into your own application.
+sidebar_position: 3
+---
+
+# Self Sign-Up
+
+This walkthrough configures <ProductName /> so that new consumers can register themselves with an email and password. <ProductName /> creates a user record and returns the new user to your app signed in.
+
+:::info Background
+[Enable Self Sign-Up](../../customer-identity#enable-self-sign-up) covers the requirements story behind this use case.
+:::
+
+:::note Prerequisites
+Complete the [Login](../add-login) walkthrough first. The user type, application, and sign-in flow set up there are required here.
+:::
+
+## Pick Your Pattern
+
+<details open>
+  <summary>Redirect-based</summary>
+
+In the redirect-based pattern, your app redirects the user to <ProductName /> for the entire registration experience. After the user fills in the sign-up form, <ProductName /> creates the account and returns them to your app signed in.
+
+### Configure <ProductName />
+
+**1. Build a registration flow**
+
+Build a `REGISTRATION` flow using the Flow Designer or the flows API. See [Build a Flow](/docs/next/guides/guides/flows/build-a-flow).
+
+Your registration flow should collect the user's credentials, provision the account, and return an auth assertion so the user lands signed in.
+
+To automatically assign a default role to every self-registered user, create the role under **Roles** → **Add Role**. Then set `properties.assignRole` to that role's ID on the `ProvisioningExecutor` node in your flow. See [Authorization](/docs/next/guides/key-concepts/authorization).
+
+<details>
+  <summary>Sample registration flow</summary>
+
+```json
+{
+  "handle": "consumer-registration-flow",
+  "name": "Consumer Registration Flow",
+  "flowType": "REGISTRATION",
+  "nodes": [
+    { "id": "start", "type": "START", "onSuccess": "user_type_resolver" },
+    {
+      "id": "user_type_resolver",
+      "type": "TASK_EXECUTION",
+      "executor": { "name": "UserTypeResolver" },
+      "onSuccess": "prompt_credentials",
+      "onIncomplete": "prompt_usertype"
+    },
+    {
+      "id": "prompt_usertype",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "heading_usertype", "label": "Choose your account type", "variant": "HEADING_1" },
+          {
+            "type": "BLOCK",
+            "id": "block_usertype",
+            "components": [
+              { "type": "SELECT", "id": "usertype_input", "ref": "userType", "label": "Account type", "placeholder": "Select an account type", "required": true, "options": [] },
+              { "type": "ACTION", "id": "action_usertype", "label": "Continue", "variant": "PRIMARY", "eventType": "SUBMIT" }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [ { "ref": "usertype_input", "identifier": "userType", "type": "SELECT", "required": true } ],
+          "action": { "ref": "action_usertype", "nextNode": "user_type_resolver" }
+        }
+      ]
+    },
+    {
+      "id": "prompt_credentials",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "heading_credentials", "label": "Create your account", "variant": "HEADING_1" },
+          {
+            "type": "BLOCK",
+            "id": "block_credentials",
+            "components": [
+              { "type": "TEXT_INPUT", "id": "input_username", "ref": "username", "label": "Username", "placeholder": "Pick a username", "required": true },
+              { "type": "PASSWORD_INPUT", "id": "input_password", "ref": "password", "label": "Password", "placeholder": "Choose a password", "required": true },
+              { "type": "ACTION", "id": "action_credentials", "label": "Continue", "variant": "PRIMARY", "eventType": "SUBMIT" }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        {
+          "inputs": [
+            { "ref": "input_username", "identifier": "username", "type": "TEXT_INPUT", "required": true },
+            { "ref": "input_password", "identifier": "password", "type": "PASSWORD_INPUT", "required": true }
+          ],
+          "action": { "ref": "action_credentials", "nextNode": "basic_auth" }
+        }
+      ]
+    },
+    {
+      "id": "basic_auth",
+      "type": "TASK_EXECUTION",
+      "executor": { "name": "BasicAuthExecutor" },
+      "onSuccess": "provisioning"
+    },
+    {
+      "id": "provisioning",
+      "type": "TASK_EXECUTION",
+      "executor": {
+        "name": "ProvisioningExecutor",
+        "inputs": [
+          { "ref": "input_username", "identifier": "username", "type": "TEXT_INPUT", "required": true },
+          { "ref": "input_password", "identifier": "password", "type": "PASSWORD_INPUT", "required": true }
+        ]
+      },
+      "onSuccess": "auth_assert",
+      "onIncomplete": "prompt_schema_attrs"
+    },
+    {
+      "id": "prompt_schema_attrs",
+      "type": "PROMPT",
+      "meta": {
+        "components": [
+          { "align": "center", "type": "TEXT", "id": "heading_schema_attrs", "label": "Tell us about you", "variant": "HEADING_1" },
+          {
+            "type": "BLOCK",
+            "id": "block_dynamic_user_inputs",
+            "components": [
+              { "type": "DYNAMIC_INPUT_PLACEHOLDER", "id": "dynamic_inputs" },
+              { "type": "ACTION", "id": "action_schema_attrs", "label": "Continue", "variant": "PRIMARY", "eventType": "SUBMIT" }
+            ]
+          }
+        ]
+      },
+      "prompts": [
+        { "inputs": [], "action": { "ref": "action_schema_attrs", "nextNode": "provisioning" } }
+      ]
+    },
+    {
+      "id": "auth_assert",
+      "type": "TASK_EXECUTION",
+      "executor": { "name": "AuthAssertExecutor" },
+      "onSuccess": "end"
+    },
+    { "id": "end", "type": "END" }
+  ]
+}
+```
+
+</details>
+
+**2. Attach the registration flow to your application**
+
+Go to **Applications** → your app → **Flows** tab. Under **Registration Flow**, select the flow you created. Save the application.
+
+See [Manage Applications](/docs/next/guides/guides/applications/manage-applications).
+
+### Integrate into Your App
+
+Trigger sign-up from your app using the SDK. The registration experience is hosted by <ProductName />, so your app only needs a sign-up entry point:
+
+| Framework   | Where to integrate                                                                                                                         |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| React       | [React Quickstart](/docs/next/guides/getting-started/connect-your-application/react) — `<SignUpButton />` component                       |
+| Next.js     | [Next.js Quickstart](/docs/next/guides/getting-started/connect-your-application/nextjs)                                                    |
+| Vue         | [Vue Quickstart](/docs/next/guides/getting-started/connect-your-application/vue)                                                           |
+| Browser SDK | [Browser SDK Overview](/docs/next/sdks/browser/overview)                                                                                   |
+
+:::tip Using a different SDK?
+The redirect-based pattern is standard OAuth 2.0 authorization code flow with PKCE, so **any OIDC-compliant SDK works** — you are not limited to the <ProductName /> SDK. Point it at your <ProductName /> server's discovery endpoint (`http://localhost:8080/oauth2/token/.well-known/openid-configuration`) and use your **Client ID** from the registered application.
+:::
+
+### Try It Out
+
+1. Start your app and open it in the browser.
+2. Click your sign-up button. The browser navigates to <ProductName />.
+3. Fill in a username, email, and password for a new user.
+4. Submit. <ProductName /> runs the registration flow, creates the user, and redirects back to your app.
+5. Verify that the new user lands in your app signed in.
+
+</details>
+
+<details>
+  <summary>App-native step-by-step</summary>
+
+Coming soon. See the [App-native pattern](../../solution-patterns#app-native) for what to expect.
+
+</details>
+
+<details>
+  <summary>App-native managed</summary>
+
+Coming soon. See the [App-native pattern](../../solution-patterns#app-native) for what to expect.
+
+</details>
+
+<details>
+  <summary>Direct API</summary>
+
+Coming soon. See the [Direct API pattern](../../solution-patterns#direct-api) for what to expect.
+
+</details>
+
+## Going Deeper
+
+- Want to understand how user types and schemas work? See [User Types](../../identity-concepts#user-types) in Identity Concepts.
+- Want to automatically assign a role to self-registered users? See [Roles](../../identity-concepts#roles) in Identity Concepts.
+- Want to see this use case running against the Wayfinder sample? See [Self Sign-Up — Try It Out](../../try-it-out/self-sign-up).

--- a/docs/content/use-cases/b2c/try-it-out.mdx
+++ b/docs/content/use-cases/b2c/try-it-out.mdx
@@ -15,6 +15,10 @@ import { WayfinderOrganization, WayfinderArchitecture } from '../../../src/compo
 
 Each walkthrough below runs one of the use cases from [Customer Identity](../customer-identity) against the Wayfinder sample, using one of the patterns from [Solution Patterns](../solution-patterns).
 
+:::tip Prefer to integrate with your own app?
+Skip the sample and wire <ProductName /> directly into your own app. See [Try In Your Own App](../try-in-your-own-app).
+:::
+
 ## Meet Wayfinder
 
 Wayfinder is a consumer travel-booking application. Through Wayfinder, consumers search for flights and hotels, book trips, and manage their travel profile.

--- a/docs/content/use-cases/b2c/try-it-out/account-recovery.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/account-recovery.mdx
@@ -18,24 +18,7 @@ Complete [Set Up Your Environment](../../try-it-out#set-up-your-environment) bef
 
 ## Set Up Account Recovery
 
-1. Recovery emails are delivered through a SMTP server. Configure a SMTP provider and apply the configuration in `repository/conf/deployment.yaml`.
-
-    **Sample SMTP Configuration:**
-
-    ```yaml
-    email:
-      smtp:
-        host: "<smtp-host>"
-        port: <smtp-port>
-        username: "<smtp-username>"
-        password: "<smtp-password>"
-        from_address: "<from-address>"
-        enable_start_tls: true
-        enable_authentication: true
-    ```
-    For the full property reference and provider-specific examples, see [Configure SMTP Server](../../../../guides/guides/smtp-server/smtp-server-configuration).
-
-2. Restart <ProductName /> for the changes to take effect.
+Recovery emails require a working SMTP connection. See [Email Configuration](/docs/next/guides/getting-started/configuration#email-configuration) to configure and enable it, then restart <ProductName /> for the changes to take effect.
 
 ## Pick Your Pattern
 
@@ -73,3 +56,4 @@ Coming soon. See the [App-native pattern](../../solution-patterns#app-native) fo
 
 - Want to understand the steps the recovery flow takes? See [Flows](../../identity-concepts#flows) in the Identity Concepts.
 - Prefer to build the recovery flow manually? See [Build the Account Recovery Flow](../../configure-it-yourself#build-the-account-recovery-flow) in Configure It Yourself.
+- Building account recovery in your own app instead of Wayfinder? See [Account Recovery — Try In Your Own App](../../try-in-your-own-app/account-recovery).

--- a/docs/content/use-cases/b2c/try-it-out/add-login.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/add-login.mdx
@@ -64,3 +64,4 @@ Coming soon. See the [Direct API pattern](../../solution-patterns#direct-api) fo
 
 - Want to understand how the access token gets its booking permissions? See [Resources and Permissions](../../identity-concepts#resources-and-permissions) and [Roles](../../identity-concepts#roles) in the Identity Concepts.
 - Prefer to set up the application and `Traveler` role manually? See [Set Up the Foundation](../../configure-it-yourself#set-up-the-foundation) in Configure It Yourself.
+- Building login in your own app instead of Wayfinder? See [Login — Try In Your Own App](../../try-in-your-own-app/add-login).

--- a/docs/content/use-cases/b2c/try-it-out/onboard-internal-users.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/onboard-internal-users.mdx
@@ -20,22 +20,7 @@ Complete [Set Up Your Environment](../../try-it-out#set-up-your-environment) bef
 
 ## Set Up Internal User Onboarding
 
-1. Invitation emails are delivered through a SMTP server. **Configure a SMTP provider** and apply the configuration in `repository/conf/deployment.yaml`.
-
-    **Sample SMTP Configuration:**
-
-    ```yaml
-    email:
-      smtp:
-        host: "<smtp-host>"
-        port: <smtp-port>
-        username: "<smtp-username>"
-        password: "<smtp-password>"
-        from_address: "<from-address>"
-        enable_start_tls: true
-        enable_authentication: true
-    ```
-    For the full property reference and provider-specific examples, see [Configure SMTP Server](../../../../guides/guides/smtp-server/smtp-server-configuration).
+1. Invitation emails require a working SMTP connection. See [Email Configuration](/docs/next/guides/getting-started/configuration#email-configuration) to configure and enable it.
 
 2. **Activate the user onboarding flow** by pointing the `user_onboarding_flow_handle` to the bundled flow in `repository/conf/deployment.yaml`:
 
@@ -62,3 +47,4 @@ The Wayfinder onboarding flow prompts the admin to pick the staff role (Support 
 
 - Want to understand how the staff user type and roles fit together? See [User Types](../../identity-concepts#user-types) and [Roles](../../identity-concepts#roles) in the Identity Concepts.
 - Prefer to build the user onboarding side of the model manually? See [Set Up Internal User Onboarding](../../configure-it-yourself#set-up-internal-user-onboarding) in Configure It Yourself.
+- Building internal user onboarding in your own setup instead of Wayfinder? See [Onboard Internal Users — Try In Your Own App](../../try-in-your-own-app/onboard-internal-users).

--- a/docs/content/use-cases/b2c/try-it-out/profile-section.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/profile-section.mdx
@@ -61,3 +61,4 @@ Coming soon. See the [Direct API pattern](../../solution-patterns#direct-api) fo
 
 - Want to understand which attributes Wayfinder stores about John? See [User Types](../../identity-concepts#user-types) in the Identity Concepts.
 - Prefer to define the `Customer` schema manually? See [Set Up the Foundation](../../configure-it-yourself#set-up-the-foundation) in Configure It Yourself.
+- Building profile management in your own app instead of Wayfinder? See [View Profile — Try In Your Own App](../../try-in-your-own-app/profile-section).

--- a/docs/content/use-cases/b2c/try-it-out/self-sign-up.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/self-sign-up.mdx
@@ -63,3 +63,4 @@ Coming soon. See the [Direct API pattern](../../solution-patterns#direct-api) fo
 
 - Want to understand how user records and roles come together? See [User Types](../../identity-concepts#user-types), [Roles](../../identity-concepts#roles), and [Flows](../../identity-concepts#flows) in the Identity Concepts.
 - Prefer to build the registration flow manually? See [Build the Registration Flow](../../configure-it-yourself#build-the-registration-flow) in Configure It Yourself.
+- Building self sign-up in your own app instead of Wayfinder? See [Self Sign-Up — Try In Your Own App](../../try-in-your-own-app/self-sign-up).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -594,6 +594,25 @@ const sidebars: SidebarsConfig = {
                 },
               ],
             },
+            {
+              type: 'category',
+              label: 'Try In Your Own App',
+              collapsible: true,
+              collapsed: true,
+              link: {type: 'doc', id: 'use-cases/b2c/try-in-your-own-app'},
+              items: [
+                {type: 'doc', id: 'use-cases/b2c/try-in-your-own-app/add-login', label: 'Login', key: 'own-app-login'},
+                {type: 'doc', id: 'use-cases/b2c/try-in-your-own-app/self-sign-up', label: 'Self Sign-Up', key: 'own-app-self-sign-up'},
+                {type: 'doc', id: 'use-cases/b2c/try-in-your-own-app/profile-section', label: 'View Profile', key: 'own-app-profile-section'},
+                {type: 'doc', id: 'use-cases/b2c/try-in-your-own-app/account-recovery', label: 'Account Recovery', key: 'own-app-account-recovery'},
+                {
+                  type: 'doc',
+                  id: 'use-cases/b2c/try-in-your-own-app/onboard-internal-users',
+                  label: 'Onboard Internal Users',
+                  key: 'own-app-onboard-internal-users',
+                },
+              ],
+            },
           ],
         },
         {


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
 The existing B2C documentation lets users try identity use cases (login, self sign-up, profile management,
  account recovery, internal user onboarding) only through the Wayfinder sample application. There was no
  guided path for developers who want to integrate  directly into their own application.

  This PR adds a "Try In Your Own App" section under the B2C use cases that walks developers through
  configuring  for each use case and points them at the SDK documentation for the integration code — without
  duplicating app-building instructions that already exist in the SDK quickstarts.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
New documentation tree — use-cases/b2c/try-in-your-own-app/:
- A landing page with prerequisites and a coverage matrix (5 use cases × 4 integration patterns). Redirect-based is fully documented; App-native and Direct API are marked "Coming soon" pending SDK support.
- Five use-case pages: Login, Self Sign-Up, View Profile, Account Recovery, Onboard Internal Users.

Structure per walkthrough — each page uses the existing "Pick Your Pattern" layout from the Wayfinder walkthroughs and applies a consistent three-part structure inside each pattern: (1) configure , with numbered steps and links to the relevant concept docs; (2) reference the SDK integration docs for the user's framework; (3) short try-it-out steps to verify end-to-end.

Flow samples as reference, not instructions — where a flow definition is needed (self sign-up, account
recovery, onboarding), the [Build a Flow] guide is referenced as the primary instruction. The full flow JSON
is provided only as a collapsible sample.

Role assignment is optional — in the self sign-up walkthrough, role creation is not a mandatory step. It is
described inline as an optional enhancement via properties.assignRole on the ProvisioningExecutor, with a
link to the Authorization guide.

SMTP deduplication — four pages previously inlined a copy of the SMTP deployment.yaml block (both Wayfinder
and own-app variants of Account Recovery and Onboard Internal Users). These are replaced with a reference to
the canonical Email Configuration section in guides/getting-started/configuration.

Sidebar — the new section is added to sidebars.ts under Consumer Applications (B2C), directly after "Try It
Out". Each item carries a unique key to avoid Docusaurus translation-key conflicts with identically-labelled
  entries in the existing tree.

Cross-links — each existing Wayfinder walkthrough gains a "Going Deeper" link to its twin in the new section.
 try-it-out.mdx gains a :::tip callout at the top pointing to the new path.


### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/3008

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Try In Your Own App" B2C section with five walkthroughs: Login, Self Sign‑Up, View Profile, Account Recovery, and Onboard Internal Users.
  * Provides step‑by‑step integration guidance for React, Next.js, Vue, Browser SDK and direct API usage, plus NextSteps navigation cards.
  * Updated Try It Out pages with cross‑references and simplified SMTP prerequisite notes.
  * Added a collapsed sidebar category for the new section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->