### PR TITLE
Pack wayfinder declarative resources into console static build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -213,6 +213,14 @@ $REACT_SDK_SAMPLE_APP_DIR = Join-Path $SAMPLE_BASE_DIR "apps/react-sdk-sample"
 $REACT_API_SAMPLE_APP_DIR = Join-Path $SAMPLE_BASE_DIR "apps/react-api-based-sample"
 $WAYFINDER_SAMPLE_APP_DIR = Join-Path $SAMPLE_BASE_DIR "apps/wayfinder-sample"
 
+# Quick Start declarative bundles staged into the Console's Vite public dir so they're served
+# at /console/quickstart-samples/<Name>/ in both dev (pnpm dev) and packaged (apps/console/) modes.
+# Add a new bundle as a single line. Name may include "/" for grouping.
+$QUICKSTART_SAMPLE_BUNDLES = @(
+    @{ Name = "wayfinder"; Source = (Join-Path $WAYFINDER_SAMPLE_APP_DIR "thunderid-config") }
+)
+$QUICKSTART_BUNDLE_STAGE_DIR = Join-Path $FRONTEND_CONSOLE_APP_SOURCE_DIR "public/quickstart-samples"
+
 # Default ports
 $GATE_APP_DEFAULT_PORT = 5190
 $CONSOLE_APP_DEFAULT_PORT = 5191
@@ -454,7 +462,9 @@ function Build-Frontend {
     Write-Host "================================================================"
     Write-Host "Building frontend apps..."
     Ensure-Pnpm
-    
+
+    Sync-QuickstartBundles
+
     # Install dependencies
     try {
         Write-Host "Installing frontend dependencies..."
@@ -669,6 +679,26 @@ function Prepare-Frontend-For-Packaging {
     }
 
     Write-Host "================================================================"
+}
+
+function Sync-QuickstartBundles {
+    # Stage Quick Start declarative bundles into the Console's public dir so they are
+    # served by Vite in dev mode and included in the production build under apps/console/.
+    Write-Host "Syncing Quick Start sample bundles to Console public dir..."
+    if (Test-Path $QUICKSTART_BUNDLE_STAGE_DIR) {
+        Remove-Item -Path $QUICKSTART_BUNDLE_STAGE_DIR -Recurse -Force
+    }
+    foreach ($bundle in $QUICKSTART_SAMPLE_BUNDLES) {
+        $dest_dir = Join-Path $QUICKSTART_BUNDLE_STAGE_DIR $bundle.Name
+        if (Test-Path $bundle.Source) {
+            Write-Host "  Staging '$($bundle.Name)' from $($bundle.Source)"
+            New-Item -Path $dest_dir -ItemType Directory -Force | Out-Null
+            Copy-Item -Path (Join-Path $bundle.Source "*") -Destination $dest_dir -Recurse -Force
+        }
+        else {
+            Write-Host "  Warning: Quick Start bundle source not found at $($bundle.Source) (dest '$($bundle.Name)')"
+        }
+    }
 }
 
 function Package {
@@ -1924,7 +1954,9 @@ function Run-Frontend {
     Write-Host "================================================================"
     Write-Host "Running frontend apps..."
     Ensure-Pnpm
-    
+
+    Sync-QuickstartBundles
+
     # Install dependencies
     try {
         Write-Host "Installing frontend dependencies..."

--- a/build.sh
+++ b/build.sh
@@ -148,6 +148,15 @@ REACT_SDK_SAMPLE_APP_DIR=$SAMPLE_BASE_DIR/apps/react-sdk-sample
 REACT_API_SAMPLE_APP_DIR=$SAMPLE_BASE_DIR/apps/react-api-based-sample
 WAYFINDER_SAMPLE_APP_DIR=$SAMPLE_BASE_DIR/apps/wayfinder-sample
 
+# Quick Start declarative bundles staged into the Console's Vite public dir so they're served
+# at /console/quickstart-samples/<dest-name>/ in both dev (pnpm dev) and packaged (apps/console/) modes.
+# Add a new bundle as a single line: "<dest-name>:<source-dir>".
+# <dest-name> may include "/" for grouping (e.g. "wayfinder/redirect-based").
+QUICKSTART_SAMPLE_BUNDLES=(
+    "wayfinder:$WAYFINDER_SAMPLE_APP_DIR/thunderid-config"
+)
+QUICKSTART_BUNDLE_STAGE_DIR="$FRONTEND_CONSOLE_APP_SOURCE_DIR/public/quickstart-samples"
+
 # Default ports
 GATE_APP_DEFAULT_PORT=5190
 CONSOLE_APP_DEFAULT_PORT=5191
@@ -376,11 +385,13 @@ function build_frontend() {
     echo "================================================================"
     echo "Building frontend apps..."
     ensure_pnpm
-    
+
+    sync_quickstart_bundles
+
     # Install dependencies
     echo "Installing frontend dependencies..."
     pnpm install --frozen-lockfile
-    
+
     echo "Building frontend applications & packages..."
     pnpm build:frontend
     
@@ -520,6 +531,27 @@ function prepare_frontend_for_packaging() {
     fi
 
     echo "================================================================"
+}
+
+function sync_quickstart_bundles() {
+    # Stage Quick Start declarative bundles into the Console's public dir so they are
+    # served by Vite in dev mode and included in the production build under apps/console/.
+    echo "Syncing Quick Start sample bundles to Console public dir..."
+    rm -rf "$QUICKSTART_BUNDLE_STAGE_DIR"
+    for entry in "${QUICKSTART_SAMPLE_BUNDLES[@]}"; do
+        local dest_name="${entry%%:*}"
+        local src_dir="${entry#*:}"
+        local dest_dir="$QUICKSTART_BUNDLE_STAGE_DIR/$dest_name"
+        if [ -d "$src_dir" ]; then
+            echo "  Staging '$dest_name' from $src_dir"
+            mkdir -p "$dest_dir"
+            shopt -s dotglob
+            cp -r "$src_dir/"* "$dest_dir"
+            shopt -u dotglob
+        else
+            echo "  Warning: Quick Start bundle source not found at $src_dir (dest '$dest_name')"
+        fi
+    done
 }
 
 function package() {
@@ -1348,7 +1380,9 @@ function run_frontend() {
     echo "================================================================"
     echo "Running frontend apps..."
     ensure_pnpm
-    
+
+    sync_quickstart_bundles
+
     # Install dependencies
     echo "Installing frontend dependencies..."
     pnpm install --frozen-lockfile

--- a/frontend/apps/console/.gitignore
+++ b/frontend/apps/console/.gitignore
@@ -27,3 +27,4 @@ coverage
 *.sln
 *.sw?
 public/version.txt
+public/quickstart-samples


### PR DESCRIPTION
### Purpose
This pull request adds support for bundling and distributing "Quick Start" declarative sample bundles as part of the Console app's static assets. The changes introduce new configuration variables and logic in both the PowerShell (`build.ps1`) and Bash (`build.sh`) build scripts to copy these sample bundles into the appropriate distribution directory during packaging.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build scripts to support packaging Quick Start declarative bundles within the Console distribution, including the Wayfinder sample configuration for enhanced user onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->