### PR TITLE
Separate trusted issuer and token exchange docs

### DIFF
--- a/docs/content/guides/guides/identity-providers/token-exchange-idp.mdx
+++ b/docs/content/guides/guides/identity-providers/token-exchange-idp.mdx
@@ -1,0 +1,127 @@
+---
+title: Token Exchange with External Identity Providers
+sidebar_position: 5
+persona: iam
+description: Exchange a token from an external identity provider for a {{ProductName}}-issued access token using RFC 8693 Token Exchange.
+---
+
+# Token Exchange with External Identity Providers
+
+<ProductName /> can exchange a token issued by an external identity provider (IdP) for a <ProductName />-issued access token. This lets a client that authenticates users via an external OIDC provider — such as Asgardeo, Google, Azure AD, or Keycloak — obtain a <ProductName />-scoped access token without requiring users to sign in again.
+
+This uses [RFC 8693 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693). For general information about the token exchange grant type, see [Token Exchange](../../protocols/oauth-oidc/token-exchange).
+
+## When to Use
+
+Use this when:
+
+- A client authenticates users via an external OIDC provider and needs a <ProductName />-scoped access token to call <ProductName />-protected APIs.
+- You want to centralize token issuance through <ProductName /> while delegating user authentication to an upstream IdP.
+
+This is different from the [trusted issuer](../../trusted-issuer) feature. Trusted issuer lets <ProductName /> accept and validate tokens from a central authorization server directly, without issuing new tokens. Token exchange accepts an external token and issues a new <ProductName /> token in return.
+
+## Prerequisites
+
+- <ProductName /> is running. See [Get Started](../../../getting-started/get-thunderid).
+- An external OIDC identity provider that issues JWTs with an `iss` claim and exposes a JWKS endpoint.
+- An access token with the `system` scope for the setup API calls.
+
+## Step 1: Register the External Identity Provider
+
+Register the external IdP in <ProductName /> and enable it for token exchange. Only three properties are required for a token-exchange-only IdP:
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `issuer` | Yes | The exact `iss` claim value in tokens from this IdP. <ProductName /> matches incoming tokens against this value to identify which IdP issued them. |
+| `jwks_endpoint` | Yes | The IdP's JWKS URL. <ProductName /> fetches public signing keys from this URL to verify token signatures. |
+| `token_exchange_enabled` | Yes | Set to `"true"` to allow this IdP's tokens to be exchanged. |
+
+The redirect-flow OIDC properties (`client_secret`, `redirect_uri`, `authorization_endpoint`, `token_endpoint`) are not required unless the same IdP is also used for redirect-based sign-in.
+
+```bash
+curl -X POST https://thunder.example.com/identity-providers \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Asgardeo",
+    "type": "OIDC",
+    "properties": [
+      {"name": "issuer", "value": "https://api.asgardeo.io/t/myorg/oauth2/token"},
+      {"name": "jwks_endpoint", "value": "https://api.asgardeo.io/t/myorg/oauth2/jwks"},
+      {"name": "token_exchange_enabled", "value": "true"}
+    ]
+  }'
+```
+
+## Step 2: Create an OAuth Application with the Token Exchange Grant
+
+Create an OAuth application and include `urn:ietf:params:oauth:grant-type:token-exchange` in its allowed grant types. This is the client that will perform exchanges on behalf of users.
+
+```bash
+curl -X POST https://thunder.example.com/applications \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Token Exchange Client",
+    "inboundAuthConfig": [{
+      "type": "oauth2",
+      "config": {
+        "clientId": "te_client",
+        "clientSecret": "te_secret",
+        "grantTypes": ["urn:ietf:params:oauth:grant-type:token-exchange"],
+        "tokenEndpointAuthMethod": "client_secret_basic"
+      }
+    }]
+  }'
+```
+
+## Step 3: Exchange the External Token
+
+Send the external IdP token to <ProductName />'s token endpoint using the token exchange grant type:
+
+```bash
+curl -X POST https://thunder.example.com/oauth2/token \
+  -u 'te_client:te_secret' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=urn:ietf:params:oauth:grant-type:token-exchange' \
+  -d 'subject_token=<JWT_FROM_EXTERNAL_IDP>' \
+  -d 'subject_token_type=urn:ietf:params:oauth:token-type:jwt'
+```
+
+A successful response returns a <ProductName />-issued access token:
+
+```json
+{
+  "access_token": "eyJ...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token"
+}
+```
+
+The issued token's `sub` claim contains the external user's subject identifier from the original token.
+
+## How <ProductName /> Validates the External Token
+
+When processing an external token for exchange, <ProductName />:
+
+1. Extracts the `iss` claim and matches it against registered IdPs with `token_exchange_enabled=true`.
+2. Fetches the matching IdP's JWKS and verifies the token signature.
+3. Checks that the token's `aud` claim contains this <ProductName /> instance's own issuer.
+4. Validates `exp` (and `nbf` if present) with the configured clock-skew leeway.
+5. Extracts the `sub` claim and non-standard claims as user attributes.
+
+If any step fails, the exchange returns HTTP 400 with `error=invalid_request` and an `"Invalid subject_token"` message.
+
+## Limitations
+
+- Only JWT tokens are supported. Opaque tokens (for example, GitHub access tokens) cannot be exchanged.
+- The external user's `sub` is passed through as-is. No local user lookup or just-in-time provisioning occurs.
+- No scope or claim mapping is applied. External token scopes use the existing intersection logic; external claims pass through filtered by the application's `userAttributes` configuration.
+- Token exchange is available to all applications that have the token exchange grant type. No per-application IdP restriction applies.
+
+## Next Steps
+
+- [Manage Identity Providers](../manage-identity-providers) — Create, update, and delete identity providers using the API.
+- [Connect an IdP to an Application](../connect-idp-to-application) — Use an IdP for redirect-based sign-in flows.
+- [Token Exchange](../../protocols/oauth-oidc/token-exchange) — Learn about the RFC 8693 token exchange grant type in <ProductName />.

