### PR TITLE
SDK support for magic link authentication

### DIFF
--- a/sdks/browser/src/utils/SPAUtils.ts
+++ b/sdks/browser/src/utils/SPAUtils.ts
@@ -45,23 +45,23 @@ class SPAUtils {
   }
 
   /**
-   * Retrieves a PKCE verifier from sessionStorage.
+   * Retrieves a PKCE verifier from storage.
    *
    * @param pkceKey - The storage key for the PKCE verifier.
    * @returns The stored verifier string, or an empty string if not found.
    */
   public static getPKCE(pkceKey: string): string {
-    return sessionStorage.getItem(pkceKey) ?? '';
+    return localStorage.getItem(pkceKey) ?? '';
   }
 
   /**
-   * Persists a PKCE verifier in sessionStorage.
+   * Persists a PKCE verifier in storage.
    *
    * @param pkceKey - The storage key.
    * @param pkce - The PKCE verifier value.
    */
   public static setPKCE(pkceKey: string, pkce: string): void {
-    sessionStorage.setItem(pkceKey, pkce);
+    localStorage.setItem(pkceKey, pkce);
   }
 
   /**
@@ -94,12 +94,12 @@ class SPAUtils {
   }
 
   /**
-   * Removes a PKCE verifier from sessionStorage.
+   * Removes a PKCE verifier from storage.
    *
    * @param pkceKey - The storage key to remove.
    */
   public static removePKCE(pkceKey: string): void {
-    sessionStorage.removeItem(pkceKey);
+    localStorage.removeItem(pkceKey);
   }
 
   /**

--- a/sdks/javascript/src/StorageManager.ts
+++ b/sdks/javascript/src/StorageManager.ts
@@ -19,9 +19,12 @@
 import {AuthClientConfig} from './models/config';
 import {OIDCDiscoveryApiResponse} from './models/oidc-discovery';
 import {SessionData} from './models/session';
-import {Stores, Storage, TemporaryStore, TemporaryStoreValue} from './models/store';
+import {Stores, Storage, TemporaryStore, HybridStore, TemporaryStoreValue} from './models/store';
+import logger from './utils/logger';
 
-type PartialData<T> = Partial<AuthClientConfig<T> | OIDCDiscoveryApiResponse | SessionData | TemporaryStore>;
+type PartialData<T> = Partial<
+  AuthClientConfig<T> | OIDCDiscoveryApiResponse | SessionData | TemporaryStore | HybridStore
+>;
 
 export const THUNDERID_SESSION_ACTIVE = 'thunderid-session-active';
 
@@ -47,7 +50,12 @@ class StorageManager<T> {
 
   protected async setValue(
     key: string,
-    attribute: keyof AuthClientConfig<T> | keyof OIDCDiscoveryApiResponse | keyof SessionData | keyof TemporaryStore,
+    attribute:
+      | keyof AuthClientConfig<T>
+      | keyof OIDCDiscoveryApiResponse
+      | keyof SessionData
+      | keyof TemporaryStore
+      | keyof HybridStore,
     value: TemporaryStoreValue,
   ): Promise<void> {
     const existingDataJSON: string = (await this.store.getData(key)) ?? null;
@@ -61,7 +69,12 @@ class StorageManager<T> {
 
   protected async removeValue(
     key: string,
-    attribute: keyof AuthClientConfig<T> | keyof OIDCDiscoveryApiResponse | keyof SessionData | keyof TemporaryStore,
+    attribute:
+      | keyof AuthClientConfig<T>
+      | keyof OIDCDiscoveryApiResponse
+      | keyof SessionData
+      | keyof TemporaryStore
+      | keyof HybridStore,
   ): Promise<void> {
     const existingDataJSON: string = (await this.store.getData(key)) ?? null;
     const existingData: PartialData<T> = existingDataJSON && JSON.parse(existingDataJSON);
@@ -110,7 +123,20 @@ class StorageManager<T> {
   }
 
   public async setTemporaryData(temporaryData: Partial<TemporaryStore>, userId?: string): Promise<void> {
-    this.setDataInBulk(this.resolveKey(Stores.TemporaryData, userId), temporaryData);
+    await this.setDataInBulk(this.resolveKey(Stores.TemporaryData, userId), temporaryData);
+  }
+
+  public async setHybridData(hybridData: Partial<HybridStore>, userId?: string): Promise<void> {
+    const resolvedKey = this.resolveKey(Stores.HybridData, userId);
+
+    if (StorageManager.isLocalStorageAvailable()) {
+      const existingDataJSON = localStorage.getItem(resolvedKey);
+      const existingData: Partial<HybridStore> = existingDataJSON ? JSON.parse(existingDataJSON) : {};
+      const dataToBeSaved = {...existingData, ...hybridData};
+      localStorage.setItem(resolvedKey, JSON.stringify(dataToBeSaved));
+    } else {
+      await this.setDataInBulk(resolvedKey, hybridData);
+    }
   }
 
   public async setSessionData(sessionData: Partial<SessionData>, userId?: string): Promise<void> {
@@ -130,7 +156,44 @@ class StorageManager<T> {
   }
 
   public async getTemporaryData(userId?: string): Promise<TemporaryStore> {
-    return JSON.parse((await this.store.getData(this.resolveKey(Stores.TemporaryData, userId))) ?? null);
+    const data: string = await this.store.getData(this.resolveKey(Stores.TemporaryData, userId));
+    if (data) {
+      try {
+        return JSON.parse(data);
+      } catch (error) {
+        logger.error(`StorageManager: Failed to parse temporary data for key ${this.resolveKey(Stores.TemporaryData, userId)}`, error);
+        return {};
+      }
+    }
+    return {};
+  }
+
+  public async getHybridData(userId?: string): Promise<HybridStore> {
+    const resolvedKey = this.resolveKey(Stores.HybridData, userId);
+
+    if (StorageManager.isLocalStorageAvailable()) {
+      const storeDataJSON = localStorage.getItem(resolvedKey);
+      if (storeDataJSON) {
+        try {
+          return JSON.parse(storeDataJSON);
+        } catch (error) {
+          logger.error(`StorageManager: Failed to parse hybrid data from local storage for key ${resolvedKey}`, error);
+          return {};
+        }
+      }
+      return {};
+    }
+
+    const storeDataJSON: string | null = (await this.store.getData(resolvedKey)) ?? null;
+    if (storeDataJSON) {
+      try {
+        return JSON.parse(storeDataJSON);
+      } catch (error) {
+        logger.error(`StorageManager: Failed to parse hybrid data from store for key ${resolvedKey}`, error);
+        return {};
+      }
+    }
+    return {};
   }
 
   public async getPersistedData(userId?: string): Promise<TemporaryStore> {
@@ -178,6 +241,16 @@ class StorageManager<T> {
     await this.store.removeData(this.resolveKey(Stores.TemporaryData, userId));
   }
 
+  public async removeHybridData(userId?: string): Promise<void> {
+    const resolvedKey = this.resolveKey(Stores.HybridData, userId);
+
+    if (StorageManager.isLocalStorageAvailable()) {
+      localStorage.removeItem(resolvedKey);
+    } else {
+      await this.store.removeData(resolvedKey);
+    }
+  }
+
   public async removeSessionData(userId?: string): Promise<void> {
     await this.store.removeData(this.resolveKey(Stores.SessionData, userId));
   }
@@ -196,7 +269,19 @@ class StorageManager<T> {
 
   public async getTemporaryDataParameter(key: keyof TemporaryStore, userId?: string): Promise<TemporaryStoreValue> {
     const data: string = await this.store.getData(this.resolveKey(Stores.TemporaryData, userId));
+    return data && JSON.parse(data)[key];
+  }
 
+  public async getHybridDataParameter(key: keyof HybridStore, userId?: string): Promise<TemporaryStoreValue> {
+    const resolvedKey = this.resolveKey(Stores.HybridData, userId);
+
+    if (StorageManager.isLocalStorageAvailable()) {
+      const existingDataJSON = localStorage.getItem(resolvedKey);
+      const existingData = existingDataJSON ? JSON.parse(existingDataJSON) : {};
+      return existingData[key];
+    }
+
+    const data: string = await this.store.getData(resolvedKey);
     return data && JSON.parse(data)[key];
   }
 
@@ -225,6 +310,23 @@ class StorageManager<T> {
     await this.setValue(this.resolveKey(Stores.TemporaryData, userId), key, value);
   }
 
+  public async setHybridDataParameter(
+    key: keyof HybridStore,
+    value: TemporaryStoreValue,
+    userId?: string,
+  ): Promise<void> {
+    const resolvedKey = this.resolveKey(Stores.HybridData, userId);
+
+    if (StorageManager.isLocalStorageAvailable()) {
+      const existingDataJSON = localStorage.getItem(resolvedKey);
+      const existingData = existingDataJSON ? JSON.parse(existingDataJSON) : {};
+      const dataToBeSaved = {...existingData, [key]: value};
+      localStorage.setItem(resolvedKey, JSON.stringify(dataToBeSaved));
+    } else {
+      await this.setValue(resolvedKey, key, value);
+    }
+  }
+
   public async setSessionDataParameter(
     key: keyof SessionData,
     value: TemporaryStoreValue,
@@ -243,6 +345,19 @@ class StorageManager<T> {
 
   public async removeTemporaryDataParameter(key: keyof TemporaryStore, userId?: string): Promise<void> {
     await this.removeValue(this.resolveKey(Stores.TemporaryData, userId), key);
+  }
+
+  public async removeHybridDataParameter(key: keyof HybridStore, userId?: string): Promise<void> {
+    const resolvedKey = this.resolveKey(Stores.HybridData, userId);
+
+    if (StorageManager.isLocalStorageAvailable()) {
+      const existingDataJSON = localStorage.getItem(resolvedKey);
+      const existingData = existingDataJSON ? JSON.parse(existingDataJSON) : {};
+      delete existingData[key];
+      localStorage.setItem(resolvedKey, JSON.stringify(existingData));
+    } else {
+      await this.removeValue(resolvedKey, key);
+    }
   }
 
   public async removeSessionDataParameter(key: keyof SessionData, userId?: string): Promise<void> {

--- a/sdks/javascript/src/ThunderIDJavaScriptClient.ts
+++ b/sdks/javascript/src/ThunderIDJavaScriptClient.ts
@@ -132,16 +132,11 @@ class ThunderIDJavaScriptClient<T = Config> implements ThunderIDClient<T> {
     const resolvedEndpoints = endpoints ? {...endpoints} : {};
 
     await this.storageManager.setConfigData(
-      deepMerge(
-        {} as Record<string, any>,
-        DEFAULT_CONFIG,
-        fullConfig as Record<string, any>,
-        {
-          applicationId: resolvedApplicationId,
-          endpoints: resolvedEndpoints,
-          scope: processOpenIDScopes((fullConfig as any).scopes),
-        }
-      ) as any
+      deepMerge({} as Record<string, any>, DEFAULT_CONFIG, fullConfig as Record<string, any>, {
+        applicationId: resolvedApplicationId,
+        endpoints: resolvedEndpoints,
+        scope: processOpenIDScopes((fullConfig as any).scopes),
+      }) as any,
     );
 
     this.baseURL = (fullConfig as any).baseUrl ?? '';
@@ -445,7 +440,7 @@ class ThunderIDJavaScriptClient<T = Config> implements ThunderIDClient<T> {
       if (configData.enablePKCE) {
         codeVerifier = this.cryptoHelper?.getCodeVerifier();
         codeChallenge = await this.cryptoHelper?.getCodeChallenge(codeVerifier);
-        await this.storageManager.setTemporaryDataParameter(pkceKey, codeVerifier, userId);
+        await this.storageManager.setHybridDataParameter(pkceKey, codeVerifier, userId);
       }
 
       if (authRequestConfig['client_secret']) {
@@ -546,9 +541,9 @@ class ThunderIDJavaScriptClient<T = Config> implements ThunderIDClient<T> {
     if (configData.enablePKCE) {
       body.set(
         'code_verifier',
-        `${await this.storageManager.getTemporaryDataParameter(extractPkceStorageKeyFromState(state), userId)}`,
+        `${await this.storageManager.getHybridDataParameter(extractPkceStorageKeyFromState(state), userId)}`,
       );
-      await this.storageManager.removeTemporaryDataParameter(extractPkceStorageKeyFromState(state), userId);
+      await this.storageManager.removeHybridDataParameter(extractPkceStorageKeyFromState(state), userId);
     }
 
     const tokenRequestHeaders: Record<string, string> = {
@@ -792,14 +787,11 @@ class ThunderIDJavaScriptClient<T = Config> implements ThunderIDClient<T> {
   }
 
   protected async getPKCECode(state: string, userId?: string): Promise<string> {
-    return (await this.storageManager.getTemporaryDataParameter(
-      extractPkceStorageKeyFromState(state),
-      userId,
-    )) as string;
+    return (await this.storageManager.getHybridDataParameter(extractPkceStorageKeyFromState(state), userId)) as string;
   }
 
   protected async setPKCECode(pkce: string, state: string, userId?: string): Promise<void> {
-    return this.storageManager.setTemporaryDataParameter(extractPkceStorageKeyFromState(state), pkce, userId);
+    return this.storageManager.setHybridDataParameter(extractPkceStorageKeyFromState(state), pkce, userId);
   }
 
   public getInstanceId(): number {

--- a/sdks/javascript/src/models/store.ts
+++ b/sdks/javascript/src/models/store.ts
@@ -64,6 +64,11 @@ export type TemporaryStoreValue = string | string[] | boolean | number | OIDCEnd
 export type TemporaryStore = Record<string, TemporaryStoreValue>;
 
 /**
+ * Represents a key-value store for hybrid data storage.
+ */
+export type HybridStore = Record<string, TemporaryStoreValue>;
+
+/**
  * Enum representing different types of data stores used in the application.
  */
 export enum Stores {
@@ -91,4 +96,9 @@ export enum Stores {
    * Store for temporary data that needs to persist only for a short duration.
    */
   TemporaryData = 'temporary_data',
+
+  /**
+   * Store for data that leverages local storage if available, falling back to the configured storage.
+   */
+  HybridData = 'hybrid_data',
 }

--- a/sdks/react/src/ThunderIDReactClient.ts
+++ b/sdks/react/src/ThunderIDReactClient.ts
@@ -278,7 +278,8 @@ class ThunderIDReactClient<T extends ThunderIDReactConfig = ThunderIDReactConfig
         ('executionId' in arg1 || 'applicationId' in arg1)
       ) {
         const authIdFromUrl: string = new URL(window.location.href).searchParams.get('authId') ?? '';
-        const authIdFromStorage: string = sessionStorage.getItem('thunderid_auth_id') ?? '';
+        const authIdFromStorage: string =
+          ((await this.getStorageManager().getHybridDataParameter('authId')) as string) ?? '';
         const authId: string = authIdFromUrl || authIdFromStorage;
         const baseUrl: string = config?.baseUrl ?? '';
 
@@ -342,11 +343,12 @@ class ThunderIDReactClient<T extends ThunderIDReactConfig = ThunderIDReactConfig
     const baseUrl: string = config?.baseUrl ?? '';
 
     const authIdFromUrl: string = new URL(window.location.href).searchParams.get('authId') ?? '';
-    const authIdFromStorage: string = sessionStorage.getItem('thunderid_auth_id') ?? '';
+    const authIdFromStorage: string =
+      ((await this.getStorageManager().getHybridDataParameter('authId')) as string) ?? '';
     const authId: string = authIdFromUrl || authIdFromStorage;
 
     if (authIdFromUrl && !authIdFromStorage) {
-      sessionStorage.setItem('thunderid_auth_id', authIdFromUrl);
+      await this.getStorageManager().setHybridDataParameter('authId', authIdFromUrl);
     }
 
     const response: any = await executeEmbeddedSignUpFlowV2({

--- a/sdks/react/src/components/auth/Callback/Callback.tsx
+++ b/sdks/react/src/components/auth/Callback/Callback.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
@@ -6,182 +6,50 @@
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
-import {navigate as browserNavigate} from '@thunderid/browser';
-import {FC, useEffect, useRef} from 'react';
+import {FC, useState} from 'react';
+import {TokenCallback, TokenCallbackProps} from './TokenCallback';
+import {OAuthCallback, OAuthCallbackProps} from './OAuthCallback';
 
 /**
- * Props for Callback component
+ * Props for the unified Callback component, combining properties for both Token and OAuth callbacks.
  */
-export interface CallbackProps {
-  /**
-   * Callback function called when an error occurs
-   */
-  onError?: (error: Error) => void;
-
-  /**
-   * Function to navigate to a different path.
-   * If not provided, falls back to the browser navigate utility (SPA navigation via History API for same-origin paths).
-   * Provide this prop to enable framework-specific navigation (e.g., from React Router).
-   */
-  onNavigate?: (path: string) => void;
-}
+export type CallbackProps = OAuthCallbackProps & TokenCallbackProps;
 
 /**
- * BaseCallback is a headless component that handles OAuth callback parameter forwarding.
- * This component extracts OAuth parameters (code, state, error) from the URL and forwards them
- * to the original component that initiated the OAuth flow.
- *
- * Works standalone using the browser navigate utility (History API) for navigation by default.
- * Pass an onNavigate prop to enable framework-specific navigation (e.g., via React Router).
- *
- * Flow: Extract OAuth parameters from URL -> Parse state parameter -> Redirect to original path with parameters
- *
- * The original component (SignIn/AcceptInvite) is responsible for:
- * - Processing the OAuth code via the SDK
- * - Calling /flow/execute
- * - Handling the assertion and auth/callback POST
- * - Managing the authenticated session
+ * A unified Callback component that automatically routes to either OAuthCallback or TokenCallback
+ * based on the presence of URL parameters ('code' for OAuth, 'token' for token-based flows).
  */
-export const Callback: FC<CallbackProps> = ({onNavigate, onError}: CallbackProps) => {
-  // Prevent double execution in React Strict Mode
-  const processingRef: any = useRef(false);
-
-  // Resolve navigation: use provided onNavigate (router-aware) or fall back to browser navigate utility
-  const navigate = (path: string): void => {
-    if (onNavigate) {
-      onNavigate(path);
-    } else {
-      browserNavigate(path);
+export const Callback: FC<CallbackProps> = (props: CallbackProps) => {
+  // Use state to lock the flow type on initial mount.
+  // This prevents the component from swapping to OAuthCallback if TokenCallback
+  // removes the '?token=' query parameter from the URL using window.history.
+  const [flowType] = useState<'token' | 'oauth'>(() => {
+    if (typeof window === 'undefined') {
+      return 'oauth';
     }
-  };
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('token') ? 'token' : 'oauth';
+  });
 
-  useEffect(() => {
-    const processOAuthCallback = (): void => {
-      // Guard against double execution
-      if (processingRef.current) {
-        return;
-      }
-      processingRef.current = true;
+  if (typeof window === 'undefined') {
+    return null;
+  }
 
-      // Declare variables outside try block for use in catch
-      let returnPath = '/';
+  if (flowType === 'token') {
+    return <TokenCallback {...props} />;
+  }
 
-      try {
-        // 1. Extract OAuth parameters from URL
-        const urlParams: URLSearchParams = new URLSearchParams(window.location.search);
-        const code: string | null = urlParams.get('code');
-        const state: string | null = urlParams.get('state');
-        const nonce: string | null = urlParams.get('nonce');
-        const oauthError: string | null = urlParams.get('error');
-        const errorDescription: string | null = urlParams.get('error_description');
-
-        // 1a. If running inside a popup (e.g. social signup), send OAuth params
-        //     back to the opener via postMessage. The parent window's handler will
-        //     close this popup after processing the code.
-        if (window.opener) {
-          window.opener.postMessage({code, error: oauthError, errorDescription, nonce, state}, window.location.origin);
-          return;
-        }
-
-        // 2. Validate and retrieve OAuth state from sessionStorage
-        if (!state) {
-          throw new Error('Missing OAuth state parameter - possible security issue');
-        }
-
-        const storedData: string | null = sessionStorage.getItem(`thunderid_oauth_${state}`);
-        if (!storedData) {
-          // If state not found, might be an error callback - try to handle gracefully
-          if (oauthError) {
-            const errorMsg: string = errorDescription || oauthError || 'OAuth authentication failed';
-            const err: Error = new Error(errorMsg);
-            onError?.(err);
-
-            const params: URLSearchParams = new URLSearchParams();
-            params.set('error', oauthError);
-            if (errorDescription) {
-              params.set('error_description', errorDescription);
-            }
-
-            navigate(`/?${params.toString()}`);
-            return;
-          }
-          throw new Error('Invalid OAuth state - possible CSRF attack');
-        }
-
-        const {path, timestamp} = JSON.parse(storedData);
-        returnPath = path || '/';
-
-        // 3. Validate state freshness
-        const MAX_STATE_AGE = 600000; // 10 minutes
-        if (Date.now() - timestamp > MAX_STATE_AGE) {
-          sessionStorage.removeItem(`thunderid_oauth_${state}`);
-          throw new Error('OAuth state expired - please try again');
-        }
-
-        // 4. Clean up state
-        sessionStorage.removeItem(`thunderid_oauth_${state}`);
-
-        // 5. Handle OAuth error response
-        if (oauthError) {
-          const errorMsg: string = errorDescription || oauthError || 'OAuth authentication failed';
-          const err: Error = new Error(errorMsg);
-          onError?.(err);
-
-          const params: URLSearchParams = new URLSearchParams();
-          params.set('error', oauthError);
-          if (errorDescription) {
-            params.set('error_description', errorDescription);
-          }
-
-          navigate(`${returnPath}?${params.toString()}`);
-          return;
-        }
-
-        // 6. Validate required parameters
-        if (!code) {
-          throw new Error('Missing OAuth authorization code');
-        }
-
-        // 7. Forward OAuth code to original component
-        // The component (SignIn/AcceptInvite) will retrieve flowId/authId from sessionStorage
-        const params: URLSearchParams = new URLSearchParams();
-        params.set('code', code);
-        if (nonce) {
-          params.set('nonce', nonce);
-        }
-
-        navigate(`${returnPath}?${params.toString()}`);
-      } catch (err) {
-        const errorMessage: string = err instanceof Error ? err.message : 'OAuth callback processing failed';
-        // eslint-disable-next-line no-console
-        console.error('OAuth callback error:', err);
-
-        onError?.(err instanceof Error ? err : new Error(errorMessage));
-
-        // Redirect back with OAuth error format
-        const params: URLSearchParams = new URLSearchParams();
-        params.set('error', 'callback_error');
-        params.set('error_description', errorMessage);
-
-        navigate(`${returnPath}?${params.toString()}`);
-      }
-    };
-
-    processOAuthCallback();
-  }, [onNavigate, onError]);
-
-  // Headless component - no UI, just processing logic
-  return null;
+  return <OAuthCallback {...props} />;
 };
 
 export default Callback;

--- a/sdks/react/src/components/auth/Callback/OAuthCallback.tsx
+++ b/sdks/react/src/components/auth/Callback/OAuthCallback.tsx
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {navigate as browserNavigate} from '@thunderid/browser';
+import {FC, useEffect, useRef} from 'react';
+
+/**
+ * Props for Callback component
+ */
+export interface OAuthCallbackProps {
+  /**
+   * Callback function called when an error occurs
+   */
+  onError?: (error: Error) => void;
+
+  /**
+   * Function to navigate to a different path.
+   * If not provided, falls back to the browser navigate utility (SPA navigation via History API for same-origin paths).
+   * Provide this prop to enable framework-specific navigation (e.g., from React Router).
+   */
+  onNavigate?: (path: string) => void;
+}
+
+/**
+ * BaseCallback is a headless component that handles OAuth callback parameter forwarding.
+ * This component extracts OAuth parameters (code, state, error) from the URL and forwards them
+ * to the original component that initiated the OAuth flow.
+ *
+ * Works standalone using the browser navigate utility (History API) for navigation by default.
+ * Pass an onNavigate prop to enable framework-specific navigation (e.g., via React Router).
+ *
+ * Flow: Extract OAuth parameters from URL -> Parse state parameter -> Redirect to original path with parameters
+ *
+ * The original component (SignIn/AcceptInvite) is responsible for:
+ * - Processing the OAuth code via the SDK
+ * - Calling /flow/execute
+ * - Handling the assertion and auth/callback POST
+ * - Managing the authenticated session
+ */
+export const OAuthCallback: FC<OAuthCallbackProps> = ({onNavigate, onError}: OAuthCallbackProps) => {
+  // Prevent double execution in React Strict Mode
+  const processingRef: any = useRef(false);
+
+  // Resolve navigation: use provided onNavigate (router-aware) or fall back to browser navigate utility
+  const navigate = (path: string): void => {
+    if (onNavigate) {
+      onNavigate(path);
+    } else {
+      browserNavigate(path);
+    }
+  };
+
+  useEffect(() => {
+    const processOAuthCallback = (): void => {
+      // Guard against double execution
+      if (processingRef.current) {
+        return;
+      }
+      processingRef.current = true;
+
+      // Declare variables outside try block for use in catch
+      let returnPath = '/';
+
+      try {
+        // 1. Extract OAuth parameters from URL
+        const urlParams: URLSearchParams = new URLSearchParams(window.location.search);
+        const code: string | null = urlParams.get('code');
+        const state: string | null = urlParams.get('state');
+        const nonce: string | null = urlParams.get('nonce');
+        const oauthError: string | null = urlParams.get('error');
+        const errorDescription: string | null = urlParams.get('error_description');
+
+        // 1a. If running inside a popup (e.g. social signup), send OAuth params
+        //     back to the opener via postMessage. The parent window's handler will
+        //     close this popup after processing the code.
+        if (window.opener) {
+          window.opener.postMessage({code, error: oauthError, errorDescription, nonce, state}, window.location.origin);
+          return;
+        }
+
+        // 2. Validate and retrieve OAuth state from sessionStorage
+        if (!state) {
+          throw new Error('Missing OAuth state parameter - possible security issue');
+        }
+
+        const storedData: string | null = sessionStorage.getItem(`thunderid_oauth_${state}`);
+        if (!storedData) {
+          // If state not found, might be an error callback - try to handle gracefully
+          if (oauthError) {
+            const errorMsg: string = errorDescription || oauthError || 'OAuth authentication failed';
+            const err: Error = new Error(errorMsg);
+            onError?.(err);
+
+            const params: URLSearchParams = new URLSearchParams();
+            params.set('error', oauthError);
+            if (errorDescription) {
+              params.set('error_description', errorDescription);
+            }
+
+            navigate(`/?${params.toString()}`);
+            return;
+          }
+          throw new Error('Invalid OAuth state - possible CSRF attack');
+        }
+
+        const {path, timestamp} = JSON.parse(storedData);
+        returnPath = path || '/';
+
+        // 3. Validate state freshness
+        const MAX_STATE_AGE = 600000; // 10 minutes
+        if (Date.now() - timestamp > MAX_STATE_AGE) {
+          sessionStorage.removeItem(`thunderid_oauth_${state}`);
+          throw new Error('OAuth state expired - please try again');
+        }
+
+        // 4. Clean up state
+        sessionStorage.removeItem(`thunderid_oauth_${state}`);
+
+        // 5. Handle OAuth error response
+        if (oauthError) {
+          const errorMsg: string = errorDescription || oauthError || 'OAuth authentication failed';
+          const err: Error = new Error(errorMsg);
+          onError?.(err);
+
+          const params: URLSearchParams = new URLSearchParams();
+          params.set('error', oauthError);
+          if (errorDescription) {
+            params.set('error_description', errorDescription);
+          }
+
+          navigate(`${returnPath}?${params.toString()}`);
+          return;
+        }
+
+        // 6. Validate required parameters
+        if (!code) {
+          throw new Error('Missing OAuth authorization code');
+        }
+
+        // 7. Forward OAuth code to original component
+        // The component (SignIn/AcceptInvite) will retrieve flowId/authId from sessionStorage
+        const params: URLSearchParams = new URLSearchParams();
+        params.set('code', code);
+        if (nonce) {
+          params.set('nonce', nonce);
+        }
+
+        navigate(`${returnPath}?${params.toString()}`);
+      } catch (err) {
+        const errorMessage: string = err instanceof Error ? err.message : 'OAuth callback processing failed';
+        // eslint-disable-next-line no-console
+        console.error('OAuth callback error:', err);
+
+        onError?.(err instanceof Error ? err : new Error(errorMessage));
+
+        // Redirect back with OAuth error format
+        const params: URLSearchParams = new URLSearchParams();
+        params.set('error', 'callback_error');
+        params.set('error_description', errorMessage);
+
+        navigate(`${returnPath}?${params.toString()}`);
+      }
+    };
+
+    processOAuthCallback();
+  }, [onNavigate, onError]);
+
+  // Headless component - no UI, just processing logic
+  return null;
+};
+
+export default OAuthCallback;

--- a/sdks/react/src/components/auth/Callback/TokenCallback.tsx
+++ b/sdks/react/src/components/auth/Callback/TokenCallback.tsx
@@ -1,0 +1,237 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {EmbeddedSignInFlowStatusV2, EmbeddedSignInFlowTypeV2, navigate as browserNavigate} from '@thunderid/browser';
+import {FC, useEffect, useRef} from 'react';
+import useThunderID from '../../../contexts/ThunderID/useThunderID';
+
+export interface TokenCallbackProps {
+  /**
+   * Callback function called when an error occurs
+   */
+  onError?: (error: Error) => void;
+
+  /**
+   * Function to navigate to a different path.
+   * If not provided, falls back to the browser navigate utility (SPA navigation via History API for same-origin paths).
+   * Provide this prop to enable framework-specific navigation (e.g., from React Router).
+   */
+  onNavigate?: (path: string) => void;
+
+  /**
+   * Callback function called when authentication is successful
+   */
+  onSuccess?: (authData: Record<string, any>) => void;
+
+  /**
+   * Custom path for the sign-in page. Defaults to '/signin'
+   */
+  signInPath?: string;
+
+  /**
+   * Custom path for the sign-up page. Defaults to '/signup'
+   */
+  signUpPath?: string;
+}
+
+export const TokenCallback: FC<TokenCallbackProps> = ({
+  onNavigate,
+  onError,
+  onSuccess,
+  signInPath = '/signin',
+  signUpPath = '/signup',
+}: TokenCallbackProps) => {
+  const processingRef: any = useRef(false);
+  const {isInitialized, isLoading, signIn, signUp, getStorageManager} = useThunderID();
+
+  const navigate = (path: string): void => {
+    if (onNavigate) {
+      onNavigate(path);
+    } else {
+      browserNavigate(path);
+    }
+  };
+
+  const clearTokenFromUrl = (): void => {
+    if (!window?.location?.href) {
+      return;
+    }
+
+    const url: URL = new URL(window.location.href);
+    url.searchParams.delete('token');
+    url.searchParams.delete('type');
+    window.history.replaceState({}, '', url.toString());
+  };
+
+  const initiateOAuthRedirect = (redirectURL: string, isRegistrationFlow?: boolean): void => {
+    const redirectUrlObj: URL = new URL(redirectURL);
+    const state: string = redirectUrlObj.searchParams.get('state') || crypto.randomUUID();
+
+    sessionStorage.setItem(
+      `thunderid_oauth_${state}`,
+      JSON.stringify({
+        path: isRegistrationFlow ? signUpPath : signInPath,
+        timestamp: Date.now(),
+      }),
+    );
+
+    browserNavigate(redirectUrlObj.toString());
+  };
+
+  const buildSignInPath = (
+    executionId?: string | null,
+    applicationId?: string | null,
+    isRegistrationFlow?: boolean,
+  ): string => {
+    const params: URLSearchParams = new URLSearchParams();
+    if (executionId) {
+      params.set('executionId', executionId);
+    }
+    if (applicationId) {
+      params.set('applicationId', applicationId);
+    }
+
+    const basePath = isRegistrationFlow ? signUpPath : signInPath;
+    return params.toString() ? `${basePath}?${params.toString()}` : basePath;
+  };
+
+  const redirectWithError = (error: Error, isRegistrationFlow?: boolean): void => {
+    sessionStorage.removeItem('thunderid_execution_id');
+
+    onError?.(error);
+
+    const params: URLSearchParams = new URLSearchParams();
+    params.set('error', 'token_verification_failed');
+    params.set('error_description', error.message);
+    const basePath = isRegistrationFlow ? signUpPath : signInPath;
+    navigate(`${basePath}?${params.toString()}`);
+  };
+
+  useEffect(() => {
+    if (!isInitialized || isLoading) {
+      return;
+    }
+
+    const processTokenCallback = async (): Promise<void> => {
+      if (processingRef.current) {
+        return;
+      }
+      processingRef.current = true;
+
+      // Read URL params before clearing them so they're accessible in both try and catch.
+      const searchParams: URLSearchParams = new URLSearchParams(window.location.search);
+      const executionId: string | null = searchParams.get('id') || searchParams.get('executionId');
+      const token: string | null = searchParams.get('token');
+      const applicationId: string | null = searchParams.get('applicationId');
+      const isRegistrationFlow: boolean = searchParams.get('type') === 'REGISTRATION';
+
+      clearTokenFromUrl();
+
+      try {
+        const storageManager: any = await getStorageManager();
+
+        if (!executionId || !token) {
+          const error: Error = new Error('Missing executionId or token in callback URL');
+          redirectWithError(error, isRegistrationFlow);
+          return;
+        }
+
+        let response: any;
+
+        if (isRegistrationFlow) {
+          response = await signUp({executionId, inputs: {token}});
+        } else {
+          response = await signIn({executionId, inputs: {token}});
+        }
+
+        if (response.type === EmbeddedSignInFlowTypeV2.Redirection) {
+          const redirectURL: string | undefined = (response.data as any)?.redirectURL || (response as any)?.redirectURL;
+          const nextExecutionId: string = response.executionId || executionId;
+          sessionStorage.setItem('thunderid_execution_id', nextExecutionId);
+
+          if (redirectURL) {
+            initiateOAuthRedirect(redirectURL, isRegistrationFlow);
+            return;
+          }
+        }
+
+        if (response.flowStatus === EmbeddedSignInFlowStatusV2.Complete) {
+          const redirectUrl: string | undefined = (response as any)?.redirectUrl || (response as any)?.redirect_uri;
+
+          sessionStorage.removeItem('thunderid_execution_id');
+          await storageManager.removeHybridDataParameter('authId');
+
+          onSuccess?.({
+            redirectUrl,
+            ...((response.data as Record<string, any>) || {}),
+          });
+
+          if (redirectUrl) {
+            window.location.href = redirectUrl;
+            return;
+          }
+
+          navigate(isRegistrationFlow ? signUpPath : signInPath);
+          return;
+        }
+
+        if (response.flowStatus === EmbeddedSignInFlowStatusV2.Error) {
+          const failureReason: string | undefined = (response as any)?.failureReason;
+          const error: Error = new Error(failureReason || 'Token validation failed. Please try again.');
+          await storageManager.removeHybridDataParameter('authId');
+          redirectWithError(error, isRegistrationFlow);
+          return;
+        }
+
+        const nextExecutionId: string = response.executionId || executionId;
+        sessionStorage.setItem('thunderid_execution_id', nextExecutionId);
+
+        if (response.challengeToken) {
+          await storageManager.setTemporaryDataParameter('challengeToken', response.challengeToken);
+        }
+
+        navigate(buildSignInPath(nextExecutionId, applicationId, isRegistrationFlow));
+      } catch (err) {
+        const error: Error = err instanceof Error ? err : new Error('Token callback processing failed');
+        // eslint-disable-next-line no-console
+        console.error('Token callback error:', err);
+        const storageManager: any = await getStorageManager();
+        if (storageManager) {
+          await storageManager.removeHybridDataParameter('authId');
+        }
+        redirectWithError(error, isRegistrationFlow);
+      }
+    };
+
+    processTokenCallback();
+  }, [
+    getStorageManager,
+    isInitialized,
+    isLoading,
+    onError,
+    onNavigate,
+    onSuccess,
+    signIn,
+    signUp,
+    signInPath,
+    signUpPath,
+  ]);
+
+  return null;
+};
+
+export default TokenCallback;

--- a/sdks/react/src/components/auth/Callback/__tests__/Callback.test.tsx
+++ b/sdks/react/src/components/auth/Callback/__tests__/Callback.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {Callback} from '../Callback';
+
+vi.mock('../TokenCallback', () => ({
+  TokenCallback: () => <div data-testid="token-callback">TokenCallback</div>,
+}));
+
+vi.mock('../OAuthCallback', () => ({
+  OAuthCallback: () => <div data-testid="oauth-callback">OAuthCallback</div>,
+}));
+
+describe('Callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('renders TokenCallback when token is present in the URL', () => {
+    window.history.replaceState({}, '', '/callback?token=secret-token');
+    render(<Callback />);
+    expect(screen.getByTestId('token-callback')).toBeDefined();
+    expect(screen.queryByTestId('oauth-callback')).toBeNull();
+  });
+
+  it('renders OAuthCallback when token is not present in the URL', () => {
+    window.history.replaceState({}, '', '/callback?code=oauth-code');
+    render(<Callback />);
+    expect(screen.getByTestId('oauth-callback')).toBeDefined();
+    expect(screen.queryByTestId('token-callback')).toBeNull();
+  });
+
+  it('maintains the initial flow type even if URL changes later', () => {
+    // Start with token in URL
+    window.history.replaceState({}, '', '/callback?token=secret-token');
+    const {rerender} = render(<Callback />);
+    expect(screen.getByTestId('token-callback')).toBeDefined();
+
+    // Simulate URL change (like what TokenCallback does when it cleans the URL)
+    window.history.replaceState({}, '', '/callback');
+    rerender(<Callback />);
+
+    // It should STILL render TokenCallback because flowType is locked in state
+    expect(screen.getByTestId('token-callback')).toBeDefined();
+    expect(screen.queryByTestId('oauth-callback')).toBeNull();
+  });
+});

--- a/sdks/react/src/components/auth/Callback/__tests__/OAuthCallback.test.tsx
+++ b/sdks/react/src/components/auth/Callback/__tests__/OAuthCallback.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, waitFor} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {OAuthCallback} from '../OAuthCallback';
+
+describe('OAuthCallback', () => {
+  let originalOpener: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    window.history.replaceState({}, '', '/');
+    originalOpener = window.opener;
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    window.history.replaceState({}, '', '/');
+    window.opener = originalOpener;
+  });
+
+  it('sends postMessage to window.opener if it exists', async () => {
+    const postMessageMock: any = vi.fn();
+    window.opener = {postMessage: postMessageMock};
+    window.history.replaceState(
+      {},
+      '',
+      '/callback?code=test-code&state=test-state&nonce=test-nonce&error=test-error&error_description=test-desc',
+    );
+
+    render(<OAuthCallback />);
+
+    await waitFor(() => {
+      expect(postMessageMock).toHaveBeenCalledWith(
+        {
+          code: 'test-code',
+          error: 'test-error',
+          errorDescription: 'test-desc',
+          nonce: 'test-nonce',
+          state: 'test-state',
+        },
+        window.location.origin,
+      );
+    });
+  });
+
+  it('navigates with error if state is missing', async () => {
+    const onError: any = vi.fn();
+    const onNavigate: any = vi.fn();
+    window.history.replaceState({}, '', '/callback?code=test-code');
+
+    render(<OAuthCallback onError={onError} onNavigate={onNavigate} />);
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({message: 'Missing OAuth state parameter - possible security issue'}),
+      );
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith(
+      '/?error=callback_error&error_description=Missing+OAuth+state+parameter+-+possible+security+issue',
+    );
+  });
+
+  it('navigates with error if state is invalid (not in sessionStorage)', async () => {
+    const onError: any = vi.fn();
+    const onNavigate: any = vi.fn();
+    window.history.replaceState({}, '', '/callback?code=test-code&state=invalid-state');
+
+    render(<OAuthCallback onError={onError} onNavigate={onNavigate} />);
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({message: 'Invalid OAuth state - possible CSRF attack'}),
+      );
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith(
+      '/?error=callback_error&error_description=Invalid+OAuth+state+-+possible+CSRF+attack',
+    );
+  });
+
+  it('navigates with error and cleans up state if state is expired', async () => {
+    const onError: any = vi.fn();
+    const onNavigate: any = vi.fn();
+
+    // Set timestamp to 11 minutes ago
+    const expiredTimestamp: number = Date.now() - 11 * 60 * 1000;
+    sessionStorage.setItem(
+      'thunderid_oauth_test-state',
+      JSON.stringify({path: '/custom-path', timestamp: expiredTimestamp}),
+    );
+
+    window.history.replaceState({}, '', '/callback?code=test-code&state=test-state');
+
+    render(<OAuthCallback onError={onError} onNavigate={onNavigate} />);
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({message: 'OAuth state expired - please try again'}),
+      );
+    });
+
+    expect(sessionStorage.getItem('thunderid_oauth_test-state')).toBeNull();
+    expect(onNavigate).toHaveBeenCalledWith(
+      '/custom-path?error=callback_error&error_description=OAuth+state+expired+-+please+try+again',
+    );
+  });
+
+  it('forwards oauth error to original component', async () => {
+    const onError: any = vi.fn();
+    const onNavigate: any = vi.fn();
+
+    sessionStorage.setItem('thunderid_oauth_test-state', JSON.stringify({path: '/custom-path', timestamp: Date.now()}));
+    window.history.replaceState(
+      {},
+      '',
+      '/callback?state=test-state&error=access_denied&error_description=User+denied+access',
+    );
+
+    render(<OAuthCallback onError={onError} onNavigate={onNavigate} />);
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({message: 'User denied access'}));
+    });
+
+    expect(sessionStorage.getItem('thunderid_oauth_test-state')).toBeNull();
+    expect(onNavigate).toHaveBeenCalledWith('/custom-path?error=access_denied&error_description=User+denied+access');
+  });
+
+  it('navigates with code and nonce on normal flow', async () => {
+    const onNavigate: any = vi.fn();
+
+    sessionStorage.setItem('thunderid_oauth_test-state', JSON.stringify({path: '/custom-path', timestamp: Date.now()}));
+    window.history.replaceState({}, '', '/callback?code=valid-code&state=test-state&nonce=test-nonce');
+
+    render(<OAuthCallback onNavigate={onNavigate} />);
+
+    await waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledWith('/custom-path?code=valid-code&nonce=test-nonce');
+    });
+
+    expect(sessionStorage.getItem('thunderid_oauth_test-state')).toBeNull();
+  });
+
+  it('navigates with error if code is missing', async () => {
+    const onError: any = vi.fn();
+    const onNavigate: any = vi.fn();
+
+    sessionStorage.setItem('thunderid_oauth_test-state', JSON.stringify({path: '/custom-path', timestamp: Date.now()}));
+    window.history.replaceState({}, '', '/callback?state=test-state');
+
+    render(<OAuthCallback onError={onError} onNavigate={onNavigate} />);
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({message: 'Missing OAuth authorization code'}));
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith(
+      '/custom-path?error=callback_error&error_description=Missing+OAuth+authorization+code',
+    );
+  });
+});

