### PR TITLE
Add tryout with sample flows to welcome flow

### DIFF
--- a/backend/cmd/server/repository/conf/deployment.yaml
+++ b/backend/cmd/server/repository/conf/deployment.yaml
@@ -50,7 +50,9 @@ jwt:
 
 cors:
   allowed_origins:
-    - "https://localhost:3000"
+    - "https://localhost:3000" # This is for test samples, remove it for production
+    - "http://localhost:5173" # This is for wayfinder test sample app, remove it for production
+    - "http://localhost:6274" # This is for wayfinder test sample app, remove it for production
     # - regex: '^https://[a-z0-9-]+\.staging\.example\.com(:[0-9]+)?$'
 
 passkey:

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2",
+  "words": [
+    "thunderid",
+    "wayfinder",
+    "mockery",
+    "oidc",
+    "oauth",
+    "streamable"
+  ]
+}

--- a/frontend/apps/console/src/App.tsx
+++ b/frontend/apps/console/src/App.tsx
@@ -32,6 +32,10 @@ import GroupCreateProvider from './features/groups/contexts/GroupCreate/GroupCre
 import RoleCreateProvider from './features/roles/contexts/RoleCreate/RoleCreateProvider';
 import UserTypeCreateProvider from './features/user-types/contexts/UserTypeCreate/UserTypeCreateProvider';
 import WelcomeRedirect from './features/welcome/components/WelcomeRedirect';
+import GetStartedPage from './features/welcome/pages/GetStartedPage';
+import TryoutSecuringAIAgentsPage from './features/welcome/pages/TryoutSecuringAIAgentsPage';
+import TryoutSecuringConsumerApp from './features/welcome/pages/TryoutSecuringConsumerAppPage';
+import TryoutSecuringMCPPage from './features/welcome/pages/TryoutSecuringMCPPage';
 import DashboardLayout from './layouts/DashboardLayout';
 import FullScreenLayout from './layouts/FullScreenLayout';
 
@@ -323,6 +327,10 @@ export default function App(): JSX.Element {
               <Route path="open-project" element={<ImportConfigurationUploadPage />} />
               <Route path="open-project/validate" element={<ImportConfigurationValidatePage />} />
               <Route path="open-project/summary" element={<ImportConfigurationSummaryPage />} />
+              <Route path="get-started" element={<GetStartedPage />} />
+              <Route path="tryout/consumer-app" element={<TryoutSecuringConsumerApp />} />
+              <Route path="tryout/ai-agents" element={<TryoutSecuringAIAgentsPage />} />
+              <Route path="tryout/mcp" element={<TryoutSecuringMCPPage />} />
             </Route>
             <Route
               path="/design"

--- a/frontend/apps/console/src/features/applications/components/ApplicationsList.tsx
+++ b/frontend/apps/console/src/features/applications/components/ApplicationsList.tsx
@@ -20,7 +20,7 @@ import {ResourceAvatar} from '@thunderid/components';
 import {useConfig} from '@thunderid/contexts';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
-import {Box, Chip, IconButton, Tooltip, Typography, ListingTable, DataGrid, useTheme} from '@wso2/oxygen-ui';
+import {Box, Chip, IconButton, Tooltip, Typography, ListingTable, DataGrid} from '@wso2/oxygen-ui';
 import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useCallback, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -31,7 +31,6 @@ import type {BasicApplication} from '../models/application';
 import getTemplateMetadata from '../utils/getTemplateMetadata';
 
 export default function ApplicationsList(): JSX.Element {
-  const theme = useTheme();
   const navigate = useNavigate();
   const {config} = useConfig();
   const {t} = useTranslation();
@@ -171,7 +170,7 @@ export default function ApplicationsList(): JSX.Element {
         ),
       },
     ],
-    [handleDeleteClick, handleEditClick, systemConsoleClientId, t, theme],
+    [handleDeleteClick, handleEditClick, systemConsoleClientId, t],
   );
 
   if (error) {

--- a/frontend/apps/console/src/features/welcome/api/__tests__/useWayfinderReleases.test.ts
+++ b/frontend/apps/console/src/features/welcome/api/__tests__/useWayfinderReleases.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {renderHook, waitFor} from '@testing-library/react';
+import type {ReactNode} from 'react';
+import {createElement} from 'react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {ReleasesData} from '../../models/download-assets';
+import useWayfinderReleases from '../useWayfinderReleases';
+
+const mockReleasesData: ReleasesData = {
+  latestRelease: {
+    tagName: 'v1.0.0',
+    assets: [
+      {
+        name: 'wayfinder-linux-amd64',
+        downloadUrl: 'https://example.com/wayfinder-linux-amd64',
+        sizeLabel: '10 MB',
+      },
+    ],
+  },
+  releases: [
+    {
+      tagName: 'v1.0.0',
+      assets: [
+        {
+          name: 'wayfinder-linux-amd64',
+          downloadUrl: 'https://example.com/wayfinder-linux-amd64',
+          sizeLabel: '10 MB',
+        },
+      ],
+    },
+  ],
+};
+
+function createWrapper(): ({children}: {children: ReactNode}) => ReactNode {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retryDelay: 0}},
+  });
+  function Wrapper({children}: {children: ReactNode}): ReactNode {
+    return createElement(QueryClientProvider, {client: queryClient}, children);
+  }
+  return Wrapper;
+}
+
+describe('useWayfinderReleases', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns data on successful fetch', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => mockReleasesData,
+    });
+
+    const {result} = renderHook(() => useWayfinderReleases('https://example.com/releases.json'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockReleasesData);
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/releases.json');
+  });
+
+  it('returns error when fetch fails with non-ok status', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+
+    const {result} = renderHook(() => useWayfinderReleases('https://example.com/releases.json'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Failed to fetch releases: 404');
+  });
+
+  it('returns error when fetch throws a network error', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const {result} = renderHook(() => useWayfinderReleases('https://example.com/releases.json'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Network error');
+  });
+
+  it('uses releasesUrl as part of query key', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => mockReleasesData,
+    });
+
+    const wrapper = createWrapper();
+
+    const {result: result1} = renderHook(() => useWayfinderReleases('https://example.com/v1/releases.json'), {
+      wrapper,
+    });
+
+    const {result: result2} = renderHook(() => useWayfinderReleases('https://example.com/v2/releases.json'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result1.current.isSuccess).toBe(true));
+    await waitFor(() => expect(result2.current.isSuccess).toBe(true));
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/v1/releases.json');
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/v2/releases.json');
+  });
+});

