### PR TITLE
Add correlation IDs to the logs with context-aware logging methods

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -96,6 +96,14 @@ issues:
   exclude-use-default: false
   exclude-dirs:
     - tests/mocks
+  exclude-rules:
+    # Temporary during the correlation-ID log migration (issue #2038):
+    # suppress deprecation errors for the old non-context log methods until
+    # all call sites are migrated to the *Context variants. Remove this rule
+    # before deleting the deprecated methods so any stragglers fail loudly.
+    - linters:
+        - staticcheck
+      text: 'Use (Info|Debug|Warn|Error)WithContext instead\. Refs #2038'
 
 output:
   show-stats: true

--- a/backend/internal/idp/cache_backed_store.go
+++ b/backend/internal/idp/cache_backed_store.go
@@ -169,7 +169,7 @@ func (s *cacheBackedIDPStore) cacheIDP(ctx context.Context, idp *IDPDTO) {
 
 	idKey := cache.CacheKey{Key: idp.ID}
 	if err := s.idpByIDCache.Set(ctx, idKey, idp); err != nil {
-		logger.Error("Failed to cache IDP by ID", log.Error(err), log.String("idpID", idp.ID))
+		logger.ErrorWithContext(ctx, "Failed to cache IDP by ID", log.Error(err), log.String("idpID", idp.ID))
 	}
 }
 
@@ -182,7 +182,8 @@ func (s *cacheBackedIDPStore) invalidateIDP(ctx context.Context, idp *IDPDTO) {
 	if idp.ID != "" {
 		idKey := cache.CacheKey{Key: idp.ID}
 		if err := s.idpByIDCache.Delete(ctx, idKey); err != nil {
-			logger.Error("Failed to invalidate IDP cache by ID", log.Error(err), log.String("idpID", idp.ID))
+			logger.ErrorWithContext(ctx, "Failed to invalidate IDP cache by ID",
+				log.Error(err), log.String("idpID", idp.ID))
 		}
 	}
 	for _, prop := range idp.Properties {
@@ -195,7 +196,7 @@ func (s *cacheBackedIDPStore) invalidateIDP(ctx context.Context, idp *IDPDTO) {
 		}
 		propKey := cache.CacheKey{Key: prop.GetName() + ":" + val}
 		if err := s.idpByPropertyCache.Delete(ctx, propKey); err != nil {
-			logger.Error("Failed to invalidate IDP property cache", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to invalidate IDP property cache", log.Error(err))
 		}
 	}
 }

--- a/backend/internal/idp/cache_backed_store_test.go
+++ b/backend/internal/idp/cache_backed_store_test.go
@@ -398,3 +398,31 @@ func (s *CacheBackedIDPStoreTestSuite) TestDeleteIdentityProvider_InnerDeleteErr
 	s.idCache.AssertNotCalled(s.T(), "Delete")
 	s.propertyCache.AssertNotCalled(s.T(), "Delete")
 }
+
+func (s *CacheBackedIDPStoreTestSuite) TestCacheIDP_SetError() {
+	idp := &IDPDTO{ID: "idp-set-err", Name: "Set Err IDP", Type: IDPTypeOIDC}
+
+	s.idCache.On("Set", mock.Anything, cache.CacheKey{Key: "idp-set-err"}, idp).
+		Return(errors.New("cache set failed"))
+
+	// The error is logged and swallowed; caching is best-effort.
+	s.cachedStore.cacheIDP(context.Background(), idp)
+
+	s.idCache.AssertCalled(s.T(), "Set", mock.Anything, cache.CacheKey{Key: "idp-set-err"}, idp)
+}
+
+func (s *CacheBackedIDPStoreTestSuite) TestInvalidateIDP_DeleteErrors() {
+	idp := makeIDPWithIssuer("idp-del-err", "Delete Err IDP", "https://idp.example.com")
+
+	s.idCache.On("Delete", mock.Anything, cache.CacheKey{Key: "idp-del-err"}).
+		Return(errors.New("cache delete failed"))
+	s.propertyCache.On("Delete", mock.Anything, cache.CacheKey{Key: PropIssuer + ":https://idp.example.com"}).
+		Return(errors.New("cache delete failed"))
+
+	// Errors are logged and swallowed; both invalidations are still attempted.
+	s.cachedStore.invalidateIDP(context.Background(), idp)
+
+	s.idCache.AssertCalled(s.T(), "Delete", mock.Anything, cache.CacheKey{Key: "idp-del-err"})
+	s.propertyCache.AssertCalled(s.T(), "Delete", mock.Anything,
+		cache.CacheKey{Key: PropIssuer + ":https://idp.example.com"})
+}