--- a/sdks/react/src/components/auth/Callback/__tests__/TokenCallback.test.tsx
+++ b/sdks/react/src/components/auth/Callback/__tests__/TokenCallback.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, waitFor} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {TokenCallback} from '../TokenCallback';
+
+const mockSignIn: any = vi.fn();
+const mockSignUp: any = vi.fn();
+const mockSetTemporaryDataParameter: any = vi.fn();
+const mockRemoveTemporaryDataParameter: any = vi.fn();
+
+const mockGetHybridDataParameter: any = vi.fn();
+const mockRemoveHybridDataParameter: any = vi.fn();
+
+const thunderIDContext: any = {
+  afterSignInUrl: undefined,
+  getStorageManager: vi.fn(() =>
+    Promise.resolve({
+      getHybridDataParameter: mockGetHybridDataParameter,
+      removeHybridDataParameter: mockRemoveHybridDataParameter,
+      removeTemporaryDataParameter: mockRemoveTemporaryDataParameter,
+      setTemporaryDataParameter: mockSetTemporaryDataParameter,
+    }),
+  ),
+  isInitialized: true,
+  isLoading: false,
+  signIn: mockSignIn,
+  signUp: mockSignUp,
+};
+
+vi.mock('../../../contexts/ThunderID/useThunderID', () => ({
+  default: () => thunderIDContext,
+}));
+
+describe('TokenCallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('verifies the token as an authentication flow when type=AUTHENTICATION is present', async () => {
+    const onNavigate: any = vi.fn();
+    mockSignIn.mockResolvedValue({
+      executionId: 'next-exec',
+      flowStatus: 'INCOMPLETE',
+      type: 'VIEW',
+    });
+    window.history.replaceState(
+      {},
+      '',
+      '/callback?id=exec-1&applicationId=app-1&token=secret-token&type=AUTHENTICATION',
+    );
+
+    render(<TokenCallback onNavigate={onNavigate} />);
+
+    await waitFor(() => {
+      expect(mockSignIn).toHaveBeenCalledWith({
+        executionId: 'exec-1',
+        inputs: {
+          token: 'secret-token',
+        },
+      });
+    });
+
+    expect(new URL(window.location.href).searchParams.get('token')).toBeNull();
+    expect(new URL(window.location.href).searchParams.get('type')).toBeNull();
+    expect(sessionStorage.getItem('thunderid_execution_id')).toBe('next-exec');
+    expect(onNavigate).toHaveBeenCalledWith('/signin?executionId=next-exec&applicationId=app-1');
+  });
+
+  it('verifies the token as a registration flow when type=REGISTRATION is present', async () => {
+    const onNavigate: any = vi.fn();
+    mockSignUp.mockResolvedValue({
+      executionId: 'next-exec',
+      flowStatus: 'INCOMPLETE',
+      type: 'VIEW',
+    });
+    window.history.replaceState({}, '', '/callback?id=exec-1&applicationId=app-1&token=secret-token&type=REGISTRATION');
+
+    render(<TokenCallback onNavigate={onNavigate} />);
+
+    await waitFor(() => {
+      expect(mockSignUp).toHaveBeenCalledWith({
+        executionId: 'exec-1',
+        inputs: {
+          token: 'secret-token',
+        },
+      });
+    });
+
+    expect(new URL(window.location.href).searchParams.get('token')).toBeNull();
+    expect(new URL(window.location.href).searchParams.get('type')).toBeNull();
+    expect(sessionStorage.getItem('thunderid_execution_id')).toBe('next-exec');
+    expect(onNavigate).toHaveBeenCalledWith('/signup?executionId=next-exec&applicationId=app-1');
+  });
+
+  it('redirects to sign-in with an error when required parameters are missing', async () => {
+    const onError: any = vi.fn();
+    const onNavigate: any = vi.fn();
+    window.history.replaceState({}, '', '/callback?id=exec-1');
+
+    render(<TokenCallback onError={onError} onNavigate={onNavigate} />);
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({message: 'Missing executionId or token in callback URL'}),
+      );
+    });
+
+    expect(mockSignIn).not.toHaveBeenCalled();
+    expect(onNavigate).toHaveBeenCalledWith(
+      '/signin?error=token_verification_failed&error_description=Missing+executionId+or+token+in+callback+URL',
+    );
+  });
+
+  it('redirects to sign-in with an error when verification fails', async () => {
+    const onError: any = vi.fn();
+    const onNavigate: any = vi.fn();
+    mockSignIn.mockRejectedValue(new Error('Invalid token'));
+    window.history.replaceState({}, '', '/callback?id=exec-1&token=secret-token');
+
+    render(<TokenCallback onError={onError} onNavigate={onNavigate} />);
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({message: 'Invalid token'}));
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('/signin?error=token_verification_failed&error_description=Invalid+token');
+  });
+});