--- a/frontend/apps/console/src/features/welcome/api/useWayfinderReleases.ts
+++ b/frontend/apps/console/src/features/welcome/api/useWayfinderReleases.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import type {ReleasesData} from '../models/download-assets';
+
+export default function useWayfinderReleases(releasesUrl: string): UseQueryResult<ReleasesData, Error> {
+  return useQuery<ReleasesData, Error>({
+    queryKey: ['wayfinder-releases', releasesUrl],
+    queryFn: async (): Promise<ReleasesData> => {
+      const response = await fetch(releasesUrl);
+      if (!response.ok) throw new Error(`Failed to fetch releases: ${response.status}`);
+      return response.json() as Promise<ReleasesData>;
+    },
+    retry: 1,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/apps/console/src/features/welcome/components/TerminalBlock.tsx
+++ b/frontend/apps/console/src/features/welcome/components/TerminalBlock.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, IconButton, Typography} from '@wso2/oxygen-ui';
+import {Check, Copy, Play} from '@wso2/oxygen-ui-icons-react';
+import type {JSX, ReactNode} from 'react';
+import {useState} from 'react';
+
+interface TerminalBlockProps {
+  command: string;
+  tabs?: ReactNode;
+}
+
+export default function TerminalBlock({command, tabs = undefined}: TerminalBlockProps): JSX.Element {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (): void => {
+    void navigator.clipboard.writeText(command).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden'}}>
+      {tabs && <Box sx={{borderBottom: '1px solid', borderColor: 'divider'}}>{tabs}</Box>}
+      <Box sx={{bgcolor: 'black', px: 2, py: 1.5, display: 'flex', alignItems: 'center', gap: 1}}>
+        <Play size={12} style={{opacity: 0.4, color: '#fff', flexShrink: 0}} />
+        <Typography variant="body2" fontFamily="monospace" sx={{flex: 1, color: 'success.light'}}>
+          {command}
+        </Typography>
+        <IconButton
+          size="small"
+          aria-label="Copy command"
+          onClick={handleCopy}
+          sx={{color: copied ? 'success.light' : 'grey.400', '&:hover': {color: 'grey.100'}}}
+        >
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+        </IconButton>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/components/WayfinderFolderImport.tsx
+++ b/frontend/apps/console/src/features/welcome/components/WayfinderFolderImport.tsx
@@ -1,0 +1,308 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useConfig} from '@thunderid/contexts';
+import {Box, Button, CircularProgress, Stack, Typography} from '@wso2/oxygen-ui';
+import {CheckCircle, FileCode, FileText, FolderOpen, RefreshCw, XCircle} from '@wso2/oxygen-ui-icons-react';
+import type {JSX} from 'react';
+import {useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import useImportConfiguration from '../../import-export/api/useImportConfiguration';
+import type {ImportResponse} from '../../import-export/models/import-configuration';
+
+const IMPORTED_KEY = 'thunderid-wayfinder-config-imported';
+
+type Status = 'idle' | 'selected' | 'importing' | 'success' | 'alreadyDone' | 'error';
+
+interface FoundFiles {
+  folderName: string;
+  yamlFile: File;
+  envFile: File | null;
+}
+
+function parseEnvFile(content: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    vars[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return vars;
+}
+
+async function pickConfigFiles(): Promise<FoundFiles> {
+  // showDirectoryPicker only reads metadata for files we explicitly request —
+  // no enumeration of the whole folder tree.
+  const w = window as unknown as {showDirectoryPicker: () => Promise<FileSystemDirectoryHandle>};
+  const dirHandle = await w.showDirectoryPicker();
+
+  const configDirHandle = await dirHandle.getDirectoryHandle('thunderid-config');
+
+  let yamlFileHandle: FileSystemFileHandle | null = null;
+  for (const name of ['thunderid-config.yaml', 'thunderid-config.yml']) {
+    try {
+      yamlFileHandle = await configDirHandle.getFileHandle(name);
+      break;
+    } catch {
+      // try next
+    }
+  }
+
+  if (!yamlFileHandle) {
+    throw new Error('yaml_not_found');
+  }
+
+  let envFileHandle: FileSystemFileHandle | null = null;
+  try {
+    envFileHandle = await configDirHandle.getFileHandle('thunderid.env');
+  } catch {
+    // env file is optional
+  }
+
+  const yamlFile = await yamlFileHandle.getFile();
+  const envFile = envFileHandle ? await envFileHandle.getFile() : null;
+
+  return {folderName: dirHandle.name, yamlFile, envFile};
+}
+
+function formatImportedDate(ts: string): string {
+  const date = new Date(Number(ts));
+  if (isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, {day: 'numeric', month: 'short', year: 'numeric'});
+}
+
+interface WayfinderFolderImportProps {
+  onSuccess?: () => void;
+}
+
+export default function WayfinderFolderImport({onSuccess = undefined}: WayfinderFolderImportProps): JSX.Element {
+  const {t} = useTranslation(['common']);
+  const {config} = useConfig();
+  const productName = config.brand.product_name;
+  const {mutateAsync: importConfig} = useImportConfiguration();
+
+  const [status, setStatus] = useState<Status>(() => {
+    const ts = localStorage.getItem(IMPORTED_KEY);
+    return ts ? 'alreadyDone' : 'idle';
+  });
+  const [found, setFound] = useState<FoundFiles | null>(null);
+  const [result, setResult] = useState<ImportResponse | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const previousTs = localStorage.getItem(IMPORTED_KEY);
+
+  const handleSelectFolder = async (): Promise<void> => {
+    try {
+      const files = await pickConfigFiles();
+      setFound(files);
+      setErrorMsg(null);
+      setStatus('selected');
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      setErrorMsg(t('common:welcome.wayfinderFolderImport.errors.cannotReadFolder'));
+      setStatus('error');
+      setFound(null);
+    }
+  };
+
+  const handleImport = async (): Promise<void> => {
+    if (!found) return;
+    setStatus('importing');
+    setErrorMsg(null);
+
+    try {
+      const content = await found.yamlFile.text();
+      const variables = found.envFile ? parseEnvFile(await found.envFile.text()) : undefined;
+
+      const response = await importConfig({content, variables, options: {upsert: true}});
+      setResult(response);
+      if (response.summary.failed > 0) {
+        setErrorMsg(t('common:welcome.wayfinderFolderImport.errors.partialFailure', {count: response.summary.failed}));
+        setStatus('error');
+      } else {
+        localStorage.setItem(IMPORTED_KEY, Date.now().toString());
+        setStatus('success');
+        onSuccess?.();
+      }
+    } catch {
+      setErrorMsg(t('common:welcome.wayfinderFolderImport.errors.importFailed'));
+      setStatus('error');
+    }
+  };
+
+  const handleReset = (): void => {
+    setStatus('idle');
+    setFound(null);
+    setResult(null);
+    setErrorMsg(null);
+  };
+
+  if (status === 'importing') {
+    return (
+      <Stack direction="row" spacing={1.5} alignItems="center">
+        <CircularProgress size={18} />
+        <Typography variant="body2" color="text.secondary">
+          {t('common:welcome.wayfinderFolderImport.status.importing')}
+        </Typography>
+      </Stack>
+    );
+  }
+
+  if (status === 'alreadyDone') {
+    return (
+      <Stack spacing={1}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <CheckCircle size={20} style={{color: 'var(--oxygen-palette-success-main)'}} />
+          <Typography variant="body2" fontWeight={600} color="success.main">
+            {t('common:welcome.wayfinderFolderImport.status.alreadyDone', {productName})}
+          </Typography>
+        </Stack>
+        {previousTs && (
+          <Typography variant="caption" color="text.secondary">
+            {t('common:welcome.wayfinderFolderImport.status.lastImported', {date: formatImportedDate(previousTs)})}
+          </Typography>
+        )}
+        <Box>
+          <Button
+            variant="text"
+            size="small"
+            startIcon={<RefreshCw size={13} />}
+            sx={{pl: 0, color: 'text.secondary', fontSize: '0.75rem'}}
+            onClick={handleReset}
+          >
+            {t('common:welcome.wayfinderFolderImport.actions.reImport')}
+          </Button>
+        </Box>
+      </Stack>
+    );
+  }
+
+  if (status === 'success' && result) {
+    return (
+      <Stack spacing={1}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <CheckCircle size={20} style={{color: 'var(--oxygen-palette-success-main)'}} />
+          <Typography variant="body2" fontWeight={600} color="success.main">
+            {t('common:welcome.wayfinderFolderImport.status.success', {productName})}
+          </Typography>
+        </Stack>
+        <Typography variant="caption" color="text.secondary">
+          {t('common:welcome.wayfinderFolderImport.status.resourcesImported', {count: result.summary.imported})}
+        </Typography>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing={1.5}>
+      {status === 'idle' && (
+        <Box>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<FolderOpen size={16} />}
+            onClick={() => void handleSelectFolder()}
+          >
+            {t('common:welcome.wayfinderFolderImport.actions.selectFolder')}
+          </Button>
+        </Box>
+      )}
+
+      {status === 'selected' && found && (
+        <Stack spacing={1.5}>
+          <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 1.5, px: 2, py: 1.5}}>
+            <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1}}>
+              <FolderOpen size={16} style={{opacity: 0.5, flexShrink: 0}} />
+              <Typography variant="body2" fontWeight={600} noWrap sx={{flex: 1}}>
+                {found.folderName}/
+              </Typography>
+              <Button
+                size="small"
+                variant="text"
+                sx={{fontSize: '0.7rem', flexShrink: 0}}
+                onClick={() => void handleSelectFolder()}
+              >
+                {t('common:welcome.wayfinderFolderImport.actions.change')}
+              </Button>
+            </Stack>
+            <Stack spacing={0.5} sx={{pl: 0.5}}>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <FileCode size={13} style={{opacity: 0.5, flexShrink: 0}} />
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  thunderid-config/{found.yamlFile.name}
+                </Typography>
+              </Stack>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <FileText size={13} style={{opacity: 0.5, flexShrink: 0}} />
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  {found.envFile
+                    ? `thunderid-config/${found.envFile.name}`
+                    : t('common:welcome.wayfinderFolderImport.status.envNotFound')}
+                </Typography>
+              </Stack>
+            </Stack>
+          </Box>
+          <Box>
+            <Button variant="contained" size="small" onClick={() => void handleImport()}>
+              {t('common:welcome.wayfinderFolderImport.actions.importConfig')}
+            </Button>
+          </Box>
+        </Stack>
+      )}
+
+      {status === 'error' && (
+        <Stack spacing={1}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <XCircle size={16} style={{color: 'var(--oxygen-palette-error-main)', flexShrink: 0}} />
+            <Typography variant="caption" color="error.main">
+              {errorMsg}
+            </Typography>
+          </Stack>
+          {result?.results
+            .filter((r) => r.status === 'failed')
+            .map((r) => (
+              <Typography
+                key={`${r.resourceType}-${r.resourceId ?? r.resourceName ?? r.message}`}
+                variant="caption"
+                color="error.main"
+                sx={{pl: 3, display: 'block'}}
+              >
+                {r.resourceType}
+                {r.resourceName ? ` · ${r.resourceName}` : ''}: {r.message}
+              </Typography>
+            ))}
+          <Box>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<RefreshCw size={13} />}
+              onClick={() => {
+                handleReset();
+                void handleSelectFolder();
+              }}
+            >
+              {t('common:welcome.wayfinderFolderImport.actions.reSelectFolder')}
+            </Button>
+          </Box>
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/components/WayfinderSampleDownload.tsx
+++ b/frontend/apps/console/src/features/welcome/components/WayfinderSampleDownload.tsx
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, Button, Chip, Collapse, Stack, Typography} from '@wso2/oxygen-ui';
+import {ChevronDown, ChevronUp, Download} from '@wso2/oxygen-ui-icons-react';
+import type {JSX} from 'react';
+import {useEffect, useMemo, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import useWayfinderReleases from '../api/useWayfinderReleases';
+import OS_LABELS from '../constants/download-assets';
+import type {DetectedPlatform} from '../models/download-assets';
+import {detectPlatform, groupAssetsByOs, parseDistributionAssets, pickAssetForPlatform} from '../utils/downloadAssets';
+
+export default function WayfinderSampleDownload({releasesUrl}: {releasesUrl: string}): JSX.Element | null {
+  const {t} = useTranslation(['common']);
+  const [platform, setPlatform] = useState<DetectedPlatform | null>(null);
+  const [showOthers, setShowOthers] = useState(false);
+
+  const pattern = useMemo(() => /^sample-app-wayfinder-[0-9A-Za-z.+-]+-(macos|linux|win)-(arm64|x64)\.zip$/i, []);
+
+  useEffect(() => {
+    detectPlatform()
+      .then(setPlatform)
+      .catch(() => undefined);
+  }, []);
+
+  const {data, isError: errored} = useWayfinderReleases(releasesUrl);
+
+  const release = data ? (data.latestRelease ?? data.releases?.[0] ?? null) : null;
+  const tag = release?.tagName ?? '';
+  const assets = useMemo(() => (release ? parseDistributionAssets(release.assets, pattern) : null), [release, pattern]);
+
+  const selected = useMemo(() => pickAssetForPlatform(assets ?? [], platform), [assets, platform]);
+  const matched = selected && selected.os === platform?.os && selected.arch === platform?.arch;
+  const groups = useMemo(() => groupAssetsByOs(assets ?? [], selected?.os ?? null), [assets, selected]);
+
+  if (errored || (assets !== null && assets.length === 0)) return null;
+  if (!selected) return null;
+
+  return (
+    <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden'}}>
+      {/* Primary download row */}
+      <Box
+        sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, p: 2, flexWrap: 'wrap'}}
+      >
+        <Box>
+          <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 0.25}}>
+            {matched
+              ? t('common:welcome.wayfinderSampleDownload.recommendedLabel')
+              : t('common:welcome.wayfinderSampleDownload.selectedLabel')}
+          </Typography>
+          <Typography variant="subtitle2" fontWeight={600}>
+            {selected.osLabel} · {selected.archLabel}
+          </Typography>
+          <Stack direction="row" spacing={1} sx={{mt: 0.5, flexWrap: 'wrap'}}>
+            {tag && <Chip label={tag} size="small" />}
+            {selected.sizeLabel && <Chip label={selected.sizeLabel} size="small" variant="outlined" />}
+          </Stack>
+        </Box>
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<Download size={16} />}
+          href={selected.downloadUrl}
+          target="_blank"
+          rel="noreferrer"
+          component="a"
+        >
+          {t('common:welcome.wayfinderSampleDownload.downloadButton', {osLabel: selected.osLabel})}
+        </Button>
+      </Box>
+
+      {/* Other platforms toggle */}
+      {groups.length > 1 && (
+        <>
+          <Box
+            role="button"
+            tabIndex={0}
+            onClick={() => setShowOthers((v) => !v)}
+            onKeyDown={(e: React.KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setShowOthers((v) => !v);
+              }
+            }}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              px: 2,
+              py: 1,
+              borderTop: '1px solid',
+              borderColor: 'divider',
+              cursor: 'pointer',
+              bgcolor: 'action.hover',
+              '&:hover': {bgcolor: 'action.selected'},
+            }}
+          >
+            {showOthers ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+            <Typography variant="caption">
+              {showOthers
+                ? t('common:welcome.wayfinderSampleDownload.hidePlatforms')
+                : t('common:welcome.wayfinderSampleDownload.otherPlatforms')}
+            </Typography>
+          </Box>
+          <Collapse in={showOthers}>
+            <Box sx={{p: 2, display: 'flex', gap: 2, flexWrap: 'wrap'}}>
+              {groups.map(({os, assets: osAssets}) => (
+                <Box key={os} sx={{minWidth: 160}}>
+                  <Typography variant="caption" fontWeight={600} color="text.secondary" sx={{display: 'block', mb: 1}}>
+                    {OS_LABELS[os]}
+                  </Typography>
+                  <Stack spacing={0.5}>
+                    {osAssets.map((asset) => (
+                      <Box
+                        key={asset.name}
+                        component="a"
+                        href={asset.downloadUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1,
+                          textDecoration: 'none',
+                          color: 'inherit',
+                          px: 1.5,
+                          py: 0.75,
+                          borderRadius: 1,
+                          border: '1px solid',
+                          borderColor: asset.downloadUrl === selected.downloadUrl ? 'primary.main' : 'divider',
+                          '&:hover': {bgcolor: 'action.hover'},
+                        }}
+                      >
+                        <Box sx={{flex: 1}}>
+                          <Typography variant="caption" sx={{display: 'block', fontWeight: 500}}>
+                            {asset.osLabel} {asset.archLabel}
+                          </Typography>
+                          {asset.sizeLabel && (
+                            <Typography variant="caption" color="text.secondary">
+                              {asset.sizeLabel}
+                            </Typography>
+                          )}
+                        </Box>
+                        <Download size={12} style={{opacity: 0.5}} />
+                      </Box>
+                    ))}
+                  </Stack>
+                </Box>
+              ))}
+            </Box>
+          </Collapse>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/components/WayfinderSampleSetup.tsx
+++ b/frontend/apps/console/src/features/welcome/components/WayfinderSampleSetup.tsx
@@ -1,0 +1,241 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useConfig} from '@thunderid/contexts';
+import {Box, Divider, Stack, Tab, Tabs, Typography} from '@wso2/oxygen-ui';
+import {CheckCircle, ChevronRight, Database, Download, Play, Settings} from '@wso2/oxygen-ui-icons-react';
+import type {JSX} from 'react';
+import {useEffect, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import TerminalBlock from './TerminalBlock';
+import WayfinderFolderImport from './WayfinderFolderImport';
+import WayfinderSampleDownload from './WayfinderSampleDownload';
+import {detectPlatform} from '../utils/downloadAssets';
+
+const IMPORTED_KEY = 'thunderid-wayfinder-config-imported';
+const EXPANDED_KEY = 'thunderid-wayfinder-setup-expanded';
+
+export default function WayfinderSampleSetup(): JSX.Element {
+  const {t} = useTranslation(['common']);
+  const {config} = useConfig();
+  const productName = config.brand.product_name;
+  const releasesUrl = config.brand.docs_url ? `${new URL(config.brand.docs_url).origin}/data/releases.json` : '';
+
+  const [osTab, setOsTab] = useState<'unix' | 'windows'>('unix');
+  const [isDone, setIsDone] = useState(() => !!localStorage.getItem(IMPORTED_KEY));
+  const [expanded, setExpanded] = useState(() => {
+    const saved = sessionStorage.getItem(EXPANDED_KEY);
+    if (saved !== null) return saved === 'true';
+    return !localStorage.getItem(IMPORTED_KEY);
+  });
+
+  useEffect(() => {
+    detectPlatform()
+      .then((p) => {
+        if (p.os === 'win') setOsTab('windows');
+      })
+      .catch(() => undefined);
+  }, []);
+
+  const handleImportSuccess = (): void => {
+    setIsDone(true);
+    setExpanded(false);
+    sessionStorage.setItem(EXPANDED_KEY, 'false');
+  };
+
+  const toggle = (): void =>
+    setExpanded((v) => {
+      sessionStorage.setItem(EXPANDED_KEY, String(!v));
+      return !v;
+    });
+
+  const subStepNumber = (n: number): JSX.Element => (
+    <Box
+      sx={{
+        width: 24,
+        height: 24,
+        borderRadius: '50%',
+        bgcolor: 'action.selected',
+        color: 'text.primary',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '0.75rem',
+        fontWeight: 700,
+        flexShrink: 0,
+        mt: 0.25,
+      }}
+    >
+      {n}
+    </Box>
+  );
+
+  const cmd = osTab === 'unix' ? './start.sh' : '.\\start.ps1';
+
+  return (
+    <Box
+      sx={{border: '1px solid', borderColor: isDone ? 'success.light' : 'divider', borderRadius: 2, overflow: 'hidden'}}
+    >
+      {/* Header */}
+      <Box
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        onClick={toggle}
+        onKeyDown={(e: React.KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+        sx={{
+          p: 2.5,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          bgcolor: 'action.selected',
+          cursor: 'pointer',
+          userSelect: 'none',
+          '&:hover': {bgcolor: 'action.hover'},
+          borderBottom: expanded ? '1px solid' : 'none',
+          borderColor: 'divider',
+        }}
+      >
+        <Box
+          sx={{
+            width: 40,
+            height: 40,
+            borderRadius: 2,
+            bgcolor: isDone ? 'success.lighter' : 'background.paper',
+            color: isDone ? 'success.main' : 'text.secondary',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          {isDone ? <CheckCircle size={22} /> : <Settings size={22} />}
+        </Box>
+        <Box sx={{flex: 1, minWidth: 0}}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="subtitle1" fontWeight={600}>
+              {t('common:welcome.wayfinderSampleSetup.title')}
+            </Typography>
+            <Typography
+              variant="caption"
+              sx={{px: 1, py: 0.25, borderRadius: 1, bgcolor: 'action.hover', color: 'text.secondary', flexShrink: 0}}
+            >
+              {t('common:welcome.wayfinderSampleSetup.oneTimeSetup')}
+            </Typography>
+          </Stack>
+          {isDone && !expanded && (
+            <Typography variant="caption" color="success.main">
+              {t('common:welcome.wayfinderSampleSetup.setupComplete')}
+            </Typography>
+          )}
+        </Box>
+        <ChevronRight
+          size={18}
+          style={{
+            transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+            transition: 'transform 0.2s',
+            flexShrink: 0,
+            color: 'inherit',
+            opacity: 0.6,
+          }}
+        />
+      </Box>
+
+      {/* Sub-steps */}
+      {expanded && (
+        <Stack divider={<Divider />}>
+          {/* 1 — Download */}
+          <Box sx={{p: 2.5}}>
+            <Stack direction="row" spacing={2} alignItems="flex-start">
+              {subStepNumber(1)}
+              <Box sx={{flex: 1}}>
+                <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 0.5}}>
+                  <Box sx={{color: 'text.secondary', display: 'flex'}}>
+                    <Download size={16} />
+                  </Box>
+                  <Typography variant="subtitle2" fontWeight={600}>
+                    {t('common:welcome.wayfinderSampleSetup.steps.getSample.title')}
+                  </Typography>
+                </Stack>
+                <Typography variant="body2" color="text.secondary" sx={{mb: 1.5}}>
+                  {t('common:welcome.wayfinderSampleSetup.steps.getSample.description')}
+                </Typography>
+                {releasesUrl ? <WayfinderSampleDownload releasesUrl={releasesUrl} /> : null}
+              </Box>
+            </Stack>
+          </Box>
+
+          {/* 2 — Configure ThunderID */}
+          <Box sx={{p: 2.5}}>
+            <Stack direction="row" spacing={2} alignItems="flex-start">
+              {subStepNumber(2)}
+              <Box sx={{flex: 1}}>
+                <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 0.5}}>
+                  <Box sx={{color: 'text.secondary', display: 'flex'}}>
+                    <Database size={16} />
+                  </Box>
+                  <Typography variant="subtitle2" fontWeight={600}>
+                    {t('common:welcome.wayfinderSampleSetup.steps.configure.title', {productName})}
+                  </Typography>
+                </Stack>
+                <Typography variant="body2" color="text.secondary" sx={{mb: 1.5}}>
+                  {t('common:welcome.wayfinderSampleSetup.steps.configure.description', {productName})}
+                </Typography>
+                <WayfinderFolderImport onSuccess={handleImportSuccess} />
+              </Box>
+            </Stack>
+          </Box>
+
+          {/* 3 — Run */}
+          <Box sx={{p: 2.5}}>
+            <Stack direction="row" spacing={2} alignItems="flex-start">
+              {subStepNumber(3)}
+              <Box sx={{flex: 1}}>
+                <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 0.5}}>
+                  <Box sx={{color: 'text.secondary', display: 'flex'}}>
+                    <Play size={16} />
+                  </Box>
+                  <Typography variant="subtitle2" fontWeight={600}>
+                    {t('common:welcome.wayfinderSampleSetup.steps.run.title')}
+                  </Typography>
+                </Stack>
+                <Typography variant="body2" color="text.secondary" sx={{mb: 1.5}}>
+                  {t('common:welcome.wayfinderSampleSetup.steps.run.description')}
+                </Typography>
+                <TerminalBlock
+                  command={cmd}
+                  tabs={
+                    <Tabs value={osTab} onChange={(_e, v: 'unix' | 'windows') => setOsTab(v)} sx={{minHeight: 40}}>
+                      <Tab label="Linux / macOS" value="unix" sx={{minHeight: 40, fontSize: '0.75rem'}} />
+                      <Tab label="Windows" value="windows" sx={{minHeight: 40, fontSize: '0.75rem'}} />
+                    </Tabs>
+                  }
+                />
+              </Box>
+            </Stack>
+          </Box>
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/components/__tests__/TerminalBlock.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/TerminalBlock.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, userEvent, act, fireEvent} from '@thunderid/test-utils';
+import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    create: (Component: React.ElementType) => Component,
+  },
+}));
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    Check: () => <span data-testid="icon-check" />,
+    Copy: () => <span data-testid="icon-copy" />,
+    Play: () => <span data-testid="icon-play" />,
+  };
+});
+
+import TerminalBlock from '../TerminalBlock';
+
+describe('TerminalBlock', () => {
+  let writeTextSpy: ReturnType<typeof vi.fn>;
+
+  beforeAll(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {writeText: vi.fn()},
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  beforeEach(() => {
+    writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const {container} = render(<TerminalBlock command="echo hello" />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders the command text', () => {
+    render(<TerminalBlock command="echo hello" />);
+    expect(screen.getByText('echo hello')).toBeInTheDocument();
+  });
+
+  it('renders tabs when provided', () => {
+    render(<TerminalBlock command="echo hello" tabs={<div data-testid="tab-content">Tab 1</div>} />);
+    expect(screen.getByTestId('tab-content')).toBeInTheDocument();
+    expect(screen.getByText('Tab 1')).toBeInTheDocument();
+  });
+
+  it('does not render tabs section when not provided', () => {
+    render(<TerminalBlock command="echo hello" />);
+    expect(screen.queryByTestId('tab-content')).not.toBeInTheDocument();
+  });
+
+  // Swapped order: check icon test first, then writeText call test
+  it('copy button shows check icon after copying', async () => {
+    const user = userEvent.setup();
+    render(<TerminalBlock command="echo hello" />);
+
+    expect(screen.getByTestId('icon-copy')).toBeInTheDocument();
+    expect(screen.queryByTestId('icon-check')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: /copy command/i}));
+
+    expect(await screen.findByTestId('icon-check')).toBeInTheDocument();
+    expect(screen.queryByTestId('icon-copy')).not.toBeInTheDocument();
+  });
+
+  it('copy button calls clipboard.writeText with the command', async () => {
+    const user = userEvent.setup();
+    render(<TerminalBlock command="echo hello" />);
+
+    await user.click(screen.getByRole('button', {name: /copy command/i}));
+
+    expect(writeTextSpy).toHaveBeenCalledWith('echo hello');
+  });
+
+  it('copy button reverts to copy icon after 2 seconds', async () => {
+    vi.useFakeTimers({toFake: ['setTimeout', 'clearTimeout']});
+    render(<TerminalBlock command="echo hello" />);
+
+    fireEvent.click(screen.getByRole('button', {name: /copy command/i}));
+
+    // Flush the .then() microtask → setCopied(true) → React re-render
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('icon-check')).toBeInTheDocument();
+
+    // Advance the 2000ms timer → setCopied(false) → React re-render
+    act(() => {
+      vi.advanceTimersByTime(2001);
+    });
+    expect(screen.getByTestId('icon-copy')).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+});

--- a/frontend/apps/console/src/features/welcome/components/__tests__/WayfinderFolderImport.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/WayfinderFolderImport.test.tsx
@@ -1,0 +1,318 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, userEvent, waitFor} from '@thunderid/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    create: (Component: React.ElementType) => Component,
+  },
+}));
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    CheckCircle: () => <span data-testid="icon-check-circle" />,
+    FileCode: () => <span data-testid="icon-file-code" />,
+    FileText: () => <span data-testid="icon-file-text" />,
+    FolderOpen: () => <span data-testid="icon-folder-open" />,
+    RefreshCw: () => <span data-testid="icon-refresh-cw" />,
+    XCircle: () => <span data-testid="icon-x-circle" />,
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts) {
+        return `${key}:${JSON.stringify(opts)}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+const {mockUseImportConfiguration, mockMutateAsync} = vi.hoisted(() => ({
+  mockUseImportConfiguration: vi.fn(),
+  mockMutateAsync: vi.fn(),
+}));
+
+vi.mock('../../../import-export/api/useImportConfiguration', () => ({
+  default: mockUseImportConfiguration,
+}));
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({config: {brand: {product_name: 'ThunderID'}}}),
+  };
+});
+
+function buildDirectoryPickerMock(
+  folderName = 'my-project',
+  {includeEnv = true}: {includeEnv?: boolean} = {},
+): FileSystemDirectoryHandle {
+  // Use plain async functions (not vi.fn()) so restoreMocks does not wipe them.
+  const yamlMockFile = {
+    name: 'thunderid-config.yaml',
+    text: (): Promise<string> => Promise.resolve('yaml content'),
+  };
+  const envMockFile = {
+    name: 'thunderid.env',
+    text: (): Promise<string> => Promise.resolve('KEY=value'),
+  };
+  const yamlHandle = {getFile: () => Promise.resolve(yamlMockFile)};
+  const envHandle = {getFile: () => Promise.resolve(envMockFile)};
+
+  const configDir = {
+    getFileHandle: (name: string) => {
+      if (name === 'thunderid-config.yaml') return Promise.resolve(yamlHandle);
+      if (name === 'thunderid-config.yml') return Promise.reject(new Error('not found'));
+      if (name === 'thunderid.env' && includeEnv) return Promise.resolve(envHandle);
+      return Promise.reject(new Error(`not found: ${name}`));
+    },
+  };
+
+  return {
+    name: folderName,
+    getDirectoryHandle: (dirName: string) => {
+      if (dirName === 'thunderid-config') return Promise.resolve(configDir);
+      return Promise.reject(new Error(`not found: ${dirName}`));
+    },
+  } as unknown as FileSystemDirectoryHandle;
+}
+
+import WayfinderFolderImport from '../WayfinderFolderImport';
+
+describe('WayfinderFolderImport', () => {
+  const mockLocalStorageGetItem = vi.fn();
+  const mockLocalStorageSetItem = vi.fn();
+
+  beforeEach(() => {
+    mockLocalStorageGetItem.mockReturnValue(null);
+    vi.stubGlobal('localStorage', {
+      getItem: mockLocalStorageGetItem,
+      setItem: mockLocalStorageSetItem,
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
+    vi.stubGlobal('showDirectoryPicker', vi.fn().mockResolvedValue(buildDirectoryPickerMock()));
+    mockUseImportConfiguration.mockReturnValue({mutateAsync: mockMutateAsync});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders without crashing', () => {
+    const {container} = render(<WayfinderFolderImport />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('shows "Select Wayfinder Sample Folder" button when idle', () => {
+    render(<WayfinderFolderImport />);
+    expect(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder')).toBeInTheDocument();
+  });
+
+  it('shows alreadyDone state when localStorage has the key', () => {
+    mockLocalStorageGetItem.mockReturnValue(Date.now().toString());
+    render(<WayfinderFolderImport />);
+    expect(
+      screen.getByText('common:welcome.wayfinderFolderImport.status.alreadyDone:{"productName":"ThunderID"}'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.wayfinderFolderImport.actions.reImport')).toBeInTheDocument();
+  });
+
+  it('re-import button in alreadyDone state resets to idle', async () => {
+    mockLocalStorageGetItem.mockReturnValue(Date.now().toString());
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.reImport'));
+
+    expect(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder')).toBeInTheDocument();
+  });
+
+  it('stays idle when directory picker is aborted', async () => {
+    const abortError = new DOMException('User aborted', 'AbortError');
+    vi.stubGlobal('showDirectoryPicker', vi.fn().mockRejectedValue(abortError));
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+
+    expect(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder')).toBeInTheDocument();
+    expect(screen.queryByTestId('icon-x-circle')).not.toBeInTheDocument();
+  });
+
+  it('shows error state when picker fails with non-abort error', async () => {
+    vi.stubGlobal('showDirectoryPicker', vi.fn().mockRejectedValue(new Error('permission denied')));
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+
+    expect(await screen.findByText('common:welcome.wayfinderFolderImport.errors.cannotReadFolder')).toBeInTheDocument();
+  });
+
+  it('shows folder name and file names after folder is selected', async () => {
+    vi.stubGlobal('showDirectoryPicker', vi.fn().mockResolvedValue(buildDirectoryPickerMock('my-project')));
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+
+    expect(await screen.findByText('my-project/')).toBeInTheDocument();
+    expect(screen.getByText(/thunderid-config\/thunderid-config\.yaml/)).toBeInTheDocument();
+    expect(screen.getByText(/thunderid-config\/thunderid\.env/)).toBeInTheDocument();
+  });
+
+  it('shows "Configure in ThunderID" button after folder is selected', async () => {
+    vi.stubGlobal('showDirectoryPicker', vi.fn().mockResolvedValue(buildDirectoryPickerMock()));
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+
+    expect(await screen.findByText('common:welcome.wayfinderFolderImport.actions.importConfig')).toBeInTheDocument();
+  });
+
+  it('clicking import calls mutateAsync', async () => {
+    mockMutateAsync.mockResolvedValue({
+      summary: {totalDocuments: 2, imported: 2, failed: 0, importedAt: ''},
+      results: [],
+    });
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+    await user.click(await screen.findByText('common:welcome.wayfinderFolderImport.actions.importConfig'));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'yaml content',
+          options: {upsert: true},
+        }),
+      );
+    });
+  });
+
+  it('shows success message on import success', async () => {
+    mockMutateAsync.mockResolvedValue({
+      summary: {totalDocuments: 2, imported: 2, failed: 0, importedAt: ''},
+      results: [],
+    });
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+    await user.click(await screen.findByText('common:welcome.wayfinderFolderImport.actions.importConfig'));
+
+    expect(
+      await screen.findByText('common:welcome.wayfinderFolderImport.status.success:{"productName":"ThunderID"}'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows error with count on partial failure', async () => {
+    mockMutateAsync.mockResolvedValue({
+      summary: {totalDocuments: 3, imported: 2, failed: 1, importedAt: ''},
+      results: [{resourceType: 'application', status: 'failed', message: 'conflict'}],
+    });
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+    await user.click(await screen.findByText('common:welcome.wayfinderFolderImport.actions.importConfig'));
+
+    expect(
+      await screen.findByText('common:welcome.wayfinderFolderImport.errors.partialFailure:{"count":1}'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows error message on import error', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('server error'));
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+    await user.click(await screen.findByText('common:welcome.wayfinderFolderImport.actions.importConfig'));
+
+    expect(await screen.findByText('common:welcome.wayfinderFolderImport.errors.importFailed')).toBeInTheDocument();
+  });
+
+  it('shows error when yaml file is not found in selected folder', async () => {
+    const noYamlDir = {
+      getFileHandle: () => Promise.reject(new Error('not found')),
+    };
+    vi.stubGlobal(
+      'showDirectoryPicker',
+      vi.fn().mockResolvedValue({
+        name: 'no-yaml-project',
+        getDirectoryHandle: (dirName: string) => {
+          if (dirName === 'thunderid-config') return Promise.resolve(noYamlDir);
+          return Promise.reject(new Error('not found'));
+        },
+      }),
+    );
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+
+    expect(await screen.findByText('common:welcome.wayfinderFolderImport.errors.cannotReadFolder')).toBeInTheDocument();
+  });
+
+  it('change button in found state re-opens folder picker', async () => {
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+    await screen.findByText('common:welcome.wayfinderFolderImport.actions.importConfig');
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.change'));
+
+    expect(
+      vi.mocked(
+        (window as unknown as {showDirectoryPicker: () => Promise<FileSystemDirectoryHandle>}).showDirectoryPicker,
+      ),
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-select folder button in error state resets and re-opens picker', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('server error'));
+    const user = userEvent.setup();
+    render(<WayfinderFolderImport />);
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.selectFolder'));
+    await user.click(await screen.findByText('common:welcome.wayfinderFolderImport.actions.importConfig'));
+    await screen.findByText('common:welcome.wayfinderFolderImport.errors.importFailed');
+
+    await user.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.reSelectFolder'));
+
+    expect(
+      vi.mocked(
+        (window as unknown as {showDirectoryPicker: () => Promise<FileSystemDirectoryHandle>}).showDirectoryPicker,
+      ),
+    ).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/apps/console/src/features/welcome/components/__tests__/WayfinderSampleDownload.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/WayfinderSampleDownload.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, userEvent, fireEvent} from '@thunderid/test-utils';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    create: (Component: React.ElementType) => Component,
+  },
+}));
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    ChevronDown: () => <span data-testid="icon-chevron-down" />,
+    ChevronUp: () => <span data-testid="icon-chevron-up" />,
+    Download: () => <span data-testid="icon-download" />,
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts) {
+        return `${key}:${JSON.stringify(opts)}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+const {mockDetectPlatform, mockUseWayfinderReleases} = vi.hoisted(() => ({
+  mockDetectPlatform: vi.fn(),
+  mockUseWayfinderReleases: vi.fn(),
+}));
+
+vi.mock('../../utils/downloadAssets', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/downloadAssets')>();
+  return {
+    ...actual,
+    detectPlatform: mockDetectPlatform,
+  };
+});
+
+vi.mock('../../api/useWayfinderReleases', () => ({
+  default: (...args: unknown[]): unknown => mockUseWayfinderReleases(...args),
+}));
+
+import WayfinderSampleDownload from '../WayfinderSampleDownload';
+
+const mockAsset = {
+  name: 'sample-app-wayfinder-1.0.0-linux-x64.zip',
+  downloadUrl: 'https://example.com/sample-app-wayfinder-1.0.0-linux-x64.zip',
+  sizeLabel: '10 MB',
+};
+
+const mockAssetMacos = {
+  name: 'sample-app-wayfinder-1.0.0-macos-arm64.zip',
+  downloadUrl: 'https://example.com/sample-app-wayfinder-1.0.0-macos-arm64.zip',
+  sizeLabel: '12 MB',
+};
+
+const mockReleasesData = {
+  latestRelease: {
+    tagName: 'v1.0.0',
+    assets: [mockAsset],
+  },
+  releases: [],
+};
+
+describe('WayfinderSampleDownload', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null when isError is true', () => {
+    mockDetectPlatform.mockResolvedValue({os: 'linux', arch: 'x64'});
+    mockUseWayfinderReleases.mockReturnValue({data: undefined, isError: true});
+    const {container} = render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when assets array is empty', () => {
+    mockDetectPlatform.mockResolvedValue({os: 'linux', arch: 'x64'});
+    mockUseWayfinderReleases.mockReturnValue({
+      data: {latestRelease: {tagName: 'v1.0.0', assets: []}, releases: []},
+      isError: false,
+    });
+    const {container} = render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when data is not yet loaded', () => {
+    mockDetectPlatform.mockResolvedValue({os: 'linux', arch: 'x64'});
+    mockUseWayfinderReleases.mockReturnValue({data: undefined, isError: false});
+    const {container} = render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows download button with OS label', async () => {
+    mockDetectPlatform.mockResolvedValue({os: 'linux', arch: 'x64'});
+    mockUseWayfinderReleases.mockReturnValue({data: mockReleasesData, isError: false});
+    render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+
+    expect(await screen.findByText(/common:welcome\.wayfinderSampleDownload\.downloadButton/)).toBeInTheDocument();
+  });
+
+  it('shows "Recommended for this device" label when platform matches', async () => {
+    mockDetectPlatform.mockResolvedValue({os: 'linux', arch: 'x64'});
+    mockUseWayfinderReleases.mockReturnValue({data: mockReleasesData, isError: false});
+    render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+
+    expect(await screen.findByText('common:welcome.wayfinderSampleDownload.recommendedLabel')).toBeInTheDocument();
+  });
+
+  it('shows "Selected download" label when platform does not match exactly', async () => {
+    mockDetectPlatform.mockResolvedValue({os: 'macos', arch: 'arm64'});
+    mockUseWayfinderReleases.mockReturnValue({data: mockReleasesData, isError: false});
+    render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+
+    expect(await screen.findByText('common:welcome.wayfinderSampleDownload.selectedLabel')).toBeInTheDocument();
+  });
+
+  it('does not show "Other download options" toggle when only one OS group', async () => {
+    mockDetectPlatform.mockResolvedValue({os: 'linux', arch: 'x64'});
+    mockUseWayfinderReleases.mockReturnValue({data: mockReleasesData, isError: false});
+    render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+
+    await screen.findByText(/common:welcome\.wayfinderSampleDownload\.downloadButton/);
+    expect(screen.queryByText('common:welcome.wayfinderSampleDownload.otherPlatforms')).not.toBeInTheDocument();
+  });
+
+  it('shows "Other download options" toggle when multiple OS groups exist', async () => {
+    mockDetectPlatform.mockResolvedValue({os: 'linux', arch: 'x64'});
+    const multiOsData = {
+      latestRelease: {
+        tagName: 'v1.0.0',
+        assets: [mockAsset, mockAssetMacos],
+      },
+      releases: [],
+    };
+    mockUseWayfinderReleases.mockReturnValue({data: multiOsData, isError: false});
+    render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+
+    expect(await screen.findByText('common:welcome.wayfinderSampleDownload.otherPlatforms')).toBeInTheDocument();
+  });
+
+  it('toggling "Other platforms" button shows other download options', async () => {
+    mockDetectPlatform.mockResolvedValue({os: 'linux', arch: 'x64'});
+    const multiOsData = {
+      latestRelease: {
+        tagName: 'v1.0.0',
+        assets: [mockAsset, mockAssetMacos],
+      },
+      releases: [],
+    };
+    mockUseWayfinderReleases.mockReturnValue({data: multiOsData, isError: false});
+    const user = userEvent.setup();
+    render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+
+    const toggle = await screen.findByText('common:welcome.wayfinderSampleDownload.otherPlatforms');
+    await user.click(toggle);
+
+    expect(await screen.findByText('common:welcome.wayfinderSampleDownload.hidePlatforms')).toBeInTheDocument();
+  });
+
+  it('handles detectPlatform rejection gracefully', async () => {
+    mockDetectPlatform.mockRejectedValue(new Error('platform detection failed'));
+    mockUseWayfinderReleases.mockReturnValue({data: mockReleasesData, isError: false});
+    render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+
+    expect(await screen.findByText(/common:welcome\.wayfinderSampleDownload\.downloadButton/)).toBeInTheDocument();
+  });
+
+  it('toggles other platforms on Enter keypress', async () => {
+    mockDetectPlatform.mockResolvedValue({os: 'linux', arch: 'x64'});
+    const multiOsData = {
+      latestRelease: {
+        tagName: 'v1.0.0',
+        assets: [
+          {
+            name: 'sample-app-wayfinder-1.0.0-linux-x64.zip',
+            downloadUrl: 'https://example.com/linux-x64.zip',
+            sizeLabel: '10 MB',
+          },
+          {
+            name: 'sample-app-wayfinder-1.0.0-macos-arm64.zip',
+            downloadUrl: 'https://example.com/macos-arm64.zip',
+            sizeLabel: '12 MB',
+          },
+        ],
+      },
+      releases: [],
+    };
+    mockUseWayfinderReleases.mockReturnValue({data: multiOsData, isError: false});
+    render(<WayfinderSampleDownload releasesUrl="https://example.com/releases.json" />);
+
+    const toggle = await screen.findByText('common:welcome.wayfinderSampleDownload.otherPlatforms');
+    fireEvent.keyDown(toggle.closest('[role="button"]') ?? toggle, {key: 'Enter'});
+
+    expect(await screen.findByText('common:welcome.wayfinderSampleDownload.hidePlatforms')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/welcome/components/__tests__/WayfinderSampleSetup.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/WayfinderSampleSetup.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, userEvent, waitFor, fireEvent} from '@thunderid/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const {mockDetectPlatform} = vi.hoisted(() => ({mockDetectPlatform: vi.fn()}));
+const mockLocalStorageGetItem = vi.fn();
+const mockLocalStorageSetItem = vi.fn();
+const mockSessionStorageGetItem = vi.fn();
+const mockSessionStorageSetItem = vi.fn();
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {
+          product_name: 'ThunderID',
+          docs_url: 'https://docs.example.com/',
+        },
+      },
+    }),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts?.productName) return `${key}:${opts.productName as string}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('../../utils/downloadAssets', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/downloadAssets')>();
+  return {...actual, detectPlatform: mockDetectPlatform};
+});
+
+vi.mock('../TerminalBlock', () => ({
+  default: ({command, tabs}: {command: string; tabs?: React.ReactNode}) => (
+    <div>
+      {tabs}
+      <pre data-testid="terminal-block">{command}</pre>
+    </div>
+  ),
+}));
+
+vi.mock('../WayfinderFolderImport', () => ({
+  default: ({onSuccess}: {onSuccess?: () => void}) => (
+    <div data-testid="wayfinder-folder-import">
+      <button onClick={onSuccess} type="button">
+        mock-import-success
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../WayfinderSampleDownload', () => ({
+  default: () => <div data-testid="wayfinder-sample-download" />,
+}));
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    CheckCircle: () => <span data-testid="icon-check-circle" />,
+    ChevronRight: () => <span data-testid="icon-chevron-right" />,
+    Database: () => <span data-testid="icon-database" />,
+    Download: () => <span data-testid="icon-download" />,
+    Play: () => <span data-testid="icon-play" />,
+    Settings: () => <span data-testid="icon-settings" />,
+  };
+});
+
+import WayfinderSampleSetup from '../WayfinderSampleSetup';
+
+describe('WayfinderSampleSetup', () => {
+  beforeEach(() => {
+    mockDetectPlatform.mockResolvedValue({os: 'linux', arch: 'x64'});
+    vi.stubGlobal('localStorage', {
+      getItem: mockLocalStorageGetItem,
+      setItem: mockLocalStorageSetItem,
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
+    vi.stubGlobal('sessionStorage', {
+      getItem: mockSessionStorageGetItem,
+      setItem: mockSessionStorageSetItem,
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
+    mockLocalStorageGetItem.mockReturnValue(null);
+    mockSessionStorageGetItem.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders without crashing', () => {
+    const {container} = render(<WayfinderSampleSetup />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders the setup title', () => {
+    render(<WayfinderSampleSetup />);
+    expect(screen.getByText('common:welcome.wayfinderSampleSetup.title')).toBeInTheDocument();
+  });
+
+  it('renders the one-time setup badge', () => {
+    render(<WayfinderSampleSetup />);
+    expect(screen.getByText('common:welcome.wayfinderSampleSetup.oneTimeSetup')).toBeInTheDocument();
+  });
+
+  it('expands by default when not previously imported', () => {
+    mockLocalStorageGetItem.mockReturnValue(null);
+    render(<WayfinderSampleSetup />);
+    expect(screen.getByTestId('wayfinder-folder-import')).toBeInTheDocument();
+    expect(screen.getByTestId('terminal-block')).toBeInTheDocument();
+  });
+
+  it('collapses by default when previously imported', () => {
+    mockLocalStorageGetItem.mockReturnValue('1234567890');
+    render(<WayfinderSampleSetup />);
+    expect(screen.queryByTestId('wayfinder-folder-import')).not.toBeInTheDocument();
+  });
+
+  it('shows setupComplete message when done and collapsed', () => {
+    mockLocalStorageGetItem.mockReturnValue('1234567890');
+    mockSessionStorageGetItem.mockReturnValue('false');
+    render(<WayfinderSampleSetup />);
+    expect(screen.getByText('common:welcome.wayfinderSampleSetup.setupComplete')).toBeInTheDocument();
+  });
+
+  it('toggles expand/collapse when header is clicked', async () => {
+    const user = userEvent.setup();
+    render(<WayfinderSampleSetup />);
+
+    expect(screen.getByTestId('terminal-block')).toBeInTheDocument();
+
+    const header = screen.getByRole('button', {name: /wayfinderSampleSetup\.title/i});
+    await user.click(header);
+
+    expect(screen.queryByTestId('terminal-block')).not.toBeInTheDocument();
+    expect(mockSessionStorageSetItem).toHaveBeenCalledWith('thunderid-wayfinder-setup-expanded', 'false');
+  });
+
+  it('respects sessionStorage expanded=true even when already imported', () => {
+    mockLocalStorageGetItem.mockReturnValue('1234567890');
+    mockSessionStorageGetItem.mockReturnValue('true');
+    render(<WayfinderSampleSetup />);
+    expect(screen.getByTestId('terminal-block')).toBeInTheDocument();
+  });
+
+  it('shows WayfinderSampleDownload when expanded', () => {
+    render(<WayfinderSampleSetup />);
+    expect(screen.getByTestId('wayfinder-sample-download')).toBeInTheDocument();
+  });
+
+  it('shows step titles when expanded', () => {
+    render(<WayfinderSampleSetup />);
+    expect(screen.getByText('common:welcome.wayfinderSampleSetup.steps.getSample.title')).toBeInTheDocument();
+    expect(screen.getByText(/wayfinderSampleSetup.steps.configure.title/)).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.wayfinderSampleSetup.steps.run.title')).toBeInTheDocument();
+  });
+
+  it('shows unix command by default', () => {
+    render(<WayfinderSampleSetup />);
+    expect(screen.getByTestId('terminal-block')).toHaveTextContent('./start.sh');
+  });
+
+  it('switches to windows command when OS tab is changed', async () => {
+    const user = userEvent.setup();
+    render(<WayfinderSampleSetup />);
+
+    await user.click(screen.getByRole('tab', {name: 'Windows'}));
+
+    expect(screen.getByTestId('terminal-block')).toHaveTextContent('.\\start.ps1');
+  });
+
+  it('auto-selects windows tab when platform is win', async () => {
+    mockDetectPlatform.mockResolvedValue({os: 'win', arch: 'x64'});
+    render(<WayfinderSampleSetup />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-block')).toHaveTextContent('.\\start.ps1');
+    });
+  });
+
+  it('collapses and marks done after import success', async () => {
+    const user = userEvent.setup();
+    render(<WayfinderSampleSetup />);
+
+    expect(screen.getByTestId('wayfinder-folder-import')).toBeInTheDocument();
+
+    await user.click(screen.getByText('mock-import-success'));
+
+    expect(screen.queryByTestId('wayfinder-folder-import')).not.toBeInTheDocument();
+    expect(mockSessionStorageSetItem).toHaveBeenCalledWith('thunderid-wayfinder-setup-expanded', 'false');
+  });
+
+  it('toggles expand/collapse when header receives Enter keypress', () => {
+    render(<WayfinderSampleSetup />);
+
+    expect(screen.getByTestId('terminal-block')).toBeInTheDocument();
+
+    const header = screen.getByRole('button', {name: /wayfinderSampleSetup\.title/i});
+    fireEvent.keyDown(header, {key: 'Enter'});
+
+    expect(screen.queryByTestId('terminal-block')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/welcome/constants/download-assets.ts
+++ b/frontend/apps/console/src/features/welcome/constants/download-assets.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {OsKey} from '../models/download-assets';
+
+const OS_LABELS: Record<OsKey, string> = {
+  linux: 'Linux',
+  macos: 'Mac OS',
+  win: 'Windows',
+};
+
+export default OS_LABELS;

--- a/frontend/apps/console/src/features/welcome/hooks/__tests__/useWelcomeClose.test.ts
+++ b/frontend/apps/console/src/features/welcome/hooks/__tests__/useWelcomeClose.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {renderHook, act} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mockNavigate = vi.fn();
+const mockShowToast = vi.fn();
+const mockSessionStorageSetItem = vi.fn();
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {product_name: 'ThunderID'},
+      },
+    }),
+    useToast: () => ({showToast: mockShowToast}),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {...actual, useNavigate: () => mockNavigate};
+});
+
+import useWelcomeClose from '../useWelcomeClose';
+
+describe('useWelcomeClose', () => {
+  beforeEach(() => {
+    vi.stubGlobal('sessionStorage', {
+      setItem: mockSessionStorageSetItem,
+      getItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns a function', () => {
+    const {result} = renderHook(() => useWelcomeClose());
+    expect(typeof result.current).toBe('function');
+  });
+
+  it('sets sessionStorage dismissed key on call', () => {
+    const {result} = renderHook(() => useWelcomeClose());
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockSessionStorageSetItem).toHaveBeenCalledWith('thunderid:welcome:dismissed', 'true');
+  });
+
+  it('navigates to /home on call', () => {
+    const {result} = renderHook(() => useWelcomeClose());
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/home');
+  });
+
+  it('shows an info toast on call', () => {
+    const {result} = renderHook(() => useWelcomeClose());
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith('common:welcome.dismissed', 'info');
+  });
+});

--- a/frontend/apps/console/src/features/welcome/hooks/useWelcomeClose.ts
+++ b/frontend/apps/console/src/features/welcome/hooks/useWelcomeClose.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useConfig, useToast} from '@thunderid/contexts';
+import {useCallback} from 'react';
+import {useTranslation} from 'react-i18next';
+import {useNavigate} from 'react-router';
+import getWelcomeDismissedStorageKey from '../utils/getWelcomeDismissedStorageKey';
+
+export default function useWelcomeClose(): () => void {
+  const navigate = useNavigate();
+  const {showToast} = useToast();
+  const {t} = useTranslation(['common']);
+  const {config} = useConfig();
+  const productName = config.brand.product_name;
+
+  return useCallback((): void => {
+    sessionStorage.setItem(getWelcomeDismissedStorageKey(productName), 'true');
+    void navigate('/home');
+    showToast(t('common:welcome.dismissed'), 'info');
+  }, [navigate, productName, showToast, t]);
+}

--- a/frontend/apps/console/src/features/welcome/models/download-assets.ts
+++ b/frontend/apps/console/src/features/welcome/models/download-assets.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type OsKey = 'linux' | 'macos' | 'win';
+export type ArchKey = 'arm64' | 'x64';
+
+export interface DetectedPlatform {
+  arch: ArchKey | null;
+  os: OsKey | null;
+}
+
+export interface ReleaseAssetInput {
+  downloadUrl: string;
+  name: string;
+  sizeLabel: string;
+}
+
+export interface DistributionAsset {
+  arch: ArchKey;
+  archLabel: string;
+  downloadUrl: string;
+  name: string;
+  os: OsKey;
+  osLabel: string;
+  sizeLabel: string;
+}
+
+export interface ReleaseEntry {
+  assets: ReleaseAssetInput[];
+  tagName: string;
+}
+
+export interface ReleasesData {
+  latestRelease: ReleaseEntry | null;
+  releases: ReleaseEntry[];
+}

--- a/frontend/apps/console/src/features/welcome/pages/CreateProjectPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/CreateProjectPage.tsx
@@ -34,6 +34,7 @@ import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import HowSolutionWorksIllustration from '../components/HowSolutionWorksIllustration';
+import useWelcomeClose from '../hooks/useWelcomeClose';
 
 const MotionBox = motion.create(Box);
 
@@ -44,12 +45,10 @@ export default function CreateProjectPage(): JSX.Element {
   const productName = config.brand.product_name;
 
   const handleContinue = (): void => {
-    void navigate('/home');
+    void navigate('/welcome/get-started');
   };
 
-  const handleClose = (): void => {
-    void navigate('/home');
-  };
+  const handleClose = useWelcomeClose();
 
   return (
     <Box sx={{minHeight: '100vh', display: 'flex', flexDirection: 'column'}}>
@@ -160,7 +159,7 @@ export default function CreateProjectPage(): JSX.Element {
               animate={{opacity: 1, scale: 1}}
               transition={{duration: 0.5, delay: 0.2}}
               sx={{
-                my: 8,
+                my: 4,
                 display: 'flex',
                 justifyContent: 'center',
                 overflow: 'auto',

--- a/frontend/apps/console/src/features/welcome/pages/GetStartedPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/GetStartedPage.tsx
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useConfig} from '@thunderid/contexts';
+import {Box, Breadcrumbs, Button, IconButton, Stack, Typography} from '@wso2/oxygen-ui';
+import {AppWindow, ChevronRight, SkipForward, X} from '@wso2/oxygen-ui-icons-react';
+import {motion} from 'framer-motion';
+import type {JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import {useNavigate} from 'react-router';
+import useWelcomeClose from '../hooks/useWelcomeClose';
+
+const MotionBox = motion.create(Box);
+
+export default function GetStartedPage(): JSX.Element {
+  const {t} = useTranslation(['common']);
+  const navigate = useNavigate();
+  const {config} = useConfig();
+  const handleClose = useWelcomeClose();
+  const productName = config.brand.product_name;
+
+  const options = [
+    {
+      id: 'onboard-app',
+      icon: <AppWindow size={36} />,
+      title: t('common:welcome.getStarted.options.onboardApp.title'),
+      description: t('common:welcome.getStarted.options.onboardApp.description', {productName}),
+      action: () => void navigate('/applications/create'),
+      actionLabel: t('common:welcome.getStarted.options.onboardApp.action'),
+    },
+  ];
+
+  return (
+    <Box sx={{minHeight: '100vh', display: 'flex', flexDirection: 'column'}}>
+      <Box sx={{flex: 1, display: 'flex', flexDirection: 'column'}}>
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 0,
+            zIndex: 10,
+            p: 4,
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Stack direction="row" spacing={2} sx={{alignItems: 'center'}}>
+            <IconButton
+              aria-label={t('common:actions.close')}
+              onClick={() => void navigate('/welcome')}
+              sx={{bgcolor: 'background.paper', '&:hover': {bgcolor: 'action.hover'}, boxShadow: 1}}
+            >
+              <X size={24} />
+            </IconButton>
+            <Breadcrumbs separator={<ChevronRight size={16} />} aria-label="breadcrumb">
+              <Typography
+                variant="h5"
+                color="inherit"
+                role="button"
+                tabIndex={0}
+                onClick={() => void navigate('/welcome')}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    void navigate('/welcome');
+                  }
+                }}
+                sx={{cursor: 'pointer', '&:hover': {textDecoration: 'underline'}}}
+              >
+                {t('common:welcome.header')}
+              </Typography>
+              <Typography
+                variant="h5"
+                color="inherit"
+                role="button"
+                tabIndex={0}
+                onClick={() => void navigate('/welcome/create-project')}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    void navigate('/welcome/create-project');
+                  }
+                }}
+                sx={{cursor: 'pointer', '&:hover': {textDecoration: 'underline'}}}
+              >
+                {t('common:welcome.createProject.breadcrumb')}
+              </Typography>
+              <Typography variant="h5" color="text.primary">
+                {t('common:welcome.getStarted.breadcrumb')}
+              </Typography>
+            </Breadcrumbs>
+          </Stack>
+        </Box>
+
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            px: {xs: 2, md: 4},
+            pb: 8,
+          }}
+        >
+          <MotionBox
+            initial={{opacity: 0, y: 20}}
+            animate={{opacity: 1, y: 0}}
+            transition={{duration: 0.5}}
+            sx={{maxWidth: '860px', width: '100%'}}
+          >
+            <Box sx={{textAlign: 'center', mb: 8}}>
+              <Typography
+                variant="h1"
+                sx={{fontSize: {xs: '1.75rem', sm: '2rem', md: '2.5rem'}, fontWeight: 600, mb: 2}}
+              >
+                {t('common:welcome.getStarted.title')}
+              </Typography>
+              <Typography
+                variant="body1"
+                color="text.secondary"
+                sx={{fontSize: {xs: '1rem', sm: '1.125rem'}, maxWidth: '560px', mx: 'auto'}}
+              >
+                {t('common:welcome.getStarted.subtitle', {productName})}
+              </Typography>
+            </Box>
+
+            <Box sx={{display: 'flex', flexDirection: {xs: 'column', md: 'row'}, gap: 3, justifyContent: 'center'}}>
+              {options.map((option, index) => (
+                <MotionBox
+                  key={option.id}
+                  initial={{opacity: 0, y: 16}}
+                  animate={{opacity: 1, y: 0}}
+                  transition={{duration: 0.35, delay: 0.2 + index * 0.1}}
+                  sx={{flex: '0 1 320px'}}
+                >
+                  <Box
+                    sx={{
+                      height: '100%',
+                      p: 4,
+                      border: '1px solid',
+                      borderColor: 'divider',
+                      borderRadius: 2,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      textAlign: 'center',
+                      gap: 2,
+                      transition: 'all 0.2s',
+                      '&:hover': {boxShadow: 2, borderColor: 'primary.main'},
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        width: 64,
+                        height: 64,
+                        borderRadius: 3,
+                        bgcolor: 'action.selected',
+                        color: 'text.secondary',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      {option.icon}
+                    </Box>
+                    <Typography variant="h6" fontWeight={600}>
+                      {option.title}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{flex: 1}}>
+                      {option.description}
+                    </Typography>
+                    <Button variant="contained" onClick={option.action} sx={{mt: 1, minWidth: 160}}>
+                      {option.actionLabel}
+                    </Button>
+                  </Box>
+                </MotionBox>
+              ))}
+            </Box>
+
+            <MotionBox
+              initial={{opacity: 0}}
+              animate={{opacity: 1}}
+              transition={{duration: 0.4, delay: 0.4}}
+              sx={{mt: 4, display: 'flex', justifyContent: 'center'}}
+            >
+              <Button
+                variant="text"
+                size="small"
+                endIcon={<SkipForward size={14} />}
+                onClick={handleClose}
+                sx={{color: 'text.secondary'}}
+              >
+                {t('common:welcome.getStarted.actions.skipToConsole')}
+              </Button>
+            </MotionBox>
+          </MotionBox>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/pages/TryoutSecuringAIAgentsPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/TryoutSecuringAIAgentsPage.tsx
@@ -1,0 +1,436 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useConfig} from '@thunderid/contexts';
+import {
+  Alert,
+  Box,
+  Button,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+  IconButton,
+  LinearProgress,
+  Breadcrumbs,
+} from '@wso2/oxygen-ui';
+import {
+  BookOpen,
+  Bot,
+  CalendarCheck,
+  Check,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Search,
+  Shield,
+  X,
+} from '@wso2/oxygen-ui-icons-react';
+import {motion} from 'framer-motion';
+import type {JSX, ReactNode} from 'react';
+import {useState} from 'react';
+import {Trans, useTranslation} from 'react-i18next';
+import {useNavigate} from 'react-router';
+import WayfinderSampleSetup from '../components/WayfinderSampleSetup';
+import useWelcomeClose from '../hooks/useWelcomeClose';
+
+const MotionBox = motion.create(Box);
+
+type ScenarioTab = 'protect' | 'browse' | 'book';
+
+interface CredentialRowProps {
+  field: 'username' | 'password';
+  value: string;
+  showPassword: boolean;
+  isCopied: boolean;
+  onToggleShow: () => void;
+  onCopy: () => void;
+}
+
+function CredentialRow({field, value, showPassword, isCopied, onToggleShow, onCopy}: CredentialRowProps): JSX.Element {
+  const isPassword = field === 'password';
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1.5,
+        px: 2,
+        py: 1,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+      }}
+    >
+      <Box sx={{flex: 1, minWidth: 0}}>
+        <Typography variant="caption" color="text.secondary" sx={{display: 'block', textTransform: 'capitalize'}}>
+          {field}
+        </Typography>
+        <Typography variant="body2" fontFamily="monospace">
+          {isPassword && !showPassword ? '••••••••' : value}
+        </Typography>
+      </Box>
+      {isPassword && (
+        <IconButton
+          size="small"
+          aria-label={showPassword ? 'Hide password' : 'Show password'}
+          onClick={onToggleShow}
+          sx={{color: 'text.secondary'}}
+        >
+          {showPassword ? <EyeOff size={14} /> : <Eye size={14} />}
+        </IconButton>
+      )}
+      <IconButton
+        size="small"
+        aria-label={`Copy ${field}`}
+        onClick={onCopy}
+        sx={{color: isCopied ? 'success.main' : 'text.secondary'}}
+      >
+        {isCopied ? <Check size={14} /> : <Copy size={14} />}
+      </IconButton>
+    </Box>
+  );
+}
+
+function CredentialsBlock({username, password}: {username: string; password: string}): JSX.Element {
+  const [showPassword, setShowPassword] = useState(false);
+  const [copiedField, setCopiedField] = useState<'username' | 'password' | null>(null);
+
+  const handleCopy = (field: 'username' | 'password', value: string): void => {
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 2000);
+    });
+  };
+
+  return (
+    <Stack spacing={1}>
+      <CredentialRow
+        field="username"
+        value={username}
+        showPassword={showPassword}
+        isCopied={copiedField === 'username'}
+        onToggleShow={() => setShowPassword((v) => !v)}
+        onCopy={() => handleCopy('username', username)}
+      />
+      <CredentialRow
+        field="password"
+        value={password}
+        showPassword={showPassword}
+        isCopied={copiedField === 'password'}
+        onToggleShow={() => setShowPassword((v) => !v)}
+        onCopy={() => handleCopy('password', password)}
+      />
+    </Stack>
+  );
+}
+
+function StepList({steps, startFrom = 1}: {steps: ReactNode[]; startFrom?: number}): JSX.Element {
+  return (
+    <Stack spacing={1} component="ol" sx={{pl: 0, m: 0, listStyle: 'none'}}>
+      {steps.map((step, i) => (
+        <Stack
+          // eslint-disable-next-line react/no-array-index-key
+          key={i}
+          component="li"
+          direction="row"
+          spacing={1.5}
+          alignItems="flex-start"
+        >
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              borderRadius: '50%',
+              bgcolor: 'action.selected',
+              color: 'text.secondary',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '0.7rem',
+              fontWeight: 700,
+              flexShrink: 0,
+              mt: 0.15,
+            }}
+          >
+            {startFrom + i}
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{flex: 1}}>
+            {step}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
+function AppLink({children = null}: {children?: ReactNode}): JSX.Element {
+  return (
+    <a
+      href="http://localhost:5173"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{color: 'inherit', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 2}}
+    >
+      {children}
+      <ExternalLink size={12} style={{flexShrink: 0, opacity: 0.7}} />
+    </a>
+  );
+}
+
+function tLink(i18nKey: string): JSX.Element {
+  return <Trans ns="common" i18nKey={i18nKey} components={{a: <AppLink />}} />;
+}
+
+export default function TryoutSecuringAIAgentsPage(): JSX.Element {
+  const {t} = useTranslation(['common']);
+  const navigate = useNavigate();
+  const {config} = useConfig();
+  const handleClose = useWelcomeClose();
+  const productName = config.brand.product_name;
+  const docsBaseUrl = (config.brand.docs_url ?? '').replace(/\/$/, '');
+
+  const [scenarioTab, setScenarioTab] = useState<ScenarioTab>('protect');
+
+  const tabDefs: {value: ScenarioTab; label: string; icon: JSX.Element}[] = [
+    {value: 'protect', label: t('common:welcome.aiAgentsTryout.scenarios.tabs.protect'), icon: <Shield size={15} />},
+    {value: 'browse', label: t('common:welcome.aiAgentsTryout.scenarios.tabs.browse'), icon: <Search size={15} />},
+    {value: 'book', label: t('common:welcome.aiAgentsTryout.scenarios.tabs.book'), icon: <CalendarCheck size={15} />},
+  ];
+
+  return (
+    <Box sx={{minHeight: '100vh', display: 'flex', flexDirection: 'column'}}>
+      <LinearProgress variant="determinate" value={0} sx={{height: 6}} />
+      <Box sx={{flex: 1, display: 'flex', flexDirection: 'column'}}>
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 0,
+            zIndex: 10,
+            p: 4,
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Stack direction="row" spacing={2} sx={{alignItems: 'center'}}>
+            <IconButton
+              aria-label={t('common:actions.close')}
+              onClick={handleClose}
+              sx={{bgcolor: 'background.paper', '&:hover': {bgcolor: 'action.hover'}, boxShadow: 1}}
+            >
+              <X size={24} />
+            </IconButton>
+            <Breadcrumbs separator={<ChevronRight size={16} />} aria-label="breadcrumb">
+              <Typography
+                variant="h5"
+                color="inherit"
+                role="button"
+                tabIndex={0}
+                onClick={() => void navigate('/welcome')}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    void navigate('/welcome');
+                  }
+                }}
+                sx={{cursor: 'pointer', '&:hover': {textDecoration: 'underline'}}}
+              >
+                {t('common:welcome.header')}
+              </Typography>
+              <Typography variant="h5" color="text.primary">
+                {t('common:welcome.aiAgentsTryout.breadcrumb')}
+              </Typography>
+            </Breadcrumbs>
+          </Stack>
+        </Box>
+
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            px: {xs: 2, md: 4},
+            pb: 8,
+          }}
+        >
+          <MotionBox
+            initial={{opacity: 0, y: 20}}
+            animate={{opacity: 1, y: 0}}
+            transition={{duration: 0.5}}
+            sx={{maxWidth: '860px', width: '100%'}}
+          >
+            <Box sx={{textAlign: 'center', mb: 6}}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{
+                  letterSpacing: 2,
+                  mb: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 0.75,
+                }}
+              >
+                <Bot size={13} />
+                {t('common:welcome.aiAgentsTryout.overline')}
+              </Typography>
+              <Typography
+                variant="h1"
+                sx={{fontSize: {xs: '1.75rem', sm: '2rem', md: '2.5rem'}, fontWeight: 600, mb: 2}}
+              >
+                {t('common:welcome.tryout.title')}
+              </Typography>
+              <Typography
+                variant="body1"
+                color="text.secondary"
+                sx={{fontSize: {xs: '1rem', sm: '1.125rem'}, maxWidth: '580px', mx: 'auto'}}
+              >
+                {t('common:welcome.aiAgentsTryout.subtitle', {productName})}
+              </Typography>
+            </Box>
+
+            <WayfinderSampleSetup />
+
+            <MotionBox
+              initial={{opacity: 0, y: 10}}
+              animate={{opacity: 1, y: 0}}
+              transition={{duration: 0.4, delay: 0.3}}
+              sx={{mt: 3}}
+            >
+              <Typography variant="h3" sx={{fontSize: '1.25rem', fontWeight: 600, mb: 2}}>
+                {t('common:welcome.aiAgentsTryout.scenarios.title')}
+              </Typography>
+              <Alert severity="info" icon={<Bot size={16} />} sx={{mb: 2, fontSize: '0.8rem'}}>
+                {t('common:welcome.aiAgentsTryout.scenarios.apiKeyNote')}
+              </Alert>
+
+              <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden'}}>
+                <Tabs
+                  value={scenarioTab}
+                  onChange={(_e, v: ScenarioTab) => setScenarioTab(v)}
+                  variant="scrollable"
+                  scrollButtons="auto"
+                  sx={{
+                    borderBottom: '1px solid',
+                    borderColor: 'divider',
+                    bgcolor: 'action.selected',
+                    minHeight: 44,
+                    '& .MuiTab-root': {minHeight: 44, fontSize: '0.8rem', gap: 0.75},
+                  }}
+                >
+                  {tabDefs.map((tab) => (
+                    <Tab key={tab.value} value={tab.value} label={tab.label} icon={tab.icon} iconPosition="start" />
+                  ))}
+                </Tabs>
+
+                <Box sx={{p: 3}}>
+                  {scenarioTab === 'protect' && (
+                    <Stack spacing={2}>
+                      <Typography variant="body2" color="text.secondary">
+                        {t('common:welcome.aiAgentsTryout.scenarios.protect.description')}
+                      </Typography>
+                      <StepList
+                        steps={[
+                          tLink('welcome.aiAgentsTryout.scenarios.protect.step1'),
+                          t('common:welcome.aiAgentsTryout.scenarios.protect.step2'),
+                          t('common:welcome.aiAgentsTryout.scenarios.protect.step3'),
+                          t('common:welcome.aiAgentsTryout.scenarios.protect.step4'),
+                        ]}
+                      />
+                      <Stack spacing={1}>
+                        <Typography variant="caption" color="text.secondary">
+                          {t('common:welcome.aiAgentsTryout.scenarios.protect.johnLabel')}
+                        </Typography>
+                        <CredentialsBlock username="john.doe" password="john.doe" />
+                      </Stack>
+                      <Stack spacing={1}>
+                        <Typography variant="caption" color="text.secondary">
+                          {t('common:welcome.aiAgentsTryout.scenarios.protect.janeLabel')}
+                        </Typography>
+                        <CredentialsBlock username="jane.smith" password="jane.smith" />
+                      </Stack>
+                    </Stack>
+                  )}
+
+                  {scenarioTab === 'browse' && (
+                    <Stack spacing={2}>
+                      <Typography variant="body2" color="text.secondary">
+                        {t('common:welcome.aiAgentsTryout.scenarios.browse.description')}
+                      </Typography>
+                      <StepList
+                        steps={[
+                          tLink('welcome.aiAgentsTryout.scenarios.browse.step1'),
+                          t('common:welcome.aiAgentsTryout.scenarios.browse.step2'),
+                          t('common:welcome.aiAgentsTryout.scenarios.browse.step3'),
+                          t('common:welcome.aiAgentsTryout.scenarios.browse.step4'),
+                        ]}
+                      />
+                      <CredentialsBlock username="john.doe" password="john.doe" />
+                    </Stack>
+                  )}
+
+                  {scenarioTab === 'book' && (
+                    <Stack spacing={2}>
+                      <Typography variant="body2" color="text.secondary">
+                        {t('common:welcome.aiAgentsTryout.scenarios.book.description')}
+                      </Typography>
+                      <StepList
+                        steps={[
+                          tLink('welcome.aiAgentsTryout.scenarios.book.step1'),
+                          t('common:welcome.aiAgentsTryout.scenarios.book.step2'),
+                          t('common:welcome.aiAgentsTryout.scenarios.book.step3'),
+                          t('common:welcome.aiAgentsTryout.scenarios.book.step4'),
+                          t('common:welcome.aiAgentsTryout.scenarios.book.step5'),
+                        ]}
+                      />
+                      <CredentialsBlock username="john.doe" password="john.doe" />
+                    </Stack>
+                  )}
+                </Box>
+              </Box>
+            </MotionBox>
+
+            <MotionBox
+              initial={{opacity: 0}}
+              animate={{opacity: 1}}
+              transition={{duration: 0.4, delay: 0.5}}
+              sx={{mt: 4, display: 'flex', justifyContent: 'center'}}
+            >
+              <Button
+                variant="text"
+                size="small"
+                startIcon={<BookOpen size={16} />}
+                onClick={() =>
+                  window.open(`${docsBaseUrl}/use-cases/ai-agents/try-it-out`, '_blank', 'noopener,noreferrer')
+                }
+              >
+                {t('common:welcome.tryout.actions.readDocs')}
+              </Button>
+            </MotionBox>
+          </MotionBox>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/pages/TryoutSecuringConsumerAppPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/TryoutSecuringConsumerAppPage.tsx
@@ -1,0 +1,566 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useConfig} from '@thunderid/contexts';
+import {
+  Box,
+  Button,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+  IconButton,
+  LinearProgress,
+  Breadcrumbs,
+  Alert,
+} from '@wso2/oxygen-ui';
+import {
+  AppWindow,
+  Check,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  X,
+  BookOpen,
+  Eye,
+  EyeOff,
+  KeyRound,
+  LogIn,
+  UserCheck,
+  UserCircle,
+  UserPlus,
+} from '@wso2/oxygen-ui-icons-react';
+import {motion} from 'framer-motion';
+import type {JSX, ReactNode} from 'react';
+import {useState} from 'react';
+import {Trans, useTranslation} from 'react-i18next';
+import {useNavigate} from 'react-router';
+import WayfinderSampleSetup from '../components/WayfinderSampleSetup';
+import useWelcomeClose from '../hooks/useWelcomeClose';
+
+const MotionBox = motion.create(Box);
+
+type ScenarioTab = 'login' | 'signup' | 'profile' | 'recovery' | 'onboard';
+
+interface CredentialRowProps {
+  field: 'username' | 'password';
+  value: string;
+  showPassword: boolean;
+  isCopied: boolean;
+  onToggleShow: () => void;
+  onCopy: () => void;
+}
+
+function CredentialRow({field, value, showPassword, isCopied, onToggleShow, onCopy}: CredentialRowProps): JSX.Element {
+  const isPassword = field === 'password';
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1.5,
+        px: 2,
+        py: 1,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+      }}
+    >
+      <Box sx={{flex: 1, minWidth: 0}}>
+        <Typography variant="caption" color="text.secondary" sx={{display: 'block', textTransform: 'capitalize'}}>
+          {field}
+        </Typography>
+        <Typography variant="body2" fontFamily="monospace">
+          {isPassword && !showPassword ? '••••••••' : value}
+        </Typography>
+      </Box>
+      {isPassword && (
+        <IconButton
+          size="small"
+          aria-label={showPassword ? 'Hide password' : 'Show password'}
+          onClick={onToggleShow}
+          sx={{color: 'text.secondary'}}
+        >
+          {showPassword ? <EyeOff size={14} /> : <Eye size={14} />}
+        </IconButton>
+      )}
+      <IconButton
+        size="small"
+        aria-label={`Copy ${field}`}
+        onClick={onCopy}
+        sx={{color: isCopied ? 'success.main' : 'text.secondary'}}
+      >
+        {isCopied ? <Check size={14} /> : <Copy size={14} />}
+      </IconButton>
+    </Box>
+  );
+}
+
+interface CredentialsBlockProps {
+  username: string;
+  password: string;
+}
+
+function CredentialsBlock({username, password}: CredentialsBlockProps): JSX.Element {
+  const [showPassword, setShowPassword] = useState(false);
+  const [copiedField, setCopiedField] = useState<'username' | 'password' | null>(null);
+
+  const handleCopy = (field: 'username' | 'password', value: string): void => {
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 2000);
+    });
+  };
+
+  return (
+    <Stack spacing={1}>
+      <CredentialRow
+        field="username"
+        value={username}
+        showPassword={showPassword}
+        isCopied={copiedField === 'username'}
+        onToggleShow={() => setShowPassword((v) => !v)}
+        onCopy={() => handleCopy('username', username)}
+      />
+      <CredentialRow
+        field="password"
+        value={password}
+        showPassword={showPassword}
+        isCopied={copiedField === 'password'}
+        onToggleShow={() => setShowPassword((v) => !v)}
+        onCopy={() => handleCopy('password', password)}
+      />
+    </Stack>
+  );
+}
+
+interface StepListProps {
+  steps: ReactNode[];
+  startFrom?: number;
+}
+
+function StepList({steps, startFrom = 1}: StepListProps): JSX.Element {
+  return (
+    <Stack spacing={1} component="ol" sx={{pl: 0, m: 0, listStyle: 'none'}}>
+      {steps.map((step, i) => (
+        <Stack
+          // eslint-disable-next-line react/no-array-index-key
+          key={i}
+          component="li"
+          direction="row"
+          spacing={1.5}
+          alignItems="flex-start"
+        >
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              borderRadius: '50%',
+              bgcolor: 'action.selected',
+              color: 'text.secondary',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '0.7rem',
+              fontWeight: 700,
+              flexShrink: 0,
+              mt: 0.15,
+            }}
+          >
+            {startFrom + i}
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{flex: 1}}>
+            {step}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
+function AppLink({children = null}: {children?: ReactNode}): JSX.Element {
+  return (
+    <a
+      href="http://localhost:5173"
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{color: 'inherit', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 2}}
+    >
+      {children}
+      <ExternalLink size={12} style={{flexShrink: 0, opacity: 0.7}} />
+    </a>
+  );
+}
+
+function tLink(i18nKey: string): JSX.Element {
+  return <Trans ns="common" i18nKey={i18nKey} components={{a: <AppLink />}} />;
+}
+
+interface FormField {
+  label: string;
+  value: string;
+}
+
+function FormFieldsBlock({fields}: {fields: FormField[]}): JSX.Element {
+  const [copiedLabel, setCopiedLabel] = useState<string | null>(null);
+
+  const handleCopy = (label: string, value: string): void => {
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopiedLabel(label);
+      setTimeout(() => setCopiedLabel(null), 2000);
+    });
+  };
+
+  return (
+    <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden'}}>
+      {fields.map((f, i) => (
+        <Box
+          key={f.label}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            px: 2,
+            py: 0.75,
+            borderTop: i === 0 ? 'none' : '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Typography variant="caption" color="text.secondary" sx={{minWidth: 96, flexShrink: 0}}>
+            {f.label}
+          </Typography>
+          <Typography variant="body2" fontFamily="monospace" sx={{flex: 1}}>
+            {f.value}
+          </Typography>
+          <IconButton
+            size="small"
+            aria-label={`Copy ${f.label}`}
+            onClick={() => handleCopy(f.label, f.value)}
+            sx={{color: copiedLabel === f.label ? 'success.main' : 'text.secondary', flexShrink: 0}}
+          >
+            {copiedLabel === f.label ? <Check size={13} /> : <Copy size={13} />}
+          </IconButton>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+export default function TryoutSecuringConsumerApp(): JSX.Element {
+  const {t} = useTranslation(['common']);
+  const navigate = useNavigate();
+  const {config} = useConfig();
+  const productName = config.brand.product_name;
+  const docsBaseUrl = (config.brand.docs_url ?? '').replace(/\/$/, '');
+
+  const [scenarioTab, setScenarioTab] = useState<ScenarioTab>('login');
+
+  const handleClose = useWelcomeClose();
+
+  const tabDefs: {value: ScenarioTab; label: string; icon: JSX.Element}[] = [
+    {value: 'login', label: t('common:welcome.consumerAppTryout.scenarios.tabs.login'), icon: <LogIn size={15} />},
+    {value: 'signup', label: t('common:welcome.consumerAppTryout.scenarios.tabs.signup'), icon: <UserPlus size={15} />},
+    {
+      value: 'profile',
+      label: t('common:welcome.consumerAppTryout.scenarios.tabs.profile'),
+      icon: <UserCircle size={15} />,
+    },
+    {
+      value: 'recovery',
+      label: t('common:welcome.consumerAppTryout.scenarios.tabs.recovery'),
+      icon: <KeyRound size={15} />,
+    },
+    {
+      value: 'onboard',
+      label: t('common:welcome.consumerAppTryout.scenarios.tabs.onboard'),
+      icon: <UserCheck size={15} />,
+    },
+  ];
+
+  return (
+    <Box sx={{minHeight: '100vh', display: 'flex', flexDirection: 'column'}}>
+      <LinearProgress variant="determinate" value={0} sx={{height: 6}} />
+
+      <Box sx={{flex: 1, display: 'flex', flexDirection: 'column'}}>
+        {/* Header */}
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 0,
+            zIndex: 10,
+            p: 4,
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Stack direction="row" spacing={2} sx={{alignItems: 'center'}}>
+            <IconButton
+              aria-label={t('common:actions.close')}
+              onClick={handleClose}
+              sx={{bgcolor: 'background.paper', '&:hover': {bgcolor: 'action.hover'}, boxShadow: 1}}
+            >
+              <X size={24} />
+            </IconButton>
+            <Breadcrumbs separator={<ChevronRight size={16} />} aria-label="breadcrumb">
+              <Typography
+                variant="h5"
+                color="inherit"
+                role="button"
+                tabIndex={0}
+                onClick={() => void navigate('/welcome')}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    void navigate('/welcome');
+                  }
+                }}
+                sx={{cursor: 'pointer', '&:hover': {textDecoration: 'underline'}}}
+              >
+                {t('common:welcome.header')}
+              </Typography>
+              <Typography variant="h5" color="text.primary">
+                {t('common:welcome.consumerAppTryout.breadcrumb')}
+              </Typography>
+            </Breadcrumbs>
+          </Stack>
+        </Box>
+
+        {/* Main Content */}
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            px: {xs: 2, md: 4},
+            pb: 8,
+          }}
+        >
+          <MotionBox
+            initial={{opacity: 0, y: 20}}
+            animate={{opacity: 1, y: 0}}
+            transition={{duration: 0.5}}
+            sx={{maxWidth: '860px', width: '100%'}}
+          >
+            {/* Title */}
+            <Box sx={{textAlign: 'center', mb: 6}}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{
+                  letterSpacing: 2,
+                  mb: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 0.75,
+                }}
+              >
+                <AppWindow size={13} />
+                {t('common:welcome.consumerAppTryout.overline')}
+              </Typography>
+              <Typography
+                variant="h1"
+                sx={{fontSize: {xs: '1.75rem', sm: '2rem', md: '2.5rem'}, fontWeight: 600, mb: 2}}
+              >
+                {t('common:welcome.tryout.title')}
+              </Typography>
+              <Typography
+                variant="body1"
+                color="text.secondary"
+                sx={{fontSize: {xs: '1rem', sm: '1.125rem'}, maxWidth: '580px', mx: 'auto'}}
+              >
+                {t('common:welcome.consumerAppTryout.subtitle', {productName})}
+              </Typography>
+            </Box>
+
+            <WayfinderSampleSetup />
+
+            <Typography variant="h3" sx={{fontSize: '1.25rem', fontWeight: 600, mt: 6, mb: 3}}>
+              {t('common:welcome.consumerAppTryout.scenarios.title')}
+            </Typography>
+
+            {/* Scenario Tabs */}
+            <MotionBox
+              initial={{opacity: 0, y: 10}}
+              animate={{opacity: 1, y: 0}}
+              transition={{duration: 0.4, delay: 0.3}}
+              sx={{mt: 3, border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden'}}
+            >
+              <Tabs
+                value={scenarioTab}
+                onChange={(_e, v: ScenarioTab) => setScenarioTab(v)}
+                variant="scrollable"
+                scrollButtons="auto"
+                sx={{
+                  borderBottom: '1px solid',
+                  borderColor: 'divider',
+                  minHeight: 44,
+                  '& .MuiTab-root': {minHeight: 44, fontSize: '0.8rem', gap: 0.75},
+                }}
+              >
+                {tabDefs.map((tab) => (
+                  <Tab key={tab.value} value={tab.value} label={tab.label} icon={tab.icon} iconPosition="start" />
+                ))}
+              </Tabs>
+
+              <Box sx={{p: 3}}>
+                {scenarioTab === 'login' && (
+                  <Stack spacing={2}>
+                    <Typography variant="body2" color="text.secondary">
+                      {t('common:welcome.consumerAppTryout.scenarios.login.description')}
+                    </Typography>
+                    <StepList
+                      steps={[
+                        tLink('welcome.consumerAppTryout.scenarios.login.step1'),
+                        t('common:welcome.consumerAppTryout.scenarios.login.step2'),
+                      ]}
+                    />
+                    <CredentialsBlock username="john.doe" password="john.doe" />
+                  </Stack>
+                )}
+
+                {scenarioTab === 'signup' && (
+                  <Stack spacing={2}>
+                    <Typography variant="body2" color="text.secondary">
+                      {t('common:welcome.consumerAppTryout.scenarios.signup.description')}
+                    </Typography>
+                    <StepList
+                      steps={[
+                        tLink('welcome.consumerAppTryout.scenarios.signup.step1'),
+                        t('common:welcome.consumerAppTryout.scenarios.signup.step2'),
+                        t('common:welcome.consumerAppTryout.scenarios.signup.step3'),
+                      ]}
+                    />
+                    <FormFieldsBlock
+                      fields={[
+                        {
+                          label: t('common:welcome.consumerAppTryout.scenarios.signup.sampleFields.username'),
+                          value: 'emma.wilson',
+                        },
+                        {
+                          label: t('common:welcome.consumerAppTryout.scenarios.signup.sampleFields.email'),
+                          value: 'emma.wilson@example.com',
+                        },
+                        {
+                          label: t('common:welcome.consumerAppTryout.scenarios.signup.sampleFields.givenName'),
+                          value: 'Emma',
+                        },
+                        {
+                          label: t('common:welcome.consumerAppTryout.scenarios.signup.sampleFields.familyName'),
+                          value: 'Wilson',
+                        },
+                      ]}
+                    />
+                    <StepList
+                      startFrom={4}
+                      steps={[
+                        t('common:welcome.consumerAppTryout.scenarios.signup.step4'),
+                        t('common:welcome.consumerAppTryout.scenarios.signup.step5'),
+                      ]}
+                    />
+                  </Stack>
+                )}
+
+                {scenarioTab === 'profile' && (
+                  <Stack spacing={2}>
+                    <Typography variant="body2" color="text.secondary">
+                      {t('common:welcome.consumerAppTryout.scenarios.profile.description')}
+                    </Typography>
+                    <StepList
+                      steps={[
+                        tLink('welcome.consumerAppTryout.scenarios.profile.step1'),
+                        t('common:welcome.consumerAppTryout.scenarios.profile.step2'),
+                        t('common:welcome.consumerAppTryout.scenarios.profile.step3'),
+                      ]}
+                    />
+                    <CredentialsBlock username="john.doe" password="john.doe" />
+                  </Stack>
+                )}
+
+                {scenarioTab === 'recovery' && (
+                  <Stack spacing={2}>
+                    <Typography variant="body2" color="text.secondary">
+                      {t('common:welcome.consumerAppTryout.scenarios.recovery.description')}
+                    </Typography>
+                    <Alert severity="info" sx={{fontSize: '0.8rem'}}>
+                      {t('common:welcome.consumerAppTryout.scenarios.recovery.smtpNote', {productName})}
+                    </Alert>
+                    <StepList
+                      steps={[
+                        tLink('welcome.consumerAppTryout.scenarios.recovery.step1'),
+                        t('common:welcome.consumerAppTryout.scenarios.recovery.step2'),
+                        t('common:welcome.consumerAppTryout.scenarios.recovery.step3'),
+                        t('common:welcome.consumerAppTryout.scenarios.recovery.step4'),
+                        t('common:welcome.consumerAppTryout.scenarios.recovery.step5'),
+                        t('common:welcome.consumerAppTryout.scenarios.recovery.step6'),
+                      ]}
+                    />
+                  </Stack>
+                )}
+
+                {scenarioTab === 'onboard' && (
+                  <Stack spacing={2}>
+                    <Typography variant="body2" color="text.secondary">
+                      {t('common:welcome.consumerAppTryout.scenarios.onboard.description')}
+                    </Typography>
+                    <Alert severity="info" sx={{fontSize: '0.8rem'}}>
+                      {t('common:welcome.consumerAppTryout.scenarios.onboard.smtpNote', {productName})}
+                    </Alert>
+                    <StepList steps={[tLink('welcome.consumerAppTryout.scenarios.onboard.step1')]} />
+                    <CredentialsBlock username="alex.carter" password="alex.carter" />
+                    <StepList
+                      startFrom={2}
+                      steps={[
+                        t('common:welcome.consumerAppTryout.scenarios.onboard.step2'),
+                        t('common:welcome.consumerAppTryout.scenarios.onboard.step3'),
+                        t('common:welcome.consumerAppTryout.scenarios.onboard.step4'),
+                      ]}
+                    />
+                  </Stack>
+                )}
+              </Box>
+            </MotionBox>
+
+            {/* Read docs link */}
+            <MotionBox
+              initial={{opacity: 0}}
+              animate={{opacity: 1}}
+              transition={{duration: 0.4, delay: 0.5}}
+              sx={{mt: 4, display: 'flex', justifyContent: 'center'}}
+            >
+              <Button
+                variant="text"
+                size="small"
+                startIcon={<BookOpen size={16} />}
+                sx={{px: 2}}
+                onClick={() => {
+                  window.open(`${docsBaseUrl}/use-cases/b2c/try-it-out`, '_blank', 'noopener,noreferrer');
+                }}
+              >
+                {t('common:welcome.tryout.actions.readDocs')}
+              </Button>
+            </MotionBox>
+          </MotionBox>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/pages/TryoutSecuringMCPPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/TryoutSecuringMCPPage.tsx
@@ -1,0 +1,519 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useConfig} from '@thunderid/contexts';
+import {Box, Button, Stack, Tab, Tabs, Typography, IconButton, LinearProgress, Breadcrumbs} from '@wso2/oxygen-ui';
+import {
+  BookOpen,
+  Check,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  Link2,
+  Play,
+  ShieldCheck,
+  Terminal,
+  MCP,
+  X,
+} from '@wso2/oxygen-ui-icons-react';
+import {motion} from 'framer-motion';
+import type {JSX, ReactNode} from 'react';
+import {useState} from 'react';
+import {Trans, useTranslation} from 'react-i18next';
+import {useNavigate} from 'react-router';
+import TerminalBlock from '../components/TerminalBlock';
+import WayfinderSampleSetup from '../components/WayfinderSampleSetup';
+import useWelcomeClose from '../hooks/useWelcomeClose';
+
+const MotionBox = motion.create(Box);
+
+type ScenarioTab = 'connect' | 'permissions';
+
+interface FormField {
+  label: string;
+  value: string;
+}
+
+function FormFieldsBlock({fields}: {fields: FormField[]}): JSX.Element {
+  const [copiedLabel, setCopiedLabel] = useState<string | null>(null);
+
+  const handleCopy = (label: string, value: string): void => {
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopiedLabel(label);
+      setTimeout(() => setCopiedLabel(null), 2000);
+    });
+  };
+
+  return (
+    <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden'}}>
+      {fields.map((f, i) => (
+        <Box
+          key={f.label}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            px: 2,
+            py: 0.75,
+            borderTop: i === 0 ? 'none' : '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Typography variant="caption" color="text.secondary" sx={{minWidth: 100, flexShrink: 0}}>
+            {f.label}
+          </Typography>
+          <Typography variant="body2" fontFamily="monospace" sx={{flex: 1}}>
+            {f.value}
+          </Typography>
+          <IconButton
+            size="small"
+            aria-label={`Copy ${f.label}`}
+            onClick={() => handleCopy(f.label, f.value)}
+            sx={{color: copiedLabel === f.label ? 'success.main' : 'text.secondary', flexShrink: 0}}
+          >
+            {copiedLabel === f.label ? <Check size={13} /> : <Copy size={13} />}
+          </IconButton>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function StepList({steps, startFrom = 1}: {steps: ReactNode[]; startFrom?: number}): JSX.Element {
+  return (
+    <Stack spacing={1} component="ol" sx={{pl: 0, m: 0, listStyle: 'none'}}>
+      {steps.map((step, i) => (
+        <Stack
+          // eslint-disable-next-line react/no-array-index-key
+          key={i}
+          component="li"
+          direction="row"
+          spacing={1.5}
+          alignItems="flex-start"
+        >
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              borderRadius: '50%',
+              bgcolor: 'action.selected',
+              color: 'text.secondary',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '0.7rem',
+              fontWeight: 700,
+              flexShrink: 0,
+              mt: 0.15,
+            }}
+          >
+            {startFrom + i}
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{flex: 1}}>
+            {step}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
+function ExternalAppLink({href, children = null}: {href: string; children?: ReactNode}): JSX.Element {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{color: 'inherit', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 2}}
+    >
+      {children}
+      <ExternalLink size={12} style={{flexShrink: 0, opacity: 0.7}} />
+    </a>
+  );
+}
+
+function tLink(i18nKey: string, href: string): JSX.Element {
+  return <Trans ns="common" i18nKey={i18nKey} components={{a: <ExternalAppLink href={href} />}} />;
+}
+
+function CodeBlock({code}: {code: string}): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = (): void => {
+    void navigator.clipboard.writeText(code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+  return (
+    <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden'}}>
+      <Box
+        sx={{
+          bgcolor: 'action.selected',
+          px: 1.5,
+          py: 0.5,
+          display: 'flex',
+          justifyContent: 'flex-end',
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+        }}
+      >
+        <IconButton
+          size="small"
+          aria-label="Copy snippet"
+          onClick={handleCopy}
+          sx={{color: copied ? 'success.main' : 'text.secondary'}}
+        >
+          {copied ? <Check size={13} /> : <Copy size={13} />}
+        </IconButton>
+      </Box>
+      <Box sx={{bgcolor: 'grey.900', px: 2, py: 1.5}}>
+        {code.split('\n').map((line) => (
+          <Typography
+            key={line.toLowerCase().split(' ').join('-')}
+            variant="body2"
+            fontFamily="monospace"
+            sx={{color: 'grey.300', whiteSpace: 'pre'}}
+          >
+            {line}
+          </Typography>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+export default function TryoutSecuringMCPPage(): JSX.Element {
+  const {t} = useTranslation(['common']);
+  const navigate = useNavigate();
+  const {config} = useConfig();
+  const handleClose = useWelcomeClose();
+  const productName = config.brand.product_name;
+  const docsBaseUrl = (config.brand.docs_url ?? '').replace(/\/$/, '');
+
+  const [scenarioTab, setScenarioTab] = useState<ScenarioTab>('connect');
+
+  const corsSnippet = `cors:\n  allowed_origins:\n    # ...existing entries...\n    - "http://localhost:6274"`;
+
+  const tabDefs: {value: ScenarioTab; label: string; icon: JSX.Element}[] = [
+    {value: 'connect', label: t('common:welcome.mcpTryout.scenarios.tabs.connect'), icon: <Link2 size={15} />},
+    {
+      value: 'permissions',
+      label: t('common:welcome.mcpTryout.scenarios.tabs.permissions'),
+      icon: <ShieldCheck size={15} />,
+    },
+  ];
+
+  const setupSteps = [
+    {
+      number: 4,
+      icon: <Terminal size={28} />,
+      title: t('common:welcome.mcpTryout.steps.installInspector.title'),
+      description: t('common:welcome.mcpTryout.steps.installInspector.description'),
+    },
+    {
+      number: 5,
+      icon: <Play size={28} />,
+      title: t('common:welcome.mcpTryout.steps.allowCors.title'),
+      description: t('common:welcome.mcpTryout.steps.allowCors.description', {productName}),
+    },
+  ];
+
+  return (
+    <Box sx={{minHeight: '100vh', display: 'flex', flexDirection: 'column'}}>
+      <LinearProgress variant="determinate" value={0} sx={{height: 6}} />
+      <Box sx={{flex: 1, display: 'flex', flexDirection: 'column'}}>
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 0,
+            zIndex: 10,
+            p: 4,
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Stack direction="row" spacing={2} sx={{alignItems: 'center'}}>
+            <IconButton
+              aria-label={t('common:actions.close')}
+              onClick={handleClose}
+              sx={{bgcolor: 'background.paper', '&:hover': {bgcolor: 'action.hover'}, boxShadow: 1}}
+            >
+              <X size={24} />
+            </IconButton>
+            <Breadcrumbs separator={<ChevronRight size={16} />} aria-label="breadcrumb">
+              <Typography
+                variant="h5"
+                color="inherit"
+                role="button"
+                tabIndex={0}
+                onClick={() => void navigate('/welcome')}
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    void navigate('/welcome');
+                  }
+                }}
+                sx={{cursor: 'pointer', '&:hover': {textDecoration: 'underline'}}}
+              >
+                {t('common:welcome.header')}
+              </Typography>
+              <Typography variant="h5" color="text.primary">
+                {t('common:welcome.mcpTryout.breadcrumb')}
+              </Typography>
+            </Breadcrumbs>
+          </Stack>
+        </Box>
+
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            px: {xs: 2, md: 4},
+            pb: 8,
+          }}
+        >
+          <MotionBox
+            initial={{opacity: 0, y: 20}}
+            animate={{opacity: 1, y: 0}}
+            transition={{duration: 0.5}}
+            sx={{maxWidth: '860px', width: '100%'}}
+          >
+            <Box sx={{textAlign: 'center', mb: 6}}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{
+                  letterSpacing: 2,
+                  mb: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 0.75,
+                }}
+              >
+                <MCP size={13} />
+                {t('common:welcome.mcpTryout.overline')}
+              </Typography>
+              <Typography
+                variant="h1"
+                sx={{fontSize: {xs: '1.75rem', sm: '2rem', md: '2.5rem'}, fontWeight: 600, mb: 2}}
+              >
+                {t('common:welcome.tryout.title')}
+              </Typography>
+              <Typography
+                variant="body1"
+                color="text.secondary"
+                sx={{fontSize: {xs: '1rem', sm: '1.125rem'}, maxWidth: '580px', mx: 'auto'}}
+              >
+                {t('common:welcome.mcpTryout.subtitle', {productName})}
+              </Typography>
+            </Box>
+
+            <WayfinderSampleSetup />
+
+            {/* MCP-specific setup steps */}
+            <Stack spacing={3} sx={{mt: 3}}>
+              {setupSteps.map((step, index) => (
+                <MotionBox
+                  key={step.number}
+                  initial={{opacity: 0, x: -10}}
+                  animate={{opacity: 1, x: 0}}
+                  transition={{duration: 0.3, delay: 0.2 + index * 0.1}}
+                >
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      gap: 3,
+                      p: 3,
+                      border: '1px solid',
+                      borderColor: 'divider',
+                      borderRadius: 2,
+                      alignItems: 'flex-start',
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        width: 36,
+                        height: 36,
+                        borderRadius: '50%',
+                        bgcolor: 'action.selected',
+                        color: 'text.primary',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontWeight: 700,
+                        fontSize: '0.875rem',
+                        flexShrink: 0,
+                        mt: 0.25,
+                      }}
+                    >
+                      {step.number}
+                    </Box>
+                    <Box sx={{flex: 1}}>
+                      <Box
+                        sx={{
+                          width: 48,
+                          height: 48,
+                          borderRadius: 2,
+                          bgcolor: 'action.selected',
+                          color: 'text.secondary',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          mb: 1.5,
+                        }}
+                      >
+                        {step.icon}
+                      </Box>
+                      <Typography variant="subtitle1" fontWeight={600} sx={{mb: 0.5}}>
+                        {step.title}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary" sx={{mb: step.number === 1 ? 1.5 : 0}}>
+                        {step.description}
+                      </Typography>
+
+                      {step.number === 4 && <TerminalBlock command="npx @modelcontextprotocol/inspector" />}
+
+                      {step.number === 5 && <CodeBlock code={corsSnippet} />}
+                    </Box>
+                  </Box>
+                </MotionBox>
+              ))}
+            </Stack>
+
+            {/* Try use cases */}
+            <MotionBox
+              initial={{opacity: 0, y: 10}}
+              animate={{opacity: 1, y: 0}}
+              transition={{duration: 0.4, delay: 0.5}}
+              sx={{mt: 4}}
+            >
+              <Typography variant="h3" sx={{fontSize: '1.25rem', fontWeight: 600, mb: 2}}>
+                {t('common:welcome.mcpTryout.scenarios.title')}
+              </Typography>
+
+              <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden'}}>
+                <Tabs
+                  value={scenarioTab}
+                  onChange={(_e, v: ScenarioTab) => setScenarioTab(v)}
+                  variant="scrollable"
+                  scrollButtons="auto"
+                  sx={{
+                    borderBottom: '1px solid',
+                    borderColor: 'divider',
+                    bgcolor: 'action.selected',
+                    minHeight: 44,
+                    '& .MuiTab-root': {minHeight: 44, fontSize: '0.8rem', gap: 0.75},
+                  }}
+                >
+                  {tabDefs.map((tab) => (
+                    <Tab key={tab.value} value={tab.value} label={tab.label} icon={tab.icon} iconPosition="start" />
+                  ))}
+                </Tabs>
+
+                <Box sx={{p: 3}}>
+                  {scenarioTab === 'connect' && (
+                    <Stack spacing={2}>
+                      <Typography variant="body2" color="text.secondary">
+                        {t('common:welcome.mcpTryout.scenarios.connect.description', {productName})}
+                      </Typography>
+                      <StepList
+                        steps={[
+                          tLink('welcome.mcpTryout.scenarios.connect.step1', 'http://localhost:6274'),
+                          t('common:welcome.mcpTryout.scenarios.connect.step2'),
+                          t('common:welcome.mcpTryout.scenarios.connect.step3'),
+                          t('common:welcome.mcpTryout.scenarios.connect.step4', {productName}),
+                          t('common:welcome.mcpTryout.scenarios.connect.step5'),
+                        ]}
+                      />
+                      <Typography variant="caption" color="text.secondary">
+                        {t('common:welcome.mcpTryout.scenarios.connect.connectionLabel')}
+                      </Typography>
+                      <FormFieldsBlock
+                        fields={[
+                          {
+                            label: t('common:welcome.mcpTryout.scenarios.connect.fields.transport'),
+                            value: 'Streamable HTTP',
+                          },
+                          {
+                            label: t('common:welcome.mcpTryout.scenarios.connect.fields.serverUrl'),
+                            value: 'http://localhost:8787/mcp',
+                          },
+                          {
+                            label: t('common:welcome.mcpTryout.scenarios.connect.fields.clientId'),
+                            value: 'EXTERNAL-MCP-CLIENT',
+                          },
+                          {
+                            label: t('common:welcome.mcpTryout.scenarios.connect.fields.clientSecret'),
+                            value: '(leave blank)',
+                          },
+                        ]}
+                      />
+                    </Stack>
+                  )}
+
+                  {scenarioTab === 'permissions' && (
+                    <Stack spacing={2}>
+                      <Typography variant="body2" color="text.secondary">
+                        {t('common:welcome.mcpTryout.scenarios.permissions.description', {productName})}
+                      </Typography>
+                      <StepList
+                        steps={[
+                          t('common:welcome.mcpTryout.scenarios.permissions.step1'),
+                          t('common:welcome.mcpTryout.scenarios.permissions.step2'),
+                          t('common:welcome.mcpTryout.scenarios.permissions.step3'),
+                          t('common:welcome.mcpTryout.scenarios.permissions.step4'),
+                        ]}
+                      />
+                    </Stack>
+                  )}
+                </Box>
+              </Box>
+            </MotionBox>
+
+            <MotionBox
+              initial={{opacity: 0}}
+              animate={{opacity: 1}}
+              transition={{duration: 0.4, delay: 0.7}}
+              sx={{mt: 4, display: 'flex', justifyContent: 'center'}}
+            >
+              <Button
+                variant="text"
+                size="small"
+                startIcon={<BookOpen size={16} />}
+                onClick={() =>
+                  window.open(
+                    `${docsBaseUrl}/use-cases/ai-agents/mcp-authorization/try-it-out`,
+                    '_blank',
+                    'noopener,noreferrer',
+                  )
+                }
+              >
+                {t('common:welcome.tryout.actions.readDocs')}
+              </Button>
+            </MotionBox>
+          </MotionBox>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/pages/WelcomePage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/WelcomePage.tsx
@@ -27,13 +27,13 @@ import {
   Users,
   ExternalLink,
   Lightbulb,
-  Rocket,
   MCP,
 } from '@wso2/oxygen-ui-icons-react';
 import {motion} from 'framer-motion';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
