### PR TITLE
Migrate backend log calls to context-aware logging method

### DIFF
--- a/backend/internal/agent/handler.go
+++ b/backend/internal/agent/handler.go
@@ -67,7 +67,7 @@ func (h *agentHandler) HandleAgentListRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
-	logger.Debug("Agent list returned",
+	logger.DebugWithContext(ctx, "Agent list returned",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", resp.TotalResults), log.Int("count", resp.Count))
 }

--- a/backend/internal/agent/service.go
+++ b/backend/internal/agent/service.go
@@ -95,7 +95,7 @@ func (s *agentService) CreateAgent(ctx context.Context, agent *model.Agent) (
 		var err error
 		agentID, err = sysutils.GenerateUUIDv7()
 		if err != nil {
-			s.logger.Error("Failed to generate agent ID", log.Error(err))
+			s.logger.ErrorWithContext(ctx, "Failed to generate agent ID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -110,7 +110,7 @@ func (s *agentService) CreateAgent(ctx context.Context, agent *model.Agent) (
 	e, sysCredsJSON, buildErr := buildAgentEntity(agentID, agent.Type, agent.OUID, agent.Attributes,
 		agent.Name, agent.Description, owner, clientID, clientSecret)
 	if buildErr != nil {
-		s.logger.Error("Failed to build agent entity", log.Error(buildErr))
+		s.logger.ErrorWithContext(ctx, "Failed to build agent entity", log.Error(buildErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -119,7 +119,8 @@ func (s *agentService) CreateAgent(ctx context.Context, agent *model.Agent) (
 		if mapped := mapEntityError(entErr); mapped != nil {
 			return nil, mapped
 		}
-		s.logger.Error("Failed to create agent entity", log.String("agentID", agentID), log.Error(entErr))
+		s.logger.ErrorWithContext(ctx, "Failed to create agent entity",
+			log.String("agentID", agentID), log.Error(entErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -167,7 +168,8 @@ func (s *agentService) GetAgent(ctx context.Context, agentID string, includeDisp
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return nil, &ErrorAgentNotFound
 		}
-		s.logger.Error("Failed to retrieve agent entity", log.String("agentID", agentID), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to retrieve agent entity",
+			log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if e.Category != entity.EntityCategoryAgent {
@@ -199,13 +201,13 @@ func (s *agentService) GetAgentList(ctx context.Context, limit, offset int,
 
 	totalCount, err := s.entityService.GetEntityListCount(ctx, entity.EntityCategoryAgent, filters)
 	if err != nil {
-		s.logger.Error("Failed to get agent list count", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to get agent list count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	entities, err := s.entityService.GetEntityList(ctx, entity.EntityCategoryAgent, limit, offset, filters)
 	if err != nil {
-		s.logger.Error("Failed to get agent list", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to get agent list", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -229,7 +231,7 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return nil, &ErrorAgentNotFound
 		}
-		s.logger.Error("Failed to retrieve agent entity for update",
+		s.logger.ErrorWithContext(ctx, "Failed to retrieve agent entity for update",
 			log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -252,7 +254,7 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 	var existingOAuthMethod string
 	existingOAuth, oauthErr := s.inboundClientService.GetOAuthProfileByEntityID(ctx, agentID)
 	if oauthErr != nil && !errors.Is(oauthErr, inboundclient.ErrInboundClientNotFound) {
-		s.logger.Error("Failed to load existing OAuth profile",
+		s.logger.ErrorWithContext(ctx, "Failed to load existing OAuth profile",
 			log.String("agentID", agentID), log.Error(oauthErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -297,7 +299,7 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 	}
 	sysAttrsJSON, marshalErr := buildSystemAttributesJSON(req.Name, req.Description, owner, clientID)
 	if marshalErr != nil {
-		s.logger.Error("Failed to build system attributes for update", log.Error(marshalErr))
+		s.logger.ErrorWithContext(ctx, "Failed to build system attributes for update", log.Error(marshalErr))
 		return nil, &serviceerror.InternalServerError
 	}
 	updatedEntity.SystemAttributes = sysAttrsJSON
@@ -306,7 +308,7 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 		if mapped := mapEntityError(err); mapped != nil {
 			return nil, mapped
 		}
-		s.logger.Error("Failed to update agent entity", log.String("agentID", agentID), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to update agent entity", log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -314,7 +316,7 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 		sysCredsJSON, credErr := buildSystemCredentialsJSON(clientSecret)
 		if credErr == nil && sysCredsJSON != nil {
 			if err := s.entityService.UpdateSystemCredentials(ctx, agentID, sysCredsJSON); err != nil {
-				s.logger.Error("Failed to update agent system credentials",
+				s.logger.ErrorWithContext(ctx, "Failed to update agent system credentials",
 					log.String("agentID", agentID), log.Error(err))
 				return nil, &serviceerror.InternalServerError
 			}
@@ -354,7 +356,8 @@ func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *service
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return &ErrorAgentNotFound
 		}
-		s.logger.Error("Failed to retrieve agent for delete", log.String("agentID", agentID), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to retrieve agent for delete",
+			log.String("agentID", agentID), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if existing.Category != entity.EntityCategoryAgent {
@@ -369,7 +372,7 @@ func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *service
 		if svcErr := s.translateInboundClientError(err); svcErr != nil {
 			return svcErr
 		}
-		s.logger.Error("Failed to delete inbound client for agent",
+		s.logger.ErrorWithContext(ctx, "Failed to delete inbound client for agent",
 			log.Error(err), log.String("agentID", agentID))
 		return &serviceerror.InternalServerError
 	}
@@ -378,7 +381,7 @@ func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *service
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return nil
 		}
-		s.logger.Error("Failed to delete agent entity", log.String("agentID", agentID), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to delete agent entity", log.String("agentID", agentID), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil
@@ -402,7 +405,8 @@ func (s *agentService) GetAgentGroups(ctx context.Context, agentID string, limit
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return nil, &ErrorAgentNotFound
 		}
-		s.logger.Error("Failed to retrieve agent for groups", log.String("agentID", agentID), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to retrieve agent for groups",
+			log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if existing.Category != entity.EntityCategoryAgent {
@@ -411,13 +415,14 @@ func (s *agentService) GetAgentGroups(ctx context.Context, agentID string, limit
 
 	totalCount, err := s.entityService.GetGroupCountForEntity(ctx, agentID)
 	if err != nil {
-		s.logger.Error("Failed to get agent group count", log.String("agentID", agentID), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to get agent group count",
+			log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	groups, err := s.entityService.GetEntityGroups(ctx, agentID, limit, offset)
 	if err != nil {
-		s.logger.Error("Failed to get agent groups", log.String("agentID", agentID), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to get agent groups", log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -453,7 +458,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 			if svcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
 				return "", "", inboundmodel.InboundClient{}, &ErrorOrganizationUnitNotFound
 			}
-			s.logger.Error("Failed to resolve OU handle", log.Any("error", svcErr))
+			s.logger.ErrorWithContext(ctx, "Failed to resolve OU handle", log.Any("error", svcErr))
 			return "", "", inboundmodel.InboundClient{}, &serviceerror.InternalServerError
 		}
 		agent.OUID = ou.ID
@@ -475,7 +480,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 		if clientID == "" {
 			generated, err := oauthutils.GenerateOAuth2ClientID()
 			if err != nil {
-				s.logger.Error("Failed to generate client ID", log.Error(err))
+				s.logger.ErrorWithContext(ctx, "Failed to generate client ID", log.Error(err))
 				return "", "", inboundmodel.InboundClient{}, &serviceerror.InternalServerError
 			}
 			clientID = generated
@@ -488,7 +493,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 		if requiresClientSecret(oauthCfg) && oauthCfg.ClientSecret == "" {
 			generated, err := oauthutils.GenerateOAuth2ClientSecret()
 			if err != nil {
-				s.logger.Error("Failed to generate client secret", log.Error(err))
+				s.logger.ErrorWithContext(ctx, "Failed to generate client secret", log.Error(err))
 				return "", "", inboundmodel.InboundClient{}, &serviceerror.InternalServerError
 			}
 			clientSecret = generated
@@ -501,7 +506,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 		if svcErr := translateInboundClientFKError(err); svcErr != nil {
 			return "", "", inboundmodel.InboundClient{}, svcErr
 		}
-		s.logger.Error("Failed to resolve inbound auth profile handles", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to resolve inbound auth profile handles", log.Error(err))
 		return "", "", inboundmodel.InboundClient{}, &serviceerror.InternalServerError
 	}
 
@@ -516,7 +521,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 			if svcErr := s.translateInboundClientError(err); svcErr != nil {
 				return "", "", inboundmodel.InboundClient{}, svcErr
 			}
-			s.logger.Error("Inbound client validation failed", log.Error(err))
+			s.logger.ErrorWithContext(ctx, "Inbound client validation failed", log.Error(err))
 			return "", "", inboundmodel.InboundClient{}, &serviceerror.InternalServerError
 		}
 	}
@@ -527,7 +532,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 // deleteEntityCompensation deletes the entity row as a best-effort rollback after a failed downstream operation.
 func (s *agentService) deleteEntityCompensation(ctx context.Context, agentID string) {
 	if err := s.entityService.DeleteEntity(ctx, agentID); err != nil {
-		s.logger.Error("Failed to delete entity during compensation",
+		s.logger.ErrorWithContext(ctx, "Failed to delete entity during compensation",
 			log.String("agentID", agentID), log.Error(err))
 	}
 }
@@ -542,7 +547,7 @@ func (s *agentService) validateOUExists(ctx context.Context, ouID string) *servi
 		if err.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
 			return &ErrorOrganizationUnitNotFound
 		}
-		s.logger.Error("Failed to verify OU existence", log.String("ouID", ouID), log.Any("error", err))
+		s.logger.ErrorWithContext(ctx, "Failed to verify OU existence", log.String("ouID", ouID), log.Any("error", err))
 		return &serviceerror.InternalServerError
 	}
 	if !exists {
@@ -562,7 +567,7 @@ func (s *agentService) resolveUpdateOUID(
 			if ouSvcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
 				return "", &ErrorOrganizationUnitNotFound
 			}
-			s.logger.Error("Failed to resolve OU handle", log.Any("error", ouSvcErr))
+			s.logger.ErrorWithContext(ctx, "Failed to resolve OU handle", log.Any("error", ouSvcErr))
 			return "", &serviceerror.InternalServerError
 		}
 		req.OUID = ou.ID
@@ -604,7 +609,8 @@ func (s *agentService) validateOwnerExists(ctx context.Context, ownerID string) 
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return &ErrorOwnerNotFound
 		}
-		s.logger.Error("Failed to verify owner existence", log.String("ownerID", ownerID), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to verify owner existence",
+			log.String("ownerID", ownerID), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil
@@ -623,7 +629,7 @@ func (s *agentService) validateNameUnique(ctx context.Context, name, excludeID s
 		if errors.Is(err, entity.ErrAmbiguousEntity) {
 			return &ErrorAgentAlreadyExistsWithName
 		}
-		s.logger.Error("Failed to verify agent name uniqueness", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to verify agent name uniqueness", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if id == nil || *id == "" {
@@ -661,7 +667,7 @@ func (s *agentService) resolveOAuthCredentials(ctx context.Context,
 	if clientID == "" {
 		generated, err := oauthutils.GenerateOAuth2ClientID()
 		if err != nil {
-			s.logger.Error("Failed to generate client ID", log.Error(err))
+			s.logger.ErrorWithContext(ctx, "Failed to generate client ID", log.Error(err))
 			return "", "", &serviceerror.InternalServerError
 		}
 		clientID = generated
@@ -683,7 +689,7 @@ func (s *agentService) resolveOAuthCredentials(ctx context.Context,
 		if !existingWasSecretBased {
 			generated, err := oauthutils.GenerateOAuth2ClientSecret()
 			if err != nil {
-				s.logger.Error("Failed to generate client secret", log.Error(err))
+				s.logger.ErrorWithContext(ctx, "Failed to generate client secret", log.Error(err))
 				return "", "", &serviceerror.InternalServerError
 			}
 			clientSecret = generated
@@ -700,7 +706,7 @@ func (s *agentService) isClientIDTaken(
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return false, nil
 		}
-		s.logger.Error("Failed to check client ID availability", log.MaskedString("clientID", clientID),
+		s.logger.ErrorWithContext(ctx, "Failed to check client ID availability", log.MaskedString("clientID", clientID),
 			log.Error(err))
 		return false, &serviceerror.InternalServerError
 	}
@@ -729,7 +735,7 @@ func (s *agentService) createInboundForAgent(ctx context.Context, agentID string
 		if svcErr := s.translateInboundClientError(err); svcErr != nil {
 			return inboundmodel.InboundClient{}, nil, svcErr
 		}
-		s.logger.Error("Failed to create inbound client for agent",
+		s.logger.ErrorWithContext(ctx, "Failed to create inbound client for agent",
 			log.Error(err), log.String("agentID", agentID))
 		return inboundmodel.InboundClient{}, nil, &serviceerror.InternalServerError
 	}
@@ -752,7 +758,7 @@ func (s *agentService) reconcileInboundForUpdate(ctx context.Context, agentID st
 				if svcErr := s.translateInboundClientError(err); svcErr != nil {
 					return inboundmodel.InboundClient{}, nil, svcErr
 				}
-				s.logger.Error("Failed to remove inbound client during update",
+				s.logger.ErrorWithContext(ctx, "Failed to remove inbound client during update",
 					log.Error(err), log.String("agentID", agentID))
 				return inboundmodel.InboundClient{}, nil, &serviceerror.InternalServerError
 			}
@@ -776,7 +782,7 @@ func (s *agentService) reconcileInboundForUpdate(ctx context.Context, agentID st
 			if svcErr := s.translateInboundClientError(err); svcErr != nil {
 				return inboundmodel.InboundClient{}, nil, svcErr
 			}
-			s.logger.Error("Failed to update inbound client",
+			s.logger.ErrorWithContext(ctx, "Failed to update inbound client",
 				log.Error(err), log.String("agentID", agentID))
 			return inboundmodel.InboundClient{}, nil, &serviceerror.InternalServerError
 		}
@@ -788,7 +794,7 @@ func (s *agentService) reconcileInboundForUpdate(ctx context.Context, agentID st
 		if svcErr := s.translateInboundClientError(err); svcErr != nil {
 			return inboundmodel.InboundClient{}, nil, svcErr
 		}
-		s.logger.Error("Failed to create inbound client during update",
+		s.logger.ErrorWithContext(ctx, "Failed to create inbound client during update",
 			log.Error(err), log.String("agentID", agentID))
 		return inboundmodel.InboundClient{}, nil, &serviceerror.InternalServerError
 	}
@@ -815,7 +821,7 @@ func (s *agentService) composeGetResponse(ctx context.Context, e *entity.Entity)
 	inbound, err := s.inboundClientService.GetInboundClientByEntityID(ctx, e.ID)
 	if err != nil {
 		if !errors.Is(err, inboundclient.ErrInboundClientNotFound) {
-			s.logger.Error("Failed to load inbound client for agent",
+			s.logger.ErrorWithContext(ctx, "Failed to load inbound client for agent",
 				log.String("agentID", e.ID), log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
@@ -833,7 +839,7 @@ func (s *agentService) composeGetResponse(ctx context.Context, e *entity.Entity)
 
 	oauth, oauthErr := s.inboundClientService.GetOAuthProfileByEntityID(ctx, e.ID)
 	if oauthErr != nil && !errors.Is(oauthErr, inboundclient.ErrInboundClientNotFound) {
-		s.logger.Error("Failed to load OAuth profile for agent",
+		s.logger.ErrorWithContext(ctx, "Failed to load OAuth profile for agent",
 			log.String("agentID", e.ID), log.Error(oauthErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -905,7 +911,8 @@ func (s *agentService) buildListResponse(ctx context.Context, entities []entity.
 func (s *agentService) lookupOUHandle(ctx context.Context, ouID string) string {
 	handles, err := s.ouService.GetOrganizationUnitHandlesByIDs(ctx, []string{ouID})
 	if err != nil {
-		s.logger.Debug("Failed to resolve OU handle for agent", log.String("ouID", ouID), log.Any("error", err))
+		s.logger.DebugWithContext(ctx, "Failed to resolve OU handle for agent",
+			log.String("ouID", ouID), log.Any("error", err))
 		return ""
 	}
 	return handles[ouID]
@@ -949,7 +956,7 @@ func (s *agentService) populateOUHandlesForList(ctx context.Context, agents []mo
 	}
 	handles, err := s.ouService.GetOrganizationUnitHandlesByIDs(ctx, ids)
 	if err != nil {
-		s.logger.Debug("Failed to resolve OU handles for agent list", log.Any("error", err))
+		s.logger.DebugWithContext(ctx, "Failed to resolve OU handles for agent list", log.Any("error", err))
 		return
 	}
 	for i := range agents {

--- a/backend/internal/application/handler.go
+++ b/backend/internal/application/handler.go
@@ -200,7 +200,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 	// TODO: Need to refactor when supporting other/multiple inbound auth types.
 	if len(appDTO.InboundAuthConfig) > 0 {
 		if appDTO.InboundAuthConfig[0].Type != inboundmodel.OAuthInboundAuthType {
-			logger.Error("Unsupported inbound authentication type returned",
+			logger.ErrorWithContext(ctx, "Unsupported inbound authentication type returned",
 				log.String("type", string(appDTO.InboundAuthConfig[0].Type)))
 
 			errResp := apierror.ErrorResponse{
@@ -213,7 +213,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 		}
 
 		if appDTO.InboundAuthConfig[0].OAuthConfig == nil {
-			logger.Error("OAuth application configuration is nil")
+			logger.ErrorWithContext(ctx, "OAuth application configuration is nil")
 
 			errResp := apierror.ErrorResponse{
 				Code:        serviceerror.InternalServerError.Code,
@@ -227,7 +227,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 		returnInboundAuthConfigs := make([]inboundmodel.InboundAuthConfig, 0, len(appDTO.InboundAuthConfig))
 		for _, config := range appDTO.InboundAuthConfig {
 			if config.OAuthConfig == nil {
-				logger.Error("OAuth application configuration is nil")
+				logger.ErrorWithContext(ctx, "OAuth application configuration is nil")
 				errResp := apierror.ErrorResponse{
 					Code:        serviceerror.InternalServerError.Code,
 					Message:     serviceerror.InternalServerError.Error,
@@ -493,7 +493,7 @@ func (ah *applicationHandler) handleError(w http.ResponseWriter, r *http.Request
 
 	if statusCode == http.StatusInternalServerError {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationHandler"))
-		logger.Error("Internal server error processing application request",
+		logger.ErrorWithContext(r.Context(), "Internal server error processing application request",
 			log.String("method", r.Method),
 			log.String("path", r.URL.Path),
 			log.String("error_code", svcErr.Code),

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -128,7 +128,7 @@ func (as *applicationService) CreateApplication(ctx context.Context, app *model.
 
 	appEntity, sysCredsJSON, buildErr := buildAppEntity(appID, app, clientID, clientSecret)
 	if buildErr != nil {
-		as.logger.Error("Failed to build entity for create", log.Error(buildErr))
+		as.logger.ErrorWithContext(ctx, "Failed to build entity for create", log.Error(buildErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -137,7 +137,8 @@ func (as *applicationService) CreateApplication(ctx context.Context, app *model.
 		if svcErr := mapEntityProviderError(epErr); svcErr != nil {
 			return nil, svcErr
 		}
-		as.logger.Error("Failed to create application entity", log.String("appID", appID), log.Error(epErr))
+		as.logger.ErrorWithContext(ctx, "Failed to create application entity",
+			log.String("appID", appID), log.Error(epErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -149,7 +150,7 @@ func (as *applicationService) CreateApplication(ctx context.Context, app *model.
 		if svcErr := as.translateInboundClientError(err); svcErr != nil {
 			return nil, svcErr
 		}
-		as.logger.Error("Failed to create application", log.Error(err), log.String("appID", appID))
+		as.logger.ErrorWithContext(ctx, "Failed to create application", log.Error(err), log.String("appID", appID))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -208,7 +209,7 @@ func (as *applicationService) ValidateApplication(ctx context.Context, app *mode
 		var err error
 		appID, err = sysutils.GenerateUUIDv7()
 		if err != nil {
-			as.logger.Error("Failed to generate UUID", log.Error(err))
+			as.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, nil, &serviceerror.InternalServerError
 		}
 	}
@@ -233,7 +234,7 @@ func (as *applicationService) ValidateApplication(ctx context.Context, app *mode
 		if svcErr := as.translateInboundClientError(err); svcErr != nil {
 			return nil, nil, svcErr
 		}
-		as.logger.Error("Inbound client validation failed", log.Error(err))
+		as.logger.ErrorWithContext(ctx, "Inbound client validation failed", log.Error(err))
 		return nil, nil, &serviceerror.InternalServerError
 	}
 	processedDTO.AuthFlowID = inboundClient.AuthFlowID
@@ -248,14 +249,14 @@ func (as *applicationService) GetApplicationList(
 	ctx context.Context) (*model.ApplicationListResponse, *serviceerror.ServiceError) {
 	totalResults, epErr := as.entityProvider.GetEntityListCount(entityprovider.EntityCategoryApp, nil)
 	if epErr != nil {
-		as.logger.Error("Failed to count application entities", log.Error(epErr))
+		as.logger.ErrorWithContext(ctx, "Failed to count application entities", log.Error(epErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	entities, epErr := as.entityProvider.GetEntityList(
 		entityprovider.EntityCategoryApp, serverconst.MaxCompositeStoreRecords, 0, nil)
 	if epErr != nil {
-		as.logger.Error("Failed to list application entities", log.Error(epErr))
+		as.logger.ErrorWithContext(ctx, "Failed to list application entities", log.Error(epErr))
 		return nil, &serviceerror.InternalServerError
 	}
 	if len(entities) == 0 {
@@ -272,7 +273,7 @@ func (as *applicationService) GetApplicationList(
 		if errors.Is(err, inboundclient.ErrCompositeResultLimitExceeded) {
 			return nil, &ErrorResultLimitExceeded
 		}
-		as.logger.Error("Failed to list inbound clients", log.Error(err))
+		as.logger.ErrorWithContext(ctx, "Failed to list inbound clients", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -291,7 +292,7 @@ func (as *applicationService) GetApplicationList(
 	for i := range entities {
 		cfg := configMap[entities[i].ID]
 		if cfg == nil {
-			as.logger.Warn("Application entity has no inbound-client row; skipping in list",
+			as.logger.WarnWithContext(ctx, "Application entity has no inbound-client row; skipping in list",
 				log.String("appID", entities[i].ID))
 			continue
 		}
@@ -314,7 +315,7 @@ func (as *applicationService) GetOAuthApplication(
 
 	client, err := as.inboundClientService.GetOAuthClientByClientID(ctx, clientID)
 	if err != nil {
-		as.logger.Error("Failed to retrieve OAuth client", log.Error(err),
+		as.logger.ErrorWithContext(ctx, "Failed to retrieve OAuth client", log.Error(err),
 			log.MaskedString("clientID", clientID))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -324,7 +325,7 @@ func (as *applicationService) GetOAuthApplication(
 
 	entity, epErr := as.entityProvider.GetEntity(client.ID)
 	if epErr != nil && epErr.Code != entityprovider.ErrorCodeEntityNotFound {
-		as.logger.Error("Failed to load entity for OAuth client",
+		as.logger.ErrorWithContext(ctx, "Failed to load entity for OAuth client",
 			log.String("entityID", client.ID), log.Error(epErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -384,7 +385,7 @@ func (as *applicationService) UpdateApplication(ctx context.Context, appID strin
 		if svcErr := as.translateInboundClientError(err); svcErr != nil {
 			return nil, svcErr
 		}
-		as.logger.Error("Failed to update application", log.Error(err), log.String("appID", appID))
+		as.logger.ErrorWithContext(ctx, "Failed to update application", log.Error(err), log.String("appID", appID))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -510,7 +511,8 @@ func (as *applicationService) DeleteApplication(ctx context.Context, appID strin
 
 	if existing, epErr := as.entityProvider.GetEntity(appID); epErr != nil {
 		if epErr.Code != entityprovider.ErrorCodeEntityNotFound {
-			as.logger.Error("Failed to load entity before delete", log.String("appID", appID), log.Error(epErr))
+			as.logger.ErrorWithContext(ctx, "Failed to load entity before delete",
+				log.String("appID", appID), log.Error(epErr))
 			return &serviceerror.InternalServerError
 		}
 	} else if existing != nil && existing.Category != entityprovider.EntityCategoryApp {
@@ -525,7 +527,7 @@ func (as *applicationService) DeleteApplication(ctx context.Context, appID strin
 		if svcErr := as.translateInboundClientError(appErr); svcErr != nil {
 			return svcErr
 		}
-		as.logger.Error("Failed to delete application", log.Error(appErr), log.String("appID", appID))
+		as.logger.ErrorWithContext(ctx, "Failed to delete application", log.Error(appErr), log.String("appID", appID))
 		return &serviceerror.InternalServerError
 	}
 
@@ -534,7 +536,8 @@ func (as *applicationService) DeleteApplication(ctx context.Context, appID strin
 		if svcErr := mapEntityProviderError(epErr); svcErr != nil {
 			return svcErr
 		}
-		as.logger.Error("Failed to delete application entity", log.String("appID", appID), log.Error(epErr))
+		as.logger.ErrorWithContext(ctx, "Failed to delete application entity",
+			log.String("appID", appID), log.Error(epErr))
 		return &serviceerror.InternalServerError
 	}
 
@@ -580,7 +583,8 @@ func (as *applicationService) getApplication(
 		if epErr.Code == entityprovider.ErrorCodeEntityNotFound {
 			entity = nil
 		} else {
-			as.logger.Error("Failed to get entity for application", log.String("appID", appID), log.Error(epErr))
+			as.logger.ErrorWithContext(ctx, "Failed to get entity for application",
+				log.String("appID", appID), log.Error(epErr))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -591,7 +595,8 @@ func (as *applicationService) getApplication(
 
 	oauthProfile, err := as.inboundClientService.GetOAuthProfileByEntityID(ctx, appID)
 	if err != nil && !errors.Is(err, inboundclient.ErrInboundClientNotFound) {
-		as.logger.Error("Failed to get OAuth profile for application", log.String("appID", appID), log.Error(err))
+		as.logger.ErrorWithContext(ctx, "Failed to get OAuth profile for application",
+			log.String("appID", appID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -917,7 +922,7 @@ func (as *applicationService) validateApplicationFields(
 	// Resolve ou_handle to an ID when the direct ID is absent.
 	// If both are provided, ou_id wins and a warning is logged.
 	if app.OUID != "" && app.OUHandle != "" {
-		as.logger.Warn("Both ou_id and ou_handle provided for application; ou_handle ignored",
+		as.logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided for application; ou_handle ignored",
 			log.String("appID", app.ID), log.String("name", app.Name))
 	} else if app.OUID == "" && app.OUHandle != "" {
 		ou, svcErr := as.ouService.GetOrganizationUnitByPath(ctx, app.OUHandle)
@@ -1778,7 +1783,7 @@ func (as *applicationService) deleteLocalizedVariants(ctx context.Context, appID
 	for _, field := range []string{"name", "logo_uri", "tos_uri", "policy_uri"} {
 		if svcErr := as.i18nService.DeleteTranslationsByKey(
 			ctx, AppI18nNamespace(), AppI18nKey(appID, field)); svcErr != nil {
-			as.logger.Error("Failed to delete localized variant on app deletion",
+			as.logger.ErrorWithContext(ctx, "Failed to delete localized variant on app deletion",
 				log.String("appID", appID),
 				log.String("field", field),
 				log.String("namespace", AppI18nNamespace()))
@@ -1812,7 +1817,7 @@ func (as *applicationService) cleanupStaleI18nKeys(
 		if isI18nRef(f.old) && !isI18nRef(f.updated) {
 			if svcErr := as.i18nService.DeleteTranslationsByKey(
 				ctx, AppI18nNamespace(), AppI18nKey(appID, f.field)); svcErr != nil {
-				as.logger.Error("Failed to delete stale i18n key",
+				as.logger.ErrorWithContext(ctx, "Failed to delete stale i18n key",
 					log.String("appID", appID),
 					log.String("field", f.field),
 					log.String("namespace", AppI18nNamespace()))

--- a/backend/internal/attributecache/service.go
+++ b/backend/internal/attributecache/service.go
@@ -72,7 +72,7 @@ func (s *attributeCacheService) CreateAttributeCache(
 	ctx context.Context, cache *AttributeCache,
 ) (*AttributeCache, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Creating attribute cache entry")
+	logger.DebugWithContext(ctx, "Creating attribute cache entry")
 
 	if cache == nil {
 		return nil, &ErrorInvalidRequestFormat
@@ -89,17 +89,17 @@ func (s *attributeCacheService) CreateAttributeCache(
 	var err error
 	cache.ID, err = utils.GenerateUUIDv7()
 	if err != nil {
-		logger.Error("Failed to generate UUID", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	err = s.store.CreateAttributeCache(ctx, *cache)
 	if err != nil {
-		logger.Error("Failed to create attribute cache", log.Error(err), log.String("id", cache.ID))
+		logger.ErrorWithContext(ctx, "Failed to create attribute cache", log.Error(err), log.String("id", cache.ID))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully created attribute cache", log.String("id", cache.ID))
+	logger.DebugWithContext(ctx, "Successfully created attribute cache", log.String("id", cache.ID))
 	return cache, nil
 }
 
@@ -108,7 +108,7 @@ func (s *attributeCacheService) GetAttributeCache(
 	ctx context.Context, id string,
 ) (*AttributeCache, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Retrieving attribute cache", log.String("id", id))
+	logger.DebugWithContext(ctx, "Retrieving attribute cache", log.String("id", id))
 
 	if strings.TrimSpace(id) == "" {
 		return nil, &ErrorMissingCacheID
@@ -117,14 +117,14 @@ func (s *attributeCacheService) GetAttributeCache(
 	cache, err := s.store.GetAttributeCache(ctx, id)
 	if err != nil {
 		if errors.Is(err, errAttributeCacheNotFound) {
-			logger.Debug("Attribute cache not found", log.String("id", id))
+			logger.DebugWithContext(ctx, "Attribute cache not found", log.String("id", id))
 			return nil, &ErrorAttributeCacheNotFound
 		}
-		logger.Error("Failed to retrieve attribute cache", log.Error(err), log.String("id", id))
+		logger.ErrorWithContext(ctx, "Failed to retrieve attribute cache", log.Error(err), log.String("id", id))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully retrieved attribute cache", log.String("id", id))
+	logger.DebugWithContext(ctx, "Successfully retrieved attribute cache", log.String("id", id))
 	return &cache, nil
 }
 
@@ -133,7 +133,7 @@ func (s *attributeCacheService) ExtendAttributeCacheTTL(
 	ctx context.Context, id string, ttlSeconds int,
 ) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Extending attribute cache TTL", log.String("id", id))
+	logger.DebugWithContext(ctx, "Extending attribute cache TTL", log.String("id", id))
 
 	if strings.TrimSpace(id) == "" {
 		return &ErrorMissingCacheID
@@ -146,14 +146,14 @@ func (s *attributeCacheService) ExtendAttributeCacheTTL(
 	err := s.store.ExtendAttributeCacheTTL(ctx, id, ttlSeconds)
 	if err != nil {
 		if errors.Is(err, errAttributeCacheNotFound) {
-			logger.Debug("Attribute cache not found", log.String("id", id))
+			logger.DebugWithContext(ctx, "Attribute cache not found", log.String("id", id))
 			return &ErrorAttributeCacheNotFound
 		}
-		logger.Error("Failed to extend attribute cache TTL", log.Error(err), log.String("id", id))
+		logger.ErrorWithContext(ctx, "Failed to extend attribute cache TTL", log.Error(err), log.String("id", id))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully extended attribute cache TTL", log.String("id", id))
+	logger.DebugWithContext(ctx, "Successfully extended attribute cache TTL", log.String("id", id))
 	return nil
 }
 
@@ -162,7 +162,7 @@ func (s *attributeCacheService) DeleteAttributeCache(
 	ctx context.Context, id string,
 ) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Deleting attribute cache", log.String("id", id))
+	logger.DebugWithContext(ctx, "Deleting attribute cache", log.String("id", id))
 
 	if strings.TrimSpace(id) == "" {
 		return &ErrorMissingCacheID
@@ -171,13 +171,13 @@ func (s *attributeCacheService) DeleteAttributeCache(
 	err := s.store.DeleteAttributeCache(ctx, id)
 	if err != nil {
 		if errors.Is(err, errAttributeCacheNotFound) {
-			logger.Debug("Attribute cache not found", log.String("id", id))
+			logger.DebugWithContext(ctx, "Attribute cache not found", log.String("id", id))
 			return &ErrorAttributeCacheNotFound
 		}
-		logger.Error("Failed to delete attribute cache", log.Error(err), log.String("id", id))
+		logger.ErrorWithContext(ctx, "Failed to delete attribute cache", log.Error(err), log.String("id", id))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully deleted attribute cache", log.String("id", id))
+	logger.DebugWithContext(ctx, "Successfully deleted attribute cache", log.String("id", id))
 	return nil
 }

--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -78,10 +78,10 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 	availableAttributes *authnprovidercm.AttributesResponse) (
 	*ConsentPromptData, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID))
-	logger.Debug("Resolving consent for user")
+	logger.DebugWithContext(ctx, "Resolving consent for user")
 
 	if !s.consentService.IsEnabled() {
-		logger.Debug("Consent service is not enabled; skipping consent check")
+		logger.DebugWithContext(ctx, "Consent service is not enabled; skipping consent check")
 		return nil, nil
 	}
 
@@ -89,10 +89,11 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 	purposes, svcErr := s.consentService.ListConsentPurposes(ctx, ouID, appID)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Client error from consent service when listing purposes", log.Any("error", svcErr))
+			logger.DebugWithContext(ctx, "Client error from consent service when listing purposes",
+				log.Any("error", svcErr))
 			return nil, &ErrorConsentPurposeFetchFailed
 		}
-		logger.Error("Failed to list consent purposes", log.Any("error", svcErr))
+		logger.ErrorWithContext(ctx, "Failed to list consent purposes", log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 	purposes, svcErr = s.applyPermissionsPurpose(ctx, purposes, ouID, appID, appName, authorizedPermissions)
@@ -100,7 +101,7 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 		return nil, svcErr
 	}
 	if len(purposes) == 0 {
-		logger.Debug("No consent purposes configured for application; skipping consent")
+		logger.DebugWithContext(ctx, "No consent purposes configured for application; skipping consent")
 		return nil, nil
 	}
 
@@ -113,10 +114,11 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 	existingConsents, svcErr := s.consentService.SearchConsents(ctx, ouID, filter)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Client error from consent service when searching consents", log.Any("error", svcErr))
+			logger.DebugWithContext(ctx, "Client error from consent service when searching consents",
+				log.Any("error", svcErr))
 			return nil, &ErrorConsentSearchFailed
 		}
-		logger.Error("Failed to search existing consents", log.Any("error", svcErr))
+		logger.ErrorWithContext(ctx, "Failed to search existing consents", log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -129,7 +131,7 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 	promptPurposes := buildPurposePrompts(purposes, essentialAttributes, optionalAttributes,
 		consentedElements, userAttributeSet, authorizedPermissions)
 	if len(promptPurposes) == 0 {
-		logger.Debug("All required consents are active; no prompt needed")
+		logger.DebugWithContext(ctx, "All required consents are active; no prompt needed")
 		return nil, nil
 	}
 
@@ -139,12 +141,12 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 	// This token should be verified in RecordConsent to ensure the user's decisions match what was prompted
 	sessionToken, err := s.createConsentSessionToken(ctx, promptData)
 	if err != nil {
-		logger.Error("Failed to create consent session token", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to create consent session token", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	promptData.SessionToken = sessionToken
 
-	logger.Debug("Consent prompt required", log.Int("purposeCount", len(promptPurposes)))
+	logger.DebugWithContext(ctx, "Consent prompt required", log.Int("purposeCount", len(promptPurposes)))
 	return promptData, nil
 }
 
@@ -155,12 +157,12 @@ func (s *consentEnforcerService) RecordConsent(ctx context.Context, ouID, appID,
 	decisions *ConsentDecisions, sessionToken string,
 	validityPeriod int64) (*consent.Consent, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID))
-	logger.Debug("Recording consent for user")
+	logger.DebugWithContext(ctx, "Recording consent for user")
 
 	// Verify and decode the consent session token to retrieve the prompted purposes
 	sessionData, err := s.verifyAndDecodeConsentSession(ctx, sessionToken)
 	if err != nil {
-		logger.Debug("Failed to verify consent session token", log.Error(err))
+		logger.DebugWithContext(ctx, "Failed to verify consent session token", log.Error(err))
 		return nil, &ErrorConsentSessionInvalid
 	}
 
@@ -188,11 +190,11 @@ func (s *consentEnforcerService) RecordConsent(ctx context.Context, ouID, appID,
 	})
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Client error from consent service when searching consents for upsert",
+			logger.DebugWithContext(ctx, "Client error from consent service when searching consents for upsert",
 				log.Any("error", svcErr))
 			return nil, &ErrorConsentSearchFailed
 		}
-		logger.Error("Failed to search existing consents for upsert", log.Any("error", svcErr))
+		logger.ErrorWithContext(ctx, "Failed to search existing consents for upsert", log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -209,7 +211,7 @@ func (s *consentEnforcerService) RecordConsent(ctx context.Context, ouID, appID,
 
 	// If the user denied any essential attribute, return an error after persisting
 	if hasEssentialDenial {
-		logger.Debug("User denied essential attribute(s)", log.String("consentID", consentRecord.ID))
+		logger.DebugWithContext(ctx, "User denied essential attribute(s)", log.String("consentID", consentRecord.ID))
 		return nil, &ErrorEssentialConsentDenied
 	}
 
@@ -224,7 +226,7 @@ func (s *consentEnforcerService) updateExistingConsent(ctx context.Context, ouID
 ) (*consent.Consent, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID),
 		log.Int("existingConsentCount", len(existingConsents)))
-	logger.Debug("Existing consent record found; updating with new decisions")
+	logger.DebugWithContext(ctx, "Existing consent record found; updating with new decisions")
 
 	// Build the consent request payload
 	req := &consent.ConsentRequest{
@@ -247,14 +249,15 @@ func (s *consentEnforcerService) updateExistingConsent(ctx context.Context, ouID
 	updated, svcErr := s.consentService.UpdateConsent(ctx, ouID, existing.ID, req)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Client error from consent service when updating consent record", log.Any("error", svcErr))
+			logger.DebugWithContext(ctx, "Client error from consent service when updating consent record",
+				log.Any("error", svcErr))
 			return nil, &ErrorConsentUpdateFailed
 		}
-		logger.Error("Failed to update consent record", log.Any("error", svcErr))
+		logger.ErrorWithContext(ctx, "Failed to update consent record", log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Consent record updated successfully", log.String("consentID", updated.ID))
+	logger.DebugWithContext(ctx, "Consent record updated successfully", log.String("consentID", updated.ID))
 	return updated, nil
 }
 
@@ -263,7 +266,7 @@ func (s *consentEnforcerService) createNewConsent(ctx context.Context, ouID, app
 	newPurposeItems []consent.ConsentPurposeItem, validityTime int64) (
 	*consent.Consent, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID))
-	logger.Debug("Creating new consent record")
+	logger.DebugWithContext(ctx, "Creating new consent record")
 
 	// Build the consent request payload
 	req := &consent.ConsentRequest{
@@ -283,15 +286,15 @@ func (s *consentEnforcerService) createNewConsent(ctx context.Context, ouID, app
 	created, svcErr := s.consentService.CreateConsent(ctx, ouID, req)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Client error from consent service when creating consent record",
+			logger.DebugWithContext(ctx, "Client error from consent service when creating consent record",
 				log.Any("error", svcErr))
 			return nil, &ErrorConsentCreateFailed
 		}
-		logger.Error("Failed to create consent record", log.Any("error", svcErr))
+		logger.ErrorWithContext(ctx, "Failed to create consent record", log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Consent recorded successfully", log.String("consentID", created.ID))
+	logger.DebugWithContext(ctx, "Consent recorded successfully", log.String("consentID", created.ID))
 	return created, nil
 }
 
@@ -752,11 +755,11 @@ func (s *consentEnforcerService) applyPermissionsPurpose(ctx context.Context,
 		created, createErr := s.consentService.CreateConsentPurpose(ctx, ouID, &input)
 		if createErr != nil {
 			if createErr.Type == serviceerror.ClientErrorType {
-				logger.Debug("Client error from consent service when creating permission purpose",
+				logger.DebugWithContext(ctx, "Client error from consent service when creating permission purpose",
 					log.Any("error", createErr))
 				return nil, &ErrorConsentPurposeCreateFailed
 			}
-			logger.Error("Failed to create permission consent purpose", log.Any("error", createErr))
+			logger.ErrorWithContext(ctx, "Failed to create permission consent purpose", log.Any("error", createErr))
 			return nil, &serviceerror.InternalServerError
 		}
 		return append(allPurposes, *created), nil
@@ -778,11 +781,11 @@ func (s *consentEnforcerService) applyPermissionsPurpose(ctx context.Context,
 	updated, updErr := s.consentService.UpdateConsentPurpose(ctx, ouID, current.ID, &input)
 	if updErr != nil {
 		if updErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Client error from consent service when updating permission purpose",
+			logger.DebugWithContext(ctx, "Client error from consent service when updating permission purpose",
 				log.Any("error", updErr))
 			return nil, &ErrorConsentPurposeUpdateFailed
 		}
-		logger.Error("Failed to update permission consent purpose", log.Any("error", updErr))
+		logger.ErrorWithContext(ctx, "Failed to update permission consent purpose", log.Any("error", updErr))
 		return nil, &serviceerror.InternalServerError
 	}
 	for i := range allPurposes {

--- a/backend/internal/authn/github/service.go
+++ b/backend/internal/authn/github/service.go
@@ -86,7 +86,7 @@ func (g *githubOAuthAuthnService) FetchUserInfo(ctx context.Context, idpID, acce
 	// If email is already present in the user info or email scope is not requested, return it directly.
 	email := authnoauth.GetStringUserClaimValue(userInfo, "email")
 	if email != "" || !g.shouldFetchEmail(oAuthClientConfig.Scopes) {
-		logger.Debug("Email is already present in the user info or email scope not requested")
+		logger.DebugWithContext(ctx, "Email is already present in the user info or email scope not requested")
 		authnoauth.ProcessSubClaim(userInfo)
 		return userInfo, nil
 	}
@@ -159,7 +159,7 @@ func (g *githubOAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpI
 func (g *githubOAuthAuthnService) Authenticate(ctx context.Context, idpID, code string) (
 	*authncm.FederatedAuthResult, *serviceerror.ServiceError) {
 	logger := g.logger.With(log.String("idpId", idpID))
-	logger.Debug("Performing federated GitHub OAuth authentication")
+	logger.DebugWithContext(ctx, "Performing federated GitHub OAuth authentication")
 
 	tokenResp, svcErr := g.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
@@ -178,7 +178,7 @@ func (g *githubOAuthAuthnService) Authenticate(ctx context.Context, idpID, code 
 		}
 	}
 	if sub == "" {
-		logger.Debug("sub claim not found in user info")
+		logger.DebugWithContext(ctx, "sub claim not found in user info")
 		return nil, &authncm.ErrorSubClaimNotFound
 	}
 

--- a/backend/internal/authn/github/utils.go
+++ b/backend/internal/authn/github/utils.go
@@ -47,27 +47,28 @@ func buildUserEmailRequest(userEmailEndpoint string, accessToken string, logger 
 // sendUserEmailRequest sends the user email request to GitHub and processes the response.
 func sendUserEmailRequest(httpReq *http.Request, httpClient syshttp.HTTPClientInterface, logger *log.Logger) (
 	[]map[string]interface{}, *serviceerror.ServiceError) {
+	ctx := httpReq.Context()
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
-		logger.Error("User email request to GitHub failed", log.Error(err))
+		logger.ErrorWithContext(ctx, "User email request to GitHub failed", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.Error("Failed to close user email response body", log.Error(closeErr))
+			logger.ErrorWithContext(ctx, "Failed to close user email response body", log.Error(closeErr))
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		logger.Error("User email endpoint returned an error response",
+		logger.ErrorWithContext(ctx, "User email endpoint returned an error response",
 			log.Int("statusCode", resp.StatusCode), log.String("response", string(body)))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	var emails []map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
-		logger.Error("Failed to decode user email response", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to decode user email response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/authn/google/service.go
+++ b/backend/internal/authn/google/service.go
@@ -106,10 +106,10 @@ func (g *googleOIDCAuthnService) ValidateTokenResponse(ctx context.Context, idpI
 func (g *googleOIDCAuthnService) ValidateIDToken(
 	ctx context.Context, idpID, idToken string) *serviceerror.ServiceError {
 	logger := g.logger.With(log.String("idpId", idpID))
-	logger.Debug("Validating ID token")
+	logger.DebugWithContext(ctx, "Validating ID token")
 
 	if strings.TrimSpace(idToken) == "" {
-		logger.Debug("ID token is empty")
+		logger.DebugWithContext(ctx, "ID token is empty")
 		return &authnoidc.ErrorInvalidIDToken
 	}
 
@@ -123,14 +123,15 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 	if oAuthClientConfig.OAuthEndpoints.JwksEndpoint != "" {
 		err := g.jwtService.VerifyJWTSignatureWithJWKS(idToken, oAuthClientConfig.OAuthEndpoints.JwksEndpoint)
 		if err != nil {
-			logger.Debug("ID token signature validation failed", log.String("error", err.Error.DefaultValue))
+			logger.DebugWithContext(ctx, "ID token signature validation failed",
+				log.String("error", err.Error.DefaultValue))
 			return &authnoidc.ErrorInvalidIDTokenSignature
 		}
 	} else {
-		logger.Debug("Skipping ID token signature validation as JWKS endpoint is not configured")
+		logger.DebugWithContext(ctx, "Skipping ID token signature validation as JWKS endpoint is not configured")
 	}
 
-	logger.Debug("Validating Google specific ID token claims")
+	logger.DebugWithContext(ctx, "Validating Google specific ID token claims")
 
 	// Extract ID token claims for Google-specific validation
 	claims, err := jwt.DecodeJWTPayload(idToken)
@@ -141,7 +142,7 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 	// Validate issuer
 	iss, ok := claims["iss"].(string)
 	if !ok || (iss != Issuer1 && iss != Issuer2) {
-		logger.Debug("Invalid ID token issuer", log.String("issuer", iss))
+		logger.DebugWithContext(ctx, "Invalid ID token issuer", log.String("issuer", iss))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_issuer_description",
 			DefaultValue: "The issuer of the ID token is not a valid Google issuer",
@@ -151,7 +152,7 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 	// Validate audience
 	aud, ok := claims["aud"].(string)
 	if !ok || aud != oAuthClientConfig.ClientID {
-		logger.Debug("Invalid ID token audience", log.String("audience", aud),
+		logger.DebugWithContext(ctx, "Invalid ID token audience", log.String("audience", aud),
 			log.MaskedString("clientId", oAuthClientConfig.ClientID))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_audience_description",
@@ -165,14 +166,14 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 	// Validate expiration time
 	exp, ok := claims["exp"].(float64)
 	if !ok {
-		logger.Debug("Invalid ID token expiration claim", log.Any("exp", claims["exp"]))
+		logger.DebugWithContext(ctx, "Invalid ID token expiration claim", log.Any("exp", claims["exp"]))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_exp_claim_description",
 			DefaultValue: "The ID token expiration claim is missing or invalid",
 		})
 	}
 	if time.Now().Unix() >= int64(exp)+leeway {
-		logger.Debug("ID token has expired", log.Int("exp", int(exp)))
+		logger.DebugWithContext(ctx, "ID token has expired", log.Int("exp", int(exp)))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_expired_description",
 			DefaultValue: "The ID token has expired",
@@ -182,14 +183,14 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 	// Check if token was issued in the future (with leeway for clock skew)
 	iat, ok := claims["iat"].(float64)
 	if !ok {
-		logger.Debug("Invalid ID token issued-at claim", log.Any("iat", claims["iat"]))
+		logger.DebugWithContext(ctx, "Invalid ID token issued-at claim", log.Any("iat", claims["iat"]))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_iat_claim_description",
 			DefaultValue: "The ID token issued-at (iat) claim is missing or invalid",
 		})
 	}
 	if time.Now().Unix() < int64(iat)-leeway {
-		logger.Debug("ID token was issued in the future", log.Int("iat", int(iat)))
+		logger.DebugWithContext(ctx, "ID token was issued in the future", log.Int("iat", int(iat)))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_future_iat_description",
 			DefaultValue: "The ID token was issued in the future",
@@ -198,11 +199,11 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 
 	// Check for specific domain if configured in additional params
 	if hd, found := claims["hd"]; found {
-		logger.Debug("hd claim found in ID token")
+		logger.DebugWithContext(ctx, "hd claim found in ID token")
 		if domain, exists := oAuthClientConfig.AdditionalParams["hd"]; exists && domain != "" {
-			logger.Debug("Validating hosted domain (hd) claim")
+			logger.DebugWithContext(ctx, "Validating hosted domain (hd) claim")
 			if hdStr, ok := hd.(string); !ok || hdStr != domain {
-				logger.Debug("Invalid hosted domain (hd) claim", log.String("hd", hdStr),
+				logger.DebugWithContext(ctx, "Invalid hosted domain (hd) claim", log.String("hd", hdStr),
 					log.String("expectedDomain", domain))
 				return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 					Key:          "error.authnservice.google.invalid_id_token_hosted_domain_description",
@@ -244,7 +245,7 @@ func (g *googleOIDCAuthnService) GetOAuthClientConfig(ctx context.Context, idpID
 func (g *googleOIDCAuthnService) Authenticate(ctx context.Context, idpID, code string) (
 	*common.FederatedAuthResult, *serviceerror.ServiceError) {
 	logger := g.logger.With(log.String("idpId", idpID))
-	logger.Debug("Performing federated Google OIDC authentication")
+	logger.DebugWithContext(ctx, "Performing federated Google OIDC authentication")
 
 	tokenResp, svcErr := g.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
@@ -263,7 +264,7 @@ func (g *googleOIDCAuthnService) Authenticate(ctx context.Context, idpID, code s
 		}
 	}
 	if sub == "" {
-		logger.Debug("sub claim not found in ID token")
+		logger.DebugWithContext(ctx, "sub claim not found in ID token")
 		return nil, &common.ErrorSubClaimNotFound
 	}
 

--- a/backend/internal/authn/magiclink/service.go
+++ b/backend/internal/authn/magiclink/service.go
@@ -84,7 +84,7 @@ func (s *magicLinkAuthnService) GenerateMagicLink(ctx context.Context,
 	queryParams map[string]string,
 	additionalClaims map[string]interface{},
 	magicLinkURL string) (string, *serviceerror.ServiceError) {
-	s.logger.Debug("Generating magic link", log.MaskedString("subject", subject))
+	s.logger.DebugWithContext(ctx, "Generating magic link", log.MaskedString("subject", subject))
 
 	if subject == "" {
 		return "", &ErrorTokenGenerationFailed
@@ -116,7 +116,7 @@ func (s *magicLinkAuthnService) GenerateMagicLink(ctx context.Context,
 	}
 
 	verifyURL := s.buildMagicLinkURL(magicLinkURL, token, queryParams)
-	s.logger.Debug("Magic link generated successfully",
+	s.logger.DebugWithContext(ctx, "Magic link generated successfully",
 		log.MaskedString("subject", subject))
 
 	return verifyURL, nil
@@ -127,7 +127,7 @@ func (s *magicLinkAuthnService) GenerateMagicLink(ctx context.Context,
 // allowing callers to handle registration flows.
 func (s *magicLinkAuthnService) Authenticate(ctx context.Context,
 	token string, subjectAttribute string) (*MagicLinkAuthnResult, *serviceerror.ServiceError) {
-	s.logger.Debug("Authenticating with magic link token")
+	s.logger.DebugWithContext(ctx, "Authenticating with magic link token")
 
 	token = strings.TrimSpace(token)
 	if token == "" {
@@ -158,7 +158,7 @@ func (s *magicLinkAuthnService) Authenticate(ctx context.Context,
 		return nil, resolveErr
 	}
 
-	s.logger.Debug("Magic link authentication successful", log.String("userId", user.ID))
+	s.logger.DebugWithContext(ctx, "Magic link authentication successful", log.String("userId", user.ID))
 	return &MagicLinkAuthnResult{InternalEntity: user}, nil
 }
 
@@ -169,7 +169,7 @@ func (s *magicLinkAuthnService) verifyToken(ctx context.Context, token string) *
 		if verifyErr.Code == jwt.ErrorTokenExpired.Code {
 			return &ErrorExpiredToken
 		}
-		s.logger.Debug("Invalid magic link token", log.String("errorCode", verifyErr.Code))
+		s.logger.DebugWithContext(ctx, "Invalid magic link token", log.String("errorCode", verifyErr.Code))
 		return &ErrorInvalidToken
 	}
 	return nil

--- a/backend/internal/authn/oauth/service.go
+++ b/backend/internal/authn/oauth/service.go
@@ -94,7 +94,7 @@ func (s *oAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpID stri
 				DefaultValue: "Error while retrieving identity provider: " + svcErr.ErrorDescription.DefaultValue,
 			})
 		}
-		logger.Error("Error while retrieving identity provider", log.String("errorCode", svcErr.Code),
+		logger.ErrorWithContext(ctx, "Error while retrieving identity provider", log.String("errorCode", svcErr.Code),
 			log.String("description", svcErr.ErrorDescription.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -104,7 +104,7 @@ func (s *oAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpID stri
 
 	oAuthClientConfig, err := parseIDPConfig(idp)
 	if err != nil {
-		logger.Error("Failed to parse identity provider configurations", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to parse identity provider configurations", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -115,14 +115,14 @@ func (s *oAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpID stri
 func (s *oAuthAuthnService) BuildAuthorizeURL(
 	ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.Debug("Building authorize URL")
+	logger.DebugWithContext(ctx, "Building authorize URL")
 
 	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(ctx, idpID)
 	if svcErr != nil {
 		return "", svcErr
 	}
 	if oAuthClientConfig.OAuthEndpoints.AuthorizationEndpoint == "" {
-		logger.Error("Authorization endpoint is not configured for the identity provider")
+		logger.ErrorWithContext(ctx, "Authorization endpoint is not configured for the identity provider")
 		return "", &serviceerror.InternalServerError
 	}
 
@@ -145,7 +145,7 @@ func (s *oAuthAuthnService) BuildAuthorizeURL(
 	authZURL, err := sysutils.GetURIWithQueryParams(oAuthClientConfig.OAuthEndpoints.AuthorizationEndpoint,
 		queryParams)
 	if err != nil {
-		logger.Error("Failed to build authorize URL", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to build authorize URL", log.Error(err))
 		return "", &serviceerror.InternalServerError
 	}
 
@@ -157,7 +157,7 @@ func (s *oAuthAuthnService) BuildAuthorizeURL(
 func (s *oAuthAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, code string, validateResponse bool) (
 	*TokenResponse, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.Debug("Exchanging authorization code for token")
+	logger.DebugWithContext(ctx, "Exchanging authorization code for token")
 
 	if strings.TrimSpace(code) == "" {
 		return nil, &ErrorEmptyAuthorizationCode
@@ -168,7 +168,7 @@ func (s *oAuthAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, cod
 		return nil, svcErr
 	}
 	if oAuthClientConfig.OAuthEndpoints.TokenEndpoint == "" {
-		logger.Error("Token endpoint is not configured for the identity provider")
+		logger.ErrorWithContext(ctx, "Token endpoint is not configured for the identity provider")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -304,7 +304,7 @@ func (s *oAuthAuthnService) GetInternalUser(sub string) (*entityprovider.Entity,
 func (s *oAuthAuthnService) Authenticate(ctx context.Context, idpID, code string) (
 	*common.FederatedAuthResult, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.Debug("Performing federated OAuth authentication")
+	logger.DebugWithContext(ctx, "Performing federated OAuth authentication")
 
 	tokenResp, svcErr := s.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
@@ -323,7 +323,7 @@ func (s *oAuthAuthnService) Authenticate(ctx context.Context, idpID, code string
 		}
 	}
 	if sub == "" {
-		logger.Debug("sub claim not found in user info")
+		logger.DebugWithContext(ctx, "sub claim not found in user info")
 		return nil, &common.ErrorSubClaimNotFound
 	}
 

--- a/backend/internal/authn/oauth/utils.go
+++ b/backend/internal/authn/oauth/utils.go
@@ -115,27 +115,28 @@ func buildTokenRequest(oAuthClientConfig *OAuthClientConfig, code string, logger
 // sendTokenRequest sends the token request to the identity provider and processes the response.
 func sendTokenRequest(httpReq *http.Request, httpClient httpservice.HTTPClientInterface, logger *log.Logger) (
 	*TokenResponse, *serviceerror.ServiceError) {
+	ctx := httpReq.Context()
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
-		logger.Error("Token request to identity provider failed", log.Error(err))
+		logger.ErrorWithContext(ctx, "Token request to identity provider failed", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.Error("Failed to close token response body", log.Error(closeErr))
+			logger.ErrorWithContext(ctx, "Failed to close token response body", log.Error(closeErr))
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		logger.Error("Token endpoint returned an error response",
+		logger.ErrorWithContext(ctx, "Token endpoint returned an error response",
 			log.Int("statusCode", resp.StatusCode), log.String("response", string(body)))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	var tokenResp TokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		logger.Error("Failed to parse token response", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to parse token response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -160,33 +161,34 @@ func buildUserInfoRequest(userInfoEndpoint string, accessToken string, logger *l
 // sendUserInfoRequest sends the user info request to the identity provider and processes the response.
 func sendUserInfoRequest(httpReq *http.Request, httpClient httpservice.HTTPClientInterface, logger *log.Logger) (
 	map[string]interface{}, *serviceerror.ServiceError) {
+	ctx := httpReq.Context()
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
-		logger.Error("Userinfo request to identity provider failed", log.Error(err))
+		logger.ErrorWithContext(ctx, "Userinfo request to identity provider failed", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.Error("Failed to close userinfo response body", log.Error(closeErr))
+			logger.ErrorWithContext(ctx, "Failed to close userinfo response body", log.Error(closeErr))
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		logger.Error("Userinfo endpoint returned an error response",
+		logger.ErrorWithContext(ctx, "Userinfo endpoint returned an error response",
 			log.Int("statusCode", resp.StatusCode), log.String("response", string(body)))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logger.Error("Failed to read userinfo response body", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to read userinfo response body", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	var userInfo map[string]interface{}
 	if err := json.Unmarshal(body, &userInfo); err != nil {
-		logger.Error("Failed to parse userinfo response", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to parse userinfo response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/authn/oidc/service.go
+++ b/backend/internal/authn/oidc/service.go
@@ -103,18 +103,18 @@ func (s *oidcAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, code
 func (s *oidcAuthnService) ValidateTokenResponse(ctx context.Context, idpID string,
 	tokenResp *authnoauth.TokenResponse, validateIDToken bool) *serviceerror.ServiceError {
 	logger := s.logger
-	logger.Debug("Validating token response")
+	logger.DebugWithContext(ctx, "Validating token response")
 
 	if tokenResp == nil {
-		logger.Debug("Empty token response received from identity provider")
+		logger.DebugWithContext(ctx, "Empty token response received from identity provider")
 		return &authnoauth.ErrorInvalidTokenResponse
 	}
 	if tokenResp.AccessToken == "" {
-		logger.Debug("Access token is empty in the token response")
+		logger.DebugWithContext(ctx, "Access token is empty in the token response")
 		return &authnoauth.ErrorInvalidTokenResponse
 	}
 	if tokenResp.IDToken == "" {
-		logger.Debug("ID token is empty in the token response")
+		logger.DebugWithContext(ctx, "ID token is empty in the token response")
 		return &authnoauth.ErrorInvalidTokenResponse
 	}
 
@@ -134,10 +134,10 @@ func (s *oidcAuthnService) ValidateTokenResponse(ctx context.Context, idpID stri
 // is called with validateResponse set to true.
 func (s *oidcAuthnService) ValidateIDToken(ctx context.Context, idpID, idToken string) *serviceerror.ServiceError {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.Debug("Validating ID token")
+	logger.DebugWithContext(ctx, "Validating ID token")
 
 	if strings.TrimSpace(idToken) == "" {
-		logger.Debug("ID token is empty")
+		logger.DebugWithContext(ctx, "ID token is empty")
 		return &ErrorInvalidIDToken
 	}
 
@@ -150,11 +150,12 @@ func (s *oidcAuthnService) ValidateIDToken(ctx context.Context, idpID, idToken s
 	if oAuthClientConfig.OAuthEndpoints.JwksEndpoint != "" {
 		err := s.jwtService.VerifyJWTWithJWKS(idToken, oAuthClientConfig.OAuthEndpoints.JwksEndpoint, "", "")
 		if err != nil {
-			logger.Debug("ID token signature validation failed", log.String("error", err.Error.DefaultValue))
+			logger.DebugWithContext(ctx, "ID token signature validation failed",
+				log.String("error", err.Error.DefaultValue))
 			return &ErrorInvalidIDTokenSignature
 		}
 	} else {
-		logger.Debug("Skipping ID token signature validation as JWKS endpoint is not configured")
+		logger.DebugWithContext(ctx, "Skipping ID token signature validation as JWKS endpoint is not configured")
 	}
 
 	// TODO: Should mandate ID token validation when the support is available through a IDP configuration.
@@ -201,7 +202,7 @@ func (s *oidcAuthnService) GetInternalUser(sub string) (*entityprovider.Entity, 
 func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID, code string) (
 	*authncm.FederatedAuthResult, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.Debug("Performing federated OIDC authentication")
+	logger.DebugWithContext(ctx, "Performing federated OIDC authentication")
 
 	tokenResp, svcErr := s.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
@@ -221,7 +222,7 @@ func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID, code string)
 		}
 	}
 	if sub == "" {
-		logger.Debug("sub claim not found in ID token")
+		logger.DebugWithContext(ctx, "sub claim not found in ID token")
 		return nil, &authncm.ErrorSubClaimNotFound
 	}
 
@@ -237,7 +238,7 @@ func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID, code string)
 					}
 				}
 			} else {
-				logger.Debug("UserInfo sub mismatch, skipping attribute merge")
+				logger.DebugWithContext(ctx, "UserInfo sub mismatch, skipping attribute merge")
 			}
 		}
 	}

--- a/backend/internal/authn/otp/service.go
+++ b/backend/internal/authn/otp/service.go
@@ -78,7 +78,7 @@ func newOTPAuthnService(otpSvc notification.OTPServiceInterface,
 func (s *otpAuthnService) SendOTP(ctx context.Context, senderID string, channel notifcommon.ChannelType,
 	recipient string) (string, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Sending OTP for authentication", log.MaskedString("recipient", recipient),
+	logger.DebugWithContext(ctx, "Sending OTP for authentication", log.MaskedString("recipient", recipient),
 		log.String("channel", string(channel)))
 
 	if svcErr := s.validateOTPSendRequest(senderID, channel, recipient); svcErr != nil {
@@ -95,7 +95,7 @@ func (s *otpAuthnService) SendOTP(ctx context.Context, senderID string, channel 
 		return "", s.handleOTPServiceError(svcErr, false, logger)
 	}
 
-	logger.Debug("OTP sent successfully, session token generated")
+	logger.DebugWithContext(ctx, "OTP sent successfully, session token generated")
 	return result.SessionToken, nil
 }
 
@@ -103,7 +103,7 @@ func (s *otpAuthnService) SendOTP(ctx context.Context, senderID string, channel 
 func (s *otpAuthnService) Authenticate(ctx context.Context, sessionToken,
 	otp string) (*OTPAuthnResult, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Verifying OTP for authentication")
+	logger.DebugWithContext(ctx, "Verifying OTP for authentication")
 
 	if svcErr := s.validateOTPVerifyRequest(sessionToken, otp); svcErr != nil {
 		return nil, svcErr

--- a/backend/internal/authn/passkey/service.go
+++ b/backend/internal/authn/passkey/service.go
@@ -88,7 +88,7 @@ func (w *passkeyService) StartRegistration(
 	}
 
 	logger := w.logger.With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Starting passkey credential registration",
+	logger.DebugWithContext(ctx, "Starting passkey credential registration",
 		log.MaskedString("userID", req.UserID),
 		log.String("relyingPartyID", req.RelyingPartyID))
 
@@ -116,7 +116,7 @@ func (w *passkeyService) StartRegistration(
 		rpDisplayName = req.RelyingPartyID
 	}
 
-	logger.Debug("Retrieved existing credentials",
+	logger.DebugWithContext(ctx, "Retrieved existing credentials",
 		log.MaskedString("entityID", req.UserID),
 		log.Int("credentialCount", len(credentials)))
 
@@ -127,7 +127,7 @@ func (w *passkeyService) StartRegistration(
 	rpOrigins := getConfiguredOrigins()
 	webAuthnService, err := newDefaultWebAuthnService(req.RelyingPartyID, rpDisplayName, rpOrigins)
 	if err != nil {
-		logger.Error("Failed to initialize WebAuthn service", log.String("error", err.Error()))
+		logger.ErrorWithContext(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -138,18 +138,18 @@ func (w *passkeyService) StartRegistration(
 	// The WebAuthn service will generate challenge and set timeout automatically
 	options, sessionData, err := webAuthnService.BeginRegistration(webAuthnUser, registrationOptions)
 	if err != nil {
-		logger.Error("Failed to begin passkey registration", log.String("error", err.Error()))
+		logger.ErrorWithContext(ctx, "Failed to begin passkey registration", log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	// Store session data in cache with TTL
 	sessionToken, svcErr := w.storeSessionData(sessionData)
 	if svcErr != nil {
-		logger.Error("Failed to store session data", log.String("error", svcErr.Error.DefaultValue))
+		logger.ErrorWithContext(ctx, "Failed to store session data", log.String("error", svcErr.Error.DefaultValue))
 		return nil, svcErr
 	}
 
-	logger.Debug("Passkey credential creation options generated successfully",
+	logger.DebugWithContext(ctx, "Passkey credential creation options generated successfully",
 		log.MaskedString("userID", req.UserID),
 		log.Int("credentialsCount", len(credentials)))
 
@@ -176,11 +176,11 @@ func (w *passkeyService) StartRegistration(
 func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyRegistrationFinishRequest) (
 	*PasskeyRegistrationFinishData, *serviceerror.ServiceError) {
 	logger := w.logger.With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Finishing passkey credential registration")
+	logger.DebugWithContext(ctx, "Finishing passkey credential registration")
 
 	// Validate input
 	if svcErr := validateRegistrationFinishRequest(req); svcErr != nil {
-		logger.Debug("Registration finish request validation failed")
+		logger.DebugWithContext(ctx, "Registration finish request validation failed")
 		return nil, svcErr
 	}
 
@@ -190,7 +190,7 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 		credentialType = "public-key"
 	}
 
-	logger.Debug("Parsing attestation response",
+	logger.DebugWithContext(ctx, "Parsing attestation response",
 		log.String("credentialID", req.CredentialID),
 		log.String("credentialType", credentialType),
 		log.Int("clientDataJSONLen", len(req.ClientDataJSON)),
@@ -205,21 +205,21 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 		req.AttestationObject,
 	)
 	if err != nil {
-		logger.Debug("Failed to parse attestation response",
+		logger.DebugWithContext(ctx, "Failed to parse attestation response",
 			log.String("error", err.Error()),
 			log.String("credentialID", req.CredentialID),
 			log.String("credentialType", credentialType))
 		return nil, &ErrorInvalidAttestationResponse
 	}
 
-	logger.Debug("Successfully parsed attestation response",
+	logger.DebugWithContext(ctx, "Successfully parsed attestation response",
 		log.String("credentialID", parsedCredential.ID),
 		log.String("credentialType", parsedCredential.Type))
 
 	// Retrieve session data from cache
 	sessionData, userID, relyingPartyID, svcErr := w.retrieveSessionData(req.SessionToken)
 	if svcErr != nil {
-		logger.Error("Failed to retrieve session data", log.String("error", svcErr.Error.DefaultValue))
+		logger.ErrorWithContext(ctx, "Failed to retrieve session data", log.String("error", svcErr.Error.DefaultValue))
 		return nil, svcErr
 	}
 
@@ -236,7 +236,7 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 	}
 	credentials := w.decodePasskeyCredentials(userID, entries)
 
-	logger.Debug("Retrieved existing credentials for entity",
+	logger.DebugWithContext(ctx, "Retrieved existing credentials for entity",
 		log.MaskedString("entityID", userID),
 		log.Int("credentialCount", len(credentials)))
 
@@ -247,14 +247,14 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 	rpOrigins := getConfiguredOrigins()
 	webAuthnService, err := newDefaultWebAuthnService(relyingPartyID, relyingPartyID, rpOrigins)
 	if err != nil {
-		logger.Error("Failed to initialize WebAuthn service", log.String("error", err.Error()))
+		logger.ErrorWithContext(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	// Verify the credential using WebAuthn service
 	credential, err := webAuthnService.CreateCredential(webAuthnUser, *sessionData, parsedCredential)
 	if err != nil {
-		logger.Error("Failed to verify and create credential", log.String("error", err.Error()))
+		logger.ErrorWithContext(ctx, "Failed to verify and create credential", log.String("error", err.Error()))
 		return nil, &ErrorInvalidAttestationResponse
 	}
 
@@ -269,7 +269,7 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 
 	// Store credential in database using user service
 	if err := w.storePasskeyCredential(ctx, userID, credential); err != nil {
-		logger.Error("Failed to store credential in database", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to store credential in database", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -296,10 +296,10 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 	isUsernameless := strings.TrimSpace(req.UserID) == ""
 
 	if isUsernameless {
-		logger.Debug("Starting usernameless passkey authentication",
+		logger.DebugWithContext(ctx, "Starting usernameless passkey authentication",
 			log.String("relyingPartyID", req.RelyingPartyID))
 	} else {
-		logger.Debug("Starting passkey authentication",
+		logger.DebugWithContext(ctx, "Starting passkey authentication",
 			log.MaskedString("userID", req.UserID),
 			log.String("relyingPartyID", req.RelyingPartyID))
 	}
@@ -313,7 +313,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 	rpOrigins := getConfiguredOrigins()
 	webAuthnService, err := newDefaultWebAuthnService(req.RelyingPartyID, req.RelyingPartyID, rpOrigins)
 	if err != nil {
-		logger.Error("Failed to initialize WebAuthn service", log.String("error", err.Error()))
+		logger.ErrorWithContext(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -324,7 +324,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 		// Usernameless flow: Use discoverable credentials
 		options, sessionData, err = webAuthnService.BeginDiscoverableLogin()
 		if err != nil {
-			logger.Error("Failed to begin usernameless passkey login", log.String("error", err.Error()))
+			logger.ErrorWithContext(ctx, "Failed to begin usernameless passkey login", log.String("error", err.Error()))
 			return nil, &serviceerror.InternalServerError
 		}
 	} else {
@@ -340,12 +340,12 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 		}
 		credentials := w.decodePasskeyCredentials(req.UserID, entries)
 
-		logger.Debug("Retrieved credentials for authentication",
+		logger.DebugWithContext(ctx, "Retrieved credentials for authentication",
 			log.MaskedString("entityID", req.UserID),
 			log.Int("credentialCount", len(credentials)))
 
 		if len(credentials) == 0 {
-			logger.Debug("No credentials found for entity", log.MaskedString("entityID", req.UserID))
+			logger.DebugWithContext(ctx, "No credentials found for entity", log.MaskedString("entityID", req.UserID))
 			return nil, &ErrorNoCredentialsFound
 		}
 
@@ -356,7 +356,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 		// The WebAuthn service will generate challenge and set timeout automatically
 		options, sessionData, err = webAuthnService.BeginLogin(webAuthnUser)
 		if err != nil {
-			logger.Error("Failed to begin passkey login", log.String("error", err.Error()))
+			logger.ErrorWithContext(ctx, "Failed to begin passkey login", log.String("error", err.Error()))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -364,7 +364,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 	// Store session data in cache with TTL
 	sessionToken, svcErr := w.storeSessionData(sessionData)
 	if svcErr != nil {
-		logger.Error("Failed to store session data", log.String("error", svcErr.Error.DefaultValue))
+		logger.ErrorWithContext(ctx, "Failed to store session data", log.String("error", svcErr.Error.DefaultValue))
 		return nil, svcErr
 	}
 
@@ -388,7 +388,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyAuthenticationFinishRequest) (
 	*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := w.logger.With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Finishing passkey authentication")
+	logger.DebugWithContext(ctx, "Finishing passkey authentication")
 
 	// Validate input
 	if svcErr := validateAuthenticationFinishRequest(req); svcErr != nil {
@@ -398,7 +398,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	// Retrieve session data from cache
 	sessionData, sessionUserID, relyingPartyID, svcErr := w.retrieveSessionData(req.SessionToken)
 	if svcErr != nil {
-		logger.Error("Failed to retrieve session data", log.String("error", svcErr.Error.DefaultValue))
+		logger.ErrorWithContext(ctx, "Failed to retrieve session data", log.String("error", svcErr.Error.DefaultValue))
 		return nil, svcErr
 	}
 
@@ -410,7 +410,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	if isUsernameless {
 		// Usernameless flow: Resolve user from userHandle in the authentication response
 		if req.UserHandle == "" {
-			logger.Error("UserHandle is required for usernameless authentication")
+			logger.ErrorWithContext(ctx, "UserHandle is required for usernameless authentication")
 			return nil, &ErrorInvalidAuthenticatorResponse
 		}
 
@@ -420,18 +420,18 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 			// Try RawURLEncoding if standard encoding fails
 			userHandleBytes, err = base64.RawURLEncoding.DecodeString(req.UserHandle)
 			if err != nil {
-				logger.Error("Failed to decode userHandle", log.Error(err))
+				logger.ErrorWithContext(ctx, "Failed to decode userHandle", log.Error(err))
 				return nil, &ErrorInvalidAuthenticatorResponse
 			}
 		}
 
 		userID = string(userHandleBytes)
-		logger.Debug("Resolved userID from userHandle for usernameless authentication",
+		logger.DebugWithContext(ctx, "Resolved userID from userHandle for usernameless authentication",
 			log.MaskedString("userID", userID))
 	} else {
 		// Username-based flow: Use userID from session
 		userID = sessionUserID
-		logger.Debug("Processing passkey authentication",
+		logger.DebugWithContext(ctx, "Processing passkey authentication",
 			log.MaskedString("userID", userID),
 			log.String("relyingPartyID", relyingPartyID))
 	}
@@ -448,12 +448,12 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	}
 	credentials := w.decodePasskeyCredentials(userID, entries)
 
-	logger.Debug("Retrieved credentials for authentication verification",
+	logger.DebugWithContext(ctx, "Retrieved credentials for authentication verification",
 		log.MaskedString("entityID", userID),
 		log.Int("credentialCount", len(credentials)))
 
 	if len(credentials) == 0 {
-		logger.Debug("No credentials found for entity", log.MaskedString("entityID", userID))
+		logger.DebugWithContext(ctx, "No credentials found for entity", log.MaskedString("entityID", userID))
 		return nil, &ErrorNoCredentialsFound
 	}
 
@@ -464,7 +464,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	rpOrigins := getConfiguredOrigins()
 	webAuthnService, err := newDefaultWebAuthnService(relyingPartyID, relyingPartyID, rpOrigins)
 	if err != nil {
-		logger.Error("Failed to initialize WebAuthn service", log.String("error", err.Error()))
+		logger.ErrorWithContext(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -472,7 +472,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	parsedResponse, err := parseAssertionResponse(req.CredentialID, req.CredentialType,
 		req.ClientDataJSON, req.AuthenticatorData, req.Signature, req.UserHandle)
 	if err != nil {
-		logger.Debug("Failed to parse assertion response", log.String("error", err.Error()))
+		logger.DebugWithContext(ctx, "Failed to parse assertion response", log.String("error", err.Error()))
 		return nil, &ErrorInvalidAuthenticatorResponse
 	}
 
@@ -487,29 +487,29 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 
 		_, credential, err = webAuthnService.ValidatePasskeyLogin(userHandler, *sessionData, parsedResponse)
 		if err != nil {
-			logger.Debug("Failed to validate passkey assertion", log.String("error", err.Error()))
+			logger.DebugWithContext(ctx, "Failed to validate passkey assertion", log.String("error", err.Error()))
 			return nil, &ErrorInvalidSignature
 		}
 	} else {
 		// Username-based flow: Use ValidateLogin with specific user
 		credential, err = webAuthnService.ValidateLogin(webAuthnUser, *sessionData, parsedResponse)
 		if err != nil {
-			logger.Debug("Failed to validate WebAuthn assertion", log.String("error", err.Error()))
+			logger.DebugWithContext(ctx, "Failed to validate WebAuthn assertion", log.String("error", err.Error()))
 			return nil, &ErrorInvalidSignature
 		}
 	}
 
-	logger.Debug("Passkey authentication verified successfully",
+	logger.DebugWithContext(ctx, "Passkey authentication verified successfully",
 		log.String("credentialID", base64.StdEncoding.EncodeToString(credential.ID)),
 		log.Any("signCount", credential.Authenticator.SignCount))
 
 	// Update credential in database to prevent replay attacks
 	if err := w.updatePasskeyCredential(ctx, userID, credential); err != nil {
-		logger.Error("Failed to update credential sign count in database", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to update credential sign count in database", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Updated credential sign count in database",
+	logger.DebugWithContext(ctx, "Updated credential sign count in database",
 		log.MaskedString("userID", userID),
 		log.String("credentialID", base64.StdEncoding.EncodeToString(credential.ID)),
 		log.Any("newSignCount", credential.Authenticator.SignCount))
@@ -524,7 +524,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 		OUID: coreEntity.OUID,
 	}
 
-	logger.Debug("Passkey authentication completed successfully",
+	logger.DebugWithContext(ctx, "Passkey authentication completed successfully",
 		log.MaskedString("entityID", userID))
 
 	return authResponse, nil
@@ -539,10 +539,10 @@ func (w *passkeyService) getEntity(
 	e, err := w.entityService.GetEntity(ctx, entityID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.Debug("Entity not found", log.MaskedString("entityID", entityID))
+			logger.DebugWithContext(ctx, "Entity not found", log.MaskedString("entityID", entityID))
 			return nil, &ErrorUserNotFound
 		}
-		logger.Error("Failed to retrieve entity", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to retrieve entity", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return e, nil
@@ -558,10 +558,10 @@ func (w *passkeyService) getStoredPasskeyEntries(
 	entries, err := w.entityService.GetCredentialsByType(ctx, entityID, passkeyCredentialType)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.Debug("Entity not found", log.MaskedString("entityID", entityID))
+			logger.DebugWithContext(ctx, "Entity not found", log.MaskedString("entityID", entityID))
 			return nil, &ErrorUserNotFound
 		}
-		logger.Error("Failed to retrieve passkey credentials", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to retrieve passkey credentials", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return entries, nil
@@ -600,7 +600,7 @@ func (w *passkeyService) storePasskeyCredential(
 
 	credentialJSON, err := json.Marshal(credential)
 	if err != nil {
-		logger.Error("Failed to marshal credential",
+		logger.ErrorWithContext(ctx, "Failed to marshal credential",
 			log.MaskedString("entityID", entityID),
 			log.Error(err))
 		return fmt.Errorf("failed to marshal credential: %w", err)
@@ -622,13 +622,13 @@ func (w *passkeyService) storePasskeyCredential(
 		return fmt.Errorf("failed to marshal passkey credentials: %w", err)
 	}
 	if err := w.entityService.UpdateSystemCredentials(ctx, entityID, payload); err != nil {
-		logger.Error("Failed to update passkey credentials",
+		logger.ErrorWithContext(ctx, "Failed to update passkey credentials",
 			log.MaskedString("entityID", entityID),
 			log.Error(err))
 		return fmt.Errorf("failed to update passkey credentials: %w", err)
 	}
 
-	logger.Debug("Successfully stored passkey credential in database",
+	logger.DebugWithContext(ctx, "Successfully stored passkey credential in database",
 		log.MaskedString("entityID", entityID),
 		log.String("credentialID", base64.StdEncoding.EncodeToString(credential.ID)))
 
@@ -653,7 +653,7 @@ func (w *passkeyService) updatePasskeyCredential(
 	for _, entry := range existingEntries {
 		var credential webauthnCredential
 		if err := json.Unmarshal([]byte(entry.Value), &credential); err != nil {
-			logger.Warn("Failed to unmarshal credential, keeping original",
+			logger.WarnWithContext(ctx, "Failed to unmarshal credential, keeping original",
 				log.MaskedString("entityID", entityID),
 				log.Error(err))
 			updatedEntries = append(updatedEntries, entry)
@@ -663,7 +663,7 @@ func (w *passkeyService) updatePasskeyCredential(
 		if string(credential.ID) == string(updatedCredential.ID) {
 			credentialJSON, marshalErr := json.Marshal(updatedCredential)
 			if marshalErr != nil {
-				logger.Error("Failed to marshal updated credential",
+				logger.ErrorWithContext(ctx, "Failed to marshal updated credential",
 					log.MaskedString("entityID", entityID),
 					log.Error(marshalErr))
 				return fmt.Errorf("failed to marshal updated credential: %w", marshalErr)
@@ -675,7 +675,7 @@ func (w *passkeyService) updatePasskeyCredential(
 			})
 			found = true
 
-			logger.Debug("Updated credential in memory",
+			logger.DebugWithContext(ctx, "Updated credential in memory",
 				log.MaskedString("entityID", entityID),
 				log.String("credentialID", base64.StdEncoding.EncodeToString(updatedCredential.ID)),
 				log.Any("newSignCount", updatedCredential.Authenticator.SignCount))
@@ -685,7 +685,7 @@ func (w *passkeyService) updatePasskeyCredential(
 	}
 
 	if !found {
-		logger.Warn("Passkey credential not found for update",
+		logger.WarnWithContext(ctx, "Passkey credential not found for update",
 			log.MaskedString("entityID", entityID),
 			log.String("credentialID", base64.StdEncoding.EncodeToString(updatedCredential.ID)))
 		return fmt.Errorf("credential not found for update")
@@ -698,13 +698,13 @@ func (w *passkeyService) updatePasskeyCredential(
 		return fmt.Errorf("failed to marshal passkey credentials: %w", err)
 	}
 	if err := w.entityService.UpdateSystemCredentials(ctx, entityID, payload); err != nil {
-		logger.Error("Failed to update credentials",
+		logger.ErrorWithContext(ctx, "Failed to update credentials",
 			log.MaskedString("entityID", entityID),
 			log.Error(err))
 		return fmt.Errorf("failed to update passkey credentials: %w", err)
 	}
 
-	logger.Debug("Successfully updated passkey credential in database",
+	logger.DebugWithContext(ctx, "Successfully updated passkey credential in database",
 		log.MaskedString("entityID", entityID),
 		log.String("credentialID", base64.StdEncoding.EncodeToString(updatedCredential.ID)),
 		log.Any("newSignCount", updatedCredential.Authenticator.SignCount))

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -132,7 +132,7 @@ func (as *authenticationService) AuthenticateWithCredentials(ctx context.Context
 	credentials map[string]interface{}, skipAssertion bool, existingAssertion string) (
 	*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.Debug("Authenticating with credentials")
+	logger.DebugWithContext(ctx, "Authenticating with credentials")
 
 	if len(identifiers) == 0 || len(credentials) == 0 {
 		return nil, &ErrorEmptyAttributesOrCredentials
@@ -145,7 +145,7 @@ func (as *authenticationService) AuthenticateWithCredentials(ctx context.Context
 	}
 
 	if basicResult == nil {
-		logger.Error("Credentials authenticate response is nil")
+		logger.ErrorWithContext(ctx, "Credentials authenticate response is nil")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -170,7 +170,7 @@ func (as *authenticationService) AuthenticateWithCredentials(ctx context.Context
 		}
 		authUserAttributesJSON, err := json.Marshal(authUserAttributes)
 		if err != nil {
-			logger.Error("Failed to marshal user attributes")
+			logger.ErrorWithContext(ctx, "Failed to marshal user attributes")
 			return nil, &serviceerror.InternalServerError
 		}
 
@@ -200,7 +200,7 @@ func (as *authenticationService) SendOTP(ctx context.Context, senderID string, c
 func (as *authenticationService) VerifyOTP(ctx context.Context, sessionToken string, skipAssertion bool,
 	existingAssertion, otpCode string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.Debug("Verifying OTP for authentication")
+	logger.DebugWithContext(ctx, "Verifying OTP for authentication")
 
 	credentials := map[string]interface{}{
 		"otp": map[string]interface{}{
@@ -248,7 +248,7 @@ func (as *authenticationService) VerifyOTP(ctx context.Context, sessionToken str
 func (as *authenticationService) StartIDPAuthentication(ctx context.Context, requestedType idp.IDPType, idpID string) (
 	*IDPAuthInitData, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.Debug("Starting IDP authentication", log.String("idpId", idpID))
+	logger.DebugWithContext(ctx, "Starting IDP authentication", log.String("idpId", idpID))
 
 	if strings.TrimSpace(idpID) == "" {
 		return nil, &common.ErrorInvalidIDPID
@@ -276,7 +276,7 @@ func (as *authenticationService) StartIDPAuthentication(ctx context.Context, req
 	case idp.IDPTypeGitHub:
 		redirectURL, buildURLErr = as.githubService.BuildAuthorizeURL(ctx, idpID)
 	default:
-		logger.Error("Unsupported IDP type", log.String("idpId", idpID),
+		logger.ErrorWithContext(ctx, "Unsupported IDP type", log.String("idpId", idpID),
 			log.String("type", string(identityProvider.Type)))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -288,7 +288,7 @@ func (as *authenticationService) StartIDPAuthentication(ctx context.Context, req
 	// Generate session token
 	sessionToken, err := as.createSessionToken(ctx, idpID, identityProvider.Type)
 	if err != nil {
-		logger.Error("Failed to create session token", log.String("idpId", idpID),
+		logger.ErrorWithContext(ctx, "Failed to create session token", log.String("idpId", idpID),
 			log.String("error", err.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -304,7 +304,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 	sessionToken string, skipAssertion bool, existingAssertion, code string) (
 	*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.Debug("Finishing IDP authentication")
+	logger.DebugWithContext(ctx, "Finishing IDP authentication")
 
 	if strings.TrimSpace(sessionToken) == "" {
 		return nil, &common.ErrorEmptySessionToken
@@ -336,7 +336,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 		return nil, as.mapFederatedAuthnError(svcErr, logger)
 	}
 	if basicResult == nil {
-		logger.Error("Federated authenticate response is nil")
+		logger.ErrorWithContext(ctx, "Federated authenticate response is nil")
 		return nil, &serviceerror.InternalServerError
 	}
 	if basicResult.IsAmbiguousUser {
@@ -362,7 +362,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 	if !skipAssertion {
 		authenticatorName, err := common.GetAuthenticatorNameForIDPType(sessionData.IDPType)
 		if err != nil {
-			logger.Error("Failed to get authenticator name for IDP type",
+			logger.ErrorWithContext(ctx, "Failed to get authenticator name for IDP type",
 				log.String("idpType", string(sessionData.IDPType)), log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
@@ -382,7 +382,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(
 	ctx context.Context, authResponse *common.AuthenticationResponse, user *entityprovider.Entity, authenticator string,
 	existingAssertion string, logger *log.Logger,
 ) *serviceerror.ServiceError {
-	logger.Debug("Generating auth assertion", log.MaskedString(log.LoggerKeyUserID, user.ID))
+	logger.DebugWithContext(ctx, "Generating auth assertion", log.MaskedString(log.LoggerKeyUserID, user.ID))
 
 	authenticatorRef := &common.AuthenticatorReference{
 		Authenticator: authenticator,
@@ -401,7 +401,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(
 
 		// Validate that the assertion subject matches the current user
 		if assertionSub != user.ID {
-			logger.Debug("Assertion subject mismatch", log.MaskedString("assertionSub", assertionSub),
+			logger.DebugWithContext(ctx, "Assertion subject mismatch", log.MaskedString("assertionSub", assertionSub),
 				log.MaskedString(log.LoggerKeyUserID, user.ID))
 			return &common.ErrorAssertionSubjectMismatch
 		}
@@ -440,7 +440,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(
 	token, _, err := as.jwtService.GenerateJWT(ctx, user.ID, jwtConfig.Issuer,
 		jwtConfig.ValidityPeriod, jwtClaims, jwt.TokenTypeJWT, "")
 	if err != nil {
-		logger.Error("Failed to generate auth assertion", log.String("error", err.Error.DefaultValue))
+		logger.ErrorWithContext(ctx, "Failed to generate auth assertion", log.String("error", err.Error.DefaultValue))
 		return &serviceerror.InternalServerError
 	}
 
@@ -473,45 +473,46 @@ func (as *authenticationService) extractClaimsFromAssertion(ctx context.Context,
 	jwtConfig := config.GetServerRuntime().Config.JWT
 
 	if err := as.jwtService.VerifyJWT(ctx, assertion, "", jwtConfig.Issuer); err != nil {
-		logger.Debug("Failed to verify JWT signature of the assertion", log.String("error", err.Error.DefaultValue))
+		logger.DebugWithContext(ctx, "Failed to verify JWT signature of the assertion",
+			log.String("error", err.Error.DefaultValue))
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
 	payload, err := jwt.DecodeJWTPayload(assertion)
 	if err != nil {
-		logger.Debug("Failed to decode JWT assertion", log.Error(err))
+		logger.DebugWithContext(ctx, "Failed to decode JWT assertion", log.Error(err))
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
 	// Extract subject claim
 	subClaim, ok := payload["sub"]
 	if !ok {
-		logger.Debug("No 'sub' claim found in JWT assertion")
+		logger.DebugWithContext(ctx, "No 'sub' claim found in JWT assertion")
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 	sub, ok := subClaim.(string)
 	if !ok || strings.TrimSpace(sub) == "" {
-		logger.Debug("Invalid 'sub' claim in JWT assertion")
+		logger.DebugWithContext(ctx, "Invalid 'sub' claim in JWT assertion")
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
 	// Extract assurance claim
 	assuranceClaim, ok := payload["assurance"]
 	if !ok {
-		logger.Debug("No assurance claim found in JWT assertion")
+		logger.DebugWithContext(ctx, "No assurance claim found in JWT assertion")
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
 	// Convert assurance claim to AssuranceContext
 	assuranceBytes, err := json.Marshal(assuranceClaim)
 	if err != nil {
-		logger.Debug("Failed to marshal assurance claim", log.Error(err))
+		logger.DebugWithContext(ctx, "Failed to marshal assurance claim", log.Error(err))
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
 	var assuranceCtx assert.AssuranceContext
 	if err := json.Unmarshal(assuranceBytes, &assuranceCtx); err != nil {
-		logger.Debug("Failed to unmarshal assurance claim to AssuranceContext", log.Error(err))
+		logger.DebugWithContext(ctx, "Failed to unmarshal assurance claim to AssuranceContext", log.Error(err))
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
@@ -630,33 +631,33 @@ func (as *authenticationService) verifyAndDecodeSessionToken(ctx context.Context
 	jwtConfig := config.GetServerRuntime().Config.JWT
 	svcErr := as.jwtService.VerifyJWT(ctx, token, "auth-svc", jwtConfig.Issuer)
 	if svcErr != nil {
-		logger.Debug("Error verifying session token", log.String("error", svcErr.Error.DefaultValue))
+		logger.DebugWithContext(ctx, "Error verifying session token", log.String("error", svcErr.Error.DefaultValue))
 		return nil, &common.ErrorInvalidSessionToken
 	}
 
 	// Parse and extract authentication session data
 	payload, err := jwt.DecodeJWTPayload(token)
 	if err != nil {
-		logger.Debug("Error decoding session token payload", log.Error(err))
+		logger.DebugWithContext(ctx, "Error decoding session token payload", log.Error(err))
 		return nil, &common.ErrorInvalidSessionToken
 	}
 
 	authDataClaim, ok := payload["auth_data"]
 	if !ok {
-		logger.Debug("auth_data claim not found in session token")
+		logger.DebugWithContext(ctx, "auth_data claim not found in session token")
 		return nil, &common.ErrorInvalidSessionToken
 	}
 
 	authDataBytes, err := json.Marshal(authDataClaim)
 	if err != nil {
-		logger.Debug("Error marshaling auth_data claim", log.Error(err))
+		logger.DebugWithContext(ctx, "Error marshaling auth_data claim", log.Error(err))
 		return nil, &common.ErrorInvalidSessionToken
 	}
 
 	var sessionData AuthSessionData
 	err = json.Unmarshal(authDataBytes, &sessionData)
 	if err != nil {
-		logger.Debug("Error marshaling auth_data claim", log.Error(err))
+		logger.DebugWithContext(ctx, "Error marshaling auth_data claim", log.Error(err))
 		return nil, &common.ErrorInvalidSessionToken
 	}
 
@@ -669,7 +670,7 @@ func (as *authenticationService) StartPasskeyRegistration(
 	authSelection *PasskeyAuthenticatorSelectionDTO, attestation string,
 ) (interface{}, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.Debug("Starting Passkey registration")
+	logger.DebugWithContext(ctx, "Starting Passkey registration")
 
 	var passkeyAuthSel *passkey.AuthenticatorSelection
 	if authSelection != nil {
@@ -698,7 +699,7 @@ func (as *authenticationService) FinishPasskeyRegistration(
 	sessionToken, credentialName string,
 ) (interface{}, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.Debug("Finishing Passkey registration")
+	logger.DebugWithContext(ctx, "Finishing Passkey registration")
 
 	req := &passkey.PasskeyRegistrationFinishRequest{
 		CredentialID:      credential.ID,
@@ -716,7 +717,7 @@ func (as *authenticationService) FinishPasskeyRegistration(
 func (as *authenticationService) StartPasskeyAuthentication(ctx context.Context, userID, relyingPartyID string) (
 	interface{}, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.Debug("Starting Passkey authentication")
+	logger.DebugWithContext(ctx, "Starting Passkey authentication")
 
 	req := &passkey.PasskeyAuthenticationStartRequest{
 		UserID:         userID,
@@ -730,7 +731,7 @@ func (as *authenticationService) FinishPasskeyAuthentication(ctx context.Context
 	response PasskeyCredentialResponseDTO, sessionToken string, skipAssertion bool,
 	existingAssertion string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.Debug("Finishing Passkey authentication")
+	logger.DebugWithContext(ctx, "Finishing Passkey authentication")
 
 	passkeyCredential := &passkey.PasskeyAuthenticationFinishRequest{
 		CredentialID:      credentialID,

--- a/backend/internal/authnprovider/manager/manager.go
+++ b/backend/internal/authnprovider/manager/manager.go
@@ -51,7 +51,7 @@ func (m *authnProviderManager) AuthenticateUser(ctx context.Context, identifiers
 	result, svcErr := m.provider.Authenticate(ctx, identifiers, credentials, metadata)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
-			m.logger.Error("provider returned server error during authentication",
+			m.logger.ErrorWithContext(ctx, "provider returned server error during authentication",
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			return AuthUser{}, nil, &serviceerror.InternalServerError
 		}
@@ -105,12 +105,12 @@ func (m *authnProviderManager) AuthenticateUser(ctx context.Context, identifiers
 func (m *authnProviderManager) GetUserAvailableAttributes(ctx context.Context,
 	authUser AuthUser) (*authnprovidercm.AttributesResponse, *serviceerror.ServiceError) {
 	if !authUser.IsAuthenticated() {
-		m.logger.Error("GetUserAvailableAttributes called with unauthenticated authUser")
+		m.logger.ErrorWithContext(ctx, "GetUserAvailableAttributes called with unauthenticated authUser")
 		return nil, &serviceerror.InternalServerError
 	}
 	data, ok := authUser.getProviderData(defaultProvider)
 	if !ok {
-		m.logger.Error("GetUserAvailableAttributes: no provider data found for default provider")
+		m.logger.ErrorWithContext(ctx, "GetUserAvailableAttributes: no provider data found for default provider")
 		return nil, &serviceerror.InternalServerError
 	}
 	return data.attributes, nil
@@ -122,12 +122,12 @@ func (m *authnProviderManager) GetUserAttributes(ctx context.Context,
 	metadata *authnprovidercm.GetAttributesMetadata,
 	authUser AuthUser) (AuthUser, *authnprovidercm.AttributesResponse, *serviceerror.ServiceError) {
 	if !authUser.IsAuthenticated() {
-		m.logger.Error("GetUserAttributes called with unauthenticated authUser")
+		m.logger.ErrorWithContext(ctx, "GetUserAttributes called with unauthenticated authUser")
 		return AuthUser{}, nil, &serviceerror.InternalServerError
 	}
 	data, ok := authUser.getProviderData(defaultProvider)
 	if !ok {
-		m.logger.Error("GetUserAttributes: no provider data found for default provider")
+		m.logger.ErrorWithContext(ctx, "GetUserAttributes: no provider data found for default provider")
 		return AuthUser{}, nil, &serviceerror.InternalServerError
 	}
 	if data.isAttributeValuesIncluded {
@@ -136,7 +136,7 @@ func (m *authnProviderManager) GetUserAttributes(ctx context.Context,
 	result, svcErr := m.provider.GetAttributes(ctx, data.token, requestedAttributes, metadata)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
-			m.logger.Error("provider returned server error while fetching attributes",
+			m.logger.ErrorWithContext(ctx, "provider returned server error while fetching attributes",
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			return AuthUser{}, nil, &serviceerror.InternalServerError
 		}

--- a/backend/internal/authz/service.go
+++ b/backend/internal/authz/service.go
@@ -58,7 +58,7 @@ func (s *authorizationService) GetAuthorizedPermissions(
 	request GetAuthorizedPermissionsRequest,
 ) (*GetAuthorizedPermissionsResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Evaluating authorization request",
+	logger.DebugWithContext(ctx, "Evaluating authorization request",
 		log.MaskedString(log.LoggerKeyUserID, request.EntityID),
 		log.Int("groupCount", len(request.GroupIDs)),
 		log.Int("requestedPermissionCount", len(request.RequestedPermissions)))
@@ -83,14 +83,14 @@ func (s *authorizationService) GetAuthorizedPermissions(
 		request.RequestedPermissions,
 	)
 	if err != nil {
-		logger.Error("Authorization evaluation failed",
+		logger.ErrorWithContext(ctx, "Authorization evaluation failed",
 			log.MaskedString(log.LoggerKeyUserID, request.EntityID),
 			log.Int("groupCount", len(request.GroupIDs)),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Authorization evaluation completed",
+	logger.DebugWithContext(ctx, "Authorization evaluation completed",
 		log.MaskedString(log.LoggerKeyUserID, request.EntityID),
 		log.Int("groupCount", len(request.GroupIDs)),
 		log.Int("requestedCount", len(request.RequestedPermissions)),

--- a/backend/internal/cert/cache_backed_store.go
+++ b/backend/internal/cert/cache_backed_store.go
@@ -198,10 +198,10 @@ func (s *cacheBackedStore) cacheCertificate(ctx context.Context, cert *Certifica
 			Key: cert.ID,
 		}
 		if err := s.certByIDCache.Set(ctx, idCacheKey, cert); err != nil {
-			logger.Error("Failed to cache certificate by ID", log.Error(err),
+			logger.ErrorWithContext(ctx, "Failed to cache certificate by ID", log.Error(err),
 				log.String("certID", cert.ID))
 		} else {
-			logger.Debug("Certificate cached by ID", log.String("certID", cert.ID))
+			logger.DebugWithContext(ctx, "Certificate cached by ID", log.String("certID", cert.ID))
 		}
 	}
 
@@ -209,10 +209,10 @@ func (s *cacheBackedStore) cacheCertificate(ctx context.Context, cert *Certifica
 	if cert.RefType != "" && cert.RefID != "" {
 		refCacheKey := getCertByReferenceCacheKey(cert.RefType, cert.RefID)
 		if err := s.certByReferenceCache.Set(ctx, refCacheKey, cert); err != nil {
-			logger.Error("Failed to cache certificate by reference", log.Error(err),
+			logger.ErrorWithContext(ctx, "Failed to cache certificate by reference", log.Error(err),
 				log.String("refType", string(cert.RefType)), log.String("refID", cert.RefID))
 		} else {
-			logger.Debug("Certificate cached by reference", log.String("refType", string(cert.RefType)),
+			logger.DebugWithContext(ctx, "Certificate cached by reference", log.String("refType", string(cert.RefType)),
 				log.String("refID", cert.RefID))
 		}
 	}
@@ -229,10 +229,10 @@ func (s *cacheBackedStore) invalidateCertificateCache(ctx context.Context, id st
 			Key: id,
 		}
 		if err := s.certByIDCache.Delete(ctx, idCacheKey); err != nil {
-			logger.Error("Failed to invalidate certificate cache by ID", log.Error(err),
+			logger.ErrorWithContext(ctx, "Failed to invalidate certificate cache by ID", log.Error(err),
 				log.String("certID", id))
 		} else {
-			logger.Debug("Certificate cache invalidated by ID", log.String("certID", id))
+			logger.DebugWithContext(ctx, "Certificate cache invalidated by ID", log.String("certID", id))
 		}
 	}
 
@@ -240,10 +240,11 @@ func (s *cacheBackedStore) invalidateCertificateCache(ctx context.Context, id st
 	if refType != "" && refID != "" {
 		refCacheKey := getCertByReferenceCacheKey(refType, refID)
 		if err := s.certByReferenceCache.Delete(ctx, refCacheKey); err != nil {
-			logger.Error("Failed to invalidate certificate cache by reference", log.Error(err),
+			logger.ErrorWithContext(ctx, "Failed to invalidate certificate cache by reference", log.Error(err),
 				log.String("refType", string(refType)), log.String("refID", refID))
 		} else {
-			logger.Debug("Certificate cache invalidated by reference", log.String("refType", string(refType)),
+			logger.DebugWithContext(ctx, "Certificate cache invalidated by reference",
+				log.String("refType", string(refType)),
 				log.String("refID", refID))
 		}
 	}

--- a/backend/internal/cert/service.go
+++ b/backend/internal/cert/service.go
@@ -75,11 +75,11 @@ func (s *certificateService) GetCertificateByID(ctx context.Context,
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.Error("Failed to get certificate by ID", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get certificate by ID", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if certObj == nil {
-		logger.Debug("Certificate not found for ID", log.String("id", id))
+		logger.DebugWithContext(ctx, "Certificate not found for ID", log.String("id", id))
 		return nil, &ErrorCertificateNotFound
 	}
 
@@ -103,12 +103,12 @@ func (s *certificateService) GetCertificateByReference(ctx context.Context, refT
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.Error("Failed to get certificate by reference", log.String("refType", string(refType)),
+		logger.ErrorWithContext(ctx, "Failed to get certificate by reference", log.String("refType", string(refType)),
 			log.String("refID", refID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if certObj == nil {
-		logger.Debug("Certificate not found for reference", log.String("refType", string(refType)),
+		logger.DebugWithContext(ctx, "Certificate not found for reference", log.String("refType", string(refType)),
 			log.String("refID", refID))
 		return nil, &ErrorCertificateNotFound
 	}
@@ -128,7 +128,8 @@ func (s *certificateService) CreateCertificate(ctx context.Context, cert *Certif
 	// Check if a certificate with the same reference already exists
 	existingCert, err := s.store.GetCertificateByReference(ctx, cert.RefType, cert.RefID)
 	if err != nil && !errors.Is(err, ErrCertificateNotFound) {
-		logger.Error("Failed to check existing certificate", log.String("refType", string(cert.RefType)),
+		logger.ErrorWithContext(ctx, "Failed to check existing certificate",
+			log.String("refType", string(cert.RefType)),
 			log.String("refID", cert.RefID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -138,7 +139,7 @@ func (s *certificateService) CreateCertificate(ctx context.Context, cert *Certif
 
 	cert.ID, err = sysutils.GenerateUUIDv7()
 	if err != nil {
-		logger.Error("Failed to generate UUID", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -146,7 +147,7 @@ func (s *certificateService) CreateCertificate(ctx context.Context, cert *Certif
 		return s.store.CreateCertificate(txCtx, cert)
 	})
 	if err != nil {
-		logger.Error("Failed to create certificate", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to create certificate", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -171,11 +172,11 @@ func (s *certificateService) UpdateCertificateByID(ctx context.Context, id strin
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.Error("Failed to get existing certificate", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get existing certificate", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if existingCert == nil {
-		logger.Debug("Certificate not found for update", log.String("id", id))
+		logger.DebugWithContext(ctx, "Certificate not found for update", log.String("id", id))
 		return nil, &ErrorCertificateNotFound
 	}
 
@@ -191,7 +192,7 @@ func (s *certificateService) UpdateCertificateByID(ctx context.Context, id strin
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.Error("Failed to update certificate by ID", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to update certificate by ID", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -219,12 +220,12 @@ func (s *certificateService) UpdateCertificateByReference(ctx context.Context, r
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.Error("Failed to get existing certificate", log.String("refType", string(refType)),
+		logger.ErrorWithContext(ctx, "Failed to get existing certificate", log.String("refType", string(refType)),
 			log.String("refID", refID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if existingCert == nil {
-		logger.Debug("Certificate not found for update", log.String("refType", string(refType)),
+		logger.DebugWithContext(ctx, "Certificate not found for update", log.String("refType", string(refType)),
 			log.String("refID", refID))
 		return nil, &ErrorCertificateNotFound
 	}
@@ -242,7 +243,8 @@ func (s *certificateService) UpdateCertificateByReference(ctx context.Context, r
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.Error("Failed to update certificate by reference", log.String("refType", string(refType)),
+		logger.ErrorWithContext(ctx, "Failed to update certificate by reference",
+			log.String("refType", string(refType)),
 			log.String("refID", refID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -262,7 +264,7 @@ func (s *certificateService) DeleteCertificateByID(ctx context.Context, id strin
 		return s.store.DeleteCertificateByID(txCtx, id)
 	})
 	if err != nil {
-		logger.Error("Failed to delete certificate by ID", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to delete certificate by ID", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -285,7 +287,8 @@ func (s *certificateService) DeleteCertificateByReference(ctx context.Context, r
 		return s.store.DeleteCertificateByReference(txCtx, refType, refID)
 	})
 	if err != nil {
-		logger.Error("Failed to delete certificate by reference", log.String("refType", string(refType)),
+		logger.ErrorWithContext(ctx, "Failed to delete certificate by reference",
+			log.String("refType", string(refType)),
 			log.String("refID", refID), log.Error(err))
 		return &serviceerror.InternalServerError
 	}

--- a/backend/internal/consent/default_client.go
+++ b/backend/internal/consent/default_client.go
@@ -262,7 +262,7 @@ func (c *defaultClient) createConsentElements(ctx context.Context, ouID string, 
 
 	result, err := sysutils.DecodeJSONResponse[elementsCreateResponseDTO](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode create-elements response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode create-elements response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -294,7 +294,7 @@ func (c *defaultClient) listConsentElements(ctx context.Context, ouID string, ns
 
 	result, err := sysutils.DecodeJSONResponse[elementListResponseDTO](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode list-elements response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode list-elements response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -336,7 +336,7 @@ func (c *defaultClient) updateConsentElement(ctx context.Context, ouID, elementI
 
 	result, err := sysutils.DecodeJSONResponse[elementResponseDTO](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode update-element response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode update-element response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	el := c.dtoToConsentElement(result)
@@ -391,7 +391,7 @@ func (c *defaultClient) validateConsentElements(ctx context.Context, ouID string
 
 	result, err := sysutils.DecodeJSONResponse[[]string](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode validate-elements response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode validate-elements response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -430,7 +430,7 @@ func (c *defaultClient) createConsentPurpose(ctx context.Context, ouID string, p
 
 	result, err := sysutils.DecodeJSONResponse[purposeResponseDTO](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode create-purpose response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode create-purpose response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	p := c.dtoToConsentPurpose(result)
@@ -463,7 +463,7 @@ func (c *defaultClient) listConsentPurposes(ctx context.Context, ouID, groupID s
 
 	result, err := sysutils.DecodeJSONResponse[purposeListResponseDTO](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode list-purposes response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode list-purposes response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -505,7 +505,7 @@ func (c *defaultClient) updateConsentPurpose(ctx context.Context, ouID, purposeI
 
 	result, err := sysutils.DecodeJSONResponse[purposeResponseDTO](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode update-purpose response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode update-purpose response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	p := c.dtoToConsentPurpose(result)
@@ -565,7 +565,7 @@ func (c *defaultClient) createConsent(ctx context.Context, ouID string, req *Con
 
 	result, err := sysutils.DecodeJSONResponse[consentResponseDTO](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode create-consent response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode create-consent response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	out := c.dtoToConsent(result)
@@ -597,7 +597,7 @@ func (c *defaultClient) searchConsents(ctx context.Context, ouID string, filter 
 
 	result, err := sysutils.DecodeJSONResponse[consentSearchResponseDTO](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode search-consents response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode search-consents response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -663,7 +663,7 @@ func (c *defaultClient) validateConsent(ctx context.Context, ouID, consentID str
 
 	result, err := sysutils.DecodeJSONResponse[consentValidateResponseDTO](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode validate-consent response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode validate-consent response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -698,7 +698,7 @@ func (c *defaultClient) updateConsent(ctx context.Context, ouID, consentID strin
 
 	result, err := sysutils.DecodeJSONResponse[consentResponseDTO](resp)
 	if err != nil {
-		c.logger.Error("Failed to decode update-consent response", log.Error(err))
+		c.logger.ErrorWithContext(ctx, "Failed to decode update-consent response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	out := c.dtoToConsent(result)
@@ -1065,7 +1065,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		var merr error
 		encodedBody, merr = json.Marshal(body)
 		if merr != nil {
-			c.logger.Debug("Failed to marshal request body", log.Error(merr))
+			c.logger.DebugWithContext(ctx, "Failed to marshal request body", log.Error(merr))
 			return nil, &ErrorInvalidRequestFormat
 		}
 	}
@@ -1078,7 +1078,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
-				c.logger.Warn("Consent request cancelled during retry", log.Error(ctx.Err()))
+				c.logger.WarnWithContext(ctx, "Consent request cancelled during retry", log.Error(ctx.Err()))
 				return nil, &serviceerror.InternalServerError
 			case <-time.After(backoff):
 			}
@@ -1096,7 +1096,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		req, err := http.NewRequestWithContext(reqCtx, method, url, bodyReader)
 		if err != nil {
 			cancel()
-			c.logger.Error("Failed to create HTTP request", log.Error(err))
+			c.logger.ErrorWithContext(ctx, "Failed to create HTTP request", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 
@@ -1109,7 +1109,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		if err != nil {
 			cancel()
 			lastErr = err
-			c.logger.Warn("Error reaching consent service, will retry if attempts remain",
+			c.logger.WarnWithContext(ctx, "Error reaching consent service, will retry if attempts remain",
 				log.Error(err), log.Int("attempt", attempt+1), log.Int("maxAttempts", maxAttempts))
 			continue
 		}
@@ -1117,7 +1117,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		// For 5xx responses, retry if attempts remain; on the last attempt return the
 		// response so checkStatus can inspect the final status code and body.
 		if resp.StatusCode >= http.StatusInternalServerError {
-			c.logger.Warn("Consent service returned server error, will retry if attempts remain",
+			c.logger.WarnWithContext(ctx, "Consent service returned server error, will retry if attempts remain",
 				log.Int("status", resp.StatusCode), log.Int("attempt", attempt+1),
 				log.Int("maxAttempts", maxAttempts))
 
@@ -1139,7 +1139,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		return resp, nil
 	}
 
-	c.logger.Error("All retry attempts exceeded for consent service request",
+	c.logger.ErrorWithContext(ctx, "All retry attempts exceeded for consent service request",
 		log.String("method", method), log.Error(lastErr))
 
 	return nil, &serviceerror.InternalServerError

--- a/backend/internal/consent/service.go
+++ b/backend/internal/consent/service.go
@@ -85,7 +85,7 @@ func (s *consentService) DeleteConsentElement(ctx context.Context, ouID string,
 	elementID string) *serviceerror.ServiceError {
 	svcErr := s.client.deleteConsentElement(ctx, ouID, elementID)
 	if svcErr != nil && svcErr.Code == ErrorConsentElementNotFound.Code {
-		s.logger.Debug("Consent element not found during delete, skipping",
+		s.logger.DebugWithContext(ctx, "Consent element not found during delete, skipping",
 			log.String("elementID", elementID))
 		return nil
 	}
@@ -131,7 +131,7 @@ func (s *consentService) DeleteConsentPurpose(ctx context.Context, ouID string,
 	purposeID string) *serviceerror.ServiceError {
 	svcErr := s.client.deleteConsentPurpose(ctx, ouID, purposeID)
 	if svcErr != nil && svcErr.Code == ErrorConsentPurposeNotFound.Code {
-		s.logger.Debug("Consent purpose not found during delete, skipping",
+		s.logger.DebugWithContext(ctx, "Consent purpose not found during delete, skipping",
 			log.String("purposeID", purposeID))
 		return nil
 	}

--- a/backend/internal/design/layout/mgt/handler.go
+++ b/backend/internal/design/layout/mgt/handler.go
@@ -84,7 +84,7 @@ func (lh *layoutMgtHandler) HandleLayoutListRequest(w http.ResponseWriter, r *ht
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, layoutListResponse)
 
-	lh.logger.Debug("Successfully listed layout configurations with pagination",
+	lh.logger.DebugWithContext(r.Context(), "Successfully listed layout configurations with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", layoutListResponse.TotalResults),
 		log.Int("count", layoutListResponse.Count))
@@ -117,7 +117,8 @@ func (lh *layoutMgtHandler) HandleLayoutPostRequest(w http.ResponseWriter, r *ht
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, layoutResponse)
 
-	lh.logger.Debug("Successfully created layout configuration", log.String("id", createdLayout.ID))
+	lh.logger.DebugWithContext(r.Context(), "Successfully created layout configuration",
+		log.String("id", createdLayout.ID))
 }
 
 // HandleLayoutGetRequest handles the get layout configuration request.
@@ -142,7 +143,7 @@ func (lh *layoutMgtHandler) HandleLayoutGetRequest(w http.ResponseWriter, r *htt
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, layoutResponse)
 
-	lh.logger.Debug("Successfully retrieved layout configuration", log.String("id", id))
+	lh.logger.DebugWithContext(r.Context(), "Successfully retrieved layout configuration", log.String("id", id))
 }
 
 // HandleLayoutPutRequest handles the update layout configuration request.
@@ -173,7 +174,7 @@ func (lh *layoutMgtHandler) HandleLayoutPutRequest(w http.ResponseWriter, r *htt
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, layoutResponse)
 
-	lh.logger.Debug("Successfully updated layout configuration", log.String("id", id))
+	lh.logger.DebugWithContext(r.Context(), "Successfully updated layout configuration", log.String("id", id))
 }
 
 // HandleLayoutDeleteRequest handles the delete layout configuration request.
@@ -186,7 +187,7 @@ func (lh *layoutMgtHandler) HandleLayoutDeleteRequest(w http.ResponseWriter, r *
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
-	lh.logger.Debug("Successfully deleted layout configuration", log.String("id", id))
+	lh.logger.DebugWithContext(r.Context(), "Successfully deleted layout configuration", log.String("id", id))
 }
 
 // parsePaginationParams parses limit and offset query parameters from the request.

--- a/backend/internal/design/resolve/handler.go
+++ b/backend/internal/design/resolve/handler.go
@@ -60,7 +60,7 @@ func (rh *designResolveHandler) HandleResolveRequest(w http.ResponseWriter, r *h
 
 	utils.WriteSuccessResponse(w, http.StatusOK, designResponse)
 
-	rh.logger.Debug("Successfully resolved design configuration",
+	rh.logger.DebugWithContext(ctx, "Successfully resolved design configuration",
 		log.String("type", string(resolveType)),
 		log.String("id", id))
 }

--- a/backend/internal/design/resolve/service.go
+++ b/backend/internal/design/resolve/service.go
@@ -82,7 +82,7 @@ func (drs *designResolveService) ResolveDesign(
 
 	// Get the application by ID
 	if drs.applicationService == nil {
-		drs.logger.Error("Application service is not available")
+		drs.logger.ErrorWithContext(ctx, "Application service is not available")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -108,14 +108,14 @@ func (drs *designResolveService) ResolveDesign(
 	// Get theme configuration if available
 	if app.ThemeID != "" {
 		if drs.themeMgtService == nil {
-			drs.logger.Error("Theme management service is not available")
+			drs.logger.ErrorWithContext(ctx, "Theme management service is not available")
 			return nil, &serviceerror.InternalServerError
 		}
 
 		themeConfig, svcErr := drs.themeMgtService.GetTheme(app.ThemeID)
 		if svcErr != nil {
 			if svcErr.Code == thememgt.ErrorThemeNotFound.Code {
-				drs.logger.Error("Data integrity issue: application references non-existent theme",
+				drs.logger.ErrorWithContext(ctx, "Data integrity issue: application references non-existent theme",
 					log.String("applicationId", id),
 					log.String("themeId", app.ThemeID))
 				return nil, &serviceerror.InternalServerError
@@ -129,14 +129,14 @@ func (drs *designResolveService) ResolveDesign(
 	// Get layout configuration if available
 	if app.LayoutID != "" {
 		if drs.layoutMgtService == nil {
-			drs.logger.Error("Layout management service is not available")
+			drs.logger.ErrorWithContext(ctx, "Layout management service is not available")
 			return nil, &serviceerror.InternalServerError
 		}
 
 		layoutConfig, svcErr := drs.layoutMgtService.GetLayout(app.LayoutID)
 		if svcErr != nil {
 			if svcErr.Code == layoutmgt.ErrorLayoutNotFound.Code {
-				drs.logger.Error("Data integrity issue: application references non-existent layout",
+				drs.logger.ErrorWithContext(ctx, "Data integrity issue: application references non-existent layout",
 					log.String("applicationId", id),
 					log.String("layoutId", app.LayoutID))
 				return nil, &serviceerror.InternalServerError
@@ -147,7 +147,7 @@ func (drs *designResolveService) ResolveDesign(
 		designResponse.Layout = layoutConfig.Layout
 	}
 
-	drs.logger.Debug("Successfully resolved design configuration",
+	drs.logger.DebugWithContext(ctx, "Successfully resolved design configuration",
 		log.String("type", string(resolveType)),
 		log.String("id", id),
 		log.String("themeId", app.ThemeID),

--- a/backend/internal/design/theme/mgt/handler.go
+++ b/backend/internal/design/theme/mgt/handler.go
@@ -87,7 +87,7 @@ func (th *themeMgtHandler) HandleThemeListRequest(w http.ResponseWriter, r *http
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, themeListResponse)
 
-	th.logger.Debug("Successfully listed theme configurations with pagination",
+	th.logger.DebugWithContext(r.Context(), "Successfully listed theme configurations with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", themeListResponse.TotalResults),
 		log.Int("count", themeListResponse.Count))
@@ -124,7 +124,8 @@ func (th *themeMgtHandler) HandleThemePostRequest(w http.ResponseWriter, r *http
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, themeResponse)
 
-	th.logger.Debug("Successfully created theme configuration", log.String("id", createdTheme.ID))
+	th.logger.DebugWithContext(r.Context(), "Successfully created theme configuration",
+		log.String("id", createdTheme.ID))
 }
 
 // HandleThemeGetRequest handles the get theme configuration request.
@@ -148,7 +149,7 @@ func (th *themeMgtHandler) HandleThemeGetRequest(w http.ResponseWriter, r *http.
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, themeResponse)
 
-	th.logger.Debug("Successfully retrieved theme configuration", log.String("id", id))
+	th.logger.DebugWithContext(r.Context(), "Successfully retrieved theme configuration", log.String("id", id))
 }
 
 // HandleThemePutRequest handles the update theme configuration request.
@@ -178,7 +179,7 @@ func (th *themeMgtHandler) HandleThemePutRequest(w http.ResponseWriter, r *http.
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, themeResponse)
 
-	th.logger.Debug("Successfully updated theme configuration", log.String("id", id))
+	th.logger.DebugWithContext(r.Context(), "Successfully updated theme configuration", log.String("id", id))
 }
 
 // HandleThemeDeleteRequest handles the delete theme configuration request.
@@ -191,7 +192,7 @@ func (th *themeMgtHandler) HandleThemeDeleteRequest(w http.ResponseWriter, r *ht
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
-	th.logger.Debug("Successfully deleted theme configuration", log.String("id", id))
+	th.logger.DebugWithContext(r.Context(), "Successfully deleted theme configuration", log.String("id", id))
 }
 
 // parsePaginationParams parses limit and offset query parameters from the request.

--- a/backend/internal/entity/cache_backed_store.go
+++ b/backend/internal/entity/cache_backed_store.go
@@ -178,7 +178,7 @@ func (s *cacheBackedEntityStore) IdentifyEntity(ctx context.Context,
 
 			if err := s.entityIDByIdentifierCache.Set(ctx,
 				compositeKey, entityID); err != nil {
-				s.logger.Error("Failed to cache entity ID by identifier",
+				s.logger.ErrorWithContext(ctx, "Failed to cache entity ID by identifier",
 					log.String("key", filterKey), log.String("value", val), log.Error(err))
 			}
 			return entityID, nil
@@ -300,7 +300,7 @@ func (s *cacheBackedEntityStore) cacheEntityIDByIdentifiers(ctx context.Context,
 		}
 		if err := s.entityIDByIdentifierCache.Set(ctx,
 			identifierCacheKey(key, val), &entity.ID); err != nil {
-			s.logger.Error("Failed to cache entity ID by identifier",
+			s.logger.ErrorWithContext(ctx, "Failed to cache entity ID by identifier",
 				log.String("key", key), log.String("value", val), log.Error(err))
 		}
 	}
@@ -316,7 +316,7 @@ func (s *cacheBackedEntityStore) invalidateIdentifierCache(ctx context.Context, 
 	} else {
 		fetched, err := s.store.GetEntity(ctx, entityID)
 		if err != nil {
-			s.logger.Error("Failed to fetch entity for identifier cache invalidation",
+			s.logger.ErrorWithContext(ctx, "Failed to fetch entity for identifier cache invalidation",
 				log.String("entityID", entityID), log.Error(err))
 			return
 		}
@@ -330,7 +330,7 @@ func (s *cacheBackedEntityStore) invalidateIdentifierCache(ctx context.Context, 
 		}
 		if err := s.entityIDByIdentifierCache.Delete(ctx,
 			identifierCacheKey(key, val)); err != nil {
-			s.logger.Error("Failed to invalidate identifier cache",
+			s.logger.ErrorWithContext(ctx, "Failed to invalidate identifier cache",
 				log.String("key", key), log.String("value", val), log.Error(err))
 		}
 	}
@@ -341,7 +341,7 @@ func (s *cacheBackedEntityStore) cacheEntityByID(ctx context.Context, entity *En
 		return
 	}
 	if err := s.entityByIDCache.Set(ctx, cache.CacheKey{Key: entity.ID}, entity); err != nil {
-		s.logger.Error("Failed to cache entity by ID",
+		s.logger.ErrorWithContext(ctx, "Failed to cache entity by ID",
 			log.String("entityID", entity.ID), log.Error(err))
 	}
 }
@@ -353,7 +353,7 @@ func (s *cacheBackedEntityStore) cacheEntityWithCredentialsByID(ctx context.Cont
 	}
 	if err := s.entityWithCredentialsByIDCache.Set(ctx,
 		cache.CacheKey{Key: ewc.Entity.ID}, ewc); err != nil {
-		s.logger.Error("Failed to cache entity with credentials by ID",
+		s.logger.ErrorWithContext(ctx, "Failed to cache entity with credentials by ID",
 			log.String("entityID", ewc.Entity.ID), log.Error(err))
 	}
 }
@@ -363,11 +363,11 @@ func (s *cacheBackedEntityStore) invalidateEntityByID(ctx context.Context, entit
 		return
 	}
 	if err := s.entityByIDCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
-		s.logger.Error("Failed to invalidate entity cache by ID",
+		s.logger.ErrorWithContext(ctx, "Failed to invalidate entity cache by ID",
 			log.String("entityID", entityID), log.Error(err))
 	}
 	if err := s.entityWithCredentialsByIDCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
-		s.logger.Error("Failed to invalidate entity with credentials cache by ID",
+		s.logger.ErrorWithContext(ctx, "Failed to invalidate entity with credentials cache by ID",
 			log.String("entityID", entityID), log.Error(err))
 	}
 }

--- a/backend/internal/entity/service.go
+++ b/backend/internal/entity/service.go
@@ -139,7 +139,7 @@ func (s *entityService) CreateEntity(ctx context.Context, entity *Entity,
 		}
 		entity.ID = id
 	}
-	s.logger.Debug("Creating entity", log.MaskedString("id", entity.ID))
+	s.logger.DebugWithContext(ctx, "Creating entity", log.MaskedString("id", entity.ID))
 
 	// Validate entity attributes and uniqueness via schema.
 	if err := s.validateEntityType(ctx, entity.Category, entity.Type, entity.Attributes, "", false); err != nil {
@@ -224,7 +224,7 @@ func (s *entityService) UpdateEntity(ctx context.Context, entityID string, entit
 	if entity == nil {
 		return nil, ErrEntityNotFound
 	}
-	s.logger.Debug("Updating entity", log.MaskedString("id", entityID))
+	s.logger.DebugWithContext(ctx, "Updating entity", log.MaskedString("id", entityID))
 
 	// Validate entity attributes and uniqueness via schema (excludes self for uniqueness).
 	if err := s.validateEntityType(ctx, entity.Category, entity.Type, entity.Attributes, entityID, true); err != nil {
@@ -275,7 +275,7 @@ func (s *entityService) UpdateEntity(ctx context.Context, entityID string, entit
 // DeleteEntity deletes an entity.
 // Uses a transaction to ensure the entity row and its indexed identifiers are deleted atomically.
 func (s *entityService) DeleteEntity(ctx context.Context, entityID string) error {
-	s.logger.Debug("Deleting entity", log.MaskedString("id", entityID))
+	s.logger.DebugWithContext(ctx, "Deleting entity", log.MaskedString("id", entityID))
 	err := s.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		return s.store.DeleteEntity(txCtx, entityID)
 	})
@@ -286,7 +286,7 @@ func (s *entityService) DeleteEntity(ctx context.Context, entityID string) error
 // Any credential fields present in the attributes are extracted, hashed, and merged
 // with the existing credentials atomically.
 func (s *entityService) UpdateAttributes(ctx context.Context, entityID string, attributes json.RawMessage) error {
-	s.logger.Debug("Updating entity attributes", log.MaskedString("id", entityID))
+	s.logger.DebugWithContext(ctx, "Updating entity attributes", log.MaskedString("id", entityID))
 
 	// Load entity to get its category and type for schema validation and credential extraction.
 	existing, err := s.store.GetEntity(ctx, entityID)
@@ -334,7 +334,7 @@ func (s *entityService) UpdateAttributes(ctx context.Context, entityID string, a
 // UpdateSystemAttributes updates the system-managed attributes of an entity.
 func (s *entityService) UpdateSystemAttributes(ctx context.Context, entityID string,
 	attrs json.RawMessage) error {
-	s.logger.Debug("Updating entity system attributes", log.MaskedString("id", entityID))
+	s.logger.DebugWithContext(ctx, "Updating entity system attributes", log.MaskedString("id", entityID))
 	return s.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		return s.store.UpdateSystemAttributes(txCtx, entityID, attrs)
 	})
@@ -739,7 +739,7 @@ func (s *entityService) populateOUHandles(ctx context.Context, entities []Entity
 	}
 	handleMap, svcErr := s.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
 	if svcErr != nil {
-		s.logger.Warn("Failed to resolve OU handles, skipping", log.Any("error", svcErr))
+		s.logger.WarnWithContext(ctx, "Failed to resolve OU handles, skipping", log.Any("error", svcErr))
 		return
 	}
 	for i := range entities {

--- a/backend/internal/entity/store.go
+++ b/backend/internal/entity/store.go
@@ -506,14 +506,15 @@ func (es *entityDBStore) IdentifyEntity(ctx context.Context,
 
 	if len(results) == 0 {
 		if es.logger.IsDebugEnabled() {
-			es.logger.Debug("Entity not found with the provided filters", log.MaskedMap("filters", filters))
+			es.logger.DebugWithContext(ctx, "Entity not found with the provided filters",
+				log.MaskedMap("filters", filters))
 		}
 		return nil, ErrEntityNotFound
 	}
 
 	if len(results) != 1 {
 		if es.logger.IsDebugEnabled() {
-			es.logger.Debug(
+			es.logger.DebugWithContext(ctx,
 				"Unexpected number of results for the provided filters",
 				log.MaskedMap("filters", filters),
 				log.Int("result_count", len(results)),

--- a/backend/internal/entitytype/cache_backed_store.go
+++ b/backend/internal/entitytype/cache_backed_store.go
@@ -207,7 +207,7 @@ func (s *cachedBackedEntityTypeStore) cacheEntityType(ctx context.Context, schem
 	if schema.ID != "" {
 		key := cacheKeyForID(schema.Category, schema.ID)
 		if err := s.schemaByIDCache.Set(ctx, key, schema); err != nil {
-			s.logger.Error("Failed to cache entity type by ID",
+			s.logger.ErrorWithContext(ctx, "Failed to cache entity type by ID",
 				log.String("schemaID", schema.ID), log.Error(err))
 		}
 	}
@@ -215,7 +215,7 @@ func (s *cachedBackedEntityTypeStore) cacheEntityType(ctx context.Context, schem
 	if schema.Name != "" {
 		key := cacheKeyForName(schema.Category, schema.Name)
 		if err := s.schemaByNameCache.Set(ctx, key, schema); err != nil {
-			s.logger.Error("Failed to cache entity type by name",
+			s.logger.ErrorWithContext(ctx, "Failed to cache entity type by name",
 				log.String("schemaName", schema.Name), log.Error(err))
 		}
 	}
@@ -227,7 +227,7 @@ func (s *cachedBackedEntityTypeStore) invalidateEntityTypeCache(ctx context.Cont
 	if schemaID != "" {
 		key := cacheKeyForID(category, schemaID)
 		if err := s.schemaByIDCache.Delete(ctx, key); err != nil {
-			s.logger.Error("Failed to invalidate entity type cache by ID",
+			s.logger.ErrorWithContext(ctx, "Failed to invalidate entity type cache by ID",
 				log.String("schemaID", schemaID), log.Error(err))
 		}
 	}
@@ -235,7 +235,7 @@ func (s *cachedBackedEntityTypeStore) invalidateEntityTypeCache(ctx context.Cont
 	if schemaName != "" {
 		key := cacheKeyForName(category, schemaName)
 		if err := s.schemaByNameCache.Delete(ctx, key); err != nil {
-			s.logger.Error("Failed to invalidate entity type cache by name",
+			s.logger.ErrorWithContext(ctx, "Failed to invalidate entity type cache by name",
 				log.String("schemaName", schemaName), log.Error(err))
 		}
 	}

--- a/backend/internal/entitytype/handler.go
+++ b/backend/internal/entitytype/handler.go
@@ -75,7 +75,7 @@ func (h *entityTypeHandler) HandleEntityTypeListRequest(w http.ResponseWriter, r
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, entityTypeListResponse)
 
-	logger.Debug("Successfully listed entity types with pagination",
+	logger.DebugWithContext(ctx, "Successfully listed entity types with pagination",
 		log.String("category", string(h.category)),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", entityTypeListResponse.TotalResults),
@@ -118,7 +118,7 @@ func (h *entityTypeHandler) HandleEntityTypePostRequest(w http.ResponseWriter, r
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdEntityType)
 
-	logger.Debug("Successfully created entity type",
+	logger.DebugWithContext(ctx, "Successfully created entity type",
 		log.String("category", string(h.category)),
 		log.String("entityTypeID", createdEntityType.ID), log.String("name", createdEntityType.Name))
 }
@@ -143,7 +143,7 @@ func (h *entityTypeHandler) HandleEntityTypeGetRequest(w http.ResponseWriter, r 
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, entityType)
 
-	logger.Debug("Successfully retrieved entity type",
+	logger.DebugWithContext(ctx, "Successfully retrieved entity type",
 		log.String("category", string(h.category)), log.String("entityTypeID", schemaID))
 }
 
@@ -171,7 +171,7 @@ func (h *entityTypeHandler) HandleEntityTypePutRequest(w http.ResponseWriter, r 
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, updatedEntityType)
 
-	logger.Debug("Successfully updated entity type",
+	logger.DebugWithContext(ctx, "Successfully updated entity type",
 		log.String("category", string(h.category)),
 		log.String("entityTypeID", schemaID), log.String("name", updatedEntityType.Name))
 }
@@ -193,7 +193,7 @@ func (h *entityTypeHandler) HandleEntityTypeDeleteRequest(w http.ResponseWriter,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
-	logger.Debug("Successfully deleted entity type",
+	logger.DebugWithContext(ctx, "Successfully deleted entity type",
 		log.String("category", string(h.category)), log.String("entityTypeID", schemaID))
 }
 

--- a/backend/internal/entitytype/service.go
+++ b/backend/internal/entitytype/service.go
@@ -133,7 +133,7 @@ func (us *entityTypeService) GetEntityTypeList(ctx context.Context, category Typ
 	}
 
 	if accessible.AllAllowed {
-		logger.Debug("Caller has access to all entity types, retrieving without OU filtering",
+		logger.DebugWithContext(ctx, "Caller has access to all entity types, retrieving without OU filtering",
 			log.String("category", string(category)))
 		return us.listAllEntityTypes(ctx, category, limit, offset, includeDisplay, logger)
 	}
@@ -241,7 +241,7 @@ func (us *entityTypeService) CreateEntityType(
 		Schema:           request.Schema,
 	}
 	if validationErr := validateEntityTypeDefinition(category, schemaToValidate); validationErr != nil {
-		logger.Debug("Entity type validation failed", log.String("name", request.Name))
+		logger.DebugWithContext(ctx, "Entity type validation failed", log.String("name", request.Name))
 		return nil, validationErr
 	}
 
@@ -266,7 +266,7 @@ func (us *entityTypeService) CreateEntityType(
 	if id == "" {
 		id, err = utils.GenerateUUIDv7()
 		if err != nil {
-			logger.Error("Failed to generate UUID", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -291,7 +291,7 @@ func (us *entityTypeService) CreateEntityType(
 		if svcErr := us.syncConsentElementsOnCreate(ctx, category, entityType.Schema, logger); svcErr != nil {
 			if delErr := us.entityTypeStore.DeleteEntityTypeByID(ctx, category,
 				entityType.ID); delErr != nil {
-				logger.Error("Failed to compensate schema creation after consent sync failure",
+				logger.ErrorWithContext(ctx, "Failed to compensate schema creation after consent sync failure",
 					log.String("schemaID", entityType.ID), log.Error(delErr))
 			}
 
@@ -333,7 +333,7 @@ func (us *entityTypeService) GetEntityType(
 		handleMap, svcErr := us.ouService.GetOrganizationUnitHandlesByIDs(
 			ctx, []string{entityType.OUID})
 		if svcErr != nil {
-			logger.Warn("Failed to resolve OU handle for entity type, skipping",
+			logger.WarnWithContext(ctx, "Failed to resolve OU handle for entity type, skipping",
 				log.String("id", schemaID), log.Any("error", svcErr))
 		} else if handle, ok := handleMap[entityType.OUID]; ok {
 			entityType.OUHandle = handle
@@ -409,7 +409,7 @@ func (us *entityTypeService) UpdateEntityType(ctx context.Context, category Type
 		Schema:           request.Schema,
 	}
 	if validationErr := validateEntityTypeDefinition(category, schemaToValidate); validationErr != nil {
-		logger.Debug("Entity type validation failed", log.String("id", schemaID))
+		logger.DebugWithContext(ctx, "Entity type validation failed", log.String("id", schemaID))
 		return nil, validationErr
 	}
 
@@ -468,7 +468,7 @@ func (us *entityTypeService) UpdateEntityType(ctx context.Context, category Type
 			entityType.Schema, logger); svcErr != nil {
 			if revertErr := us.entityTypeStore.UpdateEntityTypeByID(ctx, category, schemaID,
 				existingSchema); revertErr != nil {
-				logger.Error("Failed to compensate schema update after consent sync failure",
+				logger.ErrorWithContext(ctx, "Failed to compensate schema update after consent sync failure",
 					log.String("schemaID", schemaID), log.Error(revertErr))
 			}
 
@@ -521,7 +521,8 @@ func (us *entityTypeService) DeleteEntityType(ctx context.Context, category Type
 	if us.consentService.IsEnabled() {
 		attrNames, err := extractAttributeNames(category, existingSchema.Schema)
 		if err != nil {
-			logger.Error("Failed to extract attribute names for consent cleanup; proceeding with schema deletion",
+			logger.ErrorWithContext(ctx,
+				"Failed to extract attribute names for consent cleanup; proceeding with schema deletion",
 				log.String("schemaID", schemaID), log.Any("error", err))
 			attributeNames = []string{}
 		} else {
@@ -540,7 +541,7 @@ func (us *entityTypeService) DeleteEntityType(ctx context.Context, category Type
 	// since orphaned consent elements are safe and won't cause active harm.
 	if us.consentService.IsEnabled() && len(attributeNames) > 0 {
 		if svcErr := us.deleteConsentElements(ctx, attributeNames, logger); svcErr != nil {
-			logger.Error("Failed to delete consent elements for removed schema attributes; "+
+			logger.ErrorWithContext(ctx, "Failed to delete consent elements for removed schema attributes; "+
 				"orphaned consent elements may remain but schema deletion succeeded",
 				log.Any("attributeNames", attributeNames), log.Any("error", svcErr))
 		}
@@ -573,12 +574,12 @@ func (us *entityTypeService) ValidateEntity(
 		return false, logAndReturnServerError(logger, "Failed to validate entity attributes against schema", err)
 	}
 	if !isValid {
-		logger.Debug("Schema validation failed", log.String("category", string(category)),
+		logger.DebugWithContext(ctx, "Schema validation failed", log.String("category", string(category)),
 			log.String("entityType", entityType))
 		return false, nil
 	}
 
-	logger.Debug("Schema validation successful", log.String("category", string(category)),
+	logger.DebugWithContext(ctx, "Schema validation successful", log.String("category", string(category)),
 		log.String("entityType", entityType))
 	return true, nil
 }
@@ -619,7 +620,7 @@ func (us *entityTypeService) ValidateEntityUniqueness(
 		return false, logAndReturnServerError(logger, "Failed during uniqueness validation", err)
 	}
 	if !isValid {
-		logger.Debug("Entity attribute failed uniqueness validation",
+		logger.DebugWithContext(ctx, "Entity attribute failed uniqueness validation",
 			log.String("category", string(category)), log.String("entityType", entityType))
 		return false, nil
 	}
@@ -711,7 +712,7 @@ func (us *entityTypeService) getCompiledSchemaForEntityType(
 
 	compiled, err := model.CompileSchema(found.Schema)
 	if err != nil {
-		logger.Error("Failed to compile stored entity type", log.String("category", string(category)),
+		logger.ErrorWithContext(ctx, "Failed to compile stored entity type", log.String("category", string(category)),
 			log.String("entityType", entityType), log.Error(err))
 		return nil, fmt.Errorf("failed to compile stored entity type: %w", err)
 	}
@@ -777,7 +778,7 @@ func (us *entityTypeService) resolveEntityTypeOUHandle(
 ) *serviceerror.ServiceError {
 	if entityType.OUID != "" && entityType.OUHandle != "" {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, entityTypeLoggerComponentName))
-		logger.Warn("Both ou_id and ou_handle provided for entity type; ou_handle ignored",
+		logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided for entity type; ou_handle ignored",
 			log.String("entityTypeID", entityType.ID), log.String("name", entityType.Name))
 		return nil
 	}
@@ -802,19 +803,19 @@ func (us *entityTypeService) ensureOrganizationUnitExists(
 	logger *log.Logger,
 ) *serviceerror.ServiceError {
 	if us.ouService == nil {
-		logger.Error("Organization unit service is not configured for entity type operations")
+		logger.ErrorWithContext(ctx, "Organization unit service is not configured for entity type operations")
 		return &serviceerror.InternalServerError
 	}
 
 	exists, svcErr := us.ouService.IsOrganizationUnitExists(ctx, oUID)
 	if svcErr != nil {
-		logger.Error("Failed to verify organization unit existence",
+		logger.ErrorWithContext(ctx, "Failed to verify organization unit existence",
 			log.String("oUID", oUID), log.Any("error", svcErr))
 		return &serviceerror.InternalServerError
 	}
 
 	if !exists {
-		logger.Debug("Organization unit does not exist",
+		logger.DebugWithContext(ctx, "Organization unit does not exist",
 			log.String("oUID", oUID))
 		return invalidEntityTypeRequestErr(category, "organization unit id does not exist")
 	}
@@ -848,7 +849,7 @@ func (us *entityTypeService) populateEntityTypeOUHandles(
 
 	handleMap, svcErr := us.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
 	if svcErr != nil {
-		logger.Warn("Failed to resolve OU handles for entity types, skipping", log.Any("error", svcErr))
+		logger.WarnWithContext(ctx, "Failed to resolve OU handles for entity types, skipping", log.Any("error", svcErr))
 		return
 	}
 
@@ -1043,7 +1044,7 @@ func (us *entityTypeService) syncConsentElementsOnCreate(ctx context.Context,
 	// TODO: Replace "default" with the schema's actual OU when applications are associated with OUs.
 	const ouID = "default"
 
-	logger.Debug("Synchronizing consent elements for the new schema", log.String("ouID", ouID))
+	logger.DebugWithContext(ctx, "Synchronizing consent elements for the new schema", log.String("ouID", ouID))
 
 	names, err := extractAttributeNames(category, schema)
 	if err != nil {
@@ -1051,7 +1052,7 @@ func (us *entityTypeService) syncConsentElementsOnCreate(ctx context.Context,
 	}
 
 	if len(names) > 0 {
-		logger.Debug("Creating missing consent elements for the new schema",
+		logger.DebugWithContext(ctx, "Creating missing consent elements for the new schema",
 			log.String("ouID", ouID), log.Int("elementCount", len(names)))
 		if svcErr := us.createMissingConsentElements(ctx, ouID, names, logger); svcErr != nil {
 			return svcErr
@@ -1068,7 +1069,7 @@ func (us *entityTypeService) syncConsentElementsOnUpdate(ctx context.Context,
 	// TODO: Replace "default" with the schema's actual OU when applications are associated with OUs.
 	const ouID = "default"
 
-	logger.Debug("Synchronizing consent elements for the updated schema", log.String("ouID", ouID))
+	logger.DebugWithContext(ctx, "Synchronizing consent elements for the updated schema", log.String("ouID", ouID))
 
 	oldAttrs, err := extractAttributeNamesAsMap(category, oldSchema)
 	if err != nil {
@@ -1090,7 +1091,7 @@ func (us *entityTypeService) syncConsentElementsOnUpdate(ctx context.Context,
 	}
 
 	if len(requiredNames) > 0 {
-		logger.Debug("Ensuring consent elements exist for all requested attributes",
+		logger.DebugWithContext(ctx, "Ensuring consent elements exist for all requested attributes",
 			log.String("ouID", ouID), log.Int("requiredAttributesCount", len(requiredNames)))
 		if err := us.createMissingConsentElements(ctx, ouID, requiredNames, logger); err != nil {
 			return err
@@ -1114,11 +1115,11 @@ func (us *entityTypeService) syncConsentElementsOnUpdate(ctx context.Context,
 func (us *entityTypeService) createMissingConsentElements(ctx context.Context,
 	ouID string, names []string, logger *log.Logger) *serviceerror.ServiceError {
 	if len(names) == 0 {
-		logger.Debug("No consent elements to create for the schema", log.String("ouID", ouID))
+		logger.DebugWithContext(ctx, "No consent elements to create for the schema", log.String("ouID", ouID))
 		return nil
 	}
 
-	logger.Debug("Validating consent elements for the schema attributes",
+	logger.DebugWithContext(ctx, "Validating consent elements for the schema attributes",
 		log.String("ouID", ouID), log.Int("elementCount", len(names)))
 
 	validNames, err := us.consentService.ValidateConsentElements(ctx, ouID, names)
@@ -1144,7 +1145,7 @@ func (us *entityTypeService) createMissingConsentElements(ctx context.Context,
 	}
 
 	if len(elementsToCreate) > 0 {
-		logger.Debug("Creating new consent elements for the schema attributes",
+		logger.DebugWithContext(ctx, "Creating new consent elements for the schema attributes",
 			log.String("ouID", ouID), log.Int("elementCount", len(elementsToCreate)))
 		if _, err := us.consentService.CreateConsentElements(ctx, ouID, elementsToCreate); err != nil {
 			return wrapConsentServiceError(err, logger)
@@ -1160,11 +1161,11 @@ func (us *entityTypeService) deleteConsentElements(ctx context.Context,
 	// TODO: Replace "default" with the schema's actual OU when applications are associated with OUs.
 	const ouID = "default"
 
-	logger.Debug("Deleting consent elements for the removed schema attributes",
+	logger.DebugWithContext(ctx, "Deleting consent elements for the removed schema attributes",
 		log.String("ouID", ouID), log.Int("elementCount", len(attributeNames)))
 
 	if len(attributeNames) == 0 {
-		logger.Debug("No consent elements to delete for the schema", log.String("ouID", ouID))
+		logger.DebugWithContext(ctx, "No consent elements to delete for the schema", log.String("ouID", ouID))
 		return nil
 	}
 
@@ -1179,7 +1180,7 @@ func (us *entityTypeService) deleteConsentElements(ctx context.Context,
 		// We assume there is only one consent element per attribute name.
 		// TODO: This should be revisited when user type separation is onboarded to consent elements.
 		if len(existing) > 0 {
-			logger.Debug("Deleting consent element for the removed schema attribute",
+			logger.DebugWithContext(ctx, "Deleting consent element for the removed schema attribute",
 				log.String("ouID", ouID), log.String("attribute", attrName), log.String("elementID", existing[0].ID))
 			if err := us.consentService.DeleteConsentElement(ctx, ouID, existing[0].ID); err != nil {
 				// Silently ignore the error if it's due to associated purposes, but log a warning.
@@ -1188,7 +1189,8 @@ func (us *entityTypeService) deleteConsentElements(ctx context.Context,
 				// If it's not associated with a purpose, but exists in a different schema, we still delete it,
 				// as the consent element can be created again when configuring attribute for a application.
 				if err.Code == consent.ErrorDeletingConsentElementWithAssociatedPurpose.Code {
-					logger.Warn("Cannot delete consent element for removed attribute due to associated purposes",
+					logger.WarnWithContext(ctx,
+						"Cannot delete consent element for removed attribute due to associated purposes",
 						log.String("attribute", attrName), log.String("elementID", existing[0].ID),
 						log.String("error", err.ErrorDescription.DefaultValue))
 					continue

--- a/backend/internal/entitytype/store.go
+++ b/backend/internal/entitytype/store.go
@@ -151,7 +151,7 @@ func (s *entityTypeStore) GetEntityTypeList(ctx context.Context, category TypeCa
 	for _, row := range results {
 		entityType, err := parseEntityTypeListItemFromRow(row)
 		if err != nil {
-			logger.Error("Failed to parse entity type list item from row", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to parse entity type list item from row", log.Error(err))
 			continue
 		}
 		entityTypes = append(entityTypes, entityType)
@@ -190,7 +190,7 @@ func (s *entityTypeStore) GetEntityTypeListByOUIDs(ctx context.Context, category
 	for _, row := range results {
 		entityType, err := parseEntityTypeListItemFromRow(row)
 		if err != nil {
-			logger.Error("Failed to parse entity type list item from row", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to parse entity type list item from row", log.Error(err))
 			continue
 		}
 		entityTypes = append(entityTypes, entityType)
@@ -355,7 +355,7 @@ func (s *entityTypeStore) DeleteEntityTypeByID(ctx context.Context, category Typ
 	}
 
 	if rowsAffected == 0 {
-		logger.Debug("entity type not found with id: " + schemaID)
+		logger.DebugWithContext(ctx, "entity type not found with id: "+schemaID)
 	}
 
 	return nil
@@ -396,13 +396,14 @@ func (s *entityTypeStore) GetDisplayAttributesByNames(ctx context.Context, categ
 	for _, row := range results {
 		name, ok := row["name"].(string)
 		if !ok {
-			logger.Error("Failed to parse name from display attributes query")
+			logger.ErrorWithContext(ctx, "Failed to parse name from display attributes query")
 			continue
 		}
 
 		sysAttrs, err := parseSystemAttributes(row["system_attributes"])
 		if err != nil {
-			logger.Error("Failed to parse system attributes", log.String("schemaName", name), log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to parse system attributes",
+				log.String("schemaName", name), log.Error(err))
 			continue
 		}
 

--- a/backend/internal/flow/core/executor.go
+++ b/backend/internal/flow/core/executor.go
@@ -97,7 +97,7 @@ func (e *executor) HasRequiredInputs(ctx *NodeContext, execResp *common.Executor
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "Executor"),
 		log.String(log.LoggerKeyExecutorName, e.GetName()),
 		log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Checking inputs for the executor")
+	logger.DebugWithContext(ctx.Context, "Checking inputs for the executor")
 
 	requiredData := e.GetRequiredInputs(ctx)
 
@@ -140,7 +140,7 @@ func (e *executor) ValidatePrerequisites(ctx *NodeContext, execResp *common.Exec
 		if _, ok := ctx.UserInputs[prerequisite.Identifier]; !ok {
 			if _, ok := ctx.RuntimeData[prerequisite.Identifier]; !ok {
 				if value, ok := ctx.ForwardedData[prerequisite.Identifier]; !ok {
-					logger.Debug("Prerequisite not met for the executor",
+					logger.DebugWithContext(ctx.Context, "Prerequisite not met for the executor",
 						log.String("identifier", prerequisite.Identifier))
 					execResp.Status = common.ExecFailure
 					execResp.Error = serviceerror.CustomServiceError(ErrExecutorPrerequisiteNotMet,
@@ -152,7 +152,8 @@ func (e *executor) ValidatePrerequisites(ctx *NodeContext, execResp *common.Exec
 				} else {
 					// ForwardedData found but verify it's a string value
 					if _, isString := value.(string); !isString {
-						logger.Debug("Prerequisite not met for the executor (non-string in ForwardedData)",
+						logger.DebugWithContext(ctx.Context,
+							"Prerequisite not met for the executor (non-string in ForwardedData)",
 							log.String("identifier", prerequisite.Identifier))
 						execResp.Status = common.ExecFailure
 						execResp.Error = serviceerror.CustomServiceError(ErrExecutorPrerequisiteNotMet,

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -77,7 +77,7 @@ func newPromptNode(id string, properties map[string]interface{},
 // Execute executes the prompt node logic based on the current context.
 func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceerror.ServiceError) {
 	logger := n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing prompt node")
+	logger.DebugWithContext(ctx.Context, "Executing prompt node")
 
 	nodeResp := &common.NodeResponse{
 		Inputs:         make([]common.Input, 0),
@@ -92,7 +92,8 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 			var errResp serviceerror.ServiceError
 			if err := json.Unmarshal([]byte(jsonStr), &errResp); err == nil {
 				nodeResp.Error = &errResp
-				logger.Debug("Prompt node is handling a failure", log.String("errorCode", errResp.Code))
+				logger.DebugWithContext(ctx.Context, "Prompt node is handling a failure",
+					log.String("errorCode", errResp.Code))
 			}
 			delete(ctx.RuntimeData, "failureReasonJSON")
 			// Clear this prompt's inputs and current action
@@ -105,7 +106,7 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 
 	// Check if this is a display-only prompt node
 	if n.IsDisplayOnly() {
-		logger.Debug("Display-only prompt node, returning display content")
+		logger.DebugWithContext(ctx.Context, "Display-only prompt node, returning display content")
 
 		if ctx.Verbose && n.GetMeta() != nil {
 			nodeResp.Meta = n.GetMeta()
@@ -128,7 +129,7 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 	}
 
 	if n.resolvePromptInputs(ctx, nodeResp) {
-		logger.Debug("All required inputs and actions are available")
+		logger.DebugWithContext(ctx.Context, "All required inputs and actions are available")
 		if n.applyValidationFailureRePrompt(ctx, nodeResp) {
 			return nodeResp, nil
 		}
@@ -137,7 +138,8 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 			if nextNode := n.getNextNodeForActionRef(ctx.CurrentAction); nextNode != "" {
 				nodeResp.NextNodeID = nextNode
 			} else {
-				logger.Debug(ErrInvalidActionProvided.Error.DefaultValue, log.String("actionRef", ctx.CurrentAction))
+				logger.DebugWithContext(ctx.Context, ErrInvalidActionProvided.Error.DefaultValue,
+					log.String("actionRef", ctx.CurrentAction))
 				nodeResp.Status = common.NodeStatusFailure
 				nodeResp.Error = &ErrInvalidActionProvided
 				return nodeResp, nil
@@ -158,7 +160,7 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 	}
 
 	// If required inputs or action is not yet available, prompt for user interaction
-	logger.Debug("Required inputs or action not available, prompting user",
+	logger.DebugWithContext(ctx.Context, "Required inputs or action not available, prompting user",
 		log.Any("inputs", nodeResp.Inputs), log.Any("actions", nodeResp.Actions))
 
 	// Include meta in the response if verbose mode is enabled
@@ -251,7 +253,7 @@ func (n *promptNode) executeLoginOptions(ctx *NodeContext,
 	if ctx.CurrentAction != "" {
 		if allowedRaw := ctx.RuntimeData[common.RuntimeKeyAllowedLoginOptions]; allowedRaw != "" {
 			if !slices.Contains(strings.Fields(allowedRaw), ctx.CurrentAction) {
-				logger.Debug("Selected action is not in allowed login options",
+				logger.DebugWithContext(ctx.Context, "Selected action is not in allowed login options",
 					log.String("actionRef", ctx.CurrentAction))
 				nodeResp.Status = common.NodeStatusFailure
 				nodeResp.Error = &ErrInvalidActionProvided
@@ -282,7 +284,8 @@ func (n *promptNode) executeLoginOptions(ctx *NodeContext,
 	// Auto-select the sole remaining option so the user skips a single-choice chooser.
 	if len(actions) == 1 && len(requestedAuthClasses) > 0 {
 		ctx.CurrentAction = actions[0].Ref
-		logger.Debug("Auto-selected single login option", log.String("actionRef", ctx.CurrentAction))
+		logger.DebugWithContext(ctx.Context, "Auto-selected single login option",
+			log.String("actionRef", ctx.CurrentAction))
 		if n.resolvePromptInputs(ctx, nodeResp) {
 			if n.applyValidationFailureRePrompt(ctx, nodeResp) {
 				return nodeResp, nil
@@ -310,7 +313,8 @@ func (n *promptNode) finalizeLoginOptionsAction(ctx *NodeContext, nodeResp *comm
 	logger := n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	nextNode := n.getNextNodeForActionRef(ctx.CurrentAction)
 	if nextNode == "" {
-		logger.Debug(ErrInvalidActionProvided.Error.DefaultValue, log.String("actionRef", ctx.CurrentAction))
+		logger.DebugWithContext(ctx.Context, ErrInvalidActionProvided.Error.DefaultValue,
+			log.String("actionRef", ctx.CurrentAction))
 		nodeResp.Status = common.NodeStatusFailure
 		nodeResp.Error = &ErrInvalidActionProvided
 		return nodeResp, nil
@@ -450,10 +454,10 @@ func (n *promptNode) hasRequiredInputs(ctx *NodeContext, nodeResp *common.NodeRe
 				return !n.appendMissingInputs(ctx, nodeResp, prompt.Inputs)
 			}
 		}
-		logger.Debug("Selected action not found in prompts, treating as no action selected",
+		logger.DebugWithContext(ctx.Context, "Selected action not found in prompts, treating as no action selected",
 			log.String("action", ctx.CurrentAction))
 	} else {
-		logger.Debug("No action selected, checking inputs from all prompts")
+		logger.DebugWithContext(ctx.Context, "No action selected, checking inputs from all prompts")
 	}
 
 	// If no action selected or action not found, validate inputs from all prompts
@@ -488,7 +492,8 @@ func (n *promptNode) enrichInputsFromForwardedData(ctx *NodeContext, nodeResp *c
 	// Type assert to []common.Input.
 	forwardedInputs, ok := forwardedInputsData.([]common.Input)
 	if !ok {
-		n.logger.Debug("ForwardedData contains 'inputs' key but value is not []common.Input, skipping enrichment")
+		n.logger.DebugWithContext(ctx.Context,
+			"ForwardedData contains 'inputs' key but value is not []common.Input, skipping enrichment")
 		return
 	}
 
@@ -504,20 +509,20 @@ func (n *promptNode) enrichInputsFromForwardedData(ctx *NodeContext, nodeResp *c
 		if idx, exists := existingIndexMap[fwdInput.Identifier]; exists {
 			if fwdInput.Required && !nodeResp.Inputs[idx].Required {
 				nodeResp.Inputs[idx].Required = true
-				n.logger.Debug("Updated input required flag from ForwardedData",
+				n.logger.DebugWithContext(ctx.Context, "Updated input required flag from ForwardedData",
 					log.String("identifier", fwdInput.Identifier))
 			}
 			if fwdInput.Type == common.InputTypePassword &&
 				nodeResp.Inputs[idx].Type != common.InputTypePassword {
 				nodeResp.Inputs[idx].Type = common.InputTypePassword
-				n.logger.Debug("Updated input type to password from ForwardedData",
+				n.logger.DebugWithContext(ctx.Context, "Updated input type to password from ForwardedData",
 					log.String("identifier", fwdInput.Identifier))
 			}
 			if fwdInput.Type == common.InputTypeSelect &&
 				nodeResp.Inputs[idx].Type == common.InputTypeSelect &&
 				len(fwdInput.Options) > 0 {
 				nodeResp.Inputs[idx].Options = fwdInput.Options
-				n.logger.Debug("Enriched input with options from ForwardedData",
+				n.logger.DebugWithContext(ctx.Context, "Enriched input with options from ForwardedData",
 					log.String("identifier", fwdInput.Identifier),
 					log.Int("optionsCount", len(fwdInput.Options)))
 			}
@@ -536,7 +541,7 @@ func (n *promptNode) enrichInputsFromForwardedData(ctx *NodeContext, nodeResp *c
 		}
 		nodeResp.Inputs = append(nodeResp.Inputs, fwdInput)
 		existingIndexMap[fwdInput.Identifier] = len(nodeResp.Inputs) - 1
-		n.logger.Debug("Added dynamically-derived input from ForwardedData",
+		n.logger.DebugWithContext(ctx.Context, "Added dynamically-derived input from ForwardedData",
 			log.String("identifier", fwdInput.Identifier))
 	}
 }
@@ -577,7 +582,8 @@ func (n *promptNode) tryAutoSelectSingleAction(ctx *NodeContext) bool {
 	// Skip auto-select for confirmation prompts (no inputs) - they should wait for explicit action
 	if len(actions) == 1 && ctx.CurrentAction == "" && len(allInputs) > 0 {
 		ctx.CurrentAction = actions[0].Ref
-		n.logger.Debug("Auto-selected single action", log.String(log.LoggerKeyExecutionID, ctx.ExecutionID),
+		n.logger.DebugWithContext(ctx.Context, "Auto-selected single action",
+			log.String(log.LoggerKeyExecutionID, ctx.ExecutionID),
 			log.String("actionRef", actions[0].Ref))
 		return true
 	}

--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -86,10 +86,10 @@ func newTaskExecutionNode(id string, properties map[string]interface{}, isStartN
 // Execute executes the node's executor.
 func (n *taskExecutionNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing task execution node")
+	logger.DebugWithContext(ctx.Context, "Executing task execution node")
 
 	if n.executor == nil {
-		logger.Error("No executor configured for the node")
+		logger.ErrorWithContext(ctx.Context, "No executor configured for the node")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -158,7 +158,7 @@ func (n *taskExecutionNode) Execute(ctx *NodeContext) (*common.NodeResponse, *se
 		len(nodeResp.Inputs) == 0 {
 		// Executor returned INCOMPLETE+VIEW with no inputs — broken executor implementation.
 		// There is nothing for the client to act on; surface as a server error.
-		logger.Error("Executor returned INCOMPLETE with VIEW type but no inputs")
+		logger.ErrorWithContext(ctx.Context, "Executor returned INCOMPLETE with VIEW type but no inputs")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -190,11 +190,11 @@ func (n *taskExecutionNode) triggerExecutor(ctx *NodeContext, logger *log.Logger
 	*common.ExecutorResponse, *serviceerror.ServiceError) {
 	execResp, err := n.executor.Execute(ctx)
 	if err != nil {
-		logger.Error("Error executing node executor", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Error executing node executor", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if execResp == nil {
-		logger.Error("Executor returned a nil response")
+		logger.ErrorWithContext(ctx.Context, "Executor returned a nil response")
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/flow/core/utils.go
+++ b/backend/internal/flow/core/utils.go
@@ -131,23 +131,23 @@ func collectMissingInputs(ctx *NodeContext, presentedOptionalInputs map[string]s
 			continue
 		}
 		if _, ok := ctx.RuntimeData[input.Identifier]; ok {
-			logger.Debug("Input available in runtime data, skipping",
+			logger.DebugWithContext(ctx.Context, "Input available in runtime data, skipping",
 				log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
 			continue
 		}
 		if value, ok := ctx.ForwardedData[input.Identifier]; ok {
 			if _, isString := value.(string); isString {
-				logger.Debug("Input available in forwarded data, skipping",
+				logger.DebugWithContext(ctx.Context, "Input available in forwarded data, skipping",
 					log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
 				continue
 			}
 		}
 		if !input.Required && IsOptionalInputPrompted(presentedOptionalInputs, input.Identifier) {
-			logger.Debug("Optional input already prompted, skipping",
+			logger.DebugWithContext(ctx.Context, "Optional input already prompted, skipping",
 				log.String("identifier", input.Identifier))
 			continue
 		}
-		logger.Debug("Input not available in the context",
+		logger.DebugWithContext(ctx.Context, "Input not available in the context",
 			log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
 		missing = append(missing, input)
 	}

--- a/backend/internal/flow/executor/attribute_collector.go
+++ b/backend/internal/flow/executor/attribute_collector.go
@@ -73,7 +73,7 @@ func newAttributeCollector(
 // Execute executes the attribute collection logic.
 func (a *attributeCollector) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing attribute collect executor")
+	logger.DebugWithContext(ctx.Context, "Executing attribute collect executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -81,39 +81,39 @@ func (a *attributeCollector) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 	}
 
 	if ctx.FlowType == common.FlowTypeRegistration {
-		logger.Debug("Flow type is registration, skipping attribute collection")
+		logger.DebugWithContext(ctx.Context, "Flow type is registration, skipping attribute collection")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
 
 	if !ctx.AuthenticatedUser.IsAuthenticated {
-		logger.Debug("User is not authenticated, cannot collect attributes")
+		logger.DebugWithContext(ctx.Context, "User is not authenticated, cannot collect attributes")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserNotAuthenticated
 		return execResp, nil
 	}
 
 	if !a.ValidatePrerequisites(ctx, execResp) {
-		logger.Debug("Prerequisites validation failed for attribute collector")
+		logger.DebugWithContext(ctx.Context, "Prerequisites validation failed for attribute collector")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrPrerequisitesFailed
 		return execResp, nil
 	}
 
 	if !a.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required inputs for attribute collector is not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for attribute collector is not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
 
 	if err := a.updateUserInStore(ctx); err != nil {
-		logger.Error("Failed to update user attributes", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to update user attributes", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrAttributeCollectFailed
 		return execResp, nil
 	}
 
-	logger.Debug("User attributes updated successfully")
+	logger.DebugWithContext(ctx.Context, "User attributes updated successfully")
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }
@@ -123,7 +123,7 @@ func (a *attributeCollector) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) bool {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Checking inputs for the attribute collector")
+	logger.DebugWithContext(ctx.Context, "Checking inputs for the attribute collector")
 
 	if a.ExecutorInterface.HasRequiredInputs(ctx, execResp) {
 		return true
@@ -135,7 +135,8 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 	// Update the executor response with the required inputs retrieved from authenticated user attributes.
 	authnUserAttrs := ctx.AuthenticatedUser.Attributes
 	if len(authnUserAttrs) > 0 {
-		logger.Debug("Authenticated user attributes found, updating executor response required inputs")
+		logger.DebugWithContext(ctx.Context,
+			"Authenticated user attributes found, updating executor response required inputs")
 
 		// Clear the required data in the executor response to avoid duplicates.
 		missingAttributes := execResp.Inputs
@@ -154,19 +155,21 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 
 				attributeStr, ok := attribute.(string)
 				if ok {
-					logger.Debug("Input exists in authenticated user attributes, adding to runtime data",
+					logger.DebugWithContext(ctx.Context,
+						"Input exists in authenticated user attributes, adding to runtime data",
 						log.String("attributeName", input.Identifier))
 					execResp.RuntimeData[input.Identifier] = attributeStr
 				}
 			} else {
-				logger.Debug("Input does not exist in authenticated user attributes, adding to required inputs",
+				logger.DebugWithContext(ctx.Context,
+					"Input does not exist in authenticated user attributes, adding to required inputs",
 					log.String("attributeName", input.Identifier))
 				execResp.Inputs = append(execResp.Inputs, input)
 			}
 		}
 
 		if len(execResp.Inputs) == 0 {
-			logger.Debug("All required inputs are available in authenticated user attributes, " +
+			logger.DebugWithContext(ctx.Context, "All required inputs are available in authenticated user attributes, "+
 				"no further action needed")
 			return true
 		}
@@ -176,11 +179,12 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 	userAttributes, err := a.getUserAttributes(ctx)
 	if err != nil {
 		// Silently log the error and proceed with prompting for required inputs.
-		logger.Error("Failed to retrieve user attributes", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to retrieve user attributes", log.Error(err))
 		return false
 	}
 	if userAttributes == nil {
-		logger.Debug("No user attributes found in the user profile, proceeding with required inputs")
+		logger.DebugWithContext(ctx.Context,
+			"No user attributes found in the user profile, proceeding with required inputs")
 		return false
 	}
 
@@ -198,7 +202,7 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 			if input.Identifier == userAttributePassword {
 				continue
 			}
-			logger.Debug("Input exists in user profile, adding to runtime data",
+			logger.DebugWithContext(ctx.Context, "Input exists in user profile, adding to runtime data",
 				log.String("attributeName", input.Identifier))
 
 			// TODO: This conversion should be modified according to the storage mechanism of the
@@ -209,14 +213,15 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 				execResp.RuntimeData[input.Identifier] = fmt.Sprintf("%v", attribute)
 			}
 		} else {
-			logger.Debug("Input does not exist in user profile, adding to required inputs",
+			logger.DebugWithContext(ctx.Context, "Input does not exist in user profile, adding to required inputs",
 				log.String("attributeName", input.Identifier))
 			execResp.Inputs = append(execResp.Inputs, input)
 		}
 	}
 
 	if len(execResp.Inputs) == 0 {
-		logger.Debug("All required inputs are available in the user profile, no further action needed")
+		logger.DebugWithContext(ctx.Context,
+			"All required inputs are available in the user profile, no further action needed")
 		return true
 	}
 
@@ -226,7 +231,7 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 // getUserAttributes retrieves the user attributes from the user profile.
 func (a *attributeCollector) getUserAttributes(ctx *core.NodeContext) (map[string]interface{}, error) {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Retrieving user attributes from the user profile")
+	logger.DebugWithContext(ctx.Context, "Retrieving user attributes from the user profile")
 
 	user, err := a.getUserFromStore(ctx)
 	if err != nil {
@@ -245,7 +250,7 @@ func (a *attributeCollector) getUserAttributes(ctx *core.NodeContext) (map[strin
 	} else {
 		userAttributes = make(map[string]interface{})
 	}
-	logger.Debug("User attributes retrieved successfully")
+	logger.DebugWithContext(ctx.Context, "User attributes retrieved successfully")
 
 	return userAttributes, nil
 }
@@ -253,7 +258,7 @@ func (a *attributeCollector) getUserAttributes(ctx *core.NodeContext) (map[strin
 // updateUserInStore updates the user profile with the collected attributes.
 func (a *attributeCollector) updateUserInStore(ctx *core.NodeContext) error {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Updating user attributes")
+	logger.DebugWithContext(ctx.Context, "Updating user attributes")
 
 	user, err := a.getUserFromStore(ctx)
 	if err != nil {
@@ -269,7 +274,7 @@ func (a *attributeCollector) updateUserInStore(ctx *core.NodeContext) error {
 		return fmt.Errorf("failed to get updated user object: %w", err)
 	}
 	if !updateRequired {
-		logger.Debug("No updates required for user attributes, skipping update")
+		logger.DebugWithContext(ctx.Context, "No updates required for user attributes, skipping update")
 		return nil
 	}
 	if updatedUser == nil {
@@ -279,7 +284,8 @@ func (a *attributeCollector) updateUserInStore(ctx *core.NodeContext) error {
 	if err := a.entityProvider.UpdateAttributes(userID, updatedUser.Attributes); err != nil {
 		return fmt.Errorf("failed to update user attributes: %s", err.Message)
 	}
-	logger.Debug("User attributes updated successfully", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "User attributes updated successfully",
+		log.MaskedString(log.LoggerKeyUserID, userID))
 
 	return nil
 }
@@ -325,7 +331,7 @@ func (a *attributeCollector) getUpdatedUserObject(ctx *core.NodeContext,
 	// Get new attributes from input
 	newAttrs := a.getInputAttributes(ctx)
 	if len(newAttrs) == 0 {
-		logger.Debug("No new attributes provided, returning existing user")
+		logger.DebugWithContext(ctx.Context, "No new attributes provided, returning existing user")
 		return false, userData, nil
 	}
 

--- a/backend/internal/flow/executor/attribute_uniqueness_validator.go
+++ b/backend/internal/flow/executor/attribute_uniqueness_validator.go
@@ -70,7 +70,7 @@ func newAttributeUniquenessValidator(
 // named in the structured error when a conflict is detected, or ExecComplete when all values are free.
 func (e *attributeUniquenessValidator) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing uniqueness checker executor")
+	logger.DebugWithContext(ctx.Context, "Executing uniqueness checker executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -105,7 +105,7 @@ func (e *attributeUniquenessValidator) Execute(ctx *core.NodeContext) (*common.E
 		}
 
 		if userID != nil {
-			logger.Debug("Unique attribute conflict detected", log.String("attribute", attr))
+			logger.DebugWithContext(ctx.Context, "Unique attribute conflict detected", log.String("attribute", attr))
 			execResp.Status = common.ExecUserInputRequired
 			execResp.Error = errAttributeNotUniqueFor(attr)
 			return execResp, nil

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -96,7 +96,7 @@ func newAuthAssertExecutor(
 // Execute executes the authentication assertion logic.
 func (a *authAssertExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing authentication assertion executor")
+	logger.DebugWithContext(ctx.Context, "Executing authentication assertion executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -109,7 +109,7 @@ func (a *authAssertExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 			return nil, err
 		}
 
-		logger.Debug("Generated JWT token for authentication assertion")
+		logger.DebugWithContext(ctx.Context, "Generated JWT token for authentication assertion")
 
 		execResp.Status = common.ExecComplete
 		execResp.Assertion = token
@@ -118,7 +118,7 @@ func (a *authAssertExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 		execResp.Error = &ErrUserNotAuthenticated
 	}
 
-	logger.Debug("Authentication assertion executor execution completed",
+	logger.DebugWithContext(ctx.Context, "Authentication assertion executor execution completed",
 		log.String("status", string(execResp.Status)))
 
 	return execResp, nil
@@ -150,7 +150,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 		assertionResult, svcErr := a.authAssertGenerator.GenerateAssertion(authenticatorRefs)
 		if svcErr != nil {
 			if svcErr.Type == serviceerror.ServerErrorType {
-				logger.Error("Failed to generate auth assertion",
+				logger.ErrorWithContext(ctx.Context, "Failed to generate auth assertion",
 					log.String("error", svcErr.Error.DefaultValue))
 				return "", errors.New("something went wrong while generating auth assertion")
 			}
@@ -181,7 +181,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 		if len(resolvedAttributes) > 0 {
 			ttlSeconds, err := strconv.Atoi(ttlSecondsStr)
 			if err != nil {
-				logger.Error("Failed to parse TTL seconds from runtime data",
+				logger.ErrorWithContext(ctx.Context, "Failed to parse TTL seconds from runtime data",
 					log.String("key", common.RuntimeKeyUserAttributesCacheTTLSeconds),
 					log.String("ttlValue", ttlSecondsStr),
 					log.String("error", err.Error()))
@@ -193,7 +193,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 			}
 			result, creationErr := a.attributeCacheSvc.CreateAttributeCache(ctx.Context, attributeCache)
 			if creationErr != nil {
-				logger.Error("Failed to create attribute cache",
+				logger.ErrorWithContext(ctx.Context, "Failed to create attribute cache",
 					log.String("error", creationErr.ErrorDescription.DefaultValue))
 				return "", errors.New("failed to create attribute cache")
 			}
@@ -210,7 +210,8 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 	token, _, err := a.jwtService.GenerateJWT(
 		ctx.Context, tokenSub, iss, validityPeriod, jwtClaims, jwt.TokenTypeJWT, "")
 	if err != nil {
-		logger.Error("Failed to generate JWT token", log.String("error", err.Error.DefaultValue))
+		logger.ErrorWithContext(ctx.Context, "Failed to generate JWT token",
+			log.String("error", err.Error.DefaultValue))
 		return "", errors.New("failed to generate JWT token: " + err.Error.DefaultValue)
 	}
 
@@ -273,12 +274,12 @@ func (a *authAssertExecutor) getRequiredUserAttributes(ctx *core.NodeContext) (u
 	if _, consentRecorded := ctx.RuntimeData[common.RuntimeKeyConsentID]; consentRecorded {
 		// Get user attributes from consented attributes if consent was collected in this flow
 		if consentedAttrsStr, exists := ctx.RuntimeData[common.RuntimeKeyConsentedAttributes]; exists {
-			logger.Debug("Consent recorded with approved attributes")
+			logger.DebugWithContext(ctx.Context, "Consent recorded with approved attributes")
 			return strings.Fields(consentedAttrsStr)
 		}
 
 		// If consent was recorded but no attributes were approved, attributes are empty
-		logger.Debug("Consent recorded but no attributes approved")
+		logger.DebugWithContext(ctx.Context, "Consent recorded but no attributes approved")
 		return []string{}
 	}
 
@@ -289,15 +290,16 @@ func (a *authAssertExecutor) getRequiredUserAttributes(ctx *core.NodeContext) (u
 
 	if essentialExists || optionalExists {
 		userAttributes = []string{}
-		logger.Debug("Essential/ optional attributes exists in runtime data. Applying attribute filtering")
+		logger.DebugWithContext(ctx.Context,
+			"Essential/ optional attributes exists in runtime data. Applying attribute filtering")
 
 		if essentialExists {
-			logger.Debug("Adding required essential attributes to user attributes list")
+			logger.DebugWithContext(ctx.Context, "Adding required essential attributes to user attributes list")
 			userAttributes = append(userAttributes,
 				strings.Fields(ctx.RuntimeData[common.RuntimeKeyRequiredEssentialAttributes])...)
 		}
 		if optionalExists {
-			logger.Debug("Adding required optional attributes to user attributes list")
+			logger.DebugWithContext(ctx.Context, "Adding required optional attributes to user attributes list")
 			userAttributes = append(userAttributes,
 				strings.Fields(ctx.RuntimeData[common.RuntimeKeyRequiredOptionalAttributes])...)
 		}
@@ -308,11 +310,11 @@ func (a *authAssertExecutor) getRequiredUserAttributes(ctx *core.NodeContext) (u
 	// If consent was not recorded and no essential/ optional attributes specified, fallback to
 	// application token config
 	if ctx.Application.Assertion != nil {
-		logger.Debug("Adding application token attributes to user attributes list")
+		logger.DebugWithContext(ctx.Context, "Adding application token attributes to user attributes list")
 		return ctx.Application.Assertion.UserAttributes
 	}
 
-	logger.Debug("No user attributes configured for inclusion in assertion")
+	logger.DebugWithContext(ctx.Context, "No user attributes configured for inclusion in assertion")
 	return []string{}
 }
 
@@ -501,7 +503,7 @@ func (a *authAssertExecutor) appendOUDetailsToClaims(
 
 	organizationUnit, svcErr := a.ouService.GetOrganizationUnit(ctx, ouID)
 	if svcErr != nil {
-		logger.Error("Failed to fetch organization unit details",
+		logger.ErrorWithContext(ctx, "Failed to fetch organization unit details",
 			log.String(ouIDKey, ouID), log.Any("error", svcErr))
 		return errors.New("something went wrong while fetching organization unit: " +
 			svcErr.ErrorDescription.DefaultValue)
@@ -567,7 +569,7 @@ func (a *authAssertExecutor) appendRolesToClaims(
 
 	roles, svcErr := a.roleService.GetUserRoles(ctx.Context, ctx.AuthenticatedUser.UserID, groupIDs)
 	if svcErr != nil {
-		logger.Error("Failed to fetch user roles",
+		logger.ErrorWithContext(ctx.Context, "Failed to fetch user roles",
 			log.MaskedString(log.LoggerKeyUserID, ctx.AuthenticatedUser.UserID),
 			log.Any("error", svcErr))
 		return errors.New("something went wrong while fetching user roles: " + svcErr.ErrorDescription.DefaultValue)

--- a/backend/internal/flow/executor/authz_executor.go
+++ b/backend/internal/flow/executor/authz_executor.go
@@ -71,14 +71,15 @@ func newAuthorizationExecutor(
 // calling the authorization service, and storing authorized permissions in runtime data.
 func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing authorization executor")
+	logger.DebugWithContext(ctx.Context, "Executing authorization executor")
 
 	execResp := &common.ExecutorResponse{
 		RuntimeData: make(map[string]string),
 	}
 
 	if !ctx.AuthenticatedUser.IsAuthenticated && ctx.FlowType == common.FlowTypeRegistration {
-		logger.Debug("Sending executor complete response for unauthenticated user in registration flow")
+		logger.DebugWithContext(ctx.Context,
+			"Sending executor complete response for unauthenticated user in registration flow")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
@@ -93,12 +94,12 @@ func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.Executor
 	requestedPerms := extractRequestedPermissions(ctx)
 
 	if len(requestedPerms) == 0 {
-		logger.Debug("No permissions to check, returning empty permissions")
+		logger.DebugWithContext(ctx.Context, "No permissions to check, returning empty permissions")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
 
-	logger.Debug("Determined required permissions", log.Int("count", len(requestedPerms)))
+	logger.DebugWithContext(ctx.Context, "Determined required permissions", log.Int("count", len(requestedPerms)))
 
 	// Extract user ID and group IDs
 	userID := ctx.AuthenticatedUser.UserID
@@ -107,7 +108,7 @@ func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.Executor
 		return nil, errors.Join(errors.New("Failed to extract group IDs"), err)
 	}
 
-	logger.Debug("Calling authorization service",
+	logger.DebugWithContext(ctx.Context, "Calling authorization service",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.Int("groupCount", len(groupIDs)),
 		log.Int("permissionCount", len(requestedPerms)))
@@ -121,14 +122,15 @@ func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.Executor
 
 	authzResp, svcErr := a.authzService.GetAuthorizedPermissions(ctx.Context, authzReq)
 	if svcErr != nil {
-		logger.Error("Authorization service call failed", log.String("error", svcErr.Error.DefaultValue))
+		logger.ErrorWithContext(ctx.Context, "Authorization service call failed",
+			log.String("error", svcErr.Error.DefaultValue))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrAuthorizationFailed
 		return execResp, nil
 	}
 
 	setAuthorizedPermissions(execResp, authzResp.AuthorizedPermissions)
-	logger.Debug("Authorization completed successfully",
+	logger.DebugWithContext(ctx.Context, "Authorization completed successfully",
 		log.Int("authorizedCount", len(authzResp.AuthorizedPermissions)))
 
 	execResp.Status = common.ExecComplete
@@ -183,7 +185,8 @@ func (a *authorizationExecutor) extractGroupIDs(ctx *core.NodeContext) ([]string
 
 	// If no groups found in context, fetch transitive groups from entity provider
 	if a.entityProvider != nil && ctx.AuthenticatedUser.UserID != "" {
-		a.logger.Debug("Groups not found in context, fetching transitive groups from entity provider",
+		a.logger.DebugWithContext(ctx.Context,
+			"Groups not found in context, fetching transitive groups from entity provider",
 			log.MaskedString(log.LoggerKeyUserID, ctx.AuthenticatedUser.UserID))
 
 		groups, err := a.entityProvider.GetTransitiveEntityGroups(ctx.AuthenticatedUser.UserID)

--- a/backend/internal/flow/executor/basic_auth_executor.go
+++ b/backend/internal/flow/executor/basic_auth_executor.go
@@ -85,7 +85,7 @@ func newBasicAuthExecutor(
 // Execute executes the basic authentication logic.
 func (b *basicAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := b.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing basic authentication executor")
+	logger.DebugWithContext(ctx.Context, "Executing basic authentication executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -110,7 +110,7 @@ func (b *basicAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResp
 			return execResp, nil
 		}
 	} else if !b.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required inputs for basic authentication executor is not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for basic authentication executor is not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -146,7 +146,7 @@ func (b *basicAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResp
 	execResp.AuthenticatedUser = *authenticatedUser
 	execResp.Status = common.ExecComplete
 
-	logger.Debug("Basic authentication executor execution completed",
+	logger.DebugWithContext(ctx.Context, "Basic authentication executor execution completed",
 		log.String("status", string(execResp.Status)),
 		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
@@ -196,7 +196,8 @@ func (b *basicAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 		}
 		if execResp.Status == common.ExecFailure {
 			if execResp.Error != nil && execResp.Error.Code == ErrUserNotFound.Code {
-				logger.Debug("User not found for the provided attributes. Proceeding with registration flow.")
+				logger.DebugWithContext(ctx.Context,
+					"User not found for the provided attributes. Proceeding with registration flow.")
 				execResp.Status = common.ExecComplete
 				return &authncm.AuthenticatedUser{
 					IsAuthenticated: false,
@@ -232,7 +233,7 @@ func (b *basicAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 			return nil, nil
 		}
 
-		logger.Error("Failed to authenticate user",
+		logger.ErrorWithContext(ctx.Context, "Failed to authenticate user",
 			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return nil, errors.New("failed to authenticate user")
 	}
@@ -244,15 +245,15 @@ func (b *basicAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 
 	if err != nil {
 		if err.Code != entityprovider.ErrorCodeNotImplemented {
-			logger.Error("Failed to get user attributes", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Failed to get user attributes", log.Error(err))
 			return nil, errors.New("failed to get user attributes")
 		}
-		logger.Debug("User provider is not implemented. User attributes will be empty.")
+		logger.DebugWithContext(ctx.Context, "User provider is not implemented. User attributes will be empty.")
 	}
 
 	if err == nil && user != nil && len(user.Attributes) > 0 {
 		if err := json.Unmarshal(user.Attributes, &userAttributes); err != nil {
-			logger.Error("Failed to unmarshal user attributes", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Failed to unmarshal user attributes", log.Error(err))
 			return nil, errors.New("failed to unmarshal user attributes")
 		}
 	}

--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -89,7 +89,7 @@ func newConsentExecutor(
 // Execute runs the consent enforcement logic.
 func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing consent executor")
+	logger.DebugWithContext(ctx.Context, "Executing consent executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -98,7 +98,7 @@ func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespon
 	}
 
 	if !e.ValidatePrerequisites(ctx, execResp) {
-		logger.Debug("Prerequisites validation failed for consent executor")
+		logger.DebugWithContext(ctx.Context, "Prerequisites validation failed for consent executor")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrConsentPrereqFailed
 		return execResp, nil
@@ -110,11 +110,11 @@ func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespon
 	userID := ctx.AuthenticatedUser.UserID
 
 	if !e.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required consent decisions not provided; checking if consent is needed")
+		logger.DebugWithContext(ctx.Context, "Required consent decisions not provided; checking if consent is needed")
 		return e.checkConsent(ctx, execResp, ouID, appID, userID)
 	}
 
-	logger.Debug("Consent decisions provided; processing consent decisions")
+	logger.DebugWithContext(ctx.Context, "Consent decisions provided; processing consent decisions")
 	return e.handleConsentDecisions(ctx, execResp, ouID, appID, userID)
 }
 
@@ -122,7 +122,7 @@ func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespon
 func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.ExecutorResponse,
 	ouID, appID, userID string) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Checking if user consent is required")
+	logger.DebugWithContext(ctx.Context, "Checking if user consent is required")
 
 	essentialAttributes, optionalAttributes := e.getRequiredAttributes(ctx)
 	authorizedPermissions := strings.Fields(ctx.RuntimeData["authorized_permissions"])
@@ -136,19 +136,19 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 		availableAttributes)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Client error while resolving user consent", log.Any("error", svcErr))
+			logger.DebugWithContext(ctx.Context, "Client error while resolving user consent", log.Any("error", svcErr))
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrConsentResolutionFailed
 			return execResp, nil
 		}
 
-		logger.Error("Failed to resolve consent", log.Any("error", svcErr))
+		logger.ErrorWithContext(ctx.Context, "Failed to resolve consent", log.Any("error", svcErr))
 		return nil, errors.New("failed to resolve consent")
 	}
 
 	// All consents are active — nothing to prompt
 	if promptData == nil {
-		logger.Debug("All required consents are active; completing consent executor")
+		logger.DebugWithContext(ctx.Context, "All required consents are active; completing consent executor")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
@@ -156,7 +156,7 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 	// Consent is needed — forward prompt data to the prompt node via ForwardedData
 	promptJSON, err := json.Marshal(promptData.Purposes)
 	if err != nil {
-		logger.Error("Failed to marshal consent prompt data", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to marshal consent prompt data", log.Error(err))
 		return nil, errors.New("failed to prepare consent prompt data")
 	}
 
@@ -173,14 +173,15 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 		if timeoutSec, err := strconv.ParseInt(timeoutStr, 10, 64); err == nil && timeoutSec > 0 {
 			expiresAt := time.Now().Add(time.Duration(timeoutSec) * time.Second).UnixMilli()
 			expiresAtStr := strconv.FormatInt(expiresAt, 10)
-			logger.Debug("Consent timeout configured", log.String("expiresAt", expiresAtStr))
+			logger.DebugWithContext(ctx.Context, "Consent timeout configured", log.String("expiresAt", expiresAtStr))
 
 			execResp.AdditionalData[common.DataStepTimeout] = expiresAtStr
 			execResp.RuntimeData[common.RuntimeKeyStepTimeout] = expiresAtStr
 		}
 	}
 
-	logger.Debug("Prompting for user consent", log.Int("purposeCount", len(promptData.Purposes)))
+	logger.DebugWithContext(ctx.Context, "Prompting for user consent",
+		log.Int("purposeCount", len(promptData.Purposes)))
 	execResp.Status = common.ExecUserInputRequired
 	return execResp, nil
 }
@@ -189,11 +190,11 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp *common.ExecutorResponse,
 	ouID, appID, userID string) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Processing consent decisions from user")
+	logger.DebugWithContext(ctx.Context, "Processing consent decisions from user")
 
 	decisionsJSON, ok := ctx.UserInputs[userInputConsentDecisions]
 	if !ok || decisionsJSON == "" {
-		logger.Debug("Consent decisions input is missing or empty")
+		logger.DebugWithContext(ctx.Context, "Consent decisions input is missing or empty")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrConsentDecisionsMissing
 		return execResp, nil
@@ -206,7 +207,7 @@ func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp
 
 	var decisions consentauthn.ConsentDecisions
 	if err := json.Unmarshal([]byte(decisionsJSON), &decisions); err != nil {
-		logger.Error("Failed to parse consent decisions", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to parse consent decisions", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrConsentDecisionsParseFail
 		return execResp, nil
@@ -216,7 +217,7 @@ func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp
 	if expiresAtStr, ok := ctx.RuntimeData[common.RuntimeKeyStepTimeout]; ok && expiresAtStr != "" {
 		if expiresAt, err := strconv.ParseInt(expiresAtStr, 10, 64); err == nil {
 			if time.Now().UnixMilli() > expiresAt {
-				logger.Debug("Consent prompt has timed out", log.Any("expiresAt", expiresAt))
+				logger.DebugWithContext(ctx.Context, "Consent prompt has timed out", log.Any("expiresAt", expiresAt))
 				execResp.Status = common.ExecFailure
 				execResp.Error = &ErrConsentPromptTimedOut
 				return execResp, nil
@@ -241,20 +242,20 @@ func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp
 		// Essential consent denied: the consent record was persisted but the user denied
 		// a required attribute, so the flow cannot proceed
 		if svcErr.Code == consentauthn.ErrorEssentialConsentDenied.Code {
-			logger.Debug("User denied essential consent attributes")
+			logger.DebugWithContext(ctx.Context, "User denied essential consent attributes")
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrConsentDenied
 			return execResp, nil
 		}
 
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Client error while recording user consent", log.Any("error", svcErr))
+			logger.DebugWithContext(ctx.Context, "Client error while recording user consent", log.Any("error", svcErr))
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrConsentRecordFailed
 			return execResp, nil
 		}
 
-		logger.Error("Failed to record consent", log.Any("error", svcErr))
+		logger.ErrorWithContext(ctx.Context, "Failed to record consent", log.Any("error", svcErr))
 		return nil, errors.New("failed to record consent")
 	}
 
@@ -270,7 +271,7 @@ func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp
 	consentedPerms := collectConsentedPermissions(consentRecord)
 	execResp.RuntimeData[common.RuntimeKeyConsentedPermissions] = strings.Join(consentedPerms, " ")
 
-	logger.Debug("Consent recorded successfully", log.String("consentID", consentRecord.ID))
+	logger.DebugWithContext(ctx.Context, "Consent recorded successfully", log.String("consentID", consentRecord.ID))
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }
@@ -330,7 +331,8 @@ func (e *consentExecutor) buildAugmentedAvailableAttributes(ctx *core.NodeContex
 	if ctx.AuthUser.IsAuthenticated() {
 		attrs, svcErr := e.authnProvider.GetUserAvailableAttributes(ctx.Context, ctx.AuthUser)
 		if svcErr != nil {
-			e.logger.Debug("Failed to get available attributes from AuthUser; using AuthenticatedUser only",
+			e.logger.DebugWithContext(ctx.Context,
+				"Failed to get available attributes from AuthUser; using AuthenticatedUser only",
 				log.Any("error", svcErr))
 		} else if attrs != nil {
 			hasSource = true

--- a/backend/internal/flow/executor/credential_setter.go
+++ b/backend/internal/flow/executor/credential_setter.go
@@ -68,7 +68,7 @@ func newCredentialSetter(
 // Execute sets the password for the user identified by userID in RuntimeData.
 func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing credential set")
+	logger.DebugWithContext(ctx.Context, "Executing credential set")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -77,21 +77,21 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 
 	// Check if password is provided
 	if !e.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Requested credentials not provided, requesting input")
+		logger.DebugWithContext(ctx.Context, "Requested credentials not provided, requesting input")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
 
 	// Validate prerequisites
 	if !e.ValidatePrerequisites(ctx, execResp) {
-		logger.Debug("Prerequisites not met for credential setter")
+		logger.DebugWithContext(ctx.Context, "Prerequisites not met for credential setter")
 		return execResp, nil
 	}
 
 	// Get userID from context
 	userID := e.GetUserIDFromContext(ctx)
 	if userID == "" {
-		logger.Debug("User ID not found in flow context")
+		logger.DebugWithContext(ctx.Context, "User ID not found in flow context")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserIDMissingInContext
 		return execResp, nil
@@ -100,7 +100,7 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	var credentialKey, credentialValue string
 	requiredInputs := e.GetRequiredInputs(ctx)
 	if len(requiredInputs) == 0 {
-		logger.Debug("No required inputs configured for credential setter")
+		logger.DebugWithContext(ctx.Context, "No required inputs configured for credential setter")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCredentialInputMissing
 		return execResp, nil
@@ -109,7 +109,7 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	input := requiredInputs[0]
 	credentialKey = input.Identifier
 	if credentialKey == "" {
-		logger.Debug("Required input has empty identifier in credential setter")
+		logger.DebugWithContext(ctx.Context, "Required input has empty identifier in credential setter")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCredentialInputInvalid
 		return execResp, nil
@@ -117,7 +117,7 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	credentialValue = ctx.UserInputs[credentialKey]
 
 	if credentialValue == "" {
-		logger.Debug("Credential value is empty", log.String("credentialKey", credentialKey))
+		logger.DebugWithContext(ctx.Context, "Credential value is empty", log.String("credentialKey", credentialKey))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCredentialValueEmpty
 		return execResp, nil
@@ -128,7 +128,7 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 		credentialKey: credentialValue,
 	})
 	if err != nil {
-		logger.Debug("Failed to marshal credentials", log.Error(err))
+		logger.DebugWithContext(ctx.Context, "Failed to marshal credentials", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCredentialProcessingFailed
 		return execResp, nil
@@ -137,13 +137,15 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	// Update user credentials
 	svcErr := e.entityProvider.UpdateCredentials(userID, credentials)
 	if svcErr != nil {
-		logger.Debug("Failed to update user credentials", log.MaskedString(log.LoggerKeyUserID, userID))
+		logger.DebugWithContext(ctx.Context, "Failed to update user credentials",
+			log.MaskedString(log.LoggerKeyUserID, userID))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCredentialSetFailed
 		return execResp, nil
 	}
 
-	logger.Debug("Successfully set credentials for user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "Successfully set credentials for user",
+		log.MaskedString(log.LoggerKeyUserID, userID))
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/email_executor.go
+++ b/backend/internal/flow/executor/email_executor.go
@@ -74,7 +74,7 @@ func (e *emailExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 // executeSend resolves the email template, constructs the email, and sends it.
 func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing email executor in send mode")
+	logger.DebugWithContext(ctx.Context, "Executing email executor in send mode")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -83,7 +83,7 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 
 	// 1. Check for SkipDelivery FIRST
 	if skip, ok := ctx.RuntimeData[common.RuntimeKeySkipDelivery]; ok && skip == dataValueTrue {
-		logger.Debug("Delivery marked as skipped, completing without sending email")
+		logger.DebugWithContext(ctx.Context, "Delivery marked as skipped, completing without sending email")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
@@ -92,7 +92,7 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 		execResp.AdditionalData[common.DataEmailSent] = dataValueFalse
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrEmailServiceNotConfigured
-		logger.Debug("Email client not configured")
+		logger.DebugWithContext(ctx.Context, "Email client not configured")
 		return execResp, nil
 	}
 
@@ -106,7 +106,7 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 		return nil, err
 	}
 	if recipient == "" {
-		logger.Debug("Email recipient not found")
+		logger.DebugWithContext(ctx.Context, "Email recipient not found")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrEmailRecipientMissing
 		return execResp, nil
@@ -150,7 +150,7 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 		return execResp, nil
 	}
 
-	logger.Debug("Email sent successfully", log.MaskedString("recipient", recipient))
+	logger.DebugWithContext(ctx.Context, "Email sent successfully", log.MaskedString("recipient", recipient))
 
 	execResp.AdditionalData[common.DataEmailSent] = dataValueTrue
 	execResp.Status = common.ExecComplete
@@ -193,7 +193,8 @@ func (e *emailExecutor) resolveRecipientEmail(ctx *core.NodeContext, logger *log
 		if recipientEmail, err := GetUserAttribute(user, emailAttr); err == nil {
 			return recipientEmail, nil
 		}
-		logger.Debug("Email attribute not found in user entity", log.String("attribute", emailAttr))
+		logger.DebugWithContext(ctx.Context, "Email attribute not found in user entity",
+			log.String("attribute", emailAttr))
 	}
 
 	return "", nil
@@ -228,7 +229,7 @@ func (e *emailExecutor) resolveTemplateData(ctx *core.NodeContext) template.Temp
 					templateData[k] = v
 				}
 			default:
-				e.logger.Debug("Forwarded template data is of unknown type",
+				e.logger.DebugWithContext(ctx.Context, "Forwarded template data is of unknown type",
 					log.String("type", fmt.Sprintf("%T", forwardedTemplateData)))
 			}
 		}

--- a/backend/internal/flow/executor/federated_auth_resolver_executor.go
+++ b/backend/internal/flow/executor/federated_auth_resolver_executor.go
@@ -70,7 +70,7 @@ func newFederatedAuthResolverExecutor(
 // attribute), matching the same pattern used by the IdentifyingExecutor's filterUsersByAttributes.
 func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := f.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing federated auth resolver")
+	logger.DebugWithContext(ctx.Context, "Executing federated auth resolver")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -78,7 +78,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 	}
 
 	if !f.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required inputs not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -112,7 +112,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 	matched := filterUsersByAttributes(candidates, filters)
 
 	if len(matched) == 0 {
-		logger.Debug("No user matched the provided selection")
+		logger.DebugWithContext(ctx.Context, "No user matched the provided selection")
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = f.GetRequiredInputs(ctx)
 		execResp.Error = &ErrUserNotFound
@@ -123,7 +123,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 		// Still ambiguous — extract remaining disambiguation options and request more input
 		options := extractDisambiguationOptions(matched)
 		if len(options) == 0 {
-			logger.Debug("Candidates are indistinguishable, no further disambiguation possible")
+			logger.DebugWithContext(ctx.Context, "Candidates are indistinguishable, no further disambiguation possible")
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrFailedToIdentifyUser
 			return execResp, nil
@@ -139,7 +139,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 			common.ForwardedDataKeyInputs: options,
 		}
 
-		logger.Debug("Multiple users still match, requesting additional attributes",
+		logger.DebugWithContext(ctx.Context, "Multiple users still match, requesting additional attributes",
 			log.Int("candidateCount", len(matched)))
 		return execResp, nil
 	}
@@ -151,7 +151,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 	// proof of federated authentication, so we must fail closed.
 	sub, hasSub := ctx.RuntimeData[userAttributeSub]
 	if !hasSub || sub == "" {
-		logger.Debug("No federated sub claim found, cannot authenticate")
+		logger.DebugWithContext(ctx.Context, "No federated sub claim found, cannot authenticate")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserNotAuthenticated
 		return execResp, nil
@@ -166,7 +166,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 		UserType:        resolvedUser.Type,
 	}
 
-	logger.Debug("Federated auth resolver completed successfully",
+	logger.DebugWithContext(ctx.Context, "Federated auth resolver completed successfully",
 		log.MaskedString("userID", resolvedUser.ID))
 
 	return execResp, nil

--- a/backend/internal/flow/executor/http_request_executor.go
+++ b/backend/internal/flow/executor/http_request_executor.go
@@ -106,7 +106,7 @@ func newHTTPRequestExecutor(
 // Execute executes the HTTP request logic.
 func (h *httpRequestExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing HTTP request executor")
+	logger.DebugWithContext(ctx.Context, "Executing HTTP request executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -115,7 +115,7 @@ func (h *httpRequestExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 
 	config, err := h.parseAndValidateConfig(ctx.NodeProperties)
 	if err != nil {
-		logger.Error("Failed to parse/validate HTTP request configuration", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to parse/validate HTTP request configuration", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrHTTPRequestConfigInvalid
 		return execResp, nil
@@ -126,17 +126,18 @@ func (h *httpRequestExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 
 	response, err := h.executeRequestWithRetry(ctx, config)
 	if err != nil {
-		logger.Error("Failed to execute HTTP request", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to execute HTTP request", log.Error(err))
 		return h.handleRequestError(execResp, config, err.Error(), logger), nil
 	}
 
 	if err := h.processResponse(ctx, config, response, execResp); err != nil {
-		logger.Error("Failed to process response", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to process response", log.Error(err))
 		return h.handleRequestError(execResp, config, err.Error(), logger), nil
 	}
 
 	execResp.Status = common.ExecComplete
-	logger.Debug("HTTP request executor execution completed", log.String("status", string(execResp.Status)))
+	logger.DebugWithContext(ctx.Context, "HTTP request executor execution completed",
+		log.String("status", string(execResp.Status)))
 
 	return execResp, nil
 }
@@ -321,7 +322,7 @@ func (h *httpRequestExecutor) enrichOURuntimeData(ctx *core.NodeContext, config 
 	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	organizationUnit, svcErr := h.ouService.GetOrganizationUnit(ctx.Context, ouID)
 	if svcErr != nil {
-		logger.Warn("Failed to fetch OU details for placeholder enrichment",
+		logger.WarnWithContext(ctx.Context, "Failed to fetch OU details for placeholder enrichment",
 			log.String(ouIDKey, ouID), log.String("error", svcErr.Error.DefaultValue))
 		return
 	}
@@ -386,7 +387,8 @@ func (h *httpRequestExecutor) executeRequestWithRetry(ctx *core.NodeContext,
 	attempts := retryCount + 1
 	for attempt := 0; attempt < attempts; attempt++ {
 		if attempt > 0 {
-			logger.Debug("Retrying HTTP request", log.Int("attempt", attempt), log.Int("maxRetries", retryCount))
+			logger.DebugWithContext(ctx.Context, "Retrying HTTP request",
+				log.Int("attempt", attempt), log.Int("maxRetries", retryCount))
 			time.Sleep(time.Duration(retryDelay) * time.Millisecond)
 		}
 
@@ -432,7 +434,7 @@ func (h *httpRequestExecutor) executeRequest(ctx *core.NodeContext, config *http
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	logger.Debug("Sending HTTP request", log.String("method", config.Method),
+	logger.DebugWithContext(ctx.Context, "Sending HTTP request", log.String("method", config.Method),
 		log.MaskedString("url", config.URL))
 
 	response, err := httpClient.Do(req)
@@ -449,7 +451,7 @@ func (h *httpRequestExecutor) processResponse(ctx *core.NodeContext, config *htt
 	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	defer func() {
 		if err := response.Body.Close(); err != nil {
-			logger.Error("Failed to close response body", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Failed to close response body", log.Error(err))
 		}
 	}()
 
@@ -458,7 +460,7 @@ func (h *httpRequestExecutor) processResponse(ctx *core.NodeContext, config *htt
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	logger.Debug("Received HTTP response", log.Int("statusCode", response.StatusCode),
+	logger.DebugWithContext(ctx.Context, "Received HTTP response", log.Int("statusCode", response.StatusCode),
 		log.String("status", response.Status))
 
 	// Check for error status codes

--- a/backend/internal/flow/executor/identifying_executor.go
+++ b/backend/internal/flow/executor/identifying_executor.go
@@ -118,7 +118,7 @@ func (i *identifyingExecutor) IdentifyUser(filters map[string]interface{},
 // Execute executes the identifying executor logic.
 func (i *identifyingExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := i.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing identifying executor")
+	logger.DebugWithContext(ctx.Context, "Executing identifying executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -127,7 +127,7 @@ func (i *identifyingExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 
 	// Check if required inputs are provided
 	if !i.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required inputs for identifying executor are not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for identifying executor are not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -151,7 +151,7 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 
 	userID, err := i.IdentifyUser(userSearchAttributes, execResp)
 	if err != nil {
-		logger.Debug("Failed to identify user due to error: " + err.Error())
+		logger.DebugWithContext(ctx.Context, "Failed to identify user due to error: "+err.Error())
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrFailedToIdentifyUser
 		return execResp, nil
@@ -171,7 +171,7 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 	}
 
 	if userID == nil || *userID == "" {
-		logger.Debug("User not found for the provided attributes")
+		logger.DebugWithContext(ctx.Context, "User not found for the provided attributes")
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = i.GetRequiredInputs(ctx)
 		execResp.Error = &ErrUserNotFound
@@ -181,7 +181,7 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 	execResp.RuntimeData[userAttributeUserID] = *userID
 	execResp.Status = common.ExecComplete
 
-	logger.Debug("Identifying executor completed successfully",
+	logger.DebugWithContext(ctx.Context, "Identifying executor completed successfully",
 		log.MaskedString(log.LoggerKeyUserID, *userID))
 
 	return execResp, nil
@@ -191,7 +191,7 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 func (i *identifyingExecutor) executeResolve(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
 	logger := i.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing identifying executor in resolve mode")
+	logger.DebugWithContext(ctx.Context, "Executing identifying executor in resolve mode")
 
 	userSearchAttributes := i.buildSearchAttributes(ctx)
 
@@ -218,7 +218,7 @@ func (i *identifyingExecutor) executeResolve(ctx *core.NodeContext,
 
 	switch len(candidates) {
 	case 0:
-		logger.Debug("No matching users after filtering")
+		logger.DebugWithContext(ctx.Context, "No matching users after filtering")
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = i.GetRequiredInputs(ctx)
 		execResp.Error = &ErrUserNotFound
@@ -226,7 +226,7 @@ func (i *identifyingExecutor) executeResolve(ctx *core.NodeContext,
 	case 1:
 		execResp.RuntimeData[userAttributeUserID] = candidates[0].ID
 		execResp.Status = common.ExecComplete
-		logger.Debug("User resolved successfully",
+		logger.DebugWithContext(ctx.Context, "User resolved successfully",
 			log.MaskedString("userID", candidates[0].ID))
 		return execResp, nil
 	default:

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -85,7 +85,7 @@ func (e *inviteExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespons
 // executeGenerate generates the invite token and link.
 func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing invite executor in generate mode")
+	logger.DebugWithContext(ctx.Context, "Executing invite executor in generate mode")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -95,7 +95,7 @@ func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.Executo
 
 	inviteToken, err := e.getOrGenerateToken(ctx)
 	if err != nil {
-		logger.Debug("Failed to get or generate invite token", log.Error(err))
+		logger.DebugWithContext(ctx.Context, "Failed to get or generate invite token", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrInviteTokenGenerationFailed
 		return execResp, nil
@@ -122,7 +122,7 @@ func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.Executo
 // executeVerify validates the user-provided invite token against the stored token.
 func (e *inviteExecutor) executeVerify(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing invite executor in verify mode")
+	logger.DebugWithContext(ctx.Context, "Executing invite executor in verify mode")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -140,20 +140,21 @@ func (e *inviteExecutor) executeVerify(ctx *core.NodeContext) (*common.ExecutorR
 	storedToken, hasStoredToken := ctx.RuntimeData[common.RuntimeKeyStoredInviteToken]
 
 	if !hasStoredToken {
-		logger.Debug("No invite token found in runtime data")
+		logger.DebugWithContext(ctx.Context, "No invite token found in runtime data")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrInvalidInviteToken
 		return execResp, nil
 	}
 
 	if inviteTokenInput != storedToken {
-		logger.Debug("Invite token mismatch", log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+		logger.DebugWithContext(ctx.Context, "Invite token mismatch",
+			log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrInvalidInviteToken
 		return execResp, nil
 	}
 
-	logger.Debug("Invite token validated successfully")
+	logger.DebugWithContext(ctx.Context, "Invite token validated successfully")
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/magic_link_executor.go
+++ b/backend/internal/flow/executor/magic_link_executor.go
@@ -93,12 +93,12 @@ func newMagicLinkAuthExecutor(
 // Execute executes the Magic Link authentication logic.
 func (m *magicLinkAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := m.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing Magic Link authentication executor")
+	logger.DebugWithContext(ctx.Context, "Executing Magic Link authentication executor")
 
 	execResp := newMagicLinkExecutorResponse()
 
 	if !m.ValidatePrerequisites(ctx, execResp) {
-		logger.Debug("Prerequisites not met for Magic Link authentication executor")
+		logger.DebugWithContext(ctx.Context, "Prerequisites not met for Magic Link authentication executor")
 		return execResp, nil
 	}
 
@@ -119,7 +119,8 @@ func (m *magicLinkAuthExecutor) executeGenerate(ctx *core.NodeContext) (*common.
 	if err != nil {
 		return execResp, err
 	}
-	logger.Debug("Magic link generation completed", log.String("status", string(execResp.Status)))
+	logger.DebugWithContext(ctx.Context, "Magic link generation completed",
+		log.String("status", string(execResp.Status)))
 	return execResp, nil
 }
 
@@ -148,7 +149,8 @@ func (m *magicLinkAuthExecutor) InitiateMagicLink(ctx *core.NodeContext,
 		}
 		if userID != nil && *userID != "" {
 			// ANTI-ENUMERATION: Pretend it succeeded but skip sending the magic link.
-			logger.Debug("Registration attempted for existing user. Skipping delivery to prevent enumeration.")
+			logger.DebugWithContext(ctx.Context,
+				"Registration attempted for existing user. Skipping delivery to prevent enumeration.")
 			execResp.RuntimeData[common.RuntimeKeySkipDelivery] = dataValueTrue
 			execResp.Status = common.ExecComplete
 			return execResp, nil
@@ -164,7 +166,7 @@ func (m *magicLinkAuthExecutor) InitiateMagicLink(ctx *core.NodeContext,
 		} else {
 			identifiedUserID, providerErr := m.entityProvider.IdentifyEntity(searchAttrs)
 			if providerErr != nil || identifiedUserID == nil || *identifiedUserID == "" {
-				logger.Debug("User not found, completing without delivery for anti-enumeration")
+				logger.DebugWithContext(ctx.Context, "User not found, completing without delivery for anti-enumeration")
 				execResp.RuntimeData[common.RuntimeKeySkipDelivery] = dataValueTrue
 				execResp.Status = common.ExecComplete
 				return execResp, nil
@@ -303,7 +305,7 @@ func (m *magicLinkAuthExecutor) executeVerify(ctx *core.NodeContext) (*common.Ex
 	execResp := newMagicLinkExecutorResponse()
 
 	if !m.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required inputs for Magic Link verification are not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for Magic Link verification are not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -347,7 +349,7 @@ func (m *magicLinkAuthExecutor) executeVerify(ctx *core.NodeContext) (*common.Ex
 
 	if ctx.FlowType == common.FlowTypeRegistration {
 		if authnResult.IsExistingUser {
-			logger.Debug("User already exists during magic link registration verification.")
+			logger.DebugWithContext(ctx.Context, "User already exists during magic link registration verification.")
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrUserAlreadyExists
 			return execResp, nil
@@ -364,7 +366,7 @@ func (m *magicLinkAuthExecutor) executeVerify(ctx *core.NodeContext) (*common.Ex
 	execResp.AuthenticatedUser = *authenticatedUser
 
 	execResp.Status = common.ExecComplete
-	logger.Debug("Magic link verify completed successfully")
+	logger.DebugWithContext(ctx.Context, "Magic link verify completed successfully")
 	return execResp, nil
 }
 
@@ -374,13 +376,13 @@ func (m *magicLinkAuthExecutor) validateFlowClaims(ctx *core.NodeContext,
 	token string, logger *log.Logger) (string, *serviceerror.ServiceError) {
 	payload, decodeErr := jwt.DecodeJWTPayload(token)
 	if decodeErr != nil {
-		logger.Debug("Failed to decode magic link token", log.Error(decodeErr))
+		logger.DebugWithContext(ctx.Context, "Failed to decode magic link token", log.Error(decodeErr))
 		return "", &ErrInvalidMagicLinkToken
 	}
 
 	executionIDClaim := utils.ConvertInterfaceValueToString(payload["executionId"])
 	if executionIDClaim == "" || executionIDClaim != ctx.ExecutionID {
-		logger.Debug("Magic link token executionId mismatch")
+		logger.DebugWithContext(ctx.Context, "Magic link token executionId mismatch")
 		return "", &ErrInvalidMagicLinkToken
 	}
 
@@ -389,11 +391,11 @@ func (m *magicLinkAuthExecutor) validateFlowClaims(ctx *core.NodeContext,
 		return "", &ErrInvalidMagicLinkToken
 	}
 	if usedJti, exists := ctx.RuntimeData[common.RuntimeKeyMagicLinkUsedJti]; exists && usedJti == jtiClaim {
-		logger.Debug("Magic link token has already been used", log.String("jti", jtiClaim))
+		logger.DebugWithContext(ctx.Context, "Magic link token has already been used", log.String("jti", jtiClaim))
 		return "", &ErrInvalidMagicLinkToken
 	}
 
-	logger.Debug("Magic link token validated successfully")
+	logger.DebugWithContext(ctx.Context, "Magic link token validated successfully")
 	return jtiClaim, nil
 }
 

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -118,9 +118,11 @@ func newOAuthExecutor(
 }
 
 // Execute executes the OAuth authentication flow.
+//
+//nolint:dupl // OAuth and OIDC executors share the same execute skeleton with type-specific behavior.
 func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing OAuth authentication executor")
+	logger.DebugWithContext(ctx.Context, "Executing OAuth authentication executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -128,7 +130,7 @@ func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 	}
 
 	if !o.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required inputs for OAuth authentication executor is not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for OAuth authentication executor is not provided")
 		err := o.BuildAuthorizeFlow(ctx, execResp)
 		if err != nil {
 			return nil, err
@@ -140,7 +142,7 @@ func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 		}
 	}
 
-	logger.Debug("OAuth authentication executor execution completed",
+	logger.DebugWithContext(ctx.Context, "OAuth authentication executor execution completed",
 		log.String("status", string(execResp.Status)),
 		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
@@ -150,7 +152,7 @@ func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 // BuildAuthorizeFlow constructs the redirection to the external OAuth provider for user authentication.
 func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *common.ExecutorResponse) error {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Initiating OAuth authentication flow")
+	logger.DebugWithContext(ctx.Context, "Initiating OAuth authentication flow")
 
 	idpID, err := o.GetIdpID(ctx)
 	if err != nil {
@@ -165,7 +167,7 @@ func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *comm
 			return nil
 		}
 
-		logger.Error("Failed to build authorize URL", log.String("errorCode", svcErr.Code),
+		logger.ErrorWithContext(ctx.Context, "Failed to build authorize URL", log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return errors.New("failed to build authorize URL")
 	}
@@ -198,7 +200,7 @@ func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *comm
 func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Processing OAuth authentication response")
+	logger.DebugWithContext(ctx.Context, "Processing OAuth authentication response")
 
 	code, ok := ctx.UserInputs[userInputCode]
 	if !ok || code == "" {
@@ -214,7 +216,7 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	if returnedState, ok := ctx.UserInputs[userInputState]; ok && returnedState != "" {
 		expectedState := ctx.RuntimeData[common.RuntimeKeyOAuthState]
 		if returnedState != expectedState {
-			logger.Debug("OAuth state mismatch")
+			logger.DebugWithContext(ctx.Context, "OAuth state mismatch")
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrInvalidOAuthState
 			return nil
@@ -243,13 +245,13 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 			return nil
 		}
 
-		logger.Error("Federated authentication failed", log.String("errorCode", svcErr.Code),
+		logger.ErrorWithContext(ctx.Context, "Federated authentication failed", log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return errors.New("federated authentication failed")
 	}
 
 	if basicResult == nil {
-		logger.Error("authnProvider.AuthenticateUser returned nil result")
+		logger.ErrorWithContext(ctx.Context, "authnProvider.AuthenticateUser returned nil result")
 		return errors.New("OAuth authentication failed")
 	}
 
@@ -285,7 +287,7 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		return nil
 	}
 	if contextUser == nil {
-		logger.Error("Failed to resolve context user after OAuth authentication")
+		logger.ErrorWithContext(ctx.Context, "Failed to resolve context user after OAuth authentication")
 		return errors.New("unexpected error occurred while resolving user")
 	}
 
@@ -322,7 +324,7 @@ func (o *oAuthExecutor) GetIdpID(ctx *core.NodeContext) (string, error) {
 // getIDPName retrieves the name of the identity provider using its ID.
 func (o *oAuthExecutor) getIDPName(ctx context.Context, idpID string) (string, error) {
 	logger := o.logger
-	logger.Debug("Retrieving IDP name for the given IDP ID")
+	logger.DebugWithContext(ctx, "Retrieving IDP name for the given IDP ID")
 
 	idp, svcErr := o.idpService.GetIdentityProvider(ctx, idpID)
 	if svcErr != nil {
@@ -330,7 +332,7 @@ func (o *oAuthExecutor) getIDPName(ctx context.Context, idpID string) (string, e
 			return "", fmt.Errorf("failed to get identity provider: %s", svcErr.ErrorDescription.DefaultValue)
 		}
 
-		logger.Error("Error while retrieving identity provider", log.String("errorCode", svcErr.Code),
+		logger.ErrorWithContext(ctx, "Error while retrieving identity provider", log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return "", errors.New("error while retrieving identity provider")
 	}
@@ -365,7 +367,7 @@ func (o *oAuthExecutor) getContextUserForAuthentication(ctx *core.NodeContext,
 				// Ambiguous user: exists in multiple OUs. Set sub for downstream
 				// disambiguation but do NOT mark as eligible for provisioning since
 				// the user already exists.
-				logger.Debug("Ambiguous user detected, deferring to flow for disambiguation")
+				logger.DebugWithContext(ctx.Context, "Ambiguous user detected, deferring to flow for disambiguation")
 				execResp.Status = common.ExecComplete
 				execResp.Error = nil
 				execResp.RuntimeData[userAttributeSub] = sub
@@ -376,7 +378,7 @@ func (o *oAuthExecutor) getContextUserForAuthentication(ctx *core.NodeContext,
 			}
 
 			// Genuinely new user: no local account exists
-			logger.Debug("User not found, but authentication is allowed without a local user")
+			logger.DebugWithContext(ctx.Context, "User not found, but authentication is allowed without a local user")
 
 			err := o.resolveUserTypeForAutoProvisioning(ctx, execResp)
 			if err != nil {
@@ -428,7 +430,8 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 		// OU when cross-OU provisioning is explicitly allowed. The ProvisioningExecutor enforces
 		// the same-OU duplicate guard, so we don't need to fail here.
 		if isRegistrationWithExistingUserAllowed(ctx) && isCrossOUProvisioningAllowed(ctx) {
-			logger.Debug("Ambiguous user detected, proceeding with cross-OU provisioning eligibility")
+			logger.DebugWithContext(ctx.Context,
+				"Ambiguous user detected, proceeding with cross-OU provisioning eligibility")
 			execResp.Status = common.ExecComplete
 			execResp.Error = nil
 			execResp.RuntimeData[userAttributeSub] = sub
@@ -438,7 +441,8 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 			}, nil
 		}
 
-		logger.Debug("Ambiguous user detected in registration flow, cannot proceed with registration")
+		logger.DebugWithContext(ctx.Context,
+			"Ambiguous user detected in registration flow, cannot proceed with registration")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrAmbiguousUserIdentity
 		return nil, nil
@@ -446,7 +450,8 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 
 	// If no local user is found, proceed with registration
 	if internalUser == nil {
-		logger.Debug("User not found for the provided sub claim. Proceeding with registration flow.")
+		logger.DebugWithContext(ctx.Context,
+			"User not found for the provided sub claim. Proceeding with registration flow.")
 		execResp.Status = common.ExecComplete
 		execResp.Error = nil
 		execResp.RuntimeData[userAttributeSub] = sub
@@ -463,7 +468,8 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 			// the target OU. The same-OU duplicate guard is enforced by the ProvisioningExecutor
 			// itself, which has access to the target OU context. We intentionally do not set
 			// RuntimeKeySkipProvisioning here because we want provisioning to run.
-			logger.Debug("User already exists, proceeding with cross-OU provisioning to target OU")
+			logger.DebugWithContext(ctx.Context,
+				"User already exists, proceeding with cross-OU provisioning to target OU")
 			execResp.Status = common.ExecComplete
 			execResp.Error = nil
 			execResp.RuntimeData[userAttributeSub] = sub
@@ -473,7 +479,7 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 			}, nil
 		}
 
-		logger.Debug("User already exists, but registration flow is allowed to continue")
+		logger.DebugWithContext(ctx.Context, "User already exists, but registration flow is allowed to continue")
 		execResp.Status = common.ExecComplete
 		execResp.Error = nil
 		execResp.RuntimeData[common.RuntimeKeySkipProvisioning] = dataValueTrue
@@ -496,10 +502,10 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Resolving user type for automatic provisioning")
+	logger.DebugWithContext(ctx.Context, "Resolving user type for automatic provisioning")
 
 	if len(ctx.Application.AllowedUserTypes) == 0 {
-		logger.Debug("No allowed user types configured for the application")
+		logger.DebugWithContext(ctx.Context, "No allowed user types configured for the application")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCannotProvisionAutomatically
 		return nil
@@ -517,7 +523,8 @@ func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext
 				return nil
 			}
 
-			logger.Error("Error while retrieving user type", log.String("errorCode", svcErr.Code),
+			logger.ErrorWithContext(ctx.Context, "Error while retrieving user type",
+				log.String("errorCode", svcErr.Code),
 				log.String("description", svcErr.ErrorDescription.DefaultValue))
 			return errors.New("error while retrieving user type")
 		}
@@ -528,7 +535,8 @@ func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext
 
 	// Fail if no user types have self-registration enabled
 	if len(selfRegEnabledSchemas) == 0 {
-		logger.Debug("No user types with self-registration enabled, cannot provision automatically")
+		logger.DebugWithContext(ctx.Context,
+			"No user types with self-registration enabled, cannot provision automatically")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSelfRegistrationDisabled
 		return nil
@@ -536,7 +544,8 @@ func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext
 
 	// Fail if multiple user types have self-registration enabled
 	if len(selfRegEnabledSchemas) > 1 {
-		logger.Debug("Multiple user types with self-registration enabled, cannot resolve user type automatically")
+		logger.DebugWithContext(ctx.Context,
+			"Multiple user types with self-registration enabled, cannot resolve user type automatically")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCannotProvisionAutomatically
 		return nil

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -94,9 +94,11 @@ func newOIDCAuthExecutor(
 }
 
 // Execute executes the OIDC authentication logic.
+//
+//nolint:dupl // OAuth and OIDC executors share the same execute skeleton with type-specific behavior.
 func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing OIDC authentication executor")
+	logger.DebugWithContext(ctx.Context, "Executing OIDC authentication executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -104,7 +106,7 @@ func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	}
 
 	if !o.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required inputs for OIDC authentication executor is not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for OIDC authentication executor is not provided")
 		err := o.BuildAuthorizeFlow(ctx, execResp)
 		if err != nil {
 			return nil, err
@@ -116,7 +118,7 @@ func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 		}
 	}
 
-	logger.Debug("OIDC authentication executor execution completed",
+	logger.DebugWithContext(ctx.Context, "OIDC authentication executor execution completed",
 		log.String("status", string(execResp.Status)),
 		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
@@ -127,7 +129,7 @@ func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Processing OIDC authentication response")
+	logger.DebugWithContext(ctx.Context, "Processing OIDC authentication response")
 
 	code, ok := ctx.UserInputs[userInputCode]
 	if !ok || code == "" {
@@ -143,7 +145,7 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	if returnedState, ok := ctx.UserInputs[userInputState]; ok && returnedState != "" {
 		expectedState := ctx.RuntimeData[common.RuntimeKeyOAuthState]
 		if returnedState != expectedState {
-			logger.Debug("OAuth state mismatch")
+			logger.DebugWithContext(ctx.Context, "OAuth state mismatch")
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrInvalidOAuthState
 			return nil
@@ -172,13 +174,13 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 			return nil
 		}
 
-		logger.Error("OIDC authentication failed", log.String("errorCode", svcErr.Code),
+		logger.ErrorWithContext(ctx.Context, "OIDC authentication failed", log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return errors.New("OIDC authentication failed")
 	}
 
 	if basicResult == nil {
-		logger.Error("authnProvider.AuthenticateUser returned nil result")
+		logger.ErrorWithContext(ctx.Context, "authnProvider.AuthenticateUser returned nil result")
 		return errors.New("OIDC authentication failed")
 	}
 
@@ -224,7 +226,7 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		return nil
 	}
 	if contextUser == nil {
-		logger.Error("Failed to resolve context user after OIDC authentication")
+		logger.ErrorWithContext(ctx.Context, "Failed to resolve context user after OIDC authentication")
 		return errors.New("unexpected error occurred while resolving user")
 	}
 

--- a/backend/internal/flow/executor/ou_executor.go
+++ b/backend/internal/flow/executor/ou_executor.go
@@ -77,7 +77,7 @@ func newOUExecutor(
 // Execute executes the ou creation logic.
 func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing OU creation executor")
+	logger.DebugWithContext(ctx.Context, "Executing OU creation executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -85,14 +85,14 @@ func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, e
 	}
 
 	if !o.ValidatePrerequisites(ctx, execResp) {
-		logger.Debug("Prerequisites validation failed for OU creation")
+		logger.DebugWithContext(ctx.Context, "Prerequisites validation failed for OU creation")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrOUCreationPrereqFailed
 		return execResp, nil
 	}
 
 	if !o.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required inputs for OU creation is not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for OU creation is not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -100,7 +100,8 @@ func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, e
 	// Create the OU using the OU service.
 	ouRequest, err := o.getOrganizationUnitRequest(ctx)
 	if err != nil {
-		logger.Error("Failed to build organization unit request", log.String("error", err.Error()))
+		logger.ErrorWithContext(ctx.Context, "Failed to build organization unit request",
+			log.String("error", err.Error()))
 		return nil, err
 	}
 	createdOU, svcErr := o.ouService.CreateOrganizationUnit(ctx.Context, ouRequest)
@@ -124,20 +125,21 @@ func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, e
 			return execResp, nil
 		}
 
-		logger.Error("Error occurred while creating organization unit: ", log.String("errorCode", svcErr.Code),
+		logger.ErrorWithContext(ctx.Context, "Error occurred while creating organization unit: ",
+			log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return nil, errors.New("failed to create organization unit")
 	}
 
 	if createdOU.ID == "" {
-		logger.Error("Organization unit creation failed: received empty OU ID")
+		logger.ErrorWithContext(ctx.Context, "Organization unit creation failed: received empty OU ID")
 		return nil, errors.New("failed to create organization unit")
 	}
 
 	// Set the created OU ID in the runtime data for further use in the flow.
 	execResp.RuntimeData[ouIDKey] = createdOU.ID
 
-	logger.Debug("Organization unit created successfully", log.String(ouIDKey, createdOU.ID))
+	logger.DebugWithContext(ctx.Context, "Organization unit created successfully", log.String(ouIDKey, createdOU.ID))
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/ou_resolver_executor.go
+++ b/backend/internal/flow/executor/ou_resolver_executor.go
@@ -92,7 +92,7 @@ func (e *ouResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 
 	resolveFrom := e.getResolveFrom(ctx)
 	if resolveFrom == "" {
-		logger.Debug("resolveFrom not configured, skipping OU override")
+		logger.DebugWithContext(ctx.Context, "resolveFrom not configured, skipping OU override")
 		return execResp, nil
 	}
 
@@ -104,7 +104,7 @@ func (e *ouResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 	case ouResolveFromPromptAll:
 		return e.resolveFromPromptAll(ctx, logger)
 	default:
-		logger.Error("Unsupported resolveFrom value", log.String("resolveFrom", resolveFrom))
+		logger.ErrorWithContext(ctx.Context, "Unsupported resolveFrom value", log.String("resolveFrom", resolveFrom))
 		execResp.Status = common.ExecFailure
 		execResp.Error = serviceerror.CustomServiceError(ErrOUResolutionFailed, i18ncore.I18nMessage{
 			Key:          ErrOUResolutionFailed.ErrorDescription.Key,
@@ -119,7 +119,7 @@ func (e *ouResolverExecutor) resolveFromCaller(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse, logger *log.Logger) (*common.ExecutorResponse, error) {
 	callerOUID := security.GetOUID(ctx.Context)
 	if callerOUID == "" {
-		logger.Error("Caller OU not found in security context")
+		logger.ErrorWithContext(ctx.Context, "Caller OU not found in security context")
 		execResp.Status = common.ExecFailure
 		execResp.Error = serviceerror.CustomServiceError(ErrOUResolutionFailed, i18ncore.I18nMessage{
 			Key:          ErrOUResolutionFailed.ErrorDescription.Key,
@@ -128,7 +128,7 @@ func (e *ouResolverExecutor) resolveFromCaller(ctx *core.NodeContext,
 		return execResp, nil
 	}
 
-	logger.Debug("Overriding user OU with caller's OU", log.String("callerOUID", callerOUID))
+	logger.DebugWithContext(ctx.Context, "Overriding user OU with caller's OU", log.String("callerOUID", callerOUID))
 	execResp.RuntimeData[ouIDKey] = callerOUID
 
 	return execResp, nil
@@ -168,7 +168,7 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
 			return nil, errors.New("failed to validate selected organization unit: " + svcErr.Error.DefaultValue)
 		}
 		if !isDescendant {
-			logger.Debug("Selected OU is not a descendant of the parent OU",
+			logger.DebugWithContext(ctx.Context, "Selected OU is not a descendant of the parent OU",
 				log.String(ouIDKey, selectedOUID),
 				log.String("parentOUID", parentOUID))
 			execResp.Status = common.ExecUserInputRequired
@@ -177,7 +177,7 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
 			return execResp, nil
 		}
 
-		logger.Debug("OU selected by user", log.String(ouIDKey, selectedOUID))
+		logger.DebugWithContext(ctx.Context, "OU selected by user", log.String(ouIDKey, selectedOUID))
 		execResp.RuntimeData[ouIDKey] = selectedOUID
 		execResp.Status = common.ExecComplete
 		return execResp, nil
@@ -190,13 +190,13 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
 	}
 
 	if children.TotalResults == 0 {
-		logger.Debug("No child OUs found, skipping OU selection")
+		logger.DebugWithContext(ctx.Context, "No child OUs found, skipping OU selection")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
 
 	// Child OUs exist — prompt the user to select one.
-	logger.Debug("Child OUs found, requesting OU selection",
+	logger.DebugWithContext(ctx.Context, "Child OUs found, requesting OU selection",
 		log.String("parentOUID", parentOUID),
 		log.Int("totalChildren", children.TotalResults))
 
@@ -237,14 +237,14 @@ func (e *ouResolverExecutor) resolveFromPromptAll(ctx *core.NodeContext,
 			return execResp, nil
 		}
 
-		logger.Debug("OU selected by user", log.String(ouIDKey, selectedOUID))
+		logger.DebugWithContext(ctx.Context, "OU selected by user", log.String(ouIDKey, selectedOUID))
 		execResp.RuntimeData[ouIDKey] = selectedOUID
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
 
 	// No selection yet — prompt the user with the full OU tree.
-	logger.Debug("Requesting OU selection from full tree")
+	logger.DebugWithContext(ctx.Context, "Requesting OU selection from full tree")
 	execResp.Status = common.ExecUserInputRequired
 
 	inputs := e.GetDefaultInputs()

--- a/backend/internal/flow/executor/passkey_executor.go
+++ b/backend/internal/flow/executor/passkey_executor.go
@@ -144,7 +144,7 @@ func newPasskeyAuthExecutor(
 // Execute executes the passkey authentication logic.
 func (p *passkeyAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing passkey authentication executor")
+	logger.DebugWithContext(ctx.Context, "Executing passkey authentication executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -152,7 +152,7 @@ func (p *passkeyAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 	}
 
 	if !p.ValidatePrerequisites(ctx, execResp) {
-		logger.Debug("Prerequisites not met for passkey authentication executor")
+		logger.DebugWithContext(ctx.Context, "Prerequisites not met for passkey authentication executor")
 		return execResp, nil
 	}
 
@@ -180,15 +180,16 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 	userID := p.GetUserIDFromContext(ctx)
 
 	if userID == "" {
-		logger.Debug("Generating usernameless passkey authentication challenge")
+		logger.DebugWithContext(ctx.Context, "Generating usernameless passkey authentication challenge")
 	} else {
-		logger.Debug("Generating passkey authentication challenge", log.MaskedString(log.LoggerKeyUserID, userID))
+		logger.DebugWithContext(ctx.Context, "Generating passkey authentication challenge",
+			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
 	// Get relying party ID from node properties or use a default
 	relyingPartyID := p.getRelyingPartyID(ctx)
 	if relyingPartyID == "" {
-		logger.Error("Relying party ID not configured")
+		logger.ErrorWithContext(ctx.Context, "Relying party ID not configured")
 		return execResp, errors.New("relying party ID is not configured in node properties")
 	}
 
@@ -200,7 +201,7 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 	startData, svcErr := p.passkeyService.StartAuthentication(ctx.Context, startReq)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Failed to start passkey authentication",
+			logger.DebugWithContext(ctx.Context, "Failed to start passkey authentication",
 				log.MaskedString(log.LoggerKeyUserID, userID),
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			execResp.Status = common.ExecFailure
@@ -210,7 +211,7 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 			})
 			return execResp, nil
 		}
-		logger.Error("Failed to start passkey authentication",
+		logger.ErrorWithContext(ctx.Context, "Failed to start passkey authentication",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(errors.New(svcErr.ErrorDescription.DefaultValue)))
 		return execResp, fmt.Errorf("failed to start passkey authentication: %s", svcErr.ErrorDescription.DefaultValue)
 	}
@@ -221,7 +222,7 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 	// Marshal the challenge options to JSON
 	challengeJSON, err := json.Marshal(startData.PublicKeyCredentialRequestOptions)
 	if err != nil {
-		logger.Error("Failed to marshal challenge options", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to marshal challenge options", log.Error(err))
 		return execResp, fmt.Errorf("failed to marshal challenge options: %w", err)
 	}
 
@@ -230,9 +231,10 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 	execResp.Status = common.ExecComplete
 
 	if userID == "" {
-		logger.Debug("Usernameless passkey challenge generated successfully")
+		logger.DebugWithContext(ctx.Context, "Usernameless passkey challenge generated successfully")
 	} else {
-		logger.Debug("Passkey challenge generated successfully", log.MaskedString(log.LoggerKeyUserID, userID))
+		logger.DebugWithContext(ctx.Context, "Passkey challenge generated successfully",
+			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 	return execResp, nil
 }
@@ -241,11 +243,11 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 func (p *passkeyAuthExecutor) executeVerify(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Verifying passkey authentication response")
+	logger.DebugWithContext(ctx.Context, "Verifying passkey authentication response")
 
 	// Check for required inputs
 	if !p.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required inputs for passkey verification are not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for passkey verification are not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -253,7 +255,7 @@ func (p *passkeyAuthExecutor) executeVerify(ctx *core.NodeContext,
 	// Validate the passkey
 	err := p.validatePasskey(ctx, execResp, logger)
 	if err != nil {
-		logger.Error("Error validating passkey", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Error validating passkey", log.Error(err))
 		return execResp, fmt.Errorf("error validating passkey: %w", err)
 	}
 	if execResp.Status == common.ExecFailure || execResp.Status == common.ExecUserInputRequired {
@@ -263,14 +265,14 @@ func (p *passkeyAuthExecutor) executeVerify(ctx *core.NodeContext,
 	// Get authenticated user details
 	authenticatedUser, err := p.getAuthenticatedUser(ctx, execResp)
 	if err != nil {
-		logger.Error("Failed to get authenticated user details", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to get authenticated user details", log.Error(err))
 		return execResp, fmt.Errorf("failed to get authenticated user details: %w", err)
 	}
 
 	execResp.AuthenticatedUser = *authenticatedUser
 	execResp.Status = common.ExecComplete
 
-	logger.Debug("Passkey verification completed successfully",
+	logger.DebugWithContext(ctx.Context, "Passkey verification completed successfully",
 		log.String("status", string(execResp.Status)),
 		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
@@ -289,12 +291,13 @@ func (p *passkeyAuthExecutor) validatePasskey(ctx *core.NodeContext, execResp *c
 	signature := ctx.UserInputs[inputSignature]
 	userHandle := ctx.UserInputs[inputUserHandle]
 
-	logger.Debug("Validating passkey", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "Validating passkey", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	// Get session token from runtime data
 	sessionToken := ctx.RuntimeData[runtimePasskeySessionToken]
 	if sessionToken == "" {
-		logger.Error("No session token found for passkey authentication", log.MaskedString(log.LoggerKeyUserID, userID))
+		logger.ErrorWithContext(ctx.Context, "No session token found for passkey authentication",
+			log.MaskedString(log.LoggerKeyUserID, userID))
 		return fmt.Errorf("no session token found for passkey authentication")
 	}
 
@@ -312,7 +315,8 @@ func (p *passkeyAuthExecutor) validatePasskey(ctx *core.NodeContext, execResp *c
 		ctx.Context, nil, credentials, nil, nil, ctx.AuthUser)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Passkey verification failed", log.MaskedString(log.LoggerKeyUserID, userID),
+			logger.DebugWithContext(ctx.Context, "Passkey verification failed",
+				log.MaskedString(log.LoggerKeyUserID, userID),
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			// Return USER_INPUT_REQUIRED to allow retry on invalid passkey
 			execResp.Status = common.ExecUserInputRequired
@@ -320,7 +324,7 @@ func (p *passkeyAuthExecutor) validatePasskey(ctx *core.NodeContext, execResp *c
 			execResp.Error = &ErrInvalidPasskey
 			return nil
 		}
-		logger.Error("Failed to verify passkey", log.MaskedString(log.LoggerKeyUserID, userID),
+		logger.ErrorWithContext(ctx.Context, "Failed to verify passkey", log.MaskedString(log.LoggerKeyUserID, userID),
 			log.String("error", svcErr.ErrorDescription.DefaultValue))
 		return fmt.Errorf("failed to verify passkey: %s", svcErr.ErrorDescription.DefaultValue)
 	}
@@ -334,7 +338,8 @@ func (p *passkeyAuthExecutor) validatePasskey(ctx *core.NodeContext, execResp *c
 	// Clear session token after successful verification
 	execResp.RuntimeData[runtimePasskeySessionToken] = ""
 
-	logger.Debug("Passkey validated successfully", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "Passkey validated successfully",
+		log.MaskedString(log.LoggerKeyUserID, userID))
 	return nil
 }
 
@@ -378,7 +383,7 @@ func (p *passkeyAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Starting passkey registration")
+	logger.DebugWithContext(ctx.Context, "Starting passkey registration")
 
 	userID := p.GetUserIDFromContext(ctx)
 	if userID == "" {
@@ -389,7 +394,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 
 	relyingPartyID := p.getRelyingPartyID(ctx)
 	if relyingPartyID == "" {
-		logger.Error("Relying party ID not configured")
+		logger.ErrorWithContext(ctx.Context, "Relying party ID not configured")
 		return execResp, errors.New("relying party ID is not configured in node properties")
 	}
 
@@ -412,7 +417,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 	startData, svcErr := p.passkeyService.StartRegistration(ctx.Context, regReq)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Failed to start passkey registration",
+			logger.DebugWithContext(ctx.Context, "Failed to start passkey registration",
 				log.MaskedString(log.LoggerKeyUserID, userID),
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			execResp.Status = common.ExecFailure
@@ -422,7 +427,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 			})
 			return execResp, nil
 		}
-		logger.Error("Failed to start passkey registration",
+		logger.ErrorWithContext(ctx.Context, "Failed to start passkey registration",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(errors.New(svcErr.ErrorDescription.DefaultValue)))
 		return execResp, fmt.Errorf("failed to start passkey registration: %s", svcErr.ErrorDescription.DefaultValue)
 	}
@@ -433,7 +438,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 	// Marshal the creation options to JSON
 	creationJSON, err := json.Marshal(startData.PublicKeyCredentialCreationOptions)
 	if err != nil {
-		logger.Error("Failed to marshal creation options", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to marshal creation options", log.Error(err))
 		return execResp, fmt.Errorf("failed to marshal creation options: %w", err)
 	}
 
@@ -441,7 +446,8 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 	execResp.AdditionalData[runtimePasskeyCreationOptions] = string(creationJSON)
 	execResp.Status = common.ExecComplete
 
-	logger.Debug("Passkey registration options generated successfully", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "Passkey registration options generated successfully",
+		log.MaskedString(log.LoggerKeyUserID, userID))
 	return execResp, nil
 }
 
@@ -449,7 +455,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Finishing passkey registration")
+	logger.DebugWithContext(ctx.Context, "Finishing passkey registration")
 
 	// Check for required inputs
 	allInputs := []common.Input{
@@ -471,7 +477,7 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 	}
 
 	if missingRequiredInputs {
-		logger.Debug("Required inputs for passkey registration are not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for passkey registration are not provided")
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = allInputs
 		return execResp, nil
@@ -489,7 +495,7 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 	// Get session token from runtime data
 	sessionToken := ctx.RuntimeData[runtimePasskeySessionToken]
 	if sessionToken == "" {
-		logger.Error("No session token found for passkey registration")
+		logger.ErrorWithContext(ctx.Context, "No session token found for passkey registration")
 		return execResp, fmt.Errorf("no session token found for passkey registration")
 	}
 
@@ -507,7 +513,8 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 	finishData, svcErr := p.passkeyService.FinishRegistration(ctx.Context, finishReq)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Passkey registration failed", log.String("error", svcErr.ErrorDescription.DefaultValue))
+			logger.DebugWithContext(ctx.Context, "Passkey registration failed",
+				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			// Return USER_INPUT_REQUIRED to allow retry on invalid registration
 			execResp.Status = common.ExecUserInputRequired
 			execResp.Inputs = allInputs
@@ -517,7 +524,8 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 			})
 			return execResp, nil
 		}
-		logger.Error("Failed to finish passkey registration", log.String("error", svcErr.ErrorDescription.DefaultValue))
+		logger.ErrorWithContext(ctx.Context, "Failed to finish passkey registration",
+			log.String("error", svcErr.ErrorDescription.DefaultValue))
 		return execResp, fmt.Errorf("failed to finish passkey registration: %s", svcErr.ErrorDescription.DefaultValue)
 	}
 
@@ -538,21 +546,21 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 		// For registration flows, user may not be fully authenticated yet
 		// Return credential info but don't set authenticated user
 		execResp.Status = common.ExecComplete
-		logger.Debug("Passkey registration completed for registration flow")
+		logger.DebugWithContext(ctx.Context, "Passkey registration completed for registration flow")
 	} else {
 		// For authentication flows (adding passkey to existing account)
 		// Get and return authenticated user details
 		authenticatedUser, err := p.getAuthenticatedUser(ctx, execResp)
 		if err != nil {
-			logger.Error("Failed to get authenticated user details", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Failed to get authenticated user details", log.Error(err))
 			return execResp, fmt.Errorf("failed to get authenticated user details: %w", err)
 		}
 		execResp.AuthenticatedUser = *authenticatedUser
 		execResp.Status = common.ExecComplete
-		logger.Debug("Passkey registration completed for existing user")
+		logger.DebugWithContext(ctx.Context, "Passkey registration completed for existing user")
 	}
 
-	logger.Debug("Passkey registration finished successfully",
+	logger.DebugWithContext(ctx.Context, "Passkey registration finished successfully",
 		log.String("credentialID", finishData.CredentialID))
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/permission_validator.go
+++ b/backend/internal/flow/executor/permission_validator.go
@@ -65,11 +65,11 @@ func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 	// Get required scopes from node properties.
 	requiredScopes := e.getRequiredScopes(ctx)
 
-	logger.Debug("Checking scope protection", log.Any("requiredScopes", requiredScopes))
+	logger.DebugWithContext(ctx.Context, "Checking scope protection", log.Any("requiredScopes", requiredScopes))
 
 	// Check if context exists
 	if ctx.Context == nil {
-		logger.Debug("No context available - blocking access")
+		logger.DebugWithContext(ctx.Context, "No context available - blocking access")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrInsufficientPermissions
 		return execResp, nil
@@ -77,7 +77,7 @@ func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 
 	// Extract permissions from request context
 	userPermissions := security.GetPermissions(ctx.Context)
-	logger.Debug("Extracted permissions from context",
+	logger.DebugWithContext(ctx.Context, "Extracted permissions from context",
 		log.Int("permissionCount", len(userPermissions)),
 		log.String("permissions", strings.Join(userPermissions, ", ")))
 
@@ -85,14 +85,14 @@ func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 	if !slices.ContainsFunc(requiredScopes, func(reqScope string) bool {
 		return slices.Contains(userPermissions, reqScope)
 	}) {
-		logger.Debug("Request lacks required scope",
+		logger.DebugWithContext(ctx.Context, "Request lacks required scope",
 			log.Any("requiredScopes", requiredScopes))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrInsufficientPermissions
 		return execResp, nil
 	}
 
-	logger.Debug("Scope protection passed", log.Any("requiredScopes", requiredScopes))
+	logger.DebugWithContext(ctx.Context, "Scope protection passed", log.Any("requiredScopes", requiredScopes))
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -82,7 +82,7 @@ func newProvisioningExecutor(
 // Execute executes the user provisioning logic based on the inputs provided.
 func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing user provisioning executor")
+	logger.DebugWithContext(ctx.Context, "Executing user provisioning executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -93,7 +93,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 	if ctx.FlowType == common.FlowTypeAuthentication {
 		eligible, ok := ctx.RuntimeData[common.RuntimeKeyUserEligibleForProvisioning]
 		if !ok || eligible != dataValueTrue {
-			logger.Debug("User is not eligible for provisioning, skipping execution")
+			logger.DebugWithContext(ctx.Context, "User is not eligible for provisioning, skipping execution")
 			execResp.Status = common.ExecComplete
 			return execResp, nil
 		}
@@ -104,7 +104,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 			return execResp, nil
 		}
 
-		logger.Debug("Required inputs for provisioning executor is not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for provisioning executor is not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -114,7 +114,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 		return nil, err
 	}
 	if len(identifyingAttrs) == 0 && len(credentialAttrs) == 0 {
-		logger.Debug("No user attributes provided for provisioning")
+		logger.DebugWithContext(ctx.Context, "No user attributes provided for provisioning")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrProvisioningUserAttrsMissing
 		return execResp, nil
@@ -122,7 +122,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 
 	userID, err := p.IdentifyUser(identifyingAttrs, execResp)
 	if err != nil {
-		logger.Error("Failed to identify user", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to identify user", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrFailedToIdentifyUser
 		return execResp, nil
@@ -161,23 +161,24 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 	}
 	createdEntity, err := p.createUserInStore(ctx, userAttributes)
 	if err != nil {
-		logger.Error("Failed to create user in the store", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to create user in the store", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrProvisioningFailed
 		return execResp, nil
 	}
 	if createdEntity == nil || createdEntity.ID == "" {
-		logger.Error("Created user is nil or has no ID")
+		logger.ErrorWithContext(ctx.Context, "Created user is nil or has no ID")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrProvisioningFailed
 		return execResp, nil
 	}
 
-	logger.Debug("User created successfully", log.MaskedString(log.LoggerKeyUserID, createdEntity.ID))
+	logger.DebugWithContext(ctx.Context, "User created successfully",
+		log.MaskedString(log.LoggerKeyUserID, createdEntity.ID))
 
 	// Assign user to groups and roles
 	if err := p.assignGroupsAndRoles(ctx, createdEntity.ID); err != nil {
-		logger.Error("Failed to assign groups and roles to provisioned user",
+		logger.ErrorWithContext(ctx.Context, "Failed to assign groups and roles to provisioned user",
 			log.MaskedString(log.LoggerKeyUserID, createdEntity.ID),
 			log.Error(err))
 		execResp.Status = common.ExecFailure
@@ -196,13 +197,14 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 // Returns true if provisioning should proceed (cross-OU case), false if execution should stop.
 func (p *provisioningExecutor) handleExistingUser(ctx *core.NodeContext, userID string,
 	execResp *common.ExecutorResponse, logger *log.Logger) (bool, error) {
-	logger.Debug("User already exists", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "User already exists", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	// If it's a registration flow, check if proceeding with an existing user
 	if ctx.FlowType == common.FlowTypeRegistration {
 		existing, ok := ctx.RuntimeData[common.RuntimeKeySkipProvisioning]
 		if ok && existing == dataValueTrue {
-			logger.Debug("Proceeding with an existing user in registration flow, skipping execution")
+			logger.DebugWithContext(ctx.Context,
+				"Proceeding with an existing user in registration flow, skipping execution")
 			execResp.RuntimeData[userAttributeUserID] = userID
 			execResp.Status = common.ExecComplete
 			return false, nil
@@ -245,7 +247,7 @@ func (p *provisioningExecutor) handleExistingUser(ctx *core.NodeContext, userID 
 		return false, nil
 	}
 
-	logger.Debug("Existing user is in a different OU, proceeding with cross-OU provisioning",
+	logger.DebugWithContext(ctx.Context, "Existing user is in a different OU, proceeding with cross-OU provisioning",
 		log.String("existingOUID", existingUser.OUID),
 		log.String("targetOUID", targetOUID))
 	return true, nil
@@ -297,12 +299,14 @@ func (p *provisioningExecutor) resolveAmbiguousUserForProvisioning(ctx *core.Nod
 			return nil, fmt.Errorf("ambiguous user search returned an entity with missing OUID")
 		}
 		if m.OUID == targetOUID {
-			logger.Debug("Ambiguous user has a match in the target OU", log.MaskedString(log.LoggerKeyUserID, m.ID))
+			logger.DebugWithContext(ctx.Context, "Ambiguous user has a match in the target OU",
+				log.MaskedString(log.LoggerKeyUserID, m.ID))
 			return &m.ID, nil
 		}
 	}
 
-	logger.Debug("Ambiguous user has no match in target OU", log.Int("matchCount", len(matches)))
+	logger.DebugWithContext(ctx.Context, "Ambiguous user has no match in target OU",
+		log.Int("matchCount", len(matches)))
 	return nil, nil
 }
 
@@ -317,7 +321,7 @@ func (p *provisioningExecutor) resolveAmbiguousUserForProvisioning(ctx *core.Nod
 func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) bool {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Checking inputs for the provisioning executor")
+	logger.DebugWithContext(ctx.Context, "Checking inputs for the provisioning executor")
 
 	if execResp.RuntimeData == nil {
 		execResp.RuntimeData = make(map[string]string)
@@ -333,7 +337,7 @@ func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 	// Fetch all schema attributes (credential and non-credential) in a single call.
 	allSchemaAttrs, err := p.fetchSchemaAttributes(ctx, true, true)
 	if err != nil {
-		logger.Warn("Failed to fetch schema attributes for provisioning", log.Any("error", err))
+		logger.WarnWithContext(ctx.Context, "Failed to fetch schema attributes for provisioning", log.Any("error", err))
 		execResp.Status = common.ExecFailure
 		return false
 	}
@@ -370,7 +374,7 @@ func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 		execResp.ForwardedData = make(map[string]interface{})
 	}
 	execResp.ForwardedData[common.ForwardedDataKeyInputs] = toForward
-	logger.Debug("Schema attributes are missing, requesting via prompt",
+	logger.DebugWithContext(ctx.Context, "Schema attributes are missing, requesting via prompt",
 		log.Int("missingCount", len(allSchemaMissing)))
 	return false
 }
@@ -572,7 +576,7 @@ func (p *provisioningExecutor) getAttributesForProvisioning(
 func (p *provisioningExecutor) createUserInStore(nodeCtx *core.NodeContext,
 	userAttributes map[string]interface{}) (*entityprovider.Entity, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, nodeCtx.ExecutionID))
-	logger.Debug("Creating the user account")
+	logger.DebugWithContext(nodeCtx.Context, "Creating the user account")
 
 	ouID := p.getOUID(nodeCtx)
 	if ouID == "" {
@@ -602,7 +606,8 @@ func (p *provisioningExecutor) createUserInStore(nodeCtx *core.NodeContext,
 		return nil, fmt.Errorf("failed to create user in the store: %s", svcErr.Message)
 	}
 	if retEntity != nil && retEntity.ID != "" {
-		logger.Debug("User account created successfully", log.MaskedString(log.LoggerKeyUserID, retEntity.ID))
+		logger.DebugWithContext(nodeCtx.Context, "User account created successfully",
+			log.MaskedString(log.LoggerKeyUserID, retEntity.ID))
 	}
 
 	return retEntity, nil
@@ -647,11 +652,11 @@ func (p *provisioningExecutor) assignGroupsAndRoles(
 
 	// Skip if no group or role configured
 	if groupID == "" && roleID == "" {
-		logger.Debug("No group or role configured for assignment, skipping")
+		logger.DebugWithContext(ctx.Context, "No group or role configured for assignment, skipping")
 		return nil
 	}
 
-	logger.Debug("Assigning group and role to provisioned user",
+	logger.DebugWithContext(ctx.Context, "Assigning group and role to provisioned user",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.String("groupID", groupID),
 		log.String("roleID", roleID))
@@ -679,7 +684,8 @@ func (p *provisioningExecutor) assignGroupsAndRoles(
 		return roleErr
 	}
 
-	logger.Debug("Successfully assigned group and role", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "Successfully assigned group and role",
+		log.MaskedString(log.LoggerKeyUserID, userID))
 	return nil
 }
 
@@ -728,7 +734,7 @@ func (p *provisioningExecutor) assignToGroup(
 	groupID string,
 	logger *log.Logger,
 ) error {
-	logger.Debug("Adding user to group",
+	logger.DebugWithContext(ctx, "Adding user to group",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.String("groupID", groupID))
 
@@ -741,14 +747,14 @@ func (p *provisioningExecutor) assignToGroup(
 
 	_, svcErr := p.groupService.AddGroupMembers(ctx, groupID, members)
 	if svcErr != nil {
-		logger.Error("Failed to add user to group",
+		logger.ErrorWithContext(ctx, "Failed to add user to group",
 			log.String("groupID", groupID),
 			log.MaskedString(log.LoggerKeyUserID, userID),
 			log.String("error", svcErr.Error.DefaultValue))
 		return fmt.Errorf("failed to add user to group: %s", svcErr.Error.DefaultValue)
 	}
 
-	logger.Debug("Successfully added user to group",
+	logger.DebugWithContext(ctx, "Successfully added user to group",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.String("groupID", groupID))
 	return nil
@@ -758,13 +764,13 @@ func (p *provisioningExecutor) assignToGroup(
 func (p *provisioningExecutor) assignToRole(
 	ctx context.Context, userID string, roleID string, logger *log.Logger) error {
 	if p.roleAssignmentService == nil {
-		logger.Error("Role assignment service is not configured",
+		logger.ErrorWithContext(ctx, "Role assignment service is not configured",
 			log.String("roleID", roleID),
 			log.MaskedString(log.LoggerKeyUserID, userID))
 		return fmt.Errorf("role assignment service not configured")
 	}
 
-	logger.Debug("Adding user to role",
+	logger.DebugWithContext(ctx, "Adding user to role",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.String("roleID", roleID))
 
@@ -778,14 +784,14 @@ func (p *provisioningExecutor) assignToRole(
 
 	svcErr := p.roleAssignmentService.AddAssignments(ctx, roleID, assignments)
 	if svcErr != nil {
-		logger.Error("Failed to add role assignment",
+		logger.ErrorWithContext(ctx, "Failed to add role assignment",
 			log.String("roleID", roleID),
 			log.MaskedString(log.LoggerKeyUserID, userID),
 			log.String("error", svcErr.Error.DefaultValue))
 		return fmt.Errorf("failed to assign role: %s", svcErr.Error.DefaultValue)
 	}
 
-	logger.Debug("Successfully assigned role",
+	logger.DebugWithContext(ctx, "Successfully assigned role",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.String("roleID", roleID))
 	return nil

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -95,7 +95,7 @@ func newSMSOTPAuthExecutor(
 // Execute executes the SMS OTP authentication logic.
 func (s *smsOTPAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing SMS OTP authentication executor")
+	logger.DebugWithContext(ctx.Context, "Executing SMS OTP authentication executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -106,7 +106,7 @@ func (s *smsOTPAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 	switch ctx.ExecutorMode {
 	case ExecutorModeSend:
 		if !s.ValidatePrerequisites(ctx, execResp) {
-			logger.Debug("Prerequisites not met for SMS OTP authentication executor")
+			logger.DebugWithContext(ctx.Context, "Prerequisites not met for SMS OTP authentication executor")
 			return execResp, nil
 		}
 		return s.executeSend(ctx, execResp)
@@ -127,7 +127,7 @@ func (s *smsOTPAuthExecutor) executeSend(ctx *core.NodeContext,
 		return execResp, err
 	}
 
-	logger.Debug("SMS OTP send completed", log.String("status", string(execResp.Status)))
+	logger.DebugWithContext(ctx.Context, "SMS OTP send completed", log.String("status", string(execResp.Status)))
 
 	return execResp, nil
 }
@@ -138,7 +138,7 @@ func (s *smsOTPAuthExecutor) executeVerify(ctx *core.NodeContext,
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	if !s.HasRequiredInputs(ctx, execResp) {
-		logger.Debug("Required inputs for SMS OTP verification are not provided")
+		logger.DebugWithContext(ctx.Context, "Required inputs for SMS OTP verification are not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -148,7 +148,7 @@ func (s *smsOTPAuthExecutor) executeVerify(ctx *core.NodeContext,
 		return execResp, err
 	}
 
-	logger.Debug("SMS OTP verify completed",
+	logger.DebugWithContext(ctx.Context, "SMS OTP verify completed",
 		log.String("status", string(execResp.Status)),
 		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
@@ -159,7 +159,7 @@ func (s *smsOTPAuthExecutor) executeVerify(ctx *core.NodeContext,
 func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Sending SMS OTP to user")
+	logger.DebugWithContext(ctx.Context, "Sending SMS OTP to user")
 
 	phoneAttr := s.resolvePhoneInput(ctx, mobileNumberInput).Identifier
 	mobileNumber, err := s.getUserMobileFromContext(ctx, phoneAttr)
@@ -177,13 +177,13 @@ func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 	} else {
 		// Identify user by mobile number if not authenticated
 		if mobileNumber == "" {
-			logger.Error("Mobile number is empty in the context")
+			logger.ErrorWithContext(ctx.Context, "Mobile number is empty in the context")
 		}
 
 		filter := map[string]interface{}{phoneAttr: mobileNumber}
 		userID, err = s.IdentifyUser(filter, execResp)
 		if err != nil {
-			logger.Error("Failed to identify user", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Failed to identify user", log.Error(err))
 			return fmt.Errorf("failed to identify user: %w", err)
 		}
 	}
@@ -222,14 +222,14 @@ func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 
 	// Send the OTP to the user's mobile number.
 	if err := s.generateAndSendOTP(mobileNumber, ctx, execResp, logger); err != nil {
-		logger.Error("Failed to send OTP", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to send OTP", log.Error(err))
 		return fmt.Errorf("failed to send OTP: %w", err)
 	}
 	if execResp.Status == common.ExecFailure {
 		return nil
 	}
 
-	logger.Debug("SMS OTP sent successfully")
+	logger.DebugWithContext(ctx.Context, "SMS OTP sent successfully")
 	execResp.RuntimeData[common.RuntimeKeySMSOTPMobileNumber] = mobileNumber
 	execResp.RuntimeData[common.RuntimeKeySMSOTPPhoneAttr] = phoneAttr
 	execResp.Status = common.ExecComplete
@@ -241,11 +241,11 @@ func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 func (s *smsOTPAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Processing authentication flow response for SMS OTP")
+	logger.DebugWithContext(ctx.Context, "Processing authentication flow response for SMS OTP")
 
 	authenticatedUser, err := s.getAuthenticatedUser(ctx, execResp)
 	if err != nil {
-		logger.Error("Failed to get authenticated user details", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to get authenticated user details", log.Error(err))
 		return fmt.Errorf("failed to get authenticated user details: %w", err)
 	}
 	if execResp.Status == common.ExecFailure || execResp.Status == common.ExecUserInputRequired {
@@ -268,13 +268,13 @@ func (s *smsOTPAuthExecutor) ValidatePrerequisites(ctx *core.NodeContext,
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	if ctx.FlowType == common.FlowTypeRegistration {
-		logger.Debug("Prerequisites not met for registration flow, prompting for mobile number")
+		logger.DebugWithContext(ctx.Context, "Prerequisites not met for registration flow, prompting for mobile number")
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = []common.Input{s.resolvePhoneInput(ctx, mobileNumberInput)}
 		return false
 	}
 
-	logger.Debug("Trying to satisfy prerequisites for SMS OTP authentication executor")
+	logger.DebugWithContext(ctx.Context, "Trying to satisfy prerequisites for SMS OTP authentication executor")
 
 	s.satisfyPrerequisites(ctx, execResp)
 	if execResp.Status == common.ExecFailure {
@@ -342,16 +342,16 @@ func (s *smsOTPAuthExecutor) satisfyPrerequisites(ctx *core.NodeContext,
 	execResp.Status = ""
 	execResp.Error = nil
 
-	logger.Debug("Trying to resolve user ID from context data")
+	logger.DebugWithContext(ctx.Context, "Trying to resolve user ID from context data")
 	userIDResolved, err := s.resolveUserID(ctx)
 	if err != nil {
-		logger.Error("Failed to resolve user ID from context data", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to resolve user ID from context data", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserIDMissingInContext
 		return
 	}
 	if !userIDResolved {
-		logger.Debug("User ID could not be resolved from context data")
+		logger.DebugWithContext(ctx.Context, "User ID could not be resolved from context data")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserIDMissingInContext
 		return
@@ -362,10 +362,12 @@ func (s *smsOTPAuthExecutor) satisfyPrerequisites(ctx *core.NodeContext,
 	//  prompt the user to enter their mobile number.
 	//  We should verify whether this is the expected behavior.
 
-	logger.Debug("Retrieving mobile number from user ID", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "Retrieving mobile number from user ID",
+		log.MaskedString(log.LoggerKeyUserID, userID))
 	mobileNumber, err := s.getUserMobileNumber(userID, ctx, execResp)
 	if err != nil {
-		logger.Error("Failed to retrieve mobile number", log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to retrieve mobile number",
+			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = errFailedToRetrieveAttribute("mobile number")
 		return
@@ -374,7 +376,8 @@ func (s *smsOTPAuthExecutor) satisfyPrerequisites(ctx *core.NodeContext,
 		return
 	}
 
-	logger.Debug("Mobile number retrieved successfully", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "Mobile number retrieved successfully",
+		log.MaskedString(log.LoggerKeyUserID, userID))
 	ctx.RuntimeData[s.resolvePhoneInput(ctx, mobileNumberInput).Identifier] = mobileNumber
 
 	// Reset the executor response status and error.
@@ -390,7 +393,8 @@ func (s *smsOTPAuthExecutor) resolveUserID(ctx *core.NodeContext) (bool, error) 
 	// First, check if the user ID is already available in the context.
 	userID := s.GetUserIDFromContext(ctx)
 	if userID != "" {
-		logger.Debug("User ID found in context data", log.MaskedString(log.LoggerKeyUserID, userID))
+		logger.DebugWithContext(ctx.Context, "User ID found in context data",
+			log.MaskedString(log.LoggerKeyUserID, userID))
 		if ctx.RuntimeData == nil {
 			ctx.RuntimeData = make(map[string]string)
 		}
@@ -435,7 +439,7 @@ func (s *smsOTPAuthExecutor) resolveUserID(ctx *core.NodeContext) (bool, error) 
 // resolveUserIDFromAttribute attempts to resolve the user ID from a specific attribute in the context.
 func (s *smsOTPAuthExecutor) resolveUserIDFromAttribute(ctx *core.NodeContext,
 	attributeName string, logger *log.Logger) (bool, error) {
-	logger.Debug("Resolving user ID from attribute", log.String("attributeName", attributeName))
+	logger.DebugWithContext(ctx.Context, "Resolving user ID from attribute", log.String("attributeName", attributeName))
 
 	attributeValue := ctx.UserInputs[attributeName]
 	if attributeValue == "" {
@@ -448,7 +452,8 @@ func (s *smsOTPAuthExecutor) resolveUserIDFromAttribute(ctx *core.NodeContext,
 			return false, fmt.Errorf("failed to identify user by %s: %s", attributeName, providerErr.Error())
 		}
 		if userID != nil && *userID != "" {
-			logger.Debug("User ID resolved from attribute", log.String("attributeName", attributeName),
+			logger.DebugWithContext(ctx.Context, "User ID resolved from attribute",
+				log.String("attributeName", attributeName),
 				log.MaskedString(log.LoggerKeyUserID, *userID))
 			if ctx.RuntimeData == nil {
 				ctx.RuntimeData = make(map[string]string)
@@ -466,18 +471,18 @@ func (s *smsOTPAuthExecutor) getUserMobileNumber(userID string, ctx *core.NodeCo
 	execResp *common.ExecutorResponse) (string, error) {
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID),
 		log.MaskedString(log.LoggerKeyUserID, userID))
-	logger.Debug("Retrieving user mobile number")
+	logger.DebugWithContext(ctx.Context, "Retrieving user mobile number")
 
 	// Try to get mobile number from context
 	phoneAttr := s.resolvePhoneInput(ctx, mobileNumberInput).Identifier
 	mobileNumber, err := s.getUserMobileFromContext(ctx, phoneAttr)
 	if err == nil && mobileNumber != "" {
-		logger.Debug("Mobile number found in context, skipping user store call")
+		logger.DebugWithContext(ctx.Context, "Mobile number found in context, skipping user store call")
 		return mobileNumber, nil
 	}
 
 	// Mobile number not in context, fetch from user store
-	logger.Debug("Mobile number not in context, fetching from user store")
+	logger.DebugWithContext(ctx.Context, "Mobile number not in context, fetching from user store")
 	user, providerErr := s.entityProvider.GetEntity(userID)
 	if providerErr != nil {
 		return "", fmt.Errorf("failed to retrieve user details: %s", providerErr.Error())
@@ -498,7 +503,7 @@ func (s *smsOTPAuthExecutor) getUserMobileNumber(userID string, ctx *core.NodeCo
 	}
 
 	if mobileNumber == "" {
-		logger.Debug("Mobile number not found in user attributes or context")
+		logger.DebugWithContext(ctx.Context, "Mobile number not found in user attributes or context")
 		execResp.Status = common.ExecFailure
 		execResp.Error = errAttributeNotFoundFor("mobile")
 		return "", nil
@@ -559,14 +564,15 @@ func (s *smsOTPAuthExecutor) validateAttempts(ctx *core.NodeContext, execResp *c
 	if attemptCountStr != "" {
 		count, err := strconv.Atoi(attemptCountStr)
 		if err != nil {
-			logger.Error("Failed to parse attempt count", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Failed to parse attempt count", log.Error(err))
 			return 0, fmt.Errorf("failed to parse attempt count: %w", err)
 		}
 		attemptCount = count
 	}
 
 	if attemptCount >= s.getOTPMaxAttempts() {
-		logger.Debug("Maximum OTP attempts reached", log.MaskedString(log.LoggerKeyUserID, userID),
+		logger.DebugWithContext(ctx.Context, "Maximum OTP attempts reached",
+			log.MaskedString(log.LoggerKeyUserID, userID),
 			log.Int("attemptCount", attemptCount))
 		execResp.Status = common.ExecFailure
 		execResp.Error = errMaxOTPAttemptsReachedFor(attemptCount)
@@ -598,11 +604,11 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 
 	userID := ctx.RuntimeData[userAttributeUserID]
 
-	logger.Debug("Validating OTP", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "Validating OTP", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	providedOTP := ctx.UserInputs[userInputOTP]
 	if providedOTP == "" {
-		logger.Debug("Provided OTP is empty", log.MaskedString(log.LoggerKeyUserID, userID))
+		logger.DebugWithContext(ctx.Context, "Provided OTP is empty", log.MaskedString(log.LoggerKeyUserID, userID))
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = s.GetRequiredInputs(ctx)
 		execResp.Error = &ErrInvalidOTP
@@ -611,7 +617,8 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 
 	sessionToken := ctx.RuntimeData["otpSessionToken"]
 	if sessionToken == "" {
-		logger.Error("No session token found for OTP validation", log.MaskedString(log.LoggerKeyUserID, userID))
+		logger.ErrorWithContext(ctx.Context, "No session token found for OTP validation",
+			log.MaskedString(log.LoggerKeyUserID, userID))
 		return nil, fmt.Errorf("no session token found for OTP validation")
 	}
 
@@ -628,13 +635,14 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 			ctx.Context, nil, creds, nil, nil, ctx.AuthUser)
 		if svcErr != nil {
 			if svcErr.Code == authnprovidermgr.ErrorAuthenticationFailed.Code {
-				logger.Debug("OTP verification failed", log.MaskedString(log.LoggerKeyUserID, userID))
+				logger.DebugWithContext(ctx.Context, "OTP verification failed",
+					log.MaskedString(log.LoggerKeyUserID, userID))
 				execResp.Status = common.ExecUserInputRequired
 				execResp.Inputs = s.GetRequiredInputs(ctx)
 				execResp.Error = &ErrInvalidOTP
 				return nil, nil
 			}
-			logger.Error("Failed to verify OTP",
+			logger.ErrorWithContext(ctx.Context, "Failed to verify OTP",
 				log.MaskedString(log.LoggerKeyUserID, userID), log.Any("serviceError", svcErr))
 			return nil, fmt.Errorf("failed to verify OTP: %s", svcErr.ErrorDescription.DefaultValue)
 		}
@@ -661,20 +669,21 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 		ctx.Context, nil, creds, nil, nil, ctx.AuthUser)
 	if svcErr != nil {
 		if svcErr.Code == authnprovidermgr.ErrorAuthenticationFailed.Code {
-			logger.Debug("OTP verification failed", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.DebugWithContext(ctx.Context, "OTP verification failed",
+				log.MaskedString(log.LoggerKeyUserID, userID))
 			execResp.Status = common.ExecUserInputRequired
 			execResp.Inputs = s.GetRequiredInputs(ctx)
 			execResp.Error = &ErrInvalidOTP
 			return nil, nil
 		}
-		logger.Error("Failed to verify OTP",
+		logger.ErrorWithContext(ctx.Context, "Failed to verify OTP",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Any("serviceError", svcErr))
 		return nil, fmt.Errorf("failed to verify OTP: %s", svcErr.ErrorDescription.DefaultValue)
 	}
 	execResp.AuthUser = newAuthUser
 
 	execResp.RuntimeData["otpSessionToken"] = ""
-	logger.Debug("OTP validated successfully", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "OTP validated successfully", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	// Check if user is already authenticated
 	if ctx.AuthenticatedUser.IsAuthenticated && ctx.AuthenticatedUser.UserID != "" {
@@ -688,21 +697,22 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	// User not available in context, try to retrieve the user and get the attributes
 	userID = authnResult.UserID
 
-	logger.Debug("Fetching user details from user store", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx.Context, "Fetching user details from user store",
+		log.MaskedString(log.LoggerKeyUserID, userID))
 
 	attrs := map[string]interface{}{}
 	user, err := s.entityProvider.GetEntity(userID)
 	if err != nil {
 		if err.Code != entityprovider.ErrorCodeNotImplemented {
-			logger.Error("Failed to get user attributes", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Failed to get user attributes", log.Error(err))
 			return nil, errors.New("failed to get user attributes")
 		}
-		logger.Debug("User provider is not implemented. User attributes will be empty.")
+		logger.DebugWithContext(ctx.Context, "User provider is not implemented. User attributes will be empty.")
 	}
 
 	if err == nil && user != nil {
 		if err := json.Unmarshal(user.Attributes, &attrs); err != nil {
-			logger.Error("Failed to unmarshal user attributes", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Failed to unmarshal user attributes", log.Error(err))
 			return nil, errors.New("failed to unmarshal user attributes")
 		}
 	}

--- a/backend/internal/flow/executor/sms_executor.go
+++ b/backend/internal/flow/executor/sms_executor.go
@@ -69,7 +69,7 @@ func newSMSExecutor(flowFactory core.FlowFactoryInterface,
 // then renders the SMS body from a template and sends it.
 func (e *smsExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing SMS executor")
+	logger.DebugWithContext(ctx.Context, "Executing SMS executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -84,14 +84,15 @@ func (e *smsExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, 
 
 	recipient := resolveRecipientMobile(ctx, phoneAttr)
 	if recipient == "" {
-		logger.Debug("SMS recipient not found in user inputs or runtime data")
+		logger.DebugWithContext(ctx.Context, "SMS recipient not found in user inputs or runtime data")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSMSRecipientMissing
 		return execResp, nil
 	}
 
 	if !isValidPhoneNumber(recipient) {
-		logger.Debug("SMS recipient is not a valid phone number", log.String("phoneAttr", phoneAttr))
+		logger.DebugWithContext(ctx.Context, "SMS recipient is not a valid phone number",
+			log.String("phoneAttr", phoneAttr))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSMSInvalidPhone
 		return execResp, nil
@@ -141,7 +142,7 @@ func (e *smsExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, 
 		return nil, fmt.Errorf("SMS send failed: %s", notifSvcErr.ErrorDescription)
 	}
 
-	logger.Debug("SMS sent successfully", log.MaskedString("recipient", recipient))
+	logger.DebugWithContext(ctx.Context, "SMS sent successfully", log.MaskedString("recipient", recipient))
 
 	execResp.AdditionalData[common.DataSMSSent] = dataValueTrue
 	execResp.Status = common.ExecComplete

--- a/backend/internal/flow/executor/user_type_resolver.go
+++ b/backend/internal/flow/executor/user_type_resolver.go
@@ -83,7 +83,7 @@ func newUserTypeResolver(
 // Execute resolves the user type from inputs or prompts the user to select one.
 func (u *userTypeResolver) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := u.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.Debug("Executing user type resolver")
+	logger.DebugWithContext(ctx.Context, "Executing user type resolver")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -99,7 +99,7 @@ func (u *userTypeResolver) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	case common.FlowTypeUserOnboarding:
 		return u.handleUserOnboardingFlows(ctx, execResp)
 	default:
-		logger.Debug("User type resolver is not applicable for the flow type",
+		logger.DebugWithContext(ctx.Context, "User type resolver is not applicable for the flow type",
 			log.String("flowType", string(ctx.FlowType)))
 		execResp.Status = common.ExecComplete
 		return execResp, nil
@@ -113,7 +113,7 @@ func (u *userTypeResolver) handleAuthenticationFlows(ctx *core.NodeContext, exec
 
 	// Validate that allowed user types are defined
 	if len(ctx.Application.AllowedUserTypes) == 0 {
-		logger.Debug("No allowed user types configured for authentication")
+		logger.DebugWithContext(ctx.Context, "No allowed user types configured for authentication")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrAuthNotAvailableForApp
 		return execResp, nil
@@ -136,7 +136,7 @@ func (u *userTypeResolver) handleRegistrationFlows(ctx *core.NodeContext, execRe
 		//  userType has an attached ou. Need to find userType from the application's ou.
 		//  Also should check if self registration is enabled for the user type when the support is available.
 
-		logger.Debug("No allowed user types found for the application")
+		logger.DebugWithContext(ctx.Context, "No allowed user types found for the application")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSelfRegNotAvailableForApp
 		return execResp, nil
@@ -153,7 +153,7 @@ func (u *userTypeResolver) handleRegistrationFlows(ctx *core.NodeContext, execRe
 		}
 
 		if len(filtered) == 0 {
-			logger.Debug("No valid user types after filtering with node allowedUserTypes",
+			logger.DebugWithContext(ctx.Context, "No valid user types after filtering with node allowedUserTypes",
 				log.Any("applicationAllowed", allowed), log.Any("nodeAllowed", nodeAllowedUserTypes))
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrNoValidUserTypes
@@ -193,7 +193,7 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	if userType, ok := ctx.UserInputs[userTypeKey]; ok && userType != "" {
 		// If allowedUserTypes is configured, validate the input against it
 		if len(allowedUserTypes) > 0 && !slices.Contains(allowedUserTypes, userType) {
-			logger.Debug("User type not in allowed list", log.String(userTypeKey, userType),
+			logger.DebugWithContext(ctx.Context, "User type not in allowed list", log.String(userTypeKey, userType),
 				log.Any("allowedUserTypes", allowedUserTypes))
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrUserTypeNotAllowed
@@ -211,14 +211,14 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 		if selectedOUID, exists := ctx.RuntimeData[ouIDKey]; exists && selectedOUID != "" {
 			isValid, svcErr := u.ouService.IsParent(ctx.Context, ouID, selectedOUID)
 			if svcErr != nil {
-				logger.Error("Failed to validate user type against selected OU",
+				logger.ErrorWithContext(ctx.Context, "Failed to validate user type against selected OU",
 					log.String(userTypeKey, userType), log.String(ouIDKey, selectedOUID),
 					log.String("error", svcErr.Error.DefaultValue))
 				return nil, fmt.Errorf("failed to validate user type against selected OU: %s",
 					svcErr.Error.DefaultValue)
 			}
 			if !isValid {
-				logger.Debug("User type not valid for selected OU",
+				logger.DebugWithContext(ctx.Context, "User type not valid for selected OU",
 					log.String(userTypeKey, userType), log.String(ouIDKey, selectedOUID))
 				execResp.Status = common.ExecFailure
 				execResp.Error = &ErrUserTypeNotValidForOU
@@ -228,7 +228,8 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 
 		execResp.RuntimeData[userTypeKey] = userType
 		execResp.RuntimeData[defaultOUIDKey] = ouID
-		logger.Debug("User type resolved for user onboarding", log.String(userTypeKey, userType),
+		logger.DebugWithContext(ctx.Context, "User type resolved for user onboarding",
+			log.String(userTypeKey, userType),
 			log.String(ouIDKey, entityType.OUID))
 		execResp.Status = common.ExecComplete
 		return execResp, nil
@@ -238,14 +239,15 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	schemas, svcErr := u.entityTypeService.GetEntityTypeList(ctx.Context,
 		entitytype.TypeCategoryUser, 100, 0, false)
 	if svcErr != nil {
-		logger.Debug("Failed to list user types", log.String("error", svcErr.Error.DefaultValue))
+		logger.DebugWithContext(ctx.Context, "Failed to list user types",
+			log.String("error", svcErr.Error.DefaultValue))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserTypeRetrievalFailed
 		return execResp, nil
 	}
 
 	if len(schemas.Types) == 0 {
-		logger.Debug("No user types available")
+		logger.DebugWithContext(ctx.Context, "No user types available")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrNoUserTypesAvailable
 		return execResp, nil
@@ -266,7 +268,7 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	}
 
 	if len(availableSchemas) == 0 {
-		logger.Debug("No valid user types found after filtering",
+		logger.DebugWithContext(ctx.Context, "No valid user types found after filtering",
 			log.Any("allowedUserTypes", allowedUserTypes))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrNoValidUserTypes
@@ -276,7 +278,8 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	// If only one user type is available, select it automatically
 	if len(availableSchemas) == 1 {
 		schema := availableSchemas[0]
-		logger.Debug("User type auto-selected for user onboarding", log.String(userTypeKey, schema.Name),
+		logger.DebugWithContext(ctx.Context, "User type auto-selected for user onboarding",
+			log.String(userTypeKey, schema.Name),
 			log.String(ouIDKey, schema.OUID))
 
 		execResp.RuntimeData[userTypeKey] = schema.Name
@@ -307,7 +310,7 @@ func (u *userTypeResolver) getAllowedUserTypesFromProperties(ctx *core.NodeConte
 
 	items, ok := val.([]interface{})
 	if !ok {
-		u.logger.Debug("allowedUserTypes property is not a valid array")
+		u.logger.DebugWithContext(ctx.Context, "allowedUserTypes property is not a valid array")
 		return nil
 	}
 
@@ -319,7 +322,7 @@ func (u *userTypeResolver) getAllowedUserTypesFromProperties(ctx *core.NodeConte
 	}
 
 	if len(userTypes) > 0 {
-		u.logger.Debug("Allowed user types configured from node properties",
+		u.logger.DebugWithContext(ctx.Context, "Allowed user types configured from node properties",
 			log.Any("allowedUserTypes", userTypes))
 	}
 
@@ -354,7 +357,7 @@ func (u *userTypeResolver) filterSchemasByOU(ctx *core.NodeContext,
 	for _, schema := range schemas {
 		isValid, svcErr := u.ouService.IsParent(ctx.Context, schema.OUID, selectedOUID)
 		if svcErr != nil {
-			logger.Error("Failed to check OU ancestry for schema",
+			logger.ErrorWithContext(ctx.Context, "Failed to check OU ancestry for schema",
 				log.String("schema", schema.Name), log.String("error", svcErr.Error.DefaultValue))
 			return nil, fmt.Errorf("failed to check OU ancestry for schema %s: %s",
 				schema.Name, svcErr.Error.DefaultValue)
@@ -364,7 +367,7 @@ func (u *userTypeResolver) filterSchemasByOU(ctx *core.NodeContext,
 		}
 	}
 
-	logger.Debug("Filtered schemas by selected OU",
+	logger.DebugWithContext(ctx.Context, "Filtered schemas by selected OU",
 		log.String(ouIDKey, selectedOUID),
 		log.Int("before", len(schemas)),
 		log.Int("after", len(filtered)))
@@ -377,14 +380,15 @@ func (u *userTypeResolver) resolveUserTypeFromInput(ctx context.Context, execRes
 	userType string, allowed []string) error {
 	logger := u.logger
 	if slices.Contains(allowed, userType) {
-		logger.Debug("User type resolved from input", log.String(userTypeKey, userType))
+		logger.DebugWithContext(ctx, "User type resolved from input", log.String(userTypeKey, userType))
 
 		entityType, ouID, err := u.getEntityTypeAndOU(ctx, userType)
 		if err != nil {
 			return err
 		}
 		if !entityType.AllowSelfRegistration {
-			logger.Debug("Self registration not enabled for user type", log.String(userTypeKey, userType))
+			logger.DebugWithContext(ctx, "Self registration not enabled for user type",
+				log.String(userTypeKey, userType))
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrSelfRegDisabledForUserType
 			return nil
@@ -413,13 +417,14 @@ func (u *userTypeResolver) resolveUserTypeFromSingleAllowed(ctx context.Context,
 	}
 
 	if !entityType.AllowSelfRegistration {
-		logger.Debug("Self registration not enabled for user type", log.String(userTypeKey, allowedUserType))
+		logger.DebugWithContext(ctx, "Self registration not enabled for user type",
+			log.String(userTypeKey, allowedUserType))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSelfRegDisabledForUserType
 		return nil
 	}
 
-	logger.Debug("User type resolved from allowed list", log.String(userTypeKey, allowedUserType))
+	logger.DebugWithContext(ctx, "User type resolved from allowed list", log.String(userTypeKey, allowedUserType))
 
 	// Add userType and ouID to runtime data
 	execResp.RuntimeData[userTypeKey] = allowedUserType
@@ -451,7 +456,7 @@ func (u *userTypeResolver) resolveUserTypeFromMultipleAllowed(ctx context.Contex
 
 	// Fail if no user types have self registration enabled
 	if len(selfRegEnabledUserTypes) == 0 {
-		logger.Debug("No user types with self registration enabled")
+		logger.DebugWithContext(ctx, "No user types with self registration enabled")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSelfRegNotAvailableForApp
 		return nil
@@ -460,7 +465,7 @@ func (u *userTypeResolver) resolveUserTypeFromMultipleAllowed(ctx context.Contex
 	// If only one user type has self registration enabled, select it automatically
 	if len(selfRegEnabledUserTypes) == 1 {
 		record := selfRegEnabledUserTypes[0]
-		logger.Debug("User type auto-selected", log.String(userTypeKey, record.entityType.Name))
+		logger.DebugWithContext(ctx, "User type auto-selected", log.String(userTypeKey, record.entityType.Name))
 
 		// Add userType and ouID to runtime data
 		execResp.RuntimeData[userTypeKey] = record.entityType.Name
@@ -476,7 +481,8 @@ func (u *userTypeResolver) resolveUserTypeFromMultipleAllowed(ctx context.Contex
 		selfRegUserTypes = append(selfRegUserTypes, record.entityType.Name)
 	}
 
-	logger.Debug("Prompting for user type selection as multiple user types are available for self registration",
+	logger.DebugWithContext(ctx,
+		"Prompting for user type selection as multiple user types are available for self registration",
 		log.Any("userTypes", selfRegUserTypes))
 
 	u.promptUserSelection(execResp, selfRegUserTypes)
@@ -491,17 +497,17 @@ func (u *userTypeResolver) getEntityTypeAndOU(
 
 	entityType, svcErr := u.entityTypeService.GetEntityTypeByName(ctx, entitytype.TypeCategoryUser, userType)
 	if svcErr != nil {
-		logger.Error("Failed to resolve user type",
+		logger.ErrorWithContext(ctx, "Failed to resolve user type",
 			log.String(userTypeKey, userType), log.String("error", svcErr.Error.DefaultValue))
 		return nil, "", fmt.Errorf("failed to resolve user type: %s", userType)
 	}
 
 	if entityType.OUID == "" {
-		logger.Error("No organization unit found for user type", log.String(userTypeKey, userType))
+		logger.ErrorWithContext(ctx, "No organization unit found for user type", log.String(userTypeKey, userType))
 		return nil, "", fmt.Errorf("no organization unit found for user type: %s", userType)
 	}
 
-	logger.Debug("Entity type resolved for user type", log.String(userTypeKey, userType),
+	logger.DebugWithContext(ctx, "Entity type resolved for user type", log.String(userTypeKey, userType),
 		log.String(ouIDKey, entityType.OUID))
 	return entityType, entityType.OUID, nil
 }

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -87,7 +87,7 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 	// Execute the graph nodes until a terminal condition is met or currentNode is nil
 	challengeTokenValidated := false
 	for currentNode != nil {
-		logger.Debug("Executing node", log.String("nodeID", currentNode.GetID()),
+		logger.DebugWithContext(ctx.Context, "Executing node", log.String("nodeID", currentNode.GetID()),
 			log.String("nodeType", string(currentNode.GetType())))
 
 		nodeCtx := &core.NodeContext{
@@ -126,7 +126,8 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 
 		// Check if the node should be executed based on its condition
 		if !currentNode.ShouldExecute(nodeCtx) {
-			logger.Debug("Skipping node due to unmet condition", log.String("nodeID", currentNode.GetID()))
+			logger.DebugWithContext(ctx.Context, "Skipping node due to unmet condition",
+				log.String("nodeID", currentNode.GetID()))
 			nextNode, svcErr := fe.skipToNextNode(ctx, currentNode, logger)
 			if svcErr != nil {
 				return flowStep, svcErr
@@ -255,17 +256,17 @@ func (fe *flowEngine) setCurrentExecutionNode(ctx *EngineContext,
 	logger *log.Logger) *serviceerror.ServiceError {
 	graph := ctx.Graph
 	if graph == nil {
-		logger.Error("Flow graph is not initialized in the context")
+		logger.ErrorWithContext(ctx.Context, "Flow graph is not initialized in the context")
 		return &serviceerror.InternalServerError
 	}
 
 	currentNode := ctx.CurrentNode
 	if currentNode == nil {
-		logger.Debug("Current node is nil. Setting start node as the current node.")
+		logger.DebugWithContext(ctx.Context, "Current node is nil. Setting start node as the current node.")
 		var err error
 		currentNode, err = graph.GetStartNode()
 		if err != nil {
-			logger.Error("Start node not found in the flow graph", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Start node not found in the flow graph", log.Error(err))
 			return &serviceerror.InternalServerError
 		}
 		ctx.CurrentNode = currentNode
@@ -511,7 +512,7 @@ func (fe *flowEngine) processNodeResponse(ctx *EngineContext, nodeResp *common.N
 	flowStep *FlowStep, logger *log.Logger) (
 	core.NodeInterface, bool, *serviceerror.ServiceError) {
 	if nodeResp.Status == "" {
-		logger.Error("Node response status not found in the flow graph")
+		logger.ErrorWithContext(ctx.Context, "Node response status not found in the flow graph")
 		return nil, false, &serviceerror.InternalServerError
 	}
 
@@ -543,7 +544,7 @@ func (fe *flowEngine) processNodeResponse(ctx *EngineContext, nodeResp *common.N
 		flowStep.Error = nodeResp.Error
 		return nil, false, nil
 	default:
-		logger.Error("Unsupported response status returned from the node",
+		logger.ErrorWithContext(ctx.Context, "Unsupported response status returned from the node",
 			log.String("status", string(nodeResp.Status)))
 		return nil, false, &serviceerror.InternalServerError
 	}
@@ -566,7 +567,8 @@ func (fe *flowEngine) handleDisplayOnlyPromptResponse(ctx *EngineContext,
 
 	nextNode, exists := ctx.Graph.GetNode(nextNodeID)
 	if !exists || nextNode == nil {
-		logger.Error("Display-only prompt references unknown next node", log.String("nextNodeID", nextNodeID))
+		logger.ErrorWithContext(ctx.Context, "Display-only prompt references unknown next node",
+			log.String("nextNodeID", nextNodeID))
 		return nil, continueExecution, &serviceerror.InternalServerError
 	}
 
@@ -615,7 +617,7 @@ func (fe *flowEngine) handleCompletedResponse(ctx *EngineContext,
 	core.NodeInterface, *serviceerror.ServiceError) {
 	nextNode, err := fe.resolveToNextNode(ctx, nodeResp)
 	if err != nil {
-		logger.Error("Error moving to the next node", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Error moving to the next node", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	ctx.CurrentNode = nextNode
@@ -631,19 +633,19 @@ func (fe *flowEngine) handleIncompleteResponse(ctx *EngineContext, nodeResp *com
 	case common.NodeResponseTypeRedirection:
 		err := fe.resolveStepForRedirection(ctx, nodeResp, flowStep)
 		if err != nil {
-			logger.Error("Error while resolving step for redirection", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Error while resolving step for redirection", log.Error(err))
 			return &serviceerror.InternalServerError
 		}
 		return nil
 	case common.NodeResponseTypeView:
 		err := fe.resolveStepDetailsForPrompt(ctx, nodeResp, flowStep)
 		if err != nil {
-			logger.Error("Error while resolving step details for prompt", log.Error(err))
+			logger.ErrorWithContext(ctx.Context, "Error while resolving step details for prompt", log.Error(err))
 			return &serviceerror.InternalServerError
 		}
 		return nil
 	default:
-		logger.Error("Unsupported response type returned from the node",
+		logger.ErrorWithContext(ctx.Context, "Unsupported response type returned from the node",
 			log.String("responseType", string(nodeResp.Type)))
 		return &serviceerror.InternalServerError
 	}
@@ -658,13 +660,13 @@ func (fe *flowEngine) handleForwardResponse(ctx *EngineContext,
 	if nodeResp.Error != nil {
 		errorMsg = nodeResp.Error.Error.DefaultValue
 	}
-	logger.Debug("Forwarding to next node",
+	logger.DebugWithContext(ctx.Context, "Forwarding to next node",
 		log.String("nextNodeID", nodeResp.NextNodeID),
 		log.String("error", errorMsg))
 
 	nextNode, err := fe.resolveToNextNode(ctx, nodeResp)
 	if err != nil {
-		logger.Error("Error resolving to next node", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Error resolving to next node", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	ctx.CurrentNode = nextNode
@@ -679,12 +681,12 @@ func (fe *flowEngine) skipToNextNode(ctx *EngineContext, currentNode core.NodeIn
 
 	// Condition must specify where to skip to
 	if condition == nil || condition.OnSkip == "" {
-		logger.Error("Node has condition but onSkip is not specified",
+		logger.ErrorWithContext(ctx.Context, "Node has condition but onSkip is not specified",
 			log.String("nodeID", currentNode.GetID()))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Using condition's onSkip for skipped node",
+	logger.DebugWithContext(ctx.Context, "Using condition's onSkip for skipped node",
 		log.String("nodeID", currentNode.GetID()), log.String("onSkip", condition.OnSkip))
 
 	nodeResp := &common.NodeResponse{NextNodeID: condition.OnSkip}
@@ -692,7 +694,7 @@ func (fe *flowEngine) skipToNextNode(ctx *EngineContext, currentNode core.NodeIn
 	// Resolve to the next node
 	nextNode, err := fe.resolveToNextNode(ctx, nodeResp)
 	if err != nil {
-		logger.Error("Error moving to the next node after skipping", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Error moving to the next node after skipping", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	ctx.CurrentNode = nextNode
@@ -705,7 +707,7 @@ func (fe *flowEngine) resolveToNextNode(engineCtx *EngineContext, nodeResp *comm
 	logger := fe.logger.With(log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 	graph := engineCtx.Graph
 	if nodeResp == nil || nodeResp.NextNodeID == "" {
-		logger.Debug("No next node ID in response. Returning nil.")
+		logger.DebugWithContext(engineCtx.Context, "No next node ID in response. Returning nil.")
 		return nil, nil
 	}
 
@@ -714,7 +716,7 @@ func (fe *flowEngine) resolveToNextNode(engineCtx *EngineContext, nodeResp *comm
 		return nil, errors.New("next node not found in the graph")
 	}
 
-	logger.Debug("Moving to next node", log.String("nextNodeID", nextNode.GetID()))
+	logger.DebugWithContext(engineCtx.Context, "Moving to next node", log.String("nextNodeID", nextNode.GetID()))
 	return nextNode, nil
 }
 
@@ -835,7 +837,8 @@ func (fe *flowEngine) validateSegmentResumePolicy(ctx *EngineContext, logger *lo
 		return false
 	}
 
-	logger.Debug("Segment restart allowed; skipping challenge token validation for segment resume",
+	logger.DebugWithContext(ctx.Context,
+		"Segment restart allowed; skipping challenge token validation for segment resume",
 		log.String("segmentID", seg.ID), log.String("segmentStartNodeID", seg.StartNodeID))
 
 	return true
@@ -850,25 +853,27 @@ func (fe *flowEngine) validateChallengeToken(
 	logger := fe.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	if ctx.ChallengeTokenHash == "" {
-		logger.Debug("Challenge token hash is empty in the context; skipping validation")
+		logger.DebugWithContext(ctx.Context, "Challenge token hash is empty in the context; skipping validation")
 		return nil
 	}
 	if currentNode != nil {
 		policy := currentNode.GetExecutionPolicy()
 		if policy != nil && policy.SkipChallengeValidation {
-			logger.Debug("Current node's execution policy set to skip challenge token validation; skipping")
+			logger.DebugWithContext(ctx.Context,
+				"Current node's execution policy set to skip challenge token validation; skipping")
 			return nil
 		}
 	} else {
-		logger.Debug("Current node is nil while validating challenge token; enforcing validation")
+		logger.DebugWithContext(ctx.Context,
+			"Current node is nil while validating challenge token; enforcing validation")
 	}
 
 	if ctx.ChallengeTokenIn == "" {
-		logger.Debug("Challenge token is empty in the request")
+		logger.DebugWithContext(ctx.Context, "Challenge token is empty in the request")
 		return &ErrorInvalidChallengeToken
 	}
 	if !cryptolib.ValidateTokenHash(ctx.ChallengeTokenIn, ctx.ChallengeTokenHash) {
-		logger.Debug("Invalid challenge token provided in the request")
+		logger.DebugWithContext(ctx.Context, "Invalid challenge token provided in the request")
 		return &ErrorInvalidChallengeToken
 	}
 
@@ -883,7 +888,7 @@ func (fe *flowEngine) rotateChallengeToken(ctx *EngineContext, flowStep *FlowSte
 
 	newToken, err := cryptolib.GenerateSecureToken()
 	if err != nil {
-		logger.Error("Failed to generate new challenge token", log.Error(err))
+		logger.ErrorWithContext(ctx.Context, "Failed to generate new challenge token", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/flow/flowexec/handler.go
+++ b/backend/internal/flow/flowexec/handler.go
@@ -85,7 +85,7 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, flowResp)
 
-	logger.Debug("Flow execution request handled successfully",
+	logger.DebugWithContext(r.Context(), "Flow execution request handled successfully",
 		log.String(log.LoggerKeyExecutionID, flowResp.ExecutionID))
 }
 

--- a/backend/internal/flow/flowexec/redis_store.go
+++ b/backend/internal/flow/flowexec/redis_store.go
@@ -83,7 +83,7 @@ func (s *redisFlowStore) StoreFlowContext(ctx context.Context, dbModel FlowConte
 		return fmt.Errorf("failed to store flow context in Redis: %w", err)
 	}
 
-	logger.Debug("Stored flow context in Redis", log.String("executionID", dbModel.ExecutionID))
+	logger.DebugWithContext(ctx, "Stored flow context in Redis", log.String("executionID", dbModel.ExecutionID))
 	return nil
 }
 

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -105,7 +105,7 @@ func (s *flowExecService) Execute(ctx context.Context,
 	if isNewFlow(executionID) {
 		engineCtx, loadErr = s.loadNewContext(ctx, appID, flowType, verbose, action, inputs, logger)
 		if loadErr != nil {
-			logger.Error("Failed to load new flow context",
+			logger.ErrorWithContext(ctx, "Failed to load new flow context",
 				log.String("appID", appID),
 				log.String("flowType", flowType),
 				log.String("error", loadErr.Error.DefaultValue))
@@ -128,7 +128,7 @@ func (s *flowExecService) Execute(ctx context.Context,
 	} else {
 		engineCtx, loadErr = s.loadPrevContext(ctx, executionID, action, inputs, logger)
 		if loadErr != nil {
-			logger.Error("Failed to load previous flow context",
+			logger.ErrorWithContext(ctx, "Failed to load previous flow context",
 				log.String(log.LoggerKeyExecutionID, executionID),
 				log.String("error", loadErr.Error.DefaultValue))
 			return nil, loadErr
@@ -145,7 +145,7 @@ func (s *flowExecService) Execute(ctx context.Context,
 	if flowErr != nil {
 		if !isNewFlow(executionID) && flowErr.Code != ErrorInvalidChallengeToken.Code {
 			if removeErr := s.removeContext(ctx, engineCtx.ExecutionID, logger); removeErr != nil {
-				logger.Error("Failed to remove flow context after engine failure",
+				logger.ErrorWithContext(ctx, "Failed to remove flow context after engine failure",
 					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(removeErr))
 				return nil, &serviceerror.InternalServerError
 			}
@@ -156,7 +156,7 @@ func (s *flowExecService) Execute(ctx context.Context,
 	if isComplete(flowStep) {
 		if !isNewFlow(executionID) {
 			if removeErr := s.removeContext(ctx, engineCtx.ExecutionID, logger); removeErr != nil {
-				logger.Error("Failed to remove flow context after completion",
+				logger.ErrorWithContext(ctx, "Failed to remove flow context after completion",
 					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(removeErr))
 				return nil, &serviceerror.InternalServerError
 			}
@@ -164,13 +164,13 @@ func (s *flowExecService) Execute(ctx context.Context,
 	} else {
 		if isNewFlow(executionID) {
 			if storeErr := s.storeContext(ctx, engineCtx, logger); storeErr != nil {
-				logger.Error("Failed to store initial flow context",
+				logger.ErrorWithContext(ctx, "Failed to store initial flow context",
 					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(storeErr))
 				return nil, &serviceerror.InternalServerError
 			}
 		} else {
 			if updateErr := s.updateContext(ctx, engineCtx, &flowStep, logger); updateErr != nil {
-				logger.Error("Failed to update flow context",
+				logger.ErrorWithContext(ctx, "Failed to update flow context",
 					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(updateErr))
 				return nil, &serviceerror.InternalServerError
 			}
@@ -209,14 +209,14 @@ func (s *flowExecService) initContext(ctx context.Context, appID string, flowTyp
 	engineCtx := EngineContext{}
 	executionID, err := sysutils.GenerateUUIDv7()
 	if err != nil {
-		logger.Error("Failed to generate UUID", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	engineCtx.ExecutionID = executionID
 
 	graph, svcErr := s.flowMgtService.GetGraph(ctx, graphID)
 	if svcErr != nil {
-		logger.Error("Error retrieving flow graph from flow management service",
+		logger.ErrorWithContext(ctx, "Error retrieving flow graph from flow management service",
 			log.String("graphID", graphID), log.String("error", svcErr.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -278,21 +278,21 @@ func (s *flowExecService) loadContextFromStore(ctx context.Context, executionID 
 
 	graphID, err := dbModel.GetGraphID(ctx)
 	if err != nil {
-		logger.Error("Failed to extract graph ID from flow context",
+		logger.ErrorWithContext(ctx, "Failed to extract graph ID from flow context",
 			log.String(log.LoggerKeyExecutionID, executionID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	graph, svcErr := s.flowMgtService.GetGraph(ctx, graphID)
 	if svcErr != nil {
-		logger.Error("Error retrieving flow graph from flow management service",
+		logger.ErrorWithContext(ctx, "Error retrieving flow graph from flow management service",
 			log.String("graphID", graphID), log.String("error", svcErr.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	engineContext, err := dbModel.ToEngineContext(ctx, graph)
 	if err != nil {
-		logger.Error("Failed to convert flow context from database format",
+		logger.ErrorWithContext(ctx, "Failed to convert flow context from database format",
 			log.String(log.LoggerKeyExecutionID, executionID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -334,7 +334,7 @@ func (s *flowExecService) buildFlowApplication(
 		if errors.Is(err, inboundclient.ErrInboundClientNotFound) {
 			return nil, &ErrorInvalidAppID
 		}
-		logger.Error("Server error while retrieving inbound client",
+		logger.ErrorWithContext(ctx, "Server error while retrieving inbound client",
 			log.String("appID", appID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -344,7 +344,7 @@ func (s *flowExecService) buildFlowApplication(
 
 	entity, epErr := s.entityProvider.GetEntity(appID)
 	if epErr != nil && epErr.Code != entityprovider.ErrorCodeEntityNotFound {
-		logger.Error("Failed to retrieve entity for flow context",
+		logger.ErrorWithContext(ctx, "Failed to retrieve entity for flow context",
 			log.String("appID", appID), log.Error(epErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -406,7 +406,7 @@ func (s *flowExecService) removeContext(ctx context.Context, executionID string,
 		return fmt.Errorf("failed to remove flow context from database: %w", txErr)
 	}
 
-	logger.Debug("Flow context removed successfully from database",
+	logger.DebugWithContext(ctx, "Flow context removed successfully from database",
 		log.String(log.LoggerKeyExecutionID, executionID))
 	return nil
 }
@@ -417,7 +417,7 @@ func (s *flowExecService) updateContext(ctx context.Context, engineCtx *EngineCo
 	if flowStep.Status == common.FlowStatusComplete {
 		return s.removeContext(ctx, engineCtx.ExecutionID, logger)
 	} else {
-		logger.Debug("Flow execution is incomplete, updating the flow context",
+		logger.DebugWithContext(ctx, "Flow execution is incomplete, updating the flow context",
 			log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 
 		if engineCtx.ExecutionID == "" {
@@ -436,7 +436,7 @@ func (s *flowExecService) updateContext(ctx context.Context, engineCtx *EngineCo
 			return fmt.Errorf("failed to update flow context in database: %w", txErr)
 		}
 
-		logger.Debug("Flow context updated successfully in database",
+		logger.DebugWithContext(ctx, "Flow context updated successfully in database",
 			log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 		return nil
 	}
@@ -463,7 +463,7 @@ func (s *flowExecService) storeContext(ctx context.Context, engineCtx *EngineCon
 		return fmt.Errorf("failed to store flow context in database: %w", txErr)
 	}
 
-	logger.Debug("Flow context stored successfully in database",
+	logger.DebugWithContext(ctx, "Flow context stored successfully in database",
 		log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 	return nil
 }
@@ -502,7 +502,8 @@ func (s *flowExecService) getFlowGraph(ctx context.Context, appID string, flowTy
 		if errors.Is(err, inboundclient.ErrInboundClientNotFound) {
 			return "", &ErrorInvalidAppID
 		}
-		logger.Error("Server error while retrieving inbound client", log.String("appID", appID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Server error while retrieving inbound client",
+			log.String("appID", appID), log.Error(err))
 		return "", &serviceerror.InternalServerError
 	}
 	if client == nil {
@@ -513,7 +514,7 @@ func (s *flowExecService) getFlowGraph(ctx context.Context, appID string, flowTy
 		if !client.IsRegistrationFlowEnabled {
 			return "", &ErrorRegistrationFlowDisabled
 		} else if client.RegistrationFlowID == "" {
-			logger.Error("Registration flow is not configured for the entity",
+			logger.ErrorWithContext(ctx, "Registration flow is not configured for the entity",
 				log.String("appID", appID))
 			return "", &serviceerror.InternalServerError
 		}
@@ -524,7 +525,7 @@ func (s *flowExecService) getFlowGraph(ctx context.Context, appID string, flowTy
 		if !client.IsRecoveryFlowEnabled {
 			return "", &ErrorRecoveryFlowDisabled
 		} else if client.RecoveryFlowID == "" {
-			logger.Error("Recovery flow is not configured for the application",
+			logger.ErrorWithContext(ctx, "Recovery flow is not configured for the application",
 				log.String("appID", appID))
 			return "", &serviceerror.InternalServerError
 		}
@@ -533,7 +534,7 @@ func (s *flowExecService) getFlowGraph(ctx context.Context, appID string, flowTy
 
 	// Default to authentication flow ID
 	if client.AuthFlowID == "" {
-		logger.Error("Authentication flow is not configured for the entity",
+		logger.ErrorWithContext(ctx, "Authentication flow is not configured for the entity",
 			log.String("appID", appID))
 		return "", &serviceerror.InternalServerError
 	}
@@ -570,7 +571,7 @@ func (s *flowExecService) getSystemFlowGraph(ctx context.Context, flowType commo
 
 	flow, err := s.flowMgtService.GetFlowByHandle(ctx, handle, flowType)
 	if err != nil {
-		logger.Error("Failed to get system flow by handle",
+		logger.ErrorWithContext(ctx, "Failed to get system flow by handle",
 			log.String("handle", handle), log.String("flowType", string(flowType)))
 		return "", err
 	}
@@ -627,7 +628,7 @@ func (s *flowExecService) InitiateFlow(ctx context.Context,
 	// This uses verbose true to ensure step layouts are returned during execution
 	engineCtx, err := s.initContext(ctx, initContext.ApplicationID, flowType, true, logger)
 	if err != nil {
-		logger.Error("Failed to initialize flow context",
+		logger.ErrorWithContext(ctx, "Failed to initialize flow context",
 			log.String("appID", initContext.ApplicationID),
 			log.String("flowType", initContext.FlowType),
 			log.String("error", err.Error.DefaultValue))
@@ -639,13 +640,14 @@ func (s *flowExecService) InitiateFlow(ctx context.Context,
 
 	// Store the context without executing the flow
 	if storeErr := s.storeContext(ctx, engineCtx, logger); storeErr != nil {
-		logger.Error("Failed to store initial flow context",
+		logger.ErrorWithContext(ctx, "Failed to store initial flow context",
 			log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID),
 			log.Error(storeErr))
 		return "", &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Flow initiated successfully", log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
+	logger.DebugWithContext(ctx, "Flow initiated successfully",
+		log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 	return engineCtx.ExecutionID, nil
 }
 
@@ -658,7 +660,7 @@ func (s *flowExecService) getFlowContext(ctx context.Context, executionID string
 
 	dbModel, err := s.flowStore.GetFlowContext(ctx, executionID)
 	if err != nil {
-		logger.Error("Error retrieving flow context from store",
+		logger.ErrorWithContext(ctx, "Error retrieving flow context from store",
 			log.String(log.LoggerKeyExecutionID, executionID),
 			log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
@@ -672,7 +674,7 @@ func (s *flowExecService) getFlowContext(ctx context.Context, executionID string
 		decryptParams := cryptolib.AlgorithmParams{Algorithm: cryptolib.AlgorithmAESGCM}
 		decrypted, decryptErr := s.cryptoSvc.Decrypt(ctx, nil, decryptParams, []byte(dbModel.Context))
 		if decryptErr != nil {
-			logger.Error("Failed to decrypt flow context",
+			logger.ErrorWithContext(ctx, "Failed to decrypt flow context",
 				log.String(log.LoggerKeyExecutionID, executionID), log.Error(decryptErr))
 			return nil, &serviceerror.InternalServerError
 		}

--- a/backend/internal/flow/flowmeta/handler.go
+++ b/backend/internal/flow/flowmeta/handler.go
@@ -86,7 +86,7 @@ func (h *flowMetaHandler) HandleGetFlowMetadata(w http.ResponseWriter, r *http.R
 
 	// Return success response
 	sysutils.WriteSuccessResponse(w, http.StatusOK, metadata)
-	h.logger.Debug("Flow metadata retrieved successfully",
+	h.logger.DebugWithContext(r.Context(), "Flow metadata retrieved successfully",
 		log.String("type", metaType),
 		log.String("id", id))
 }

--- a/backend/internal/flow/flowmeta/service.go
+++ b/backend/internal/flow/flowmeta/service.go
@@ -122,7 +122,7 @@ func (fms *flowMetaService) GetFlowMetadata(
 	fms.populateDesignMetadata(ctx, metaType, id, ouID, response)
 	fms.populateI18nMetadata(response, lang, ns)
 
-	fms.logger.Debug("Successfully retrieved flow metadata",
+	fms.logger.DebugWithContext(ctx, "Successfully retrieved flow metadata",
 		log.String("type", string(metaType)),
 		log.String("id", id))
 
@@ -173,7 +173,7 @@ func (fms *flowMetaService) populateTypeMetadata(
 		if errors.Is(err, inboundclient.ErrInboundClientNotFound) {
 			return "", &ErrorApplicationNotFound
 		}
-		fms.logger.Error("Failed to get inbound client", log.String("appID", id), log.Error(err))
+		fms.logger.ErrorWithContext(ctx, "Failed to get inbound client", log.String("appID", id), log.Error(err))
 		return "", &ErrorApplicationFetchFailed
 	}
 	if client == nil {
@@ -182,7 +182,7 @@ func (fms *flowMetaService) populateTypeMetadata(
 
 	entity, epErr := fms.entityProvider.GetEntity(id)
 	if epErr != nil && epErr.Code != entityprovider.ErrorCodeEntityNotFound {
-		fms.logger.Error("Failed to get entity", log.String("appID", id), log.Error(epErr))
+		fms.logger.ErrorWithContext(ctx, "Failed to get entity", log.String("appID", id), log.Error(epErr))
 		return "", &ErrorApplicationFetchFailed
 	}
 
@@ -196,7 +196,7 @@ func (fms *flowMetaService) populateTypeMetadata(
 			return "", &ErrorOUNotFound
 		}
 
-		fms.logger.Error("Failed to get root organization unit",
+		fms.logger.ErrorWithContext(ctx, "Failed to get root organization unit",
 			log.String("error", ouErr.Error.DefaultValue),
 			log.String("code", ouErr.Code))
 		return "", &ErrorOUFetchFailed
@@ -224,7 +224,7 @@ func (fms *flowMetaService) populateOUMetadata(
 			return &ErrorOUNotFound
 		}
 
-		fms.logger.Error("Failed to get organization unit",
+		fms.logger.ErrorWithContext(ctx, "Failed to get organization unit",
 			log.String("ouID", ouID),
 			log.String("error", svcErr.Error.DefaultValue),
 			log.String("code", svcErr.Code))
@@ -261,7 +261,7 @@ func (fms *flowMetaService) populateDesignMetadata(
 
 	designResp, svcErr := fms.designResolve.ResolveDesign(ctx, designType, designID)
 	if svcErr != nil {
-		fms.logger.Debug("Failed to get design configuration",
+		fms.logger.DebugWithContext(ctx, "Failed to get design configuration",
 			log.String("type", string(designType)),
 			log.String("id", designID),
 			log.String("error", svcErr.Error.DefaultValue))

--- a/backend/internal/flow/mgt/cache_backed_store.go
+++ b/backend/internal/flow/mgt/cache_backed_store.go
@@ -205,9 +205,9 @@ func (s *cacheBackedFlowStore) cacheFlow(ctx context.Context, flow *CompleteFlow
 			Key: flow.ID,
 		}
 		if err := s.flowByIDCache.Set(ctx, cacheKey, flow); err != nil {
-			logger.Error("Failed to cache flow by ID", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to cache flow by ID", log.Error(err))
 		} else {
-			logger.Debug("Flow cached by ID")
+			logger.DebugWithContext(ctx, "Flow cached by ID")
 		}
 	}
 
@@ -215,10 +215,10 @@ func (s *cacheBackedFlowStore) cacheFlow(ctx context.Context, flow *CompleteFlow
 	if flow.Handle != "" && flow.FlowType != "" {
 		handleCacheKey := getFlowByHandleCacheKey(flow.Handle, flow.FlowType)
 		if err := s.flowByHandleCache.Set(ctx, handleCacheKey, flow); err != nil {
-			logger.Error("Failed to cache flow by handle", log.String("handle", flow.Handle),
+			logger.ErrorWithContext(ctx, "Failed to cache flow by handle", log.String("handle", flow.Handle),
 				log.String("flowType", string(flow.FlowType)), log.Error(err))
 		} else {
-			logger.Debug("Flow cached by handle",
+			logger.DebugWithContext(ctx, "Flow cached by handle",
 				log.String("handle", flow.Handle), log.String("flowType", string(flow.FlowType)))
 		}
 	}
@@ -233,9 +233,9 @@ func (s *cacheBackedFlowStore) invalidateFlowCache(ctx context.Context, flowID s
 			Key: flowID,
 		}
 		if err := s.flowByIDCache.Delete(ctx, cacheKey); err != nil {
-			logger.Error("Failed to invalidate flow cache by ID", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to invalidate flow cache by ID", log.Error(err))
 		} else {
-			logger.Debug("Flow cache invalidated by ID")
+			logger.DebugWithContext(ctx, "Flow cache invalidated by ID")
 		}
 	}
 }
@@ -249,7 +249,7 @@ func (s *cacheBackedFlowStore) invalidateFlowCacheByHandle(
 
 	cacheKey := getFlowByHandleCacheKey(handle, flowType)
 	if err := s.flowByHandleCache.Delete(ctx, cacheKey); err != nil {
-		s.logger.Error("Failed to invalidate flow cache by handle",
+		s.logger.ErrorWithContext(ctx, "Failed to invalidate flow cache by handle",
 			log.String("handle", handle), log.String("flowType", string(flowType)), log.Error(err))
 	}
 }

--- a/backend/internal/flow/mgt/graph_builder.go
+++ b/backend/internal/flow/mgt/graph_builder.go
@@ -72,13 +72,13 @@ func (b *graphBuilder) GetGraph(ctx context.Context, flow *CompleteFlowDefinitio
 	logger := b.logger.With(log.String("flowID", flow.ID))
 	// Check cache first
 	if cachedGraph, ok := b.graphCache.Get(ctx, flow.ID); ok {
-		logger.Debug("Graph retrieved from cache")
+		logger.DebugWithContext(ctx, "Graph retrieved from cache")
 		return cachedGraph, nil
 	}
 
 	graph, err := b.buildGraph(flow)
 	if err != nil {
-		logger.Error("Failed to build graph", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to build graph", log.Error(err))
 		return nil, serviceerror.CustomServiceError(ErrorGraphBuildFailure, i18ncore.I18nMessage{
 			Key:          "error.flowmgtservice.graph_build_failure_description",
 			DefaultValue: err.Error(),
@@ -87,9 +87,9 @@ func (b *graphBuilder) GetGraph(ctx context.Context, flow *CompleteFlowDefinitio
 
 	// Cache the built graph
 	if cacheErr := b.graphCache.Set(ctx, flow.ID, graph); cacheErr != nil {
-		logger.Error("Failed to cache graph", log.Error(cacheErr))
+		logger.ErrorWithContext(ctx, "Failed to cache graph", log.Error(cacheErr))
 	}
-	logger.Debug("Graph built and cached successfully")
+	logger.DebugWithContext(ctx, "Graph built and cached successfully")
 
 	return graph, nil
 }
@@ -101,9 +101,10 @@ func (b *graphBuilder) InvalidateCache(ctx context.Context, flowID string) {
 	}
 
 	if err := b.graphCache.Invalidate(ctx, flowID); err != nil {
-		b.logger.Error("Failed to delete graph from cache", log.String("flowID", flowID), log.Error(err))
+		b.logger.ErrorWithContext(ctx, "Failed to delete graph from cache",
+			log.String("flowID", flowID), log.Error(err))
 	}
-	b.logger.Debug("Graph cache invalidated", log.String("flowID", flowID))
+	b.logger.DebugWithContext(ctx, "Graph cache invalidated", log.String("flowID", flowID))
 }
 
 // buildGraph converts a CompleteFlowDefinition to a core.GraphInterface for execution.

--- a/backend/internal/flow/mgt/handler.go
+++ b/backend/internal/flow/mgt/handler.go
@@ -82,7 +82,7 @@ func (h *flowMgtHandler) listFlows(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteSuccessResponse(w, http.StatusOK, flowList)
-	h.logger.Debug("Flows listed successfully", log.Int(logKeyCount, flowList.Count))
+	h.logger.DebugWithContext(ctx, "Flows listed successfully", log.Int(logKeyCount, flowList.Count))
 }
 
 // createFlow handles POST requests to create a new flow definition.
@@ -102,7 +102,7 @@ func (h *flowMgtHandler) createFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteSuccessResponse(w, http.StatusCreated, createdFlow)
-	h.logger.Debug("Flow created successfully", log.String(logKeyFlowID, createdFlow.ID))
+	h.logger.DebugWithContext(ctx, "Flow created successfully", log.String(logKeyFlowID, createdFlow.ID))
 }
 
 // getFlow handles GET requests to retrieve a flow definition by its ID.
@@ -121,7 +121,7 @@ func (h *flowMgtHandler) getFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteSuccessResponse(w, http.StatusOK, flow)
-	h.logger.Debug("Flow retrieved successfully", log.String(logKeyFlowID, flowID))
+	h.logger.DebugWithContext(ctx, "Flow retrieved successfully", log.String(logKeyFlowID, flowID))
 }
 
 // updateFlow handles PUT requests to update an existing flow definition.
@@ -147,7 +147,7 @@ func (h *flowMgtHandler) updateFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteSuccessResponse(w, http.StatusOK, updatedFlow)
-	h.logger.Debug("Flow updated successfully", log.String(logKeyFlowID, flowID))
+	h.logger.DebugWithContext(ctx, "Flow updated successfully", log.String(logKeyFlowID, flowID))
 }
 
 // deleteFlow handles DELETE requests to remove a flow definition by its ID.
@@ -166,7 +166,7 @@ func (h *flowMgtHandler) deleteFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	h.logger.Debug("Flow deleted successfully", log.String(logKeyFlowID, flowID))
+	h.logger.DebugWithContext(ctx, "Flow deleted successfully", log.String(logKeyFlowID, flowID))
 }
 
 // Flow version management HTTP handler methods
@@ -187,7 +187,7 @@ func (h *flowMgtHandler) listFlowVersions(w http.ResponseWriter, r *http.Request
 	}
 
 	utils.WriteSuccessResponse(w, http.StatusOK, versionList)
-	h.logger.Debug("Flow versions listed successfully", log.String(logKeyFlowID, flowID))
+	h.logger.DebugWithContext(ctx, "Flow versions listed successfully", log.String(logKeyFlowID, flowID))
 }
 
 // getFlowVersion handles GET requests to retrieve a specific version of a flow definition.
@@ -214,7 +214,7 @@ func (h *flowMgtHandler) getFlowVersion(w http.ResponseWriter, r *http.Request) 
 	}
 
 	utils.WriteSuccessResponse(w, http.StatusOK, flowVersion)
-	h.logger.Debug("Flow version retrieved successfully",
+	h.logger.DebugWithContext(ctx, "Flow version retrieved successfully",
 		log.String(logKeyFlowID, flowID), log.Int(logKeyVersion, version))
 }
 
@@ -240,7 +240,7 @@ func (h *flowMgtHandler) restoreFlowVersion(w http.ResponseWriter, r *http.Reque
 	}
 
 	utils.WriteSuccessResponse(w, http.StatusOK, flow)
-	h.logger.Debug("Flow version restored successfully",
+	h.logger.DebugWithContext(ctx, "Flow version restored successfully",
 		log.String(logKeyFlowID, flowID), log.Int(logKeyVersion, request.Version))
 }
 

--- a/backend/internal/flow/mgt/service.go
+++ b/backend/internal/flow/mgt/service.go
@@ -121,7 +121,7 @@ func (s *flowMgtService) ListFlows(ctx context.Context, limit, offset int, flowT
 
 	flows, totalCount, err := s.store.ListFlows(ctx, limit, offset, string(flowType))
 	if err != nil {
-		s.logger.Error("Failed to list flows", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to list flows", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -147,7 +147,7 @@ func (s *flowMgtService) CreateFlow(ctx context.Context, flowDef *FlowDefinition
 	if flowID == "" {
 		generated, genErr := utils.GenerateUUIDv7()
 		if genErr != nil {
-			s.logger.Error("Failed to generate UUID v7", log.Error(genErr))
+			s.logger.ErrorWithContext(ctx, "Failed to generate UUID v7", log.Error(genErr))
 			return nil, &serviceerror.InternalServerError
 		}
 		flowID = generated
@@ -184,11 +184,11 @@ func (s *flowMgtService) CreateFlow(ctx context.Context, flowDef *FlowDefinition
 		if errors.Is(txErr, errFlowHandleExists) {
 			return nil, &ErrorDuplicateFlowHandle
 		}
-		s.logger.Error("Failed to create flow", log.Error(txErr))
+		s.logger.ErrorWithContext(ctx, "Failed to create flow", log.Error(txErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	s.logger.Debug("Flow created successfully", log.String(logKeyFlowID, flowID))
+	s.logger.DebugWithContext(ctx, "Flow created successfully", log.String(logKeyFlowID, flowID))
 
 	s.tryInferRegistrationFlow(ctx, flowID, flowDef)
 
@@ -207,7 +207,7 @@ func (s *flowMgtService) GetFlow(ctx context.Context, flowID string) (
 		if errors.Is(err, errFlowNotFound) {
 			return nil, &ErrorFlowNotFound
 		}
-		s.logger.Error("Failed to get flow", log.String(logKeyFlowID, flowID), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to get flow", log.String(logKeyFlowID, flowID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -229,7 +229,7 @@ func (s *flowMgtService) GetFlowByHandle(ctx context.Context, handle string, flo
 		if errors.Is(err, errFlowNotFound) {
 			return nil, &ErrorFlowNotFound
 		}
-		s.logger.Error("Failed to get flow by handle", log.String("handle", handle),
+		s.logger.ErrorWithContext(ctx, "Failed to get flow by handle", log.String("handle", handle),
 			log.String("flowType", string(flowType)), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -286,11 +286,11 @@ func (s *flowMgtService) UpdateFlow(ctx context.Context, flowID string, flowDef 
 		if errors.Is(txErr, errFlowNotFound) {
 			return nil, &ErrorFlowNotFound
 		}
-		logger.Error("Failed to update flow", log.Error(txErr))
+		logger.ErrorWithContext(ctx, "Failed to update flow", log.Error(txErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Flow updated successfully")
+	logger.DebugWithContext(ctx, "Flow updated successfully")
 
 	// Invalidate the cached graph since the flow has been updated
 	s.graphBuilder.InvalidateCache(ctx, flowID)
@@ -312,7 +312,7 @@ func (s *flowMgtService) DeleteFlow(ctx context.Context, flowID string) *service
 			// Silently return if the flow does not exist
 			return nil
 		}
-		logger.Error("Failed to get existing flow", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get existing flow", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -322,11 +322,11 @@ func (s *flowMgtService) DeleteFlow(ctx context.Context, flowID string) *service
 
 	err = s.store.DeleteFlow(ctx, flowID)
 	if err != nil {
-		logger.Error("Failed to delete flow", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to delete flow", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Flow deleted successfully")
+	logger.DebugWithContext(ctx, "Flow deleted successfully")
 
 	// Invalidate the cached graph since the flow has been deleted
 	s.graphBuilder.InvalidateCache(ctx, flowID)
@@ -350,13 +350,13 @@ func (s *flowMgtService) ListFlowVersions(ctx context.Context, flowID string) (
 		if errors.Is(err, errFlowNotFound) {
 			return nil, &ErrorFlowNotFound
 		}
-		logger.Error("Failed to get existing flow", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get existing flow", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	versions, err := s.store.ListFlowVersions(ctx, flowID)
 	if err != nil {
-		logger.Error("Failed to list flow versions", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to list flow versions", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -386,7 +386,7 @@ func (s *flowMgtService) GetFlowVersion(ctx context.Context, flowID string, vers
 		if errors.Is(err, errVersionNotFound) {
 			return nil, &ErrorVersionNotFound
 		}
-		s.logger.Error("Failed to get flow version", log.String(logKeyFlowID, flowID),
+		s.logger.ErrorWithContext(ctx, "Failed to get flow version", log.String(logKeyFlowID, flowID),
 			log.Int(logKeyVersion, version), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -424,11 +424,11 @@ func (s *flowMgtService) RestoreFlowVersion(ctx context.Context, flowID string, 
 		if errors.Is(txErr, errVersionNotFound) {
 			return nil, &ErrorVersionNotFound
 		}
-		logger.Error("Failed to restore flow version", log.Error(txErr))
+		logger.ErrorWithContext(ctx, "Failed to restore flow version", log.Error(txErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Flow version restored successfully")
+	logger.DebugWithContext(ctx, "Flow version restored successfully")
 
 	// Invalidate the cached graph since a version has been restored
 	s.graphBuilder.InvalidateCache(ctx, flowID)
@@ -451,7 +451,7 @@ func (s *flowMgtService) GetGraph(ctx context.Context, flowID string) (
 		if errors.Is(err, errFlowNotFound) {
 			return nil, &ErrorFlowNotFound
 		}
-		s.logger.Error("Failed to get flow for graph building", log.String(logKeyFlowID, flowID),
+		s.logger.ErrorWithContext(ctx, "Failed to get flow for graph building", log.String(logKeyFlowID, flowID),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -581,12 +581,12 @@ func (s *flowMgtService) tryInferRegistrationFlow(ctx context.Context, authFlowI
 	logger := s.logger.With(log.String("authFlowID", authFlowID))
 
 	if !config.GetServerRuntime().Config.Flow.AutoInferRegistration {
-		logger.Debug("Automatic registration flow inference is disabled")
+		logger.DebugWithContext(ctx, "Automatic registration flow inference is disabled")
 		return
 	}
 
 	if authFlowDef.FlowType != common.FlowTypeAuthentication {
-		logger.Debug("Flow is not an authentication flow, skipping registration inference",
+		logger.DebugWithContext(ctx, "Flow is not an authentication flow, skipping registration inference",
 			log.String("flowType", string(authFlowDef.FlowType)))
 		return
 	}
@@ -594,33 +594,33 @@ func (s *flowMgtService) tryInferRegistrationFlow(ctx context.Context, authFlowI
 	// Check if auth flow already contains PasskeyAuthExecutor with registration modes
 	// If so, skip registration flow inference as the auth flow handles registration internally
 	if s.hasPasskeyRegistrationModes(authFlowDef) {
-		logger.Debug("Authentication flow contains PasskeyAuthExecutor with " +
+		logger.DebugWithContext(ctx, "Authentication flow contains PasskeyAuthExecutor with "+
 			"register_start and register_finish modes, skipping registration inference")
 		return
 	}
 
-	logger.Debug("Inferring registration flow from authentication flow",
+	logger.DebugWithContext(ctx, "Inferring registration flow from authentication flow",
 		log.String("flowName", authFlowDef.Name))
 
 	regFlowDef, inferErr := s.inferenceService.InferRegistrationFlow(authFlowDef)
 	if inferErr != nil {
-		logger.Error("Failed to infer registration flow", log.Error(inferErr))
+		logger.ErrorWithContext(ctx, "Failed to infer registration flow", log.Error(inferErr))
 		return
 	}
 
 	regFlowID, uuidErr := utils.GenerateUUIDv7()
 	if uuidErr != nil {
-		logger.Error("Failed to generate UUID for inferred registration flow", log.Error(uuidErr))
+		logger.ErrorWithContext(ctx, "Failed to generate UUID for inferred registration flow", log.Error(uuidErr))
 		return
 	}
 
 	_, storeErr := s.store.CreateFlow(ctx, regFlowID, regFlowDef)
 	if storeErr != nil {
-		logger.Error("Failed to create inferred registration flow", log.Error(storeErr))
+		logger.ErrorWithContext(ctx, "Failed to create inferred registration flow", log.Error(storeErr))
 		return
 	}
 
-	logger.Debug("Successfully inferred and created registration flow",
+	logger.DebugWithContext(ctx, "Successfully inferred and created registration flow",
 		log.String("authFlowName", authFlowDef.Name), log.String("regFlowID", regFlowID),
 		log.String("regFlowName", regFlowDef.Name))
 }

--- a/backend/internal/group/handler.go
+++ b/backend/internal/group/handler.go
@@ -67,7 +67,7 @@ func (gh *groupHandler) HandleGroupListRequest(w http.ResponseWriter, r *http.Re
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, groupListResponse)
 
-	logger.Debug("Successfully listed groups with pagination",
+	logger.DebugWithContext(ctx, "Successfully listed groups with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", groupListResponse.TotalResults),
 		log.Int("count", groupListResponse.Count))
@@ -100,7 +100,7 @@ func (gh *groupHandler) HandleGroupListByPathRequest(w http.ResponseWriter, r *h
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, groupListResponse)
 
-	logger.Debug("Successfully listed groups by path", log.String("path", path),
+	logger.DebugWithContext(ctx, "Successfully listed groups by path", log.String("path", path),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", groupListResponse.TotalResults),
 		log.Int("count", groupListResponse.Count))
@@ -134,7 +134,7 @@ func (gh *groupHandler) HandleGroupPostRequest(w http.ResponseWriter, r *http.Re
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdGroup)
 
-	logger.Debug("Successfully created group", log.String("group id", createdGroup.ID))
+	logger.DebugWithContext(ctx, "Successfully created group", log.String("group id", createdGroup.ID))
 }
 
 // HandleGroupPostByPathRequest handles the create group by OU path request.
@@ -169,7 +169,8 @@ func (gh *groupHandler) HandleGroupPostByPathRequest(w http.ResponseWriter, r *h
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, group)
 
-	logger.Debug("Successfully created group by path", log.String("path", path), log.String("groupName", group.Name))
+	logger.DebugWithContext(ctx, "Successfully created group by path",
+		log.String("path", path), log.String("groupName", group.Name))
 }
 
 // HandleGroupGetRequest handles the get group by id request.
@@ -199,7 +200,7 @@ func (gh *groupHandler) HandleGroupGetRequest(w http.ResponseWriter, r *http.Req
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, group)
 
-	logger.Debug("Successfully retrieved group", log.String("group id", id))
+	logger.DebugWithContext(ctx, "Successfully retrieved group", log.String("group id", id))
 }
 
 // HandleGroupPutRequest handles the update group request.
@@ -242,7 +243,7 @@ func (gh *groupHandler) HandleGroupPutRequest(w http.ResponseWriter, r *http.Req
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, group)
 
-	logger.Debug("Successfully updated group", log.String("group id", id))
+	logger.DebugWithContext(ctx, "Successfully updated group", log.String("group id", id))
 }
 
 // HandleGroupDeleteRequest handles the delete group request.
@@ -269,7 +270,7 @@ func (gh *groupHandler) HandleGroupDeleteRequest(w http.ResponseWriter, r *http.
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
-	logger.Debug("Successfully deleted group", log.String("group id", id))
+	logger.DebugWithContext(ctx, "Successfully deleted group", log.String("group id", id))
 }
 
 // HandleGroupMembersGetRequest handles the get group members request.
@@ -305,7 +306,7 @@ func (gh *groupHandler) HandleGroupMembersGetRequest(w http.ResponseWriter, r *h
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, memberListResponse)
 
-	logger.Debug("Successfully retrieved group members", log.String("group id", id),
+	logger.DebugWithContext(ctx, "Successfully retrieved group members", log.String("group id", id),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", memberListResponse.TotalResults),
 		log.Int("count", memberListResponse.Count))
@@ -337,7 +338,7 @@ func (gh *groupHandler) HandleGroupMembersAddRequest(w http.ResponseWriter, r *h
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, group)
-	logger.Debug("Successfully added members to group", log.String("group id", id))
+	logger.DebugWithContext(ctx, "Successfully added members to group", log.String("group id", id))
 }
 
 // HandleGroupMembersRemoveRequest handles the remove members from group request.
@@ -366,7 +367,7 @@ func (gh *groupHandler) HandleGroupMembersRemoveRequest(w http.ResponseWriter, r
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, group)
-	logger.Debug("Successfully removed members from group", log.String("group id", id))
+	logger.DebugWithContext(ctx, "Successfully removed members from group", log.String("group id", id))
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.

--- a/backend/internal/group/service.go
+++ b/backend/internal/group/service.go
@@ -115,13 +115,13 @@ func (gs *groupService) listAllGroups(ctx context.Context, limit, offset int, in
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	totalCount, err := gs.groupStore.GetGroupListCount(ctx)
 	if err != nil {
-		logger.Error("Failed to get group count", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get group count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	groups, err := gs.groupStore.GetGroupList(ctx, limit, offset)
 	if err != nil {
-		logger.Error("Failed to list groups", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to list groups", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -164,7 +164,7 @@ func (gs *groupService) listGroupsByOUIDs(ctx context.Context, ouIDs []string, l
 
 	totalCount, err := gs.groupStore.GetGroupListCountByOUIDs(ctx, ouIDs)
 	if err != nil {
-		logger.Error("Failed to get group count by OU IDs", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get group count by OU IDs", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -180,7 +180,7 @@ func (gs *groupService) listGroupsByOUIDs(ctx context.Context, ouIDs []string, l
 
 	groups, err := gs.groupStore.GetGroupListByOUIDs(ctx, ouIDs, limit, offset)
 	if err != nil {
-		logger.Error("Failed to list groups by OU IDs", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to list groups by OU IDs", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -209,7 +209,7 @@ func (gs *groupService) GetGroupsByPath(
 	ctx context.Context, handlePath string, limit, offset int, includeDisplay bool,
 ) (*GroupListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Getting groups by path", log.String("path", handlePath))
+	logger.DebugWithContext(ctx, "Getting groups by path", log.String("path", handlePath))
 
 	serviceError := gs.validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -235,13 +235,13 @@ func (gs *groupService) GetGroupsByPath(
 
 	totalCount, err := gs.groupStore.GetGroupsByOrganizationUnitCount(ctx, oUID)
 	if err != nil {
-		logger.Error("Failed to get group count by organization unit", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get group count by organization unit", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	groups, err := gs.groupStore.GetGroupsByOrganizationUnit(ctx, oUID, limit, offset)
 	if err != nil {
-		logger.Error("Failed to list groups by organization unit", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to list groups by organization unit", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -270,7 +270,7 @@ func (gs *groupService) GetGroupsByPath(
 func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequest) (
 	*Group, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Creating group", log.String("name", request.Name))
+	logger.DebugWithContext(ctx, "Creating group", log.String("name", request.Name))
 
 	if err := gs.validateCreateGroupRequest(request); err != nil {
 		return nil, err
@@ -310,7 +310,7 @@ func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequ
 		if err := gs.groupStore.CheckGroupNameConflictForCreate(
 			txCtx, request.Name, request.OUID); err != nil {
 			if errors.Is(err, ErrGroupNameConflict) {
-				logger.Debug("Group name conflict detected", log.String("name", request.Name))
+				logger.DebugWithContext(ctx, "Group name conflict detected", log.String("name", request.Name))
 				capturedSvcErr = &ErrorGroupNameConflict
 				return errors.New("rollback for group name conflict")
 			}
@@ -348,7 +348,7 @@ func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequ
 	}
 
 	if err != nil {
-		logger.Error("Failed to create group", log.Error(err), log.String("name", request.Name))
+		logger.ErrorWithContext(ctx, "Failed to create group", log.Error(err), log.String("name", request.Name))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -359,7 +359,8 @@ func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequ
 	}
 	createdGroup.Members = resolvedMembers
 
-	logger.Debug("Successfully created group", log.String("id", createdGroup.ID), log.String("name", createdGroup.Name))
+	logger.DebugWithContext(ctx, "Successfully created group",
+		log.String("id", createdGroup.ID), log.String("name", createdGroup.Name))
 	return createdGroup, nil
 }
 
@@ -368,7 +369,8 @@ func (gs *groupService) CreateGroupByPath(
 	ctx context.Context, handlePath string, request CreateGroupByPathRequest,
 ) (*Group, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Creating group by path", log.String("path", handlePath), log.String("name", request.Name))
+	logger.DebugWithContext(ctx, "Creating group by path",
+		log.String("path", handlePath), log.String("name", request.Name))
 
 	serviceError := gs.validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -399,7 +401,7 @@ func (gs *groupService) GetGroup(
 	ctx context.Context, groupID string, includeDisplay bool,
 ) (*Group, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Retrieving group", log.String("id", groupID))
+	logger.DebugWithContext(ctx, "Retrieving group", log.String("id", groupID))
 
 	if groupID == "" {
 		return nil, &ErrorMissingGroupID
@@ -408,10 +410,10 @@ func (gs *groupService) GetGroup(
 	groupDAO, err := gs.groupStore.GetGroup(ctx, groupID)
 	if err != nil {
 		if errors.Is(err, ErrGroupNotFound) {
-			logger.Debug("Group not found", log.String("id", groupID))
+			logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
 			return nil, &ErrorGroupNotFound
 		}
-		logger.Error("Failed to retrieve group", log.String("id", groupID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to retrieve group", log.String("id", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -431,14 +433,15 @@ func (gs *groupService) GetGroup(
 		handleMap, svcErr := gs.ouService.GetOrganizationUnitHandlesByIDs(
 			ctx, []string{group.OUID})
 		if svcErr != nil {
-			logger.Warn("Failed to resolve OU handle for group, skipping",
+			logger.WarnWithContext(ctx, "Failed to resolve OU handle for group, skipping",
 				log.String("id", groupID), log.Any("error", svcErr))
 		} else if handle, ok := handleMap[group.OUID]; ok {
 			group.OUHandle = handle
 		}
 	}
 
-	logger.Debug("Successfully retrieved group", log.String("id", group.ID), log.String("name", group.Name))
+	logger.DebugWithContext(ctx, "Successfully retrieved group",
+		log.String("id", group.ID), log.String("name", group.Name))
 	return &group, nil
 }
 
@@ -446,7 +449,7 @@ func (gs *groupService) GetGroup(
 func (gs *groupService) UpdateGroup(
 	ctx context.Context, groupID string, request UpdateGroupRequest) (*Group, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Updating group", log.String("id", groupID), log.String("name", request.Name))
+	logger.DebugWithContext(ctx, "Updating group", log.String("id", groupID), log.String("name", request.Name))
 
 	if groupID == "" {
 		return nil, &ErrorMissingGroupID
@@ -463,7 +466,7 @@ func (gs *groupService) UpdateGroup(
 		existingGroupDAO, err := gs.groupStore.GetGroup(txCtx, groupID)
 		if err != nil {
 			if errors.Is(err, ErrGroupNotFound) {
-				logger.Debug("Group not found", log.String("id", groupID))
+				logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
 				capturedSvcErr = &ErrorGroupNotFound
 				return errors.New("rollback for group not found")
 			}
@@ -508,7 +511,8 @@ func (gs *groupService) UpdateGroup(
 				txCtx, request.Name, request.OUID, groupID)
 			if err != nil {
 				if errors.Is(err, ErrGroupNameConflict) {
-					logger.Debug("Group name conflict detected during update", log.String("name", request.Name))
+					logger.DebugWithContext(ctx, "Group name conflict detected during update",
+						log.String("name", request.Name))
 					capturedSvcErr = &ErrorGroupNameConflict
 					return errors.New("rollback for group name conflict")
 				}
@@ -537,18 +541,19 @@ func (gs *groupService) UpdateGroup(
 	}
 
 	if err != nil {
-		logger.Error("Failed to update group", log.Error(err), log.String("groupID", groupID))
+		logger.ErrorWithContext(ctx, "Failed to update group", log.Error(err), log.String("groupID", groupID))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully updated group", log.String("id", groupID), log.String("name", request.Name))
+	logger.DebugWithContext(ctx, "Successfully updated group",
+		log.String("id", groupID), log.String("name", request.Name))
 	return updatedGroup, nil
 }
 
 // DeleteGroup delete the specified group by its id.
 func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Deleting group", log.String("id", groupID))
+	logger.DebugWithContext(ctx, "Deleting group", log.String("id", groupID))
 
 	if groupID == "" {
 		return &ErrorMissingGroupID
@@ -560,7 +565,7 @@ func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *servic
 		existingGroupDAO, err := gs.groupStore.GetGroup(txCtx, groupID)
 		if err != nil {
 			if errors.Is(err, ErrGroupNotFound) {
-				logger.Debug("Group not found", log.String("id", groupID))
+				logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
 				capturedSvcErr = &ErrorGroupNotFound
 				return errors.New("rollback for group not found")
 			}
@@ -588,11 +593,11 @@ func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *servic
 	}
 
 	if err != nil {
-		logger.Error("Failed to delete group", log.Error(err), log.String("groupID", groupID))
+		logger.ErrorWithContext(ctx, "Failed to delete group", log.Error(err), log.String("groupID", groupID))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully deleted group", log.String("id", groupID))
+	logger.DebugWithContext(ctx, "Successfully deleted group", log.String("id", groupID))
 	return nil
 }
 
@@ -612,10 +617,10 @@ func (gs *groupService) GetGroupMembers(ctx context.Context, groupID string, lim
 	existingGroupDAO, err := gs.groupStore.GetGroup(ctx, groupID)
 	if err != nil {
 		if errors.Is(err, ErrGroupNotFound) {
-			logger.Debug("Group not found", log.String("id", groupID))
+			logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
 			return nil, &ErrorGroupNotFound
 		}
-		logger.Error("Failed to retrieve group", log.String("id", groupID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to retrieve group", log.String("id", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -630,13 +635,13 @@ func (gs *groupService) GetGroupMembers(ctx context.Context, groupID string, lim
 
 	totalCount, err := gs.groupStore.GetGroupMemberCount(ctx, groupID)
 	if err != nil {
-		logger.Error("Failed to get group member count", log.String("groupID", groupID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get group member count", log.String("groupID", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	members, err := gs.groupStore.GetGroupMembers(ctx, groupID, limit, offset)
 	if err != nil {
-		logger.Error("Failed to get group members", log.String("groupID", groupID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get group members", log.String("groupID", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -686,7 +691,7 @@ func (gs *groupService) resolveMembers(
 	if len(entityIDs) > 0 {
 		entities, err := gs.entityService.GetEntitiesByIDs(ctx, entityIDs)
 		if err != nil {
-			logger.Error("Failed to batch-fetch entities for member resolution", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to batch-fetch entities for member resolution", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		entityMap = make(map[string]*entity.Entity, len(entities))
@@ -710,7 +715,7 @@ func (gs *groupService) resolveMembers(
 		var svcErr *serviceerror.ServiceError
 		groupsMap, svcErr = gs.GetGroupsByIDs(ctx, groupIDs)
 		if svcErr != nil {
-			logger.Warn("Failed to batch-fetch groups for display resolution", log.Any("error", svcErr))
+			logger.WarnWithContext(ctx, "Failed to batch-fetch groups for display resolution", log.Any("error", svcErr))
 		}
 	}
 
@@ -722,7 +727,7 @@ func (gs *groupService) resolveMembers(
 		case memberTypeEntity:
 			e, ok := entityMap[members[i].ID]
 			if !ok {
-				logger.Warn("Skipping orphaned entity member", log.String("id", members[i].ID))
+				logger.WarnWithContext(ctx, "Skipping orphaned entity member", log.String("id", members[i].ID))
 				continue
 			}
 			// Set the public type from the entity category ("user", "app", or "agent").
@@ -803,10 +808,10 @@ func (gs *groupService) modifyGroupMembers(
 	existingGroup, err := gs.groupStore.GetGroup(ctx, groupID)
 	if err != nil {
 		if errors.Is(err, ErrGroupNotFound) {
-			logger.Debug("Group not found", log.String("id", groupID))
+			logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
 			return nil, &ErrorGroupNotFound
 		}
-		logger.Error("Failed to fetch group", log.String("id", groupID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to fetch group", log.String("id", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -839,7 +844,7 @@ func (gs *groupService) modifyGroupMembers(
 		existingGroupDAO, err := gs.groupStore.GetGroup(txCtx, groupID)
 		if err != nil {
 			if errors.Is(err, ErrGroupNotFound) {
-				logger.Debug("Group not found", log.String("id", groupID))
+				logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
 				capturedSvcErr = &ErrorGroupNotFound
 				return errors.New("rollback for group not found")
 			}
@@ -874,7 +879,7 @@ func (gs *groupService) modifyGroupMembers(
 	}
 
 	if err != nil {
-		logger.Error(errMsg, log.String("id", groupID), log.Error(err))
+		logger.ErrorWithContext(ctx, errMsg, log.String("id", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -884,7 +889,7 @@ func (gs *groupService) modifyGroupMembers(
 		return nil, svcErr
 	}
 	updatedGroup.Members = resolvedMembers
-	logger.Debug(successMsg, log.String("id", groupID))
+	logger.DebugWithContext(ctx, successMsg, log.String("id", groupID))
 	return &updatedGroup, nil
 }
 
@@ -956,7 +961,7 @@ func (gs *groupService) validateEntityMembers(
 
 	entities, err := gs.entityService.GetEntitiesByIDs(ctx, entityIDs)
 	if err != nil {
-		logger.Error("Failed to fetch entities for member validation", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to fetch entities for member validation", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -969,7 +974,7 @@ func (gs *groupService) validateEntityMembers(
 		claimed := typeByID[e.ID]
 		actual := MemberType(e.Category)
 		if claimed != actual {
-			logger.Debug("Member type mismatch", log.String("id", e.ID),
+			logger.DebugWithContext(ctx, "Member type mismatch", log.String("id", e.ID),
 				log.String("claimed", string(claimed)), log.String("actual", string(actual)))
 			return &ErrorInvalidMemberID
 		}
@@ -993,12 +998,13 @@ func (gs *groupService) validateEntityMembers(
 
 	outOfScopeIDs, err := gs.entityService.ValidateEntityIDsInOUs(ctx, userIDs, accessibleOUs.IDs)
 	if err != nil {
-		logger.Error("Failed to validate user IDs in OUs", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to validate user IDs in OUs", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
 	if len(outOfScopeIDs) > 0 {
-		logger.Debug("User IDs outside accessible OUs", log.MaskedStrings("outOfScopeIDs", outOfScopeIDs))
+		logger.DebugWithContext(ctx, "User IDs outside accessible OUs",
+			log.MaskedStrings("outOfScopeIDs", outOfScopeIDs))
 		return &serviceerror.ErrorUnauthorized
 	}
 
@@ -1029,7 +1035,7 @@ func (gs *groupService) validateOU(ctx context.Context, ouID string) *serviceerr
 
 	isExists, err := gs.ouService.IsOrganizationUnitExists(ctx, ouID)
 	if err != nil {
-		logger.Error("Failed to check organization unit existence", log.Any("error: ", err))
+		logger.ErrorWithContext(ctx, "Failed to check organization unit existence", log.Any("error: ", err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -1058,7 +1064,7 @@ func resolveDisplayAttributePaths(
 	displayPaths, svcErr := schemaService.GetDisplayAttributesByNames(ctx, entitytype.TypeCategoryUser, uniqueTypes)
 	if svcErr != nil {
 		if logger != nil {
-			logger.Warn("Failed to resolve display attribute paths, skipping display resolution",
+			logger.WarnWithContext(ctx, "Failed to resolve display attribute paths, skipping display resolution",
 				log.Any("error", svcErr))
 		}
 		return nil
@@ -1087,12 +1093,12 @@ func (gs *groupService) ValidateGroupIDs(ctx context.Context, groupIDs []string)
 
 	invalidGroupIDs, err := gs.groupStore.ValidateGroupIDs(ctx, groupIDs)
 	if err != nil {
-		logger.Error("Failed to validate group IDs", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to validate group IDs", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
 	if len(invalidGroupIDs) > 0 {
-		logger.Debug("Invalid group IDs found", log.Any("invalidGroupIDs", invalidGroupIDs))
+		logger.DebugWithContext(ctx, "Invalid group IDs found", log.Any("invalidGroupIDs", invalidGroupIDs))
 		return &ErrorInvalidGroupMemberID
 	}
 
@@ -1121,7 +1127,7 @@ func (gs *groupService) GetGroupsByIDs(
 
 	groupDAOs, err := gs.groupStore.GetGroupsByIDs(ctx, uniqueIDs)
 	if err != nil {
-		logger.Error("Failed to get groups by IDs", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get groups by IDs", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1173,7 +1179,7 @@ func (gs *groupService) populateGroupOUHandles(ctx context.Context, groups []Gro
 
 	handleMap, svcErr := gs.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
 	if svcErr != nil {
-		logger.Warn("Failed to resolve OU handles for groups, skipping", log.Any("error", svcErr))
+		logger.WarnWithContext(ctx, "Failed to resolve OU handles for groups, skipping", log.Any("error", svcErr))
 		return
 	}
 
@@ -1208,7 +1214,7 @@ func (gs *groupService) checkGroupAccess(
 
 	hasAccess, err := gs.authzService.IsActionAllowed(ctx, action, &actionCtx)
 	if err != nil {
-		logger.Error("Failed to check authorization", log.String("err", err.Error.DefaultValue))
+		logger.ErrorWithContext(ctx, "Failed to check authorization", log.String("err", err.Error.DefaultValue))
 		return &serviceerror.InternalServerError
 	}
 	if !hasAccess {

--- a/backend/internal/group/store.go
+++ b/backend/internal/group/store.go
@@ -348,7 +348,7 @@ func (s *groupStore) DeleteGroup(ctx context.Context, id string) error {
 	}
 
 	if result == 0 {
-		logger.Debug("Group not found with id: " + id)
+		logger.DebugWithContext(ctx, "Group not found with id: "+id)
 	}
 
 	return nil

--- a/backend/internal/inboundclient/cache_backed_store.go
+++ b/backend/internal/inboundclient/cache_backed_store.go
@@ -154,7 +154,8 @@ func (c *cachedBackStore) cacheInboundClient(ctx context.Context, client *inboun
 	}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InboundClientCachedBackStore"))
 	if err := c.inboundClientCache.Set(ctx, cache.CacheKey{Key: client.ID}, client); err != nil {
-		logger.Error("Failed to cache inbound client", log.String("entityID", client.ID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to cache inbound client",
+			log.String("entityID", client.ID), log.Error(err))
 	}
 }
 
@@ -164,7 +165,7 @@ func (c *cachedBackStore) cacheOAuthProfile(ctx context.Context, entityID string
 	}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InboundClientCachedBackStore"))
 	if err := c.oauthProfileCache.Set(ctx, cache.CacheKey{Key: entityID}, profile); err != nil {
-		logger.Error("Failed to cache OAuth profile", log.String("entityID", entityID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to cache OAuth profile", log.String("entityID", entityID), log.Error(err))
 	}
 }
 
@@ -174,7 +175,8 @@ func (c *cachedBackStore) invalidateInboundClient(ctx context.Context, entityID 
 	}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InboundClientCachedBackStore"))
 	if err := c.inboundClientCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
-		logger.Error("Failed to invalidate inbound client cache", log.String("entityID", entityID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to invalidate inbound client cache",
+			log.String("entityID", entityID), log.Error(err))
 	}
 }
 
@@ -184,6 +186,7 @@ func (c *cachedBackStore) invalidateOAuthProfile(ctx context.Context, entityID s
 	}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InboundClientCachedBackStore"))
 	if err := c.oauthProfileCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
-		logger.Error("Failed to invalidate OAuth profile cache", log.String("entityID", entityID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to invalidate OAuth profile cache",
+			log.String("entityID", entityID), log.Error(err))
 	}
 }

--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -1053,7 +1053,7 @@ func (s *inboundClientService) validateAllowedUserTypes(
 		entityTypeList, svcErr := s.entityType.GetEntityTypeList(
 			security.WithRuntimeContext(ctx), entitytype.TypeCategoryUser, limit, offset, false)
 		if svcErr != nil {
-			s.logger.Error("Failed to retrieve user type list for validation",
+			s.logger.ErrorWithContext(ctx, "Failed to retrieve user type list for validation",
 				log.String("error", svcErr.Error.DefaultValue), log.String("code", svcErr.Code))
 			return ErrUserSchemaLookupFailed
 		}
@@ -1397,7 +1397,7 @@ func (s *inboundClientService) syncConsentOnUpdate(ctx context.Context,
 		// is left alone — it has an independent lifecycle bound to the resource service.
 		if delErr := s.consentService.DeleteConsentPurpose(ctx, ouID, existing[0].ID); delErr != nil {
 			if delErr.Code == consent.ErrorDeletingConsentPurposeWithAssociatedRecords.Code {
-				s.logger.Warn("Cannot delete attribute consent purpose due to existing consents",
+				s.logger.WarnWithContext(ctx, "Cannot delete attribute consent purpose due to existing consents",
 					log.String("entityID", entityID))
 				return nil
 			}
@@ -1431,7 +1431,7 @@ func (s *inboundClientService) syncConsentOnDelete(ctx context.Context, entityID
 	for _, p := range purposes {
 		if delErr := s.consentService.DeleteConsentPurpose(ctx, ouID, p.ID); delErr != nil {
 			if delErr.Code == consent.ErrorDeletingConsentPurposeWithAssociatedRecords.Code {
-				s.logger.Warn("Cannot delete consent purpose due to existing consents",
+				s.logger.WarnWithContext(ctx, "Cannot delete consent purpose due to existing consents",
 					log.String("entityID", entityID), log.String("purposeID", p.ID),
 					log.String("purposeNamespace", string(p.Namespace)))
 				continue

--- a/backend/internal/notification/message_handler.go
+++ b/backend/internal/notification/message_handler.go
@@ -62,7 +62,8 @@ func (h *messageNotificationSenderHandler) HandleSenderListRequest(w http.Respon
 	for _, sender := range senders {
 		senderResponse, err := getSenderResponseFromDTO(&sender)
 		if err != nil {
-			logger.Error("Failed to convert sender to response", log.String("sender", sender.Name), log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to convert sender to response",
+				log.String("sender", sender.Name), log.Error(err))
 			h.handleError(w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
 			return
 		}
@@ -84,7 +85,7 @@ func (h *messageNotificationSenderHandler) HandleSenderCreateRequest(w http.Resp
 
 	senderDTO, err := getDTOFromSenderRequest(sender)
 	if err != nil {
-		logger.Error("Failed to process sender request", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to process sender request", log.Error(err))
 		h.handleError(w, &serviceerror.InternalServerError, "Failed to process sender request: "+err.Error())
 		return
 	}
@@ -108,7 +109,8 @@ func (h *messageNotificationSenderHandler) HandleSenderCreateRequest(w http.Resp
 
 	senderResponse, err := getSenderResponseFromDTO(createdSender)
 	if err != nil {
-		logger.Error("Failed to convert sender to response", log.String("sender", createdSender.Name), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to convert sender to response",
+			log.String("sender", createdSender.Name), log.Error(err))
 		h.handleError(w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
 		return
 	}
@@ -142,7 +144,8 @@ func (h *messageNotificationSenderHandler) HandleSenderGetRequest(w http.Respons
 
 	senderResponse, err := getSenderResponseFromDTO(sender)
 	if err != nil {
-		logger.Error("Failed to convert sender to response", log.String("sender", sender.Name), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to convert sender to response",
+			log.String("sender", sender.Name), log.Error(err))
 		h.handleError(w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
 		return
 	}
@@ -167,7 +170,7 @@ func (h *messageNotificationSenderHandler) HandleSenderUpdateRequest(w http.Resp
 
 	senderDTO, err := getDTOFromSenderRequest(sender)
 	if err != nil {
-		logger.Error("Failed to process sender request", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to process sender request", log.Error(err))
 		h.handleError(w, &serviceerror.InternalServerError, "Failed to process sender request: "+err.Error())
 		return
 	}
@@ -180,7 +183,8 @@ func (h *messageNotificationSenderHandler) HandleSenderUpdateRequest(w http.Resp
 
 	senderResponse, err := getSenderResponseFromDTO(updatedSender)
 	if err != nil {
-		logger.Error("Failed to convert sender to response", log.String("sender", updatedSender.Name), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to convert sender to response",
+			log.String("sender", updatedSender.Name), log.Error(err))
 		h.handleError(w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
 		return
 	}

--- a/backend/internal/notification/mgt_service.go
+++ b/backend/internal/notification/mgt_service.go
@@ -65,7 +65,7 @@ func (s *notificationSenderMgtService) CreateSender(
 	ctx context.Context, sender common.NotificationSenderDTO) (
 	*common.NotificationSenderDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.Debug("Creating notification sender", log.String("name", sender.Name))
+	logger.DebugWithContext(ctx, "Creating notification sender", log.String("name", sender.Name))
 
 	if err := declarativeresource.CheckDeclarativeCreate(); err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s *notificationSenderMgtService) CreateSender(
 	if sender.ID == "" {
 		id, err := s.uuidGenerator()
 		if err != nil {
-			logger.Error("Failed to generate UUID", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		sender.ID = id
@@ -92,7 +92,7 @@ func (s *notificationSenderMgtService) CreateSender(
 			return err
 		}
 		if senderRetv != nil {
-			logger.Debug("Notification sender already exists", log.String("name", sender.Name),
+			logger.DebugWithContext(ctx, "Notification sender already exists", log.String("name", sender.Name),
 				log.String("id", senderRetv.ID))
 			svcErr = &ErrorDuplicateSenderName
 			return errors.New("sender already exists")
@@ -110,7 +110,8 @@ func (s *notificationSenderMgtService) CreateSender(
 		return nil, svcErr
 	}
 	if transactErr != nil {
-		logger.Error("Failed to create notification sender", log.Error(transactErr), log.String("name", sender.Name))
+		logger.ErrorWithContext(ctx, "Failed to create notification sender",
+			log.Error(transactErr), log.String("name", sender.Name))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -128,11 +129,11 @@ func (s *notificationSenderMgtService) CreateSender(
 func (s *notificationSenderMgtService) ListSenders(ctx context.Context) ([]common.NotificationSenderDTO,
 	*serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.Debug("Listing all notification senders")
+	logger.DebugWithContext(ctx, "Listing all notification senders")
 
 	senders, err := s.notificationStore.listSenders(ctx)
 	if err != nil {
-		logger.Error("Failed to list notification senders", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to list notification senders", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -143,7 +144,7 @@ func (s *notificationSenderMgtService) ListSenders(ctx context.Context) ([]commo
 func (s *notificationSenderMgtService) GetSender(ctx context.Context, id string) (*common.NotificationSenderDTO,
 	*serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.Debug("Retrieving notification sender", log.String("id", id))
+	logger.DebugWithContext(ctx, "Retrieving notification sender", log.String("id", id))
 
 	if id == "" {
 		return nil, &ErrorInvalidSenderID
@@ -151,7 +152,7 @@ func (s *notificationSenderMgtService) GetSender(ctx context.Context, id string)
 
 	sender, err := s.notificationStore.getSenderByID(ctx, id)
 	if err != nil {
-		logger.Error("Failed to retrieve notification sender", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to retrieve notification sender", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -166,7 +167,7 @@ func (s *notificationSenderMgtService) GetSender(ctx context.Context, id string)
 func (s *notificationSenderMgtService) GetSenderByName(ctx context.Context, name string) (*common.NotificationSenderDTO,
 	*serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.Debug("Retrieving notification sender by name", log.String("name", name))
+	logger.DebugWithContext(ctx, "Retrieving notification sender by name", log.String("name", name))
 
 	if name == "" {
 		return nil, &ErrorInvalidSenderName
@@ -174,7 +175,7 @@ func (s *notificationSenderMgtService) GetSenderByName(ctx context.Context, name
 
 	sender, err := s.notificationStore.getSenderByName(ctx, name)
 	if err != nil {
-		logger.Error("Failed to retrieve notification sender", log.String("name", name), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to retrieve notification sender", log.String("name", name), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -189,7 +190,7 @@ func (s *notificationSenderMgtService) GetSenderByName(ctx context.Context, name
 func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id string,
 	sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.Debug("Updating notification sender", log.String("id", id), log.String("name", sender.Name))
+	logger.DebugWithContext(ctx, "Updating notification sender", log.String("id", id), log.String("name", sender.Name))
 
 	if err := declarativeresource.CheckDeclarativeUpdate(); err != nil {
 		return nil, err
@@ -210,7 +211,7 @@ func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id stri
 			return err
 		}
 		if senderRetv == nil {
-			logger.Debug("Notification sender not found", log.String("id", id))
+			logger.DebugWithContext(ctx, "Notification sender not found", log.String("id", id))
 			svcErr = &ErrorSenderNotFound
 			return errors.New("sender not found")
 		}
@@ -222,7 +223,7 @@ func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id stri
 				return err
 			}
 			if senderWithUpdatedName != nil && senderWithUpdatedName.ID != id {
-				logger.Debug("Another sender with the same name already exists",
+				logger.DebugWithContext(ctx, "Another sender with the same name already exists",
 					log.String("name", sender.Name), log.String("existingID", senderWithUpdatedName.ID))
 				svcErr = &ErrorDuplicateSenderName
 				return errors.New("duplicate name")
@@ -231,7 +232,7 @@ func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id stri
 
 		// Ensure the type is not changed
 		if sender.Type != senderRetv.Type {
-			logger.Debug("Attempting to change sender type", log.String("id", id),
+			logger.DebugWithContext(ctx, "Attempting to change sender type", log.String("id", id),
 				log.String("originalType", string(senderRetv.Type)), log.String("newType", string(sender.Type)))
 			svcErr = &ErrorSenderTypeUpdateNotAllowed
 			return errors.New("cannot change type")
@@ -249,7 +250,8 @@ func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id stri
 		return nil, svcErr
 	}
 	if transactErr != nil {
-		logger.Error("Failed to update notification sender", log.Error(transactErr), log.String("id", id))
+		logger.ErrorWithContext(ctx, "Failed to update notification sender",
+			log.Error(transactErr), log.String("id", id))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -266,7 +268,7 @@ func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id stri
 // DeleteSender deletes a notification sender
 func (s *notificationSenderMgtService) DeleteSender(ctx context.Context, id string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.Debug("Deleting notification sender", log.String("id", id))
+	logger.DebugWithContext(ctx, "Deleting notification sender", log.String("id", id))
 
 	if err := declarativeresource.CheckDeclarativeDelete(); err != nil {
 		return err
@@ -284,7 +286,8 @@ func (s *notificationSenderMgtService) DeleteSender(ctx context.Context, id stri
 	})
 
 	if transactErr != nil {
-		logger.Error("Failed to delete notification sender", log.Error(transactErr), log.String("id", id))
+		logger.ErrorWithContext(ctx, "Failed to delete notification sender",
+			log.Error(transactErr), log.String("id", id))
 		return &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/notification/notification_sender_service.go
+++ b/backend/internal/notification/notification_sender_service.go
@@ -71,7 +71,8 @@ func (s *notificationSenderService) Send(ctx context.Context, channel common.Cha
 	}
 
 	if err := _client.Send(channel, data); err != nil {
-		s.logger.Error("Failed to send notification", log.String("channel", string(channel)), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to send notification",
+			log.String("channel", string(channel)), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -69,7 +69,7 @@ func newOTPService(notifSenderSvc NotificationSenderMgtSvcInterface,
 func (s *otpService) SendOTP(
 	ctx context.Context, otpDTO common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "OTPService"))
-	logger.Debug("Sending OTP", log.MaskedString("recipient", otpDTO.Recipient),
+	logger.DebugWithContext(ctx, "Sending OTP", log.MaskedString("recipient", otpDTO.Recipient),
 		log.String("channel", otpDTO.Channel), log.String("senderId", otpDTO.SenderID))
 
 	if err := s.validateOTPSendRequest(otpDTO); err != nil {
@@ -92,7 +92,7 @@ func (s *otpService) SendOTP(
 
 	otp, err := s.generateOTP()
 	if err != nil {
-		logger.Error("Failed to generate OTP", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to generate OTP", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -117,11 +117,11 @@ func (s *otpService) SendOTP(
 
 	sessionToken, err := s.createSessionToken(ctx, sessionData)
 	if err != nil {
-		logger.Error("Failed to create session token", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to create session token", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("OTP sent successfully", log.MaskedString("recipient", otpDTO.Recipient))
+	logger.DebugWithContext(ctx, "OTP sent successfully", log.MaskedString("recipient", otpDTO.Recipient))
 
 	return &common.SendOTPResultDTO{
 		SessionToken: sessionToken,
@@ -132,7 +132,7 @@ func (s *otpService) SendOTP(
 func (s *otpService) VerifyOTP(
 	ctx context.Context, otpDTO common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "OTPService"))
-	logger.Debug("Verifying OTP")
+	logger.DebugWithContext(ctx, "Verifying OTP")
 
 	if err := s.validateOTPVerifyRequest(otpDTO); err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func (s *otpService) VerifyOTP(
 	// Check if OTP has expired
 	currentTime := time.Now().UnixMilli()
 	if currentTime > sessionData.ExpiryTime {
-		logger.Debug("OTP has expired")
+		logger.DebugWithContext(ctx, "OTP has expired")
 		return &common.VerifyOTPResultDTO{
 			Status:    common.OTPVerifyStatusInvalid,
 			Recipient: sessionData.Recipient,
@@ -156,7 +156,7 @@ func (s *otpService) VerifyOTP(
 	// Verify OTP value by comparing hashes
 	providedOTPHash := cryptolib.GenerateThumbprintFromString(otpDTO.OTPCode)
 	if providedOTPHash != sessionData.OTPValue {
-		logger.Debug("Invalid OTP provided")
+		logger.DebugWithContext(ctx, "Invalid OTP provided")
 		return &common.VerifyOTPResultDTO{
 			Status:    common.OTPVerifyStatusInvalid,
 			Recipient: sessionData.Recipient,
@@ -259,7 +259,7 @@ func (s *otpService) sendSMSOTP(ctx context.Context, recipient, otp string,
 	templateData := template.TemplateData{"otp": otp, "expiryMinutes": expiryMinutes}
 	rendered, svcErr := s.templateService.Render(ctx, template.ScenarioOTP, template.TemplateTypeSMS, templateData)
 	if svcErr != nil {
-		logger.Error("Failed to render SMS OTP template", log.String("error", svcErr.Code))
+		logger.ErrorWithContext(ctx, "Failed to render SMS OTP template", log.String("error", svcErr.Code))
 		return &serviceerror.InternalServerError
 	}
 
@@ -274,7 +274,7 @@ func (s *otpService) sendSMSOTP(ctx context.Context, recipient, otp string,
 
 	notifData := common.NotificationData{Recipient: recipient, Body: rendered.Body}
 	if err := _client.Send(common.ChannelTypeSMS, notifData); err != nil {
-		logger.Error("Failed to send SMS OTP", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to send SMS OTP", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -308,7 +308,7 @@ func (s *otpService) verifyAndDecodeSessionToken(ctx context.Context, token stri
 	jwtConfig := config.GetServerRuntime().Config.JWT
 	svcErr := s.jwtService.VerifyJWT(ctx, token, "otp-svc", jwtConfig.Issuer)
 	if svcErr != nil {
-		logger.Debug("Invalid session token", log.String("error", svcErr.Error.DefaultValue))
+		logger.DebugWithContext(ctx, "Invalid session token", log.String("error", svcErr.Error.DefaultValue))
 		return nil, &ErrorInvalidSessionToken
 	}
 

--- a/backend/internal/notification/store.go
+++ b/backend/internal/notification/store.go
@@ -163,7 +163,7 @@ func (s *notificationStore) getSender(ctx context.Context, query dbmodel.DBQuery
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
 	if len(results) == 0 {
-		logger.Debug("Notification sender not found", log.String("identifier", identifier))
+		logger.DebugWithContext(ctx, "Notification sender not found", log.String("identifier", identifier))
 		return nil, nil
 	}
 	if len(results) > 1 {
@@ -234,7 +234,7 @@ func (s *notificationStore) deleteSender(ctx context.Context, id string) error {
 		return fmt.Errorf("failed to execute delete query: %w", err)
 	}
 	if rowsAffected == 0 {
-		logger.Debug("No sender found to delete", log.String("id", id))
+		logger.DebugWithContext(ctx, "No sender found to delete", log.String("id", id))
 	}
 
 	return nil

--- a/backend/internal/oauth/jwks/handler.go
+++ b/backend/internal/oauth/jwks/handler.go
@@ -51,7 +51,7 @@ func (h *jwksHandler) HandleJWKSRequest(w http.ResponseWriter, r *http.Request) 
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, jwksResponse)
-	logger.Debug("JWKS response successfully sent")
+	logger.DebugWithContext(ctx, "JWKS response successfully sent")
 }
 
 // logAndWriteError logs server errors and writes an appropriate error response to the HTTP response writer.

--- a/backend/internal/oauth/jwks/service.go
+++ b/backend/internal/oauth/jwks/service.go
@@ -59,7 +59,7 @@ func newJWKSService(cryptoProvider kmprovider.RuntimeCryptoProvider) JWKSService
 func (s *jwksService) GetJWKS(ctx context.Context) (*JWKSResponse, *serviceerror.ServiceError) {
 	publicKeys, err := s.cryptoProvider.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
 	if err != nil {
-		s.logger.Error("Failed to retrieve public keys", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to retrieve public keys", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -89,7 +89,7 @@ func (s *jwksService) GetJWKS(ctx context.Context) (*JWKSResponse, *serviceerror
 		case ed25519.PublicKey:
 			jwksKeys = append(jwksKeys, getEdDSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256))
 		default:
-			s.logger.Debug("Unsupported public key type for JWKS", log.String("keyID", keyInfo.KeyID))
+			s.logger.DebugWithContext(ctx, "Unsupported public key type for JWKS", log.String("keyID", keyInfo.KeyID))
 			continue
 		}
 	}

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -19,6 +19,7 @@
 package authz
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -72,7 +73,7 @@ func (ah *authorizeHandler) HandleAuthorizeGetRequest(w http.ResponseWriter, r *
 			}
 			redirectURI, err := oauth2utils.GetURIWithQueryParams(authErr.ClientRedirectURI, queryParams)
 			if err != nil {
-				ah.logger.Error("Failed to construct client redirect URI", log.Error(err))
+				ah.logger.ErrorWithContext(ctx, "Failed to construct client redirect URI", log.Error(err))
 				ah.redirectToErrorPage(w, r, oauth2const.ErrorServerError, "Failed to process authorization request")
 				return
 			}
@@ -126,7 +127,8 @@ func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWrit
 	logger := ah.logger
 
 	if r == nil || w == nil {
-		logger.Error("Request or response writer is nil")
+		// The request may be nil here, so there is no request context to propagate.
+		logger.ErrorWithContext(context.Background(), "Request or response writer is nil")
 		return nil
 	}
 
@@ -143,7 +145,7 @@ func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWrit
 	}
 
 	if err != nil {
-		ah.logger.Debug("Invalid authorize request", log.Error(err))
+		ah.logger.DebugWithContext(r.Context(), "Invalid authorize request", log.Error(err))
 		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
 			http.StatusBadRequest, nil)
 	}
@@ -224,17 +226,20 @@ func (ah *authorizeHandler) redirectToLoginPage(w http.ResponseWriter, r *http.R
 	logger := ah.logger
 
 	if w == nil || r == nil {
-		logger.Error("Response writer or request is nil. Cannot redirect to login page.")
+		// The request may be nil here, so there is no request context to propagate.
+		logger.ErrorWithContext(context.Background(),
+			"Response writer or request is nil. Cannot redirect to login page.")
 		return
 	}
+	ctx := r.Context()
 
 	redirectURI, err := getLoginPageRedirectURI(queryParams)
 	if err != nil {
-		logger.Error("Failed to construct login page URL", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to construct login page URL", log.Error(err))
 		ah.redirectToErrorPage(w, r, oauth2const.ErrorServerError, "Failed to process authorization request")
 		return
 	}
-	logger.Debug("Redirecting to login page")
+	logger.DebugWithContext(ctx, "Redirecting to login page")
 
 	http.Redirect(w, r, redirectURI, http.StatusFound)
 }
@@ -261,17 +266,20 @@ func (ah *authorizeHandler) redirectToErrorPage(w http.ResponseWriter, r *http.R
 	logger := ah.logger
 
 	if w == nil || r == nil {
-		logger.Error("Response writer or request is nil. Cannot redirect to error page.")
+		// The request may be nil here, so there is no request context to propagate.
+		logger.ErrorWithContext(context.Background(),
+			"Response writer or request is nil. Cannot redirect to error page.")
 		return
 	}
+	ctx := r.Context()
 
 	redirectURL, err := getErrorPageRedirectURL(code, msg)
 	if err != nil {
-		logger.Error("Failed to construct error page URL", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to construct error page URL", log.Error(err))
 		http.Error(w, "Failed to redirect to error page", http.StatusInternalServerError)
 		return
 	}
-	logger.Debug("Redirecting to error page")
+	logger.DebugWithContext(ctx, "Redirecting to error page")
 
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -123,7 +123,7 @@ func (as *authorizeService) GetAuthorizationCodeDetails(
 		return nil
 	})
 	if err != nil {
-		as.logger.Error("Failed to get authorization code details", log.Error(err))
+		as.logger.ErrorWithContext(ctx, "Failed to get authorization code details", log.Error(err))
 		return nil, err
 	}
 	return record, nil
@@ -146,7 +146,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 	// Retrieve the OAuth client based on the client ID.
 	app, lookupErr := as.inboundClient.GetOAuthClientByClientID(ctx, clientID)
 	if lookupErr != nil {
-		as.logger.Error("Failed to retrieve OAuth client", log.Error(lookupErr))
+		as.logger.ErrorWithContext(ctx, "Failed to retrieve OAuth client", log.Error(lookupErr))
 		return nil, &AuthorizationError{
 			Code:    oauth2const.ErrorServerError,
 			Message: "Failed to process authorization request",
@@ -181,7 +181,7 @@ func (as *authorizeService) handlePARAuthorizationRequest(
 ) (*AuthorizationInitResult, *AuthorizationError) {
 	oauthParams, err := as.parService.ResolvePushedAuthorizationRequest(ctx, requestURI, clientID)
 	if err != nil {
-		as.logger.Debug("Failed to resolve PAR request", log.Error(err))
+		as.logger.DebugWithContext(ctx, "Failed to resolve PAR request", log.Error(err))
 		if errors.Is(err, par.ErrPARResolutionFailed) {
 			return nil, &AuthorizationError{
 				Code:    oauth2const.ErrorServerError,
@@ -229,7 +229,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 		var err error
 		claimsRequest, err = oauth2utils.ParseClaimsRequest(claimsParam)
 		if err != nil {
-			as.logger.Debug("Failed to parse claims parameter", log.Error(err))
+			as.logger.DebugWithContext(ctx, "Failed to parse claims parameter", log.Error(err))
 			return nil, &AuthorizationError{
 				Code:    oauth2const.ErrorInvalidRequest,
 				Message: "The claims request parameter is malformed or contains invalid values",
@@ -291,7 +291,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 	// TODO: This should be removed when supporting other means of authorization.
 	if redirectURI == "" {
 		if len(app.RedirectURIs) == 0 {
-			as.logger.Error("OAuth application has no registered redirect URIs",
+			as.logger.ErrorWithContext(ctx, "OAuth application has no registered redirect URIs",
 				log.String("client_id", app.ClientID))
 			return nil, &AuthorizationError{
 				Code:    oauth2const.ErrorServerError,
@@ -333,7 +333,7 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 
 	executionID, flowErr := as.flowExecService.InitiateFlow(ctx, flowInitCtx)
 	if flowErr != nil {
-		as.logger.Error("Failed to initiate authentication flow",
+		as.logger.ErrorWithContext(ctx, "Failed to initiate authentication flow",
 			log.String("error_code", flowErr.Code))
 		return nil, &AuthorizationError{
 			Code:              oauth2const.ErrorServerError,
@@ -351,7 +351,7 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 	// Store authorization request context in the store.
 	identifier, storeErr := as.authReqStore.AddRequest(ctx, authRequestCtx)
 	if storeErr != nil {
-		as.logger.Error("Failed to store authorization request context", log.Error(storeErr))
+		as.logger.ErrorWithContext(ctx, "Failed to store authorization request context", log.Error(storeErr))
 		return nil, &AuthorizationError{
 			Code:              oauth2const.ErrorServerError,
 			Message:           "Failed to process authorization request",
@@ -371,7 +371,7 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 	// TODO: May require another redirection to a warn consent page when it directly goes to a federated IDP.
 	parsedRedirectURI, err := utils.ParseURL(oauthParams.RedirectURI)
 	if err != nil {
-		as.logger.Error("Failed to parse redirect URI", log.Error(err))
+		as.logger.ErrorWithContext(ctx, "Failed to parse redirect URI", log.Error(err))
 		return nil, &AuthorizationError{
 			Code:              oauth2const.ErrorServerError,
 			Message:           "Failed to process authorization request",
@@ -426,7 +426,7 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 
 		// Verify the assertion.
 		if err := as.verifyAssertion(ctx, assertion); err != nil {
-			as.logger.Debug("Assertion verification failed", log.Error(err))
+			as.logger.DebugWithContext(ctx, "Assertion verification failed", log.Error(err))
 			authErr = &AuthorizationError{
 				Code:              oauth2const.ErrorInvalidRequest,
 				Message:           "Authorization request failed",
@@ -468,7 +468,7 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 			if err := validateSubClaimConstraint(
 				authRequestCtx.OAuthParameters.ClaimsRequest, claims.userID,
 			); err != nil {
-				as.logger.Debug("Sub claim validation failed", log.Error(err))
+				as.logger.DebugWithContext(ctx, "Sub claim validation failed", log.Error(err))
 				authErr = &AuthorizationError{
 					Code:              oauth2const.ErrorAccessDenied,
 					Message:           "Authorization request failed",
@@ -540,12 +540,12 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 
 	if authErr != nil {
 		if authErr.Code == oauth2const.ErrorServerError {
-			as.logger.Error("Failed to process authorization callback", log.Error(err))
+			as.logger.ErrorWithContext(ctx, "Failed to process authorization callback", log.Error(err))
 		}
 		return "", authErr
 	}
 	if err != nil {
-		as.logger.Error("Failed to process authorization callback", log.Error(err))
+		as.logger.ErrorWithContext(ctx, "Failed to process authorization callback", log.Error(err))
 		return "", &AuthorizationError{
 			Code:    oauth2const.ErrorServerError,
 			Message: "Failed to process authorization request",
@@ -559,17 +559,17 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 func (as *authorizeService) loadAuthRequestContext(ctx context.Context, authID string) (*authRequestContext, error) {
 	ok, authRequestCtx, err := as.authReqStore.GetRequest(ctx, authID)
 	if err != nil {
-		as.logger.Error("Failed to retrieve authorization request context", log.Error(err))
+		as.logger.ErrorWithContext(ctx, "Failed to retrieve authorization request context", log.Error(err))
 		return nil, errors.New("failed to retrieve authorization request context")
 	}
 	if !ok {
-		as.logger.Debug("Authorization request context not found", log.String("auth_id", authID))
+		as.logger.DebugWithContext(ctx, "Authorization request context not found", log.String("auth_id", authID))
 		return nil, errAuthRequestNotFound
 	}
 
 	// Remove the authorization request context after retrieval.
 	if clearErr := as.authReqStore.ClearRequest(ctx, authID); clearErr != nil {
-		as.logger.Error("Failed to clear authorization request context", log.Error(clearErr))
+		as.logger.ErrorWithContext(ctx, "Failed to clear authorization request context", log.Error(clearErr))
 	}
 	return &authRequestCtx, nil
 }
@@ -577,7 +577,7 @@ func (as *authorizeService) loadAuthRequestContext(ctx context.Context, authID s
 // verifyAssertion verifies the JWT assertion.
 func (as *authorizeService) verifyAssertion(ctx context.Context, assertion string) error {
 	if err := as.jwtService.VerifyJWT(ctx, assertion, "", ""); err != nil {
-		as.logger.Debug("Invalid assertion signature", log.String("error", err.Error.DefaultValue))
+		as.logger.DebugWithContext(ctx, "Invalid assertion signature", log.String("error", err.Error.DefaultValue))
 		return errors.New("invalid assertion signature")
 	}
 	return nil

--- a/backend/internal/oauth/oauth2/clientauth/clientauth.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth.go
@@ -110,7 +110,7 @@ func authenticate(
 
 	case constants.TokenEndpointAuthMethodPrivateKeyJWT:
 		if clientAssertionType != constants.SupportedClientAssertionType {
-			logger.Debug("Invalid client assertion: unsupported client assertion type")
+			logger.DebugWithContext(ctx, "Invalid client assertion: unsupported client assertion type")
 			return nil, errInvalidClientAssertion
 		}
 		extracted, err := extractClientIDFromAssertion(clientAssertion)
@@ -132,7 +132,8 @@ func authenticate(
 
 	oauthApp, err := inboundClient.GetOAuthClientByClientID(ctx, clientID)
 	if err != nil {
-		logger.Error("Failed to retrieve OAuth client", log.Error(err), log.MaskedString("clientID", clientID))
+		logger.ErrorWithContext(ctx, "Failed to retrieve OAuth client",
+			log.Error(err), log.MaskedString("clientID", clientID))
 		return nil, errInvalidClientCredentials
 	}
 	if oauthApp == nil {
@@ -149,7 +150,7 @@ func authenticate(
 	case constants.TokenEndpointAuthMethodPrivateKeyJWT:
 		if err := validateClientAssertion(oauthApp, jwtService, endpointURL, clientID,
 			clientAssertion); err != nil {
-			logger.Debug("Invalid client assertion: " + err.Error())
+			logger.DebugWithContext(ctx, "Invalid client assertion: "+err.Error())
 			return nil, errInvalidClientAssertion
 		}
 	case constants.TokenEndpointAuthMethodClientSecretBasic,
@@ -159,7 +160,7 @@ func authenticate(
 			map[string]interface{}{"clientSecret": clientSecret},
 			nil, nil, authnprovidermgr.AuthUser{})
 		if authnErr != nil {
-			logger.Debug("Client secret authentication failed",
+			logger.DebugWithContext(ctx, "Client secret authentication failed",
 				log.MaskedString("clientID", clientID))
 			return nil, errInvalidClientCredentials
 		}

--- a/backend/internal/oauth/oauth2/dcr/handler.go
+++ b/backend/internal/oauth/oauth2/dcr/handler.go
@@ -59,7 +59,7 @@ func (dh *dcrHandler) HandleDCRRegistration(w http.ResponseWriter, r *http.Reque
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
 			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DCRHandler"))
-			logger.Error("Internal server error processing DCR registration request",
+			logger.ErrorWithContext(ctx, "Internal server error processing DCR registration request",
 				log.MaskedString("client_name", dcrRequest.ClientName),
 				log.String("error_code", svcErr.Code),
 				log.String("error", svcErr.Error.DefaultValue),

--- a/backend/internal/oauth/oauth2/dcr/service.go
+++ b/backend/internal/oauth/oauth2/dcr/service.go
@@ -86,12 +86,12 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 	if request.OUID == "" {
 		rootOUs, svcErr := ds.ouService.GetOrganizationUnitList(ctx, 1, 0, nil)
 		if svcErr != nil {
-			logger.Error("Failed to retrieve root organization units for DCR",
+			logger.ErrorWithContext(ctx, "Failed to retrieve root organization units for DCR",
 				log.String("error", svcErr.Error.DefaultValue))
 			return nil, &ErrorServerError
 		}
 		if rootOUs == nil || rootOUs.TotalResults == 0 || len(rootOUs.OrganizationUnits) == 0 {
-			logger.Error("No root organization unit available for DCR registration")
+			logger.ErrorWithContext(ctx, "No root organization unit available for DCR registration")
 			return nil, &ErrorServerError
 		}
 		request.OUID = rootOUs.OrganizationUnits[0].ID
@@ -99,7 +99,8 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 
 	appDTO, svcErr := ds.convertDCRToApplication(request)
 	if svcErr != nil {
-		logger.Error("Failed to convert DCR request to application DTO", log.String("error", svcErr.Error.DefaultValue))
+		logger.ErrorWithContext(ctx, "Failed to convert DCR request to application DTO",
+			log.String("error", svcErr.Error.DefaultValue))
 		return nil, &ErrorServerError
 	}
 
@@ -111,12 +112,12 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 		createdApp, svcErr := ds.appService.CreateApplication(txCtx, appDTO)
 		if svcErr != nil {
 			if svcErr.Type == serviceerror.ServerErrorType {
-				logger.Error("Failed to create application via Application service",
+				logger.ErrorWithContext(ctx, "Failed to create application via Application service",
 					log.String("error_code", svcErr.Code))
 				capturedErr = &ErrorServerError
 				return errors.New("failed to create application")
 			}
-			logger.Debug("Failed to create application via Application service",
+			logger.DebugWithContext(ctx, "Failed to create application via Application service",
 				log.String("error_code", svcErr.Code))
 			capturedErr = ds.mapApplicationErrorToDCRError(svcErr)
 			return errors.New("failed to create application")
@@ -127,7 +128,7 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 		var convErr *serviceerror.ServiceError
 		response, convErr = ds.convertApplicationToDCRResponse(createdApp, request.ClientName)
 		if convErr != nil {
-			logger.Error("Failed to convert application to DCR response",
+			logger.ErrorWithContext(ctx, "Failed to convert application to DCR response",
 				log.String("error", convErr.Error.DefaultValue))
 			capturedErr = convErr
 			return errors.New("conversion failed")
@@ -151,7 +152,7 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 	// If the compensation DeleteApplication also fails, the app record is left without localized
 	// metadata — an accepted gap that can be cleaned up manually or via a future sweep.
 	if writeErr := ds.writeLocalizedVariants(ctx, createdAppID, request); writeErr != nil {
-		logger.Error("Failed to write localized variants for DCR client; compensating by deleting app",
+		logger.ErrorWithContext(ctx, "Failed to write localized variants for DCR client; compensating by deleting app",
 			log.String("appID", createdAppID), log.String("error", writeErr.Error.DefaultValue))
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer cleanupCancel()
@@ -159,12 +160,13 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 			if cleanErr := ds.i18nService.DeleteTranslationsByKey(
 				cleanupCtx, application.AppI18nNamespace(), application.AppI18nKey(createdAppID, field),
 			); cleanErr != nil {
-				logger.Error("Failed to clean up partial i18n row after write failure",
+				logger.ErrorWithContext(ctx, "Failed to clean up partial i18n row after write failure",
 					log.String("appID", createdAppID), log.String("field", field))
 			}
 		}
 		if delSvcErr := ds.appService.DeleteApplication(cleanupCtx, createdAppID); delSvcErr != nil {
-			logger.Error("Compensation delete failed after i18n write failure; app record may be orphaned",
+			logger.ErrorWithContext(ctx,
+				"Compensation delete failed after i18n write failure; app record may be orphaned",
 				log.String("appID", createdAppID))
 		}
 		return nil, writeErr
@@ -401,7 +403,7 @@ func (ds *dcrService) writeLocalizedVariants(
 	ctx context.Context, appID string, request *DCRRegistrationRequest) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DCRService"))
 	if ds.i18nService == nil {
-		logger.Debug("i18n service not configured, skipping localized variant writes")
+		logger.DebugWithContext(ctx, "i18n service not configured, skipping localized variant writes")
 		return nil
 	}
 	ns := application.AppI18nNamespace()
@@ -446,13 +448,13 @@ func (ds *dcrService) writeLocalizedVariants(
 	}
 	if svcErr := ds.i18nService.SetTranslationOverridesForNamespace(ctx, ns, entries); svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug("Invalid client metadata in localized variants",
+			logger.DebugWithContext(ctx, "Invalid client metadata in localized variants",
 				log.String("appID", appID),
 				log.String("errorCode", svcErr.Code),
 				log.String("error", svcErr.Error.DefaultValue))
 			return &ErrorServerError
 		}
-		logger.Error("Failed to write localized variants",
+		logger.ErrorWithContext(ctx, "Failed to write localized variants",
 			log.String("appID", appID),
 			log.String("errorCode", svcErr.Code),
 			log.String("error", svcErr.Error.DefaultValue))

--- a/backend/internal/oauth/oauth2/discovery/handler.go
+++ b/backend/internal/oauth/oauth2/discovery/handler.go
@@ -52,7 +52,7 @@ func (dh *discoveryHandler) HandleOAuth2AuthorizationServerMetadata(w http.Respo
 	metadata := dh.discoveryService.GetOAuth2AuthorizationServerMetadata(ctx)
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, metadata)
-	logger.Debug("OAuth 2.0 Authorization Server Metadata response sent successfully")
+	logger.DebugWithContext(ctx, "OAuth 2.0 Authorization Server Metadata response sent successfully")
 }
 
 // HandleOIDCDiscovery handles OpenID Connect Discovery requests
@@ -67,5 +67,5 @@ func (dh *discoveryHandler) HandleOIDCDiscovery(w http.ResponseWriter, r *http.R
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, metadata)
-	logger.Debug("OIDC discovery response sent successfully")
+	logger.DebugWithContext(ctx, "OIDC discovery response sent successfully")
 }

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -129,7 +129,8 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 	if authCode.AttributeCacheID != "" {
 		userAttributes, err := h.attributeCache.GetAttributeCache(ctx, authCode.AttributeCacheID)
 		if err != nil {
-			logger.Error("Failed to get user attributes from attribute cache. " + err.ErrorDescription.DefaultValue)
+			logger.ErrorWithContext(ctx,
+				"Failed to get user attributes from attribute cache. "+err.ErrorDescription.DefaultValue)
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
 				ErrorDescription: "Failed to get user attributes from attribute cache",
@@ -236,7 +237,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 			CompletedACR:   authCode.CompletedACR,
 		})
 		if err != nil {
-			logger.Error("Failed to generate ID token", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to generate ID token", log.Error(err))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
 				ErrorDescription: "Failed to generate token",
@@ -280,7 +281,7 @@ func (h *authorizationCodeGrantHandler) retrieveAndValidateAuthCode(
 		// Validate PKCE
 		if err := pkce.ValidatePKCE(authCode.CodeChallenge, authCode.CodeChallengeMethod,
 			tokenRequest.CodeVerifier); err != nil {
-			logger.Debug("PKCE validation failed", log.Error(err))
+			logger.DebugWithContext(ctx, "PKCE validation failed", log.Error(err))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorInvalidGrant,
 				ErrorDescription: "Invalid code verifier",

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
@@ -112,7 +112,7 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 			if groupErr != nil {
 				// Ignore unimplemented providers to preserve existing behavior.
 				if groupErr.Code != entityprovider.ErrorCodeNotImplemented {
-					logger.Error("Failed to resolve app group memberships",
+					logger.ErrorWithContext(ctx, "Failed to resolve app group memberships",
 						log.String("appID", oauthApp.ID), log.String("error", groupErr.Error()))
 					return nil, &model.ErrorResponse{
 						Error:            constants.ErrorServerError,
@@ -134,7 +134,7 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 			RequestedPermissions: scopes,
 		})
 		if svcErr != nil {
-			logger.Error("Failed to get authorized permissions for app",
+			logger.ErrorWithContext(ctx, "Failed to get authorized permissions for app",
 				log.String("appID", oauthApp.ID), log.String("error", svcErr.Error.DefaultValue))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -104,7 +104,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	refreshTokenClaims, err := h.tokenValidator.ValidateRefreshToken(
 		ctx, tokenRequest.RefreshToken, tokenRequest.ClientID)
 	if err != nil {
-		logger.Debug("Failed to validate refresh token", log.Error(err))
+		logger.DebugWithContext(ctx, "Failed to validate refresh token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorInvalidGrant,
 			ErrorDescription: "Invalid refresh token",
@@ -168,7 +168,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	if refreshTokenClaims.AttributeCacheID != "" {
 		cacheEntry, fetchErr = h.attrCacheService.GetAttributeCache(ctx, refreshTokenClaims.AttributeCacheID)
 		if fetchErr != nil {
-			logger.Error("Failed to get user attributes from attribute cache",
+			logger.ErrorWithContext(ctx, "Failed to get user attributes from attribute cache",
 				log.String("error", fetchErr.ErrorDescription.DefaultValue))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
@@ -176,7 +176,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 			}
 		}
 		if cacheEntry == nil {
-			logger.Error("Attribute cache entry not found for cache ID",
+			logger.ErrorWithContext(ctx, "Attribute cache entry not found for cache ID",
 				log.String("cache_id", refreshTokenClaims.AttributeCacheID))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
@@ -206,7 +206,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	}
 	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, accessTokenCtx)
 	if err != nil {
-		logger.Error("Failed to generate access token", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to generate access token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorServerError,
 			ErrorDescription: "Failed to generate access token",
@@ -229,7 +229,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 			ClaimsRequest:  refreshTokenClaims.ClaimsRequest,
 		})
 		if idErr != nil {
-			logger.Error("Failed to generate ID token", log.Error(idErr))
+			logger.ErrorWithContext(ctx, "Failed to generate ID token", log.Error(idErr))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
 				ErrorDescription: "Failed to generate token",
@@ -245,14 +245,14 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	// Issue a new refresh token if renew_on_grant is enabled; otherwise reuse the existing one.
 	// RFC 8707 §5: the refresh token preserves the full original audience, not the narrowed one.
 	if renewRefreshToken {
-		logger.Debug("Renewing refresh token", log.String("client_id", tokenRequest.ClientID))
+		logger.DebugWithContext(ctx, "Renewing refresh token", log.String("client_id", tokenRequest.ClientID))
 		errResp := h.IssueRefreshToken(ctx, tokenResponse, oauthApp,
 			refreshTokenClaims.Sub, refreshTokenClaims.Audiences,
 			refreshTokenClaims.GrantType, newTokenScopes,
 			refreshTokenClaims.ClaimsRequest, refreshTokenClaims.ClaimsLocales,
 			refreshTokenClaims.AttributeCacheID)
 		if errResp != nil && errResp.Error != "" {
-			logger.Error("Failed to issue refresh token", log.String("error", errResp.Error))
+			logger.ErrorWithContext(ctx, "Failed to issue refresh token", log.String("error", errResp.Error))
 			return nil, errResp
 		}
 	} else {
@@ -357,7 +357,7 @@ func (h *refreshTokenGrantHandler) extendCacheTTL(
 	desiredTTL := int(maxExpiry-now) + constants.AttributeCacheTTLBufferSeconds
 	if desiredTTL > cacheEntry.TTLSeconds {
 		if extErr := h.attrCacheService.ExtendAttributeCacheTTL(ctx, cacheID, desiredTTL); extErr != nil {
-			logger.Error("Failed to extend attribute cache TTL",
+			logger.ErrorWithContext(ctx, "Failed to extend attribute cache TTL",
 				log.String("cache_id", cacheID),
 				log.String("error", extErr.Error.String()))
 			return &model.ErrorResponse{

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -139,7 +139,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	// Validate and extract subject token claims
 	subjectClaims, err := h.tokenValidator.ValidateSubjectToken(ctx, tokenRequest.SubjectToken, oauthApp)
 	if err != nil {
-		logger.Debug("Failed to validate subject token", log.Error(err))
+		logger.DebugWithContext(ctx, "Failed to validate subject token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorInvalidRequest,
 			ErrorDescription: "Invalid subject_token",
@@ -157,7 +157,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	if tokenRequest.ActorToken != "" {
 		actorClaims, err = h.tokenValidator.ValidateSubjectToken(ctx, tokenRequest.ActorToken, oauthApp)
 		if err != nil {
-			logger.Debug("Failed to validate actor token", log.Error(err))
+			logger.DebugWithContext(ctx, "Failed to validate actor token", log.Error(err))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorInvalidRequest,
 				ErrorDescription: "Invalid actor_token",
@@ -208,7 +208,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 		DPoPJkt:        dpop.GetJkt(ctx),
 	})
 	if err != nil {
-		logger.Error("Failed to generate token", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to generate token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorServerError,
 			ErrorDescription: "Failed to generate token",

--- a/backend/internal/oauth/oauth2/introspect/handler.go
+++ b/backend/internal/oauth/oauth2/introspect/handler.go
@@ -61,7 +61,7 @@ func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *h
 
 	response, err := h.service.IntrospectToken(ctx, token, tokenTypeHint)
 	if err != nil {
-		h.logger.Error("Failed to introspect token", log.Error(err))
+		h.logger.ErrorWithContext(ctx, "Failed to introspect token", log.Error(err))
 		sysutils.WriteJSONError(w, constants.ErrorServerError,
 			"An unexpected error occurred while processing the request",
 			http.StatusInternalServerError, nil)

--- a/backend/internal/oauth/oauth2/introspect/service.go
+++ b/backend/internal/oauth/oauth2/introspect/service.go
@@ -65,7 +65,7 @@ func (s *tokenIntrospectionService) IntrospectToken(
 
 	_, payload, err := jwt.DecodeJWT(token)
 	if err != nil {
-		logger.Debug("Failed to decode JWT", log.Error(err))
+		logger.DebugWithContext(ctx, "Failed to decode JWT", log.Error(err))
 		return &IntrospectResponse{
 			Active: false,
 		}, nil
@@ -80,7 +80,7 @@ func (s *tokenIntrospectionService) IntrospectToken(
 // validateToken verifies the signature and validity of the token.
 func (s *tokenIntrospectionService) validateToken(ctx context.Context, logger *log.Logger, token string) bool {
 	if err := s.jwtService.VerifyJWT(ctx, token, "", ""); err != nil {
-		logger.Debug("Failed to verify refresh token", log.String("error", err.Error.DefaultValue))
+		logger.DebugWithContext(ctx, "Failed to verify refresh token", log.String("error", err.Error.DefaultValue))
 		return false
 	}
 	return true

--- a/backend/internal/oauth/oauth2/jwksresolver/resolver.go
+++ b/backend/internal/oauth/oauth2/jwksresolver/resolver.go
@@ -75,7 +75,7 @@ func (r *Resolver) ResolveEncryptionKey(
 	policy KeyUsePolicy,
 ) (crypto.PublicKey, string, *serviceerror.ServiceError) {
 	if certificate == nil || certificate.Type == "" {
-		r.logger.Error("No certificate configured for encryption key resolution")
+		r.logger.ErrorWithContext(ctx, "No certificate configured for encryption key resolution")
 		return nil, "", &serviceerror.InternalServerError
 	}
 
@@ -90,7 +90,7 @@ func (r *Resolver) ResolveEncryptionKey(
 		}
 		jwksData = body
 	default:
-		r.logger.Error("Unsupported certificate type for encryption key resolution",
+		r.logger.ErrorWithContext(ctx, "Unsupported certificate type for encryption key resolution",
 			log.String("type", string(certificate.Type)))
 		return nil, "", &serviceerror.InternalServerError
 	}
@@ -102,26 +102,28 @@ func (r *Resolver) ResolveEncryptionKey(
 // It does not log JWKS body, key material, or HTTP response headers.
 func (r *Resolver) fetchJWKS(ctx context.Context, jwksURI string) ([]byte, *serviceerror.ServiceError) {
 	if r.httpClient == nil {
-		r.logger.Error("HTTP client is not configured for JWKS resolver")
+		r.logger.ErrorWithContext(ctx, "HTTP client is not configured for JWKS resolver")
 		return nil, &serviceerror.InternalServerError
 	}
 	if err := syshttp.IsSSRFSafeURL(jwksURI); err != nil {
-		r.logger.Error("JWKS URI is not SSRF-safe", log.String("endpoint", jwksEndpoint(jwksURI)), log.Error(err))
+		r.logger.ErrorWithContext(ctx, "JWKS URI is not SSRF-safe",
+			log.String("endpoint", jwksEndpoint(jwksURI)), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURI, nil)
 	if err != nil {
-		r.logger.Error("Failed to build JWKS request", log.Error(err))
+		r.logger.ErrorWithContext(ctx, "Failed to build JWKS request", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	resp, err := r.httpClient.Do(req)
 	if err != nil {
-		r.logger.Error("Failed to fetch JWKS from URI", log.String("endpoint", jwksEndpoint(jwksURI)), log.Error(err))
+		r.logger.ErrorWithContext(ctx, "Failed to fetch JWKS from URI",
+			log.String("endpoint", jwksEndpoint(jwksURI)), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		r.logger.Error("JWKS URI returned non-200 status",
+		r.logger.ErrorWithContext(ctx, "JWKS URI returned non-200 status",
 			log.String("endpoint", jwksEndpoint(jwksURI)), log.Int("statusCode", resp.StatusCode))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -129,11 +131,12 @@ func (r *Resolver) fetchJWKS(ctx context.Context, jwksURI string) ([]byte, *serv
 	limitedReader := io.LimitReader(resp.Body, maxJWKSBytes+1)
 	body, err := io.ReadAll(limitedReader)
 	if err != nil {
-		r.logger.Error("Failed to read JWKS response body", log.Error(err))
+		r.logger.ErrorWithContext(ctx, "Failed to read JWKS response body", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if len(body) > maxJWKSBytes {
-		r.logger.Error("JWKS URI response exceeds 1 MB size limit", log.String("endpoint", jwksEndpoint(jwksURI)))
+		r.logger.ErrorWithContext(ctx, "JWKS URI response exceeds 1 MB size limit",
+			log.String("endpoint", jwksEndpoint(jwksURI)))
 		return nil, &serviceerror.InternalServerError
 	}
 	return body, nil

--- a/backend/internal/oauth/oauth2/par/handler.go
+++ b/backend/internal/oauth/oauth2/par/handler.go
@@ -62,7 +62,7 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 	// Client authentication is handled by the ClientAuthMiddleware.
 	clientInfo := clientauth.GetOAuthClient(ctx)
 	if clientInfo == nil {
-		h.logger.Error("OAuth client not found in context - ClientAuthMiddleware must be applied")
+		h.logger.ErrorWithContext(ctx, "OAuth client not found in context - ClientAuthMiddleware must be applied")
 		utils.WriteJSONError(w, oauth2const.ErrorServerError,
 			"Something went wrong", http.StatusInternalServerError, nil)
 		return
@@ -80,7 +80,7 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 	if errCode != "" {
 		statusCode := http.StatusBadRequest
 		if errCode == oauth2const.ErrorServerError {
-			h.logger.Error("Internal server error verifying DPoP header",
+			h.logger.ErrorWithContext(ctx, "Internal server error verifying DPoP header",
 				log.MaskedString("clientID", clientInfo.ClientID),
 				log.String("errorCode", errCode),
 				log.String("errorDescription", errDesc),
@@ -88,7 +88,7 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 			statusCode = http.StatusInternalServerError
 		}
 		if errCode == oauth2const.ErrorInvalidDPoPProof {
-			h.logger.Debug("DPoP proof rejected at PAR",
+			h.logger.DebugWithContext(ctx, "DPoP proof rejected at PAR",
 				log.MaskedString("clientID", clientInfo.ClientID),
 				log.String("error", errDesc))
 			errDesc = "Invalid DPoP proof"
@@ -110,7 +110,7 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 	if errCode != "" {
 		statusCode := http.StatusBadRequest
 		if errCode == oauth2const.ErrorServerError {
-			h.logger.Error("Internal server error processing pushed authorization request",
+			h.logger.ErrorWithContext(ctx, "Internal server error processing pushed authorization request",
 				log.MaskedString("clientID", clientInfo.ClientID),
 				log.String("errorCode", errCode),
 				log.String("errorDescription", errDesc),
@@ -134,7 +134,7 @@ func (h *parHandler) verifyDPoPHeader(ctx context.Context, r *http.Request) (str
 		return "", oauth2const.ErrorInvalidDPoPProof, "Multiple DPoP headers"
 	}
 	if h.dpopVerifier == nil {
-		h.logger.Error("DPoP verifier is not configured")
+		h.logger.ErrorWithContext(ctx, "DPoP verifier is not configured")
 		return "", oauth2const.ErrorServerError, "Something went wrong"
 	}
 	result, err := h.dpopVerifier.Verify(ctx, dpop.VerifyParams{

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -147,7 +147,7 @@ func (s *parService) HandlePushedAuthorizationRequest(
 
 	randomKey, err := s.store.Store(ctx, parRequest, expiresIn)
 	if err != nil {
-		s.logger.Error("Failed to store pushed authorization request", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to store pushed authorization request", log.Error(err))
 		return nil, oauth2const.ErrorServerError, "Failed to process pushed authorization request"
 	}
 
@@ -178,7 +178,7 @@ func (s *parService) ResolvePushedAuthorizationRequest(
 
 	parRequest, found, err := s.store.Consume(ctx, randomKey)
 	if err != nil {
-		s.logger.Error("Failed to consume PAR request", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to consume PAR request", log.Error(err))
 		return nil, ErrPARResolutionFailed
 	}
 	if !found {
@@ -188,7 +188,7 @@ func (s *parService) ResolvePushedAuthorizationRequest(
 	// Verify client_id binding: the client making the authorization request must match
 	// the client that pushed the authorization request.
 	if parRequest.ClientID != clientID {
-		s.logger.Debug("Client ID mismatch for PAR request",
+		s.logger.DebugWithContext(ctx, "Client ID mismatch for PAR request",
 			log.String("expected", parRequest.ClientID),
 			log.String("actual", clientID))
 		return nil, errClientIDMismatch

--- a/backend/internal/oauth/oauth2/token/handler.go
+++ b/backend/internal/oauth/oauth2/token/handler.go
@@ -87,7 +87,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 	// Get authenticated client from context (set by ClientAuthMiddleware).
 	clientInfo := clientauth.GetOAuthClient(r.Context())
 	if clientInfo == nil {
-		logger.Error("OAuth client not found in context - ClientAuthMiddleware must be applied")
+		logger.ErrorWithContext(ctx, "OAuth client not found in context - ClientAuthMiddleware must be applied")
 		utils.WriteJSONError(w, constants.ErrorServerError,
 			"Something went wrong", http.StatusInternalServerError, nil)
 		return
@@ -127,7 +127,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 			}
 			description := tokenError.ErrorDescription
 			if tokenError.Error == constants.ErrorInvalidDPoPProof {
-				logger.Debug("DPoP proof rejected", log.String("error", description))
+				logger.DebugWithContext(ctx, "DPoP proof rejected", log.String("error", description))
 				description = "Invalid DPoP proof"
 			}
 			utils.WriteJSONError(w, tokenError.Error, description, statusCode, nil)
@@ -138,7 +138,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	logger.Debug("Token response sending", log.String("client_id", clientInfo.ClientID))
+	logger.DebugWithContext(ctx, "Token response sending", log.String("client_id", clientInfo.ClientID))
 
 	// Must include the following headers when sensitive data is returned.
 	w.Header().Set(sysconst.CacheControlHeaderName, sysconst.CacheControlNoStore)

--- a/backend/internal/oauth/oauth2/token/service.go
+++ b/backend/internal/oauth/oauth2/token/service.go
@@ -123,7 +123,7 @@ func (ts *tokenService) ProcessTokenRequest(
 				ErrorDescription: "Unsupported grant type",
 			}
 		}
-		logger.Error("Failed to get grant handler", log.Error(handlerErr))
+		logger.ErrorWithContext(ctx, "Failed to get grant handler", log.Error(handlerErr))
 		publishTokenIssuanceFailedEvent(ts.observabilitySvc, ctx, clientID, grantTypeStr, scopeStr,
 			500, "Failed to get grant handler", startTime)
 		return nil, &model.ErrorResponse{
@@ -197,12 +197,12 @@ func (ts *tokenService) ProcessTokenRequest(
 	// Issue refresh token if applicable.
 	if grantType == constants.GrantTypeAuthorizationCode &&
 		oauthApp.IsAllowedGrantType(constants.GrantTypeRefreshToken) {
-		logger.Debug("Issuing refresh token for the token request",
+		logger.DebugWithContext(ctx, "Issuing refresh token for the token request",
 			log.String("client_id", clientID), log.String("grant_type", grantTypeStr))
 
 		refreshGrantHandler, handlerErr := ts.grantHandlerProvider.GetGrantHandler(constants.GrantTypeRefreshToken)
 		if handlerErr != nil {
-			logger.Error("Failed to get refresh grant handler", log.Error(handlerErr))
+			logger.ErrorWithContext(ctx, "Failed to get refresh grant handler", log.Error(handlerErr))
 			publishTokenIssuanceFailedEvent(ts.observabilitySvc, ctx, clientID, grantTypeStr, scopeStr,
 				500, "Failed to get refresh grant handler", startTime)
 			return nil, &model.ErrorResponse{
@@ -212,7 +212,7 @@ func (ts *tokenService) ProcessTokenRequest(
 		}
 		refreshGrantHandlerTyped, ok := refreshGrantHandler.(granthandlers.RefreshTokenGrantHandlerInterface)
 		if !ok {
-			logger.Error("Failed to cast refresh grant handler",
+			logger.ErrorWithContext(ctx, "Failed to cast refresh grant handler",
 				log.String("client_id", clientID), log.String("grant_type", grantTypeStr))
 			publishTokenIssuanceFailedEvent(ts.observabilitySvc, ctx, clientID, grantTypeStr, scopeStr,
 				500, "Internal Server Error", startTime)
@@ -264,7 +264,7 @@ func (ts *tokenService) ProcessTokenRequest(
 		}
 	}
 
-	logger.Debug("Token generated successfully",
+	logger.DebugWithContext(ctx, "Token generated successfully",
 		log.String("client_id", clientID), log.String("grant_type", grantTypeStr))
 
 	ts.publishTokenIssuedEvent(ctx, clientID, grantTypeStr, scopes, startTime)

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -95,13 +95,13 @@ func (s *userInfoService) GetUserInfo(
 
 	accessTokenClaims, err := s.tokenValidator.ValidateAccessToken(ctx, accessToken)
 	if err != nil {
-		s.logger.Debug("Failed to verify access token", log.Error(err))
+		s.logger.DebugWithContext(ctx, "Failed to verify access token", log.Error(err))
 		return nil, &errorInvalidAccessToken
 	}
 
 	boundJkt, _ := dpop.ExtractCnfJkt(accessTokenClaims.Claims)
 	if boundJkt != "" {
-		s.logger.Debug("DPoP-bound access token presented under Bearer scheme")
+		s.logger.DebugWithContext(ctx, "DPoP-bound access token presented under Bearer scheme")
 		return nil, &errorBearerDowngrade
 	}
 
@@ -120,18 +120,18 @@ func (s *userInfoService) GetUserInfoForDPoP(
 
 	accessTokenClaims, err := s.tokenValidator.ValidateAccessToken(ctx, accessToken)
 	if err != nil {
-		s.logger.Debug("Failed to verify access token", log.Error(err))
+		s.logger.DebugWithContext(ctx, "Failed to verify access token", log.Error(err))
 		return nil, &errorInvalidAccessToken
 	}
 
 	expectedJkt, _ := dpop.ExtractCnfJkt(accessTokenClaims.Claims)
 	if expectedJkt == "" {
-		s.logger.Debug("DPoP scheme used with non-bound access token")
+		s.logger.DebugWithContext(ctx, "DPoP scheme used with non-bound access token")
 		return nil, &errorDPoPProofInvalid
 	}
 
 	if s.dpopVerifier == nil {
-		s.logger.Error("DPoP verifier not configured")
+		s.logger.ErrorWithContext(ctx, "DPoP verifier not configured")
 		return nil, &serviceerror.InternalServerError
 	}
 	if _, dpopErr := s.dpopVerifier.Verify(ctx, dpop.VerifyParams{
@@ -141,7 +141,7 @@ func (s *userInfoService) GetUserInfoForDPoP(
 		AccessToken: accessToken,
 		ExpectedJkt: expectedJkt,
 	}); dpopErr != nil {
-		s.logger.Debug("DPoP proof verification failed", log.Error(dpopErr))
+		s.logger.DebugWithContext(ctx, "DPoP proof verification failed", log.Error(dpopErr))
 		return nil, &errorDPoPProofInvalid
 	}
 
@@ -182,7 +182,8 @@ func (s *userInfoService) buildResponseFromClaims(
 	userAttributes, err := tokenservice.FetchUserAttributes(ctx, s.attributeCacheSvc,
 		allowedUserAttributes, attributeCacheID)
 	if err != nil {
-		s.logger.Error("Failed to fetch user attributes", log.MaskedString(log.LoggerKeyUserID, sub), log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to fetch user attributes",
+			log.MaskedString(log.LoggerKeyUserID, sub), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -229,7 +230,7 @@ func (s *userInfoService) generateJWEUserInfo(
 
 	payload, err := json.Marshal(response)
 	if err != nil {
-		s.logger.Error("Failed to marshal userinfo claims for JWE")
+		s.logger.ErrorWithContext(ctx, "Failed to marshal userinfo claims for JWE")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -241,7 +242,7 @@ func (s *userInfoService) generateJWEUserInfo(
 		rpKID,
 	)
 	if svcErr != nil {
-		s.logger.Error("Failed to encrypt userinfo JWE")
+		s.logger.ErrorWithContext(ctx, "Failed to encrypt userinfo JWE")
 		return nil, svcErr
 	}
 
@@ -276,7 +277,7 @@ func (s *userInfoService) generateNestedJWTUserInfo(
 		rpKID,
 	)
 	if svcErr != nil {
-		s.logger.Error("Failed to encrypt nested JWT userinfo JWE")
+		s.logger.ErrorWithContext(ctx, "Failed to encrypt nested JWT userinfo JWE")
 		return nil, svcErr
 	}
 
@@ -319,10 +320,10 @@ func (s *userInfoService) generateJWSUserInfo(
 	)
 	if err != nil {
 		if err.Code == jwt.ErrorUnsupportedJWSAlgorithm.Code {
-			s.logger.Error("UserInfo signing algorithm is not supported by the server key",
+			s.logger.ErrorWithContext(ctx, "UserInfo signing algorithm is not supported by the server key",
 				log.String("alg", signingAlg), log.String("error", err.Error.DefaultValue))
 		} else {
-			s.logger.Error("Failed to generate signed UserInfo JWT",
+			s.logger.ErrorWithContext(ctx, "Failed to generate signed UserInfo JWT",
 				log.String("error", err.Error.DefaultValue))
 		}
 		return nil, &serviceerror.InternalServerError

--- a/backend/internal/ou/cache_backed_store.go
+++ b/backend/internal/ou/cache_backed_store.go
@@ -189,7 +189,7 @@ func (s *cacheBackedOUStore) cacheOUByID(ctx context.Context, ou *OrganizationUn
 		return
 	}
 	if err := s.ouByIDCache.Set(ctx, cache.CacheKey{Key: ou.ID}, ou); err != nil {
-		s.logger.Error("Failed to cache OU by ID",
+		s.logger.ErrorWithContext(ctx, "Failed to cache OU by ID",
 			log.String("ouID", ou.ID), log.Error(err))
 	}
 }
@@ -200,7 +200,7 @@ func (s *cacheBackedOUStore) cacheOUByHandleParent(ctx context.Context, ou *Orga
 	}
 	key := handleParentCacheKey(ou.Handle, ou.Parent)
 	if err := s.ouByHandleParentCache.Set(ctx, cache.CacheKey{Key: key}, ou); err != nil {
-		s.logger.Error("Failed to cache OU by handle+parent",
+		s.logger.ErrorWithContext(ctx, "Failed to cache OU by handle+parent",
 			log.String("handle", ou.Handle), log.Error(err))
 	}
 }
@@ -210,7 +210,7 @@ func (s *cacheBackedOUStore) invalidateOUByID(ctx context.Context, id string) {
 		return
 	}
 	if err := s.ouByIDCache.Delete(ctx, cache.CacheKey{Key: id}); err != nil {
-		s.logger.Error("Failed to invalidate OU cache by ID",
+		s.logger.ErrorWithContext(ctx, "Failed to invalidate OU cache by ID",
 			log.String("ouID", id), log.Error(err))
 	}
 }
@@ -236,7 +236,7 @@ func (s *cacheBackedOUStore) getHandleParentKey(ctx context.Context, id string) 
 
 func (s *cacheBackedOUStore) deleteHandleParentCacheKey(ctx context.Context, key string) {
 	if err := s.ouByHandleParentCache.Delete(ctx, cache.CacheKey{Key: key}); err != nil {
-		s.logger.Error("Failed to invalidate OU cache by handle+parent",
+		s.logger.ErrorWithContext(ctx, "Failed to invalidate OU cache by handle+parent",
 			log.String("cacheKey", key), log.Error(err))
 	}
 }

--- a/backend/internal/ou/handler.go
+++ b/backend/internal/ou/handler.go
@@ -74,7 +74,7 @@ func (ouh *organizationUnitHandler) HandleOUListRequest(w http.ResponseWriter, r
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, ouListResponse)
 
-	logger.Debug("Successfully listed organization units with pagination",
+	logger.DebugWithContext(ctx, "Successfully listed organization units with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", ouListResponse.TotalResults),
 		log.Int("count", ouListResponse.Count))
@@ -105,7 +105,7 @@ func (ouh *organizationUnitHandler) HandleOUPostRequest(w http.ResponseWriter, r
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdOU)
 
-	logger.Debug("Successfully created organization unit", log.String("ouId", createdOU.ID))
+	logger.DebugWithContext(ctx, "Successfully created organization unit", log.String("ouId", createdOU.ID))
 }
 
 // HandleOUGetRequest handles the get organization unit by id request.
@@ -126,7 +126,7 @@ func (ouh *organizationUnitHandler) HandleOUGetRequest(w http.ResponseWriter, r 
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, ou)
 
-	logger.Debug("Successfully retrieved organization unit", log.String("ouId", id))
+	logger.DebugWithContext(ctx, "Successfully retrieved organization unit", log.String("ouId", id))
 }
 
 // HandleOUPutRequest handles the update organization unit request.
@@ -152,7 +152,7 @@ func (ouh *organizationUnitHandler) HandleOUPutRequest(w http.ResponseWriter, r 
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, ou)
 
-	logger.Debug("Successfully updated organization unit", log.String("ouId", id))
+	logger.DebugWithContext(ctx, "Successfully updated organization unit", log.String("ouId", id))
 }
 
 // HandleOUDeleteRequest handles the delete organization unit request.
@@ -172,7 +172,7 @@ func (ouh *organizationUnitHandler) HandleOUDeleteRequest(w http.ResponseWriter,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
-	logger.Debug("Successfully deleted organization unit", log.String("ouId", id))
+	logger.DebugWithContext(ctx, "Successfully deleted organization unit", log.String("ouId", id))
 }
 
 // HandleOUChildrenListRequest handles the list child organization units request.
@@ -354,7 +354,8 @@ func (ouh *organizationUnitHandler) handleResourceListRequest(
 		count = resp.Count
 	}
 
-	logger.Debug("Successfully listed resources in organization unit", log.String("resourceType", resourceType),
+	logger.DebugWithContext(r.Context(), "Successfully listed resources in organization unit",
+		log.String("resourceType", resourceType),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", totalResults),
 		log.Int("count", count))
@@ -378,7 +379,7 @@ func (ouh *organizationUnitHandler) HandleOUGetByPathRequest(w http.ResponseWrit
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, ou)
 
-	logger.Debug("Successfully retrieved organization unit by path", log.String("path", path))
+	logger.DebugWithContext(ctx, "Successfully retrieved organization unit by path", log.String("path", path))
 }
 
 // HandleOUPutByPathRequest handles the update organization unit by hierarchical handle path request.
@@ -404,7 +405,7 @@ func (ouh *organizationUnitHandler) HandleOUPutByPathRequest(w http.ResponseWrit
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, ou)
 
-	logger.Debug("Successfully updated organization unit by path", log.String("path", path))
+	logger.DebugWithContext(ctx, "Successfully updated organization unit by path", log.String("path", path))
 }
 
 // HandleOUDeleteByPathRequest handles the delete organization unit by hierarchical handle path request.
@@ -424,7 +425,7 @@ func (ouh *organizationUnitHandler) HandleOUDeleteByPathRequest(w http.ResponseW
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
-	logger.Debug("Successfully deleted organization unit by path", log.String("path", path))
+	logger.DebugWithContext(ctx, "Successfully deleted organization unit by path", log.String("path", path))
 }
 
 // handleResourceListByPathRequest is a generic handler for listing resources under an organization unit by path.
@@ -471,7 +472,7 @@ func (ouh *organizationUnitHandler) handleResourceListByPathRequest(
 			count = resp.Count
 		}
 
-		logger.Debug("Successfully listed resources in organization unit by path",
+		logger.DebugWithContext(r.Context(), "Successfully listed resources in organization unit by path",
 			log.String("resourceType", resourceType), log.String("path", path),
 			log.Int("limit", limit), log.Int("offset", offset),
 			log.Int("totalResults", totalResults), log.Int("count", count))

--- a/backend/internal/ou/hierarchy_resolver.go
+++ b/backend/internal/ou/hierarchy_resolver.go
@@ -61,7 +61,7 @@ func (r *ouHierarchyAdapter) IsAncestor(
 	visited := make(map[string]struct{})
 	for {
 		if _, ok := visited[current]; ok {
-			logger.Error("Cyclic organization unit parent chain detected during ancestry check",
+			logger.ErrorWithContext(ctx, "Cyclic organization unit parent chain detected during ancestry check",
 				log.String("ouID", current))
 			return false, nil
 		}
@@ -71,11 +71,11 @@ func (r *ouHierarchyAdapter) IsAncestor(
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
 				// Broken chain — cannot confirm ancestry; deny-safe.
-				logger.Debug("Encountered missing organization unit during ancestry check",
+				logger.DebugWithContext(ctx, "Encountered missing organization unit during ancestry check",
 					log.String("ouID", current))
 				return false, nil
 			}
-			logger.Error("Failed to traverse organization unit hierarchy during ancestry check",
+			logger.ErrorWithContext(ctx, "Failed to traverse organization unit hierarchy during ancestry check",
 				log.Error(err))
 			return false, &serviceerror.InternalServerError
 		}
@@ -112,7 +112,7 @@ func (r *ouHierarchyAdapter) GetAncestorOUIDs(
 
 	for {
 		if _, ok := visited[current]; ok {
-			logger.Error("Cyclic organization unit parent chain detected while collecting ancestors",
+			logger.ErrorWithContext(ctx, "Cyclic organization unit parent chain detected while collecting ancestors",
 				log.String("ouID", current))
 			return nil, &serviceerror.InternalServerError
 		}
@@ -121,11 +121,11 @@ func (r *ouHierarchyAdapter) GetAncestorOUIDs(
 		ou, err := r.store.GetOrganizationUnit(ctx, current)
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
-				logger.Debug("Encountered missing organization unit while collecting ancestors",
+				logger.DebugWithContext(ctx, "Encountered missing organization unit while collecting ancestors",
 					log.String("ouID", current))
 				return nil, &ErrorOrganizationUnitNotFound
 			}
-			logger.Error("Failed to traverse organization unit hierarchy while collecting ancestors",
+			logger.ErrorWithContext(ctx, "Failed to traverse organization unit hierarchy while collecting ancestors",
 				log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}

--- a/backend/internal/ou/service.go
+++ b/backend/internal/ou/service.go
@@ -163,7 +163,7 @@ func (ous *organizationUnitService) listAllOrganizationUnits(
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
 	totalCount, err := ous.ouStore.GetOrganizationUnitListCount(ctx, f)
 	if err != nil {
-		logger.Error("Failed to get organization unit count", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get organization unit count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -173,7 +173,7 @@ func (ous *organizationUnitService) listAllOrganizationUnits(
 		if errors.Is(err, ErrResultLimitExceededInCompositeMode) {
 			return nil, &ErrorResultLimitExceeded
 		}
-		logger.Error("Failed to list organization units", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to list organization units", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -209,7 +209,7 @@ func (ous *organizationUnitService) listAccessibleOrganizationUnits(
 		// reflects the filtered count, not the raw authorized-ID count.
 		allOUs, err := ous.ouStore.GetOrganizationUnitsByIDs(ctx, ids)
 		if err != nil {
-			logger.Error("Failed to get organization units by IDs", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to get organization units by IDs", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 
@@ -264,7 +264,7 @@ func (ous *organizationUnitService) listAccessibleOrganizationUnits(
 
 	pageOUs, err := ous.ouStore.GetOrganizationUnitsByIDs(ctx, pageIDs)
 	if err != nil {
-		logger.Error("Failed to get organization units by IDs", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get organization units by IDs", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -282,7 +282,7 @@ func (ous *organizationUnitService) CreateOrganizationUnit(
 	ctx context.Context, request OrganizationUnitRequestWithID,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Creating organization unit", log.String("name", request.Name))
+	logger.DebugWithContext(ctx, "Creating organization unit", log.String("name", request.Name))
 
 	// Fail if store is in declarative mode
 	if isDeclarativeModeEnabled() {
@@ -374,11 +374,12 @@ func (ous *organizationUnitService) CreateOrganizationUnit(
 		return OrganizationUnit{}, capturedSvcErr
 	}
 	if err != nil {
-		logger.Error("Failed to create organization unit", log.Error(err), log.String("name", request.Name))
+		logger.ErrorWithContext(ctx, "Failed to create organization unit",
+			log.Error(err), log.String("name", request.Name))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully created organization unit", log.String("ouID", createdOU.ID))
+	logger.DebugWithContext(ctx, "Successfully created organization unit", log.String("ouID", createdOU.ID))
 
 	return createdOU, nil
 }
@@ -388,7 +389,7 @@ func (ous *organizationUnitService) GetOrganizationUnit(
 	ctx context.Context, id string,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Getting organization unit", log.String("ouID", id))
+	logger.DebugWithContext(ctx, "Getting organization unit", log.String("ouID", id))
 
 	if svcErr := ous.checkOUAccess(ctx, security.ActionReadOU, id); svcErr != nil {
 		return OrganizationUnit{}, svcErr
@@ -399,7 +400,7 @@ func (ous *organizationUnitService) GetOrganizationUnit(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
 		}
-		logger.Error("Failed to get organization unit", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get organization unit", log.Error(err))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 
@@ -411,7 +412,7 @@ func (ous *organizationUnitService) GetOrganizationUnitByPath(
 	ctx context.Context, handlePath string,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Getting organization unit by path", log.String("path", handlePath))
+	logger.DebugWithContext(ctx, "Getting organization unit by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -423,7 +424,7 @@ func (ous *organizationUnitService) GetOrganizationUnitByPath(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
 		}
-		logger.Error("Failed to get organization unit by path", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get organization unit by path", log.Error(err))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 
@@ -439,11 +440,11 @@ func (ous *organizationUnitService) IsOrganizationUnitExists(
 	ctx context.Context, id string,
 ) (bool, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Checking if organization unit exists", log.String("ouID", id))
+	logger.DebugWithContext(ctx, "Checking if organization unit exists", log.String("ouID", id))
 
 	exists, err := ous.ouStore.IsOrganizationUnitExists(ctx, id)
 	if err != nil {
-		logger.Error("Failed to check organization unit existence", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check organization unit existence", log.Error(err))
 		return false, &serviceerror.InternalServerError
 	}
 
@@ -474,10 +475,11 @@ func (ous *organizationUnitService) IsParent(
 		parentOU, err := ous.ouStore.GetOrganizationUnit(ctx, *currentParent)
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
-				logger.Debug("Encountered missing organization unit in hierarchy", log.String("ouID", *currentParent))
+				logger.DebugWithContext(ctx, "Encountered missing organization unit in hierarchy",
+					log.String("ouID", *currentParent))
 				return false, &ErrorOrganizationUnitNotFound
 			}
-			logger.Error("Failed to traverse organization unit hierarchy", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to traverse organization unit hierarchy", log.Error(err))
 			return false, &serviceerror.InternalServerError
 		}
 
@@ -492,7 +494,7 @@ func (ous *organizationUnitService) UpdateOrganizationUnit(
 	ctx context.Context, id string, request OrganizationUnitRequestWithID,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Updating organization unit", log.String("ouID", id))
+	logger.DebugWithContext(ctx, "Updating organization unit", log.String("ouID", id))
 
 	if svcErr := ous.checkOUAccess(ctx, security.ActionUpdateOU, id); svcErr != nil {
 		return OrganizationUnit{}, svcErr
@@ -524,11 +526,11 @@ func (ous *organizationUnitService) UpdateOrganizationUnit(
 		return OrganizationUnit{}, capturedSvcErr
 	}
 	if err != nil {
-		logger.Error("Failed to update organization unit", log.Error(err), log.String("ouID", id))
+		logger.ErrorWithContext(ctx, "Failed to update organization unit", log.Error(err), log.String("ouID", id))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully updated organization unit", log.String("ouID", id))
+	logger.DebugWithContext(ctx, "Successfully updated organization unit", log.String("ouID", id))
 	return updatedOU, nil
 }
 
@@ -537,7 +539,7 @@ func (ous *organizationUnitService) UpdateOrganizationUnitByPath(
 	ctx context.Context, handlePath string, request OrganizationUnitRequestWithID,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Updating organization unit by path", log.String("path", handlePath))
+	logger.DebugWithContext(ctx, "Updating organization unit by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -581,11 +583,12 @@ func (ous *organizationUnitService) UpdateOrganizationUnitByPath(
 		return OrganizationUnit{}, capturedSvcErr
 	}
 	if err != nil {
-		logger.Error("Failed to update organization unit by path", log.Error(err), log.String("path", handlePath))
+		logger.ErrorWithContext(ctx, "Failed to update organization unit by path",
+			log.Error(err), log.String("path", handlePath))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully updated organization unit by path", log.String("ouID", updatedOU.ID))
+	logger.DebugWithContext(ctx, "Successfully updated organization unit by path", log.String("ouID", updatedOU.ID))
 	return updatedOU, nil
 }
 
@@ -612,7 +615,7 @@ func (ous *organizationUnitService) updateOUInternal(
 	if request.Parent != nil {
 		exists, err := ous.ouStore.IsOrganizationUnitExists(ctx, *request.Parent)
 		if err != nil {
-			logger.Error("Failed to check parent organization unit existence", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to check parent organization unit existence", log.Error(err))
 			return OrganizationUnit{}, &serviceerror.InternalServerError
 		}
 		if !exists {
@@ -631,7 +634,7 @@ func (ous *organizationUnitService) updateOUInternal(
 	if parentChanged || existingOU.Name != request.Name {
 		nameConflict, err = ous.ouStore.CheckOrganizationUnitNameConflict(ctx, request.Name, request.Parent)
 		if err != nil {
-			logger.Error("Failed to check organization unit name conflict", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to check organization unit name conflict", log.Error(err))
 			return OrganizationUnit{}, &serviceerror.InternalServerError
 		}
 	}
@@ -644,7 +647,7 @@ func (ous *organizationUnitService) updateOUInternal(
 	if parentChanged || existingOU.Handle != request.Handle {
 		handleConflict, err = ous.ouStore.CheckOrganizationUnitHandleConflict(ctx, request.Handle, request.Parent)
 		if err != nil {
-			logger.Error("Failed to check organization unit handle conflict", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to check organization unit handle conflict", log.Error(err))
 			return OrganizationUnit{}, &serviceerror.InternalServerError
 		}
 	}
@@ -674,7 +677,7 @@ func (ous *organizationUnitService) updateOUInternal(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
 		}
-		logger.Error("Failed to update organization unit", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to update organization unit", log.Error(err))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 	return updatedOU, nil
@@ -684,7 +687,7 @@ func (ous *organizationUnitService) updateOUInternal(
 func (ous *organizationUnitService) DeleteOrganizationUnit(
 	ctx context.Context, id string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Deleting organization unit", log.String("ouID", id))
+	logger.DebugWithContext(ctx, "Deleting organization unit", log.String("ouID", id))
 
 	if svcErr := ous.checkOUAccess(ctx, security.ActionDeleteOU, id); svcErr != nil {
 		return svcErr
@@ -715,11 +718,11 @@ func (ous *organizationUnitService) DeleteOrganizationUnit(
 		return capturedSvcErr
 	}
 	if err != nil {
-		logger.Error("Failed to delete organization unit", log.Error(err), log.String("ouID", id))
+		logger.ErrorWithContext(ctx, "Failed to delete organization unit", log.Error(err), log.String("ouID", id))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully deleted organization unit", log.String("ouID", id))
+	logger.DebugWithContext(ctx, "Successfully deleted organization unit", log.String("ouID", id))
 	return nil
 }
 
@@ -728,7 +731,7 @@ func (ous *organizationUnitService) DeleteOrganizationUnitByPath(
 	ctx context.Context, handlePath string,
 ) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Deleting organization unit by path", log.String("path", handlePath))
+	logger.DebugWithContext(ctx, "Deleting organization unit by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -772,11 +775,12 @@ func (ous *organizationUnitService) DeleteOrganizationUnitByPath(
 		return capturedSvcErr
 	}
 	if err != nil {
-		logger.Error("Failed to delete organization unit by path", log.Error(err), log.String("path", handlePath))
+		logger.ErrorWithContext(ctx, "Failed to delete organization unit by path",
+			log.Error(err), log.String("path", handlePath))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully deleted organization unit by path", log.String("ouID", ouID))
+	logger.DebugWithContext(ctx, "Successfully deleted organization unit by path", log.String("ouID", ouID))
 	return nil
 }
 
@@ -792,7 +796,7 @@ func (ous *organizationUnitService) deleteOUInternal(
 	// Check child OUs (own table).
 	childCount, err := ous.ouStore.GetOrganizationUnitChildrenCount(ctx, id, nil)
 	if err != nil {
-		logger.Error("Failed to check child organization units", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check child organization units", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if childCount > 0 {
@@ -801,12 +805,12 @@ func (ous *organizationUnitService) deleteOUInternal(
 
 	// Check users via resolver.
 	if ous.userResolver == nil {
-		logger.Error("OUUserResolver not initialized")
+		logger.ErrorWithContext(ctx, "OUUserResolver not initialized")
 		return &serviceerror.InternalServerError
 	}
 	userCount, err := ous.userResolver.GetUserCountByOUID(ctx, id)
 	if err != nil {
-		logger.Error("Failed to check organization unit users", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check organization unit users", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if userCount > 0 {
@@ -815,12 +819,12 @@ func (ous *organizationUnitService) deleteOUInternal(
 
 	// Check groups via resolver.
 	if ous.groupResolver == nil {
-		logger.Error("OUGroupResolver not initialized")
+		logger.ErrorWithContext(ctx, "OUGroupResolver not initialized")
 		return &serviceerror.InternalServerError
 	}
 	groupCount, err := ous.groupResolver.GetGroupCountByOUID(ctx, id)
 	if err != nil {
-		logger.Error("Failed to check organization unit groups", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check organization unit groups", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if groupCount > 0 {
@@ -832,7 +836,7 @@ func (ous *organizationUnitService) deleteOUInternal(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return &ErrorOrganizationUnitNotFound
 		}
-		logger.Error("Failed to delete organization unit", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to delete organization unit", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil
@@ -880,7 +884,7 @@ func (ous *organizationUnitService) GetOrganizationUnitUsers(
 	users, ok := items.([]User)
 	if !ok {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-		logger.Error("Failed to cast user list response for organization unit", log.String("ouID", id))
+		logger.ErrorWithContext(ctx, "Failed to cast user list response for organization unit", log.String("ouID", id))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -952,7 +956,7 @@ func (ous *organizationUnitService) GetOrganizationUnitChildrenByPath(
 	ctx context.Context, handlePath string, limit, offset int, f *filter.FilterGroup,
 ) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Getting organization unit children by path", log.String("path", handlePath))
+	logger.DebugWithContext(ctx, "Getting organization unit children by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -964,7 +968,7 @@ func (ous *organizationUnitService) GetOrganizationUnitChildrenByPath(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		logger.Error("Failed to get organization unit by path", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get organization unit by path", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -976,7 +980,7 @@ func (ous *organizationUnitService) GetOrganizationUnitUsersByPath(
 	ctx context.Context, handlePath string, limit, offset int, includeDisplay bool,
 ) (*UserListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Getting organization unit users by path", log.String("path", handlePath))
+	logger.DebugWithContext(ctx, "Getting organization unit users by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -988,7 +992,7 @@ func (ous *organizationUnitService) GetOrganizationUnitUsersByPath(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		logger.Error("Failed to get organization unit by path", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get organization unit by path", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1000,7 +1004,7 @@ func (ous *organizationUnitService) GetOrganizationUnitGroupsByPath(
 	ctx context.Context, handlePath string, limit, offset int,
 ) (*GroupListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Getting organization unit groups by path", log.String("path", handlePath))
+	logger.DebugWithContext(ctx, "Getting organization unit groups by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -1012,7 +1016,7 @@ func (ous *organizationUnitService) GetOrganizationUnitGroupsByPath(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		logger.Error("Failed to get organization unit by path", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get organization unit by path", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1115,7 +1119,7 @@ func (ous *organizationUnitService) getResourceListWithExistenceCheck(
 	mapCompositeError bool,
 ) (interface{}, int, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.Debug("Getting resource for organization unit", log.String("resource_type", resourceType),
+	logger.DebugWithContext(ctx, "Getting resource for organization unit", log.String("resource_type", resourceType),
 		log.String("ouID", id))
 
 	if err := validatePaginationParams(limit, offset); err != nil {
@@ -1125,7 +1129,7 @@ func (ous *organizationUnitService) getResourceListWithExistenceCheck(
 	// Check if the organization unit exists
 	exists, err := ous.ouStore.IsOrganizationUnitExists(ctx, id)
 	if err != nil {
-		logger.Error("Failed to check organization unit existence", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check organization unit existence", log.Error(err))
 		return nil, 0, &serviceerror.InternalServerError
 	}
 	if !exists {
@@ -1138,13 +1142,15 @@ func (ous *organizationUnitService) getResourceListWithExistenceCheck(
 		if mapCompositeError && errors.Is(err, ErrResultLimitExceededInCompositeMode) {
 			return nil, 0, &ErrorResultLimitExceeded
 		}
-		logger.Error("Failed to list resource", log.String("resource_type", resourceType), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to list resource",
+			log.String("resource_type", resourceType), log.Error(err))
 		return nil, 0, &serviceerror.InternalServerError
 	}
 
 	totalCount, err := getCountFunc(ctx, id)
 	if err != nil {
-		logger.Error("Failed to get resource count", log.String("resource_type", resourceType), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get resource count",
+			log.String("resource_type", resourceType), log.Error(err))
 		return nil, 0, &serviceerror.InternalServerError
 	}
 
@@ -1209,7 +1215,7 @@ func (ous *organizationUnitService) GetOrganizationUnitHandlesByIDs(
 
 	ouBasics, err := ous.ouStore.GetOrganizationUnitsByIDs(ctx, ids)
 	if err != nil {
-		logger.Error("Failed to get organization units by IDs", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get organization units by IDs", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/ou/store.go
+++ b/backend/internal/ou/store.go
@@ -297,7 +297,7 @@ func (s *organizationUnitStore) GetOrganizationUnitByPath(
 			if !errors.Is(err, ErrOrganizationUnitNotFound) {
 				return OrganizationUnit{}, err
 			}
-			logger.Debug("Organization unit not found in path",
+			logger.DebugWithContext(ctx, "Organization unit not found in path",
 				log.String("handle", handle),
 				log.Int("pathIndex", i),
 				log.String("fullPath", fullPath))

--- a/backend/internal/resource/service.go
+++ b/backend/internal/resource/service.go
@@ -161,7 +161,7 @@ func (rs *resourceService) CreateResourceServer(
 	ctx context.Context,
 	resourceServer ResourceServer,
 ) (*ResourceServer, *serviceerror.ServiceError) {
-	rs.logger.Debug("Creating resource server", log.String("name", resourceServer.Name))
+	rs.logger.DebugWithContext(ctx, "Creating resource server", log.String("name", resourceServer.Name))
 
 	if err := rs.validateResourceServerCreate(resourceServer); err != nil {
 		return nil, err
@@ -171,21 +171,22 @@ func (rs *resourceService) CreateResourceServer(
 	_, svcErr := rs.ouService.GetOrganizationUnit(ctx, resourceServer.OUID)
 	if svcErr != nil {
 		if svcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
-			rs.logger.Debug("Organization unit not found", log.String("ouID", resourceServer.OUID))
+			rs.logger.DebugWithContext(ctx, "Organization unit not found", log.String("ouID", resourceServer.OUID))
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		rs.logger.Error("Failed to validate organization unit", log.String("error", svcErr.Error.DefaultValue))
+		rs.logger.ErrorWithContext(ctx, "Failed to validate organization unit",
+			log.String("error", svcErr.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	// Check name uniqueness
 	nameExists, err := rs.resourceStore.CheckResourceServerNameExists(ctx, resourceServer.Name)
 	if err != nil {
-		rs.logger.Error("Failed to check resource server name", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check resource server name", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if nameExists {
-		rs.logger.Debug("Resource server name already exists", log.String("name", resourceServer.Name))
+		rs.logger.DebugWithContext(ctx, "Resource server name already exists", log.String("name", resourceServer.Name))
 		return nil, &ErrorNameConflict
 	}
 
@@ -193,11 +194,11 @@ func (rs *resourceService) CreateResourceServer(
 	if resourceServer.Handle != "" {
 		handleExists, err := rs.resourceStore.CheckResourceServerHandleExists(ctx, resourceServer.Handle)
 		if err != nil {
-			rs.logger.Error("Failed to check resource server handle", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to check resource server handle", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		if handleExists {
-			rs.logger.Debug("Resource server handle already exists",
+			rs.logger.DebugWithContext(ctx, "Resource server handle already exists",
 				log.String("handle", resourceServer.Handle))
 			return nil, &ErrorHandleConflict
 		}
@@ -207,11 +208,11 @@ func (rs *resourceService) CreateResourceServer(
 	if resourceServer.Identifier != "" {
 		identifierExists, err := rs.resourceStore.CheckResourceServerIdentifierExists(ctx, resourceServer.Identifier)
 		if err != nil {
-			rs.logger.Error("Failed to check resource server identifier", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to check resource server identifier", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		if identifierExists {
-			rs.logger.Debug("Resource server identifier already exists",
+			rs.logger.DebugWithContext(ctx, "Resource server identifier already exists",
 				log.String("identifier", resourceServer.Identifier))
 			return nil, &ErrorIdentifierConflict
 		}
@@ -237,7 +238,7 @@ func (rs *resourceService) CreateResourceServer(
 		var err error
 		id, err = utils.GenerateUUIDv7()
 		if err != nil {
-			rs.logger.Error("Failed to generate UUID", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	} else {
@@ -246,7 +247,7 @@ func (rs *resourceService) CreateResourceServer(
 			return nil, svcErr
 		}
 		if svcErr == nil {
-			rs.logger.Debug("Resource server ID already exists", log.String("id", id))
+			rs.logger.DebugWithContext(ctx, "Resource server ID already exists", log.String("id", id))
 			return nil, &ErrorResourceServerIDConflict
 		}
 	}
@@ -255,7 +256,7 @@ func (rs *resourceService) CreateResourceServer(
 	var createdRS *ResourceServer
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.CreateResourceServer(txCtx, id, resourceServer); err != nil {
-			rs.logger.Error("Failed to create resource server", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to create resource server", log.Error(err))
 			return err
 		}
 
@@ -273,7 +274,7 @@ func (rs *resourceService) CreateResourceServer(
 		return nil, &serviceerror.InternalServerError
 	}
 
-	rs.logger.Debug("Successfully created resource server", log.String("id", id))
+	rs.logger.DebugWithContext(ctx, "Successfully created resource server", log.String("id", id))
 	return createdRS, nil
 }
 
@@ -288,10 +289,10 @@ func (rs *resourceService) GetResourceServer(
 	resourceServer, err := rs.resourceStore.GetResourceServer(ctx, id)
 	if err != nil {
 		if errors.Is(err, errResourceServerNotFound) {
-			rs.logger.Debug("Resource server not found", log.String("id", id))
+			rs.logger.DebugWithContext(ctx, "Resource server not found", log.String("id", id))
 			return nil, &ErrorResourceServerNotFound
 		}
-		rs.logger.Error("Failed to get resource server", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to get resource server", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -309,11 +310,11 @@ func (rs *resourceService) GetResourceServerByIdentifier(
 	resourceServer, err := rs.resourceStore.GetResourceServerByIdentifier(ctx, identifier)
 	if err != nil {
 		if errors.Is(err, errResourceServerNotFound) {
-			rs.logger.Debug("Resource server not found for identifier",
+			rs.logger.DebugWithContext(ctx, "Resource server not found for identifier",
 				log.String("identifier", identifier))
 			return nil, &ErrorResourceServerNotFound
 		}
-		rs.logger.Error("Failed to get resource server by identifier", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to get resource server by identifier", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -333,7 +334,7 @@ func (rs *resourceService) GetResourceServerList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.Error("Failed to get resource server count", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to get resource server count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -342,7 +343,7 @@ func (rs *resourceService) GetResourceServerList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.Error("Failed to list resource servers", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to list resource servers", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -373,16 +374,16 @@ func (rs *resourceService) UpdateResourceServer(
 	existingResServer, err := rs.resourceStore.GetResourceServer(ctx, id)
 	if err != nil {
 		if errors.Is(err, errResourceServerNotFound) {
-			rs.logger.Debug("Resource server not found", log.String("id", id))
+			rs.logger.DebugWithContext(ctx, "Resource server not found", log.String("id", id))
 			return nil, &ErrorResourceServerNotFound
 		}
-		rs.logger.Error("Failed to check resource server existence", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check resource server existence", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	// Check if resource server is declarative (immutable)
 	if rs.IsResourceServerDeclarative(id) {
-		rs.logger.Debug("Cannot modify declarative resource server", log.String("id", id))
+		rs.logger.DebugWithContext(ctx, "Cannot modify declarative resource server", log.String("id", id))
 		return nil, serviceerror.CustomServiceError(ErrorImmutableResourceServer, core.I18nMessage{
 			Key:          ErrorImmutableResourceServer.ErrorDescription.Key,
 			DefaultValue: fmt.Sprintf(ErrorImmutableResourceServer.ErrorDescription.DefaultValue, id),
@@ -405,11 +406,11 @@ func (rs *resourceService) UpdateResourceServer(
 	} else if resourceServer.Identifier != existingResServer.Identifier {
 		identifierExists, err := rs.resourceStore.CheckResourceServerIdentifierExists(ctx, resourceServer.Identifier)
 		if err != nil {
-			rs.logger.Error("Failed to check resource server identifier", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to check resource server identifier", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		if identifierExists {
-			rs.logger.Debug("Resource server identifier already exists",
+			rs.logger.DebugWithContext(ctx, "Resource server identifier already exists",
 				log.String("identifier", resourceServer.Identifier))
 			return nil, &ErrorIdentifierConflict
 		}
@@ -428,7 +429,7 @@ func (rs *resourceService) UpdateResourceServer(
 	if existingResServer.Name != resourceServer.Name {
 		nameExists, err := rs.resourceStore.CheckResourceServerNameExists(ctx, resourceServer.Name)
 		if err != nil {
-			rs.logger.Error("Failed to check resource server name", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to check resource server name", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		if nameExists {
@@ -439,7 +440,7 @@ func (rs *resourceService) UpdateResourceServer(
 	var updatedRS *ResourceServer
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.UpdateResourceServer(txCtx, id, resourceServer); err != nil {
-			rs.logger.Error("Failed to update resource server", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to update resource server", log.Error(err))
 			return err
 		}
 
@@ -468,7 +469,7 @@ func (rs *resourceService) DeleteResourceServer(ctx context.Context, id string) 
 
 	// Check if resource server is declarative (immutable)
 	if rs.IsResourceServerDeclarative(id) {
-		rs.logger.Debug("Cannot delete declarative resource server", log.String("id", id))
+		rs.logger.DebugWithContext(ctx, "Cannot delete declarative resource server", log.String("id", id))
 		return serviceerror.CustomServiceError(ErrorImmutableResourceServer, core.I18nMessage{
 			Key:          ErrorImmutableResourceServer.ErrorDescription.Key,
 			DefaultValue: fmt.Sprintf(ErrorImmutableResourceServer.ErrorDescription.DefaultValue, id),
@@ -480,14 +481,14 @@ func (rs *resourceService) DeleteResourceServer(ctx context.Context, id string) 
 		if errors.Is(err, errResourceServerNotFound) {
 			return nil // Idempotent delete
 		}
-		rs.logger.Error("Failed to check resource server existence", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check resource server existence", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
 	// Check for dependencies
 	hasDeps, err := rs.resourceStore.CheckResourceServerHasDependencies(ctx, id)
 	if err != nil {
-		rs.logger.Error("Failed to check dependencies", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check dependencies", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if hasDeps {
@@ -497,7 +498,7 @@ func (rs *resourceService) DeleteResourceServer(ctx context.Context, id string) 
 	// Use transaction for write operation
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.DeleteResourceServer(txCtx, id); err != nil {
-			rs.logger.Error("Failed to delete resource server", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to delete resource server", log.Error(err))
 			return err
 		}
 		return nil
@@ -538,7 +539,7 @@ func (rs *resourceService) CreateResource(
 			if errors.Is(err, errResourceNotFound) {
 				return nil, &ErrorParentResourceNotFound
 			}
-			rs.logger.Error("Failed to check parent resource", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to check parent resource", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		parentResource = &res
@@ -549,7 +550,7 @@ func (rs *resourceService) CreateResource(
 		ctx, resourceServerID, resource.Handle, resource.Parent,
 	)
 	if err != nil {
-		rs.logger.Error("Failed to check resource handle", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check resource handle", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if handleExists {
@@ -561,7 +562,7 @@ func (rs *resourceService) CreateResource(
 
 	id, err := utils.GenerateUUIDv7()
 	if err != nil {
-		rs.logger.Error("Failed to generate UUID", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -571,14 +572,14 @@ func (rs *resourceService) CreateResource(
 		if err := rs.resourceStore.CreateResource(
 			txCtx, id, resourceServerID, resource.Parent, resource,
 		); err != nil {
-			rs.logger.Error("Failed to create resource", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to create resource", log.Error(err))
 			return err
 		}
 
 		if err := rs.syncConsentOnPermissionCreate(
 			txCtx, resource.Permission, resource.Description,
 		); err != nil {
-			rs.logger.Error("Failed to sync consent element for resource", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for resource", log.Error(err))
 			return err
 		}
 
@@ -617,7 +618,7 @@ func (rs *resourceService) GetResource(
 		if errors.Is(err, errResourceNotFound) {
 			return nil, &ErrorResourceNotFound
 		}
-		rs.logger.Error("Failed to get resource", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to get resource", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -658,7 +659,7 @@ func (rs *resourceService) GetResourceList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.Error("Failed to get top-level resource count", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to get top-level resource count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -667,7 +668,7 @@ func (rs *resourceService) GetResourceList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.Error("Failed to list resources", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to list resources", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -696,7 +697,7 @@ func (rs *resourceService) GetAllResourceList(
 
 	totalCount, err := rs.resourceStore.GetResourceListCount(ctx, resourceServerID)
 	if err != nil {
-		rs.logger.Error("Failed to get resource count", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to get resource count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if totalCount == 0 {
@@ -708,7 +709,7 @@ func (rs *resourceService) GetAllResourceList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.Error("Failed to list all resources", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to list all resources", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return resources, nil
@@ -725,7 +726,7 @@ func (rs *resourceService) UpdateResource(
 
 	// Check if resource server is declarative (immutable)
 	if rs.IsResourceServerDeclarative(resourceServerID) {
-		rs.logger.Debug(
+		rs.logger.DebugWithContext(ctx,
 			"Cannot modify resource in declarative resource server",
 			log.String("resource_server_id", resourceServerID),
 		)
@@ -747,7 +748,7 @@ func (rs *resourceService) UpdateResource(
 		if errors.Is(err, errResourceNotFound) {
 			return nil, &ErrorResourceNotFound
 		}
-		rs.logger.Error("Failed to check resource existence", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check resource existence", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -764,14 +765,14 @@ func (rs *resourceService) UpdateResource(
 	var updatedResource *Resource
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.UpdateResource(txCtx, id, resourceServerID, updateResource); err != nil {
-			rs.logger.Error("Failed to update resource", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to update resource", log.Error(err))
 			return err
 		}
 
 		if err := rs.syncConsentOnPermissionUpdate(
 			txCtx, currentResource.Permission, updateResource.Description,
 		); err != nil {
-			rs.logger.Error("Failed to sync consent element for resource", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for resource", log.Error(err))
 			return err
 		}
 
@@ -799,7 +800,7 @@ func (rs *resourceService) DeleteResource(
 
 	// Check if resource server is declarative (immutable)
 	if rs.IsResourceServerDeclarative(resourceServerID) {
-		rs.logger.Debug(
+		rs.logger.DebugWithContext(ctx,
 			"Cannot delete resource in declarative resource server",
 			log.String("resource_server_id", resourceServerID),
 		)
@@ -815,7 +816,7 @@ func (rs *resourceService) DeleteResource(
 		if errors.Is(err, errResourceServerNotFound) {
 			return nil // Idempotent delete
 		}
-		rs.logger.Error("Failed to check resource server", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check resource server", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -825,14 +826,14 @@ func (rs *resourceService) DeleteResource(
 		if errors.Is(err, errResourceNotFound) {
 			return nil // Idempotent delete
 		}
-		rs.logger.Error("Failed to check resource existence", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check resource existence", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
 	// Check for dependencies
 	hasDeps, err := rs.resourceStore.CheckResourceHasDependencies(ctx, id)
 	if err != nil {
-		rs.logger.Error("Failed to check dependencies", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check dependencies", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if hasDeps {
@@ -842,13 +843,13 @@ func (rs *resourceService) DeleteResource(
 	// Use transaction for write operation
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.DeleteResource(txCtx, id, resourceServerID); err != nil {
-			rs.logger.Error("Failed to delete resource", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to delete resource", log.Error(err))
 			return err
 		}
 		if err := rs.syncConsentOnPermissionDelete(
 			txCtx, currentResource.Permission,
 		); err != nil {
-			rs.logger.Error("Failed to sync consent element for resource delete", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for resource delete", log.Error(err))
 			return err
 		}
 		return nil
@@ -893,7 +894,7 @@ func (rs *resourceService) CreateAction(
 		ctx, resourceServerID, resourceID, action.Handle,
 	)
 	if err != nil {
-		rs.logger.Error("Failed to check action handle", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check action handle", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if handleExists {
@@ -905,7 +906,7 @@ func (rs *resourceService) CreateAction(
 
 	id, err := utils.GenerateUUIDv7()
 	if err != nil {
-		rs.logger.Error("Failed to generate UUID", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -913,14 +914,14 @@ func (rs *resourceService) CreateAction(
 	var createdAction *Action
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.CreateAction(txCtx, id, resourceServerID, resourceID, action); err != nil {
-			rs.logger.Error("Failed to create action", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to create action", log.Error(err))
 			return err
 		}
 
 		if err := rs.syncConsentOnPermissionCreate(
 			txCtx, action.Permission, action.Description,
 		); err != nil {
-			rs.logger.Error("Failed to sync consent element for action", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for action", log.Error(err))
 			return err
 		}
 
@@ -975,7 +976,7 @@ func (rs *resourceService) GetAction(
 		if errors.Is(err, errActionNotFound) {
 			return nil, &ErrorActionNotFound
 		}
-		rs.logger.Error("Failed to get action", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to get action", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return &action, nil
@@ -1021,7 +1022,7 @@ func (rs *resourceService) GetActionList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.Error("Failed to get action count", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to get action count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1030,7 +1031,7 @@ func (rs *resourceService) GetActionList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.Error("Failed to list actions", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to list actions", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1094,7 +1095,7 @@ func (rs *resourceService) UpdateAction(
 		if errors.Is(err, errActionNotFound) {
 			return nil, &ErrorActionNotFound
 		}
-		rs.logger.Error("Failed to get action", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to get action", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1111,14 +1112,14 @@ func (rs *resourceService) UpdateAction(
 		if err := rs.resourceStore.UpdateAction(
 			txCtx, id, resourceServerID, resID, updateAction,
 		); err != nil {
-			rs.logger.Error("Failed to update action", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to update action", log.Error(err))
 			return err
 		}
 
 		if err := rs.syncConsentOnPermissionUpdate(
 			txCtx, currentAction.Permission, updateAction.Description,
 		); err != nil {
-			rs.logger.Error("Failed to sync consent element for action", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for action", log.Error(err))
 			return err
 		}
 
@@ -1153,7 +1154,7 @@ func (rs *resourceService) DeleteAction(
 
 	// Check if resource server is declarative (immutable)
 	if rs.IsResourceServerDeclarative(resourceServerID) {
-		rs.logger.Debug(
+		rs.logger.DebugWithContext(ctx,
 			"Cannot delete action in declarative resource server",
 			log.String("resource_server_id", resourceServerID),
 		)
@@ -1188,7 +1189,7 @@ func (rs *resourceService) DeleteAction(
 	// Check if action exists
 	exists, err := rs.resourceStore.IsActionExist(ctx, id, resourceServerID, resID)
 	if err != nil {
-		rs.logger.Error("Failed to check action existence", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check action existence", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if !exists {
@@ -1208,7 +1209,7 @@ func (rs *resourceService) DeleteAction(
 		default:
 			// Any other failure must abort: deleting without syncing would leave the consent
 			// element orphaned.
-			rs.logger.Error("Failed to load action for consent sync", log.Error(getErr))
+			rs.logger.ErrorWithContext(ctx, "Failed to load action for consent sync", log.Error(getErr))
 			return &serviceerror.InternalServerError
 		}
 	}
@@ -1216,12 +1217,12 @@ func (rs *resourceService) DeleteAction(
 	// Use transaction for write operation
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.DeleteAction(txCtx, id, resourceServerID, resID); err != nil {
-			rs.logger.Error("Failed to delete action", log.Error(err))
+			rs.logger.ErrorWithContext(ctx, "Failed to delete action", log.Error(err))
 			return err
 		}
 		if permissionToSync != "" {
 			if err := rs.syncConsentOnPermissionDelete(txCtx, permissionToSync); err != nil {
-				rs.logger.Error("Failed to sync consent element for action delete", log.Error(err))
+				rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for action delete", log.Error(err))
 				return err
 			}
 		}
@@ -1240,7 +1241,7 @@ func (rs *resourceService) ValidatePermissions(
 	resourceServerID string,
 	permissions []string,
 ) ([]string, *serviceerror.ServiceError) {
-	rs.logger.Debug("Validating permissions",
+	rs.logger.DebugWithContext(ctx, "Validating permissions",
 		log.String("resourceServerId", resourceServerID),
 		log.Int("permissionCount", len(permissions)))
 
@@ -1252,12 +1253,12 @@ func (rs *resourceService) ValidatePermissions(
 	_, err := rs.resourceStore.GetResourceServer(ctx, resourceServerID)
 	if err != nil {
 		if !errors.Is(err, errResourceServerNotFound) {
-			rs.logger.Error("Failed to validate resource server existence",
+			rs.logger.ErrorWithContext(ctx, "Failed to validate resource server existence",
 				log.String("resourceServerId", resourceServerID),
 				log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
-		rs.logger.Debug("Resource server not found",
+		rs.logger.DebugWithContext(ctx, "Resource server not found",
 			log.String("resourceServerId", resourceServerID))
 		// Return all permissions as invalid if resource server doesn't exist
 		return permissions, nil
@@ -1266,7 +1267,7 @@ func (rs *resourceService) ValidatePermissions(
 	// Call store to validate permissions
 	invalidPermissions, storeErr := rs.resourceStore.ValidatePermissions(ctx, resourceServerID, permissions)
 	if storeErr != nil {
-		rs.logger.Error("Failed to validate permissions in store",
+		rs.logger.ErrorWithContext(ctx, "Failed to validate permissions in store",
 			log.String("resourceServerId", resourceServerID),
 			log.Error(storeErr))
 		return nil, &serviceerror.InternalServerError
@@ -1287,7 +1288,7 @@ func (rs *resourceService) FindResourceServersByPermissions(
 
 	resourceServers, err := rs.resourceStore.FindResourceServersByPermissions(ctx, permissions)
 	if err != nil {
-		rs.logger.Error("Failed to find resource servers by permissions", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to find resource servers by permissions", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return resourceServers, nil
@@ -1300,7 +1301,7 @@ func (rs *resourceService) ResolveResourceServerOUHandle(
 	ctx context.Context, server *ResourceServer,
 ) *serviceerror.ServiceError {
 	if server.OUID != "" && server.OUHandle != "" {
-		rs.logger.Warn("Both ou_id and ou_handle provided for resource server; ou_handle ignored",
+		rs.logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided for resource server; ou_handle ignored",
 			log.String("resourceServerID", server.ID), log.String("name", server.Name))
 		return nil
 	}
@@ -1330,7 +1331,7 @@ func (rs *resourceService) validateAndGetResourceServer(
 		if errors.Is(err, errResourceServerNotFound) {
 			return ResourceServer{}, &ErrorResourceServerNotFound
 		}
-		rs.logger.Error("Failed to check resource server", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check resource server", log.Error(err))
 		return ResourceServer{}, &serviceerror.InternalServerError
 	}
 	return resourceServer, nil
@@ -1347,7 +1348,7 @@ func (rs *resourceService) validateAndGetResourceByID(
 		if errors.Is(err, errResourceNotFound) {
 			return Resource{}, &ErrorResourceNotFound
 		}
-		rs.logger.Error("Failed to check resource", log.Error(err))
+		rs.logger.ErrorWithContext(ctx, "Failed to check resource", log.Error(err))
 		return Resource{}, &serviceerror.InternalServerError
 	}
 	return resource, nil

--- a/backend/internal/role/assignment_service.go
+++ b/backend/internal/role/assignment_service.go
@@ -92,11 +92,11 @@ func (as *roleAssignmentService) GetRoleAssignmentsByType(ctx context.Context, i
 
 	exists, err := as.roleStore.IsRoleExist(ctx, id)
 	if err != nil {
-		logger.Error("Failed to check role existence", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if !exists {
-		logger.Debug("Role not found", log.String("id", id))
+		logger.DebugWithContext(ctx, "Role not found", log.String("id", id))
 		return nil, &ErrorRoleNotFound
 	}
 
@@ -119,7 +119,7 @@ func (as *roleAssignmentService) GetRoleAssignmentsByType(ctx context.Context, i
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
 		}
-		logger.Error("Failed to get role assignments count", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get role assignments count", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -132,7 +132,7 @@ func (as *roleAssignmentService) GetRoleAssignmentsByType(ctx context.Context, i
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
 		}
-		logger.Error("Failed to get role assignments", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get role assignments", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -169,7 +169,7 @@ func (as *roleAssignmentService) getAssignmentsByEntityCategory(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
 		}
-		logger.Error("Failed to get entity assignments count", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get entity assignments count", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -181,7 +181,7 @@ func (as *roleAssignmentService) getAssignmentsByEntityCategory(
 			if errors.Is(err, errResultLimitExceededInCompositeMode) {
 				return nil, &ResultLimitExceededInCompositeMode
 			}
-			logger.Error("Failed to get entity assignments", log.String("id", id), log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to get entity assignments", log.String("id", id), log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -195,7 +195,7 @@ func (as *roleAssignmentService) getAssignmentsByEntityCategory(
 		}
 		entities, fetchErr := as.entityService.GetEntitiesByIDs(ctx, entityIDs)
 		if fetchErr != nil {
-			logger.Error("Failed to batch fetch entities for category filter", log.Error(fetchErr))
+			logger.ErrorWithContext(ctx, "Failed to batch fetch entities for category filter", log.Error(fetchErr))
 			return nil, &serviceerror.InternalServerError
 		}
 		for _, e := range entities {
@@ -245,7 +245,7 @@ func (as *roleAssignmentService) getAssignmentsByEntityCategory(
 func (as *roleAssignmentService) AddAssignments(
 	ctx context.Context, id string, assignments []RoleAssignment) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, assignmentLoggerComponentName))
-	logger.Debug("Adding assignments to role", log.String("id", id))
+	logger.DebugWithContext(ctx, "Adding assignments to role", log.String("id", id))
 
 	normalized, svcErr := as.prepareAssignments(ctx, id, assignments)
 	if svcErr != nil {
@@ -255,11 +255,11 @@ func (as *roleAssignmentService) AddAssignments(
 	if err := as.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		return as.roleStore.AddAssignments(txCtx, id, normalized)
 	}); err != nil {
-		logger.Error("Failed to add assignments to role", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to add assignments to role", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully added assignments to role", log.String("id", id))
+	logger.DebugWithContext(ctx, "Successfully added assignments to role", log.String("id", id))
 	return nil
 }
 
@@ -268,7 +268,7 @@ func (as *roleAssignmentService) AddAssignments(
 func (as *roleAssignmentService) RemoveAssignments(
 	ctx context.Context, id string, assignments []RoleAssignment) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, assignmentLoggerComponentName))
-	logger.Debug("Removing assignments from role", log.String("id", id))
+	logger.DebugWithContext(ctx, "Removing assignments from role", log.String("id", id))
 
 	normalized, svcErr := as.prepareAssignments(ctx, id, assignments)
 	if svcErr != nil {
@@ -278,11 +278,11 @@ func (as *roleAssignmentService) RemoveAssignments(
 	if err := as.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		return as.roleStore.RemoveAssignments(txCtx, id, normalized)
 	}); err != nil {
-		logger.Error("Failed to remove assignments from role", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to remove assignments from role", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully removed assignments from role", log.String("id", id))
+	logger.DebugWithContext(ctx, "Successfully removed assignments from role", log.String("id", id))
 	return nil
 }
 
@@ -304,11 +304,11 @@ func (as *roleAssignmentService) prepareAssignments(
 
 	exists, err := as.roleStore.IsRoleExist(ctx, id)
 	if err != nil {
-		logger.Error("Failed to check role existence", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if !exists {
-		logger.Debug("Role not found", log.String("id", id))
+		logger.DebugWithContext(ctx, "Role not found", log.String("id", id))
 		return nil, &ErrorRoleNotFound
 	}
 
@@ -381,7 +381,7 @@ func validateAssignmentIDs(
 
 		entities, err := entitySvc.GetEntitiesByIDs(ctx, entityIDs)
 		if err != nil {
-			logger.Error("Failed to fetch entities for assignment validation", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to fetch entities for assignment validation", log.Error(err))
 			return &serviceerror.InternalServerError
 		}
 
@@ -393,7 +393,7 @@ func validateAssignmentIDs(
 			claimed := typeByID[e.ID]
 			actual := AssigneeType(e.Category)
 			if claimed != actual {
-				logger.Debug("Assignment type mismatch", log.String("id", e.ID),
+				logger.DebugWithContext(ctx, "Assignment type mismatch", log.String("id", e.ID),
 					log.String("claimed", string(claimed)), log.String("actual", string(actual)))
 				return &ErrorInvalidAssignmentID
 			}
@@ -403,10 +403,10 @@ func validateAssignmentIDs(
 	if len(groupIDs) > 0 {
 		if err := groupSvc.ValidateGroupIDs(ctx, groupIDs); err != nil {
 			if err.Code == group.ErrorInvalidGroupMemberID.Code {
-				logger.Debug("Invalid group member IDs found")
+				logger.DebugWithContext(ctx, "Invalid group member IDs found")
 				return &ErrorInvalidAssignmentID
 			}
-			logger.Error("Failed to validate group IDs", log.String("error", err.Error.DefaultValue))
+			logger.ErrorWithContext(ctx, "Failed to validate group IDs", log.String("error", err.Error.DefaultValue))
 			return &serviceerror.InternalServerError
 		}
 	}
@@ -437,7 +437,7 @@ func (as *roleAssignmentService) resolveAssignments(
 	if len(entityIDs) > 0 {
 		entities, err := as.entityService.GetEntitiesByIDs(ctx, entityIDs)
 		if err != nil {
-			logger.Error("Failed to batch fetch entities for assignments", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to batch fetch entities for assignments", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		entityMap = make(map[string]*entity.Entity, len(entities))
@@ -451,7 +451,7 @@ func (as *roleAssignmentService) resolveAssignments(
 		var svcErr *serviceerror.ServiceError
 		groupsMap, svcErr = as.groupService.GetGroupsByIDs(ctx, groupIDs)
 		if svcErr != nil {
-			logger.Warn("Failed to batch fetch groups for display names", log.Any("error", svcErr))
+			logger.WarnWithContext(ctx, "Failed to batch fetch groups for display names", log.Any("error", svcErr))
 		}
 	}
 
@@ -475,7 +475,7 @@ func (as *roleAssignmentService) resolveAssignments(
 		case assigneeTypeEntity:
 			e, ok := entityMap[a.ID]
 			if !ok {
-				logger.Warn("Skipping orphaned entity assignment", log.String("id", a.ID))
+				logger.WarnWithContext(ctx, "Skipping orphaned entity assignment", log.String("id", a.ID))
 				continue
 			}
 			ra.Type = AssigneeType(e.Category)
@@ -539,7 +539,7 @@ func resolveDisplayAttributePaths(
 	displayPaths, svcErr := schemaService.GetDisplayAttributesByNames(ctx, entitytype.TypeCategoryUser, uniqueTypes)
 	if svcErr != nil {
 		if logger != nil {
-			logger.Warn("Failed to resolve display attribute paths, skipping display resolution",
+			logger.WarnWithContext(ctx, "Failed to resolve display attribute paths, skipping display resolution",
 				log.Any("error", svcErr))
 		}
 		return nil

--- a/backend/internal/role/handler.go
+++ b/backend/internal/role/handler.go
@@ -79,7 +79,7 @@ func (rh *roleHandler) HandleRoleListRequest(w http.ResponseWriter, r *http.Requ
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, roleListResponse)
 
-	logger.Debug("Successfully listed roles with pagination",
+	logger.DebugWithContext(ctx, "Successfully listed roles with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", roleListResponse.TotalResults),
 		log.Int("count", roleListResponse.Count))
@@ -112,7 +112,7 @@ func (rh *roleHandler) HandleRolePostRequest(w http.ResponseWriter, r *http.Requ
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdRole)
 
-	logger.Debug("Successfully created role", log.String("roleId", createdRole.ID))
+	logger.DebugWithContext(ctx, "Successfully created role", log.String("roleId", createdRole.ID))
 }
 
 // HandleRoleGetRequest handles the get role by id request.
@@ -132,7 +132,7 @@ func (rh *roleHandler) HandleRoleGetRequest(w http.ResponseWriter, r *http.Reque
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, role)
 
-	logger.Debug("Successfully retrieved role", log.String("role id", id))
+	logger.DebugWithContext(ctx, "Successfully retrieved role", log.String("role id", id))
 }
 
 // HandleRolePutRequest handles the update role request.
@@ -163,7 +163,7 @@ func (rh *roleHandler) HandleRolePutRequest(w http.ResponseWriter, r *http.Reque
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, role)
 
-	logger.Debug("Successfully updated role", log.String("role id", id))
+	logger.DebugWithContext(ctx, "Successfully updated role", log.String("role id", id))
 }
 
 // HandleRoleDeleteRequest handles the delete role request.
@@ -179,7 +179,7 @@ func (rh *roleHandler) HandleRoleDeleteRequest(w http.ResponseWriter, r *http.Re
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
-	logger.Debug("Successfully deleted role", log.String("role id", id))
+	logger.DebugWithContext(ctx, "Successfully deleted role", log.String("role id", id))
 }
 
 // HandleRoleAssignmentsGetRequest handles the get role assignments request.
@@ -233,7 +233,7 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, assignmentListResponse)
 
-	logger.Debug("Successfully retrieved role assignments", log.String("role id", id),
+	logger.DebugWithContext(ctx, "Successfully retrieved role assignments", log.String("role id", id),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Bool("includeDisplay", includeDisplay),
 		log.String("assigneeType", assigneeType),
@@ -265,7 +265,7 @@ func (rh *roleHandler) HandleRoleAddAssignmentsRequest(w http.ResponseWriter, r 
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
-	logger.Debug("Successfully added assignments to role", log.String("role id", id))
+	logger.DebugWithContext(ctx, "Successfully added assignments to role", log.String("role id", id))
 }
 
 // HandleRoleRemoveAssignmentsRequest handles the remove assignments from role request.
@@ -292,7 +292,7 @@ func (rh *roleHandler) HandleRoleRemoveAssignmentsRequest(w http.ResponseWriter,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
-	logger.Debug("Successfully removed assignments from role", log.String("role id", id))
+	logger.DebugWithContext(ctx, "Successfully removed assignments from role", log.String("role id", id))
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -98,7 +98,7 @@ func (rs *roleService) GetRoleList(ctx context.Context, limit, offset int) (*Rol
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
 		}
-		logger.Error("Failed to get role count", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get role count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -107,7 +107,7 @@ func (rs *roleService) GetRoleList(ctx context.Context, limit, offset int) (*Rol
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
 		}
-		logger.Error("Failed to list roles", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to list roles", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -124,7 +124,7 @@ func (rs *roleService) GetRoleList(ctx context.Context, limit, offset int) (*Rol
 		}
 		ouHandles, svcErr := rs.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
 		if svcErr != nil {
-			logger.Warn("Failed to resolve OU handles for roles, skipping", log.Any("error", svcErr))
+			logger.WarnWithContext(ctx, "Failed to resolve OU handles for roles, skipping", log.Any("error", svcErr))
 		} else {
 			for i := range roles {
 				roles[i].OUHandle = ouHandles[roles[i].OUID]
@@ -148,11 +148,11 @@ func (rs *roleService) CreateRole(
 	ctx context.Context, role RoleCreationDetail,
 ) (*RoleWithPermissionsAndAssignments, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Creating role", log.String("name", role.Name))
+	logger.DebugWithContext(ctx, "Creating role", log.String("name", role.Name))
 
 	// Check if role creation is allowed (not in declarative-only mode)
 	if isDeclarativeModeEnabled() {
-		logger.Debug("Cannot create role in declarative-only mode")
+		logger.DebugWithContext(ctx, "Cannot create role in declarative-only mode")
 		return nil, &ErrorDeclarativeModeCreateNotAllowed
 	}
 
@@ -166,10 +166,11 @@ func (rs *roleService) CreateRole(
 	ou, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
 	if svcErr != nil {
 		if svcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
-			logger.Debug("Organization unit not found", log.String("ouID", role.OUID))
+			logger.DebugWithContext(ctx, "Organization unit not found", log.String("ouID", role.OUID))
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		logger.Error("Failed to validate organization unit", log.String("error", svcErr.Error.DefaultValue))
+		logger.ErrorWithContext(ctx, "Failed to validate organization unit",
+			log.String("error", svcErr.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -190,11 +191,11 @@ func (rs *roleService) CreateRole(
 	// Check if role name already exists in the organization unit
 	nameExists, err := rs.roleStore.CheckRoleNameExists(ctx, role.OUID, role.Name)
 	if err != nil {
-		logger.Error("Failed to check role name existence", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check role name existence", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if nameExists {
-		logger.Debug("Role name already exists in organization unit",
+		logger.DebugWithContext(ctx, "Role name already exists in organization unit",
 			log.String("name", role.Name), log.String("ouID", role.OUID))
 		return nil, &ErrorRoleNameConflict
 	}
@@ -203,17 +204,17 @@ func (rs *roleService) CreateRole(
 	if id == "" {
 		id, err = utils.GenerateUUIDv7()
 		if err != nil {
-			logger.Error("Failed to generate UUID", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	} else {
 		_, err = rs.roleStore.GetRole(ctx, id)
 		if err != nil && !errors.Is(err, ErrRoleNotFound) {
-			logger.Error("Failed to check role ID existence", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to check role ID existence", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		if err == nil {
-			logger.Debug("Role ID already exists", log.String("id", id))
+			logger.DebugWithContext(ctx, "Role ID already exists", log.String("id", id))
 			return nil, &ErrorRoleIDConflict
 		}
 	}
@@ -236,11 +237,11 @@ func (rs *roleService) CreateRole(
 	})
 
 	if err != nil {
-		logger.Error("Failed to create role", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to create role", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully created role", log.String("id", id), log.String("name", role.Name))
+	logger.DebugWithContext(ctx, "Successfully created role", log.String("id", id), log.String("name", role.Name))
 	return serviceRole, nil
 }
 
@@ -248,7 +249,7 @@ func (rs *roleService) CreateRole(
 func (rs *roleService) GetRoleWithPermissions(ctx context.Context, id string) (
 	*RoleWithPermissions, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Retrieving role", log.String("id", id))
+	logger.DebugWithContext(ctx, "Retrieving role", log.String("id", id))
 
 	if id == "" {
 		return nil, &ErrorMissingRoleID
@@ -257,22 +258,23 @@ func (rs *roleService) GetRoleWithPermissions(ctx context.Context, id string) (
 	role, err := rs.roleStore.GetRole(ctx, id)
 	if err != nil {
 		if errors.Is(err, ErrRoleNotFound) {
-			logger.Debug("Role not found", log.String("id", id))
+			logger.DebugWithContext(ctx, "Role not found", log.String("id", id))
 			return nil, &ErrorRoleNotFound
 		}
-		logger.Error("Failed to retrieve role", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to retrieve role", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	ou, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
 	if svcErr != nil {
-		logger.Warn("Failed to resolve OU handle for role, skipping",
+		logger.WarnWithContext(ctx, "Failed to resolve OU handle for role, skipping",
 			log.String("id", id), log.Any("error", svcErr))
 	} else {
 		role.OUHandle = ou.Handle
 	}
 
-	logger.Debug("Successfully retrieved role", log.String("id", role.ID), log.String("name", role.Name))
+	logger.DebugWithContext(ctx, "Successfully retrieved role",
+		log.String("id", role.ID), log.String("name", role.Name))
 	return &role, nil
 }
 
@@ -280,7 +282,7 @@ func (rs *roleService) GetRoleWithPermissions(ctx context.Context, id string) (
 func (rs *roleService) UpdateRoleWithPermissions(
 	ctx context.Context, id string, role RoleUpdateDetail) (*RoleWithPermissions, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Updating role", log.String("id", id), log.String("name", role.Name))
+	logger.DebugWithContext(ctx, "Updating role", log.String("id", id), log.String("name", role.Name))
 
 	if id == "" {
 		return nil, &ErrorMissingRoleID
@@ -297,17 +299,17 @@ func (rs *roleService) UpdateRoleWithPermissions(
 
 	exists, err := rs.roleStore.IsRoleExist(ctx, id)
 	if err != nil {
-		logger.Error("Failed to check role existence", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if !exists {
-		logger.Debug("Role not found", log.String("id", id))
+		logger.DebugWithContext(ctx, "Role not found", log.String("id", id))
 		return nil, &ErrorRoleNotFound
 	}
 
 	// Check if role is declarative - cannot modify declarative roles
 	if rs.isRoleDeclarative(ctx, id) {
-		logger.Debug("Cannot modify declarative role", log.String("id", id))
+		logger.DebugWithContext(ctx, "Cannot modify declarative role", log.String("id", id))
 		return nil, &ErrorImmutableRole
 	}
 
@@ -315,21 +317,22 @@ func (rs *roleService) UpdateRoleWithPermissions(
 	ou, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
 	if svcErr != nil {
 		if svcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
-			logger.Debug("Organization unit not found", log.String("ouID", role.OUID))
+			logger.DebugWithContext(ctx, "Organization unit not found", log.String("ouID", role.OUID))
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		logger.Error("Failed to validate organization unit", log.String("error", svcErr.Error.DefaultValue))
+		logger.ErrorWithContext(ctx, "Failed to validate organization unit",
+			log.String("error", svcErr.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	// Check if role name already exists in the organization unit (excluding the current role)
 	nameExists, err := rs.roleStore.CheckRoleNameExistsExcludingID(ctx, role.OUID, role.Name, id)
 	if err != nil {
-		logger.Error("Failed to check role name existence", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check role name existence", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if nameExists {
-		logger.Debug("Role name already exists in organization unit",
+		logger.DebugWithContext(ctx, "Role name already exists in organization unit",
 			log.String("name", role.Name), log.String("ouID", role.OUID))
 		return nil, &ErrorRoleNameConflict
 	}
@@ -339,11 +342,11 @@ func (rs *roleService) UpdateRoleWithPermissions(
 	})
 
 	if err != nil {
-		logger.Error("Failed to update role", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to update role", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully updated role", log.String("id", id), log.String("name", role.Name))
+	logger.DebugWithContext(ctx, "Successfully updated role", log.String("id", id), log.String("name", role.Name))
 	return &RoleWithPermissions{
 		ID:          id,
 		Name:        role.Name,
@@ -357,7 +360,7 @@ func (rs *roleService) UpdateRoleWithPermissions(
 // DeleteRole delete the specified role by its id.
 func (rs *roleService) DeleteRole(ctx context.Context, id string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Deleting role", log.String("id", id))
+	logger.DebugWithContext(ctx, "Deleting role", log.String("id", id))
 
 	if id == "" {
 		return &ErrorMissingRoleID
@@ -365,17 +368,17 @@ func (rs *roleService) DeleteRole(ctx context.Context, id string) *serviceerror.
 
 	exists, err := rs.roleStore.IsRoleExist(ctx, id)
 	if err != nil {
-		logger.Error("Failed to check role existence", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if !exists {
-		logger.Debug("Role not found", log.String("id", id))
+		logger.DebugWithContext(ctx, "Role not found", log.String("id", id))
 		return nil
 	}
 
 	// Check if role is declarative - cannot delete declarative roles
 	if rs.isRoleDeclarative(ctx, id) {
-		logger.Debug("Cannot delete declarative role", log.String("id", id))
+		logger.DebugWithContext(ctx, "Cannot delete declarative role", log.String("id", id))
 		return &ErrorImmutableRole
 	}
 
@@ -389,11 +392,11 @@ func (rs *roleService) DeleteRole(ctx context.Context, id string) *serviceerror.
 		return rs.roleStore.DeleteRole(txCtx, id)
 	})
 	if err != nil {
-		logger.Error("Failed to delete role", log.String("id", id), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to delete role", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Successfully deleted role", log.String("id", id))
+	logger.DebugWithContext(ctx, "Successfully deleted role", log.String("id", id))
 	return nil
 }
 
@@ -402,7 +405,7 @@ func (rs *roleService) GetAuthorizedPermissions(
 	ctx context.Context, entityID string, groups []string, requestedPermissions []string,
 ) ([]string, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Authorizing permissions",
+	logger.DebugWithContext(ctx, "Authorizing permissions",
 		log.MaskedString(log.LoggerKeyUserID, entityID), log.Int("groupCount", len(groups)))
 
 	// Handle nil groups slice
@@ -423,14 +426,14 @@ func (rs *roleService) GetAuthorizedPermissions(
 	// Get authorized permissions from store
 	authorizedPermissions, err := rs.roleStore.GetAuthorizedPermissions(ctx, entityID, groups, requestedPermissions)
 	if err != nil {
-		logger.Error("Failed to get authorized permissions",
+		logger.ErrorWithContext(ctx, "Failed to get authorized permissions",
 			log.MaskedString(log.LoggerKeyUserID, entityID),
 			log.Int("groupCount", len(groups)),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.Debug("Retrieved authorized permissions",
+	logger.DebugWithContext(ctx, "Retrieved authorized permissions",
 		log.MaskedString(log.LoggerKeyUserID, entityID),
 		log.Int("groupCount", len(groups)),
 		log.Int("requestedCount", len(requestedPermissions)),
@@ -444,7 +447,8 @@ func (rs *roleService) GetUserRoles(
 	ctx context.Context, entityID string, groupIDs []string,
 ) ([]string, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Getting entity roles", log.MaskedString("entityID", entityID), log.Int("groupCount", len(groupIDs)))
+	logger.DebugWithContext(ctx, "Getting entity roles",
+		log.MaskedString("entityID", entityID), log.Int("groupCount", len(groupIDs)))
 
 	if groupIDs == nil {
 		groupIDs = []string{}
@@ -456,7 +460,7 @@ func (rs *roleService) GetUserRoles(
 
 	roles, err := rs.roleStore.GetUserRoles(ctx, entityID, groupIDs)
 	if err != nil {
-		logger.Error("Failed to get entity roles",
+		logger.ErrorWithContext(ctx, "Failed to get entity roles",
 			log.MaskedString("entityID", entityID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -482,7 +486,7 @@ func (rs *roleService) ResolveRoleOUHandle(
 ) *serviceerror.ServiceError {
 	if role.OUID != "" && role.OUHandle != "" {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-		logger.Warn("Both ou_id and ou_handle provided for role; ou_handle ignored",
+		logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided for role; ou_handle ignored",
 			log.String("roleID", role.ID), log.String("name", role.Name))
 		return nil
 	}
@@ -583,7 +587,7 @@ func (rs *roleService) validatePermissions(
 	// Validate each resource server's permissions
 	for _, resPerm := range permissions {
 		if resPerm.ResourceServerID == "" {
-			logger.Debug("Empty resource server ID")
+			logger.DebugWithContext(ctx, "Empty resource server ID")
 			return &ErrorInvalidPermissions
 		}
 
@@ -599,7 +603,7 @@ func (rs *roleService) validatePermissions(
 		)
 
 		if svcErr != nil {
-			logger.Error("Failed to validate permissions",
+			logger.ErrorWithContext(ctx, "Failed to validate permissions",
 				log.String("resourceServerId", resPerm.ResourceServerID),
 				log.String("error", svcErr.Error.DefaultValue))
 			return &serviceerror.InternalServerError
@@ -607,7 +611,7 @@ func (rs *roleService) validatePermissions(
 
 		// If any permissions are invalid, return error
 		if len(invalidPerms) > 0 {
-			logger.Debug("Invalid permissions found",
+			logger.DebugWithContext(ctx, "Invalid permissions found",
 				log.String("resourceServerId", resPerm.ResourceServerID),
 				log.Any("invalidPermissions", invalidPerms),
 				log.Int("count", len(invalidPerms)))
@@ -634,7 +638,8 @@ func (rs *roleService) isRoleDeclarative(ctx context.Context, roleID string) boo
 		// Log at Warn level and fail open - treat as non-declarative on error
 		// RISK: In composite mode, this could allow modification of declarative roles if the check fails
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-		logger.Warn("Failed to check if role is declarative", log.String("roleID", roleID), log.Error(err))
+		logger.WarnWithContext(ctx, "Failed to check if role is declarative",
+			log.String("roleID", roleID), log.Error(err))
 		return false
 	}
 

--- a/backend/internal/role/store.go
+++ b/backend/internal/role/store.go
@@ -341,7 +341,7 @@ func (s *roleStore) DeleteRole(ctx context.Context, id string) error {
 	}
 
 	if rowsAffected == 0 {
-		logger.Debug("Role not found with id: " + id)
+		logger.DebugWithContext(ctx, "Role not found with id: "+id)
 	}
 
 	return nil

--- a/backend/internal/system/cache/cache.go
+++ b/backend/internal/system/cache/cache.go
@@ -56,7 +56,8 @@ func (c *Cache[T]) Set(ctx context.Context, key CacheKey, value T) error {
 
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
 		if err := c.cacheImpl.Set(ctx, key, value); err != nil {
-			logger.Warn("Failed to set value in the cache", log.String("key", key.ToString()), log.Error(err))
+			logger.WarnWithContext(ctx, "Failed to set value in the cache",
+				log.String("key", key.ToString()), log.Error(err))
 		}
 	}
 
@@ -82,7 +83,8 @@ func (c *Cache[T]) Delete(ctx context.Context, key CacheKey) error {
 
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
 		if err := c.cacheImpl.Delete(ctx, key); err != nil {
-			logger.Warn("Failed to delete value from the cache", log.String("key", key.ToString()), log.Error(err))
+			logger.WarnWithContext(ctx, "Failed to delete value from the cache",
+				log.String("key", key.ToString()), log.Error(err))
 		}
 	}
 
@@ -95,10 +97,10 @@ func (c *Cache[T]) Clear(ctx context.Context) error {
 		log.String("cacheName", c.cacheName))
 
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
-		logger.Debug("Clearing all entries in the cache")
+		logger.DebugWithContext(ctx, "Clearing all entries in the cache")
 
 		if err := c.cacheImpl.Clear(ctx); err != nil {
-			logger.Warn("Failed to clear the cache", log.Error(err))
+			logger.WarnWithContext(ctx, "Failed to clear the cache", log.Error(err))
 		}
 	}
 

--- a/backend/internal/system/cache/inmemorycache.go
+++ b/backend/internal/system/cache/inmemorycache.go
@@ -176,7 +176,7 @@ func newInMemoryCache[T any](name string, enabled bool,
 }
 
 // Set adds or updates an entry in the cache.
-func (c *inMemoryCache[T]) Set(_ context.Context, key CacheKey, value T) error {
+func (c *inMemoryCache[T]) Set(ctx context.Context, key CacheKey, value T) error {
 	if !c.enabled {
 		return nil
 	}
@@ -235,11 +235,11 @@ func (c *inMemoryCache[T]) Set(_ context.Context, key CacheKey, value T) error {
 	}
 	c.cache[key] = inMemoryCacheEntry
 
-	logger.Debug("Cache entry set", log.String("key", key.ToString()))
+	logger.DebugWithContext(ctx, "Cache entry set", log.String("key", key.ToString()))
 
 	// Check if there's a requirement to evict an entry
 	if len(c.cache) > c.size {
-		logger.Debug("Cache size exceeded, evicting an entry")
+		logger.DebugWithContext(ctx, "Cache size exceeded, evicting an entry")
 		c.evict()
 	}
 
@@ -247,7 +247,7 @@ func (c *inMemoryCache[T]) Set(_ context.Context, key CacheKey, value T) error {
 }
 
 // Get retrieves a value from the cache.
-func (c *inMemoryCache[T]) Get(_ context.Context, key CacheKey) (T, bool) {
+func (c *inMemoryCache[T]) Get(ctx context.Context, key CacheKey) (T, bool) {
 	if !c.enabled {
 		var zero T
 		return zero, false
@@ -287,12 +287,12 @@ func (c *inMemoryCache[T]) Get(_ context.Context, key CacheKey) (T, bool) {
 		heap.Fix(c.lfuHeap, entry.heapItem.index)
 	}
 
-	logger.Debug("Cache hit", log.String("key", key.ToString()))
+	logger.DebugWithContext(ctx, "Cache hit", log.String("key", key.ToString()))
 	return entry.Value, true
 }
 
 // Delete removes an entry from the cache.
-func (c *inMemoryCache[T]) Delete(_ context.Context, key CacheKey) error {
+func (c *inMemoryCache[T]) Delete(ctx context.Context, key CacheKey) error {
 	if !c.enabled {
 		return nil
 	}
@@ -308,7 +308,7 @@ func (c *inMemoryCache[T]) Delete(_ context.Context, key CacheKey) error {
 }
 
 // Clear removes all entries from the cache.
-func (c *inMemoryCache[T]) Clear(_ context.Context) error {
+func (c *inMemoryCache[T]) Clear(ctx context.Context) error {
 	if !c.enabled {
 		return nil
 	}
@@ -327,7 +327,7 @@ func (c *inMemoryCache[T]) Clear(_ context.Context) error {
 	c.missCount.Store(0)
 	c.evictCount.Store(0)
 
-	logger.Debug("Cleared all entries in the cache")
+	logger.DebugWithContext(ctx, "Cleared all entries in the cache")
 	return nil
 }
 

--- a/backend/internal/system/cache/redis_cache.go
+++ b/backend/internal/system/cache/redis_cache.go
@@ -86,18 +86,18 @@ func (c *redisCache[T]) Set(ctx context.Context, key CacheKey, value T) error {
 
 	data, err := json.Marshal(value)
 	if err != nil {
-		logger.Warn("Failed to marshal value for Redis cache", log.Error(err))
+		logger.WarnWithContext(ctx, "Failed to marshal value for Redis cache", log.Error(err))
 		return err
 	}
 
 	fullKey := c.buildKey(key)
 
 	if err := c.client.Set(ctx, fullKey, data, c.ttl).Err(); err != nil {
-		logger.Warn("Failed to set value in Redis cache", log.Error(err))
+		logger.WarnWithContext(ctx, "Failed to set value in Redis cache", log.Error(err))
 		return err
 	}
 
-	logger.Debug("Cache entry set in Redis", log.String("key", key.ToString()))
+	logger.DebugWithContext(ctx, "Cache entry set in Redis", log.String("key", key.ToString()))
 	return nil
 }
 
@@ -119,20 +119,20 @@ func (c *redisCache[T]) Get(ctx context.Context, key CacheKey) (T, bool) {
 			atomic.AddInt64(&c.missCount, 1)
 			return zero, false
 		}
-		logger.Warn("Failed to get value from Redis cache", log.Error(err))
+		logger.WarnWithContext(ctx, "Failed to get value from Redis cache", log.Error(err))
 		atomic.AddInt64(&c.missCount, 1)
 		return zero, false
 	}
 
 	var value T
 	if err := json.Unmarshal(data, &value); err != nil {
-		logger.Warn("Failed to unmarshal value from Redis cache", log.Error(err))
+		logger.WarnWithContext(ctx, "Failed to unmarshal value from Redis cache", log.Error(err))
 		atomic.AddInt64(&c.missCount, 1)
 		return zero, false
 	}
 
 	atomic.AddInt64(&c.hitCount, 1)
-	logger.Debug("Cache hit from Redis", log.String("key", key.ToString()))
+	logger.DebugWithContext(ctx, "Cache hit from Redis", log.String("key", key.ToString()))
 	return value, true
 }
 

--- a/backend/internal/system/database/provider/dbclient.go
+++ b/backend/internal/system/database/provider/dbclient.go
@@ -79,7 +79,7 @@ func (client *DBClient) QueryContext(
 	args ...interface{},
 ) ([]map[string]interface{}, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DBClient"))
-	logger.Debug("Executing query", log.String("queryID", query.GetID()))
+	logger.DebugWithContext(ctx, "Executing query", log.String("queryID", query.GetID()))
 
 	sqlQuery := query.GetQuery(client.dbType)
 
@@ -102,7 +102,7 @@ func (client *DBClient) QueryContext(
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
-			logger.Error("Error closing rows", log.Error(closeErr))
+			logger.ErrorWithContext(ctx, "Error closing rows", log.Error(closeErr))
 		}
 	}()
 
@@ -147,7 +147,7 @@ func (client *DBClient) Execute(query model.DBQuery, args ...interface{}) (int64
 // If a transaction exists in the context, it will be used automatically.
 func (client *DBClient) ExecuteContext(ctx context.Context, query model.DBQuery, args ...interface{}) (int64, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DBClient"))
-	logger.Debug("Executing query", log.String("queryID", query.GetID()))
+	logger.DebugWithContext(ctx, "Executing query", log.String("queryID", query.GetID()))
 
 	sqlQuery := query.GetQuery(client.dbType)
 

--- a/backend/internal/system/export/handler.go
+++ b/backend/internal/system/export/handler.go
@@ -62,7 +62,7 @@ func (eh *exportHandler) HandleExportRequest(w http.ResponseWriter, r *http.Requ
 	exportResponse, svcErr := eh.service.ExportResources(r.Context(), exportRequest)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
-			logger.Error("Error exporting resources", log.Any("serviceError", svcErr))
+			logger.ErrorWithContext(r.Context(), "Error exporting resources", log.Any("serviceError", svcErr))
 		}
 		eh.handleError(w, svcErr)
 		return
@@ -97,6 +97,7 @@ func buildCombinedResources(files []ExportFile) string {
 
 // HandleExportZipRequest handles the export request and returns a ZIP file containing all resources.
 func (eh *exportHandler) HandleExportZipRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ExportHandler"))
 
 	exportRequest, err := sysutils.DecodeJSONBody[ExportRequest](r)
@@ -114,7 +115,7 @@ func (eh *exportHandler) HandleExportZipRequest(w http.ResponseWriter, r *http.R
 	exportResponse, svcErr := eh.service.ExportResources(r.Context(), exportRequest)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
-			logger.Error("Error exporting resources", log.Any("serviceError", svcErr))
+			logger.ErrorWithContext(ctx, "Error exporting resources", log.Any("serviceError", svcErr))
 		}
 		eh.handleError(w, svcErr)
 		return
@@ -122,7 +123,7 @@ func (eh *exportHandler) HandleExportZipRequest(w http.ResponseWriter, r *http.R
 
 	// Generate ZIP file and send response
 	if err := eh.generateAndSendZipResponse(w, logger, exportResponse); err != nil {
-		logger.Error("Error generating ZIP response", log.Error(err))
+		logger.ErrorWithContext(ctx, "Error generating ZIP response", log.Error(err))
 		errResp := apierror.ErrorResponse{
 			Code:        serviceerror.InternalServerError.Code,
 			Message:     serviceerror.InternalServerError.Error,

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -263,7 +263,7 @@ func (es *exportService) exportResourcesWithExporter(
 		// Export all resources
 		ids, err := exporter.GetAllResourceIDs(ctx)
 		if err != nil {
-			logger.Warn("Failed to get all resources",
+			logger.WarnWithContext(ctx, "Failed to get all resources",
 				log.String("resourceType", resourceType), log.Any("error", err))
 			return []ExportFile{}, variableValues, []declarativeresource.ExportError{}
 		}
@@ -276,7 +276,7 @@ func (es *exportService) exportResourcesWithExporter(
 		// Get the resource
 		resource, _, svcErr := exporter.GetResourceByID(ctx, resourceID)
 		if svcErr != nil {
-			logger.Warn("Failed to get resource for export",
+			logger.WarnWithContext(ctx, "Failed to get resource for export",
 				log.String("resourceType", resourceType),
 				log.String("resourceID", resourceID),
 				log.String("error", svcErr.Error.DefaultValue))
@@ -302,14 +302,14 @@ func (es *exportService) exportResourcesWithExporter(
 
 		if options.Format == formatJSON {
 			// Convert to JSON format (could be implemented later)
-			logger.Warn("JSON format not yet implemented, falling back to YAML")
+			logger.WarnWithContext(ctx, "JSON format not yet implemented, falling back to YAML")
 			options.Format = formatYAML
 		}
 
 		templateContent, vars, err := es.generateTemplateFromStruct(
 			resource, exporter.GetParameterizerType(), validatedName, exporter)
 		if err != nil {
-			logger.Warn("Failed to generate template from struct",
+			logger.WarnWithContext(ctx, "Failed to generate template from struct",
 				log.String("resourceType", resourceType),
 				log.String("resourceID", resourceID),
 				log.String("error", err.Error()))

--- a/backend/internal/system/healthcheck/handler/healthcheckhandler.go
+++ b/backend/internal/system/healthcheck/handler/healthcheckhandler.go
@@ -44,24 +44,27 @@ func NewHealthCheckHandler(svc service.HealthCheckServiceInterface) *HealthCheck
 func (hch *HealthCheckHandler) HandleLivenessRequest(w http.ResponseWriter, r *http.Request) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckHandler"))
 	w.WriteHeader(http.StatusOK)
-	logger.Debug("Health Check Liveness response sent")
+	logger.DebugWithContext(r.Context(), "Health Check Liveness response sent")
 }
 
 // HandleReadinessRequest handles the health check readiness request.
 func (hch *HealthCheckHandler) HandleReadinessRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckHandler"))
 
 	serverstatus := hch.Service.CheckReadiness()
 
 	statusCode := http.StatusOK
 	if serverstatus.Status != model.StatusUp {
-		logger.Error("Readiness check failed", log.String("serverstatus", string(serverstatus.Status)))
+		logger.ErrorWithContext(ctx, "Readiness check failed",
+			log.String("serverstatus", string(serverstatus.Status)))
 		statusCode = http.StatusServiceUnavailable
 	} else {
-		logger.Debug("Readiness check passed", log.String("serverstatus", string(serverstatus.Status)))
+		logger.DebugWithContext(ctx, "Readiness check passed",
+			log.String("serverstatus", string(serverstatus.Status)))
 	}
 
 	sysutils.WriteSuccessResponse(w, statusCode, serverstatus)
 
-	logger.Debug("Health Check Readiness response sent")
+	logger.DebugWithContext(ctx, "Health Check Readiness response sent")
 }

--- a/backend/internal/system/i18n/mgt/handler.go
+++ b/backend/internal/system/i18n/mgt/handler.go
@@ -56,7 +56,7 @@ func (h *i18nHandler) HandleListLanguages(w http.ResponseWriter, r *http.Request
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
-	logger.Debug("Successfully retrieved languages", log.Int("count", len(localeCodes)))
+	logger.DebugWithContext(r.Context(), "Successfully retrieved languages", log.Int("count", len(localeCodes)))
 }
 
 // HandleResolveTranslationsByLanguage handles GET /i18n/languages/{language}/translations/resolve
@@ -76,7 +76,7 @@ func (h *i18nHandler) HandleResolveTranslationsByLanguage(w http.ResponseWriter,
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
-	logger.Debug("Successfully resolved translations",
+	logger.DebugWithContext(r.Context(), "Successfully resolved translations",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
 		log.Int("totalResults", resp.TotalResults))
@@ -102,7 +102,7 @@ func (h *i18nHandler) HandleSetOverrideTranslationsByLanguage(w http.ResponseWri
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
-	logger.Debug("Successfully set override translations",
+	logger.DebugWithContext(r.Context(), "Successfully set override translations",
 		log.String("language", sanitizedLanguage),
 		log.Int("totalResults", resp.TotalResults))
 }
@@ -121,7 +121,8 @@ func (h *i18nHandler) HandleClearOverrideTranslationsByLanguage(w http.ResponseW
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	logger.Debug("Successfully cleared override translations", log.String("language", sanitizedLanguage))
+	logger.DebugWithContext(r.Context(), "Successfully cleared override translations",
+		log.String("language", sanitizedLanguage))
 }
 
 // HandleResolveTranslation handles GET /i18n/languages/{language}/translations/ns/{namespace}/keys/{key}/resolve
@@ -143,7 +144,7 @@ func (h *i18nHandler) HandleResolveTranslation(w http.ResponseWriter, r *http.Re
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
-	logger.Debug("Successfully resolved translation",
+	logger.DebugWithContext(r.Context(), "Successfully resolved translation",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
 		log.String("key", sanitizedKey))
@@ -177,7 +178,7 @@ func (h *i18nHandler) HandleSetOverrideTranslation(w http.ResponseWriter, r *htt
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
-	logger.Debug("Successfully set override translation",
+	logger.DebugWithContext(r.Context(), "Successfully set override translation",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
 		log.String("key", sanitizedKey))
@@ -203,7 +204,7 @@ func (h *i18nHandler) HandleClearOverrideTranslation(w http.ResponseWriter, r *h
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	logger.Debug("Successfully cleared override translation",
+	logger.DebugWithContext(r.Context(), "Successfully cleared override translation",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
 		log.String("key", sanitizedKey))

--- a/backend/internal/system/i18n/mgt/service.go
+++ b/backend/internal/system/i18n/mgt/service.go
@@ -213,7 +213,7 @@ func (s *i18nService) SetTranslationOverridesForNamespace(
 		return nil
 	}
 	if err := s.store.UpsertTranslations(ctx, translations); err != nil {
-		s.logger.Error("Failed to set translation overrides for namespace", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to set translation overrides for namespace", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil
@@ -400,7 +400,7 @@ func (s *i18nService) DeleteTranslationsByKey(
 		return &ErrorInvalidKey
 	}
 	if err := s.store.DeleteTranslationsByKey(ctx, namespace, key); err != nil {
-		s.logger.Error("Failed to delete translations by namespace and key", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to delete translations by namespace and key", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil
@@ -414,7 +414,7 @@ func (s *i18nService) DeleteTranslationsByNamespace(
 		return &ErrorInvalidNamespace
 	}
 	if err := s.store.DeleteTranslationsByNamespace(ctx, namespace); err != nil {
-		s.logger.Error("Failed to delete translations by namespace", log.Error(err))
+		s.logger.ErrorWithContext(ctx, "Failed to delete translations by namespace", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil

--- a/backend/internal/system/importer/service_adapters.go
+++ b/backend/internal/system/importer/service_adapters.go
@@ -49,7 +49,7 @@ func (s *importService) resolveImportOUHandle(
 ) (string, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ImportService"))
 	if ouID != "" && ouHandle != "" {
-		logger.Warn("Both ou_id and ou_handle provided; ou_handle ignored",
+		logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided; ou_handle ignored",
 			log.String("resourceType", resourceType),
 			log.String("resourceID", resourceID),
 			log.String("resourceName", resourceName))

--- a/backend/internal/system/jose/jwe/service.go
+++ b/backend/internal/system/jose/jwe/service.go
@@ -141,7 +141,7 @@ func (js *jweService) Encrypt(payload []byte, recipientPublicKey crypto.PublicKe
 func (js *jweService) Decrypt(ctx context.Context, jweToken string) ([]byte, *serviceerror.ServiceError) {
 	header, headerBase64, encryptedKey, iv, ciphertext, tag, err := DecodeJWE(jweToken)
 	if err != nil {
-		js.logger.Debug("Failed to decode JWE: " + err.Error())
+		js.logger.DebugWithContext(ctx, "Failed to decode JWE: "+err.Error())
 		return nil, &ErrorDecodingJWE
 	}
 
@@ -160,21 +160,21 @@ func (js *jweService) Decrypt(ctx context.Context, jweToken string) ([]byte, *se
 	// Build cryptolib params for CEK decryption using the server's key.
 	params, paramsErr := buildDecryptParams(alg, enc, header)
 	if paramsErr != nil {
-		js.logger.Debug("Failed to build decrypt params: " + paramsErr.Error())
+		js.logger.DebugWithContext(ctx, "Failed to build decrypt params: "+paramsErr.Error())
 		return nil, &ErrorUnsupportedJWEAlgorithm
 	}
 
 	// Decrypt CEK via the runtime crypto provider (uses server's private key).
 	cek, err := js.cryptoProvider.Decrypt(ctx, &js.keyRef, params, encryptedKey)
 	if err != nil {
-		js.logger.Error("Failed to decrypt CEK: " + err.Error())
+		js.logger.ErrorWithContext(ctx, "Failed to decrypt CEK: "+err.Error())
 		return nil, &ErrorJWEDecryptionFailed
 	}
 
 	// Decrypt content.
 	payload, err := decryptContent(ciphertext, iv, tag, cek, enc, []byte(headerBase64))
 	if err != nil {
-		js.logger.Error("Failed to decrypt content: " + err.Error())
+		js.logger.ErrorWithContext(ctx, "Failed to decrypt content: "+err.Error())
 		return nil, &ErrorJWEDecryptionFailed
 	}
 

--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -124,21 +124,21 @@ func (js *jwtService) GenerateJWT(
 		jwsAlg = jws.Algorithm(alg)
 	}
 	if js.cryptoProvider == nil {
-		js.logger.Error("Crypto provider not initialized for JWT generation")
+		js.logger.ErrorWithContext(ctx, "Crypto provider not initialized for JWT generation")
 		return "", 0, &serviceerror.InternalServerError
 	}
 
 	// Validate that claims["aud"] is present and of an accepted type.
 	audValue, hasAud := claims["aud"]
 	if !hasAud {
-		js.logger.Error("GenerateJWT called without aud in claims")
+		js.logger.ErrorWithContext(ctx, "GenerateJWT called without aud in claims")
 		return "", 0, &serviceerror.InternalServerError
 	}
 	switch audValue.(type) {
 	case string, []string:
 		// valid
 	default:
-		js.logger.Error("GenerateJWT called with unsupported aud type in claims")
+		js.logger.ErrorWithContext(ctx, "GenerateJWT called with unsupported aud type in claims")
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -156,7 +156,7 @@ func (js *jwtService) GenerateJWT(
 
 	headerJSON, err := json.Marshal(header)
 	if err != nil {
-		js.logger.Error("Failed to marshal JWT header: " + err.Error())
+		js.logger.ErrorWithContext(ctx, "Failed to marshal JWT header: "+err.Error())
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -174,7 +174,7 @@ func (js *jwtService) GenerateJWT(
 
 	jti, err := utils.GenerateUUIDv7()
 	if err != nil {
-		js.logger.Error("Failed to generate UUID", log.Error(err))
+		js.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -197,7 +197,7 @@ func (js *jwtService) GenerateJWT(
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		js.logger.Error("Failed to marshal JWT payload: " + err.Error())
+		js.logger.ErrorWithContext(ctx, "Failed to marshal JWT payload: "+err.Error())
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -209,7 +209,7 @@ func (js *jwtService) GenerateJWT(
 	signingInput := headerBase64 + "." + payloadBase64
 	signature, err := js.cryptoProvider.Sign(ctx, js.keyRef, js.signAlg, []byte(signingInput))
 	if err != nil {
-		js.logger.Error("Failed to sign JWT: " + err.Error())
+		js.logger.ErrorWithContext(ctx, "Failed to sign JWT: "+err.Error())
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -224,7 +224,7 @@ func (js *jwtService) VerifyJWT(
 	ctx context.Context, jwtToken string, expectedAud, expectedIss string,
 ) *serviceerror.ServiceError {
 	if js.cryptoProvider == nil {
-		js.logger.Error("Crypto provider not initialized for JWT verification")
+		js.logger.ErrorWithContext(ctx, "Crypto provider not initialized for JWT verification")
 		return &serviceerror.InternalServerError
 	}
 
@@ -270,7 +270,7 @@ func (js *jwtService) VerifyJWTWithJWKS(
 // VerifyJWTSignature verifies the signature of a JWT token using the server's public key.
 func (js *jwtService) VerifyJWTSignature(ctx context.Context, jwtToken string) *serviceerror.ServiceError {
 	if js.cryptoProvider == nil {
-		js.logger.Error("Crypto provider not initialized for JWT verification")
+		js.logger.ErrorWithContext(ctx, "Crypto provider not initialized for JWT verification")
 		return &serviceerror.InternalServerError
 	}
 	parts := strings.Split(jwtToken, ".")
@@ -302,7 +302,7 @@ func (js *jwtService) VerifyJWTSignature(ctx context.Context, jwtToken string) *
 	// Retrieve all public keys from the provider and match by thumbprint
 	keys, providerErr := js.cryptoProvider.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
 	if providerErr != nil {
-		js.logger.Error("Failed to retrieve public keys for JWT verification: " + providerErr.Error())
+		js.logger.ErrorWithContext(ctx, "Failed to retrieve public keys for JWT verification: "+providerErr.Error())
 		return &serviceerror.InternalServerError
 	}
 	var matchedKey *kmprovider.PublicKeyInfo

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
@@ -119,7 +119,7 @@ func (s *runtimeCryptoService) Decrypt(
 }
 
 func (s *runtimeCryptoService) Sign(
-	_ context.Context, keyRef kmprovider.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte,
+	ctx context.Context, keyRef kmprovider.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte,
 ) ([]byte, error) {
 	if s.pkiService == nil {
 		return nil, errors.New("PKI service not initialized")
@@ -133,7 +133,7 @@ func (s *runtimeCryptoService) Sign(
 }
 
 func (s *runtimeCryptoService) GetPublicKeys(
-	_ context.Context, filter kmprovider.PublicKeyFilter,
+	ctx context.Context, filter kmprovider.PublicKeyFilter,
 ) ([]kmprovider.PublicKeyInfo, error) {
 	if s.pkiService == nil {
 		return nil, errors.New("PKI service not initialized")
@@ -160,7 +160,7 @@ func (s *runtimeCryptoService) GetPublicKeys(
 			case "P-521":
 				alg = cryptolib.AlgorithmES512
 			default:
-				s.logger.Warn("Unsupported EC curve; skipping",
+				s.logger.WarnWithContext(ctx, "Unsupported EC curve; skipping",
 					log.String("keyID", id),
 					log.String("curve", pub.Curve.Params().Name))
 				continue
@@ -168,7 +168,7 @@ func (s *runtimeCryptoService) GetPublicKeys(
 		case ed25519.PublicKey:
 			alg = cryptolib.AlgorithmEdDSA
 		default:
-			s.logger.Debug("Unsupported public key type; skipping", log.String("keyID", id))
+			s.logger.DebugWithContext(ctx, "Unsupported public key type; skipping", log.String("keyID", id))
 			continue
 		}
 
@@ -193,7 +193,7 @@ func (s *runtimeCryptoService) GetPublicKeys(
 }
 
 func (s *runtimeCryptoService) GetTLSMaterial(
-	_ context.Context,
+	ctx context.Context,
 ) (*kmprovider.TLSMaterial, error) {
 	if s.pkiService == nil {
 		return nil, errors.New("PKI service not initialized")

--- a/backend/internal/system/security/service.go
+++ b/backend/internal/system/security/service.go
@@ -202,7 +202,7 @@ func (s *securityService) handleAuthError(
 	}
 
 	if skipSecurity {
-		s.logger.Debug(
+		s.logger.DebugWithContext(ctx,
 			"Proceeding without authentication/authorization enforcement as skipSecurity is enabled",
 			log.Error(err),
 			log.String("path", path))

--- a/backend/internal/system/sysauthz/service.go
+++ b/backend/internal/system/sysauthz/service.go
@@ -95,14 +95,14 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 
 	// Step 1: Check if SKIP_SECURITY flag is set.
 	if security.IsSecuritySkipped(ctx) {
-		logger.Debug("Authorization skipped: SKIP_SECURITY is enabled",
+		logger.DebugWithContext(ctx, "Authorization skipped: SKIP_SECURITY is enabled",
 			log.String("action", string(action)))
 		return true, nil
 	}
 
 	// Step 2: Check if this is an internal runtime caller.
 	if security.IsRuntimeContext(ctx) {
-		logger.Debug("Authorization granted: runtime context for the action",
+		logger.DebugWithContext(ctx, "Authorization granted: runtime context for the action",
 			log.String("action", string(action)))
 		return true, nil
 	}
@@ -110,7 +110,7 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 	// Step 3: Verify the caller is authenticated.
 	subject := security.GetSubject(ctx)
 	if subject == "" {
-		logger.Debug("Authorization denied: unauthenticated caller",
+		logger.DebugWithContext(ctx, "Authorization denied: unauthenticated caller",
 			log.String("action", string(action)))
 		return false, nil
 	}
@@ -125,7 +125,7 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 	// Step 5: Allow resource owners to access their own resources (self-service).
 	if isResourceOwner(ctx, actionCtx) {
 		if logger.IsDebugEnabled() {
-			logger.Debug("Authorization granted: resource owner",
+			logger.DebugWithContext(ctx, "Authorization granted: resource owner",
 				log.String("action", string(action)),
 				log.MaskedString("subject", subject))
 		}
@@ -136,7 +136,7 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 	requiredPermission := security.ResolveActionPermission(action)
 	if !security.HasSufficientPermission(permissions, requiredPermission) {
 		if logger.IsDebugEnabled() {
-			logger.Debug("Authorization denied: insufficient permissions",
+			logger.DebugWithContext(ctx, "Authorization denied: insufficient permissions",
 				log.String("action", string(action)),
 				log.MaskedString("subject", subject))
 		}
@@ -150,7 +150,7 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 	}
 	if !allowed {
 		if logger.IsDebugEnabled() {
-			logger.Debug("Authorization denied: policy evaluation failed",
+			logger.DebugWithContext(ctx, "Authorization denied: policy evaluation failed",
 				log.String("action", string(action)),
 				log.MaskedString("subject", subject))
 		}
@@ -158,7 +158,7 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 	}
 
 	if logger.IsDebugEnabled() {
-		logger.Debug("Authorization granted",
+		logger.DebugWithContext(ctx, "Authorization granted",
 			log.String("action", string(action)),
 			log.MaskedString("subject", subject))
 	}
@@ -195,7 +195,7 @@ func (s *systemAuthorizationService) GetAccessibleResources(ctx context.Context,
 
 	// Step 1: Check if SKIP_SECURITY flag is set.
 	if security.IsSecuritySkipped(ctx) {
-		logger.Debug("GetAccessibleResources skipped: SKIP_SECURITY is enabled",
+		logger.DebugWithContext(ctx, "GetAccessibleResources skipped: SKIP_SECURITY is enabled",
 			log.String("action", string(action)),
 			log.String("resourceType", string(resourceType)))
 		return &AccessibleResources{AllAllowed: true}, nil
@@ -203,7 +203,7 @@ func (s *systemAuthorizationService) GetAccessibleResources(ctx context.Context,
 
 	// Step 2: Check if this is an internal runtime caller — return all resources.
 	if security.IsRuntimeContext(ctx) {
-		logger.Debug("GetAccessibleResources: runtime context, returning all resources",
+		logger.DebugWithContext(ctx, "GetAccessibleResources: runtime context, returning all resources",
 			log.String("action", string(action)),
 			log.String("resourceType", string(resourceType)))
 		return &AccessibleResources{AllAllowed: true}, nil
@@ -212,7 +212,7 @@ func (s *systemAuthorizationService) GetAccessibleResources(ctx context.Context,
 	// Step 3: Verify the caller is authenticated.
 	subject := security.GetSubject(ctx)
 	if subject == "" {
-		logger.Debug("GetAccessibleResources denied: unauthenticated caller",
+		logger.DebugWithContext(ctx, "GetAccessibleResources denied: unauthenticated caller",
 			log.String("action", string(action)),
 			log.String("resourceType", string(resourceType)))
 		return &AccessibleResources{AllAllowed: false, IDs: []string{}}, nil
@@ -229,7 +229,7 @@ func (s *systemAuthorizationService) GetAccessibleResources(ctx context.Context,
 	requiredPermission := security.ResolveActionPermission(action)
 	if !security.HasSufficientPermission(permissions, requiredPermission) {
 		if logger.IsDebugEnabled() {
-			logger.Debug("GetAccessibleResources denied: insufficient permissions",
+			logger.DebugWithContext(ctx, "GetAccessibleResources denied: insufficient permissions",
 				log.String("action", string(action)),
 				log.String("resourceType", string(resourceType)),
 				log.MaskedString("subject", subject))
@@ -243,7 +243,7 @@ func (s *systemAuthorizationService) GetAccessibleResources(ctx context.Context,
 		return nil, svcErr
 	}
 	if logger.IsDebugEnabled() && !result.AllAllowed {
-		logger.Debug("GetAccessibleResources: restricted by policy",
+		logger.DebugWithContext(ctx, "GetAccessibleResources: restricted by policy",
 			log.String("action", string(action)),
 			log.String("resourceType", string(resourceType)),
 			log.MaskedString("subject", subject),

--- a/backend/internal/system/template/service.go
+++ b/backend/internal/system/template/service.go
@@ -49,7 +49,7 @@ func (s *templateService) GetTemplateByScenario(
 	scenario ScenarioType,
 	tmplType TemplateType,
 ) (*TemplateDTO, *serviceerror.ServiceError) {
-	s.logger.Debug("Retrieving template by scenario and type",
+	s.logger.DebugWithContext(ctx, "Retrieving template by scenario and type",
 		log.String("scenario", string(scenario)),
 		log.String("type", string(tmplType)))
 	tmpl, err := s.store.GetTemplateByScenario(ctx, scenario, tmplType)
@@ -57,7 +57,7 @@ func (s *templateService) GetTemplateByScenario(
 		if errors.Is(err, errTemplateNotFound) {
 			return nil, &ErrorTemplateNotFound
 		}
-		s.logger.Error("Failed to retrieve template by scenario",
+		s.logger.ErrorWithContext(ctx, "Failed to retrieve template by scenario",
 			log.String("scenario", string(scenario)),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -73,7 +73,7 @@ func (s *templateService) Render(
 	tmplType TemplateType,
 	data TemplateData,
 ) (*RenderedTemplate, *serviceerror.ServiceError) {
-	s.logger.Debug("Rendering template", log.String("scenario", string(scenario)))
+	s.logger.DebugWithContext(ctx, "Rendering template", log.String("scenario", string(scenario)))
 	tmpl, svcErr := s.GetTemplateByScenario(ctx, scenario, tmplType)
 	if svcErr != nil {
 		return nil, svcErr
@@ -100,12 +100,13 @@ func (s *templateService) Render(
 		IsHTML:  tmpl.ContentType == "text/html",
 	}
 
-	s.logger.Debug("Template rendered successfully",
+	s.logger.DebugWithContext(ctx, "Template rendered successfully",
 		log.String("scenario", string(scenario)),
 		log.String("templateID", tmpl.ID))
 
 	if tmpl.Type == TemplateTypeSMS && len(rendered.Body) > 160 {
-		s.logger.Warn("Rendered SMS body exceeds 160 characters; message may be split into multiple segments",
+		s.logger.WarnWithContext(ctx,
+			"Rendered SMS body exceeds 160 characters; message may be split into multiple segments",
 			log.Int("length", len(rendered.Body)))
 	}
 

--- a/backend/internal/user/display_util.go
+++ b/backend/internal/user/display_util.go
@@ -45,7 +45,7 @@ func ResolveDisplayAttributePaths(
 	displayPaths, svcErr := schemaService.GetDisplayAttributesByNames(ctx, entitytype.TypeCategoryUser, uniqueTypes)
 	if svcErr != nil {
 		if logger != nil {
-			logger.Warn("Failed to resolve display attribute paths, skipping display resolution",
+			logger.WarnWithContext(ctx, "Failed to resolve display attribute paths, skipping display resolution",
 				log.Any("error", svcErr))
 		}
 		return nil

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -82,7 +82,7 @@ func (uh *userHandler) HandleUserListRequest(w http.ResponseWriter, r *http.Requ
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, userListResponse)
 
-	logger.Debug("Successfully listed users with pagination",
+	logger.DebugWithContext(ctx, "Successfully listed users with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", userListResponse.TotalResults),
 		log.Int("count", userListResponse.Count),
@@ -121,7 +121,7 @@ func (uh *userHandler) HandleUserPostRequest(w http.ResponseWriter, r *http.Requ
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdUser)
 
 	// Log the user creation response.
-	logger.Debug("User POST response sent", log.MaskedString(log.LoggerKeyUserID, createdUser.ID))
+	logger.DebugWithContext(ctx, "User POST response sent", log.MaskedString(log.LoggerKeyUserID, createdUser.ID))
 }
 
 // HandleUserGetRequest handles the user request.
@@ -153,7 +153,7 @@ func (uh *userHandler) HandleUserGetRequest(w http.ResponseWriter, r *http.Reque
 	sysutils.WriteSuccessResponse(w, http.StatusOK, user)
 
 	// Log the user response.
-	logger.Debug("User GET response sent", log.MaskedString(log.LoggerKeyUserID, id))
+	logger.DebugWithContext(ctx, "User GET response sent", log.MaskedString(log.LoggerKeyUserID, id))
 }
 
 // HandleUserGroupsGetRequest handles the get user groups request.
@@ -185,7 +185,7 @@ func (ah *userHandler) HandleUserGroupsGetRequest(w http.ResponseWriter, r *http
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, groupListResponse)
 
-	logger.Debug("Successfully retrieved user groups", log.MaskedString(log.LoggerKeyUserID, id),
+	logger.DebugWithContext(ctx, "Successfully retrieved user groups", log.MaskedString(log.LoggerKeyUserID, id),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", groupListResponse.TotalResults),
 		log.Int("count", groupListResponse.Count))
@@ -229,7 +229,7 @@ func (uh *userHandler) HandleUserPutRequest(w http.ResponseWriter, r *http.Reque
 	sysutils.WriteSuccessResponse(w, http.StatusOK, user)
 
 	// Log the user response.
-	logger.Debug("User PUT response sent", log.MaskedString(log.LoggerKeyUserID, id))
+	logger.DebugWithContext(ctx, "User PUT response sent", log.MaskedString(log.LoggerKeyUserID, id))
 }
 
 // HandleUserDeleteRequest handles the delete user request.
@@ -258,7 +258,7 @@ func (uh *userHandler) HandleUserDeleteRequest(w http.ResponseWriter, r *http.Re
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
 
 	// Log the user response.
-	logger.Debug("User DELETE response sent", log.MaskedString(log.LoggerKeyUserID, id))
+	logger.DebugWithContext(ctx, "User DELETE response sent", log.MaskedString(log.LoggerKeyUserID, id))
 }
 
 // HandleUserListByPathRequest handles the list users by OU path request.
@@ -298,7 +298,7 @@ func (uh *userHandler) HandleUserListByPathRequest(w http.ResponseWriter, r *htt
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, userListResponse)
 
-	logger.Debug("Successfully listed users by path", log.String("path", path),
+	logger.DebugWithContext(ctx, "Successfully listed users by path", log.String("path", path),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", userListResponse.TotalResults),
 		log.Int("count", userListResponse.Count),
@@ -337,7 +337,8 @@ func (uh *userHandler) HandleUserPostByPathRequest(w http.ResponseWriter, r *htt
 
 	sysutils.WriteSuccessResponse(w, http.StatusCreated, user)
 
-	logger.Debug("Successfully created user by path", log.String("path", path), log.String("userType", user.Type))
+	logger.DebugWithContext(ctx, "Successfully created user by path",
+		log.String("path", path), log.String("userType", user.Type))
 }
 
 // HandleSelfUserGetRequest handles the self user retrieval.
@@ -362,7 +363,7 @@ func (uh *userHandler) HandleSelfUserGetRequest(w http.ResponseWriter, r *http.R
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, user)
 
-	logger.Debug("Self user GET response sent", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Self user GET response sent", log.MaskedString(log.LoggerKeyUserID, userID))
 }
 
 // HandleSelfUserPutRequest handles the self user update.
@@ -395,7 +396,7 @@ func (uh *userHandler) HandleSelfUserPutRequest(w http.ResponseWriter, r *http.R
 
 	sysutils.WriteSuccessResponse(w, http.StatusOK, updatedUser)
 
-	logger.Debug("Self user PUT response sent", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Self user PUT response sent", log.MaskedString(log.LoggerKeyUserID, userID))
 }
 
 // HandleSelfUserCredentialUpdateRequest handles the credential update for the authenticated user.
@@ -426,7 +427,8 @@ func (uh *userHandler) HandleSelfUserCredentialUpdateRequest(w http.ResponseWrit
 	}
 
 	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
-	logger.Debug("Self user credential update response sent", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Self user credential update response sent",
+		log.MaskedString(log.LoggerKeyUserID, userID))
 }
 
 // parsePaginationParams parses limit and offset query parameters from the request.

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -99,7 +99,8 @@ func (us *userService) GetUserList(ctx context.Context, limit, offset int,
 	accessible, svcErr := us.authzService.GetAccessibleResources(
 		ctx, security.ActionListUsers, security.ResourceTypeOU)
 	if svcErr != nil {
-		logger.Error("Failed to resolve accessible resources for listing users", log.Any("error", svcErr))
+		logger.ErrorWithContext(ctx, "Failed to resolve accessible resources for listing users",
+			log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -184,7 +185,7 @@ func (us *userService) GetUsersByPath(
 	includeDisplay bool,
 ) (*UserListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Getting users by path", log.String("path", handlePath))
+	logger.DebugWithContext(ctx, "Getting users by path", log.String("path", handlePath))
 
 	serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -244,7 +245,8 @@ func (us *userService) GetUsersByPath(
 		}
 		fetchedEntities, err := us.entityService.GetEntitiesByIDs(ctx, userIDs)
 		if err != nil {
-			logger.Warn("Failed to batch fetch users for display names, skipping display resolution", log.Error(err))
+			logger.WarnWithContext(ctx, "Failed to batch fetch users for display names, skipping display resolution",
+				log.Error(err))
 			// Fall back to bare IDs without display — partial display is worse than none.
 			users = make([]User, len(ouResponse.Users))
 			for i, ouUser := range ouResponse.Users {
@@ -320,7 +322,7 @@ func (us *userService) CreateUser(ctx context.Context, user *User) (*User, *serv
 	if user.ID == "" {
 		user.ID, err = us.uuidGenerator()
 		if err != nil {
-			logger.Error("Failed to generate UUID", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -337,7 +339,7 @@ func (us *userService) CreateUser(ctx context.Context, user *User) (*User, *serv
 	// Sync cleaned attributes back — entity service removed credential fields from Attributes.
 	user.Attributes = created.Attributes
 
-	logger.Debug("Successfully created user", log.MaskedString(log.LoggerKeyUserID, user.ID))
+	logger.DebugWithContext(ctx, "Successfully created user", log.MaskedString(log.LoggerKeyUserID, user.ID))
 	return user, nil
 }
 
@@ -346,7 +348,8 @@ func (us *userService) CreateUserByPath(
 	ctx context.Context, handlePath string, request CreateUserByPathRequest,
 ) (*User, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Creating user by path", log.String("path", handlePath), log.String("type", request.Type))
+	logger.DebugWithContext(ctx, "Creating user by path",
+		log.String("path", handlePath), log.String("type", request.Type))
 
 	serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -381,7 +384,7 @@ func (us *userService) GetUser(
 	ctx context.Context, userID string, includeDisplay bool,
 ) (*User, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Retrieving user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Retrieving user", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	if userID == "" {
 		return nil, &ErrorMissingUserID
@@ -390,7 +393,7 @@ func (us *userService) GetUser(
 	e, err := us.entityService.GetEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.Debug("User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
 		return nil, logErrorAndReturnServerError(logger, "Failed to retrieve user", err,
@@ -414,14 +417,14 @@ func (us *userService) GetUser(
 
 		handleMap, svcErr := us.ouService.GetOrganizationUnitHandlesByIDs(ctx, []string{user.OUID})
 		if svcErr != nil {
-			logger.Warn("Failed to resolve OU handle for user, skipping",
+			logger.WarnWithContext(ctx, "Failed to resolve OU handle for user, skipping",
 				log.Any("error", svcErr))
 		} else if handle, ok := handleMap[user.OUID]; ok {
 			user.OUHandle = handle
 		}
 	}
 
-	logger.Debug("Successfully retrieved user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Successfully retrieved user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return &user, nil
 }
 
@@ -442,7 +445,7 @@ func (as *userService) GetUserGroups(ctx context.Context, userID string, limit, 
 	userEntity, err := as.entityService.GetEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.Debug("User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
 		return nil, logErrorAndReturnServerError(logger, "Failed to retrieve user", err,
@@ -460,14 +463,15 @@ func (as *userService) GetUserGroups(ctx context.Context, userID string, limit, 
 
 	totalCount, err := as.entityService.GetGroupCountForEntity(ctx, userID)
 	if err != nil {
-		logger.Error("Failed to get group count for user",
+		logger.ErrorWithContext(ctx, "Failed to get group count for user",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	entityGroups, err := as.entityService.GetEntityGroups(ctx, userID, limit, offset)
 	if err != nil {
-		logger.Error("Failed to get user groups", log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get user groups",
+			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	path := fmt.Sprintf("/users/%s/groups", userID)
@@ -488,7 +492,7 @@ func (as *userService) GetUserGroups(ctx context.Context, userID string, limit, 
 func (us *userService) UpdateUser(
 	ctx context.Context, userID string, user *User) (*User, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Updating user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Updating user", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	if userID == "" {
 		return nil, &ErrorMissingUserID
@@ -502,7 +506,7 @@ func (us *userService) UpdateUser(
 	existingEntity, err := us.entityService.GetEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.Debug("User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
 		return nil, logErrorAndReturnServerError(logger, "Failed to retrieve user", err,
@@ -554,7 +558,7 @@ func (us *userService) UpdateUser(
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
-	logger.Debug("Successfully updated user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Successfully updated user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return user, nil
 }
 
@@ -563,7 +567,7 @@ func (us *userService) UpdateUserAttributes(
 	ctx context.Context, userID string, attributes json.RawMessage,
 ) (*User, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Updating user attributes", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Updating user attributes", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	if strings.TrimSpace(userID) == "" {
 		return nil, &ErrorMissingUserID
@@ -577,7 +581,7 @@ func (us *userService) UpdateUserAttributes(
 	existingEntity, getErr := us.entityService.GetEntity(ctx, userID)
 	if getErr != nil {
 		if errors.Is(getErr, entity.ErrEntityNotFound) {
-			logger.Debug("User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
 		return nil, logErrorAndReturnServerError(logger, "Failed to get user", getErr,
@@ -591,7 +595,7 @@ func (us *userService) UpdateUserAttributes(
 	// Reject credential fields here: this endpoint is for attribute updates only.
 	// Credentials must go through UpdateUserCredentials, which enforces its own authz and validation.
 	if us.entityTypeService == nil {
-		logger.Error("Entity type service is not configured for user operations")
+		logger.ErrorWithContext(ctx, "Entity type service is not configured for user operations")
 		return nil, &serviceerror.InternalServerError
 	}
 	schemaCredentialInfos, svcErr := us.entityTypeService.GetAttributes(ctx,
@@ -637,7 +641,7 @@ func (us *userService) UpdateUserAttributes(
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
-	logger.Debug("Successfully updated user attributes", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Successfully updated user attributes", log.MaskedString(log.LoggerKeyUserID, userID))
 	return &existingUser, nil
 }
 
@@ -648,7 +652,7 @@ func (us *userService) UpdateUserCredentials(
 	credentials json.RawMessage,
 ) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Updating user credentials", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Updating user credentials", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	if strings.TrimSpace(userID) == "" {
 		return &ErrorAuthenticationFailed
@@ -661,7 +665,7 @@ func (us *userService) UpdateUserCredentials(
 	// Parse credentials to extract credential types
 	var credentialsMap map[string]json.RawMessage
 	if err := json.Unmarshal(credentials, &credentialsMap); err != nil {
-		logger.Debug("Failed to parse credentials", log.Error(err))
+		logger.DebugWithContext(ctx, "Failed to parse credentials", log.Error(err))
 		return &ErrorInvalidRequestFormat
 	}
 
@@ -673,7 +677,7 @@ func (us *userService) UpdateUserCredentials(
 	existingEntity, err := us.entityService.GetEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.Debug("User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return &ErrorUserNotFound
 		}
 		return logErrorAndReturnServerError(logger, "Failed to retrieve user", err,
@@ -722,7 +726,7 @@ func (us *userService) UpdateUserCredentials(
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
-	logger.Debug("Successfully updated user credentials",
+	logger.DebugWithContext(ctx, "Successfully updated user credentials",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.Int("credentialTypesCount", len(credentialsMap)))
 	return nil
@@ -731,7 +735,7 @@ func (us *userService) UpdateUserCredentials(
 // DeleteUser delete the user for given user id.
 func (us *userService) DeleteUser(ctx context.Context, userID string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Debug("Deleting user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Deleting user", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	if userID == "" {
 		return &ErrorMissingUserID
@@ -741,7 +745,7 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *serviceer
 	existingEntity, err := us.entityService.GetEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.Debug("User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return &ErrorUserNotFound
 		}
 		return logErrorAndReturnServerError(logger, "Failed to retrieve user", err,
@@ -766,14 +770,14 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *serviceer
 	err = us.entityService.DeleteEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.Debug("User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return &ErrorUserNotFound
 		}
 		return logErrorAndReturnServerError(logger, "Failed to delete user", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
-	logger.Debug("Successfully deleted user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.DebugWithContext(ctx, "Successfully deleted user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return nil
 }
 
@@ -810,7 +814,7 @@ func (us *userService) populateOUHandles(ctx context.Context, users []User, logg
 
 	handleMap, svcErr := us.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
 	if svcErr != nil {
-		logger.Warn("Failed to resolve OU handles, skipping", log.Any("error", svcErr))
+		logger.WarnWithContext(ctx, "Failed to resolve OU handles, skipping", log.Any("error", svcErr))
 		return
 	}
 
@@ -834,7 +838,7 @@ func (us *userService) validateOrganizationUnitForUserType(
 	}
 
 	if us.ouService == nil {
-		logger.Error("Organization unit service is not configured for user operations")
+		logger.ErrorWithContext(ctx, "Organization unit service is not configured for user operations")
 		return &serviceerror.InternalServerError
 	}
 
@@ -857,7 +861,7 @@ func (us *userService) validateOrganizationUnitForUserType(
 	}
 
 	if us.entityTypeService == nil {
-		logger.Error("Entity type service is not configured for user operations")
+		logger.ErrorWithContext(ctx, "Entity type service is not configured for user operations")
 		return &serviceerror.InternalServerError
 	}
 
@@ -867,13 +871,13 @@ func (us *userService) validateOrganizationUnitForUserType(
 		if svcErr.Code == entitytype.ErrorEntityTypeNotFound.Code {
 			return &ErrorEntityTypeNotFound
 		}
-		logger.Error("Failed to retrieve user type",
+		logger.ErrorWithContext(ctx, "Failed to retrieve user type",
 			log.String("userType", userType), log.Any("error", svcErr))
 		return &serviceerror.InternalServerError
 	}
 
 	if entityType == nil {
-		logger.Error("Entity type service returned nil response", log.String("userType", userType))
+		logger.ErrorWithContext(ctx, "Entity type service returned nil response", log.String("userType", userType))
 		return &serviceerror.InternalServerError
 	}
 
@@ -897,7 +901,7 @@ func (us *userService) validateOrganizationUnitForUserType(
 	}
 
 	if !isParent {
-		logger.Debug("Organization unit mismatch for user type",
+		logger.DebugWithContext(ctx, "Organization unit mismatch for user type",
 			log.String("userType", userType),
 			log.String("oUID", oUID),
 			log.String("schemaOUID", entityType.OUID))
@@ -1009,7 +1013,7 @@ func (us *userService) checkUserDeclarative(
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return &ErrorUserNotFound
 		}
-		logger.Error("Failed to check if user is declarative",
+		logger.ErrorWithContext(ctx, "Failed to check if user is declarative",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
@@ -1028,7 +1032,7 @@ func (us *userService) checkUserAccess(
 	allowed, svcErr := us.authzService.IsActionAllowed(ctx, action,
 		&sysauthz.ActionContext{ResourceType: security.ResourceTypeUser, OUID: ouID, ResourceID: resourceID})
 	if svcErr != nil {
-		logger.Error("Failed to check authorization for action",
+		logger.ErrorWithContext(ctx, "Failed to check authorization for action",
 			log.String("action", string(action)), log.Any("error", svcErr))
 		return &serviceerror.InternalServerError
 	}
@@ -1052,7 +1056,7 @@ func (us *userService) ResolveUserOUHandle(
 ) *serviceerror.ServiceError {
 	if user.OUID != "" && user.OUHandle != "" {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-		logger.Warn("Both ou_id and ou_handle provided for user; ou_handle ignored",
+		logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided for user; ou_handle ignored",
 			log.MaskedString(log.LoggerKeyUserID, user.ID))
 		return nil
 	}


### PR DESCRIPTION
### Purpose
Second step of the correlation ID logging migration (Refs #2038, follows #3141), mechanically migrating 1,412 log call sites across 131 files from deprecated non-context logging methods to context-aware *WithContext variants so log entries include request trace IDs (correlation IDs), with no behavioral changes or function signature modifications beyond cosmetic parameter renames.

**Log Example with Correlation ID**
```
time=2026-06-05T14:40:47.226+05:30 level=ERROR msg="Failed to load new flow context" component=FlowExecService appID=019e9707-fd20-7d0c-b93e-842823017101 flowType=LOGIN error="Invalid request" trace_id=9b2b6438-6503-4306-a19c-c4941d4165cb
time=2026-06-05T14:40:47.226+05:30 level=INFO msg="127.0.0.1 - - [05/Jun/2026:14:40:47 +0530] POST /flow/execute HTTP/1.1 400 248 1 9b2b6438-6503-4306-a19c-c4941d4165cb"
```

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

Call sites were classified by the context source available in the enclosing function and rewritten accordingly:

  | Context source in scope | Rewrite |
  |---|---|
  | `ctx context.Context` parameter (any name) | `logger.ErrorWithContext(ctx, ...)` |
  | `*core.NodeContext` / `*flowexec.EngineContext` parameter (both embed `Context context.Context`) | `logger.ErrorWithContext(ctx.Context, ...)` |
  | `*http.Request` parameter | existing `ctx := r.Context()` local, or `r.Context()` |

Deliberate decisions reviewers will notice:

  - **`_ context.Context` → `ctx context.Context`** in a few methods (`system/cache/inmemorycache.go`, `kmprovider/defaultkm/runtime_crypto_provider.go`): these methods receive the request context but previously ignored it; the log calls inside them are exactly what it is for. Parameter rename only — no interface or caller impact.
  - **Three `context.Background()` sites in `oauth/oauth2/authz/handler.go`**, each with a justification comment: they sit inside `r == nil` guards, so there is no request context to propagate. (Caught by `TestGetOAuthMessage_NilRequest` during verification.)
  - **`//nolint:dupl` on the OAuth/OIDC executors' `Execute` methods**: the two bodies are intentionally parallel implementations that were already token-identical; the longer method names pushed them over the `dupl` threshold. Annotated with reasons, following existing repo precedent (`system/importer/service_adapters.go`).

**Not migrated (intentional, ~473 calls remain on the deprecated methods, suppressed by the temporary SA1019 exclude-rule from #3141):** call sites with no context source in scope. These need non-mechanical changes and will be migrated one package per follow-up PR:

  - Service interfaces missing `ctx` entirely (`design/theme`, `design/layout`, `system/i18n`, `system/jose`, `system/kmprovider/pki`, `authn/oauth`) — signature ripples + `make mockery`.
  - Private helpers that need a `ctx` parameter added(`authn/passkey/store`, `consent/default_client`, `flow/mgt/inference`,`flow/mgt/graph_builder`, and others).
  - `system/observability` — events are processed asynchronously; correlation is event-carried (`event.Event.TraceID`), not context-threaded.
  - `cmd/server` startup/shutdown — no request exists; these legitimately stay context-free until the Phase 3 cleanup.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2038

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3141

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced internal logging infrastructure to improve system observability and debugging capabilities. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->