### PR TITLE
Pack env files to the wayfinder sample distributions

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1138,9 +1138,13 @@ function Package-Wayfinder-Sample {
     $frontendDest = Join-Path $dist_folder "frontend"
     New-Item -Path $frontendDest -ItemType Directory -Force | Out-Null
     Copy-Item -Path $frontendDist -Destination $frontendDest -Recurse -Force
-    foreach ($item in @("package.json", "package-lock.json", "index.html", "vite.config.js", ".env.example", "README.md")) {
+    foreach ($item in @("package.json", "package-lock.json", "index.html", "vite.config.js", "README.md")) {
         $src = Join-Path $WAYFINDER_SAMPLE_APP_DIR "frontend/$item"
         if (Test-Path $src) { Copy-Item -Path $src -Destination $frontendDest -Force }
+    }
+    $frontendEnvExample = Join-Path $WAYFINDER_SAMPLE_APP_DIR "frontend/.env.example"
+    if (Test-Path $frontendEnvExample) {
+        Copy-Item -Path $frontendEnvExample -Destination (Join-Path $frontendDest ".env") -Force
     }
     foreach ($subdir in @("src", "public")) {
         $src = Join-Path $WAYFINDER_SAMPLE_APP_DIR "frontend/$subdir"
@@ -1152,9 +1156,13 @@ function Package-Wayfinder-Sample {
         $svcDest = Join-Path $dist_folder $svc
         Write-Host "Copying Wayfinder sample $svc source..."
         New-Item -Path $svcDest -ItemType Directory -Force | Out-Null
-        foreach ($item in @("package.json", "package-lock.json", "tsconfig.json", "README.md", ".env.example", "agent.ts")) {
+        foreach ($item in @("package.json", "package-lock.json", "tsconfig.json", "README.md", "agent.ts")) {
             $src = Join-Path $svcSrc $item
             if (Test-Path $src) { Copy-Item -Path $src -Destination $svcDest -Force }
+        }
+        $svcEnvExample = Join-Path $svcSrc ".env.example"
+        if (Test-Path $svcEnvExample) {
+            Copy-Item -Path $svcEnvExample -Destination (Join-Path $svcDest ".env") -Force
         }
         foreach ($subdir in @("src", "scripts")) {
             $src = Join-Path $svcSrc $subdir

--- a/build.sh
+++ b/build.sh
@@ -850,7 +850,7 @@ function package_wayfinder_sample() {
             cp -r "$WAYFINDER_SAMPLE_APP_DIR/frontend/public" "$dist_folder/frontend/"
         fi
         if [ -f "$WAYFINDER_SAMPLE_APP_DIR/frontend/.env.example" ]; then
-            cp "$WAYFINDER_SAMPLE_APP_DIR/frontend/.env.example" "$dist_folder/frontend/"
+            cp "$WAYFINDER_SAMPLE_APP_DIR/frontend/.env.example" "$dist_folder/frontend/.env"
         fi
         if [ -f "$WAYFINDER_SAMPLE_APP_DIR/frontend/README.md" ]; then
             cp "$WAYFINDER_SAMPLE_APP_DIR/frontend/README.md" "$dist_folder/frontend/"
@@ -875,7 +875,7 @@ function package_wayfinder_sample() {
             cp "$svc_src/README.md" "$svc_dest/"
         fi
         if [ -f "$svc_src/.env.example" ]; then
-            cp "$svc_src/.env.example" "$svc_dest/"
+            cp "$svc_src/.env.example" "$svc_dest/.env"
         fi
         if [ -d "$svc_src/src" ]; then
             cp -r "$svc_src/src" "$svc_dest/"

--- a/docs/content/use-cases/ai-agents/try-it-out.mdx
+++ b/docs/content/use-cases/ai-agents/try-it-out.mdx
@@ -68,7 +68,7 @@ Download the latest Wayfinder sample distribution. It ships with a `thunderid-co
 
 ### Configure the Sample
 
-The `backend/`, `ai-agent/`, and `frontend/` folders each ship with a `.env.example`. Copy each to `.env` in the same folder; the defaults already point at <ProductName /> on `https://localhost:8090`. The only placeholder you must fill in is the LLM API key in `ai-agent/.env` — an Anthropic API key from [console.anthropic.com](https://console.anthropic.com), or a Google Gemini API key from [aistudio.google.com](https://aistudio.google.com).
+The `backend/`, `ai-agent/`, and `frontend/` folders each ship with a `.env` file. The defaults already point at <ProductName /> on `https://localhost:8090`. The only placeholder you must fill in is the LLM API key in `ai-agent/.env` — an Anthropic API key from [console.anthropic.com](https://console.anthropic.com), or a Google Gemini API key from [aistudio.google.com](https://aistudio.google.com).
 
 ### Import the Sample Bundle
 


### PR DESCRIPTION
### Purpose
This pull request updates the packaging scripts for the Wayfinder sample application to improve how environment example files are handled. The main change is that `.env.example` files are now copied and renamed to `.env` in the distribution directories for both the frontend and service components, ensuring that the packaged output is ready for local configuration without manual renaming.

This improves the getting started experience of wayfinder sample where users no longer have to manually create the `.env` file before the sample startup.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Packaged sample now includes ready-to-use environment configuration files in the distribution instead of example templates, simplifying setup for downloaded samples.
* **Documentation**
  * Updated setup instructions to reflect that distributed samples contain configured env files; only the LLM API key needs to be filled in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->