### PR TITLE
Upgrade react-router to 7.15.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ catalogs:
       specifier: 16.0.1
       version: 16.0.1
     react-router:
-      specifier: 7.12.0
-      version: 7.12.0
+      specifier: 7.15.0
+      version: 7.15.0
     rimraf:
       specifier: 6.1.3
       version: 6.1.3
@@ -498,7 +498,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-syntax-highlighter:
         specifier: ^16.1.0
         version: 16.1.1(react@19.2.3)
@@ -646,7 +646,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: 'catalog:'
@@ -749,7 +749,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
@@ -837,7 +837,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
@@ -946,7 +946,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1049,7 +1049,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
@@ -1152,7 +1152,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1783,7 +1783,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -1882,8 +1882,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.3(react@19.2.3)
       react-router:
-        specifier: ^7.12.0
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^7.15.0
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -2004,8 +2004,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
       react-router-dom:
-        specifier: 7.12.0
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 7.15.0
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: 9.27.0
@@ -2019,9 +2019,6 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.7)
-      '@types/react-router-dom':
-        specifier: '5'
-        version: 5.3.3
       '@vitejs/plugin-react':
         specifier: 4.4.1
         version: 4.4.1(rolldown-vite@7.1.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.15.29)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.47.1)(yaml@2.8.3))
@@ -2475,7 +2472,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -13463,8 +13460,8 @@ packages:
     peerDependencies:
       react: '>=15'
 
-  react-router-dom@7.12.0:
-    resolution: {integrity: sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==}
+  react-router-dom@7.15.0:
+    resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -13475,8 +13472,8 @@ packages:
     peerDependencies:
       react: '>=15'
 
