### PR TITLE
Post synthetic codecov/patch success for docs-only PRs

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -275,6 +275,9 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      statuses: write
     outputs:
       should-run: ${{ steps.filter.outputs.code }}
     steps:
@@ -301,6 +304,17 @@ jobs:
       - name: ⏭️ Docs-only changes
         if: steps.filter.outputs.code != 'true'
         run: echo "Only documentation changes detected - skipping frontend and E2E tests"
+      - name: ⏭️ Post codecov/patch success for docs-only changes
+        if: steps.filter.outputs.code != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          gh api repos/${{ github.repository }}/statuses/$HEAD_SHA \
+            --method POST \
+            --field state=success \
+            --field context='codecov/patch' \
+            --field description='No code changes — coverage check not applicable'
 
   test-frontend-packages:
     name: 🧪 Frontend Packages Tests


### PR DESCRIPTION
### Purpose

Docs-only PRs (changes exclusively under `docs/` or `README.md`) skip all code jobs — build, tests, and coverage uploads. Because no coverage data ever reaches Codecov, it never posts the `codecov/patch` status check. Since `codecov/patch` is a required check in branch protection, these PRs get permanently stuck with \"Waiting for status to be reported\".

### Approach

Added a new step to the `detect-code-changes` job that fires **only** when `code != 'true'` (i.e. docs-only). It posts a `success` commit status directly to GitHub for the `codecov/patch` context via `gh api`, with description \"No code changes — coverage check not applicable\".

This is semantically correct: `codecov/patch` measures coverage of changed lines in the PR diff. A docs-only PR has zero changed code lines, so there is nothing to measure and `success` is the right outcome.

Added `statuses: write` permission to the job so the API call is authorised. The `contents: read` permission is also declared explicitly (previously inherited implicitly).

PRs with any code changes are completely unaffected — the step is guarded by the same `code != 'true'` condition already used to skip all other jobs.

**Verified against:** https://github.com/thunder-id/thunderid/pull/3084 (docs-only PR currently stuck on `codecov/patch`).

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to better handle documentation-only pull requests by appropriately marking coverage checks as not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->