### PR TITLE
Fix unique key violation when importing roles with assignments a second time

### DIFF
--- a/backend/internal/role/store_constants.go
+++ b/backend/internal/role/store_constants.go
@@ -87,7 +87,7 @@ var (
 	queryCreateRoleAssignment = dbmodel.DBQuery{
 		ID: "RLQ-ROLE_MGT-10",
 		Query: `INSERT INTO "ROLE_ASSIGNMENT" (ROLE_ID, ASSIGNEE_TYPE, ASSIGNEE_ID, DEPLOYMENT_ID)
-			VALUES ($1, $2, $3, $4)`,
+			VALUES ($1, $2, $3, $4) ON CONFLICT (ROLE_ID, DEPLOYMENT_ID, ASSIGNEE_TYPE, ASSIGNEE_ID) DO NOTHING`,
 	}
 
 	// queryGetRoleAssignments retrieves all assignments for a role with pagination.


### PR DESCRIPTION
### Purpose
When importing the same roles a second time (upsert), the import fails with a unique key violation on the `ROLE_ASSIGNMENT` table. The `queryCreateRoleAssignment` SQL used a plain `INSERT` with no conflict handling. Since `ROLE_ASSIGNMENT` has a composite primary key on `(ROLE_ID, DEPLOYMENT_ID, ASSIGNEE_TYPE, ASSIGNEE_ID)`, re-importing the same assignments on the second run violates the constraint.

### Approach
Added `ON CONFLICT (ROLE_ID, DEPLOYMENT_ID, ASSIGNEE_TYPE, ASSIGNEE_ID) DO NOTHING` to `queryCreateRoleAssignment`, making assignment inserts idempotent. This matches the existing pattern used by `QueryAddMemberToGroup` in the group store, which already handles duplicate member insertions the same way.

### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/3148

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role assignment handling to gracefully process duplicate assignment attempts without causing errors, enhancing system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->