+import useWelcomeClose from '../hooks/useWelcomeClose';
 import getWelcomeDismissedStorageKey from '../utils/getWelcomeDismissedStorageKey';
 
 const MotionBox = motion.create(Box);
@@ -45,11 +45,7 @@ export default function WelcomePage(): JSX.Element {
   const {config} = useConfig();
   const productName = config.brand.product_name;
   const docsBaseUrl = (config.brand.docs_url ?? '').replace(/\/$/, '');
-
-  const handleClose = (): void => {
-    sessionStorage.setItem(getWelcomeDismissedStorageKey(productName), 'true');
-    void navigate('/home');
-  };
+  const handleClose = useWelcomeClose();
 
   const handleCreateNewProject = (): void => {
     sessionStorage.setItem(getWelcomeDismissedStorageKey(productName), 'true');
@@ -78,25 +74,31 @@ export default function WelcomePage(): JSX.Element {
 
   const learnProduct = [
     {
-      id: 'learn-b2c',
+      id: 'learn-consumer-app',
       icon: <Users size={18} />,
-      label: t('common:welcome.tryoutProduct.b2c'),
-      description: t('common:welcome.tryoutProduct.b2cDesc'),
-      url: `${docsBaseUrl}/use-cases/b2c/try-it-out`,
+      label: t('common:welcome.tryoutProduct.consumerApp'),
+      description: t('common:welcome.tryoutProduct.consumerAppDesc'),
+      action: () => {
+        sessionStorage.setItem(getWelcomeDismissedStorageKey(productName), 'true');
+        void navigate('/welcome/tryout/consumer-app');
+      },
     },
     {
       id: 'learn-ai-agents',
       icon: <Bot size={18} />,
       label: t('common:welcome.tryoutProduct.aiAgents'),
       description: t('common:welcome.tryoutProduct.aiAgentsDesc'),
-      url: `${docsBaseUrl}/use-cases/ai-agents/try-it-out`,
+      action: () => window.open(`${docsBaseUrl}/use-cases/ai-agents/try-it-out`, '_blank', 'noopener,noreferrer'),
+      endIcon: <ExternalLink size={14} />,
     },
     {
       id: 'learn-mcp',
       icon: <MCP size={18} />,
       label: t('common:welcome.tryoutProduct.mcp'),
       description: t('common:welcome.tryoutProduct.mcpDesc'),
-      url: `${docsBaseUrl}/use-cases/ai-agents/mcp-authorization/try-it-out`,
+      action: () =>
+        window.open(`${docsBaseUrl}/use-cases/ai-agents/mcp-authorization/try-it-out`, '_blank', 'noopener,noreferrer'),
+      endIcon: <ExternalLink size={14} />,
     },
   ];
 
@@ -200,220 +202,223 @@ export default function WelcomePage(): JSX.Element {
             gap: {xs: 3, md: 4},
           }}
         >
-          {/* Two Column Layout for Start and Walkthrough */}
           <Box
             sx={{
               display: 'flex',
               flexDirection: {xs: 'column', md: 'row'},
-              gap: {xs: 3, md: 10},
+              gap: {xs: 3, md: 6},
+              alignItems: 'stretch',
             }}
           >
             {/* Left Column - Start */}
-            <Box
-              sx={{
-                flex: 1,
-              }}
-            >
-              <Stack spacing={2}>
-                {startActions.map((action, index) => (
-                  <MotionBox
-                    key={action.id}
-                    initial={{opacity: 0, x: -10}}
-                    animate={{opacity: 1, x: 0}}
-                    transition={{duration: 0.2, delay: 0.15 + index * 0.05}}
-                  >
-                    <Card
-                      variant="outlined"
-                      sx={{
-                        p: 2.5,
-                        cursor: 'pointer',
-                        transition: 'all 0.2s',
-                        '&:hover': {
-                          transform: 'translateY(-2px)',
-                          boxShadow: 2,
-                          borderColor: 'primary.main',
-                        },
-                      }}
-                      onClick={action.action}
-                    >
-                      <Stack spacing={1.5}>
-                        <Box sx={{display: 'flex', alignItems: 'flex-start', gap: 1.5}}>
-                          <Box
-                            sx={{
-                              width: 40,
-                              height: 40,
-                              borderRadius: 1,
-                              bgcolor: 'primary.lighter',
-                              color: 'primary.main',
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                              flexShrink: 0,
-                            }}
-                          >
-                            {action.icon}
-                          </Box>
-                          <Box sx={{flex: 1}}>
-                            <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5}}>
-                              <Typography variant="subtitle1" fontWeight={600}>
-                                {action.label}
-                              </Typography>
-                              <ChevronRight size={18} />
-                            </Box>
-                            <Typography variant="body2" color="text.secondary">
-                              {action.description}
-                            </Typography>
-                          </Box>
-                        </Box>
-                      </Stack>
-                    </Card>
-                  </MotionBox>
-                ))}
-              </Stack>
-            </Box>
-
-            {/* Right Column - Walkthrough */}
-            <Box
-              sx={{
-                flex: 1,
-                display: {xs: 'none', md: 'block'},
-              }}
-            >
-              <MotionBox
-                initial={{opacity: 0, y: 20}}
-                animate={{opacity: 1, y: 0}}
-                transition={{duration: 0.3, delay: 0.3}}
+            <Box sx={{flex: 1, display: 'flex', flexDirection: 'column', gap: 2}}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{letterSpacing: 1.5, display: 'block', mb: 0.5}}
               >
