### PR TITLE
Add eventType to OTP verify button step

### DIFF
--- a/frontend/apps/console/src/features/flows/data/steps.json
+++ b/frontend/apps/console/src/features/flows/data/steps.json
@@ -47,6 +47,7 @@
               "category": "ACTION",
               "type": "ACTION",
               "variant": "PRIMARY",
+              "eventType": "SUBMIT",
               "label": "Verify",
               "action": {
                 "type": "EXECUTOR",
@@ -105,6 +106,7 @@
               "category": "ACTION",
               "type": "ACTION",
               "variant": "PRIMARY",
+              "eventType": "SUBMIT",
               "label": "Verify",
               "action": {
                 "type": "EXECUTOR",


### PR DESCRIPTION
### Purpose
$subject

Before:

<img width="1469" height="826" alt="Screenshot 2026-06-04 at 11 00 59" src="https://github.com/user-attachments/assets/d7f66018-9800-48ad-8bbb-249f3905ac95" />

After:

<img width="1469" height="826" alt="Screenshot 2026-06-04 at 11 03 32" src="https://github.com/user-attachments/assets/4c3c90dd-d930-451b-818f-57dc7ff9ffaa" />

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3071

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OTP verification workflow actions for Email and SMS delivery methods to properly handle submission events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->