### PR TITLE
Reduce chunk proliferation with vendor manualChunks and lazy locale import

### DIFF
--- a/frontend/apps/console/src/hocs/withI18n.tsx
+++ b/frontend/apps/console/src/hocs/withI18n.tsx
@@ -17,11 +17,12 @@
  */
 
 import {I18nDefaultConstants} from '@thunderid/i18n';
-import enUS from '@thunderid/i18n/locales/en-US';
 import i18next from 'i18next';
 import type {JSX, ComponentType} from 'react';
 import {initReactI18next} from 'react-i18next';
 import I18nProvider from '../i18n/I18nProvider';
+
+const enUS = await import('@thunderid/i18n/locales/en-US').then((m) => m.default);
 
 await i18next.use(initReactI18next).init({
   resources: {

--- a/frontend/apps/console/vite.config.ts
+++ b/frontend/apps/console/vite.config.ts
@@ -60,6 +60,36 @@ const prismjsGlobalFix = {
 // https://vite.dev/config/
 export default defineConfig({
   base: BASE_URL,
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules/@mui/x-data-grid') || id.includes('node_modules/@mui/x-virtualizer')) {
+            return 'vendor-mui-x';
+          }
+          if (
+            id.includes('node_modules/@mui/material') ||
+            id.includes('node_modules/@mui/system') ||
+            id.includes('node_modules/@mui/styled-engine')
+          ) {
+            return 'vendor-mui';
+          }
+          if (id.includes('node_modules/@emotion/')) {
+            return 'vendor-emotion';
+          }
+          if (id.includes('node_modules/@wso2/oxygen-ui')) {
+            return 'vendor-oxygen';
+          }
+          if (id.includes('node_modules/react-i18next') || id.includes('node_modules/i18next')) {
+            return 'vendor-i18n';
+          }
+          if (id.includes('node_modules/react-dom') || id.includes('node_modules/react/')) {
+            return 'vendor-react';
+          }
+        },
+      },
+    },
+  },
   define: {
     VERSION: JSON.stringify(VERSION),
     ANALYZER_ENABLED: JSON.stringify(ANALYZER_ENABLED),


### PR DESCRIPTION
### Purpose

Reduces chunk proliferation in the Console production build by grouping vendor dependencies into stable named chunks, and defers the large translations JSON from the initial entry chunk.

After converting all ~31 page imports to `React.lazy()` (part of #3025), Rolldown's automatic chunk splitting produced 113 JS files including hundreds of tiny per-component files (`DialogTitle-*.js`, `DialogContentText-*.js`, multiple `dist-***.js` from internal workspace packages).

### Approach

**`vite.config.ts` — `manualChunks` vendor grouping**

Groups the major dependency trees into stable named chunks shared cleanly across all lazy page splits:

| Chunk name | Contents |
|---|---|
| `vendor-react` | `react`, `react-dom` |
| `vendor-mui` | `@mui/material`, `@mui/system`, `@mui/styled-engine` |
| `vendor-mui-x` | `@mui/x-data-grid`, `@mui/x-virtualizer` |
| `vendor-emotion` | `@emotion/*` |
| `vendor-oxygen` | `@wso2/oxygen-ui` |
| `vendor-i18n` | `i18next`, `react-i18next` |

Without this, each `@mui/material` component imported by multiple lazy pages gets its own auto-named chunk (e.g. `DialogTitle-BcXyz.js`), and internal `@thunderid/*` workspace package modules produce many unnamed `dist-***.js` chunks.

**`withI18n.tsx` — dynamic locale import**

Changed the static `import enUS from '@thunderid/i18n/locales/en-US'` to a top-level `await import(...)` so the large translations JSON is not pulled into the initial entry chunk.

### Related Issues
- Refs #3025

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved locale loading to resolve default language dynamically for faster, more responsive startup.
  * Optimized bundling with enhanced code-splitting to reduce initial load and improve runtime performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->