-                <Box
-                  sx={{
-                    border: '1px solid',
-                    borderColor: 'divider',
-                    borderRadius: 1,
-                  }}
+                {t('common:welcome.sections.start')}
+              </Typography>
+              {startActions.map((action, index) => (
+                <MotionBox
+                  key={action.id}
+                  initial={{opacity: 0, y: 10}}
+                  animate={{opacity: 1, y: 0}}
+                  transition={{duration: 0.25, delay: 0.1 + index * 0.07}}
                 >
-                  <Typography
-                    variant="h2"
+                  <Card
+                    variant="outlined"
+                    onClick={action.action}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        action.action();
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
                     sx={{
-                      py: 2.8,
-                      px: 2.2,
-                      m: 0,
-                      backgroundColor: 'background.paper',
-                      fontSize: '1.25rem',
-                      fontWeight: 600,
-                      borderRadius: '8px 8px 0 0',
+                      p: 3,
+                      cursor: 'pointer',
+                      transition: 'all 0.2s',
+                      border: '1px solid',
+                      borderColor: 'divider',
+                      '&:hover': {
+                        transform: 'translateY(-2px)',
+                        boxShadow: 3,
+                        borderColor: 'primary.main',
+                        '& .start-label': {color: 'primary.main'},
+                      },
                     }}
                   >
-                    <Rocket size={20} style={{marginRight: 12, marginBottom: 2, verticalAlign: 'middle'}} />
-                    {t('common:welcome.sections.tryoutProduct', {productName})}
-                  </Typography>
-                  <Box
-                    sx={{
-                      overflow: 'hidden',
-                    }}
-                  >
-                    {learnProduct.map((item, index) => (
-                      <MotionBox
-                        key={item.id}
-                        initial={{opacity: 0, x: 10}}
-                        animate={{opacity: 1, x: 0}}
-                        transition={{duration: 0.2, delay: 0.3 + index * 0.05}}
-                      >
-                        <Box
-                          component="a"
-                          href={item.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 1.5,
-                            cursor: 'pointer',
-                            color: 'inherit',
-                            textDecoration: 'none',
-                            px: 2,
-                            py: 1.5,
-                            borderBottom: index < learnProduct.length - 1 ? '1px solid' : 'none',
-                            borderColor: 'divider',
-                            '&:hover': {
-                              bgcolor: 'action.hover',
-                              '& .learnproduct-title': {
-                                color: 'primary.main',
-                                textDecoration: 'underline',
-                              },
-                            },
-                          }}
-                        >
-                          <Box sx={{color: 'text.secondary', display: 'flex', flexShrink: 0, mr: 0.5}}>{item.icon}</Box>
-                          <Stack spacing={0.5} sx={{flex: 1}}>
-                            <Typography
-                              className="learnproduct-title"
-                              variant="body1"
-                              fontWeight={500}
-                              sx={{transition: 'all 0.2s'}}
-                            >
-                              {item.label}
-                            </Typography>
-                            <Typography variant="body2" color="text.secondary">
-                              {item.description}
-                            </Typography>
-                          </Stack>
-                          <Box sx={{color: 'text.disabled', display: 'flex', flexShrink: 0}}>
-                            <ExternalLink size={14} />
-                          </Box>
-                        </Box>
-                      </MotionBox>
-                    ))}
-                  </Box>
-                </Box>
-
-                <Stack spacing={2} sx={{mt: 4}}>
-                  {walkthroughs.map((walkthrough, index) => (
-                    <MotionBox
-                      key={walkthrough.id}
-                      initial={{opacity: 0, x: 10}}
-                      animate={{opacity: 1, x: 0}}
-                      transition={{duration: 0.2, delay: 0.35 + index * 0.05}}
-                      sx={{px: 2}}
-                    >
+                    <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
                       <Box
-                        onClick={walkthrough.action}
                         sx={{
+                          width: 44,
+                          height: 44,
+                          borderRadius: 1.5,
+                          bgcolor: 'primary.main',
+                          color: '#fff',
                           display: 'flex',
                           alignItems: 'center',
-                          gap: 1.5,
-                          cursor: 'pointer',
-                          py: 1,
-                          '&:hover': {
-                            '& .walkthrough-title': {
-                              color: 'primary.main',
-                              textDecoration: 'underline',
-                            },
-                          },
+                          justifyContent: 'center',
+                          flexShrink: 0,
                         }}
                       >
-                        <Box sx={{color: 'text.secondary', display: 'flex', flexShrink: 0}}>{walkthrough.icon}</Box>
-                        <Stack spacing={0.5}>
-                          <Typography
-                            className="walkthrough-title"
-                            variant="body1"
-                            fontWeight={500}
-                            sx={{
-                              transition: 'all 0.2s',
-                            }}
-                          >
-                            {walkthrough.label}
-                            <Box sx={{color: 'text.disabled', display: 'inline-block', ml: 1}}>
-                              <ExternalLink size={14} />
-                            </Box>
-                          </Typography>
-                          <Typography variant="body2" color="text.secondary">
-                            {walkthrough.description}
-                          </Typography>
-                        </Stack>
+                        {action.icon}
                       </Box>
-                    </MotionBox>
-                  ))}
-                </Stack>
+                      <Box sx={{flex: 1, minWidth: 0}}>
+                        <Typography
+                          className="start-label"
+                          variant="subtitle1"
+                          fontWeight={600}
+                          sx={{transition: 'color 0.2s', mb: 0.25}}
+                        >
+                          {action.label}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary" noWrap>
+                          {action.description}
+                        </Typography>
+                      </Box>
+                      <ChevronRight size={18} style={{flexShrink: 0, opacity: 0.4}} />
+                    </Box>
+                  </Card>
+                </MotionBox>
+              ))}
+
+              <MotionBox
+                initial={{opacity: 0}}
+                animate={{opacity: 1}}
+                transition={{duration: 0.3, delay: 0.35}}
+                sx={{mt: 1}}
+              >
+                {walkthroughs.map((walkthrough) => (
+                  <Box
+                    key={walkthrough.id}
+                    onClick={walkthrough.action}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        walkthrough.action();
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.5,
+                      cursor: 'pointer',
+                      px: 1,
+                      py: 1,
+                      borderRadius: 1,
+                      '&:hover': {'& .walkthrough-title': {color: 'primary.main', textDecoration: 'underline'}},
+                    }}
+                  >
+                    <Box sx={{color: 'text.secondary', display: 'flex', flexShrink: 0}}>{walkthrough.icon}</Box>
+                    <Typography
+                      className="walkthrough-title"
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{transition: 'all 0.2s', flex: 1, display: 'flex', alignItems: 'center', gap: 0.5}}
+                    >
+                      {walkthrough.label}
+                      <ExternalLink size={12} style={{flexShrink: 0, opacity: 0.4}} />
+                    </Typography>
+                  </Box>
+                ))}
+              </MotionBox>
+            </Box>
+
+            {/* Divider */}
+            <Box sx={{width: '1px', bgcolor: 'divider', display: {xs: 'none', md: 'block'}, alignSelf: 'stretch'}} />
+
+            {/* Right Column - Tryout scenarios */}
+            <Box sx={{flex: 1, display: 'flex', flexDirection: 'column', gap: 2}}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{letterSpacing: 1.5, display: 'block', mb: 0.5}}
+              >
+                {t('common:welcome.sections.tryoutProduct', {productName})}
+              </Typography>
+              <MotionBox
+                initial={{opacity: 0, y: 10}}
+                animate={{opacity: 1, y: 0}}
+                transition={{duration: 0.3, delay: 0.2}}
+                sx={{border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden'}}
+              >
+                {learnProduct.map((item, index) => (
+                  <Box
+                    key={item.id}
+                    onClick={item.action}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        item.action();
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 2,
+                      cursor: 'pointer',
+                      px: 2.5,
+                      py: 2,
+                      borderBottom: index < learnProduct.length - 1 ? '1px solid' : 'none',
+                      borderColor: 'divider',
+                      transition: 'background 0.15s',
+                      '&:hover': {
+                        bgcolor: 'action.hover',
+                        '& .tryout-label': {color: 'primary.main'},
+                        '& .tryout-end-icon': {opacity: 1},
+                      },
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        width: 36,
+                        height: 36,
+                        borderRadius: 1.5,
+                        bgcolor: 'action.selected',
+                        color: 'text.secondary',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexShrink: 0,
+                      }}
+                    >
+                      {item.icon}
+                    </Box>
+                    <Stack spacing={0.25} sx={{flex: 1, minWidth: 0}}>
+                      <Typography
+                        className="tryout-label"
+                        variant="body2"
+                        fontWeight={600}
+                        sx={{transition: 'color 0.2s'}}
+                      >
+                        {item.label}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary" noWrap>
+                        {item.description}
+                      </Typography>
+                    </Stack>
+                    <Box
+                      className="tryout-end-icon"
+                      sx={{
+                        color: 'text.disabled',
+                        display: 'flex',
+                        flexShrink: 0,
+                        opacity: 0.5,
+                        transition: 'opacity 0.2s',
+                      }}
+                    >
+                      {item.endIcon ?? <ChevronRight size={14} />}
+                    </Box>
+                  </Box>
+                ))}
               </MotionBox>
             </Box>
           </Box>

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/CreateProjectPage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/CreateProjectPage.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {render, screen, userEvent} from '@thunderid/test-utils';
+import {render, screen, userEvent, fireEvent} from '@thunderid/test-utils';
 import {afterEach, describe, expect, it, vi} from 'vitest';
 
 const mockNavigate = vi.fn();
