### PR TITLE
Revert fix docs only code coverage issue

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -275,9 +275,6 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: read
-      statuses: write
     outputs:
       should-run: ${{ steps.filter.outputs.code }}
     steps:
@@ -304,17 +301,6 @@ jobs:
       - name: ⏭️ Docs-only changes
         if: steps.filter.outputs.code != 'true'
         run: echo "Only documentation changes detected - skipping frontend and E2E tests"
-      - name: ⏭️ Post codecov/patch success for docs-only changes
-        if: steps.filter.outputs.code != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: |
-          gh api repos/${{ github.repository }}/statuses/$HEAD_SHA \
-            --method POST \
-            --field state=success \
-            --field context='codecov/patch' \
-            --field description='No code changes — coverage check not applicable'
 
   test-frontend-packages:
     name: 🧪 Frontend Packages Tests


### PR DESCRIPTION
### Purpose
Reverts #3147 to replace the direct status write approach with a `workflow_run`-based solution that works for fork PRs.

The original fix used `gh api` to post `codecov/patch` status directly from the `detect-code-changes` job. This fails for all PRs from forks because GitHub restricts `GITHUB_TOKEN` to read-only in `pull_request` workflows triggered from forks, regardless of the `permissions:` block declared.

Since this is an open source repo where all PRs come from forks, the fix never worked as intended.

### Related PRs
- Reverts #3147
- Follow-up: replaces with `workflow_run` pattern

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided.
- [ ] Tests provided.
- [ ] Breaking changes.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes.** This pull request contains internal CI/CD workflow configuration updates that do not affect end-user functionality or experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->