--- a/backend/internal/idp/declarative_resource.go
+++ b/backend/internal/idp/declarative_resource.go
@@ -225,7 +225,9 @@ func validateIDPWrapper(dto interface{}) error {
 
 	// Use the full validateIDP function which validates properties and applies defaults
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IDPDeclarativeResource"))
-	svcErr := validateIDP(idpDTO, logger)
+	// Declarative resources are validated at server startup, outside any request,
+	// so there is no request context (or trace ID) to propagate.
+	svcErr := validateIDP(context.Background(), idpDTO, logger)
 	if svcErr != nil {
 		return fmt.Errorf("validation failed: %s", svcErr.Error)
 	}

--- a/backend/internal/idp/handler.go
+++ b/backend/internal/idp/handler.go
@@ -60,7 +60,7 @@ func (ih *idpHandler) HandleIDPPostRequest(w http.ResponseWriter, r *http.Reques
 
 	properties, err := getSanitizedProperties(createRequest.Properties)
 	if err != nil {
-		logger.Error("Failed to sanitize properties", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to sanitize properties", log.Error(err))
 		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
 		return
 	}
@@ -79,7 +79,8 @@ func (ih *idpHandler) HandleIDPPostRequest(w http.ResponseWriter, r *http.Reques
 
 	idpResponse, err := getIDPResponse(*createdIDP)
 	if err != nil {
-		logger.Error("Failed to convert IDP to response", log.String("idp", createdIDP.Name), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to convert IDP to response",
+			log.String("idp", createdIDP.Name), log.Error(err))
 		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
 		return
 	}
@@ -134,7 +135,7 @@ func (ih *idpHandler) HandleIDPGetRequest(w http.ResponseWriter, r *http.Request
 
 	idpResponse, err := getIDPResponse(*idp)
 	if err != nil {
-		logger.Error("Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
 		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
 		return
 	}
@@ -170,7 +171,7 @@ func (ih *idpHandler) HandleIDPPutRequest(w http.ResponseWriter, r *http.Request
 
 	properties, err := getSanitizedProperties(updateRequest.Properties)
 	if err != nil {
-		logger.Error("Failed to sanitize properties", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to sanitize properties", log.Error(err))
 		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
 		return
 	}
@@ -191,7 +192,7 @@ func (ih *idpHandler) HandleIDPPutRequest(w http.ResponseWriter, r *http.Request
 
 	idpResponse, err := getIDPResponse(*idp)
 	if err != nil {
-		logger.Error("Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
 		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
 		return
 	}

--- a/backend/internal/idp/handler_test.go
+++ b/backend/internal/idp/handler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
+	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 )
 
@@ -515,4 +516,53 @@ func (s *IDPHandlerTestSuite) TestWriteServiceErrorResponse() {
 			s.Equal(tc.expectedStatus, rr.Code)
 		})
 	}
+}
+
+// initConfigWithTestCryptoKey initializes the server runtime with the shared
+// test crypto key so that secret property encryption works in tests.
+func initConfigWithTestCryptoKey() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("/tmp/test", &config.Config{
+		Crypto: config.CryptoConfig{
+			Encryption: config.EncryptionConfig{
+				Key: testCryptoKey,
+			},
+		},
+	})
+}
+
+func (s *IDPHandlerTestSuite) TestHandleIDPPostRequest_WithSecretProperty() {
+	initConfigWithTestCryptoKey()
+	defer config.ResetServerRuntime()
+
+	reqBody := idpRequest{
+		Name: "Secret IDP",
+		Type: "OIDC",
+		Properties: []cmodels.PropertyDTO{
+			{Name: "client_secret", Value: "s3cret", IsSecret: true},
+		},
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/identity-providers", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	secretProp, err := cmodels.NewProperty("client_secret", "s3cret", true)
+	s.NoError(err)
+	s.mockService.On("CreateIdentityProvider", mock.Anything, mock.Anything).
+		Return(&IDPDTO{
+			ID:         "idp-123",
+			Name:       "Secret IDP",
+			Type:       IDPTypeOIDC,
+			Properties: []cmodels.Property{*secretProp},
+		}, (*serviceerror.ServiceError)(nil))
+
+	s.handler.HandleIDPPostRequest(rr, req)
+
+	s.Equal(http.StatusCreated, rr.Code)
+
+	// Secret property values must be masked in the response.
+	var response idpResponse
+	s.NoError(json.NewDecoder(rr.Body).Decode(&response))
+	s.Len(response.Properties, 1)
+	s.Equal("******", response.Properties[0].Value)
 }

--- a/backend/internal/idp/init_test.go
+++ b/backend/internal/idp/init_test.go
@@ -238,13 +238,13 @@ func (suite *IDPInitTestSuite) TestValidateIDPForInit_Valid() {
 	}
 
 	logger := log.GetLogger()
-	err := validateIDP(idp, logger)
+	err := validateIDP(context.Background(), idp, logger)
 	suite.Nil(err)
 }
 
 func (suite *IDPInitTestSuite) TestValidateIDPForInit_NilIDP() {
 	logger := log.GetLogger()
-	err := validateIDP(nil, logger)
+	err := validateIDP(context.Background(), nil, logger)
 	suite.NotNil(err)
 	suite.Equal(ErrorIDPNil.Code, err.Code)
 }
@@ -257,7 +257,7 @@ func (suite *IDPInitTestSuite) TestValidateIDPForInit_EmptyName() {
 	}
 
 	logger := log.GetLogger()
-	err := validateIDP(idp, logger)
+	err := validateIDP(context.Background(), idp, logger)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidIDPName.Code, err.Code)
 }
@@ -270,7 +270,7 @@ func (suite *IDPInitTestSuite) TestValidateIDPForInit_EmptyType() {
 	}
 
 	logger := log.GetLogger()
-	err := validateIDP(idp, logger)
+	err := validateIDP(context.Background(), idp, logger)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidIDPType.Code, err.Code)
 }
@@ -283,7 +283,7 @@ func (suite *IDPInitTestSuite) TestValidateIDPForInit_InvalidType() {
 	}
 
 	logger := log.GetLogger()
-	err := validateIDP(idp, logger)
+	err := validateIDP(context.Background(), idp, logger)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidIDPType.Code, err.Code)
 }

--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -69,14 +69,14 @@ func (is *idpService) CreateIdentityProvider(
 		return nil, &declarativeresource.ErrorDeclarativeResourceCreateOperation
 	}
 
