### PR TITLE
Update subject claim handling in client credential grant

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
@@ -162,7 +162,7 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 	}
 
 	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, &tokenservice.AccessTokenBuildContext{
-		Subject:          tokenRequest.ClientID,
+		Subject:          oauthApp.ID,
 		Audiences:        audiences,
 		ClientID:         tokenRequest.ClientID,
 		Scopes:           scopes,

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
@@ -52,6 +52,7 @@ import (
 // nolint:gosec // Test token, not a real credential
 const testJWTToken = "test-jwt-token-123"
 const testResourceURL = "https://mcp.example.com/mcp"
+const testEntityID = "agent-entity-123"
 
 type ClientCredentialsGrantHandlerTestSuite struct {
 	suite.Suite
@@ -108,7 +109,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) SetupTest() {
 		Return([]entityprovider.EntityGroup{}, nil).Maybe()
 
 	suite.oauthApp = &inboundmodel.OAuthClient{
-		ID:                      "app123",
+		ID:                      testEntityID,
 		ClientID:                testClientID,
 		RedirectURIs:            []string{"https://example.com/callback"},
 		GrantTypes:              []constants.GrantType{constants.GrantTypeClientCredentials},
@@ -205,7 +206,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 			suite.mockTokenBuilder.On("BuildAccessToken",
 				mock.Anything,
 				mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-					return ctx.Subject == testClientID &&
+					return ctx.Subject == testEntityID &&
 						(len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
 						ctx.ClientID == testClientID &&
 						tokenservice.JoinScopes(ctx.Scopes) == tokenservice.JoinScopes(tc.expectedScopes)
@@ -216,7 +217,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 				ExpiresIn: 3600,
 				Scopes:    tc.expectedScopes,
 				ClientID:  testClientID,
-				Subject:   testClientID,
+				Subject:   testEntityID,
 				Audiences: []string{testClientID},
 			}, nil)
 
@@ -230,8 +231,9 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 			assert.Equal(t, tc.expectedScopes, result.AccessToken.Scopes)
 			assert.Equal(t, testClientID, result.AccessToken.ClientID)
 
-			// Verify token attributes
-			assert.Equal(t, testClientID, result.AccessToken.Subject)
+			// The sub claim must be the resource entity ID, not the OAuth client_id.
+			assert.Equal(t, testEntityID, result.AccessToken.Subject)
+			assert.NotEqual(t, result.AccessToken.ClientID, result.AccessToken.Subject)
 			assert.Contains(t, result.AccessToken.Audiences, testClientID)
 
 			suite.mockTokenBuilder.AssertExpectations(t)
@@ -287,7 +289,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 	expectedToken := testJWTToken
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-			return ctx.Subject == testClientID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
+			return ctx.Subject == testEntityID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID) &&
 				tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
 		})).Return(&model.TokenDTO{
 		Token:     expectedToken,
@@ -296,7 +298,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 		ExpiresIn: 3600,
 		Scopes:    []string{"read"},
 		ClientID:  "client123",
-		Subject:   testClientID,
+		Subject:   testEntityID,
 		Audiences: []string{testClientID},
 	}, nil)
 
@@ -306,8 +308,8 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_NilTokenAtt
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), expectedToken, result.AccessToken.Token)
 
-	// Verify token attributes
-	assert.Equal(suite.T(), testClientID, result.AccessToken.Subject)
+	// The sub claim must be the resource entity ID, not the OAuth client_id.
+	assert.Equal(suite.T(), testEntityID, result.AccessToken.Subject)
 	assert.Contains(suite.T(), result.AccessToken.Audiences, testClientID)
 
 	suite.mockTokenBuilder.AssertExpectations(suite.T())
@@ -418,7 +420,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithResourc
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			capturedAudiences = ctx.Audiences
-			return ctx.Subject == testClientID &&
+			return ctx.Subject == testEntityID &&
 				len(ctx.Audiences) == 1 &&
 				ctx.Audiences[0] == "https://mcp.example.com/mcp"
 		})).Return(&model.TokenDTO{
@@ -428,7 +430,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithResourc
 		ExpiresIn: 3600,
 		Scopes:    []string{"read"},
 		ClientID:  "client123",
-		Subject:   testClientID,
+		Subject:   testEntityID,
 		Audiences: []string{"https://mcp.example.com/mcp"},
 	}, nil)
 
