### PR TITLE
Guard DOMPurify hook registration in RichTextAdapter for SSR

### DIFF
--- a/frontend/packages/design/src/components/flow/adapters/RichTextAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/RichTextAdapter.tsx
@@ -37,12 +37,14 @@ const APPLICATION_URL_META_KEY = 'application.url';
 
 const REGISTRATION_ENABLED_META_KEY = 'isRegistrationFlowEnabled';
 
-DOMPurify.removeHooks('afterSanitizeAttributes');
-DOMPurify.addHook('afterSanitizeAttributes', (node: globalThis.Element) => {
-  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
-    node.setAttribute('rel', 'noopener noreferrer');
-  }
-});
+if (typeof window !== 'undefined') {
+  DOMPurify.removeHooks('afterSanitizeAttributes');
+  DOMPurify.addHook('afterSanitizeAttributes', (node: globalThis.Element) => {
+    if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+}
 const RECOVERY_ENABLED_META_KEY = 'isRecoveryFlowEnabled';
 
 interface RichTextAdapterProps {


### PR DESCRIPTION
### Purpose

The docs site (Docusaurus) build started failing with:

> `TypeError: dompurify__WEBPACK_IMPORTED_MODULE_8__.A.removeHooks is not a function`

after #2576 introduced module-level `DOMPurify.removeHooks` / `DOMPurify.addHook` calls in `RichTextAdapter.tsx`.

DOMPurify's ESM entry returns a stub factory (without hook methods like `addHook` / `removeHooks`) when no `window` is available — see [`purify.es.mjs:296-306`](https://github.com/cure53/DOMPurify/blob/main/src/purify.ts). Because the hook registration ran at module top level, it was evaluated during Docusaurus' Node SSR pass (which transitively imports `@thunderid/design` via the docs build), crashing the build.

### Approach

Wrap the hook setup in a `typeof window !== 'undefined'` guard so it only runs in the browser. The runtime behavior in the browser is unchanged — the hook is still registered once at module load, before any `DOMPurify.sanitize(...)` call from `RichTextAdapter` runs.

### Related Issues

- 

### Related PRs

- #2576

### Checklist

- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided.
- [ ] Tests provided.
- [ ] Breaking changes.

### Security checks

- [ ] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-side rendering compatibility with rich text components while maintaining security for external links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->