@@ -88,13 +88,13 @@ describe('CreateProjectPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/home');
   });
 
-  it('navigates to /home when get started button is clicked', async () => {
+  it('navigates to /welcome/get-started when get started button is clicked', async () => {
     const user = userEvent.setup();
     render(<CreateProjectPage />);
 
     await user.click(screen.getByRole('button', {name: 'common:welcome.createProject.actions.getStarted'}));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/home');
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome/get-started');
   });
 
   it('renders breadcrumb with welcome header', () => {
@@ -108,6 +108,18 @@ describe('CreateProjectPage', () => {
 
     await user.click(screen.getByText('common:welcome.header'));
 
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('navigates to /welcome on breadcrumb welcome Enter keypress', () => {
+    render(<CreateProjectPage />);
+    fireEvent.keyDown(screen.getByText('common:welcome.header'), {key: 'Enter'});
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('navigates to /welcome on breadcrumb welcome Space keypress', () => {
+    render(<CreateProjectPage />);
+    fireEvent.keyDown(screen.getByText('common:welcome.header'), {key: ' '});
     expect(mockNavigate).toHaveBeenCalledWith('/welcome');
   });
 });

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/GetStartedPage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/GetStartedPage.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, userEvent, fireEvent} from '@thunderid/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mockNavigate = vi.fn();
+const mockSessionStorageSetItem = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {
+          product_name: 'ThunderID',
+          favicon: {light: 'assets/images/favicon.ico', dark: 'assets/images/favicon-inverted.ico'},
+        },
+      },
+    }),
+    useToast: () => ({showToast: mockShowToast}),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts?.productName) {
+        return `${key}:${opts.productName as string}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {...actual, useNavigate: () => mockNavigate};
+});
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    create: (Component: React.ElementType) => Component,
+  },
+}));
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    AppWindow: () => <span data-testid="icon-app-window" />,
+    ChevronRight: () => <span data-testid="icon-chevron-right" />,
+    SkipForward: () => <span data-testid="icon-skip-forward" />,
+    X: () => <span data-testid="icon-x" />,
+  };
+});
+
+import GetStartedPage from '../GetStartedPage';
+
+describe('GetStartedPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('sessionStorage', {
+      setItem: mockSessionStorageSetItem,
+      getItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders without crashing', () => {
+    const {container} = render(<GetStartedPage />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders close button', () => {
+    render(<GetStartedPage />);
+    expect(screen.getByRole('button', {name: /common:actions\.close/i})).toBeInTheDocument();
+  });
+
+  it('renders breadcrumb with welcome and create-project links', () => {
+    render(<GetStartedPage />);
+    expect(screen.getByText('common:welcome.header')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.createProject.breadcrumb')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.getStarted.breadcrumb')).toBeInTheDocument();
+  });
+
+  it('renders title and subtitle', () => {
+    render(<GetStartedPage />);
+    expect(screen.getByText('common:welcome.getStarted.title')).toBeInTheDocument();
+    expect(screen.getByText(/common:welcome\.getStarted\.subtitle/i)).toBeInTheDocument();
+  });
+
+  it('renders onboard app option', () => {
+    render(<GetStartedPage />);
+    expect(screen.getByText('common:welcome.getStarted.options.onboardApp.title')).toBeInTheDocument();
+    expect(screen.getByText(/common:welcome\.getStarted\.options\.onboardApp\.description/i)).toBeInTheDocument();
+  });
+
+  it('renders skip to console button', () => {
+    render(<GetStartedPage />);
+    expect(screen.getByText('common:welcome.getStarted.actions.skipToConsole')).toBeInTheDocument();
+  });
+
+  it('navigates to /applications/create on onboard app click', async () => {
+    const user = userEvent.setup();
+    render(<GetStartedPage />);
+
+    const actionButton = screen.getByText('common:welcome.getStarted.options.onboardApp.action');
+    await user.click(actionButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/applications/create');
+  });
+
+  it('navigates to /home and sets session storage on skip', async () => {
+    const user = userEvent.setup();
+    render(<GetStartedPage />);
+
+    await user.click(screen.getByText('common:welcome.getStarted.actions.skipToConsole'));
+
+    expect(mockSessionStorageSetItem).toHaveBeenCalledWith('thunderid:welcome:dismissed', 'true');
+    expect(mockNavigate).toHaveBeenCalledWith('/home');
+    expect(mockShowToast).toHaveBeenCalledWith('common:welcome.dismissed', 'info');
+  });
+
+  it('navigates to /welcome on close', async () => {
+    const user = userEvent.setup();
+    render(<GetStartedPage />);
+
+    await user.click(screen.getByRole('button', {name: /common:actions\.close/i}));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('navigates to /welcome on welcome breadcrumb click', async () => {
+    const user = userEvent.setup();
+    render(<GetStartedPage />);
+
+    await user.click(screen.getByText('common:welcome.header'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('navigates to /welcome/create-project on create-project breadcrumb click', async () => {
+    const user = userEvent.setup();
+    render(<GetStartedPage />);
+
+    await user.click(screen.getByText('common:welcome.createProject.breadcrumb'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome/create-project');
+  });
+
+  it('navigates to /welcome on welcome breadcrumb Enter keypress', () => {
+    render(<GetStartedPage />);
+    fireEvent.keyDown(screen.getByText('common:welcome.header'), {key: 'Enter'});
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('navigates to /welcome/create-project on create-project breadcrumb Enter keypress', () => {
+    render(<GetStartedPage />);
+    fireEvent.keyDown(screen.getByText('common:welcome.createProject.breadcrumb'), {key: 'Enter'});
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome/create-project');
+  });
+});

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringAIAgentsPage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringAIAgentsPage.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, userEvent, fireEvent} from '@thunderid/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mockNavigate = vi.fn();
+const mockSessionStorageSetItem = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {
+          product_name: 'ThunderID',
+          docs_url: 'https://docs.example.com/',
+          favicon: {light: 'assets/images/favicon.ico', dark: 'assets/images/favicon-inverted.ico'},
+        },
+      },
+    }),
+    useToast: () => ({showToast: mockShowToast}),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  Trans: ({i18nKey, components = {}}: {i18nKey: string; components?: Record<string, React.ReactElement>}) => (
+    <span>
+      {i18nKey}
+      {components?.a}
+    </span>
+  ),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts?.productName) return `${key}:${opts.productName as string}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {...actual, useNavigate: () => mockNavigate};
+});
+
+vi.mock('framer-motion', () => ({
+  motion: {create: (Component: React.ElementType) => Component},
+}));
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    BookOpen: () => <span data-testid="icon-book-open" />,
+    Bot: () => <span data-testid="icon-bot" />,
+    CalendarCheck: () => <span data-testid="icon-calendar-check" />,
+    Check: () => <span data-testid="icon-check" />,
+    ChevronRight: () => <span data-testid="icon-chevron-right" />,
+    Copy: () => <span data-testid="icon-copy" />,
+    ExternalLink: () => <span data-testid="icon-external-link" />,
+    Eye: () => <span data-testid="icon-eye" />,
+    EyeOff: () => <span data-testid="icon-eye-off" />,
+    Search: () => <span data-testid="icon-search" />,
+    Shield: () => <span data-testid="icon-shield" />,
+    X: () => <span data-testid="icon-x" />,
+  };
+});
+
+vi.mock('../../components/WayfinderSampleSetup', () => ({
+  default: () => <div data-testid="wayfinder-sample-setup" />,
+}));
+
+import TryoutSecuringAIAgentsPage from '../TryoutSecuringAIAgentsPage';
+
+describe('TryoutSecuringAIAgentsPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('sessionStorage', {
+      setItem: mockSessionStorageSetItem,
+      getItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
+    vi.stubGlobal('open', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders without crashing', () => {
+    const {container} = render(<TryoutSecuringAIAgentsPage />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders close button', () => {
+    render(<TryoutSecuringAIAgentsPage />);
+    expect(screen.getByRole('button', {name: /common:actions\.close/i})).toBeInTheDocument();
+  });
+
+  it('renders breadcrumb', () => {
+    render(<TryoutSecuringAIAgentsPage />);
+    expect(screen.getByText('common:welcome.header')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.aiAgentsTryout.breadcrumb')).toBeInTheDocument();
+  });
+
+  it('renders overline and title', () => {
+    render(<TryoutSecuringAIAgentsPage />);
+    expect(screen.getByText('common:welcome.aiAgentsTryout.overline')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.tryout.title')).toBeInTheDocument();
+  });
+
+  it('renders WayfinderSampleSetup', () => {
+    render(<TryoutSecuringAIAgentsPage />);
+    expect(screen.getByTestId('wayfinder-sample-setup')).toBeInTheDocument();
+  });
+
+  it('renders scenario tabs', () => {
+    render(<TryoutSecuringAIAgentsPage />);
+    expect(screen.getByText('common:welcome.aiAgentsTryout.scenarios.tabs.protect')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.aiAgentsTryout.scenarios.tabs.browse')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.aiAgentsTryout.scenarios.tabs.book')).toBeInTheDocument();
+  });
+
+  it('shows protect scenario by default', () => {
+    render(<TryoutSecuringAIAgentsPage />);
+    expect(screen.getByText('common:welcome.aiAgentsTryout.scenarios.protect.description')).toBeInTheDocument();
+  });
+
+  it('navigates to /home and sets session storage on close', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringAIAgentsPage />);
+
+    await user.click(screen.getByRole('button', {name: /common:actions\.close/i}));
+
+    expect(mockSessionStorageSetItem).toHaveBeenCalledWith('thunderid:welcome:dismissed', 'true');
+    expect(mockNavigate).toHaveBeenCalledWith('/home');
+    expect(mockShowToast).toHaveBeenCalledWith('common:welcome.dismissed', 'info');
+  });
+
+  it('navigates to /welcome on breadcrumb welcome click', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringAIAgentsPage />);
+
+    await user.click(screen.getByText('common:welcome.header'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('opens docs URL on read docs click', async () => {
+    const mockOpen = vi.fn();
+    vi.stubGlobal('open', mockOpen);
+    const user = userEvent.setup();
+    render(<TryoutSecuringAIAgentsPage />);
+
+    await user.click(screen.getByText('common:welcome.tryout.actions.readDocs'));
+
+    expect(mockOpen).toHaveBeenCalledWith(
+      'https://docs.example.com/use-cases/ai-agents/try-it-out',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('navigates to /welcome on breadcrumb Enter keypress', () => {
+    render(<TryoutSecuringAIAgentsPage />);
+    fireEvent.keyDown(screen.getByText('common:welcome.header'), {key: 'Enter'});
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('shows browse scenario when browse tab is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringAIAgentsPage />);
+
+    await user.click(screen.getByText('common:welcome.aiAgentsTryout.scenarios.tabs.browse'));
+
+    expect(screen.getByText('common:welcome.aiAgentsTryout.scenarios.browse.description')).toBeInTheDocument();
+  });
+
+  it('shows book scenario when book tab is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringAIAgentsPage />);
+
+    await user.click(screen.getByText('common:welcome.aiAgentsTryout.scenarios.tabs.book'));
+
+    expect(screen.getByText('common:welcome.aiAgentsTryout.scenarios.book.description')).toBeInTheDocument();
+  });
+
+  describe('credential interactions', () => {
+    let writeTextSpy: ReturnType<typeof vi.fn>;
+
+    beforeAll(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {writeText: vi.fn()},
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    beforeEach(() => {
+      writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('toggles password visibility in credentials block', async () => {
+      const user = userEvent.setup();
+      render(<TryoutSecuringAIAgentsPage />);
+
+      await user.click(screen.getAllByRole('button', {name: 'Show password'})[0]);
+
+      expect(screen.getAllByRole('button', {name: 'Hide password'})[0]).toBeInTheDocument();
+    });
+
+    it('copies username to clipboard in credentials block', async () => {
+      const user = userEvent.setup();
+      render(<TryoutSecuringAIAgentsPage />);
+
+      await user.click(screen.getAllByRole('button', {name: 'Copy username'})[0]);
+
+      expect(writeTextSpy).toHaveBeenCalledWith('john.doe');
+    });
+  });
+});

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringConsumerAppPage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringConsumerAppPage.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, userEvent, fireEvent} from '@thunderid/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mockNavigate = vi.fn();
+const mockSessionStorageSetItem = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {
+          product_name: 'ThunderID',
+          docs_url: 'https://docs.example.com/',
+          favicon: {light: 'assets/images/favicon.ico', dark: 'assets/images/favicon-inverted.ico'},
+        },
+      },
+    }),
+    useToast: () => ({showToast: mockShowToast}),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  Trans: ({i18nKey, components = {}}: {i18nKey: string; components?: Record<string, React.ReactElement>}) => (
+    <span>
+      {i18nKey}
+      {components?.a}
+    </span>
+  ),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts?.productName) return `${key}:${opts.productName as string}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {...actual, useNavigate: () => mockNavigate};
+});
+
+vi.mock('framer-motion', () => ({
+  motion: {create: (Component: React.ElementType) => Component},
+}));
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    AppWindow: () => <span data-testid="icon-app-window" />,
+    BookOpen: () => <span data-testid="icon-book-open" />,
+    Check: () => <span data-testid="icon-check" />,
+    ChevronRight: () => <span data-testid="icon-chevron-right" />,
+    Copy: () => <span data-testid="icon-copy" />,
+    ExternalLink: () => <span data-testid="icon-external-link" />,
+    Eye: () => <span data-testid="icon-eye" />,
+    EyeOff: () => <span data-testid="icon-eye-off" />,
+    KeyRound: () => <span data-testid="icon-key-round" />,
+    LogIn: () => <span data-testid="icon-log-in" />,
+    UserCheck: () => <span data-testid="icon-user-check" />,
+    UserCircle: () => <span data-testid="icon-user-circle" />,
+    UserPlus: () => <span data-testid="icon-user-plus" />,
+    X: () => <span data-testid="icon-x" />,
+  };
+});
+
+vi.mock('../../components/WayfinderSampleSetup', () => ({
+  default: () => <div data-testid="wayfinder-sample-setup" />,
+}));
+
+import TryoutSecuringConsumerApp from '../TryoutSecuringConsumerAppPage';
+
+describe('TryoutSecuringConsumerAppPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('sessionStorage', {
+      setItem: mockSessionStorageSetItem,
+      getItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
+    vi.stubGlobal('open', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders without crashing', () => {
+    const {container} = render(<TryoutSecuringConsumerApp />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders close button', () => {
+    render(<TryoutSecuringConsumerApp />);
+    expect(screen.getByRole('button', {name: /common:actions\.close/i})).toBeInTheDocument();
+  });
+
+  it('renders breadcrumb', () => {
+    render(<TryoutSecuringConsumerApp />);
+    expect(screen.getByText('common:welcome.header')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.consumerAppTryout.breadcrumb')).toBeInTheDocument();
+  });
+
+  it('renders overline and title', () => {
+    render(<TryoutSecuringConsumerApp />);
+    expect(screen.getByText('common:welcome.consumerAppTryout.overline')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.tryout.title')).toBeInTheDocument();
+  });
+
+  it('renders WayfinderSampleSetup', () => {
+    render(<TryoutSecuringConsumerApp />);
+    expect(screen.getByTestId('wayfinder-sample-setup')).toBeInTheDocument();
+  });
+
+  it('renders scenario tabs', () => {
+    render(<TryoutSecuringConsumerApp />);
+    expect(screen.getByText('common:welcome.consumerAppTryout.scenarios.tabs.login')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.consumerAppTryout.scenarios.tabs.signup')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.consumerAppTryout.scenarios.tabs.profile')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.consumerAppTryout.scenarios.tabs.recovery')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.consumerAppTryout.scenarios.tabs.onboard')).toBeInTheDocument();
+  });
+
+  it('shows login scenario by default', () => {
+    render(<TryoutSecuringConsumerApp />);
+    expect(screen.getByText('common:welcome.consumerAppTryout.scenarios.login.description')).toBeInTheDocument();
+  });
+
+  it('navigates to /home and sets session storage on close', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringConsumerApp />);
+
+    await user.click(screen.getByRole('button', {name: /common:actions\.close/i}));
+
+    expect(mockSessionStorageSetItem).toHaveBeenCalledWith('thunderid:welcome:dismissed', 'true');
+    expect(mockNavigate).toHaveBeenCalledWith('/home');
+    expect(mockShowToast).toHaveBeenCalledWith('common:welcome.dismissed', 'info');
+  });
+
+  it('navigates to /welcome on breadcrumb welcome click', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringConsumerApp />);
+
+    await user.click(screen.getByText('common:welcome.header'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('opens docs URL on read docs click', async () => {
+    const mockOpen = vi.fn();
+    vi.stubGlobal('open', mockOpen);
+    const user = userEvent.setup();
+    render(<TryoutSecuringConsumerApp />);
+
+    await user.click(screen.getByText('common:welcome.tryout.actions.readDocs'));
+
+    expect(mockOpen).toHaveBeenCalledWith(
+      'https://docs.example.com/use-cases/b2c/try-it-out',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('navigates to /welcome on breadcrumb Enter keypress', () => {
+    render(<TryoutSecuringConsumerApp />);
+    fireEvent.keyDown(screen.getByText('common:welcome.header'), {key: 'Enter'});
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('shows signup scenario when signup tab is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringConsumerApp />);
+
+    await user.click(screen.getByText('common:welcome.consumerAppTryout.scenarios.tabs.signup'));
+
+    expect(screen.getByText('common:welcome.consumerAppTryout.scenarios.signup.description')).toBeInTheDocument();
+  });
+
+  it('shows profile scenario when profile tab is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringConsumerApp />);
+
+    await user.click(screen.getByText('common:welcome.consumerAppTryout.scenarios.tabs.profile'));
+
+    expect(screen.getByText('common:welcome.consumerAppTryout.scenarios.profile.description')).toBeInTheDocument();
+  });
+
+  describe('credential interactions', () => {
+    let writeTextSpy: ReturnType<typeof vi.fn>;
+
+    beforeAll(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {writeText: vi.fn()},
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    beforeEach(() => {
+      writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('toggles password visibility in credentials block', async () => {
+      const user = userEvent.setup();
+      render(<TryoutSecuringConsumerApp />);
+
+      await user.click(screen.getAllByRole('button', {name: 'Show password'})[0]);
+
+      expect(screen.getAllByRole('button', {name: 'Hide password'})[0]).toBeInTheDocument();
+    });
+
+    it('copies username to clipboard in credentials block', async () => {
+      const user = userEvent.setup();
+      render(<TryoutSecuringConsumerApp />);
+
+      await user.click(screen.getAllByRole('button', {name: 'Copy username'})[0]);
+
+      expect(writeTextSpy).toHaveBeenCalledWith('john.doe');
+    });
+
+    it('copies a form field when signup tab copy button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TryoutSecuringConsumerApp />);
+
+      await user.click(screen.getByText('common:welcome.consumerAppTryout.scenarios.tabs.signup'));
+      const copyButtons = screen.getAllByRole('button', {
+        name: /^Copy common:welcome\.consumerAppTryout\.scenarios\.signup\.sampleFields\./,
+      });
+      await user.click(copyButtons[0]);
+
+      expect(writeTextSpy).toHaveBeenCalledWith('emma.wilson');
+    });
+  });
+});

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringMCPPage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringMCPPage.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, userEvent, fireEvent} from '@thunderid/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mockNavigate = vi.fn();
+const mockSessionStorageSetItem = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({
+      config: {
+        brand: {
+          product_name: 'ThunderID',
+          docs_url: 'https://docs.example.com/',
+          favicon: {light: 'assets/images/favicon.ico', dark: 'assets/images/favicon-inverted.ico'},
+        },
+      },
+    }),
+    useToast: () => ({showToast: mockShowToast}),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  Trans: ({i18nKey, components = {}}: {i18nKey: string; components?: Record<string, React.ReactElement>}) => (
+    <span>
+      {i18nKey}
+      {components?.a}
+    </span>
+  ),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts?.productName) return `${key}:${opts.productName as string}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {...actual, useNavigate: () => mockNavigate};
+});
+
+vi.mock('framer-motion', () => ({
+  motion: {create: (Component: React.ElementType) => Component},
+}));
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    BookOpen: () => <span data-testid="icon-book-open" />,
+    Check: () => <span data-testid="icon-check" />,
+    ChevronRight: () => <span data-testid="icon-chevron-right" />,
+    Copy: () => <span data-testid="icon-copy" />,
+    ExternalLink: () => <span data-testid="icon-external-link" />,
+    Link2: () => <span data-testid="icon-link2" />,
+    MCP: () => <span data-testid="icon-mcp" />,
+    Play: () => <span data-testid="icon-play" />,
+    ShieldCheck: () => <span data-testid="icon-shield-check" />,
+    Terminal: () => <span data-testid="icon-terminal" />,
+    X: () => <span data-testid="icon-x" />,
+  };
+});
+
+vi.mock('../../components/WayfinderSampleSetup', () => ({
+  default: () => <div data-testid="wayfinder-sample-setup" />,
+}));
+
+vi.mock('../../components/TerminalBlock', () => ({
+  default: ({command}: {command: string}) => <pre data-testid="terminal-block">{command}</pre>,
+}));
+
+import TryoutSecuringMCPPage from '../TryoutSecuringMCPPage';
+
+describe('TryoutSecuringMCPPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('sessionStorage', {
+      setItem: mockSessionStorageSetItem,
+      getItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
+    vi.stubGlobal('open', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders without crashing', () => {
+    const {container} = render(<TryoutSecuringMCPPage />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders close button', () => {
+    render(<TryoutSecuringMCPPage />);
+    expect(screen.getByRole('button', {name: /common:actions\.close/i})).toBeInTheDocument();
+  });
+
+  it('renders breadcrumb', () => {
+    render(<TryoutSecuringMCPPage />);
+    expect(screen.getByText('common:welcome.header')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.mcpTryout.breadcrumb')).toBeInTheDocument();
+  });
+
+  it('renders overline and title', () => {
+    render(<TryoutSecuringMCPPage />);
+    expect(screen.getByText('common:welcome.mcpTryout.overline')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.tryout.title')).toBeInTheDocument();
+  });
+
+  it('renders WayfinderSampleSetup', () => {
+    render(<TryoutSecuringMCPPage />);
+    expect(screen.getByTestId('wayfinder-sample-setup')).toBeInTheDocument();
+  });
+
+  it('renders scenario tabs', () => {
+    render(<TryoutSecuringMCPPage />);
+    expect(screen.getByText('common:welcome.mcpTryout.scenarios.tabs.connect')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.mcpTryout.scenarios.tabs.permissions')).toBeInTheDocument();
+  });
+
+  it('navigates to /home and sets session storage on close', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringMCPPage />);
+
+    await user.click(screen.getByRole('button', {name: /common:actions\.close/i}));
+
+    expect(mockSessionStorageSetItem).toHaveBeenCalledWith('thunderid:welcome:dismissed', 'true');
+    expect(mockNavigate).toHaveBeenCalledWith('/home');
+    expect(mockShowToast).toHaveBeenCalledWith('common:welcome.dismissed', 'info');
+  });
+
+  it('navigates to /welcome on breadcrumb welcome click', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringMCPPage />);
+
+    await user.click(screen.getByText('common:welcome.header'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('opens docs URL on read docs click', async () => {
+    const mockOpen = vi.fn();
+    vi.stubGlobal('open', mockOpen);
+    const user = userEvent.setup();
+    render(<TryoutSecuringMCPPage />);
+
+    await user.click(screen.getByText('common:welcome.tryout.actions.readDocs'));
+
+    expect(mockOpen).toHaveBeenCalledWith(
+      'https://docs.example.com/use-cases/ai-agents/mcp-authorization/try-it-out',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('navigates to /welcome on breadcrumb Enter keypress', () => {
+    render(<TryoutSecuringMCPPage />);
+    fireEvent.keyDown(screen.getByText('common:welcome.header'), {key: 'Enter'});
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome');
+  });
+
+  it('shows permissions scenario when permissions tab is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TryoutSecuringMCPPage />);
+
+    await user.click(screen.getByText('common:welcome.mcpTryout.scenarios.tabs.permissions'));
+
+    expect(screen.getByText(/common:welcome\.mcpTryout\.scenarios\.permissions\.description/)).toBeInTheDocument();
+  });
+
+  describe('clipboard interactions', () => {
+    let writeTextSpy: ReturnType<typeof vi.fn>;
+
+    beforeAll(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {writeText: vi.fn()},
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    beforeEach(() => {
+      writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('renders terminal block and tabs with user interaction', async () => {
+      const user = userEvent.setup();
+      render(<TryoutSecuringMCPPage />);
+      expect(screen.getByTestId('terminal-block')).toBeInTheDocument();
+      await user.click(screen.getByText('common:welcome.mcpTryout.scenarios.tabs.connect'));
+      expect(screen.getByText(/common:welcome\.mcpTryout\.scenarios\.connect\.description/)).toBeInTheDocument();
+    });
+
+    it('copies a form field in the connect tab', async () => {
+      const user = userEvent.setup();
+      render(<TryoutSecuringMCPPage />);
+
+      const copyButtons = screen.getAllByRole('button', {
+        name: /^Copy common:welcome\.mcpTryout\.scenarios\.connect\.fields\./,
+      });
+      await user.click(copyButtons[0]);
+
+      expect(writeTextSpy).toHaveBeenCalledWith('Streamable HTTP');
+    });
+
+    it('copies the CORS snippet via CodeBlock', async () => {
+      const user = userEvent.setup();
+      render(<TryoutSecuringMCPPage />);
+
+      await user.click(screen.getByRole('button', {name: 'Copy snippet'}));
+
+      expect(writeTextSpy).toHaveBeenCalledWith(expect.stringContaining('allowed_origins'));
+    });
+  });
+});

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/WelcomePage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/WelcomePage.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
       config: {
         brand: {
           product_name: 'ThunderID',
+          docs_url: 'https://docs.example.com/',
           favicon: {light: 'assets/images/favicon.ico', dark: 'assets/images/favicon-inverted.ico'},
         },
       },
@@ -72,12 +73,15 @@ vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
   return {
     ...actual,
-    FolderOpen: () => <span data-testid="icon-folder-open" />,
-    X: () => <span data-testid="icon-x" />,
+    Bot: () => <span data-testid="icon-bot" />,
     ChevronRight: () => <span data-testid="icon-chevron-right" />,
-    BookOpen: () => <span data-testid="icon-book-open" />,
+    ExternalLink: () => <span data-testid="icon-external-link" />,
+    FolderOpen: () => <span data-testid="icon-folder-open" />,
     Lightbulb: () => <span data-testid="icon-lightbulb" />,
+    MCP: () => <span data-testid="icon-mcp" />,
     PackagePlus: () => <span data-testid="icon-package-plus" />,
+    Users: () => <span data-testid="icon-users" />,
+    X: () => <span data-testid="icon-x" />,
   };
 });
 
@@ -138,7 +142,7 @@ describe('WelcomePage', () => {
 
   it('renders learn product items', () => {
     render(<WelcomePage />);
-    expect(screen.getByText('common:welcome.tryoutProduct.b2c')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.tryoutProduct.consumerApp')).toBeInTheDocument();
     expect(screen.getByText('common:welcome.tryoutProduct.aiAgents')).toBeInTheDocument();
   });
 
@@ -159,21 +163,65 @@ describe('WelcomePage', () => {
     expect(mockOpen).toHaveBeenCalledWith(expect.any(String), '_blank', 'noopener,noreferrer');
   });
 
-  it('renders learn product items as links with correct href', () => {
+  it('renders learn product items that navigate on click', () => {
     render(<WelcomePage />);
-
-    const b2cLink = screen.getByText('common:welcome.tryoutProduct.b2c').closest('a');
-    expect(b2cLink).toHaveAttribute('href', expect.stringContaining('/use-cases/b2c/try-it-out'));
-    expect(b2cLink).toHaveAttribute('target', '_blank');
-    expect(b2cLink).toHaveAttribute('rel', 'noopener noreferrer');
-
-    const aiAgentsLink = screen.getByText('common:welcome.tryoutProduct.aiAgents').closest('a');
-    expect(aiAgentsLink).toHaveAttribute('href', expect.stringContaining('/use-cases/ai-agents/try-it-out'));
+    expect(screen.getByText('common:welcome.tryoutProduct.consumerApp')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.tryoutProduct.aiAgents')).toBeInTheDocument();
   });
 
   it('uses product name from config', () => {
     render(<WelcomePage />);
     // The openImportDesc key is interpolated with productName
     expect(screen.getByText(/openImportDesc.*ThunderID/i)).toBeInTheDocument();
+  });
+
+  it('navigates to /welcome/open-project when open import is clicked', async () => {
+    const user = userEvent.setup();
+    render(<WelcomePage />);
+
+    await user.click(screen.getByText('common:welcome.start.openImport'));
+
+    expect(mockSessionStorageSetItem).toHaveBeenCalledWith('thunderid:welcome:dismissed', 'true');
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome/open-project');
+  });
+
+  it('navigates to /welcome/tryout/consumer-app when consumer app item is clicked', async () => {
+    const user = userEvent.setup();
+    render(<WelcomePage />);
+
+    await user.click(screen.getByText('common:welcome.tryoutProduct.consumerApp'));
+
+    expect(mockSessionStorageSetItem).toHaveBeenCalledWith('thunderid:welcome:dismissed', 'true');
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome/tryout/consumer-app');
+  });
+
+  it('opens AI agents docs URL on ai-agents item click', async () => {
+    const mockOpen = vi.fn();
+    vi.stubGlobal('open', mockOpen);
+    const user = userEvent.setup();
+    render(<WelcomePage />);
+
+    await user.click(screen.getByText('common:welcome.tryoutProduct.aiAgents'));
+
+    expect(mockOpen).toHaveBeenCalledWith(
+      'https://docs.example.com/use-cases/ai-agents/try-it-out',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('opens MCP docs URL on mcp item click', async () => {
+    const mockOpen = vi.fn();
+    vi.stubGlobal('open', mockOpen);
+    const user = userEvent.setup();
+    render(<WelcomePage />);
+
+    await user.click(screen.getByText('common:welcome.tryoutProduct.mcp'));
+
+    expect(mockOpen).toHaveBeenCalledWith(
+      'https://docs.example.com/use-cases/ai-agents/mcp-authorization/try-it-out',
+      '_blank',
+      'noopener,noreferrer',
+    );
   });
 });

--- a/frontend/apps/console/src/features/welcome/utils/__tests__/downloadAssets.test.ts
+++ b/frontend/apps/console/src/features/welcome/utils/__tests__/downloadAssets.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import type {DistributionAsset, ReleaseAssetInput} from '../../models/download-assets';
+import {detectPlatform, groupAssetsByOs, parseDistributionAssets, pickAssetForPlatform} from '../downloadAssets';
+
+const PATTERN = /^sample-app-wayfinder-[0-9A-Za-z.+-]+-(macos|linux|win)-(arm64|x64)\.zip$/i;
+
+function makeAsset(name: string, extra: Partial<ReleaseAssetInput> = {}): ReleaseAssetInput {
+  return {downloadUrl: `https://example.com/${name}`, name, sizeLabel: '10 MB', ...extra};
+}
+
+describe('parseDistributionAssets', () => {
+  it('parses matching linux x64 asset', () => {
+    const result = parseDistributionAssets([makeAsset('sample-app-wayfinder-1.0.0-linux-x64.zip')], PATTERN);
+    expect(result).toHaveLength(1);
+    expect(result[0].os).toBe('linux');
+    expect(result[0].arch).toBe('x64');
+    expect(result[0].osLabel).toBe('Linux');
+    expect(result[0].archLabel).toBe('x64');
+  });
+
+  it('parses matching linux arm64 asset', () => {
+    const result = parseDistributionAssets([makeAsset('sample-app-wayfinder-1.0.0-linux-arm64.zip')], PATTERN);
+    expect(result).toHaveLength(1);
+    expect(result[0].os).toBe('linux');
+    expect(result[0].arch).toBe('arm64');
+    expect(result[0].archLabel).toBe('ARM64');
+  });
+
+  it('parses matching macos arm64 asset with Apple Silicon label', () => {
+    const result = parseDistributionAssets([makeAsset('sample-app-wayfinder-1.0.0-macos-arm64.zip')], PATTERN);
+    expect(result).toHaveLength(1);
+    expect(result[0].os).toBe('macos');
+    expect(result[0].arch).toBe('arm64');
+    expect(result[0].archLabel).toBe('ARM64 (Apple Silicon)');
+    expect(result[0].osLabel).toBe('Mac OS');
+  });
+
+  it('parses matching macos x64 asset with Intel label', () => {
+    const result = parseDistributionAssets([makeAsset('sample-app-wayfinder-1.0.0-macos-x64.zip')], PATTERN);
+    expect(result).toHaveLength(1);
+    expect(result[0].os).toBe('macos');
+    expect(result[0].arch).toBe('x64');
+    expect(result[0].archLabel).toBe('x64 (Intel)');
+  });
+
+  it('parses matching win x64 asset', () => {
+    const result = parseDistributionAssets([makeAsset('sample-app-wayfinder-1.0.0-win-x64.zip')], PATTERN);
+    expect(result).toHaveLength(1);
+    expect(result[0].os).toBe('win');
+    expect(result[0].arch).toBe('x64');
+    expect(result[0].osLabel).toBe('Windows');
+  });
+
+  it('ignores non-matching asset names', () => {
+    const result = parseDistributionAssets(
+      [makeAsset('some-other-tool-1.0.0-linux-x64.zip'), makeAsset('README.md')],
+      PATTERN,
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns correct download URL and sizeLabel', () => {
+    const asset = makeAsset('sample-app-wayfinder-1.0.0-linux-x64.zip', {
+      downloadUrl: 'https://releases.example.com/dl/file.zip',
+      sizeLabel: '22 MB',
+    });
+    const result = parseDistributionAssets([asset], PATTERN);
+    expect(result[0].downloadUrl).toBe('https://releases.example.com/dl/file.zip');
+    expect(result[0].sizeLabel).toBe('22 MB');
+  });
+
+  it('parses multiple assets', () => {
+    const assets = [
+      makeAsset('sample-app-wayfinder-1.0.0-linux-x64.zip'),
+      makeAsset('sample-app-wayfinder-1.0.0-macos-arm64.zip'),
+      makeAsset('sample-app-wayfinder-1.0.0-win-x64.zip'),
+    ];
+    const result = parseDistributionAssets(assets, PATTERN);
+    expect(result).toHaveLength(3);
+  });
+});
+
+describe('pickAssetForPlatform', () => {
+  const linuxX64: DistributionAsset = {
+    arch: 'x64',
+    archLabel: 'x64',
+    downloadUrl: 'https://example.com/linux-x64.zip',
+    name: 'sample-app-wayfinder-1.0.0-linux-x64.zip',
+    os: 'linux',
+    osLabel: 'Linux',
+    sizeLabel: '10 MB',
+  };
+  const linuxArm64: DistributionAsset = {
+    arch: 'arm64',
+    archLabel: 'ARM64',
+    downloadUrl: 'https://example.com/linux-arm64.zip',
+    name: 'sample-app-wayfinder-1.0.0-linux-arm64.zip',
+    os: 'linux',
+    osLabel: 'Linux',
+    sizeLabel: '11 MB',
+  };
+  const macosArm64: DistributionAsset = {
+    arch: 'arm64',
+    archLabel: 'ARM64 (Apple Silicon)',
+    downloadUrl: 'https://example.com/macos-arm64.zip',
+    name: 'sample-app-wayfinder-1.0.0-macos-arm64.zip',
+    os: 'macos',
+    osLabel: 'Mac OS',
+    sizeLabel: '12 MB',
+  };
+
+  it('returns null when assets array is empty', () => {
+    expect(pickAssetForPlatform([], {os: 'linux', arch: 'x64'})).toBeNull();
+  });
+
+  it('returns exact match when os and arch match', () => {
+    const result = pickAssetForPlatform([linuxX64, linuxArm64, macosArm64], {os: 'linux', arch: 'x64'});
+    expect(result).toBe(linuxX64);
+  });
+
+  it('falls back to same OS when arch does not match', () => {
+    const result = pickAssetForPlatform([linuxX64, macosArm64], {os: 'linux', arch: 'arm64'});
+    expect(result).toBe(linuxX64);
+  });
+
+  it('falls back to first asset when no OS matches', () => {
+    const result = pickAssetForPlatform([linuxX64, macosArm64], {os: 'win', arch: 'x64'});
+    expect(result).toBe(linuxX64);
+  });
+
+  it('returns null only when empty regardless of platform', () => {
+    expect(pickAssetForPlatform([], null)).toBeNull();
+    expect(pickAssetForPlatform([], {os: 'macos', arch: 'arm64'})).toBeNull();
+  });
+
+  it('picks preferred arch when platform has os but no arch', () => {
+    const result = pickAssetForPlatform([linuxX64, linuxArm64], {os: 'linux', arch: null});
+    // PREFERRED_ARCHS = ['x64', 'arm64'], x64 comes first
+    expect(result).toBe(linuxX64);
+  });
+});
+
+describe('groupAssetsByOs', () => {
+  const linuxX64: DistributionAsset = {
+    arch: 'x64',
+    archLabel: 'x64',
+    downloadUrl: 'https://example.com/linux-x64.zip',
+    name: 'linux-x64.zip',
+    os: 'linux',
+    osLabel: 'Linux',
+    sizeLabel: '10 MB',
+  };
+  const winX64: DistributionAsset = {
+    arch: 'x64',
+    archLabel: 'x64',
+    downloadUrl: 'https://example.com/win-x64.zip',
+    name: 'win-x64.zip',
+    os: 'win',
+    osLabel: 'Windows',
+    sizeLabel: '11 MB',
+  };
+  const macosArm64: DistributionAsset = {
+    arch: 'arm64',
+    archLabel: 'ARM64 (Apple Silicon)',
+    downloadUrl: 'https://example.com/macos-arm64.zip',
+    name: 'macos-arm64.zip',
+    os: 'macos',
+    osLabel: 'Mac OS',
+    sizeLabel: '12 MB',
+  };
+
+  it('groups assets by OS', () => {
+    const groups = groupAssetsByOs([linuxX64, winX64, macosArm64]);
+    const osList = groups.map((g) => g.os);
+    expect(osList).toContain('linux');
+    expect(osList).toContain('win');
+    expect(osList).toContain('macos');
+  });
+
+  it('preferred OS appears first', () => {
+    const groups = groupAssetsByOs([linuxX64, winX64, macosArm64], 'macos');
+    expect(groups[0].os).toBe('macos');
+  });
+
+  it('excludes empty OS groups', () => {
+    const groups = groupAssetsByOs([linuxX64, macosArm64]);
+    expect(groups.find((g) => g.os === 'win')).toBeUndefined();
+    expect(groups).toHaveLength(2);
+  });
+
+  it('returns default order when no preferred OS', () => {
+    const groups = groupAssetsByOs([linuxX64, winX64, macosArm64]);
+    // Default order is linux, win, macos
+    expect(groups[0].os).toBe('linux');
+    expect(groups[1].os).toBe('win');
+    expect(groups[2].os).toBe('macos');
+  });
+});
+
+describe('detectPlatform', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns {os: null, arch: null} when navigator is undefined', async () => {
+    vi.stubGlobal('navigator', undefined);
+    const result = await detectPlatform();
+    expect(result).toEqual({os: null, arch: null});
+  });
+
+  it('detects macOS from userAgent', async () => {
+    vi.stubGlobal('navigator', {
+      platform: 'MacIntel',
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+    });
+    const result = await detectPlatform();
+    expect(result.os).toBe('macos');
+  });
+
+  it('detects Windows from userAgent', async () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Win32',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+    });
+    const result = await detectPlatform();
+    expect(result.os).toBe('win');
+  });
+
+  it('detects Linux from userAgent', async () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Linux x86_64',
+      userAgent: 'Mozilla/5.0 (X11; Linux x86_64)',
+    });
+    const result = await detectPlatform();
+    expect(result.os).toBe('linux');
+  });
+
+  it('uses userAgentData.getHighEntropyValues when available', async () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Linux x86_64',
+      userAgent: 'Mozilla/5.0',
+      userAgentData: {
+        getHighEntropyValues: vi.fn().mockResolvedValue({
+          platform: 'macOS',
+          architecture: 'arm',
+          bitness: '64',
+        }),
+      },
+    });
+    const result = await detectPlatform();
+    expect(result.os).toBe('macos');
+    expect(result.arch).toBe('arm64');
+  });
+
+  it('returns null os when platform is not recognized', async () => {
+    vi.stubGlobal('navigator', {
+      platform: 'FreeBSD',
+      userAgent: 'some unknown browser on freebsd',
+    });
+    const result = await detectPlatform();
+    expect(result.os).toBeNull();
+  });
+
+  it('falls back to userAgent detection when getHighEntropyValues throws', async () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Linux x86_64',
+      userAgent: 'Mozilla/5.0 (X11; Linux x86_64)',
+      userAgentData: {
+        getHighEntropyValues: vi.fn().mockRejectedValue(new Error('not allowed')),
+      },
+    });
+    const result = await detectPlatform();
+    expect(result.os).toBe('linux');
+  });
+});