@@ -463,7 +465,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithoutReso
 			if len(ctx.Audiences) > 0 {
 				capturedAudience = ctx.Audiences[0]
 			}
-			return ctx.Subject == testClientID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID)
+			return ctx.Subject == testEntityID && (len(ctx.Audiences) > 0 && ctx.Audiences[0] == testClientID)
 		})).Return(&model.TokenDTO{
 		Token:     testJWTToken,
 		TokenType: constants.TokenTypeBearer,
@@ -471,7 +473,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_WithoutReso
 		ExpiresIn: 3600,
 		Scopes:    []string{"read"},
 		ClientID:  "client123",
-		Subject:   testClientID,
+		Subject:   testEntityID,
 		Audiences: []string{testClientID},
 	}, nil)
 
@@ -676,7 +678,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ImplicitRSD
 		ExpiresIn: 3600,
 		Scopes:    []string{"r1:s1"},
 		ClientID:  testClientID,
-		Subject:   testClientID,
+		Subject:   testEntityID,
 		Audiences: []string{rsIdentifier},
 	}, nil)
 
@@ -742,7 +744,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ImplicitRSD
 		ExpiresIn: 3600,
 		Scopes:    []string{"r1:s1"},
 		ClientID:  testClientID,
-		Subject:   testClientID,
+		Subject:   testEntityID,
 		Audiences: []string{rsIdentifier1, rsIdentifier2},
 	}, nil)
 

--- a/docs/content/guides/guides/agents/agent-authentication.mdx
+++ b/docs/content/guides/guides/agents/agent-authentication.mdx
@@ -107,7 +107,7 @@ All agent access tokens are signed JWTs (`typ: at+jwt`) and share a common set o
 
 | Claim | M2M (`client_credentials`) | OBO (token exchange) |
 |---|---|---|
-| `sub` | The agent's Client ID. | The original user's subject identifier. |
+| `sub` | The agent's resource ID. | The original user's subject identifier. |
 | `iss` | <ProductName /> instance URL. | <ProductName /> instance URL. |
 | `aud` | Resource server identifier(s), or Client ID as fallback. | Resource server identifier(s), or Client ID as fallback. |
 | `scope` | Authorized scopes from the agent's group/role assignments. | A subset of the user's original scopes. |
@@ -124,7 +124,7 @@ When a token exchange request includes an explicit `actor_token`, the issued OBO
 
 ```json
 "act": {
-  "sub": "<ACTOR_CLIENT_ID>",
+  "sub": "<ACTOR_RESOURCE_ID>",
   "iss": "<ISSUER>"
 }
 ```

--- a/samples/apps/wayfinder-sample/backend/src/mcp.js
+++ b/samples/apps/wayfinder-sample/backend/src/mcp.js
@@ -85,7 +85,7 @@ function callerTag(user) {
     return "anon";
   }
 
-  const type = user.rawClaims?.sub === user.rawClaims?.client_id ? "m2m" : "user";
+  const type = user.rawClaims?.grant_type === "client_credentials" ? "m2m" : "user";
 
   return `${type}:${user.id || "-"}`;
 }

--- a/samples/apps/wayfinder-sample/backend/src/server.js
+++ b/samples/apps/wayfinder-sample/backend/src/server.js
@@ -55,7 +55,7 @@ function logRequest(method, pathname, claims) {
     console.log(`${method} ${pathname}`);
     return;
   }
-  const type = claims.sub === claims.client_id ? "m2m" : "user";
+  const type = claims.grant_type === "client_credentials" ? "m2m" : "user";
   const aud = Array.isArray(claims.aud) ? claims.aud.join(",") : (claims.aud || "-");
   console.log(
     `${method} ${pathname} | type: ${type} | client_id: ${claims.client_id || "-"} | sub: ${claims.sub || "-"} | aud: ${aud} | scope: ${claims.scope || "-"}`


### PR DESCRIPTION
### Purpose
$subject

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
In the m2m tokens, we are no longer returning the client_id as the sub claim. It will be the resource id.

#### 🔄 Migration Guide
If there's sub claim validation, change those with the resource id instead of the client_id


### Related Issues
- https://github.com/thunder-id/thunderid/issues/3131


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * OAuth access tokens now correctly use the resource entity ID as the subject claim instead of the client ID, ensuring proper token identification across M2M and user authentication flows.

* **Documentation**
  * Updated JWT token claims documentation to reflect the corrected subject claim behavior for both M2M and OBO token types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->