### PR TITLE
Implement SDK bundle optimizations

### DIFF
--- a/sdks/javascript/package.json
+++ b/sdks/javascript/package.json
@@ -16,6 +16,7 @@
   "author": "WSO2",
   "license": "Apache-2.0",
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.cjs",
   "module": "dist/index.js",
   "exports": {

--- a/sdks/react/package.json
+++ b/sdks/react/package.json
@@ -14,11 +14,12 @@
   "author": "WSO2",
   "license": "Apache-2.0",
   "type": "module",
-  "main": "dist/cjs/index.js",
+  "sideEffects": false,
+  "main": "dist/cjs/index.cjs",
   "module": "dist/index.js",
   "exports": {
     "import": "./dist/index.js",
-    "require": "./dist/cjs/index.js"
+    "require": "./dist/cjs/index.cjs"
   },
   "files": [
     "dist",

--- a/sdks/react/rolldown.config.js
+++ b/sdks/react/rolldown.config.js
@@ -66,16 +66,21 @@ const commonOptions = {
 
 const esmBundle = await rolldown(commonOptions);
 await esmBundle.write({
-  file: 'dist/index.js',
+  dir: 'dist',
   format: 'esm',
+  preserveModules: true,
+  preserveModulesRoot: 'src',
   sourcemap: true,
 });
 await esmBundle.close();
 
 const cjsBundle = await rolldown(commonOptions);
 await cjsBundle.write({
-  file: 'dist/cjs/index.js',
+  dir: 'dist/cjs',
+  entryFileNames: '[name].cjs',
   format: 'cjs',
+  preserveModules: true,
+  preserveModulesRoot: 'src',
   sourcemap: true,
 });
 await cjsBundle.close();


### PR DESCRIPTION
### Purpose

Reduces the console and gate app initial bundle sizes by introducing route-level lazy loading and improving tree-shaking across the ThunderID SDK stack.

Key results from bundle analysis:
- SDK chunk in the console dropped from **628 KB → 166 KB** (74% reduction) after enabling `preserveModules` and `sideEffects: false` on the React and JavaScript SDKs.

### Approach

**Route-level lazy loading (`console`, `gate`):**
- All page-level components in `App.tsx` for both apps are converted to `React.lazy()` + `Suspense`, ensuring each route's bundle is only fetched on navigation.

**`@thunderid/react` SDK — `preserveModules` + `sideEffects: false`:**
- `rolldown.config.js`: switched ESM and CJS outputs from `file` (single bundle) to `dir` with `preserveModules: true` and `preserveModulesRoot: 'src'`. CJS output uses `entryFileNames: '[name].cjs'`.
- `package.json`: added `"sideEffects": false` and updated CJS entry paths to `.cjs`.
- Without `sideEffects: false`, Vite includes all modules regardless of imports — both changes are required together for tree-shaking to work.

**`@thunderid/javascript` SDK — `sideEffects: false`:**
- The JavaScript SDK already had `preserveModules`. Adding `"sideEffects": false` to `package.json` unlocks Vite's tree-shaking for unused exports.

**Cleanup:**
- Removed unused `prismjs` and `@types/prismjs` dependencies from the console.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized JavaScript and React SDK package configurations for more efficient bundling
  * Improved SDK build outputs to better preserve code organization and debugging capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->