--- a/sdks/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
+++ b/sdks/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
@@ -217,7 +217,8 @@ const SignIn: FC<SignInProps> = ({
   variant,
   children,
 }: SignInProps): ReactElement => {
-  const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading, meta, getStorageManager, scopes} = useThunderID();
+  const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading, meta, getStorageManager, scopes} =
+    useThunderID();
   const {t} = useTranslation(preferences?.i18n);
 
   // State management for the flow
@@ -301,7 +302,12 @@ const SignIn: FC<SignInProps> = ({
     setExecutionId(null);
     await setChallengeToken(null);
     setIsFlowInitialized(false);
-    sessionStorage.removeItem('thunderid_auth_id');
+    try {
+      const storageManager: any = await getStorageManager();
+      await storageManager?.removeHybridDataParameter?.('authId');
+    } catch {
+      logger.warn('Failed to clear authId from hybrid storage.');
+    }
     setIsTimeoutDisabled(false);
     // Reset refs to allow new flows to start properly
     oauthCodeProcessedRef.current = false;
@@ -328,9 +334,14 @@ const SignIn: FC<SignInProps> = ({
   /**
    * Handle authId from URL and store it in sessionStorage.
    */
-  const handleAuthId = (authId: string | null): void => {
+  const handleAuthId = async (authId: string | null): Promise<void> => {
     if (authId) {
-      sessionStorage.setItem('thunderid_auth_id', authId);
+      try {
+        const storageManager: any = await getStorageManager();
+        await storageManager?.setHybridDataParameter?.('authId', authId);
+      } catch {
+        logger.warn('Failed to store authId in hybrid storage.');
+      }
     }
   };
 
@@ -440,6 +451,7 @@ const SignIn: FC<SignInProps> = ({
       if (urlParams.executionId) {
         response = (await signIn({
           executionId: urlParams.executionId,
+          ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
         })) as EmbeddedSignInFlowResponseV2;
       } else {
         response = (await signIn({
@@ -510,6 +522,7 @@ const SignIn: FC<SignInProps> = ({
     if (
       isInitialized &&
       !isLoading &&
+      isStorageReady &&
       !isFlowInitialized &&
       !initializationAttemptedRef.current &&
       !currentExecutionId &&
@@ -521,7 +534,7 @@ const SignIn: FC<SignInProps> = ({
       initializationAttemptedRef.current = true;
       initializeFlow();
     }
-  }, [isInitialized, isLoading, isFlowInitialized, currentExecutionId]);
+  }, [isInitialized, isLoading, isStorageReady, isFlowInitialized, currentExecutionId]);
 
   /**
    * Handle step timeout if configured in additionalData.
@@ -707,7 +720,12 @@ const SignIn: FC<SignInProps> = ({
         await setChallengeToken(null);
         setIsFlowInitialized(false);
         sessionStorage.removeItem('thunderid_execution_id');
-        sessionStorage.removeItem('thunderid_auth_id');
+        try {
+          const storageManager: any = await getStorageManager();
+          await storageManager?.removeHybridDataParameter?.('authId');
+        } catch {
+          logger.warn('Failed to clear authId from hybrid storage after completion.');
+        }
 
         // Clean up OAuth URL params before redirect
         cleanupOAuthUrlParams(true);

--- a/sdks/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
+++ b/sdks/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
@@ -285,6 +285,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
   const [isFlowInitialized, setIsFlowInitialized] = useState(false);
   const [currentFlow, setCurrentFlow] = useState<EmbeddedSignUpFlowResponseV2 | null>(null);
   const [apiError, setApiError] = useState<Error | null>(null);
+  const [isStorageReady, setIsStorageReady] = useState(false);
   const [passkeyState, setPasskeyState] = useState<PasskeyState>({
     actionId: null,
     creationOptions: null,
@@ -312,6 +313,8 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
         }
       } catch {
         // StorageManager unavailable — continue without persisted token
+      } finally {
+        setIsStorageReady(true);
       }
     })();
   }, [isSdkInitialized]);
@@ -441,7 +444,9 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
     [t],
   );
 
-  const formFields: any = (currentFlow?.data as any)?.components ? extractFormFields((currentFlow!.data as any).components) : [];
+  const formFields: any = (currentFlow?.data as any)?.components
+    ? extractFormFields((currentFlow!.data as any).components)
+    : [];
 
   const form: any = useForm<Record<string, string>>({
     fields: formFields,
@@ -936,7 +941,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
       return;
     }
 
-    if (isInitialized && !isFlowInitialized && !initializationAttemptedRef.current) {
+    if (isInitialized && isStorageReady && !isFlowInitialized && !initializationAttemptedRef.current) {
       initializationAttemptedRef.current = true;
 
       (async (): Promise<void> => {
@@ -945,13 +950,22 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
         clearMessages();
 
         try {
-          const rawResponse: any = await onInitialize?.();
+          const payload: any = challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : undefined;
+          const rawResponse: any = await onInitialize?.(payload);
           const response: any = normalizeFlowResponseLocal(rawResponse);
 
           await setChallengeToken(response.challengeToken ?? null);
           setCurrentFlow(response);
           setIsFlowInitialized(true);
           onFlowChange?.(response);
+
+          // Clean up executionId and applicationId from URL after storing in state
+          if (window?.location?.href) {
+            const url: URL = new URL(window.location.href);
+            url.searchParams.delete('executionId');
+            url.searchParams.delete('applicationId');
+            window.history.replaceState({}, '', url.toString());
+          }
 
           if (response.flowStatus === EmbeddedSignUpFlowStatusV2.Error) {
             handleError(response);
@@ -983,6 +997,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
     }
   }, [
     isInitialized,
+    isStorageReady,
     isFlowInitialized,
     onInitialize,
     onComplete,

--- a/sdks/react/src/components/presentation/auth/SignUp/v2/SignUp.tsx
+++ b/sdks/react/src/components/presentation/auth/SignUp/v2/SignUp.tsx
@@ -61,19 +61,31 @@ const SignUp: FC<SignUpProps> = ({
   /**
    * Initialize the sign-up flow.
    */
-  const handleInitialize = async (
-    payload?: EmbeddedSignUpFlowRequestV2,
-  ): Promise<EmbeddedSignUpFlowResponseV2> => {
+  const handleInitialize = async (payload?: EmbeddedSignUpFlowRequestV2): Promise<EmbeddedSignUpFlowResponseV2> => {
     const urlParams: URLSearchParams = new URL(window.location.href).searchParams;
+    const executionIdFromUrl: string = urlParams.get('executionId') || '';
     const applicationIdFromUrl: string = urlParams.get('applicationId') ?? '';
 
     const effectiveApplicationId: any = applicationId ?? applicationIdFromUrl;
 
-    const initialPayload: EmbeddedSignUpFlowRequestV2 = payload ?? {
-      flowType: EmbeddedFlowType.Registration,
-      ...(effectiveApplicationId && {applicationId: effectiveApplicationId}),
-      ...(scopes && {scopes}),
-    };
+    const challengeToken: string | undefined = (payload as any)?.challengeToken;
+
+    let initialPayload: EmbeddedSignUpFlowRequestV2 | any;
+    if (executionIdFromUrl) {
+      initialPayload = {
+        executionId: executionIdFromUrl,
+        ...(challengeToken ? {challengeToken} : {}),
+      };
+    } else if (!payload || !('flowType' in payload)) {
+      initialPayload = {
+        ...(payload || {}),
+        flowType: EmbeddedFlowType.Registration,
+        ...(effectiveApplicationId && {applicationId: effectiveApplicationId}),
+        ...(scopes && {scopes}),
+      };
+    } else {
+      initialPayload = payload;
+    }
 
     return (await signUp(initialPayload)) as EmbeddedSignUpFlowResponseV2;
   };
@@ -94,8 +106,9 @@ const SignUp: FC<SignUpProps> = ({
       return;
     }
 
-    const redirectURL: string | undefined =
-      (response?.data as Record<string, unknown>)?.['redirectURL'] as string | undefined;
+    const redirectURL: string | undefined = (response?.data as Record<string, unknown>)?.['redirectURL'] as
+      | string
+      | undefined;
 
     if (
       response?.type === EmbeddedSignUpFlowTypeV2.Redirection &&
@@ -115,11 +128,7 @@ const SignUp: FC<SignUpProps> = ({
 
     // For non-redirection responses (regular sign-up completion), handle redirect if configured.
     // Skip when assertion is present — the SDK stored the session and the caller handled navigation.
-    if (
-      response?.type !== EmbeddedSignUpFlowTypeV2.Redirection &&
-      afterSignUpUrl &&
-      !(response as any)?.assertion
-    ) {
+    if (response?.type !== EmbeddedSignUpFlowTypeV2.Redirection && afterSignUpUrl && !(response as any)?.assertion) {
       window.location.href = afterSignUpUrl;
     }
   };

--- a/sdks/react/src/contexts/ThunderID/ThunderIDContext.ts
+++ b/sdks/react/src/contexts/ThunderID/ThunderIDContext.ts
@@ -213,8 +213,7 @@ export type ThunderIDContextProps = {
 
   user: any;
   platform?: Platform;
-} & Pick<ThunderIDReactConfig, 'storage'> &
-  Pick<ThunderIDReactClient, 'clearSession' | 'switchOrganization'>;
+} & Pick<ThunderIDReactClient, 'clearSession' | 'switchOrganization'>;
 
 /**
  * Context object for managing the Authentication flow builder core context.
@@ -256,7 +255,6 @@ const ThunderIDContext: Context<ThunderIDContextProps | null> = createContext<nu
   signOut: () => Promise.resolve({} as any),
   signUp: () => Promise.resolve({} as any),
   signUpUrl: undefined,
-  storage: 'sessionStorage',
   switchOrganization: null as unknown as ThunderIDContextProps['switchOrganization'],
   user: null,
 });

--- a/sdks/react/src/index.ts
+++ b/sdks/react/src/index.ts
@@ -137,6 +137,8 @@ export {BaseAcceptInvite, AcceptInvite} from './components/presentation/auth/Acc
 export type {AcceptInviteFlowResponse} from './components/presentation/auth/AcceptInvite';
 
 export * from './components/auth/Callback/Callback';
+export * from './components/auth/Callback/TokenCallback';
+export * from './components/auth/Callback/OAuthCallback';
 
 // Sign-In Options
 export {default as IdentifierFirst} from './components/presentation/auth/SignIn/v1/options/IdentifierFirst';

--- a/sdks/vue/src/ThunderIDVueClient.ts
+++ b/sdks/vue/src/ThunderIDVueClient.ts
@@ -42,6 +42,7 @@ import {
   EmbeddedSignInFlowStatusV2,
   EmbeddedSignUpFlowStatusV2,
   deriveOrganizationHandleFromBaseUrl,
+  StorageManager,
 } from '@thunderid/browser';
 import getAllOrganizations from './api/getAllOrganizations';
 import getMeOrganizations from './api/getMeOrganizations';
@@ -117,7 +118,7 @@ class ThunderIDVueClient<T extends ThunderIDVueConfig = ThunderIDVueConfig> exte
       let baseUrl: string = options?.baseUrl;
 
       if (!baseUrl) {
-        const configData: any = this.getStorageManager().getConfigData();
+        const configData: any = await this.getStorageManager().getConfigData();
         baseUrl = configData?.baseUrl;
       }
 
@@ -144,7 +145,7 @@ class ThunderIDVueClient<T extends ThunderIDVueConfig = ThunderIDVueConfig> exte
         let baseUrl: string = options?.baseUrl;
 
         if (!baseUrl) {
-          const configData: any = this.getStorageManager().getConfigData();
+          const configData: any = await this.getStorageManager().getConfigData();
           baseUrl = configData?.baseUrl;
         }
 
@@ -175,7 +176,7 @@ class ThunderIDVueClient<T extends ThunderIDVueConfig = ThunderIDVueConfig> exte
       let baseUrl: string = options?.baseUrl;
 
       if (!baseUrl) {
-        const configData: any = this.getStorageManager().getConfigData();
+        const configData: any = await this.getStorageManager().getConfigData();
         baseUrl = configData?.baseUrl;
       }
 
@@ -197,7 +198,7 @@ class ThunderIDVueClient<T extends ThunderIDVueConfig = ThunderIDVueConfig> exte
       let baseUrl: string = options?.baseUrl;
 
       if (!baseUrl) {
-        const configData: any = this.getStorageManager().getConfigData();
+        const configData: any = await this.getStorageManager().getConfigData();
         baseUrl = configData?.baseUrl;
       }
 
@@ -235,7 +236,7 @@ class ThunderIDVueClient<T extends ThunderIDVueConfig = ThunderIDVueConfig> exte
   override async switchOrganization(organization: Organization): Promise<TokenResponse | Response> {
     return this.withLoading(async () => {
       try {
-        const configData: any = this.getStorageManager().getConfigData();
+        const configData: any = await this.getStorageManager().getConfigData();
         const sourceInstanceId: number | undefined = configData?.organizationChain?.sourceInstanceId;
 
         if (!organization.id) {
@@ -306,12 +307,13 @@ class ThunderIDVueClient<T extends ThunderIDVueConfig = ThunderIDVueConfig> exte
         !isEmpty(arg1) &&
         ('executionId' in arg1 || 'applicationId' in arg1)
       ) {
-        const configData: any = this.getStorageManager().getConfigData();
+        const configData: any = await this.getStorageManager().getConfigData();
         const authIdFromUrl: string | null = new URL(window.location.href).searchParams.get('authId');
-        const authIdFromStorage: string | null = sessionStorage.getItem('thunderid_auth_id');
+        const authIdFromStorage: string | null = (await this.getStorageManager().getHybridDataParameter('authId')) as
+          | string
+          | null;
         const authId: string = authIdFromUrl || authIdFromStorage || '';
-        const baseUrlFromStorage: string | null = sessionStorage.getItem('thunderid_base_url');
-        const baseUrl: string = configData?.baseUrl || baseUrlFromStorage || '';
+        const baseUrl: string = configData?.baseUrl || '';
 
         const response: EmbeddedSignInFlowResponseV2 = await executeEmbeddedSignInFlowV2({
           authId,
@@ -368,16 +370,18 @@ class ThunderIDVueClient<T extends ThunderIDVueConfig = ThunderIDVueConfig> exte
   override async signUp(options?: SignUpOptions): Promise<void>;
   override async signUp(payload: EmbeddedFlowExecuteRequestPayload): Promise<EmbeddedFlowExecuteResponse>;
   override async signUp(...args: any[]): Promise<void | EmbeddedFlowExecuteResponse> {
-    const configData: any = this.getStorageManager().getConfigData();
+    const configData: any = await this.getStorageManager().getConfigData();
     const firstArg: any = args[0];
-    const baseUrl: string = configData?.baseUrl;
+    const baseUrl: string = configData?.baseUrl || '';
 
     const authIdFromUrl: string | null = new URL(window.location.href).searchParams.get('authId');
-    const authIdFromStorage: string | null = sessionStorage.getItem('thunderid_auth_id');
+    const authIdFromStorage: string | null = (await this.getStorageManager().getHybridDataParameter('authId')) as
+      | string
+      | null;
     const authId: string = authIdFromUrl || authIdFromStorage || '';
 
     if (authIdFromUrl && !authIdFromStorage) {
-      sessionStorage.setItem('thunderid_auth_id', authIdFromUrl);
+      await this.getStorageManager().setHybridDataParameter('authId', authIdFromUrl);
     }
 
     const response: any = await executeEmbeddedSignUpFlowV2({
@@ -450,7 +454,7 @@ class ThunderIDVueClient<T extends ThunderIDVueConfig = ThunderIDVueConfig> exte
     return super.decodeJwtToken<TResult>(token);
   }
 
-  public override getStorageManager(): any {
+  public override getStorageManager(): StorageManager<T> {
     return super.getStorageManager();
   }
 }

--- a/sdks/vue/src/components/auth/sign-in/v2/SignIn.ts
+++ b/sdks/vue/src/components/auth/sign-in/v2/SignIn.ts
@@ -50,7 +50,6 @@ import {extractErrorMessage, normalizeFlowResponse} from '../../../../utils/v2/f
 import {handlePasskeyAuthentication, handlePasskeyRegistration} from '../../../../utils/v2/passkey';
 
 const EXECUTION_ID_STORAGE_KEY = 'thunderid_execution_id';
-const AUTH_ID_STORAGE_KEY = 'thunderid_auth_id';
 
 interface PasskeyState {
   actionId: string | null;
@@ -114,7 +113,15 @@ const SignIn: Component = defineComponent({
     props: Readonly<{className: string; size: 'small' | 'medium' | 'large'; variant: 'elevated' | 'outlined' | 'flat'}>,
     {slots, emit, attrs}: SetupContext,
   ): () => VNode | null {
-    const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading: sdkLoading, scopes} = useThunderID();
+    const {
+      applicationId,
+      afterSignInUrl,
+      signIn,
+      isInitialized,
+      isLoading: sdkLoading,
+      scopes,
+      getStorageManager,
+    } = useThunderID();
     const {meta: flowMeta} = useFlowMeta();
     const {t} = useI18n();
 
@@ -151,10 +158,13 @@ const SignIn: Component = defineComponent({
       }
     };
 
-    const clearFlowState = (): void => {
+    const clearFlowState = async (): Promise<void> => {
       persistExecutionId(null);
       isFlowInitialized.value = false;
-      sessionStorage.removeItem(AUTH_ID_STORAGE_KEY);
+      const sm = getStorageManager();
+      if (sm) {
+        await sm.removeHybridDataParameter('authId');
+      }
       isTimeoutDisabled.value = false;
       oauthCodeProcessedFlag.value = false;
     };
@@ -212,7 +222,10 @@ const SignIn: Component = defineComponent({
       oauthCodeProcessedFlag.value = false;
 
       if (urlParams.authId) {
-        sessionStorage.setItem(AUTH_ID_STORAGE_KEY, urlParams.authId);
+        const sm = getStorageManager();
+        if (sm) {
+          await sm.setHybridDataParameter('authId', urlParams.authId);
+        }
       }
 
       const effectiveApplicationId: string | null | undefined = applicationId || urlParams.applicationId;
@@ -247,7 +260,12 @@ const SignIn: Component = defineComponent({
           const redirectURL: string | undefined = (response.data as any)?.redirectURL || (response as any)?.redirectURL;
           if (redirectURL && window?.location) {
             if (response.executionId) persistExecutionId(response.executionId);
-            if (urlParams.authId) sessionStorage.setItem(AUTH_ID_STORAGE_KEY, urlParams.authId);
+            if (urlParams.authId) {
+              const sm = getStorageManager();
+              if (sm) {
+                await sm.setHybridDataParameter('authId', urlParams.authId);
+              }
+            }
             initiateOAuthRedirect(redirectURL);
             return;
           }
@@ -346,7 +364,12 @@ const SignIn: Component = defineComponent({
           if (redirectURL && window?.location) {
             if (response.executionId) persistExecutionId(response.executionId);
             const urlParams: UrlParams = getUrlParams();
-            if (urlParams.authId) sessionStorage.setItem(AUTH_ID_STORAGE_KEY, urlParams.authId);
+            if (urlParams.authId) {
+              const sm = getStorageManager();
+              if (sm) {
+                await sm.setHybridDataParameter('authId', urlParams.authId);
+              }
+            }
             initiateOAuthRedirect(redirectURL);
             return;
           }
@@ -394,7 +417,10 @@ const SignIn: Component = defineComponent({
           isSubmitting.value = false;
           persistExecutionId(null);
           isFlowInitialized.value = false;
-          sessionStorage.removeItem(AUTH_ID_STORAGE_KEY);
+          const sm = getStorageManager();
+          if (sm) {
+            await sm.removeHybridDataParameter('authId');
+          }
           cleanupOAuthUrlParams();
 
           emit('success', {
@@ -543,11 +569,14 @@ const SignIn: Component = defineComponent({
 
     // ── Lifecycle ─────────────────────────────────────────────────────────
 
-    onMounted(() => {
+    onMounted(async () => {
       const urlParams: UrlParams = getUrlParams();
 
       if (urlParams.authId) {
-        sessionStorage.setItem(AUTH_ID_STORAGE_KEY, urlParams.authId);
+        const sm = getStorageManager();
+        if (sm) {
+          await sm.setHybridDataParameter('authId', urlParams.authId);
+        }
       }
     });
 

--- a/sdks/vue/src/models/contexts.ts
+++ b/sdks/vue/src/models/contexts.ts
@@ -28,6 +28,7 @@ import type {
   Platform,
   Schema,
   SignInOptions,
+  StorageManager,
   Theme,
   TokenExchangeRequestConfig,
   TokenResponse,
@@ -64,6 +65,7 @@ export interface ThunderIDContext {
   getAccessToken: () => Promise<string>;
   getDecodedIdToken: () => Promise<IdToken>;
   getIdToken: () => Promise<string>;
+  getStorageManager: () => StorageManager<any>;
   // ── HTTP ──
   http: {
     request: (requestConfig?: HttpRequestConfig) => Promise<HttpResponse<any>>;

--- a/sdks/vue/src/providers/FlowMetaProvider.ts
+++ b/sdks/vue/src/providers/FlowMetaProvider.ts
@@ -87,8 +87,7 @@ const FlowMetaProvider: Component = defineComponent({
       try {
         const result: FlowMetadataResponse = await getFlowMetaV2({
           baseUrl,
-          id: applicationId,
-          type: FlowMetaType.App,
+          ...(applicationId ? {id: applicationId, type: FlowMetaType.App} : {}),
         });
         meta.value = result;
       } catch (err: unknown) {
@@ -107,9 +106,8 @@ const FlowMetaProvider: Component = defineComponent({
       try {
         const result: FlowMetadataResponse = await getFlowMetaV2({
           baseUrl,
-          id: applicationId,
+          ...(applicationId ? {id: applicationId, type: FlowMetaType.App} : {}),
           language,
-          type: FlowMetaType.App,
         });
 
         // Inject translations before switching language so the i18n state is updated

--- a/sdks/vue/src/providers/ThunderIDProvider.ts
+++ b/sdks/vue/src/providers/ThunderIDProvider.ts
@@ -205,8 +205,8 @@ const ThunderIDProvider: Component = defineComponent({
     // ── Build config from props ──
     function buildConfig(): ThunderIDVueConfig {
       return {
-        afterSignInUrl: props.afterSignInUrl,
-        afterSignOutUrl: props.afterSignOutUrl,
+        afterSignInUrl: props.afterSignInUrl ?? window.location.origin,
+        afterSignOutUrl: props.afterSignOutUrl ?? window.location.origin,
         applicationId: props.applicationId,
         baseUrl: props.baseUrl,
         clientId: props.clientId,
@@ -350,6 +350,7 @@ const ThunderIDProvider: Component = defineComponent({
       getAccessToken: (): Promise<string> => client.getAccessToken(),
       getDecodedIdToken: (): Promise<IdToken> => client.getDecodedIdToken(),
       getIdToken: (): Promise<string> => client.getIdToken(),
+      getStorageManager: () => client.getStorageManager(),
       http: {
         request: (requestConfig?: any): Promise<HttpResponse<any>> => client.request(requestConfig),
         requestAll: (requestConfigs?: any[]): Promise<HttpResponse<any>[]> => client.requestAll(requestConfigs),
@@ -385,7 +386,12 @@ const ThunderIDProvider: Component = defineComponent({
       const config: ThunderIDVueConfig = buildConfig();
       await client.initialize(config);
 
-      const initializedConfig: any = client.getConfiguration();
+      // 2. Load the OpenID provider configuration
+      // We manually initialize this here because `initialize` doesn't load it for us.
+      // This is needed for endpoints like /.well-known/openid-configuration.
+      await client.getDiscoveryResponse();
+
+      const initializedConfig: any = await (client.getConfiguration() as any);
 
       if (initializedConfig?.baseUrl) {
         sessionStorage.setItem('thunderid_base_url', initializedConfig.baseUrl);


### PR DESCRIPTION
### Purpose
Add React, Vue, and JavaScript SDK support for Magic Link authentication and registration flows. Introduces the `TokenCallback` component which reads the `type` query parameter from the magic link URL (`type=REGISTRATION` / `type=AUTHENTICATION`) to determine whether to invoke `signIn` or `signUp`.

### Approach
The `TokenCallback` reads the `type` param set by the backend and routes accordingly. The parameter is cleared from the address bar after reading.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2971

### Related PRs
- Backend support for MagicLink Frontend Implementation (feature/Magic-Link-Frontend-backend)
- MagicLink Frontend Implementation: https://github.com/thunder-id/thunderid/pull/2987/

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hybrid storage mode (localStorage-first with fallback) and separate OAuth vs token callback components.

* **Bug Fixes / Improvements**
  * PKCE and auth state now use more durable hybrid/localStorage-backed persistence.
  * Sign-in/up and client flows wait for storage readiness and persist/cleanup authId via the new storage layer.

* **Tests**
  * Added tests covering token callback, OAuth callback, and callback routing/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->