--- a/docs/content/guides/guides/trusted-issuer.mdx
+++ b/docs/content/guides/guides/trusted-issuer.mdx
@@ -1,24 +1,32 @@
 ---
-title: Trusted Issuer
+title: Secure ThunderID Using a Third-Party Identity Provider
 ---
 
-# Trusted Issuer
+# Secure ThunderID Using a Third-Party Identity Provider
 
-<ProductName /> can accept access tokens issued by an external authorization server and validate them locally using that server's JWKS endpoint. This enables federated authentication scenarios. An authorized user base can live on a separate central authorization server and still access a <ProductName /> instance that acts purely as a resource server. The resource-server <ProductName /> instance does not issue its own tokens for those users.
+By default, <ProductName /> only accepts tokens it issued itself. Your users might authenticate against an external authorization server — another <ProductName /> instance, an enterprise identity provider, or any standard OIDC provider. In that case, those users cannot call <ProductName />'s own APIs or sign in to the <ProductName /> Console unless <ProductName /> can validate their tokens.
 
-You can enable this by adding a `server.security.trusted_issuer` block to `repository/conf/deployment.yaml`.
+The trusted issuer feature enables this. You configure <ProductName /> to trust a specific external authorization server, and <ProductName /> fetches that server's public signing keys to validate incoming tokens locally. <ProductName /> acts as the resource server: it accepts and validates tokens the external server issued, without issuing its own tokens for those users or duplicating the user directory.
+
+You enable this by adding a `server.security.trusted_issuer` block to `repository/conf/deployment.yaml` on the resource-server instance.
 
 ## When to Enable
 
-Enable `trusted_issuer` on a <ProductName /> instance when:
+Enable trusted issuer on a <ProductName /> instance when:
 
-- You run a multi-tenant deployment with one central <ProductName /> acting as the identity provider and other <ProductName /> instances acting as resource servers.
-- You want tenant instances to delegate login to the central <ProductName /> rather than duplicate user directories.
-- Bearer tokens arriving at the tenant instance are signed by the central <ProductName /> and carry an `iss` claim that identifies it.
+- Users authenticate against an external authorization server and need to call <ProductName />'s own APIs or sign in to the <ProductName /> Console using those tokens.
+- You want <ProductName /> to act as a resource server for an external IdP without duplicating user directories or re-issuing tokens.
+- Incoming bearer tokens are signed by the external server and carry an `iss` claim that identifies it.
 
-If a <ProductName /> instance only serves its own users and issues its own tokens, omit the `server.security.trusted_issuer` block. Trusted issuer validation activates as soon as `server.security.trusted_issuer.issuer` is set; `jwks_url` and `audience` are then required and <ProductName /> fails to start if either is missing.
+If a <ProductName /> instance only serves its own users and issues its own tokens, omit the `server.security.trusted_issuer` block.
 
-## Configuration
+## Prerequisites
+
+- A running <ProductName /> instance that acts as the resource server.
+- An external authorization server (another <ProductName /> instance, an enterprise IdP, or any OIDC-compatible provider) that issues JWTs with an `iss` claim and exposes a JWKS endpoint.
+- The central server's issuer URL and JWKS endpoint URL.
+
+## Configure the Server
 
 Add a `server.security.trusted_issuer` block to the tenant instance's `deployment.yaml`:
 