--- a/frontend/apps/console/src/features/welcome/utils/downloadAssets.ts
+++ b/frontend/apps/console/src/features/welcome/utils/downloadAssets.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type {
+  ArchKey,
+  DetectedPlatform,
+  DistributionAsset,
+  OsKey,
+  ReleaseAssetInput,
+  ReleaseEntry,
+  ReleasesData,
+} from '../models/download-assets';
+import OS_LABELS from '../constants/download-assets';
+import type {ArchKey, DetectedPlatform, DistributionAsset, OsKey, ReleaseAssetInput} from '../models/download-assets';
+
+const VALID_OS = new Set<string>(Object.keys(OS_LABELS));
+const VALID_ARCH = new Set<string>(['arm64', 'x64']);
+
+function archLabel(os: OsKey, arch: ArchKey): string {
+  if (os === 'macos') return arch === 'arm64' ? 'ARM64 (Apple Silicon)' : 'x64 (Intel)';
+  return arch === 'arm64' ? 'ARM64' : 'x64';
+}
+
+export function parseDistributionAssets(assets: ReleaseAssetInput[], pattern: RegExp): DistributionAsset[] {
+  const result: DistributionAsset[] = [];
+  for (const asset of assets) {
+    pattern.lastIndex = 0;
+    const match = pattern.exec(asset.name);
+    if (!match) continue;
+    if (!VALID_OS.has(match[1]) || !VALID_ARCH.has(match[2])) continue;
+    const os = match[1] as OsKey;
+    const arch = match[2] as ArchKey;
+    result.push({
+      arch,
+      archLabel: archLabel(os, arch),
+      downloadUrl: asset.downloadUrl,
+      name: asset.name,
+      os,
+      osLabel: OS_LABELS[os],
+      sizeLabel: asset.sizeLabel,
+    });
+  }
+  return result;
+}
+
+const PREFERRED_ARCHS: ArchKey[] = ['x64', 'arm64'];
+
+export function pickAssetForPlatform(
+  assets: DistributionAsset[],
+  platform: DetectedPlatform | null,
+): DistributionAsset | null {
+  if (assets.length === 0) return null;
+  if (platform?.arch) {
+    return (
+      assets.find((a) => a.os === platform.os && a.arch === platform.arch) ??
+      assets.find((a) => a.os === platform.os) ??
+      assets[0]
+    );
+  }
+  const osAssets = assets.filter((a) => a.os === platform?.os);
+  if (osAssets.length > 0) {
+    return PREFERRED_ARCHS.map((arch) => osAssets.find((a) => a.arch === arch)).find(Boolean) ?? osAssets[0];
+  }
+  return assets[0];
+}
+
+export function groupAssetsByOs(
+  assets: DistributionAsset[],
+  preferredOs?: OsKey | null,
+): {os: OsKey; assets: DistributionAsset[]}[] {
+  const defaultOrder: OsKey[] = ['linux', 'win', 'macos'];
+  const order = preferredOs ? [preferredOs, ...defaultOrder.filter((o) => o !== preferredOs)] : defaultOrder;
+  return order.map((os) => ({os, assets: assets.filter((a) => a.os === os)})).filter((g) => g.assets.length > 0);
+}
+
+interface NavigatorWithUserAgentData extends Navigator {
+  userAgentData?: {
+    getHighEntropyValues?: (
+      hints: ('architecture' | 'bitness' | 'platform')[],
+    ) => Promise<{architecture?: string; bitness?: string; platform?: string}>;
+  };
+}
+
+function detectOperatingSystem(userAgent: string, platform: string): OsKey | null {
+  const ua = userAgent.toLowerCase();
+  const pf = platform.toLowerCase();
+  if (pf.includes('mac') || /(mac os x|macintosh)/.test(ua)) return 'macos';
+  if (pf.includes('win') || ua.includes('windows')) return 'win';
+  if (pf.includes('linux') || ua.includes('linux')) return 'linux';
+  return null;
+}
+
+function detectArchitecture(userAgent: string, os: OsKey | null): ArchKey | null {
+  const ua = userAgent.toLowerCase();
+  if (/(arm64|aarch64|armv8|apple silicon|silicon)/.test(ua)) return 'arm64';
+  if (/\b(wow64|win64|x64|x86_64|amd64|intel)\b/.test(ua)) {
+    if (os === 'macos') return null;
+    return 'x64';
+  }
+  return null;
+}
+
+export async function detectPlatform(): Promise<DetectedPlatform> {
+  if (typeof navigator === 'undefined') return {arch: null, os: null};
+  const {platform, userAgent} = navigator;
+  const fallbackOs = detectOperatingSystem(userAgent, platform);
+  const fallback: DetectedPlatform = {arch: detectArchitecture(userAgent, fallbackOs), os: fallbackOs};
+  const {userAgentData} = navigator as NavigatorWithUserAgentData;
+  if (!userAgentData?.getHighEntropyValues) return fallback;
+  try {
+    const v = await userAgentData.getHighEntropyValues(['architecture', 'bitness', 'platform']);
+    const detPf = v.platform?.toLowerCase() ?? '';
+    const detArch = v.architecture?.toLowerCase() ?? '';
+    const detBits = v.bitness?.toLowerCase() ?? '';
+    const os: OsKey | null =
+      detPf === 'macos' ? 'macos' : detPf === 'windows' ? 'win' : detPf === 'linux' ? 'linux' : fallback.os;
+    const arch: ArchKey | null =
+      detArch === 'arm' ? 'arm64' : detArch === 'x86' && detBits === '64' ? 'x64' : fallback.arch;
+    return {arch, os};
+  } catch {
+    return fallback;
+  }
+}