-  react-router@7.12.0:
-    resolution: {integrity: sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==}
+  react-router@7.15.0:
+    resolution: {integrity: sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -29817,11 +29814,11 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router-dom@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router-dom@7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-router: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   react-router@5.3.4(react@19.2.3):
     dependencies:
@@ -29836,7 +29833,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router@7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       cookie: 1.1.1
       react: 19.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ catalog:
   react-dom: 19.2.3
   react-hook-form: 7.65.0
   react-i18next: 16.0.1
-  react-router: 7.12.0
+  react-router: 7.15.0
   rimraf: 6.1.3
   rolldown: 1.0.0-beta.45
   rollup-plugin-visualizer: 6.0.5

--- a/samples/apps/react-api-based-sample/package-lock.json
+++ b/samples/apps/react-api-based-sample/package-lock.json
@@ -11,7 +11,7 @@
         "@wso2/oxygen-ui": "0.0.1-alpha.11",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router": "^7.12.0"
+        "react-router": "^7.15.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -52,7 +52,6 @@
       "version": "7.28.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -232,6 +231,7 @@
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -278,6 +278,7 @@
     "node_modules/@base-ui-components/utils": {
       "version": "0.1.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@floating-ui/utils": "^0.2.10",
@@ -332,6 +333,7 @@
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -349,6 +351,7 @@
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -359,18 +362,21 @@
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
     },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/react": {
       "version": "11.14.0",
@@ -398,6 +404,7 @@
     "node_modules/@emotion/serialize": {
       "version": "1.3.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.2",
         "@emotion/memoize": "^0.9.0",
@@ -408,7 +415,8 @@
     },
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/styled": {
       "version": "11.14.1",
@@ -434,22 +442,26 @@
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/utils": {
       "version": "1.4.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -588,7 +600,8 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.10",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@fontsource-variable/inter": {
       "version": "5.2.8",
@@ -680,6 +693,7 @@
     "node_modules/@mui/core-downloads-tracker": {
       "version": "7.3.7",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
@@ -736,6 +750,7 @@
     "node_modules/@mui/private-theming": {
       "version": "7.3.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/utils": "^7.3.7",
@@ -761,6 +776,7 @@
     "node_modules/@mui/styled-engine": {
       "version": "7.3.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@emotion/cache": "^11.14.0",
@@ -832,6 +848,7 @@
     "node_modules/@mui/types": {
       "version": "7.4.10",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -847,6 +864,7 @@
     "node_modules/@mui/utils": {
       "version": "7.3.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/types": "^7.4.10",
@@ -911,6 +929,7 @@
     "node_modules/@mui/x-charts-vendor": {
       "version": "8.14.0",
       "license": "MIT AND ISC",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@types/d3-color": "^3.1.3",
@@ -936,6 +955,7 @@
     "node_modules/@mui/x-data-grid": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/utils": "^7.3.3",
@@ -972,6 +992,7 @@
     "node_modules/@mui/x-data-grid/node_modules/@mui/x-internals": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/utils": "^7.3.3",
@@ -992,6 +1013,7 @@
     "node_modules/@mui/x-date-pickers": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/utils": "^7.3.3",
@@ -1056,6 +1078,7 @@
     "node_modules/@mui/x-date-pickers/node_modules/@mui/x-internals": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/utils": "^7.3.3",
@@ -1076,6 +1099,7 @@
     "node_modules/@mui/x-internal-gestures": {
       "version": "0.3.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       }
@@ -1083,6 +1107,7 @@
     "node_modules/@mui/x-internals": {
       "version": "8.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/utils": "^7.3.3",
@@ -1141,6 +1166,7 @@
     "node_modules/@mui/x-virtualizer": {
       "version": "0.2.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/utils": "^7.3.3",
@@ -1161,6 +1187,7 @@
     "node_modules/@mui/x-virtualizer/node_modules/@mui/x-internals": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/utils": "^7.3.3",
@@ -1214,6 +1241,7 @@
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -1510,37 +1538,44 @@
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-delaunay": {
       "version": "6.0.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/d3-color": "*"
       }
     },
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-sankey": {
       "version": "0.12.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/d3-shape": "^1"
       }
     },
     "node_modules/@types/d3-sankey/node_modules/@types/d3-path": {
       "version": "1.0.11",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-sankey/node_modules/@types/d3-shape": {
       "version": "1.3.12",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/d3-path": "^1"
       }
@@ -1548,6 +1583,7 @@
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/d3-time": "*"
       }
@@ -1555,17 +1591,20 @@
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/d3-path": "*"
       }
     },
     "node_modules/@types/d3-time": {
       "version": "3.0.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1581,23 +1620,23 @@
       "version": "24.10.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/react": {
       "version": "19.2.9",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1613,6 +1652,7 @@
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "*"
       }
@@ -1662,7 +1702,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -1942,7 +1981,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1995,6 +2033,7 @@
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -2025,7 +2064,8 @@
     },
     "node_modules/bezier-easing": {
       "version": "2.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
@@ -2058,7 +2098,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2117,6 +2156,7 @@
     "node_modules/clsx": {
       "version": "2.1.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2146,7 +2186,8 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2164,6 +2205,7 @@
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -2195,6 +2237,7 @@
     "node_modules/d3-array": {
       "version": "2.12.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "internmap": "^1.0.0"
       }
@@ -2202,6 +2245,7 @@
     "node_modules/d3-color": {
       "version": "3.1.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2209,6 +2253,7 @@
     "node_modules/d3-delaunay": {
       "version": "6.0.4",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "delaunator": "5"
       },
@@ -2219,6 +2264,7 @@
     "node_modules/d3-format": {
       "version": "3.1.2",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2226,6 +2272,7 @@
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -2236,6 +2283,7 @@
     "node_modules/d3-path": {
       "version": "3.1.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2243,6 +2291,7 @@
     "node_modules/d3-sankey": {
       "version": "0.12.3",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-array": "1 - 2",
         "d3-shape": "^1.2.0"
@@ -2250,11 +2299,13 @@
     },
     "node_modules/d3-sankey/node_modules/d3-path": {
       "version": "1.0.9",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-sankey/node_modules/d3-shape": {
       "version": "1.3.7",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-path": "1"
       }
@@ -2262,6 +2313,7 @@
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -2276,6 +2328,7 @@
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-path": "^3.1.0"
       },
@@ -2286,6 +2339,7 @@
     "node_modules/d3-time": {
       "version": "3.1.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -2296,6 +2350,7 @@
     "node_modules/d3-time-format": {
       "version": "4.1.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3-time": "1 - 3"
       },
@@ -2306,6 +2361,7 @@
     "node_modules/d3-timer": {
       "version": "3.0.1",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2342,6 +2398,7 @@
     "node_modules/delaunator": {
       "version": "5.0.1",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "robust-predicates": "^3.0.2"
       }
@@ -2357,6 +2414,7 @@
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -2370,6 +2428,7 @@
     "node_modules/error-ex": {
       "version": "1.3.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -2396,7 +2455,6 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2601,7 +2659,8 @@
     },
     "node_modules/find-root": {
       "version": "1.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2650,6 +2709,7 @@
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2695,6 +2755,7 @@
     "node_modules/hasown": {
       "version": "2.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2718,13 +2779,15 @@
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
     },
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2758,15 +2821,18 @@
     },
     "node_modules/internmap": {
       "version": "1.0.1",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -2833,7 +2899,8 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3135,7 +3202,8 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3159,6 +3227,7 @@
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -3245,6 +3314,7 @@
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3306,6 +3376,7 @@
     "node_modules/parse-json": {
       "version": "5.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -3337,11 +3408,13 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3356,7 +3429,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3404,6 +3476,7 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3412,7 +3485,8 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3425,7 +3499,6 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3433,7 +3506,6 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3443,7 +3515,8 @@
     },
     "node_modules/react-is": {
       "version": "19.2.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3478,6 +3551,7 @@
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -3491,11 +3565,13 @@
     },
     "node_modules/reselect": {
       "version": "5.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.11",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -3520,7 +3596,8 @@
     },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/rolldown": {
       "version": "1.0.0-beta.50",
@@ -3598,6 +3675,7 @@
     "node_modules/source-map": {
       "version": "0.5.7",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3623,7 +3701,8 @@
     },
     "node_modules/stylis": {
       "version": "4.2.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -3639,6 +3718,7 @@
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3697,7 +3777,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3775,6 +3854,7 @@
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -3784,7 +3864,6 @@
       "version": "7.2.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.97.0",
         "fdir": "^6.5.0",
@@ -3887,6 +3966,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -3912,7 +3992,6 @@
       "version": "4.3.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/samples/apps/react-api-based-sample/package.json
+++ b/samples/apps/react-api-based-sample/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react-router": "^7.12.0",
+    "react-router": "^7.15.0",
     "@wso2/oxygen-ui": "0.0.1-alpha.11",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/samples/apps/react-vanilla-sample/package-lock.json
+++ b/samples/apps/react-vanilla-sample/package-lock.json
@@ -15,14 +15,13 @@
         "@mui/system": "7.1.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "react-router-dom": "7.12.0"
+        "react-router-dom": "7.15.0"
       },
       "devDependencies": {
         "@eslint/js": "9.27.0",
         "@types/node": "22.15.29",
         "@types/react": "19.2.7",
         "@types/react-dom": "19.2.3",
-        "@types/react-router-dom": "5",
         "@vitejs/plugin-react": "4.4.1",
         "eslint": "9.27.0",
         "eslint-plugin-react-hooks": "5.2.0",
@@ -1825,13 +1824,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1878,29 +1870,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
-      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -3514,9 +3483,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
-      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3536,12 +3505,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
-      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.12.0"
+        "react-router": "7.15.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/samples/apps/react-vanilla-sample/package.json
+++ b/samples/apps/react-vanilla-sample/package.json
@@ -21,14 +21,13 @@
     "@mui/system": "7.1.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-router-dom": "7.12.0"
+    "react-router-dom": "7.15.0"
   },
   "devDependencies": {
     "@eslint/js": "9.27.0",
     "@types/node": "22.15.29",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
-    "@types/react-router-dom": "5",
     "@vitejs/plugin-react": "4.4.1",
     "eslint": "9.27.0",
     "eslint-plugin-react-hooks": "5.2.0",


### PR DESCRIPTION
### Purpose
Upgrade react-router from 7.12.0 to 7.15.0 to fix three high-severity vulnerabilities (RCE via turbo-stream deserialization, XSS via RSC redirect, and DoS via __manifest endpoint).

### Approach
Bumped the version in the pnpm workspace catalog and in the two sample apps that had their own pinned versions, then updated the lockfile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated react-router dependencies across the workspace and sample applications to version 7.15.0 to keep routing libraries current and aligned across projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->