@@ -34,18 +42,21 @@ server:
           value: "tenant-123"
 ```
 
-| Field | Description |
-|-------|-------------|
-| `issuer` | The exact value of the `iss` claim that incoming tokens must carry. This should match the central authorization server's issuer URL. |
-| `jwks_url` | The JWKS endpoint on the central server. <ProductName /> uses it to fetch the signing keys needed to verify token signatures. |
-| `audience` | The expected `aud` claim on incoming tokens. Set this to the resource-server <ProductName /> instance's own public URL. The client at the central authorization server must send a matching `resource` parameter in the authorization request so the issued token's `aud` points at this instance. |
-| `required_claims` | Optional list of claims that every accepted token must contain, each with an expected value. Tokens missing a required claim, or carrying a different value, are rejected. Use this to enforce any additional constraints on accepted tokens. |
+| Field | Required | Description |
+|-------|----------|-------------|
+| `issuer` | Yes | The issuer URL of the central authorization server. <ProductName /> matches this against the `iss` claim on every incoming token and rejects any token that does not match exactly, including differences in scheme, host, port, or trailing slash. |
+| `jwks_url` | Yes | The JWKS endpoint on the central server. <ProductName /> fetches the public signing keys from this URL and uses them to verify token signatures. |
+| `audience` | Yes | The `aud` value that tokens from the central server must carry. Set this to the resource-server <ProductName /> instance's own public URL. The client at the central server must include a matching `resource` parameter in the authorization request so the issued token targets this instance. |
+| `required_claims` | No | A list of claims that every accepted token must contain, each paired with an expected value. Tokens that are missing a required claim or carry a different value are rejected. Use this to scope accepted tokens further, for example to a specific organization unit. |
 
-The JWKS cache TTL is configured at `server.security.jwks_cache_ttl`, not inside this block. The same cache backs every JWKS consumer in the server, including trusted issuer validation and federated OIDC authenticators. See [Security Configuration](/docs/next/guides/getting-started/configuration#security-configuration) for details.
 
-## Console Portal Configuration
+The JWKS cache time-to-live applies to signing keys fetched from this endpoint and is configured at `server.security.jwks_cache_ttl`, not inside the `trusted_issuer` block. See [Security Configuration](/docs/next/guides/getting-started/configuration#security-configuration) for details.
 
-The `server.security.trusted_issuer` block on the server only controls how <ProductName /> validates incoming tokens. <ProductName />'s console portal still authenticates against this <ProductName /> instance unless you also delegate its login to the external authorization server. To delegate console login, add a `trusted_issuer` entry to the console's runtime configuration at `apps/console/config.js`:
+## Configure the Console
+
+The `server.security.trusted_issuer` block controls how <ProductName /> validates incoming API tokens. It does not affect how users sign in to the <ProductName /> Console. By default, the Console still authenticates users against the local <ProductName /> instance.
+
+To delegate Console sign-in to the central authorization server, add a `trusted_issuer` entry to the Console's runtime configuration at `apps/console/config.js`:
 
 ```js
 window.__THUNDERID_RUNTIME_CONFIG__ = {
@@ -64,64 +75,58 @@ window.__THUNDERID_RUNTIME_CONFIG__ = {
 
 | Field | Description |
 |-------|-------------|
-| `hostname` | The hostname of the external authorization server the console redirects users to for login. |
-| `port` | Port on the external authorization server. |
+| `hostname` | The hostname of the external authorization server the Console redirects users to for sign-in. |
+| `port` | The port on the external authorization server. |
 | `http_only` | Set to `true` only for local or development authorization servers served over HTTP. |
-| `public_url` | Fully-qualified URL of the external authorization server. Used by the console to build authorization requests. |
-| `client_id` | OAuth client ID registered on the external authorization server for this <ProductName /> instance's console. |
-| `scopes` | Scopes the console requests from the external authorization server. Must include every scope <ProductName />'s APIs require. |
-| `type` | Set to `"generic"` when the trusted issuer is a generic OIDC provider. When set, the console skips <ProductName />-specific bootstrap calls (flow metadata, branding preferences) that would fail against a generic provider and uses the IdP's `end_session_endpoint` for sign-out. Defaults to `"thunderid"`. |
+| `public_url` | The fully qualified URL of the external authorization server. The Console uses this to build authorization requests. |
+| `client_id` | The OAuth client ID registered on the external authorization server for this <ProductName /> instance's Console. |
+| `scopes` | The scopes the Console requests from the external authorization server. Include every scope that <ProductName />'s APIs require. |
+| `type` | Set to `"generic"` when the central authorization server is a generic OIDC provider rather than another <ProductName /> instance. When set, the Console skips <ProductName />-specific bootstrap calls (flow metadata, branding preferences) that would fail against a generic provider, and uses the provider's `end_session_endpoint` for sign-out. Defaults to `"thunderid"`. |
 
-When this block is present, the console delegates login to the external authorization server. When omitted, the console authenticates against this <ProductName /> instance normally.
+When this block is present, the Console delegates sign-in to the external authorization server. When it is absent, the Console authenticates against the local <ProductName /> instance.
 
 :::note
-The external authorization server must permit this <ProductName /> instance's origin in its CORS allowed-origins configuration. Otherwise, browser calls from the console to the authorization server's `/oauth2/token`, `/oauth2/jwks`, and related endpoints are blocked.
+The external authorization server must permit this <ProductName /> instance's origin in its CORS allowed-origins configuration. Otherwise, browser calls from the Console to the authorization server's `/oauth2/token`, `/oauth2/jwks`, and related endpoints are blocked.
 :::
 
 ## How Validation Works
 
-:::info JWT Validation Update
-<ProductName />'s trusted issuer token validation now accepts tokens that omit the `nbf` (not before) claim, aligning with [RFC 7519 Section 4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5). The `aud` (audience) claim is now accepted as either a single string or a JSON array of strings per [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3). These changes improve compatibility with commercial OIDC providers that do not emit `nbf` or that issue array-form `aud`. No client-side migration is required; tokens that were accepted before remain valid.
-:::
-
-When trusted issuer is configured, <ProductName /> routes token verification by the bearer token's `iss` claim (see [Self-Issued Tokens](#self-issued-tokens) below). For a token whose `iss` matches `trusted_issuer.issuer`, <ProductName />:
+When a request arrives with a bearer token, <ProductName /> reads the token's `iss` claim to decide which verifier to use. For a token whose `iss` matches `trusted_issuer.issuer`, <ProductName /> performs the following checks in order:
 
 1. Parses the JWT and confirms its `iss` claim matches `trusted_issuer.issuer`.
 2. Fetches signing keys from `trusted_issuer.jwks_url` and verifies the signature.
 3. Checks the `exp` claim and rejects expired tokens.
-4. If the `nbf` (not before) claim is present, checks that the current time is not before the `nbf` value. If `nbf` is absent, the token is still accepted.
-5. Confirms the `aud` claim matches `trusted_issuer.audience`. The `aud` claim can be either a single string or a JSON array of strings; <ProductName /> accepts the token if the configured audience appears in either form.
+4. Checks the `nbf` (not before) claim if present. If `nbf` is absent, the token is still accepted.
+5. Confirms the `aud` claim matches `trusted_issuer.audience`. The `aud` claim may be a single string or a JSON array of strings; <ProductName /> accepts the token if the configured audience appears in either form.
 6. Checks that every entry in `required_claims` is present with the expected value.
 
-If any step fails, the token is rejected.
+If any check fails, <ProductName /> rejects the token.
 
-### Claim Handling Details
+### Claim Details
 
-**`nbf` (Not Before):** This claim is optional per [RFC 7519 Section 4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5). Many commercial OIDC providers do not include `nbf` in their tokens. <ProductName /> accepts tokens that omit `nbf` entirely. When `nbf` is present, <ProductName /> enforces it with the configured clock-skew leeway.
+**`iss` (Issuer):** Must match `trusted_issuer.issuer` exactly, including scheme, host, and any path.
 
-**`aud` (Audience):** This claim can be a single string or an array of strings per [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3). Some identity providers issue array-form `aud` when multiple audiences are bound to the application (for example, the resource API together with the provider's own `/userinfo` endpoint). <ProductName /> matches the configured `trusted_issuer.audience` value against both forms: exact string equality for single-string `aud`, and membership for array `aud`.
+**`exp` (Expiry):** Required. Tokens that omit `exp` or carry a non-numeric value are rejected.
 
-**`exp` (Expiry):** This claim is required. Tokens that omit `exp` or provide a non-numeric value are rejected.
+**`nbf` (Not Before):** Optional per [RFC 7519 Section 4.1.5](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5). Many commercial OIDC providers omit this claim. When `nbf` is present, <ProductName /> enforces it with the configured clock-skew leeway.
 
-Each `required_claims` entry is matched by exact string equality: the claim must be present on the token and its value must match the configured `value` exactly.
+**`aud` (Audience):** May be a single string or an array of strings per [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3). Some providers issue an array `aud` when a token targets more than one audience, for example both the resource API and the provider's own `/userinfo` endpoint. <ProductName /> matches the configured `trusted_issuer.audience` value against both forms.
+
+**`required_claims`:** Each entry matches by exact string equality. The claim must be present on the token and its value must equal the configured `value`.
+
+**Accepted signature algorithms:** `RS256`, `PS256`, `RS512`, `ES256`, `ES384`, `ES512`, `EdDSA`. Tokens signed with any other algorithm are rejected.
 
 ### Self-Issued Tokens
 
-Configuring `server.security.trusted_issuer` is additive. It does not stop <ProductName /> from accepting the tokens it issues itself. <ProductName /> selects the verification method from the token's `iss` claim:
+Configuring `server.security.trusted_issuer` does not stop <ProductName /> from accepting the tokens it issues itself. <ProductName /> selects the verifier based on the token's `iss` claim:
 
-- `iss` matches `trusted_issuer.issuer` — the token is verified against the configured JWKS endpoint, following the steps above.
-- `iss` matches this <ProductName /> instance's own issuer (`jwt.issuer`, which defaults to the instance's public URL) — the token is verified with the instance's local signing key, exactly as when no trusted issuer is configured.
-- Any other `iss`, or a token whose payload cannot be read, is rejected.
+- `iss` matches `trusted_issuer.issuer` — the token is verified against the central server's JWKS endpoint.
+- `iss` matches this <ProductName /> instance's own issuer (configured at `jwt.issuer`, defaulting to the instance's public URL) — the token is verified with the local signing key.
+- Any other `iss` value, or a token whose payload cannot be parsed, is rejected.
 
-Because of this, the tokens this instance issues for itself keep working against its own secured APIs, even with a trusted issuer configured. This includes:
+This means service accounts, the system bootstrap token, and Console sessions that are not delegated all continue to work unchanged. Verification never falls back between verifiers: a token routed to the JWKS verifier that fails signature validation is rejected immediately. <ProductName /> does not retry it against the local signing key.
 
-- access tokens from this instance's `client_credentials` grant (service-to-service callers),
-- the system token used during bootstrap and auto-provisioning, and
-- the console session, when console login is not delegated.
-
-Verification never falls back across issuers. A token routed to one verifier is not retried with the other. For example, a token that claims `trusted_issuer.issuer` but fails JWKS verification is rejected. <ProductName /> does not then check it against the local signing key. Setting an `iss` value alone grants nothing, because the signature must still verify against that issuer's keys.
-
-<ProductName /> accepts tokens signed with `RS256`, `PS256`, `RS512`, `ES256`, `ES384`, `ES512`, or `EdDSA`. Tokens using any other algorithm are rejected. JWKS responses are cached in-process for `server.security.jwks_cache_ttl` seconds (default: 300), so plan external-server key rotations with at least that much overlap.
+JWKS responses are cached in-process for `server.security.jwks_cache_ttl` seconds (default: 300). Plan key rotations on the central server with at least that much overlap so tenant instances do not reject tokens signed with a new key before the cache refreshes.
 
 ## Helm Configuration
 
@@ -140,7 +145,7 @@ configuration:
             value: "tenant-123"
 ```
 
-To configure the console portal instead of editing `apps/console/config.js` directly, set `configuration.consoleClient.trustedIssuer` in the chart values. The fields mirror those described in [Console Portal Configuration](#console-portal-configuration) but use camelCase (`httpOnly`, `publicUrl`, `clientId`):
+To configure the Console without editing `apps/console/config.js` directly, set `configuration.consoleClient.trustedIssuer` in the chart values. The fields mirror those in [Configure the Console](#configure-the-console) but use camelCase:
 
 ```yaml
 configuration:
@@ -159,127 +164,15 @@ configuration:
 
 | Symptom | Likely Cause | Fix |
 |---------|--------------|-----|
-| Login redirect hangs or the token exchange fails with a CORS error in the browser console | <ProductName />'s origin is not permitted by the external authorization server's CORS configuration | Add <ProductName />'s origin to the authorization server's CORS allowed-origins configuration. |
-| Tokens rejected with "issuer mismatch" | `trusted_issuer.issuer` does not exactly match the `iss` claim on incoming tokens | Set `trusted_issuer.issuer` to match exactly (scheme, host, port, trailing slash). |
-| Tokens rejected with "audience mismatch" | The authorization server is not sending a `resource` parameter, so `aud` defaults to the client ID instead of <ProductName />'s URL | Either set `trusted_issuer.audience` to the client ID, or configure the client to send `resource=<server-url>` in the authorization request. |
-| Tokens rejected with "required claim missing" | A claim listed under `required_claims` is not present on the token, or its value differs | Remove the claim from `required_claims`, or configure the authorization server to include it with the expected value. |
-| JWKS fetch fails | `trusted_issuer.jwks_url` cannot be reached from <ProductName />, or the authorization server uses a certificate <ProductName /> does not trust | Check that the network allows the request, and install the authorization server's CA certificate on <ProductName /> if needed. |
-| Console never redirects to the external authorization server | `consoleClient.trustedIssuer` not set, or `publicUrl`/`hostname` still point at <ProductName /> | Verify the `consoleClient.trustedIssuer` block and re-render the chart. |
+| Console sign-in redirect hangs or token exchange fails with a CORS error | <ProductName />'s origin is not in the external authorization server's CORS allowed-origins list | Add the <ProductName /> instance's origin to the authorization server's CORS configuration. |
+| Tokens rejected with "issuer mismatch" | `trusted_issuer.issuer` does not exactly match the `iss` claim on incoming tokens | Set `trusted_issuer.issuer` to match exactly, including scheme, host, port, and trailing slash. |
+| Tokens rejected with "audience mismatch" | The authorization server is not receiving a `resource` parameter, so `aud` defaults to the client ID instead of <ProductName />'s URL | Either set `trusted_issuer.audience` to the client ID, or configure the client to send `resource=<server-url>` in the authorization request. |
+| Tokens rejected with "required claim missing" | A claim listed under `required_claims` is absent from the token or its value does not match | Remove the entry from `required_claims`, or configure the authorization server to include the claim with the expected value. |
+| JWKS fetch fails | `trusted_issuer.jwks_url` is unreachable, or the authorization server uses a certificate that <ProductName /> does not trust | Verify network connectivity to the URL, and install the authorization server's CA certificate on the <ProductName /> instance if needed. |
+| Console does not redirect to the external authorization server | `consoleClient.trustedIssuer` is not set, or `publicUrl`/`hostname` still point at the local <ProductName /> instance | Verify the `consoleClient.trustedIssuer` block and re-render the Helm chart. |
 
-## Token Exchange with External Identity Providers
+## Related Guides
 
-Along with accepting external tokens for API authentication (above), <ProductName /> supports exchanging external IDP tokens for <ProductName />-issued access tokens via [RFC 8693 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693). This is useful when:
-
-- A client authenticates users via an external OIDC provider (Asgardeo, Google, Azure AD, Keycloak) and needs a <ProductName />-scoped access token.
-- You want to centralize token issuance through <ProductName /> while delegating authentication to an upstream IDP.
-
-### How It Works
-
-1. Register the external IDP in <ProductName /> with token exchange properties (`issuer`, `jwks_endpoint`, `token_exchange_enabled`).
-2. A client sends the external token to <ProductName />'s token endpoint with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`.
-3. <ProductName /> resolves the token's `iss` claim to a registered IDP, verifies the signature via the IDP's JWKS endpoint, and validates the audience.
-4. <ProductName /> issues a new access token with the external user's `sub` claim passed through.
-
-### Setup
-
-#### 1. Register an OIDC Identity Provider
-
-Create an IDP via the `/identity-providers` API with the following properties:
-
-| Property | Required | Description |
-|----------|----------|-------------|
-| `issuer` | Yes | The exact `iss` claim value in tokens from this IDP (e.g., `https://localhost:8090/oauth2/token`). |
-| `jwks_endpoint` | Yes | The IDP's JWKS URL for signature verification. |
-| `token_exchange_enabled` | Yes | Set to `"true"` to enable this IDP for token exchange. |
-
-For token-exchange-only IDPs, only the three properties above are required. The redirect-flow OIDC
-properties (`client_secret`, `redirect_uri`, `authorization_endpoint`, `token_endpoint`) are **not**
-required. They are only needed when the same IDP is also used for redirect-based login.
-
-Example:
-
-```bash
-curl -X POST https://thunder.example.com/identity-providers \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "Asgardeo",
-    "type": "OIDC",
-    "properties": [
-      {"name": "issuer", "value": "https://localhost:8090/oauth2/token"},
-      {"name": "jwks_endpoint", "value": "https://localhost:8090/oauth2/jwks"},
-      {"name": "token_exchange_enabled", "value": "true"}
-    ]
-  }'
-```
-
-#### 2. Create an OAuth Application with Token Exchange Grant
-
-The application must include `urn:ietf:params:oauth:grant-type:token-exchange` in its allowed grant types:
-
-```bash
-curl -X POST https://thunder.example.com/applications \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "Token Exchange Client",
-    "inboundAuthConfig": [{
-      "type": "oauth2",
-      "config": {
-        "clientId": "te_client",
-        "clientSecret": "te_secret",
-        "grantTypes": ["urn:ietf:params:oauth:grant-type:token-exchange"],
-        "tokenEndpointAuthMethod": "client_secret_basic"
-      }
-    }]
-  }'
-```
-
-#### 3. Exchange the External Token
-
-```bash
-curl -X POST https://thunder.example.com/oauth2/token \
-  -u 'te_client:te_secret' \
-  -H 'Content-Type: application/x-www-form-urlencoded' \
-  -d 'grant_type=urn:ietf:params:oauth:grant-type:token-exchange' \
-  -d 'subject_token=<JWT_FROM_EXTERNAL_IDP>' \
-  -d 'subject_token_type=urn:ietf:params:oauth:token-type:jwt'
-```
-
-Response:
-
-```json
-{
-  "access_token": "eyJ...",
-  "token_type": "Bearer",
-  "expires_in": 3600,
-  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token"
-}
-```
-
-The issued token's `sub` claim contains the external user's subject identifier from the original token.
-
-### Validation Rules
-
-When processing an external token for exchange, <ProductName />:
-
-1. Extracts the `iss` claim and matches it against IDPs with `token_exchange_enabled=true`.
-2. Fetches the IDP's JWKS and verifies the token signature.
-3. Checks that the token's `aud` claim contains this server's own issuer.
-4. Validates `exp` (and `nbf` if present) with the configured clock-skew leeway.
-5. Extracts `sub` and non-standard claims as user attributes.
-
-If any step fails, the exchange returns HTTP 400 with `error=invalid_request` and a generic `"Invalid subject_token"` message.
-
-### Limitations
-
-- Only JWT tokens are supported for external exchange. Opaque tokens from providers like GitHub cannot be exchanged.
-- The external user's `sub` is passed through as-is — no local user lookup or JIT provisioning is performed.
-- No scope or claim mapping is applied. External token scopes use the existing intersection logic; external claims pass through filtered by the app's `userAttributes` configuration.
-- Trust is global: all token-exchange-enabled IDPs are available to all applications that have the `token-exchange` grant type.
-
-## Reference
-
-- Configuration reference: [Trusted Issuer Configuration](/docs/next/guides/getting-started/configuration#trusted-issuer-configuration)
-- [Resource Indicators](../resource-indicators) — use the `resource` parameter to set the `aud` claim on tokens issued by the central authorization server so they target this <ProductName /> instance.
-- [Manage Resource Servers](../resource-servers) — define resource servers with identifiers and permissions.
+- [Resource Indicators](../protocols/oauth-oidc/resource-indicators) — Use the `resource` parameter to set the `aud` claim on tokens issued by the central authorization server.
+- [Resource Servers](../resource-servers) — Define resource servers with identifiers and permissions.
+- [Security Configuration](/docs/next/guides/getting-started/configuration#security-configuration) — Configure JWKS cache TTL and other security settings.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -169,7 +169,6 @@ const sidebars: SidebarsConfig = {
       ],
     },
 
-
     // Use Cases Section
     {
       type: 'html',
@@ -236,9 +235,7 @@ const sidebars: SidebarsConfig = {
                   label: 'Learn More',
                   collapsible: true,
                   collapsed: true,
-                  items: [
-                    {type: 'doc', id: 'use-cases/b2c/identity-concepts', label: 'Identity Concepts'},
-                  ],
+                  items: [{type: 'doc', id: 'use-cases/b2c/identity-concepts', label: 'Identity Concepts'}],
                 },
               ],
             },