--- a/frontend/packages/design/src/themes/DefaultTheme.ts
+++ b/frontend/packages/design/src/themes/DefaultTheme.ts
@@ -258,6 +258,19 @@ export const DefaultThemeConfig = {
       defaultProps: {
         size: 'small',
       },
+      styleOverrides: {
+        option: {
+          '&.Mui-focused, &[data-focus="true"]': {
+            backgroundColor: 'var(--oxygen-palette-action-hover) !important',
+          },
+          '&[aria-selected="true"]': {
+            backgroundColor: 'var(--oxygen-palette-action-selected) !important',
+          },
+          '&[aria-selected="true"].Mui-focused, &[aria-selected="true"][data-focus="true"]': {
+            backgroundColor: 'var(--oxygen-palette-action-selected) !important',
+          },
+        },
+      },
     },
     MuiDataGrid: {
       styleOverrides: {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -150,11 +150,12 @@ const translations = {
 
     // Welcome screen
     'welcome.header': 'Welcome',
+    'welcome.dismissed': 'Welcome window can be reopened through the user dropdown menu.',
     'welcome.sections.start': 'Start',
     'welcome.sections.recent': 'Recent',
     'welcome.sections.tryoutProduct': 'Tryout',
-    'welcome.tryoutProduct.b2c': 'Securing Consumer App (B2C)',
-    'welcome.tryoutProduct.b2cDesc': 'Tryout user journeys for a consumer-facing app',
+    'welcome.tryoutProduct.consumerApp': 'Securing Consumer App',
+    'welcome.tryoutProduct.consumerAppDesc': 'Tryout user journeys for a consumer-facing app',
     'welcome.tryoutProduct.aiAgents': 'Securing AI Agents',
     'welcome.tryoutProduct.aiAgentsDesc': 'Tryout identity patterns for AI agents and tools',
     'welcome.tryoutProduct.mcp': 'Securing MCP',
@@ -186,6 +187,255 @@ const translations = {
     'welcome.createProject.cards.runServer.description':
       '{{productName}} will run in immutable mode with the attached configurations.',
     'welcome.createProject.actions.getStarted': 'Get Started',
+    'welcome.wayfinderSampleSetup.title': 'Setup Wayfinder Sample',
+    'welcome.wayfinderSampleSetup.oneTimeSetup': 'One-time setup',
+    'welcome.wayfinderSampleSetup.setupComplete': 'Already set up — you can skip this section',
+    'welcome.wayfinderSampleSetup.steps.getSample.title': 'Get the Wayfinder Sample',
+    'welcome.wayfinderSampleSetup.steps.getSample.description':
+      'Download the latest Wayfinder sample distribution. It ships with the web frontend, AI agent service, Wayfinder server, and a thunderid-config/ directory with the configuration bundle.',
+    'welcome.wayfinderSampleSetup.steps.configure.title': 'Configure Wayfinder Sample in {{productName}}',
+    'welcome.wayfinderSampleSetup.steps.configure.description':
+      'Select your extracted Wayfinder sample folder. The importer reads the thunderid-config/ directory and applies the configuration to {{productName}}. Skip this step if already done.',
+    'welcome.wayfinderSampleSetup.steps.run.title': 'Run the Sample',
+    'welcome.wayfinderSampleSetup.steps.run.description':
+      'Start all Wayfinder services from the extracted sample directory.',
+    'welcome.wayfinderSampleDownload.recommendedLabel': 'Recommended for this device',
+    'welcome.wayfinderSampleDownload.selectedLabel': 'Selected download',
+    'welcome.wayfinderSampleDownload.downloadButton': 'Download for {{osLabel}}',
+    'welcome.wayfinderSampleDownload.otherPlatforms': 'Other download options',
+    'welcome.wayfinderSampleDownload.hidePlatforms': 'Hide other platforms',
+
+    'welcome.wayfinderFolderImport.actions.selectFolder': 'Select Wayfinder Sample Folder',
+    'welcome.wayfinderFolderImport.actions.change': 'Change',
+    'welcome.wayfinderFolderImport.actions.importConfig': 'Configure in ThunderID',
+    'welcome.wayfinderFolderImport.actions.reImport': 'Re-import',
+    'welcome.wayfinderFolderImport.actions.reSelectFolder': 'Re-select Folder',
+    'welcome.wayfinderFolderImport.status.importing': 'Importing configuration…',
+    'welcome.wayfinderFolderImport.status.alreadyDone': 'Wayfinder sample already configured in {{productName}}',
+    'welcome.wayfinderFolderImport.status.lastImported': 'Last imported on {{date}} — you can skip this step.',
+    'welcome.wayfinderFolderImport.status.success': 'Wayfinder sample configured in {{productName}} successfully',
+    'welcome.wayfinderFolderImport.status.resourcesImported_one': '{{count}} resource imported',
+    'welcome.wayfinderFolderImport.status.resourcesImported_other': '{{count}} resources imported',
+    'welcome.wayfinderFolderImport.status.envNotFound': 'thunderid-config/*.env — not found',
+    'welcome.wayfinderFolderImport.errors.cannotReadFolder': 'Could not read the selected folder.',
+    'welcome.wayfinderFolderImport.errors.importFailed': 'Import failed. Please try again.',
+    'welcome.wayfinderFolderImport.errors.partialFailure': 'Import completed with {{count}} failed resource(s).',
+
+    'welcome.tryout.breadcrumb': 'Try It Out',
+    'welcome.tryout.title': 'Try It Out',
+    'welcome.tryout.actions.readDocs': 'Read Documentation for more guides and details',
+    'welcome.tryout.importConfigs.title': 'Configure Wayfinder Sample in {{productName}}',
+    'welcome.tryout.importConfigs.description':
+      'Select your extracted Wayfinder sample folder. The importer reads the thunderid-config/ directory inside and applies the configuration to {{productName}}.',
+
+    'welcome.getStarted.breadcrumb': 'Get started',
+    'welcome.getStarted.actions.skipToConsole': 'Skip to console',
+    'welcome.getStarted.title': 'Get Started',
+    'welcome.getStarted.subtitle': 'Onboard your first application and start securing it with {{productName}}.',
+    'welcome.getStarted.options.onboardApp.title': 'Onboard your first app',
+    'welcome.getStarted.options.onboardApp.description':
+      'Register your application in {{productName}} and integrate authentication step by step.',
+    'welcome.getStarted.options.onboardApp.action': 'Add Application',
+    'welcome.getStarted.options.skip.title': 'Skip for now',
+    'welcome.getStarted.options.skip.description':
+      'Head straight to the console and explore {{productName}} on your own.',
+    'welcome.getStarted.options.skip.action': 'Go to Console',
+
+    'welcome.consumerAppTryout.breadcrumb': 'Tryout Securing Consumer App',
+    'welcome.consumerAppTryout.overline': 'Securing Consumer App',
+    'welcome.consumerAppTryout.title': 'Secure Your Consumer App',
+    'welcome.consumerAppTryout.subtitle':
+      'Run consumer app use cases against the Wayfinder sample, a fictional consumer travel-booking app.',
+    'welcome.consumerAppTryout.steps.getSample.title': 'Get the Wayfinder Sample',
+    'welcome.consumerAppTryout.steps.getSample.description':
+      'Download the latest Wayfinder sample distribution. It ships with a thunderid-config/ directory containing a declarative YAML bundle and a thunderid.env file with the environment variables it references.',
+    'welcome.consumerAppTryout.steps.getSample.action': 'Download Sample',
+    'welcome.consumerAppTryout.steps.importConfigs.title': 'Configure Wayfinder Sample in {{productName}}',
+    'welcome.consumerAppTryout.steps.importConfigs.description':
+      'Select your extracted Wayfinder sample folder. The importer reads the thunderid-config/ directory inside and applies the configuration to {{productName}}.',
+    'welcome.consumerAppTryout.steps.runSample.title': 'Run the Sample',
+    'welcome.consumerAppTryout.steps.runSample.description':
+      'Start all Wayfinder services from the extracted sample directory.',
+    'welcome.consumerAppTryout.steps.runSample.action': 'See Run Instructions',
+    'welcome.consumerAppTryout.steps.login.title': 'Log In to the App',
+    'welcome.consumerAppTryout.steps.login.description':
+      'Open the Wayfinder sample app and sign in with the demo credentials below.',
+
+    'welcome.consumerAppTryout.scenarios.title': 'Try use cases',
+    'welcome.consumerAppTryout.scenarios.tabs.login': 'Log In',
+    'welcome.consumerAppTryout.scenarios.tabs.signup': 'Self Sign-Up',
+    'welcome.consumerAppTryout.scenarios.tabs.profile': 'View Profile',
+    'welcome.consumerAppTryout.scenarios.tabs.recovery': 'Account Recovery',
+    'welcome.consumerAppTryout.scenarios.tabs.onboard': 'Onboard Staff',
+
+    'welcome.consumerAppTryout.scenarios.login.description':
+      'Sign in with the demo consumer account to explore the Wayfinder app.',
+    'welcome.consumerAppTryout.scenarios.login.step1': 'Open the Wayfinder app at <a>http://localhost:5173</a>.',
+    'welcome.consumerAppTryout.scenarios.login.step2': 'Click Sign in and use the credentials below.',
+
+    'welcome.consumerAppTryout.scenarios.signup.description':
+      'Register a new customer account and see ThunderID assign the Traveler role automatically on completion.',
+    'welcome.consumerAppTryout.scenarios.signup.step1': 'Open <a>http://localhost:5173</a> and click Sign in.',
+    'welcome.consumerAppTryout.scenarios.signup.step2': 'On the ThunderID page, click Sign up.',
+    'welcome.consumerAppTryout.scenarios.signup.step3': 'Fill in the registration form using the sample details below.',
+    'welcome.consumerAppTryout.scenarios.signup.sampleFields.username': 'Username',
+    'welcome.consumerAppTryout.scenarios.signup.sampleFields.email': 'Email',
+    'welcome.consumerAppTryout.scenarios.signup.sampleFields.givenName': 'Given name',
+    'welcome.consumerAppTryout.scenarios.signup.sampleFields.familyName': 'Family name',
+    'welcome.consumerAppTryout.scenarios.signup.step4':
+      'Submit. ThunderID creates a Customer user, records terms acceptance, and assigns the Traveler role.',
+    'welcome.consumerAppTryout.scenarios.signup.step5':
+      'The browser redirects back to Wayfinder with the new account authenticated.',
+
+    'welcome.consumerAppTryout.scenarios.profile.description':
+      'Explore the self-service profile page — view account details, edit attributes, and change your password.',
+    'welcome.consumerAppTryout.scenarios.profile.step1': 'Sign in as john.doe at <a>http://localhost:5173</a>.',
+    'welcome.consumerAppTryout.scenarios.profile.step2':
+      'Click the username in the top-right corner and select Profile.',
+    'welcome.consumerAppTryout.scenarios.profile.step3':
+      'View account details, edit profile attributes, or change your password. The page calls the identity provider directly with your session token.',
+
+    'welcome.consumerAppTryout.scenarios.recovery.description':
+      'Walk through the password recovery flow — John forgets his password and resets it via email.',
+    'welcome.consumerAppTryout.scenarios.recovery.smtpNote':
+      "Recovery emails require a configured SMTP server. Add your SMTP settings under email.smtp in {{productName}}'s deployment.yaml and restart the server before trying this flow.",
+    'welcome.consumerAppTryout.scenarios.recovery.step1': 'Open <a>http://localhost:5173</a> and click Sign in.',
+    'welcome.consumerAppTryout.scenarios.recovery.step2': 'On the ThunderID sign-in page, click Forgot password?',
+    'welcome.consumerAppTryout.scenarios.recovery.step3': 'Enter john.doe as the username and submit.',
+    'welcome.consumerAppTryout.scenarios.recovery.step4':
+      "ThunderID sends a recovery email to John's registered address.",
+    'welcome.consumerAppTryout.scenarios.recovery.step5': 'Open the link in the email and set a new password.',
+    'welcome.consumerAppTryout.scenarios.recovery.step6': 'Sign in again with the new credentials.',
+
+    'welcome.consumerAppTryout.scenarios.onboard.description':
+      'Invite and onboard a new staff member using the staff invitation flow. The invited user selects a role (Support or DestinationsAdmin) during onboarding.',
+    'welcome.consumerAppTryout.scenarios.onboard.smtpNote':
+      "Staff invitation emails require a configured SMTP server. Add your SMTP settings under email.smtp in {{productName}}'s deployment.yaml and restart the server before trying this flow.",
+    'welcome.consumerAppTryout.scenarios.onboard.step1':
+      'Sign in as alex.carter (OpsAdmin) at <a>http://localhost:5173</a> using the credentials below.',
+    'welcome.consumerAppTryout.scenarios.onboard.step2':
+      'Navigate to the staff management section and invite a new staff member by email.',
+    'welcome.consumerAppTryout.scenarios.onboard.step3':
+      'The invited user receives an onboarding email. They open the link and complete the onboarding flow, choosing between the Support and DestinationsAdmin roles.',
+    'welcome.consumerAppTryout.scenarios.onboard.step4':
+      'Once onboarded, the new staff member can sign in to the app with their chosen role permissions active.',
+
+    'welcome.aiAgentsTryout.breadcrumb': 'Tryout Securing AI Agents',
+    'welcome.aiAgentsTryout.overline': 'Securing AI Agents',
+    'welcome.aiAgentsTryout.subtitle':
+      'Run AI agent use cases against the Wayfinder sample, a travel-booking app with a built-in AI chat assistant.',
+    'welcome.aiAgentsTryout.steps.getSample.title': 'Get the Wayfinder Sample',
+    'welcome.aiAgentsTryout.steps.getSample.description':
+      'Download the latest Wayfinder sample distribution. It ships with a thunderid-config/ directory, the Wayfinder web frontend, the AI Agent service, and the Wayfinder Server.',
+    'welcome.aiAgentsTryout.steps.importConfigs.title': 'Configure Wayfinder Sample in {{productName}}',
+    'welcome.aiAgentsTryout.steps.importConfigs.description':
+      'Select your extracted Wayfinder sample folder. The importer reads the thunderid-config/ directory inside and applies the configuration to {{productName}}.',
+    'welcome.aiAgentsTryout.steps.configureSample.title': 'Configure the Sample',
+    'welcome.aiAgentsTryout.steps.configureSample.description':
+      'Copy each .env.example to .env in backend/, ai-agent/, and frontend/. Fill in your LLM API key in ai-agent/.env — an Anthropic key from console.anthropic.com or a Gemini key from aistudio.google.com.',
+    'welcome.aiAgentsTryout.steps.runSample.title': 'Run the Sample',
+    'welcome.aiAgentsTryout.steps.runSample.description':
+      'Start all Wayfinder services from the extracted sample directory.',
+    'welcome.aiAgentsTryout.steps.login.title': 'Log In to the App',
+    'welcome.aiAgentsTryout.steps.login.description':
+      'Open the Wayfinder sample app and sign in with the demo credentials below.',
+
+    'welcome.aiAgentsTryout.scenarios.title': 'Try use cases',
+    'welcome.aiAgentsTryout.scenarios.apiKeyNote':
+      'The AI agent requires an LLM API key. Edit ai-agent/.env in the sample directory and set ANTHROPIC_API_KEY or GOOGLE_API_KEY before starting the services.',
+    'welcome.aiAgentsTryout.scenarios.tabs.protect': 'Protect the Agent',
+    'welcome.aiAgentsTryout.scenarios.tabs.browse': 'Browse with Agent',
+    'welcome.aiAgentsTryout.scenarios.tabs.book': 'Book on Behalf',
+
+    'welcome.aiAgentsTryout.scenarios.protect.description':
+      'See scope-based access control in action — John can use the AI concierge, but Jane cannot.',
+    'welcome.aiAgentsTryout.scenarios.protect.step1':
+      'Open <a>http://localhost:5173</a> and sign in as john.doe / john.doe.',
+    'welcome.aiAgentsTryout.scenarios.protect.step2':
+      "Open the chat widget (bottom-right corner) and send any message. The concierge responds — John's token carries the agent:access scope.",
+    'welcome.aiAgentsTryout.scenarios.protect.step3': 'Sign out and sign in as jane.smith / jane.smith.',
+    'welcome.aiAgentsTryout.scenarios.protect.step4':
+      'Open the chat and send a message. The request is rejected with a 403 — Jane does not have the Wayfinder Chat User role.',
+    'welcome.aiAgentsTryout.scenarios.protect.johnLabel': 'John Doe — has agent:access (Wayfinder Chat User role)',
+    'welcome.aiAgentsTryout.scenarios.protect.janeLabel': 'Jane Smith — no agent:access',
+
+    'welcome.aiAgentsTryout.scenarios.browse.description':
+      'Watch the agent use its own machine-to-machine token to call read-only tools — no user consent popup required.',
+    'welcome.aiAgentsTryout.scenarios.browse.step1':
+      'Sign in as john.doe at <a>http://localhost:5173</a> and open the chat widget.',
+    'welcome.aiAgentsTryout.scenarios.browse.step2':
+      'Ask a browsing question, for example: "What flights are there from Colombo to Singapore?"',
+    'welcome.aiAgentsTryout.scenarios.browse.step3':
+      'The agent calls the Wayfinder MCP server with its own M2M token (client_credentials grant). No popup appears.',
+    'welcome.aiAgentsTryout.scenarios.browse.step4':
+      'You can also try: "Suggest a few flight deals." The agent calls the recommend_bookings tool, which requires the booking:recommend scope — granted to the Wayfinder Concierge via its Recommender role.',
+
+    'welcome.aiAgentsTryout.scenarios.book.description':
+      'Trigger the on-behalf-of consent flow — the agent pauses, asks for your permission, and only proceeds after you approve.',
+    'welcome.aiAgentsTryout.scenarios.book.step1':
+      'Sign in as john.doe at <a>http://localhost:5173</a> and open the chat widget.',
+    'welcome.aiAgentsTryout.scenarios.book.step2': 'Ask the agent to book something, for example: "Book flight 2".',
+    'welcome.aiAgentsTryout.scenarios.book.step3':
+      'The agent returns a consent request. A popup opens — sign in as john.doe and select which booking permissions to grant (booking:read, booking:create, booking:cancel).',
+    'welcome.aiAgentsTryout.scenarios.book.step4':
+      'After approval the agent retries the action using a user-context token. The booking succeeds.',
+    'welcome.aiAgentsTryout.scenarios.book.step5':
+      'To see the rejection path, repeat the flow but deny booking:create in the consent screen. The agent returns a 403.',
+
+    'welcome.mcpTryout.breadcrumb': 'Tryout Securing MCP',
+    'welcome.mcpTryout.overline': 'Securing MCP',
+    'welcome.mcpTryout.subtitle':
+      'Connect an external MCP client to the Wayfinder MCP server, signed in through {{productName}}.',
+    'welcome.mcpTryout.steps.prerequisite.title': 'Complete AI Agents Setup',
+    'welcome.mcpTryout.steps.prerequisite.description':
+      'This tryout extends the AI Agents environment. Complete the Securing AI Agents tryout setup first — the same bundle seeds the EXTERNAL-MCP-CLIENT application used here.',
+    'welcome.mcpTryout.steps.importConfigs.title': 'Configure Wayfinder Sample in {{productName}}',
+    'welcome.mcpTryout.steps.importConfigs.description':
+      'Select your extracted Wayfinder sample folder. The importer reads the thunderid-config/ directory inside and applies the configuration to {{productName}}.',
+    'welcome.mcpTryout.steps.verifyApp.title': 'Verify the Application',
+    'welcome.mcpTryout.steps.verifyApp.description':
+      'In the {{productName}} Console, open Applications and confirm EXTERNAL-MCP-CLIENT is listed.',
+    'welcome.mcpTryout.steps.verifyApp.action': 'Open Applications',
+    'welcome.mcpTryout.steps.installInspector.title': 'Install MCP Inspector',
+    'welcome.mcpTryout.steps.installInspector.description':
+      'Launch MCP Inspector locally — a browser-based reference UI for MCP servers with built-in OAuth support.',
+    'welcome.mcpTryout.steps.allowCors.title': 'Allow Inspector in CORS',
+    'welcome.mcpTryout.steps.allowCors.description':
+      "Add Inspector's origin to {{productName}}'s CORS allow-list in repository/conf/deployment.yaml, then restart {{productName}}.",
+
+    'welcome.mcpTryout.scenarios.title': 'Try use cases',
+    'welcome.mcpTryout.scenarios.tabs.connect': 'Connect & Sign In',
+    'welcome.mcpTryout.scenarios.tabs.permissions': 'Test Permissions',
+
+    'welcome.mcpTryout.scenarios.connect.description':
+      'Point MCP Inspector at the Wayfinder MCP server, authenticate through {{productName}}, and grant booking permissions at the consent screen.',
+    'welcome.mcpTryout.scenarios.connect.step1':
+      'Open <a>http://localhost:6274</a> in your browser (Inspector should already be running from the setup step above).',
+    'welcome.mcpTryout.scenarios.connect.step2':
+      'Set Transport to Streamable HTTP and Server URL to http://localhost:8787/mcp.',
+    'welcome.mcpTryout.scenarios.connect.step3':
+      'Enable OAuth. Set Client ID to EXTERNAL-MCP-CLIENT and leave Client Secret blank (public client).',
+    'welcome.mcpTryout.scenarios.connect.step4':
+      'Click Connect. You are redirected to {{productName}} — sign in as john.doe / john.doe.',
+    'welcome.mcpTryout.scenarios.connect.step5':
+      'At the consent screen select the booking permissions to grant (booking:read, booking:create, booking:cancel) and confirm.',
+    'welcome.mcpTryout.scenarios.connect.connectionLabel': 'Connection details',
+    'welcome.mcpTryout.scenarios.connect.fields.transport': 'Transport',
+    'welcome.mcpTryout.scenarios.connect.fields.serverUrl': 'Server URL',
+    'welcome.mcpTryout.scenarios.connect.fields.clientId': 'Client ID',
+    'welcome.mcpTryout.scenarios.connect.fields.clientSecret': 'Client Secret',
+
+    'welcome.mcpTryout.scenarios.permissions.description':
+      'Call MCP tools and observe how {{productName}} enforces the scopes you granted at consent. Reconnect with different permissions to see the difference.',
+    'welcome.mcpTryout.scenarios.permissions.step1':
+      'In the Tools tab, call create_booking. Set type=flight, itemId=flight-cmb-sin-01, travelers=1. The call succeeds if you granted booking:create.',
+    'welcome.mcpTryout.scenarios.permissions.step2':
+      'Call delete_all_bookings. If booking:cancel was not granted you get: "Insufficient scope for tool delete_all_bookings. Required: booking:cancel".',
+    'welcome.mcpTryout.scenarios.permissions.step3':
+      'To narrow or expand permissions, disconnect from Inspector and reconnect.',
+    'welcome.mcpTryout.scenarios.permissions.step4':
+      'Re-authenticate as john.doe and toggle different scopes at the consent screen, then retry the previously denied tool call — it now succeeds.',
+
     'welcome.setupComplete.breadcrumb': 'Complete',
     'welcome.setupComplete.title': "You're all set!",
     'welcome.setupComplete.subtitle':
@@ -3045,6 +3295,61 @@ const translations = {
   // ============================================================================
   // How Solution Works Illustration - Shared illustration translations
   // ============================================================================
+  consumerAppIllustration: {
+    step1Title: 'Get the Wayfinder Sample',
+    step1Sub: 'Download the sample distribution',
+    step2Title: 'Register Application',
+    step2Line1: 'Set redirect URIs',
+    step2Line2: 'and client credentials',
+    step2Line3: 'in the console',
+    step2Sub: 'Creates the app in the console',
+    step3Title: 'Run the Sample',
+    step3Sub: 'Linux / macOS or Windows',
+  },
+  aiAgentsIllustration: {
+    consumers: 'Consumers',
+    johnDoe: 'John Doe',
+    janeSmith: 'Jane Smith',
+    use: 'Use',
+    wayfinderWeb: 'Wayfinder Web',
+    wayfinderWebSub: 'Browser SPA with chat widget',
+    wayfinderWebDetail: 'Book travel, chat with the agent',
+    identityAuthority: 'Identity Authority',
+    managesIdentities: 'Manages identities',
+    issuesTokens: 'and issues tokens',
+    aiAgent: 'AI Agent',
+    aiAgentSub: 'Wayfinder Concierge',
+    drivesConversation: 'Drives the conversation',
+    wayfinderServer: 'Wayfinder Server',
+    wayfinderServerSub: 'Booking API + MCP tools',
+    holdsData: 'Holds flights, hotels, bookings',
+    signIn: 'Sign in',
+    issueUserToken: 'Issue user token',
+    chat: 'Chat',
+    authenticatedCalls: 'Authenticated calls',
+    callMcpTools: 'Call MCP tools',
+    getAgentTokens: 'Get agent tokens',
+    issueAgentTokens: 'Issue agent / on-behalf-of tokens',
+    validateTokens: 'Validate tokens',
+  },
+  mcpIllustration: {
+    user: 'User',
+    johnDoe: 'John Doe',
+    use: 'Use',
+    externalMcpClient: 'External MCP Client',
+    mcpInspector: 'MCP Inspector',
+    discoversSignsIn: 'Discovers, signs in, calls MCP tools',
+    identityAuthority: 'Identity Authority',
+    managesIdentities: 'Manages identities',
+    issuesTokens: 'and issues tokens',
+    wayfinderServer: 'Wayfinder Server',
+    wayfinderServerSub: 'Booking API + MCP tools',
+    holdsData: 'Holds flights, hotels, bookings',
+    signIn: 'Sign in',
+    issueTokens: 'Issue tokens',
+    callMcpTools: 'Call MCP tools',
+    validateTokens: 'Validate tokens',
+  },
   howSolutionWorksIllustration: {
     validateTest: 'Validate / Test',
     configureProject: 'Configure Project',


### PR DESCRIPTION
This pull request introduces several new features and improvements related to the Wayfinder onboarding and import experience, as well as minor updates to configuration and developer tooling. The most significant changes are the addition of new onboarding routes and pages, the implementation of Wayfinder release fetching and import functionality, and the inclusion of new reusable UI components.

<img width="1726" height="911" alt="image" src="https://github.com/user-attachments/assets/1e1edd64-bc36-4b54-adc8-368cbed02b3c" />

<img width="1726" height="911" alt="image" src="https://github.com/user-attachments/assets/3a0438cc-48b7-478e-9ee8-abb986aeda47" />

<img width="1726" height="911" alt="image" src="https://github.com/user-attachments/assets/0f9f77cb-e788-48d6-a8e1-b918a3c61e2f" />

<img width="1726" height="911" alt="image" src="https://github.com/user-attachments/assets/4d530f43-25bb-4813-adcd-099246adc91f" />


**Wayfinder onboarding and import features:**

* Added new onboarding routes and pages to the frontend app, including "Get Started" and "Tryout" pages for different scenarios, by updating the routing in `App.tsx` and importing the relevant components. [[1]](diffhunk://#diff-9076cde6c3b6d05029b6e8be25ecf6e56a13239ad66a3e6f0384f73ffd0615c1R35-R38) [[2]](diffhunk://#diff-9076cde6c3b6d05029b6e8be25ecf6e56a13239ad66a3e6f0384f73ffd0615c1R35-R38)
* Implemented a new `WayfinderFolderImport` component that allows users to select a folder, parse configuration files, and import them, with support for error handling, status display, and re-importing.
* Added a `useWayfinderReleases` React hook to fetch release metadata for Wayfinder, with error handling and caching, and included comprehensive unit tests for this hook. [[1]](diffhunk://#diff-917c43dc77145e9c5db20555d8f808620c104e6e7744731a87259a1a77ce9c5dR1-R33) [[2]](diffhunk://#diff-b4a8f13eea7f1284997c900b33446313fb26452638c6e1a3b24a82cab073a3f9R1-R137)

**Reusable UI components:**

* Introduced a new `TerminalBlock` component for displaying terminal commands with copy-to-clipboard functionality and improved user feedback.

**Configuration and developer tooling:**

* Updated CORS allowed origins in the backend deployment configuration to include additional local development URLs for Wayfinder sample apps, with comments indicating these should be removed in production.
* Added a `cspell.json` file to configure spell checking for project-specific terms and technology names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Welcome/onboarding: Get Started, multi-step Try-Outs (consumer app, AI agents, MCP) with interactive credentials, copy-to-clipboard, and walkthroughs.
  * Wayfinder sample: platform-aware download, guided one-time setup, folder import flow, and reusable terminal command block.
  * Release-fetching hook and download-asset utilities for Wayfinder.

* **Refactor**
  * Centralized welcome close behavior and updated navigation/layout.

* **Documentation**
  * Expanded English translations for welcome/get-started content.

* **Tests**
  * New/expanded test suites for welcome UI, hooks, Wayfinder utilities, and components.

* **Chores**
  * Spell-check config, expanded local dev CORS origins, and autocomplete styling tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->