### PR TITLE
Fix authorization denied when loading declarative applications and agents on startup

### DIFF
--- a/backend/internal/agent/declarative_resource.go
+++ b/backend/internal/agent/declarative_resource.go
@@ -34,6 +34,7 @@ import (
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
 )
 
 const (
@@ -223,7 +224,8 @@ func makeAgentEntityParser(
 			InboundAuthProfile: req.InboundAuthProfile,
 			InboundAuthConfig:  req.InboundAuthConfig,
 		}
-		clientID, clientSecret, _, svcErr := agentSvc.ValidateAgent(context.Background(), agent, req.ID)
+		clientID, clientSecret, _, svcErr := agentSvc.ValidateAgent(
+			security.WithRuntimeContext(context.Background()), agent, req.ID)
 		if svcErr != nil {
 			return nil, nil, nil, fmt.Errorf("failed to validate agent '%s': %v", req.ID, svcErr)
 		}
@@ -275,7 +277,8 @@ func makeAgentInboundParser(agentSvc AgentServiceInterface) func([]byte) (*inbou
 			InboundAuthProfile: req.InboundAuthProfile,
 			InboundAuthConfig:  req.InboundAuthConfig,
 		}
-		_, _, resolvedClient, svcErr := agentSvc.ValidateAgent(context.Background(), agent, req.ID)
+		_, _, resolvedClient, svcErr := agentSvc.ValidateAgent(
+			security.WithRuntimeContext(context.Background()), agent, req.ID)
 		if svcErr != nil {
 			return nil, fmt.Errorf("failed to validate agent '%s': %v", req.ID, svcErr)
 		}

--- a/backend/internal/application/declarative_resource.go
+++ b/backend/internal/application/declarative_resource.go
@@ -31,6 +31,7 @@ import (
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
 
 	"gopkg.in/yaml.v3"
 )
@@ -135,7 +136,8 @@ func makeAppInboundParser(appService ApplicationServiceInterface) func([]byte) (
 		if err != nil {
 			return nil, err
 		}
-		validatedApp, _, svcErr := appService.ValidateApplication(context.Background(), appDTO)
+		validatedApp, _, svcErr := appService.ValidateApplication(
+			security.WithRuntimeContext(context.Background()), appDTO)
 		if svcErr != nil {
 			return nil, fmt.Errorf("error validating application '%s': %v", appDTO.Name, svcErr)
 		}
@@ -290,7 +292,8 @@ func makeAppEntityParser(
 			return nil, nil, nil, fmt.Errorf("failed to parse application YAML: %w", err)
 		}
 
-		_, inboundAuthConfig, svcErr := appService.ValidateApplication(context.Background(), appDTO)
+		_, inboundAuthConfig, svcErr := appService.ValidateApplication(
+			security.WithRuntimeContext(context.Background()), appDTO)
 		if svcErr != nil {
 			return nil, nil, nil, fmt.Errorf("error validating application '%s': %v", appDTO.Name, svcErr)
 		}


### PR DESCRIPTION
## Summary

- Wrap `context.Background()` with `security.WithRuntimeContext` in the declarative resource parsers for applications and agents, so OU handle resolution succeeds during server startup when there is no authenticated caller in context.

## Problem

When starting the server with declarative resources configured (composite or declarative store mode), loading applications or agents that use `ou_handle` fails immediately:

```
Authorization denied: unauthenticated caller  action=ou:read
validateApplicationFields failed: could not resolve ou_handle to an OU ID
Failed to initialize ApplicationService: failed to load declarative resources for app: ...
```

The parsers in `application/declarative_resource.go` and `agent/declarative_resource.go` call `ValidateApplication` / `ValidateAgent` with a bare `context.Background()`. Both service methods pass that context directly to `ouService.GetOrganizationUnitByPath`, which goes through the system authorization service. With no authenticated subject and no runtime flag in the context, the check is denied and the server exits.

Analogous methods (`ResolveRoleOUHandle`, `ResolveUserOUHandle`, `ResolveEntityTypeHandles`, `ResolveResourceServerOUHandle`) already apply `security.WithRuntimeContext(ctx)` internally before calling the OU service, so they are not affected.

## Changes

- `internal/application/declarative_resource.go` — use `security.WithRuntimeContext(context.Background())` in `makeAppInboundParser` and `makeAppEntityParser`
- `internal/agent/declarative_resource.go` — use `security.WithRuntimeContext(context.Background())` in `makeAgentEntityParser` and `makeAgentInboundParser`

Closes #3106

## Test plan

- [ ] Start the server with a declarative application YAML that sets `ou_handle: default` — server should start without error
- [ ] Start the server with a declarative agent YAML that sets `ou_handle: default` — server should start without error
- [ ] Verify the existing unit tests for application and agent declarative resource loading still pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enhanced runtime security context usage during agent and application validation to strengthen enforcement of security checks.
  * Applies to onboarding and configuration validation flows; no changes to public APIs or user-visible behavior.
  * Internal-only update; no action required from operators or integrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->