@@ -250,9 +247,24 @@ const sidebars: SidebarsConfig = {
               link: {type: 'doc', id: 'use-cases/b2c/try-in-your-own-app'},
               items: [
                 {type: 'doc', id: 'use-cases/b2c/try-in-your-own-app/add-login', label: 'Login', key: 'own-app-login'},
-                {type: 'doc', id: 'use-cases/b2c/try-in-your-own-app/self-sign-up', label: 'Self Sign-Up', key: 'own-app-self-sign-up'},
-                {type: 'doc', id: 'use-cases/b2c/try-in-your-own-app/profile-section', label: 'View Profile', key: 'own-app-profile-section'},
-                {type: 'doc', id: 'use-cases/b2c/try-in-your-own-app/account-recovery', label: 'Account Recovery', key: 'own-app-account-recovery'},
+                {
+                  type: 'doc',
+                  id: 'use-cases/b2c/try-in-your-own-app/self-sign-up',
+                  label: 'Self Sign-Up',
+                  key: 'own-app-self-sign-up',
+                },
+                {
+                  type: 'doc',
+                  id: 'use-cases/b2c/try-in-your-own-app/profile-section',
+                  label: 'View Profile',
+                  key: 'own-app-profile-section',
+                },
+                {
+                  type: 'doc',
+                  id: 'use-cases/b2c/try-in-your-own-app/account-recovery',
+                  label: 'Account Recovery',
+                  key: 'own-app-account-recovery',
+                },
                 {
                   type: 'doc',
                   id: 'use-cases/b2c/try-in-your-own-app/onboard-internal-users',
@@ -283,7 +295,12 @@ const sidebars: SidebarsConfig = {
               collapsed: true,
               items: [
                 {type: 'doc', id: 'use-cases/ai-agents/overview', label: 'Agent Identity'},
-                {type: 'doc', id: 'use-cases/ai-agents/solution-patterns', label: 'Solution Patterns', key: 'ai-agents-solution-patterns'},
+                {
+                  type: 'doc',
+                  id: 'use-cases/ai-agents/solution-patterns',
+                  label: 'Solution Patterns',
+                  key: 'ai-agents-solution-patterns',
+                },
                 {
                   type: 'category',
                   label: 'Try It Out',
@@ -311,9 +328,7 @@ const sidebars: SidebarsConfig = {
           label: 'Secure Token Service (STS)',
           collapsible: true,
           collapsed: true,
-          items: [
-            {type: 'doc', id: 'use-cases/sts/krakend', label: 'Protect APIs on KrakenD'},
-          ],
+          items: [{type: 'doc', id: 'use-cases/sts/krakend', label: 'Protect APIs on KrakenD'}],
         },
       ],
     },
@@ -438,6 +453,12 @@ const sidebars: SidebarsConfig = {
                   id: 'guides/guides/identity-providers/connect-idp-to-application',
                   label: 'Connect IdP to Application',
                 },
+                {
+                  type: 'doc',
+                  id: 'guides/guides/identity-providers/token-exchange-idp',
+                  label: 'Token Exchange',
+                  key: 'idp-token-exchange',
+                },
               ],
             },
             {
@@ -496,7 +517,7 @@ const sidebars: SidebarsConfig = {
         {
           type: 'doc',
           id: 'guides/guides/trusted-issuer',
-          label: 'Trusted Issuer',
+          label: 'Secure Using a Third-Party IdP',
         },
         {
           type: 'doc',
@@ -580,10 +601,25 @@ const sidebars: SidebarsConfig = {
                   collapsed: true,
                   collapsible: true,
                   items: [
-                    {type: 'doc', id: 'guides/guides/protocols/oauth-oidc/authorization-code', label: 'Authorization Code'},
-                    {type: 'doc', id: 'guides/guides/protocols/oauth-oidc/client-credentials', label: 'Client Credentials'},
+                    {
+                      type: 'doc',
+                      id: 'guides/guides/protocols/oauth-oidc/authorization-code',
+                      label: 'Authorization Code',
+                    },
+                    {
+                      type: 'doc',
+                      id: 'guides/guides/protocols/oauth-oidc/client-credentials',
+                      label: 'Client Credentials',
+                    },
                     {type: 'doc', id: 'guides/guides/protocols/oauth-oidc/refresh-token', label: 'Refresh Token'},
-                    {type: 'doc', id: 'guides/guides/protocols/oauth-oidc/token-exchange', label: 'Token Exchange'},
+                    // Unique `key` avoids a translation-key collision with the "Token Exchange"
+                    // item under Identity Providers (i18n key is derived from the label).
+                    {
+                      type: 'doc',
+                      id: 'guides/guides/protocols/oauth-oidc/token-exchange',
+                      label: 'Token Exchange',
+                      key: 'oauth-token-exchange',
+                    },
                   ],
                 },
                 {
@@ -607,9 +643,21 @@ const sidebars: SidebarsConfig = {
                   items: [
                     {type: 'doc', id: 'guides/guides/protocols/oauth-oidc/pkce', label: 'PKCE'},
                     {type: 'doc', id: 'guides/guides/protocols/oauth-oidc/par', label: 'Pushed Authorization Requests'},
-                    {type: 'doc', id: 'guides/guides/protocols/oauth-oidc/dpop', label: 'DPoP — Sender-Constrained Tokens'},
-                    {type: 'doc', id: 'guides/guides/protocols/oauth-oidc/issuer-identification', label: 'Issuer Identification'},
-                    {type: 'doc', id: 'guides/guides/protocols/oauth-oidc/resource-indicators', label: 'Resource Indicators'},
+                    {
+                      type: 'doc',
+                      id: 'guides/guides/protocols/oauth-oidc/dpop',
+                      label: 'DPoP — Sender-Constrained Tokens',
+                    },
+                    {
+                      type: 'doc',
+                      id: 'guides/guides/protocols/oauth-oidc/issuer-identification',
+                      label: 'Issuer Identification',
+                    },
+                    {
+                      type: 'doc',
+                      id: 'guides/guides/protocols/oauth-oidc/resource-indicators',
+                      label: 'Resource Indicators',
+                    },
                   ],
                 },
                 {
@@ -618,7 +666,11 @@ const sidebars: SidebarsConfig = {
                   collapsed: true,
                   collapsible: true,
                   items: [
-                    {type: 'doc', id: 'guides/guides/protocols/oauth-oidc/token-introspection', label: 'Token Introspection'},
+                    {
+                      type: 'doc',
+                      id: 'guides/guides/protocols/oauth-oidc/token-introspection',
+                      label: 'Token Introspection',
+                    },
                   ],
                 },
                 {


### PR DESCRIPTION
## Summary

- Rewrites `trusted-issuer.mdx` to focus solely on securing ThunderID's own APIs and Console login using tokens from a third-party identity provider (ThunderID as a resource server). Renames the page to *Secure ThunderID Using a Third-Party Identity Provider*.
- Extracts the unrelated Token Exchange with External IDPs section into a new guide at `identity-providers/token-exchange-idp.mdx`, placed under the Identity Providers section of the sidebar.
- Adds the new page to `sidebars.ts` under Identity Providers.

## Test plan

- [ ] Verify `trusted-issuer.mdx` renders correctly and no longer contains the token exchange section.
- [ ] Verify `identity-providers/token-exchange-idp.mdx` renders and appears in the sidebar under Identity Providers → Token Exchange.
- [ ] Confirm all internal cross-links between the two pages resolve correctly.
- [ ] Run Vale locally and resolve any warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Token Exchange guide describing RFC 8693 usage with external IdPs: when to use it, prerequisites, IdP registration, OAuth setup, example flows, validation/failure behavior, limitations, and next steps.
  * Expanded and moved Trusted Issuer guidance into Deployment Patterns with configuration, validation flow, console delegation, caching, troubleshooting, and related links.
  * Updated site navigation and in-guide links to surface these guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->