-	if svcErr := validateIDP(idp, logger); svcErr != nil {
+	if svcErr := validateIDP(ctx, idp, logger); svcErr != nil {
 		return nil, svcErr
 	}
 
 	if idp.ID == "" {
 		id, genErr := is.uuidGenerator()
 		if genErr != nil {
-			logger.Error("failed to generate ID for identity provider", log.Error(genErr))
+			logger.ErrorWithContext(ctx, "failed to generate ID for identity provider", log.Error(genErr))
 			return nil, &serviceerror.InternalServerError
 		}
 		idp.ID = id
@@ -109,7 +109,8 @@ func (is *idpService) CreateIdentityProvider(
 		return nil, svcErr
 	}
 	if err != nil {
-		logger.Error("Failed to create identity provider", log.Error(err), log.String("idpName", idp.Name))
+		logger.ErrorWithContext(ctx, "Failed to create identity provider",
+			log.Error(err), log.String("idpName", idp.Name))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -124,7 +125,7 @@ func (is *idpService) GetIdentityProviderList(ctx context.Context) ([]BasicIDPDT
 		if errors.Is(err, ErrResultLimitExceededInCompositeMode) {
 			return nil, &ErrorResultLimitExceededInCompositeMode
 		}
-		logger.Error("Failed to get identity provider list", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get identity provider list", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -143,7 +144,7 @@ func (is *idpService) GetIdentityProvider(ctx context.Context, idpID string) (*I
 		if errors.Is(err, ErrIDPNotFound) {
 			return nil, &ErrorIDPNotFound
 		}
-		logger.Error("Failed to get identity provider", log.String("idpID", idpID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get identity provider", log.String("idpID", idpID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -163,7 +164,8 @@ func (is *idpService) GetIdentityProviderByName(ctx context.Context,
 		if errors.Is(err, ErrIDPNotFound) {
 			return nil, &ErrorIDPNotFound
 		}
-		logger.Error("Failed to get identity provider by name", log.String("idpName", idpName), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get identity provider by name",
+			log.String("idpName", idpName), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -183,7 +185,7 @@ func (is *idpService) GetIdentityProvidersByProperty(ctx context.Context,
 		if errors.Is(err, ErrIDPNotFound) {
 			return nil, &ErrorIDPNotFound
 		}
-		logger.Error("Failed to get identity providers by property",
+		logger.ErrorWithContext(ctx, "Failed to get identity providers by property",
 			log.String("propertyKey", propertyKey),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -205,7 +207,7 @@ func (is *idpService) UpdateIdentityProvider(ctx context.Context, idpID string, 
 	if strings.TrimSpace(idpID) == "" {
 		return nil, &ErrorInvalidIDPID
 	}
-	if svcErr := validateIDP(idp, logger); svcErr != nil {
+	if svcErr := validateIDP(ctx, idp, logger); svcErr != nil {
 		return nil, svcErr
 	}
 
@@ -250,7 +252,7 @@ func (is *idpService) UpdateIdentityProvider(ctx context.Context, idpID string, 
 		return nil, svcErr
 	}
 	if err != nil {
-		logger.Error("Failed to update identity provider", log.Error(err), log.String("idpID", idpID))
+		logger.ErrorWithContext(ctx, "Failed to update identity provider", log.Error(err), log.String("idpID", idpID))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -297,7 +299,7 @@ func (is *idpService) DeleteIdentityProvider(ctx context.Context, idpID string) 
 		return svcErr
 	}
 	if err != nil {
-		logger.Error("Failed to delete identity provider", log.Error(err), log.String("idpID", idpID))
+		logger.ErrorWithContext(ctx, "Failed to delete identity provider", log.Error(err), log.String("idpID", idpID))
 		return &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/idp/service_test.go
+++ b/backend/internal/idp/service_test.go
@@ -840,7 +840,7 @@ func (s *IDPServiceTestSuite) TestValidateIDP() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			logger := log.GetLogger()
-			err := validateIDP(tc.idp, logger)
+			err := validateIDP(context.Background(), tc.idp, logger)
 			if tc.expectError {
 				s.NotNil(err)
 				s.Equal(tc.errorCode, err.Code)

--- a/backend/internal/idp/store.go
+++ b/backend/internal/idp/store.go
@@ -303,7 +303,7 @@ func (s *idpStore) DeleteIdentityProvider(ctx context.Context, id string) error 
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
 	if rowsAffected == 0 {
-		logger.Debug("idp not found with id: " + id)
+		logger.DebugWithContext(ctx, "idp not found with id: "+id)
 	}
 
 	return nil

--- a/backend/internal/idp/utils.go
+++ b/backend/internal/idp/utils.go
@@ -19,6 +19,7 @@
 package idp
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -46,7 +47,7 @@ func GetPropertyValue(properties []cmodels.Property, name string) string {
 }
 
 // validateIDP validates the identity provider details.
-func validateIDP(idp *IDPDTO, logger *log.Logger) *serviceerror.ServiceError {
+func validateIDP(ctx context.Context, idp *IDPDTO, logger *log.Logger) *serviceerror.ServiceError {
 	if idp == nil {
 		return &ErrorIDPNil
 	}
@@ -64,7 +65,7 @@ func validateIDP(idp *IDPDTO, logger *log.Logger) *serviceerror.ServiceError {
 	}
 
 	// Validate and apply default properties based on IDP type
-	updatedProperties, svcErr := validateIDPProperties(idp.Type, idp.Properties, logger)
+	updatedProperties, svcErr := validateIDPProperties(ctx, idp.Type, idp.Properties, logger)
 	if svcErr != nil {
 		return svcErr
 	}
@@ -74,11 +75,12 @@ func validateIDP(idp *IDPDTO, logger *log.Logger) *serviceerror.ServiceError {
 }
 
 // validateIDPProperties validates the properties of the identity provider based on its type.
-func validateIDPProperties(idpType IDPType, properties []cmodels.Property, logger *log.Logger) (
-	[]cmodels.Property, *serviceerror.ServiceError) {
+func validateIDPProperties(ctx context.Context, idpType IDPType, properties []cmodels.Property,
+	logger *log.Logger) ([]cmodels.Property, *serviceerror.ServiceError) {
 	config, exists := idpPropertyConfigs[idpType]
 	if !exists {
-		logger.Error("No property configuration found for IDP type", log.String("idpType", string(idpType)))
+		logger.ErrorWithContext(ctx, "No property configuration found for IDP type",
+			log.String("idpType", string(idpType)))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -143,7 +145,8 @@ func validateIDPProperties(idpType IDPType, properties []cmodels.Property, logge
 	// Apply default properties
 	for propName, defaultValue := range config.Defaults {
 		if _, exists := filteredPropsMap[propName]; !exists {
-			if err := createAndAppendProperty(filteredPropsMap, propName, defaultValue, false, logger); err != nil {
+			err := createAndAppendProperty(ctx, filteredPropsMap, propName, defaultValue, false, logger)
+			if err != nil {
 				return nil, err
 			}
 		}
@@ -151,7 +154,7 @@ func validateIDPProperties(idpType IDPType, properties []cmodels.Property, logge
 
 	// Ensure openid scope for OIDC and Google IDPs
 	if idpType == IDPTypeOIDC || idpType == IDPTypeGoogle {
-		if err := ensureOpenIDScope(filteredPropsMap, logger); err != nil {
+		if err := ensureOpenIDScope(ctx, filteredPropsMap, logger); err != nil {
 			return nil, err
 		}
 	}
@@ -160,10 +163,11 @@ func validateIDPProperties(idpType IDPType, properties []cmodels.Property, logge
 }
 
 // ensureOpenIDScope ensures that the openid scope is present in the scopes property.
-func ensureOpenIDScope(propertyMap map[string]cmodels.Property, logger *log.Logger) *serviceerror.ServiceError {
+func ensureOpenIDScope(ctx context.Context, propertyMap map[string]cmodels.Property,
+	logger *log.Logger) *serviceerror.ServiceError {
 	scopesProp, exists := propertyMap[PropScopes]
 	if !exists {
-		err := createAndAppendProperty(propertyMap, PropScopes, "openid", false, logger)
+		err := createAndAppendProperty(ctx, propertyMap, PropScopes, "openid", false, logger)
 		if err != nil {
 			return err
 		}
@@ -188,7 +192,7 @@ func ensureOpenIDScope(propertyMap map[string]cmodels.Property, logger *log.Logg
 	scopes = filteredScopes
 
 	if len(scopes) == 0 {
-		err := createAndAppendProperty(propertyMap, PropScopes, "openid", false, logger)
+		err := createAndAppendProperty(ctx, propertyMap, PropScopes, "openid", false, logger)
 		if err != nil {
 			return err
 		}
@@ -198,7 +202,7 @@ func ensureOpenIDScope(propertyMap map[string]cmodels.Property, logger *log.Logg
 		scopes = append(scopes, "openid")
 		updatedScopes := sysutils.StringifyStringArray(scopes, ",")
 		if err := createAndAppendProperty(
-			propertyMap, PropScopes, updatedScopes, scopesProp.IsSecret(), logger); err != nil {
+			ctx, propertyMap, PropScopes, updatedScopes, scopesProp.IsSecret(), logger); err != nil {
 			return err
 		}
 	}
@@ -207,12 +211,12 @@ func ensureOpenIDScope(propertyMap map[string]cmodels.Property, logger *log.Logg
 }
 
 // createAndAppendProperty creates a new property and appends it to the property map.
-func createAndAppendProperty(propertyMap map[string]cmodels.Property,
+func createAndAppendProperty(ctx context.Context, propertyMap map[string]cmodels.Property,
 	name, value string, isSecret bool, logger *log.Logger,
 ) *serviceerror.ServiceError {
 	prop, err := cmodels.NewProperty(name, value, isSecret)
 	if err != nil {
-		logger.Error("Failed to create property", log.String("propertyName", name), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to create property", log.String("propertyName", name), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	propertyMap[name] = *prop

--- a/backend/internal/idp/utils_test.go
+++ b/backend/internal/idp/utils_test.go
@@ -19,11 +19,13 @@
 package idp
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
+	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
@@ -51,7 +53,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OAuth_AllRequired() {
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6}
 
-	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOAuth, properties, s.logger)
 
 	s.Nil(err)
 	s.NotNil(result)
@@ -69,7 +71,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OAuth_WithOptional() {
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6, *prop7}
 
-	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOAuth, properties, s.logger)
 
 	s.Nil(err)
 	s.NotNil(result)
@@ -82,7 +84,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OAuth_MissingRequired() {
 
 	properties := []cmodels.Property{*prop1, *prop2}
 
-	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOAuth, properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
@@ -100,7 +102,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDC_AllRequired() {
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5}
 
-	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOIDC, properties, s.logger)
 
 	s.Nil(err)
 	s.NotNil(result)
@@ -127,7 +129,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDC_WithExistingScopes() 
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6}
 
-	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOIDC, properties, s.logger)
 
 	s.Nil(err)
 	s.NotNil(result)
@@ -152,7 +154,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDC_ScopesAlreadyHasOpenI
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6}
 
-	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOIDC, properties, s.logger)
 
 	s.Nil(err)
 	s.NotNil(result)
@@ -172,7 +174,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_Google_WithDefaults() {
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3}
 
-	result, err := validateIDPProperties(IDPTypeGoogle, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeGoogle, properties, s.logger)
 
 	s.Nil(err)
 	s.NotNil(result)
@@ -199,7 +201,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_Google_WithCustomEndpoints
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
 
-	result, err := validateIDPProperties(IDPTypeGoogle, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeGoogle, properties, s.logger)
 
 	s.Nil(err)
 	s.NotNil(result)
@@ -221,7 +223,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_GitHub_WithDefaults() {
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3}
 
-	result, err := validateIDPProperties(IDPTypeGitHub, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeGitHub, properties, s.logger)
 
 	s.Nil(err)
 	s.NotNil(result)
@@ -246,7 +248,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_GitHub_WithCustomEndpoints
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
 
-	result, err := validateIDPProperties(IDPTypeGitHub, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeGitHub, properties, s.logger)
 
 	s.Nil(err)
 	s.NotNil(result)
@@ -266,7 +268,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_EmptyPropertyName() {
 
 	properties := []cmodels.Property{*prop1}
 
-	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOAuth, properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
@@ -279,7 +281,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_EmptyPropertyValue() {
 
 	properties := []cmodels.Property{*prop1}
 
-	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOAuth, properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
@@ -293,7 +295,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_UnsupportedProperty() {
 
 	properties := []cmodels.Property{*prop1, *prop2}
 
-	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOAuth, properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
@@ -307,7 +309,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_InvalidIDPType() {
 
 	properties := []cmodels.Property{*prop1}
 
-	result, err := validateIDPProperties(IDPType("INVALID"), properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPType("INVALID"), properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
@@ -339,7 +341,7 @@ func (s *IDPUtilsTestSuite) TestPropertyMapToSlice() {
 func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_NoExistingScopes() {
 	propertyMap := make(map[string]cmodels.Property)
 
-	err := ensureOpenIDScope(propertyMap, s.logger)
+	err := ensureOpenIDScope(context.Background(), propertyMap, s.logger)
 
 	s.Nil(err)
 	s.Contains(propertyMap, PropScopes)
@@ -355,7 +357,7 @@ func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_WithExistingScopes() {
 		PropScopes: *prop,
 	}
 
-	err := ensureOpenIDScope(propertyMap, s.logger)
+	err := ensureOpenIDScope(context.Background(), propertyMap, s.logger)
 
 	s.Nil(err)
 
@@ -372,7 +374,7 @@ func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_AlreadyHasOpenID() {
 		PropScopes: *prop,
 	}
 
-	err := ensureOpenIDScope(propertyMap, s.logger)
+	err := ensureOpenIDScope(context.Background(), propertyMap, s.logger)
 
 	s.Nil(err)
 
@@ -388,7 +390,7 @@ func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_EmptyScopesValue() {
 		PropScopes: *prop,
 	}
 
-	err := ensureOpenIDScope(propertyMap, s.logger)
+	err := ensureOpenIDScope(context.Background(), propertyMap, s.logger)
 
 	s.Nil(err)
 
@@ -411,14 +413,14 @@ func (s *IDPUtilsTestSuite) TestValidateIDP_ValidOAuth() {
 		Properties: []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6},
 	}
 
-	err := validateIDP(idp, s.logger)
+	err := validateIDP(context.Background(), idp, s.logger)
 
 	s.Nil(err)
 	s.NotNil(idp.Properties)
 }
 
 func (s *IDPUtilsTestSuite) TestValidateIDP_NilIDP() {
-	err := validateIDP(nil, s.logger)
+	err := validateIDP(context.Background(), nil, s.logger)
 
 	s.NotNil(err)
 	s.Equal(ErrorIDPNil.Code, err.Code)
@@ -430,7 +432,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDP_EmptyName() {
 		Type: IDPTypeOAuth,
 	}
 
-	err := validateIDP(idp, s.logger)
+	err := validateIDP(context.Background(), idp, s.logger)
 
 	s.NotNil(err)
 	s.Equal(ErrorInvalidIDPName.Code, err.Code)
@@ -442,7 +444,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDP_EmptyType() {
 		Type: "",
 	}
 
-	err := validateIDP(idp, s.logger)
+	err := validateIDP(context.Background(), idp, s.logger)
 
 	s.NotNil(err)
 	s.Equal(ErrorInvalidIDPType.Code, err.Code)
@@ -454,7 +456,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDP_InvalidType() {
 		Type: "INVALID",
 	}
 
-	err := validateIDP(idp, s.logger)
+	err := validateIDP(context.Background(), idp, s.logger)
 
 	s.NotNil(err)
 	s.Equal(ErrorInvalidIDPType.Code, err.Code)
@@ -474,7 +476,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDP_WithWhitespaceName() {
 		Properties: []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6},
 	}
 
-	err := validateIDP(idp, s.logger)
+	err := validateIDP(context.Background(), idp, s.logger)
 
 	s.NotNil(err)
 	s.Equal(ErrorInvalidIDPName.Code, err.Code)
@@ -486,7 +488,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDP_WithWhitespaceType() {
 		Type: "   ",
 	}
 
-	err := validateIDP(idp, s.logger)
+	err := validateIDP(context.Background(), idp, s.logger)
 
 	s.NotNil(err)
 	s.Equal(ErrorInvalidIDPType.Code, err.Code)
@@ -497,7 +499,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_WithWhitespacePropertyName
 
 	properties := []cmodels.Property{*prop1}
 
-	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOAuth, properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
@@ -510,7 +512,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_WithWhitespacePropertyValu
 
 	properties := []cmodels.Property{*prop1}
 
-	result, err := validateIDPProperties(IDPTypeOAuth, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOAuth, properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
@@ -521,7 +523,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_WithWhitespacePropertyValu
 func (s *IDPUtilsTestSuite) TestCreateAndAppendProperty_Success() {
 	propertyMap := make(map[string]cmodels.Property)
 
-	err := createAndAppendProperty(propertyMap, "test_prop", "test_value", false, s.logger)
+	err := createAndAppendProperty(context.Background(), propertyMap, "test_prop", "test_value", false, s.logger)
 
 	s.Nil(err)
 	s.Contains(propertyMap, "test_prop")
@@ -538,7 +540,7 @@ func (s *IDPUtilsTestSuite) TestCreateAndAppendProperty_OverwriteExisting() {
 		"test_prop": *prop1,
 	}
 
-	err := createAndAppendProperty(propertyMap, "test_prop", "new_value", false, s.logger)
+	err := createAndAppendProperty(context.Background(), propertyMap, "test_prop", "new_value", false, s.logger)
 
 	s.Nil(err)
 	s.Contains(propertyMap, "test_prop")
@@ -554,7 +556,7 @@ func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_WithWhitespaceScopes() {
 		PropScopes: *prop,
 	}
 
-	err := ensureOpenIDScope(propertyMap, s.logger)
+	err := ensureOpenIDScope(context.Background(), propertyMap, s.logger)
 
 	s.Nil(err)
 
@@ -569,7 +571,7 @@ func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_CommaSeparatedScopes() {
 		PropScopes: *prop,
 	}
 
-	err := ensureOpenIDScope(propertyMap, s.logger)
+	err := ensureOpenIDScope(context.Background(), propertyMap, s.logger)
 
 	s.Nil(err)
 
@@ -590,7 +592,7 @@ func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_WithEmptyStringInScopes() {
 		PropScopes: *prop,
 	}
 
-	err := ensureOpenIDScope(propertyMap, s.logger)
+	err := ensureOpenIDScope(context.Background(), propertyMap, s.logger)
 	s.Nil(err)
 
 	scopesProp := propertyMap[PropScopes]
@@ -612,7 +614,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_TokenExchangeOnly_OIDC_Suc
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3}
 
-	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOIDC, properties, s.logger)
 
 	s.Nil(err)
 	s.NotNil(result)
@@ -626,7 +628,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_TokenExchangeEnabled_Missi
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3}
 
-	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOIDC, properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
@@ -643,7 +645,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_TokenExchangeEnabled_Missi
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3}
 
-	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOIDC, properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
@@ -660,7 +662,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDCWithoutTokenExchange_S
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3}
 
-	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOIDC, properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
@@ -678,11 +680,50 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDCWithoutTokenExchange_M
 
 	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
 
-	result, err := validateIDPProperties(IDPTypeOIDC, properties, s.logger)
+	result, err := validateIDPProperties(context.Background(), IDPTypeOIDC, properties, s.logger)
 
 	s.NotNil(err)
 	s.Nil(result)
 	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
 	s.Contains(err.ErrorDescription.DefaultValue, "required property")
 	s.Contains(err.ErrorDescription.DefaultValue, PropClientSecret)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDP_PropertyValidationFailure() {
+	prop, _ := cmodels.NewProperty("", "value", false)
+	idp := &IDPDTO{
+		Name:       "Test IDP",
+		Type:       IDPTypeOAuth,
+		Properties: []cmodels.Property{*prop},
+	}
+
+	err := validateIDP(context.Background(), idp, s.logger)
+
+	s.NotNil(err)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_SecretPropertyValueUnreadable() {
+	// Initialize the server runtime with the test crypto key; the secret
+	// property below holds a value that is not valid ciphertext, so reading
+	// it fails on decryption.
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("/tmp/test", &config.Config{
+		Crypto: config.CryptoConfig{
+			Encryption: config.EncryptionConfig{
+				Key: testCryptoKey,
+			},
+		},
+	})
+	defer config.ResetServerRuntime()
+
+	properties, dErr := cmodels.DeserializePropertiesFromJSONObject(
+		`{"client_secret":{"value":"not-valid-ciphertext","isSecret":true}}`)
+	s.NoError(dErr)
+
+	result, err := validateIDPProperties(context.Background(), IDPTypeOAuth, properties, s.logger)
+
+	s.Nil(result)
+	s.NotNil(err)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
 }

--- a/backend/internal/system/log/log.go
+++ b/backend/internal/system/log/log.go
@@ -41,6 +41,37 @@ type Logger struct {
 	internal *slog.Logger
 }
 
+// contextHandler decorates a slog.Handler to add the trace ID (correlation ID)
+// from the context to every log record, when present. The trace ID is set in
+// the request context by the CorrelationIDMiddleware.
+type contextHandler struct {
+	slog.Handler
+}
+
+// Handle adds the trace ID from the context to the record before delegating
+// to the wrapped handler. The trace ID is only added when it is actually
+// present in the context; sysContext.GetTraceID is not used here as it
+// generates a new ID when absent, which would stamp unrelated log records
+// with distinct, misleading trace IDs.
+func (h *contextHandler) Handle(ctx context.Context, record slog.Record) error {
+	if ctx != nil {
+		if traceID, ok := ctx.Value(sysContext.TraceIDKey).(string); ok && traceID != "" {
+			record.AddAttrs(slog.String(LoggerKeyTraceID, traceID))
+		}
+	}
+	return h.Handler.Handle(ctx, record)
+}
+
+// WithAttrs preserves the context decoration on loggers derived via With.
+func (h *contextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &contextHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+// WithGroup preserves the context decoration on loggers derived via WithGroup.
+func (h *contextHandler) WithGroup(name string) slog.Handler {
+	return &contextHandler{Handler: h.Handler.WithGroup(name)}
+}
+
 // GetLogger creates and returns a singleton instance of the logger.
 func GetLogger() *Logger {
 	once.Do(func() {
@@ -75,7 +106,7 @@ func initLogger() error {
 	}
 
 	logger = &Logger{
-		internal: slog.New(logHandler),
+		internal: slog.New(&contextHandler{Handler: logHandler}),
 	}
 
 	return nil
@@ -109,23 +140,59 @@ func (l *Logger) IsDebugEnabled() bool {
 }
 
 // Info logs an informational message with custom fields.
+//
+// Deprecated: Info does not propagate the request context, so log entries
+// miss the trace ID (correlation ID). Use InfoWithContext instead. Refs #2038.
 func (l *Logger) Info(msg string, fields ...Field) {
 	l.internal.Info(msg, convertFields(fields)...)
 }
 
 // Debug logs a debug message with custom fields.
+//
+// Deprecated: Debug does not propagate the request context, so log entries
+// miss the trace ID (correlation ID). Use DebugWithContext instead. Refs #2038.
 func (l *Logger) Debug(msg string, fields ...Field) {
 	l.internal.Debug(msg, convertFields(fields)...)
 }
 
 // Warn logs a warning message with custom fields.
+//
+// Deprecated: Warn does not propagate the request context, so log entries
+// miss the trace ID (correlation ID). Use WarnWithContext instead. Refs #2038.
 func (l *Logger) Warn(msg string, fields ...Field) {
 	l.internal.Warn(msg, convertFields(fields)...)
 }
 
 // Error logs an error message with custom fields.
+//
+// Deprecated: Error does not propagate the request context, so log entries
+// miss the trace ID (correlation ID). Use ErrorWithContext instead. Refs #2038.
 func (l *Logger) Error(msg string, fields ...Field) {
 	l.internal.Error(msg, convertFields(fields)...)
+}
+
+// InfoWithContext logs an informational message with custom fields, automatically
+// including the trace ID (correlation ID) from the context if present.
+func (l *Logger) InfoWithContext(ctx context.Context, msg string, fields ...Field) {
+	l.internal.InfoContext(ctx, msg, convertFields(fields)...)
+}
+
+// DebugWithContext logs a debug message with custom fields, automatically
+// including the trace ID (correlation ID) from the context if present.
+func (l *Logger) DebugWithContext(ctx context.Context, msg string, fields ...Field) {
+	l.internal.DebugContext(ctx, msg, convertFields(fields)...)
+}
+
+// WarnWithContext logs a warning message with custom fields, automatically
+// including the trace ID (correlation ID) from the context if present.
+func (l *Logger) WarnWithContext(ctx context.Context, msg string, fields ...Field) {
+	l.internal.WarnContext(ctx, msg, convertFields(fields)...)
+}
+
+// ErrorWithContext logs an error message with custom fields, automatically
+// including the trace ID (correlation ID) from the context if present.
+func (l *Logger) ErrorWithContext(ctx context.Context, msg string, fields ...Field) {
+	l.internal.ErrorContext(ctx, msg, convertFields(fields)...)
 }
 
 // Fatal logs a fatal message with custom fields and exits the application.

--- a/backend/internal/system/log/log_test.go
+++ b/backend/internal/system/log/log_test.go
@@ -20,6 +20,7 @@ package log
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
 	"os"
@@ -30,6 +31,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/constants"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 )
 
 type LogTestSuite struct {
@@ -322,6 +324,111 @@ func (suite *LogTestSuite) TestMaskedMap() {
 		MaskedMap("filters", input)
 		assert.Equal(t, "alice@example.com", input["email"])
 	})
+}
+
+// newContextTestLogger creates a Logger backed by a contextHandler writing to buf.
+func newContextTestLogger(buf *bytes.Buffer) *Logger {
+	handlerOptions := &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}
+	return &Logger{
+		internal: slog.New(&contextHandler{Handler: slog.NewTextHandler(buf, handlerOptions)}),
+	}
+}
+
+func (suite *LogTestSuite) TestContextLogMethodsWithTraceID() {
+	var buf bytes.Buffer
+	log := newContextTestLogger(&buf)
+
+	ctx := sysContext.WithTraceID(context.Background(), "test-trace-123")
+
+	log.DebugWithContext(ctx, "Debug message", Field{Key: "test", Value: "debug"})
+	log.InfoWithContext(ctx, "Info message", Field{Key: "test", Value: "info"})
+	log.WarnWithContext(ctx, "Warning message", Field{Key: "test", Value: "warn"})
+	log.ErrorWithContext(ctx, "Error message", Field{Key: "test", Value: "error"})
+
+	output := buf.String()
+	assert.Contains(suite.T(), output, "Debug message")
+	assert.Contains(suite.T(), output, "Info message")
+	assert.Contains(suite.T(), output, "Warning message")
+	assert.Contains(suite.T(), output, "Error message")
+
+	lines := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n"))
+	assert.Equal(suite.T(), 4, len(lines))
+	for _, line := range lines {
+		assert.Contains(suite.T(), string(line), LoggerKeyTraceID+"=test-trace-123")
+	}
+}
+
+func (suite *LogTestSuite) TestContextLogMethodsWithoutTraceID() {
+	var buf bytes.Buffer
+	log := newContextTestLogger(&buf)
+
+	ctx := context.Background()
+
+	log.DebugWithContext(ctx, "Debug message")
+	log.InfoWithContext(ctx, "Info message")
+	log.WarnWithContext(ctx, "Warning message")
+	log.ErrorWithContext(ctx, "Error message")
+
+	output := buf.String()
+	assert.Contains(suite.T(), output, "Info message")
+	assert.NotContains(suite.T(), output, LoggerKeyTraceID+"=")
+}
+
+func (suite *LogTestSuite) TestDeprecatedMethodsEmitNoTraceID() {
+	var buf bytes.Buffer
+	log := newContextTestLogger(&buf)
+
+	log.Info("Info message") //nolint:staticcheck // Deprecated method must keep working until removal
+
+	output := buf.String()
+	assert.Contains(suite.T(), output, "Info message")
+	assert.NotContains(suite.T(), output, LoggerKeyTraceID+"=")
+}
+
+func (suite *LogTestSuite) TestContextHandlerPreservedByWith() {
+	var buf bytes.Buffer
+	log := newContextTestLogger(&buf)
+
+	ctx := sysContext.WithTraceID(context.Background(), "test-trace-456")
+
+	derivedLogger := log.With(Field{Key: "component", Value: "TestComponent"})
+	derivedLogger.InfoWithContext(ctx, "Derived log message")
+
+	output := buf.String()
+	assert.Contains(suite.T(), output, "Derived log message")
+	assert.Contains(suite.T(), output, "component=TestComponent")
+	assert.Contains(suite.T(), output, LoggerKeyTraceID+"=test-trace-456")
+}
+
+func (suite *LogTestSuite) TestContextHandlerPreservedByWithGroup() {
+	var buf bytes.Buffer
+	handlerOptions := &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}
+	internal := slog.New(&contextHandler{Handler: slog.NewTextHandler(&buf, handlerOptions)})
+
+	ctx := sysContext.WithTraceID(context.Background(), "test-trace-789")
+
+	internal.WithGroup("group").InfoContext(ctx, "Grouped log message", slog.String("key", "value"))
+
+	output := buf.String()
+	assert.Contains(suite.T(), output, "Grouped log message")
+	assert.Contains(suite.T(), output, "group.key=value")
+	assert.Contains(suite.T(), output, LoggerKeyTraceID+"=test-trace-789")
+}
+
+func (suite *LogTestSuite) TestGetLoggerUsesContextHandler() {
+	logger = nil
+	once = sync.Once{}
+
+	err := os.Setenv(constants.LogLevelEnvironmentVariable, "info")
+	assert.NoError(suite.T(), err)
+
+	log := GetLogger()
+	_, ok := log.internal.Handler().(*contextHandler)
+	assert.True(suite.T(), ok, "GetLogger should wrap the handler with contextHandler")
 }
 
 func (suite *LogTestSuite) TestConvertFields() {


### PR DESCRIPTION
### Purpose
Resolves the inability to trace all log entries belonging to a single request. The correlation ID infrastructure already existed (`CorrelationIDMiddleware` extracts/generates a trace ID per request and stores it in the request context), but application log statements never consumed it — only 2 call sites in the backend attached the trace ID, so logs could not be filtered per request when investigating errors.

This PR introduces context-aware logging so that every log entry made with a request context is automatically stamped with `trace_id=<correlation-id>`, and migrates the `idp` package as the first consumer.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

**1. Context-aware logging in `internal/system/log` (the foundation):**

  - A `contextHandler` (`slog.Handler` decorator) wraps the existing `TextHandler`. Its `Handle(ctx, record)` reads the trace ID from the context and appends it to every record — one central choke point, so no call site can "forget" the trace ID once it passes a context.
  - New `InfoContext` / `DebugContext` / `WarnContext` / `ErrorContext`methods on the `Logger` wrapper, mirroring the stdlib `slog` API, deliver the request context to the handler at log time.
  - The handler reads `ctx.Value(TraceIDKey)` directly instead of`sysContext.GetTraceID`, because the latter generates a new random UUID when the context has none — which would stamp unrelated records (startup, lifecycle) with distinct, misleading trace IDs.

**2. Deprecation of the non-context methods (migration driver):**

  - `Info`/`Debug`/`Warn`/`Error` are marked `// Deprecated:` pointing to their replacements. End state (follow-up PRs): once all ~1,861 call sites are migrated, the deprecated methods will be deleted so an uncorrelated log statement becomes a compile error.
  - ⚠️  **Maintainer attention — lint config change:** static check's SA1019 flags every call to a deprecated method as a lint error (~1,861 hits repo-wide). A temporary `exclude-rules` entry in `backend/.golangci.yml` suppresses SA1019 **only for these four methods** so CI stays green during the incremental migration, while IDEs still surface strikethrough deprecation warnings. The exclusion will be removed right before deleting the methods, so any stragglers fail loudly.

 **3. First package migration — `internal/idp`:**

  - All handler/service/store/cache log calls switched to the `*Context` variants using the `ctx` already in scope.
  - `ctx` threaded through the validation helper chain (`validateIDP` → `validateIDPProperties` → `ensureOpenIDScope` → `createAndAppendProperty`).
  - Declarative-resource validation passes `context.Background()` with a justification comment (runs at server startup — no request exists).
  - One intentional leftover: `ValidateResource` in `declarative_resource.go` logs via the deprecated method, as its signature is owned by the `declarativeresource` package interface — it will migrate with that package.

Remaining packages will be migrated in follow-up PRs (one package/group per PR), after which the deprecated methods get deleted.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2038

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved context-aware logging to include request trace IDs for better observability.
  * Responses now mask secret property values when returning created identity-provider data.

* **Tests**
  * Added tests for context-aware logging behavior.
  * Added tests for secret-property handling in IDP requests.
  * Added tests for cache error-handling to ensure resilient behavior.

* **Chores**
  * Temporary lint suppression to ease logging migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->