### PR TITLE
Add resource_type as an attribute in declarative_resources

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.yaml
+++ b/backend/cmd/server/bootstrap/01-default-resources.yaml
@@ -1,11 +1,11 @@
-# resource_type: organization_unit
+resource_type: organization_unit
 id: 01900000-0000-7000-8000-000000000001
 handle: default
 name: Default
 description: Default organization unit
 logoUrl: "emoji:🏛️"
 ---
-# resource_type: user_type
+resource_type: user_type
 id: 01900000-0000-7000-8000-000000000010
 category: user
 name: Person
@@ -58,7 +58,7 @@ schema:
     required: false
     credential: true
 ---
-# resource_type: user_type
+resource_type: user_type
 id: 01900000-0000-7000-8000-000000000011
 category: agent
 name: default
@@ -92,7 +92,7 @@ schema:
       - assistant
       - custom
 ---
-# resource_type: resource_server
+resource_type: resource_server
 id: 01900000-0000-7000-8000-000000000020
 name: System
 description: System resource server
@@ -135,7 +135,7 @@ resources:
         handle: view
         description: Read-only access to user types
 ---
-# resource_type: flow
+resource_type: flow
 id: 01900000-0000-7000-8000-000000000061
 name: Default Authentication Flow
 handle: default-flow
@@ -299,7 +299,7 @@ nodes:
       x: 2527
       y: 509
 ---
-# resource_type: flow
+resource_type: flow
 id: 01900000-0000-7000-8000-000000000068
 name: Console App Authentication Flow
 handle: console-app-flow
@@ -378,7 +378,7 @@ nodes:
 - id: end
   type: END
 ---
-# resource_type: flow
+resource_type: flow
 id: 01900000-0000-7000-8000-000000000067
 name: Default Recovery Flow
 handle: default-flow
@@ -666,7 +666,7 @@ nodes:
       x: 3600
       y: 375
 ---
-# resource_type: flow
+resource_type: flow
 id: 01900000-0000-7000-8000-000000000064
 name: Default Registration Flow
 handle: default-flow
@@ -906,7 +906,7 @@ nodes:
       x: 2451
       y: 629
 ---
-# resource_type: flow
+resource_type: flow
 id: 01900000-0000-7000-8000-000000000069
 name: Console App Registration Flow
 handle: console-app-flow
@@ -1064,7 +1064,7 @@ nodes:
 - id: end
   type: END
 ---
-# resource_type: flow
+resource_type: flow
 id: 01900000-0000-7000-8000-000000000066
 name: Default User Onboarding Flow
 handle: default-flow
@@ -1679,7 +1679,7 @@ nodes:
       x: 7103
       y: 637
 ---
-# resource_type: theme
+resource_type: theme
 id: 01900000-0000-7000-8000-000000000071
 handle: acrylic-orange
 displayName: Acrylic Orange
@@ -2181,7 +2181,7 @@ theme:
       - linear-gradient(rgba(255 255 255 / 0.163), rgba(255 255 255 / 0.163))
       - linear-gradient(rgba(255 255 255 / 0.165), rgba(255 255 255 / 0.165))
 ---
-# resource_type: theme
+resource_type: theme
 id: 01900000-0000-7000-8000-000000000072
 handle: acrylic-purple
 displayName: Acrylic Purple
@@ -2683,7 +2683,7 @@ theme:
       - linear-gradient(rgba(255 255 255 / 0.163), rgba(255 255 255 / 0.163))
       - linear-gradient(rgba(255 255 255 / 0.165), rgba(255 255 255 / 0.165))
 ---
-# resource_type: theme
+resource_type: theme
 id: 01900000-0000-7000-8000-000000000073
 handle: classic
 displayName: Classic
@@ -3183,7 +3183,7 @@ theme:
       - linear-gradient(rgba(255 255 255 / 0.163), rgba(255 255 255 / 0.163))
       - linear-gradient(rgba(255 255 255 / 0.165), rgba(255 255 255 / 0.165))
 ---
-# resource_type: theme
+resource_type: theme
 id: 01900000-0000-7000-8000-000000000074
 handle: high-contrast
 displayName: High Contrast
@@ -3683,7 +3683,7 @@ theme:
       - linear-gradient(rgba(255 255 255 / 0.163), rgba(255 255 255 / 0.163))
       - linear-gradient(rgba(255 255 255 / 0.165), rgba(255 255 255 / 0.165))
 ---
-# resource_type: theme
+resource_type: theme
 id: 01900000-0000-7000-8000-000000000075
 handle: pale-gray
 displayName: Pale Gray
@@ -4185,7 +4185,7 @@ theme:
       - linear-gradient(rgba(255 255 255 / 0.163), rgba(255 255 255 / 0.163))
       - linear-gradient(rgba(255 255 255 / 0.165), rgba(255 255 255 / 0.165))
 ---
-# resource_type: theme
+resource_type: theme
 id: 01900000-0000-7000-8000-000000000076
 handle: pale-indigo
 displayName: Pale Indigo
@@ -4687,7 +4687,7 @@ theme:
       - linear-gradient(rgba(255 255 255 / 0.163), rgba(255 255 255 / 0.163))
       - linear-gradient(rgba(255 255 255 / 0.165), rgba(255 255 255 / 0.165))
 ---
-# resource_type: application
+resource_type: application
 id: 01900000-0000-7000-8000-000000000060
 name: Console
 description: Management application for ThunderID
@@ -4753,7 +4753,7 @@ inboundAuthConfig:
         ou:
           - ouId
 ---
-# resource_type: user
+resource_type: user
 id: 01900000-0000-7000-8000-000000000030
 type: Person
 ouHandle: default
@@ -4769,7 +4769,7 @@ attributes:
 credentials:
   password: "{{ .ADMIN_PASSWORD }}"
 ---
-# resource_type: group
+resource_type: group
 id: 01900000-0000-7000-8000-000000000040
 name: Administrators
 description: System administrators group
@@ -4778,7 +4778,7 @@ members:
   - id: 01900000-0000-7000-8000-000000000030
     type: user
 ---
-# resource_type: role
+resource_type: role
 id: 01900000-0000-7000-8000-000000000050
 name: Administrator
 description: System administrator role with full permissions
@@ -4791,7 +4791,7 @@ assignments:
   - id: 01900000-0000-7000-8000-000000000040
     type: group
 ---
-# resource_type: translation
+resource_type: translation
 id: 01900000-0000-7000-8000-000000000091
 language: en-US
 translations:

--- a/backend/internal/system/declarative_resource/loader.go
+++ b/backend/internal/system/declarative_resource/loader.go
@@ -54,7 +54,7 @@ func NewResourceLoader(config ResourceConfig, store Storer) *ResourceLoader {
 // LoadResources loads all resources using the following precedence:
 //  1. A file supplied via the --resources startup argument.
 //  2. YAML files found directly in config/resources/ (multi-document format with
-//     "# resource_type: <type>" headers), when present.
+//     "resource_type: <type>" fields), when present.
 //  3. Individual YAML files inside the config/resources/<DirectoryName>/ subdirectory.
 //
 // Returns an error if any step fails.

--- a/backend/internal/system/declarative_resource/loader_test.go
+++ b/backend/internal/system/declarative_resource/loader_test.go
@@ -645,7 +645,7 @@ func (suite *ResourceLoaderTestSuite) removeRootYAMLFile(filename string) {
 // TestLoadResources_FromRootDirFile verifies that a YAML file placed directly in
 // config/resources/ is picked up when no --resources flag is set and no subdir exists.
 func (suite *ResourceLoaderTestSuite) TestLoadResources_FromRootDirFile() {
-	content := `# resource_type: testresource
+	content := `resource_type: testresource
 id: root-res-1
 name: Root Resource
 description: Loaded from root dir
@@ -682,7 +682,7 @@ description: Should be shadowed
 value: 1`)
 
 	// level-2: root dir file with matching resource_type
-	suite.createRootYAMLFile("root-prec2.yaml", `# resource_type: prec-subdir-di
+	suite.createRootYAMLFile("root-prec2.yaml", `resource_type: prec-subdir-di
 id: root-res
 name: Root Resource
 description: From root dir
@@ -711,7 +711,7 @@ value: 99
 // TestLoadResources_ArgFileTakesPrecedenceOverRootDir verifies level-1 beats level-2.
 func (suite *ResourceLoaderTestSuite) TestLoadResources_ArgFileTakesPrecedenceOverRootDir() {
 	// level-2: root dir file
-	suite.createRootYAMLFile("root-prec3.yaml", `# resource_type: argvresource
+	suite.createRootYAMLFile("root-prec3.yaml", `resource_type: argvresource
 id: from-root
 name: Root File Resource
 description: Should be ignored
@@ -720,7 +720,7 @@ value: 1
 	defer suite.removeRootYAMLFile("root-prec3.yaml")
 
 	// level-1: explicit arg file (wins)
-	argContent := `# resource_type: argvresource
+	argContent := `resource_type: argvresource
 id: from-arg
 name: Arg File Resource
 description: From arg file

--- a/backend/internal/system/declarative_resource/manager.go
+++ b/backend/internal/system/declarative_resource/manager.go
@@ -35,7 +35,7 @@ import (
 )
 
 // GetConfigsFromFile reads documents for the given resourceType from a single multi-document YAML file.
-// Documents are matched by a "# resource_type: <type>" comment header.
+// Documents are matched by a "resource_type: <type>" field.
 // Environment variable substitution is applied per-document so that non-variable content (e.g.
 // UI template expressions like {{ t(...) }}) in other documents does not interfere.
 func GetConfigsFromFile(filePath, resourceType string) ([][]byte, error) {
@@ -96,23 +96,18 @@ func splitYAMLDocuments(content []byte) [][]byte {
 }
 
 // documentMatchesResourceType checks whether a YAML document chunk declares the given resource type
-// via a "# resource_type: <type>" comment.
+// via a "resource_type: <type>" field.
+// We scan line-by-line rather than parsing the whole document to avoid YAML parse errors caused
+// by unquoted Go template expressions (e.g. {{.VAR}}) that appear in other fields.
 func documentMatchesResourceType(doc []byte, resourceType string) bool {
+	prefix := []byte("resource_type:")
 	for _, line := range bytes.Split(doc, []byte("\n")) {
-		if len(bytes.TrimSpace(line)) == 0 {
-			continue
-		}
-		if line[0] != '#' {
-			break
-		}
-		normalized := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(string(line), "#")))
-		for _, prefix := range []string{"resource_type:", "resource type:", "resourcetype:"} {
-			if strings.HasPrefix(normalized, prefix) {
-				t := strings.TrimSpace(strings.TrimPrefix(normalized, prefix))
-				t = strings.Trim(t, "\"'")
-				if t == resourceType {
-					return true
-				}
+		trimmed := bytes.TrimSpace(line)
+		if bytes.HasPrefix(trimmed, prefix) {
+			value := bytes.TrimSpace(bytes.TrimPrefix(trimmed, prefix))
+			value = bytes.Trim(value, `"'`)
+			if string(value) == resourceType {
+				return true
 			}
 		}
 	}

--- a/backend/internal/system/declarative_resource/manager_file_test.go
+++ b/backend/internal/system/declarative_resource/manager_file_test.go
@@ -81,7 +81,7 @@ func (s *ResourcesFileTestSuite) TestSplitYAMLDocuments_SingleDocument() {
 }
 
 func (s *ResourcesFileTestSuite) TestSplitYAMLDocuments_MultipleDocuments() {
-	content := []byte("# resource_type: identity_provider\nname: idp1\n---\n# resource_type: flow\nhandle: flow1\n")
+	content := []byte("resource_type: identity_provider\nname: idp1\n---\nresource_type: flow\nhandle: flow1\n")
 	docs := splitYAMLDocuments(content)
 	s.Len(docs, 2)
 	s.Contains(string(docs[0]), "identity_provider")
@@ -89,7 +89,7 @@ func (s *ResourcesFileTestSuite) TestSplitYAMLDocuments_MultipleDocuments() {
 }
 
 func (s *ResourcesFileTestSuite) TestSplitYAMLDocuments_LeadingSeparator() {
-	content := []byte("---\n# resource_type: identity_provider\nname: idp1\n")
+	content := []byte("---\nresource_type: identity_provider\nname: idp1\n")
 	docs := splitYAMLDocuments(content)
 	s.Len(docs, 1)
 	s.Contains(string(docs[0]), "identity_provider")
@@ -108,42 +108,42 @@ func (s *ResourcesFileTestSuite) TestSplitYAMLDocuments_OnlyWhitespace() {
 // ─── documentMatchesResourceType ─────────────────────────────────────────────
 
 func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_Match() {
-	doc := []byte("# resource_type: identity_provider\nname: my-idp\n")
+	doc := []byte("resource_type: identity_provider\nname: my-idp\n")
 	s.True(documentMatchesResourceType(doc, "identity_provider"))
 }
 
 func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_NoMatch() {
-	doc := []byte("# resource_type: flow\nhandle: my-flow\n")
+	doc := []byte("resource_type: flow\nhandle: my-flow\n")
 	s.False(documentMatchesResourceType(doc, "identity_provider"))
 }
 
-func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_NoComment() {
+func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_NoField() {
 	doc := []byte("name: my-idp\ntype: GOOGLE\n")
 	s.False(documentMatchesResourceType(doc, "identity_provider"))
 }
 
-func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_QuotedType() {
-	doc := []byte("# resource_type: \"translation\"\nlanguage: en-US\n")
+func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_QuotedValue() {
+	doc := []byte("resource_type: \"translation\"\nlanguage: en-US\n")
 	s.True(documentMatchesResourceType(doc, "translation"))
 }
 
-func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_AlternativePrefix() {
-	doc := []byte("# resource type: flow\nhandle: signin\n")
-	s.True(documentMatchesResourceType(doc, "flow"))
+func (s *ResourcesFileTestSuite) TestDocumentMatchesResourceType_WithTemplateVariables() {
+	doc := []byte("resource_type: application\nname: Console\nclient_id: {{.CONSOLE_CLIENT_ID}}\n")
+	s.True(documentMatchesResourceType(doc, "application"))
 }
 
 // ─── GetConfigsFromFile ───────────────────────────────────────────────────────
 
 func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_ReturnsOnlyMatchingType() {
-	content := `# resource_type: identity_provider
+	content := `resource_type: identity_provider
 name: google-idp
 type: GOOGLE
 ---
-# resource_type: flow
+resource_type: flow
 handle: signin
 name: Sign-in Flow
 ---
-# resource_type: identity_provider
+resource_type: identity_provider
 name: github-idp
 type: GITHUB
 `
@@ -158,10 +158,10 @@ type: GITHUB
 }
 
 func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_NoMatchingType_ReturnsEmpty() {
-	content := `# resource_type: flow
+	content := `resource_type: flow
 handle: signin
 ---
-# resource_type: flow
+resource_type: flow
 handle: signup
 `
 	filePath := s.writeResourcesFile(content)
@@ -175,7 +175,7 @@ handle: signup
 func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_SubstitutesEnvVars() {
 	s.setEnvVar("TEST_IDP_CLIENT_ID", "my-client-id-123")
 
-	content := `# resource_type: identity_provider
+	content := `resource_type: identity_provider
 name: oauth-idp
 clientId: {{.TEST_IDP_CLIENT_ID}}
 `
@@ -192,7 +192,7 @@ clientId: {{.TEST_IDP_CLIENT_ID}}
 func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_NonGoTemplateExpressionsPassThrough() {
 	// Flow document contains {{ t(...) }} and {{meta(...)}} — these are UI expressions
 	// that must not be mangled by the env-var substitution step.
-	content := `# resource_type: flow
+	content := `resource_type: flow
 handle: signin
 name: Sign-in Flow
 meta: '{"label":"{{ t(signin:title) }}","url":"{{meta(application.url)}}"}'
@@ -209,7 +209,7 @@ meta: '{"label":"{{ t(signin:title) }}","url":"{{meta(application.url)}}"}'
 
 func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_BareIdentifierExpressionsPassThrough() {
 	// Translation documents may contain {{appName}} (no dot) as a runtime placeholder.
-	content := `# resource_type: translation
+	content := `resource_type: translation
 language: en-US
 translations:
   complete: Welcome back to {{appName}}
@@ -228,11 +228,11 @@ func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_EnvVarAndNonGoTemplateIn
 	// Each is processed independently — the flow doc must never cause a parse error.
 	s.setEnvVar("TEST_CLIENT_ID", "app-client-id")
 
-	content := `# resource_type: application
+	content := `resource_type: application
 name: My App
 clientId: {{.TEST_CLIENT_ID}}
 ---
-# resource_type: flow
+resource_type: flow
 handle: signin
 meta: '{"label":"{{ t(signin:title) }}"}'
 `
@@ -250,7 +250,7 @@ meta: '{"label":"{{ t(signin:title) }}"}'
 }
 
 func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_MissingEnvVar_ReturnsError() {
-	content := `# resource_type: identity_provider
+	content := `resource_type: identity_provider
 name: oauth-idp
 clientId: {{.MISSING_ENV_VAR_XYZ}}
 `
@@ -281,20 +281,20 @@ func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_EmptyFile_ReturnsEmpty()
 }
 
 func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_MultipleTypesInFile() {
-	content := `# resource_type: organization_unit
+	content := `resource_type: organization_unit
 handle: default
 name: Default OU
 ---
-# resource_type: identity_provider
+resource_type: identity_provider
 name: google-idp
 type: GOOGLE
 ---
-# resource_type: translation
+resource_type: translation
 language: en-US
 translations:
   title: Sign In
 ---
-# resource_type: flow
+resource_type: flow
 handle: signin
 name: Sign-in Flow
 `
@@ -320,7 +320,7 @@ name: Sign-in Flow
 func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_RelativePathResolvesFromCWD() {
 	tmpDir := s.T().TempDir()
 	s.Require().NoError(os.WriteFile(filepath.Join(tmpDir, "resources.yaml"),
-		[]byte("# resource_type: flow\nhandle: x\n"), 0600))
+		[]byte("resource_type: flow\nhandle: x\n"), 0600))
 
 	origDir, err := os.Getwd()
 	s.Require().NoError(err)

--- a/backend/internal/system/declarative_resource/manager_test.go
+++ b/backend/internal/system/declarative_resource/manager_test.go
@@ -563,7 +563,7 @@ func (suite *FileBasedRuntimeManagerTestSuite) removeRootResourceFile(filename s
 }
 
 func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_MatchingDocument() {
-	content := `# resource_type: widget
+	content := `resource_type: widget
 id: w1
 name: Widget One
 `
@@ -578,7 +578,7 @@ name: Widget One
 }
 
 func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_NoMatchingDocument() {
-	content := `# resource_type: other
+	content := `resource_type: other
 id: o1
 name: Other Resource
 `
@@ -592,15 +592,15 @@ name: Other Resource
 }
 
 func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_MultipleFilesAndDocuments() {
-	file1 := `# resource_type: widget
+	file1 := `resource_type: widget
 id: w1
 name: Widget One
 ---
-# resource_type: gadget
+resource_type: gadget
 id: g1
 name: Gadget One
 `
-	file2 := `# resource_type: widget
+	file2 := `resource_type: widget
 id: w2
 name: Widget Two
 `
@@ -616,7 +616,7 @@ name: Widget Two
 }
 
 func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_IgnoresSubdirectories() {
-	content := `# resource_type: widget
+	content := `resource_type: widget
 id: w1
 name: In Subdir
 `
@@ -634,7 +634,7 @@ func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_Ignores
 	err := os.MkdirAll(rootDir, 0750)
 	suite.Require().NoError(err)
 	txtPath := filepath.Join(rootDir, "root-ignored.txt")
-	err = os.WriteFile(txtPath, []byte("# resource_type: widget\nid: w1\n"), 0600)
+	err = os.WriteFile(txtPath, []byte("resource_type: widget\nid: w1\n"), 0600)
 	suite.Require().NoError(err)
 	defer func() { _ = os.Remove(txtPath) }()
 
@@ -652,7 +652,7 @@ func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_EmptyOn
 }
 
 func (suite *FileBasedRuntimeManagerTestSuite) TestGetConfigsFromRootDir_YmlExtension() {
-	content := `# resource_type: thing
+	content := `resource_type: thing
 id: t1
 name: Thing One
 `

--- a/backend/internal/system/export/handler_test.go
+++ b/backend/internal/system/export/handler_test.go
@@ -469,7 +469,7 @@ func (suite *HandlerTestSuite) TestHandleExportRequest_Success() {
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(suite.T(), err)
 	assert.Contains(suite.T(), response.Resources, "# File: Test_App_1.yaml")
-	assert.Contains(suite.T(), response.Resources, "# resource_type: application")
+	assert.Contains(suite.T(), response.Resources, "resource_type: application")
 	assert.Contains(suite.T(), response.Resources, "name: Test App 1")
 	assert.Equal(suite.T(), "", response.EnvironmentVariables)
 }
@@ -575,7 +575,7 @@ func (suite *HandlerTestSuite) TestHandleExportRequest_MultipleFiles() {
 	assert.Contains(suite.T(), response.Resources, "---")
 	assert.Equal(suite.T(), "", response.EnvironmentVariables)
 
-	resourceTypeHeaders := strings.Count(response.Resources, "# resource_type: application")
+	resourceTypeHeaders := strings.Count(response.Resources, "resource_type: application")
 	assert.Equal(suite.T(), 2, resourceTypeHeaders)
 }
 

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -326,7 +326,7 @@ func (es *exportService) exportResourcesWithExporter(
 		for k, v := range vars {
 			variableValues[k] = v
 		}
-		content = addResourceTypeComment(templateContent, resourceType)
+		content = addResourceTypeField(templateContent, resourceType)
 
 		// Determine file name and folder path based on options
 		fileName = es.generateFileName(validatedName, resourceType, resourceID, options)
@@ -363,12 +363,12 @@ func (es *exportService) generateTemplateFromStruct(ctx context.Context, data in
 	return template, vars, nil
 }
 
-func addResourceTypeComment(content, resourceType string) string {
-	commentLine := "# resource_type: " + resourceType
-	if strings.HasPrefix(content, commentLine+"\n") || content == commentLine {
+func addResourceTypeField(content, resourceType string) string {
+	fieldLine := "resource_type: " + resourceType
+	if strings.HasPrefix(content, fieldLine+"\n") || content == fieldLine {
 		return content
 	}
-	return commentLine + "\n" + content
+	return fieldLine + "\n" + content
 }
 
 // sanitizeFileName sanitizes a filename by removing invalid characters.

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -169,16 +169,16 @@ func (suite *ExportServiceTestSuite) TestExportResources_DefaultOptions() {
 	assert.Nil(suite.T(), result.EnvFile)
 	assert.Equal(suite.T(), 1, result.Summary.TotalFiles)
 	assert.Contains(suite.T(), result.Summary.ResourceTypes, "application")
-	assert.Contains(suite.T(), result.Files[0].Content, "# resource_type: application")
+	assert.Contains(suite.T(), result.Files[0].Content, "resource_type: application")
 }
 
-func (suite *ExportServiceTestSuite) TestAddResourceTypeComment() {
+func (suite *ExportServiceTestSuite) TestAddResourceTypeField() {
 	content := "name: sample\n"
-	annotated := addResourceTypeComment(content, "application")
+	annotated := addResourceTypeField(content, "application")
 
-	assert.Equal(suite.T(), "# resource_type: application\nname: sample\n", annotated)
+	assert.Equal(suite.T(), "resource_type: application\nname: sample\n", annotated)
 
-	annotatedAgain := addResourceTypeComment(annotated, "application")
+	annotatedAgain := addResourceTypeField(annotated, "application")
 	assert.Equal(suite.T(), annotated, annotatedAgain)
 }
 

--- a/backend/internal/system/importer/parser.go
+++ b/backend/internal/system/importer/parser.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -59,7 +58,6 @@ func parseDocuments(content string) ([]parsedDocument, error) {
 	decoder := yaml.NewDecoder(bytes.NewReader([]byte(content)))
 
 	docs := make([]parsedDocument, 0)
-	var previousFootComment string
 
 	for seq := 0; ; seq++ {
 		var doc yaml.Node
@@ -80,16 +78,9 @@ func parseDocuments(content string) ([]parsedDocument, error) {
 			return nil, fmt.Errorf("document %d root must be a YAML mapping", seq+1)
 		}
 
-		resourceType := classifyResourceTypeWithComments(&doc, root, previousFootComment)
+		resourceType := resourceTypeFromField(root)
 		if resourceType == resourceTypeUnknown {
 			return nil, fmt.Errorf("unable to determine resource type for document %d", seq+1)
-		}
-
-		// Save the foot comments for the next document, because yaml.v3 attaches
-		// the next document's head comment (after ---) as the previous document's foot comment.
-		previousFootComment = doc.FootComment
-		if previousFootComment == "" {
-			previousFootComment = root.FootComment
 		}
 
 		docs = append(docs, parsedDocument{
@@ -102,63 +93,15 @@ func parseDocuments(content string) ([]parsedDocument, error) {
 	return docs, nil
 }
 
-func classifyResourceTypeWithComments(doc *yaml.Node, node *yaml.Node, previousFootComment string) string {
-	commentCandidates := []string{
-		previousFootComment,
-		doc.HeadComment,
-		doc.LineComment,
-		node.HeadComment,
-		node.LineComment,
-	}
-	for _, contentNode := range node.Content {
-		commentCandidates = append(
-			commentCandidates,
-			contentNode.HeadComment,
-			contentNode.LineComment,
-		)
-	}
-
-	if resourceType := resourceTypeFromComments(commentCandidates...); resourceType != resourceTypeUnknown {
-		return resourceType
-	}
-
-	return classifyResourceType(node)
-}
-
-func resourceTypeFromComments(comments ...string) string {
-	for _, comment := range comments {
-		if resourceType := parseResourceTypeFromComment(comment); resourceType != resourceTypeUnknown {
-			return resourceType
-		}
-	}
-
-	return resourceTypeUnknown
-}
-
-func parseResourceTypeFromComment(comment string) string {
-	if strings.TrimSpace(comment) == "" {
-		return resourceTypeUnknown
-	}
-
-	for _, line := range strings.Split(comment, "\n") {
-		normalized := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(line, "#")))
-		if normalized == "" {
-			continue
-		}
-
-		for _, prefix := range []string{"resource_type:", "resource type:", "resourcetype:"} {
-			if !strings.HasPrefix(normalized, prefix) {
-				continue
-			}
-
-			resourceType := strings.TrimSpace(strings.TrimPrefix(normalized, prefix))
-			resourceType = strings.Trim(resourceType, "\"'")
-			if isKnownResourceType(resourceType) {
-				return resourceType
+func resourceTypeFromField(node *yaml.Node) string {
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == "resource_type" {
+			value := node.Content[i+1].Value
+			if isKnownResourceType(value) {
+				return value
 			}
 		}
 	}
-
 	return resourceTypeUnknown
 }
 
@@ -185,102 +128,4 @@ func isKnownResourceType(resourceType string) bool {
 
 	_, exists := knownTypes[resourceType]
 	return exists
-}
-
-func classifyResourceType(node *yaml.Node) string {
-	matches := make([]string, 0, 4)
-
-	if hasAllKeys(node, "language", "translations") {
-		matches = append(matches, resourceTypeTranslation)
-	}
-
-	if hasAllKeys(node, "schema") && hasAnyKey(node, "ouId", "ouHandle") {
-		matches = append(matches, resourceTypeEntityType)
-	}
-
-	if hasAllKeys(node, "identifier", "resources") {
-		matches = append(matches, resourceTypeResourceServer)
-	}
-
-	if hasAllKeys(node, "name", "permissions") {
-		matches = append(matches, resourceTypeRole)
-	}
-
-	if hasAllKeys(node, "displayName", "theme") {
-		matches = append(matches, resourceTypeTheme)
-	}
-
-	if hasAllKeys(node, "displayName", "layout") {
-		matches = append(matches, resourceTypeLayout)
-	}
-
-	if hasAllKeys(node, "type", "attributes") && hasAnyKey(node, "ouId", "ouHandle") {
-		matches = append(matches, resourceTypeUser)
-	}
-
-	if hasAllKeys(node, "flowType", "nodes", "handle", "name") {
-		matches = append(matches, resourceTypeFlow)
-	}
-
-	if hasAllKeys(node, "type", "properties", "name") {
-		matches = append(matches, resourceTypeIdentityProvider)
-	}
-
-	if hasAnyKey(node, "owner") ||
-		(hasAnyKey(node, "type") &&
-			hasAnyKey(node, "authFlowId", "registrationFlowId", "inboundAuthConfig", "allowedUserTypes") &&
-			!hasAnyKey(node, "properties")) {
-		matches = append(matches, resourceTypeAgent)
-	}
-
-	if !hasAnyKey(node, "owner") &&
-		!(hasAnyKey(node, "type") &&
-			hasAnyKey(node, "authFlowId", "registrationFlowId", "inboundAuthConfig", "allowedUserTypes") &&
-			!hasAnyKey(node, "properties")) &&
-		hasAnyKey(node, "authFlowId", "registrationFlowId", "inboundAuthConfig", "allowedUserTypes") {
-		matches = append(matches, resourceTypeApplication)
-	}
-
-	if hasAllKeys(node, "name") && hasAnyKey(node, "ouId", "ouHandle") &&
-		!hasAnyKey(node, "handle", "permissions", "identifier", "type", "flowType",
-			"displayName", "properties", "schema") {
-		matches = append(matches, resourceTypeGroup)
-	}
-
-	if hasAllKeys(node, "handle", "name") &&
-		!hasAnyKey(node, "flowType", "nodes", "authFlowId", "registrationFlowId", "inboundAuthConfig") {
-		matches = append(matches, resourceTypeOrganizationUnit)
-	}
-
-	if len(matches) != 1 {
-		return resourceTypeUnknown
-	}
-
-	return matches[0]
-}
-
-func hasAllKeys(node *yaml.Node, keys ...string) bool {
-	for _, key := range keys {
-		if !hasAnyKey(node, key) {
-			return false
-		}
-	}
-	return true
-}
-
-func hasAnyKey(node *yaml.Node, keys ...string) bool {
-	if node == nil || node.Kind != yaml.MappingNode {
-		return false
-	}
-
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		key := node.Content[i]
-		for _, candidate := range keys {
-			if key.Value == candidate {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/backend/internal/system/importer/parser_resolver_test.go
+++ b/backend/internal/system/importer/parser_resolver_test.go
@@ -102,15 +102,18 @@ func TestResolveTemplate_DoesNotCollideWithLiteralPlaceholderLookingText(t *test
 
 func TestParseDocuments(t *testing.T) {
 	content := strings.Join([]string{
+		"resource_type: application",
 		"name: app-one",
 		"authFlowId: flow-1",
 		"---",
+		"resource_type: identity_provider",
 		"name: idp-one",
 		"type: GOOGLE",
 		"properties:",
 		"- name: client_id",
 		"  value: abc",
 		"---",
+		"resource_type: flow",
 		"id: flow-1",
 		"handle: login",
 		"name: Login Flow",
@@ -127,73 +130,9 @@ func TestParseDocuments(t *testing.T) {
 	assert.Equal(t, resourceTypeFlow, docs[2].ResourceType)
 }
 
-func TestClassifyResourceType_AdditionalResources(t *testing.T) {
-	testCases := []struct {
-		name     string
-		yamlDoc  string
-		expected string
-	}{
-		{
-			name:     "organization unit",
-			yamlDoc:  "id: ou-1\nhandle: root\nname: Root\n",
-			expected: resourceTypeOrganizationUnit,
-		},
-		{
-			name:     "user type with organization_unit_id",
-			yamlDoc:  "id: sch-1\nname: Schema\nouId: ou-1\nschema: '{}'\n",
-			expected: resourceTypeEntityType,
-		},
-		{
-			name:     "user type with ou_handle",
-			yamlDoc:  "id: sch-1\nname: Schema\nouHandle: customers\nschema: '{}'\n",
-			expected: resourceTypeEntityType,
-		},
-		{
-			name:     "resource server",
-			yamlDoc:  "id: rs-1\nidentifier: api://rs-1\ndelimiter: ':'\nresources: []\n",
-			expected: resourceTypeResourceServer,
-		},
-		{name: "role", yamlDoc: "id: role-1\nname: Admin\npermissions: []\n", expected: resourceTypeRole},
-		{name: "theme", yamlDoc: "id: th-1\ndisplayName: Theme\ntheme: {}\n", expected: resourceTypeTheme},
-		{name: "layout", yamlDoc: "id: ly-1\ndisplayName: Layout\nlayout: {}\n", expected: resourceTypeLayout},
-		{name: "user", yamlDoc: "id: u-1\ntype: person\nouId: ou-1\nattributes: {}\n", expected: resourceTypeUser},
-		{name: "translation", yamlDoc: "language: en-US\ntranslations: {}\n", expected: resourceTypeTranslation},
-		{
-			name:     "agent with owner",
-			yamlDoc:  "id: agt-1\nouId: ou-1\ntype: default\nname: Test Agent\nowner: owner-id-1\n",
-			expected: resourceTypeAgent,
-		},
-		{
-			name: "agent with auth_flow_id is still agent not application",
-			yamlDoc: "id: agt-2\nouId: ou-1\ntype: default\nname: OAuth Agent\n" +
-				"owner: owner-id-1\nauthFlowId: flow-1\n",
-			expected: resourceTypeAgent,
-		},
-		{
-			name: "agent without owner but with type and auth_flow_id",
-			yamlDoc: "id: agt-3\nouId: ou-1\ntype: default\nname: Auth Agent\n" +
-				"authFlowId: flow-1\n",
-			expected: resourceTypeAgent,
-		},
-		{
-			name:     "application without top-level type is still application",
-			yamlDoc:  "name: app-one\nauthFlowId: flow-1\n",
-			expected: resourceTypeApplication,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			docs, err := parseDocuments(testCase.yamlDoc)
-			require.NoError(t, err)
-			require.Len(t, docs, 1)
-			assert.Equal(t, testCase.expected, docs[0].ResourceType)
-		})
-	}
-}
-
 func TestParseDocuments_AgentDocument(t *testing.T) {
 	content := strings.Join([]string{
+		"resource_type: agent",
 		"id: agt-1",
 		"ouId: ou-1",
 		"type: default",
@@ -210,6 +149,7 @@ func TestParseDocuments_AgentDocument(t *testing.T) {
 
 func TestParseDocuments_AgentWithOAuthNotClassifiedAsApplication(t *testing.T) {
 	content := strings.Join([]string{
+		"resource_type: agent",
 		"id: agt-2",
 		"ouId: ou-1",
 		"type: default",
@@ -229,8 +169,8 @@ func TestParseDocuments_AgentWithOAuthNotClassifiedAsApplication(t *testing.T) {
 	assert.Equal(t, resourceTypeAgent, docs[0].ResourceType)
 }
 
-func TestParseDocuments_UsesResourceTypeComment(t *testing.T) {
-	content := "# resource_type: application\nname: idp-one\ntype: GOOGLE\nproperties: []\n"
+func TestParseDocuments_UsesResourceTypeField(t *testing.T) {
+	content := "resource_type: application\nname: idp-one\ntype: GOOGLE\nproperties: []\n"
 
 	docs, err := parseDocuments(content)
 	require.NoError(t, err)
@@ -238,8 +178,8 @@ func TestParseDocuments_UsesResourceTypeComment(t *testing.T) {
 	assert.Equal(t, resourceTypeApplication, docs[0].ResourceType)
 }
 
-func TestParseDocuments_UsesResourceTypeCommentWithFileHeader(t *testing.T) {
-	content := "# File: app-one.yaml\n# resource_type: application\nname: app-one\nauthFlowId: flow-1\n"
+func TestParseDocuments_ResourceTypeFieldTakesPrecedenceOverStructure(t *testing.T) {
+	content := "resource_type: application\nname: app-one\nauth_flow_id: flow-1\n"
 
 	docs, err := parseDocuments(content)
 	require.NoError(t, err)
@@ -272,23 +212,17 @@ func TestParseDocuments_FailsForUnknownResourceType(t *testing.T) {
 	assert.Contains(t, err.Error(), "unable to determine resource type")
 }
 
-func TestParseDocuments_FailsForAmbiguousResourceType(t *testing.T) {
-	content := strings.Join([]string{
-		"name: maybe-role-or-idp",
-		"type: GOOGLE",
-		"permissions: []",
-		"properties: []",
-		"",
-	}, "\n")
+func TestParseDocuments_FailsForInvalidResourceType(t *testing.T) {
+	content := "resource_type: not_a_real_type\nname: something\n"
 
 	_, err := parseDocuments(content)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to determine resource type")
 }
 
-func TestParseDocuments_ExplicitResourceTypeOverridesAmbiguousHeuristics(t *testing.T) {
+func TestParseDocuments_ExplicitResourceTypeOverridesAmbiguousStructure(t *testing.T) {
 	content := strings.Join([]string{
-		"# resource_type: identity_provider",
+		"resource_type: identity_provider",
 		"name: google",
 		"type: GOOGLE",
 		"permissions: []",

--- a/backend/internal/system/importer/server_config_import_test.go
+++ b/backend/internal/system/importer/server_config_import_test.go
@@ -52,7 +52,7 @@ func newServerConfigImportService(sc serverConfigAdapter) ImportServiceInterface
 	return newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, sc)
 }
 
-const serverConfigImportDoc = `# resource_type: server_config
+const serverConfigImportDoc = `resource_type: server_config
 name: cors
 value:
   - "https://app.example.com"

--- a/backend/internal/system/importer/service_test.go
+++ b/backend/internal/system/importer/service_test.go
@@ -719,7 +719,7 @@ func TestImportResources_CreateApplication(t *testing.T) {
 	svc := newTestImportService(nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
+		Content: "resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n",
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetRuntime},
 	})
 
@@ -738,7 +738,7 @@ func TestImportResources_UpdateApplication(t *testing.T) {
 	})
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
+		Content: "resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n",
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetRuntime},
 	})
 
@@ -754,7 +754,7 @@ func TestImportResources_DryRunCreateApplicationWithoutWrite(t *testing.T) {
 	svc := newTestImportService(appSvc)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
+		Content: "resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n",
 		DryRun:  true,
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetRuntime},
 	})
@@ -776,7 +776,7 @@ func TestImportResources_DryRunUpdateApplicationWithoutWrite(t *testing.T) {
 	svc := newTestImportService(appSvc)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
+		Content: "resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n",
 		DryRun:  true,
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetRuntime},
 	})
@@ -793,7 +793,7 @@ func TestImportResources_DryRunValidationFailure(t *testing.T) {
 	svc := newTestImportService(nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id:\n- app-1\nname: My App\nauthFlowId: flow-1\n",
+		Content: "resource_type: application\nid:\n- app-1\nname: My App\nauthFlowId: flow-1\n",
 		DryRun:  true,
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetRuntime},
 	})
@@ -808,12 +808,14 @@ func TestImportResources_CreateIDPAndFlow(t *testing.T) {
 	svc := newTestImportService(nil)
 
 	content := strings.Join([]string{
+		"resource_type: identity_provider",
 		"name: idp-one",
 		"type: GOOGLE",
 		"properties:",
 		"- name: client_id",
 		"  value: abc",
 		"---",
+		"resource_type: flow",
 		"handle: login",
 		"name: Login Flow",
 		"flowType: AUTHENTICATION",
@@ -837,7 +839,7 @@ func TestImportResources_DefaultsToRuntimeTarget(t *testing.T) {
 	svc := newTestImportService(appSvc)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
+		Content: "resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n",
 	})
 
 	require.Nil(t, err)
@@ -854,8 +856,8 @@ func TestImportResources_PreservesExplicitFalseOptions(t *testing.T) {
 
 	falseVal := false
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n" +
-			"---\nid: app-2\nname: My App 2\nauthFlowId: flow-1\n",
+		Content: "resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n" +
+			"---\nresource_type: application\nid: app-2\nname: My App 2\nauthFlowId: flow-1\n",
 		Options: &ImportOptions{
 			Upsert:          &falseVal,
 			ContinueOnError: &falseVal,
@@ -874,7 +876,7 @@ func TestImportResources_ApplicationAdapterNotConfigured(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
+		Content: "resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n",
 	})
 
 	require.Nil(t, err)
@@ -894,6 +896,7 @@ func TestImportResources_RoleImportIncludesAssignments(t *testing.T) {
 	)
 
 	content := strings.Join([]string{
+		"resource_type: role",
 		"id: role-1",
 		"name: Admin",
 		"ouId: ou-1",
@@ -924,6 +927,7 @@ func TestImportResources_GroupImportIncludesMembers(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: group",
 		"id: group-new",
 		"name: Engineers",
 		"ouId: ou-1",
@@ -954,6 +958,7 @@ func TestImportResources_RoleImportNoAssignments(t *testing.T) {
 	)
 
 	content := strings.Join([]string{
+		"resource_type: role",
 		"id: role-new",
 		"name: Viewer",
 		"ouId: ou-1",
@@ -979,6 +984,7 @@ func TestImportResources_RoleUpsertUpdateIncludesAssignments(t *testing.T) {
 	)
 
 	content := strings.Join([]string{
+		"resource_type: role",
 		"id: role-1",
 		"name: Admin",
 		"ouId: ou-1",
@@ -1016,6 +1022,7 @@ func TestImportResources_RoleAssignmentFailureReturnsError(t *testing.T) {
 
 	// role-1 exists in the fake → update path → AddAssignments is called separately → fails
 	content := strings.Join([]string{
+		"resource_type: role",
 		"id: role-1",
 		"name: Admin",
 		"ouId: ou-1",
@@ -1038,6 +1045,7 @@ func TestImportResources_GroupImportNoMembers(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: group",
 		"id: group-new",
 		"name: Empty",
 		"ouId: ou-1",
@@ -1058,6 +1066,7 @@ func TestImportResources_GroupUpsertUpdateIncludesMembers(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: group",
 		"id: group-1",
 		"name: Admins",
 		"ouId: ou-1",
@@ -1090,6 +1099,7 @@ func TestImportResources_GroupMemberFailureReturnsError(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: group",
 		"id: group-new",
 		"name: Engineers",
 		"ouId: ou-1",
@@ -1111,6 +1121,7 @@ func TestImportResources_UserCredentialFailureRollsBackCreate(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: user",
 		"id: user-1",
 		"type: customer",
 		"ouId: ou-1",
@@ -1136,6 +1147,7 @@ func TestImportResources_OrganizationUnitUpsertCreatePreservesID(t *testing.T) {
 	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: organization_unit",
 		"id: ou-123",
 		"handle: eng",
 		"name: Engineering",
@@ -1164,6 +1176,7 @@ func TestImportResources_FlowUpsertCreatePreservesID(t *testing.T) {
 	svc := newImportService(nil, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: flow",
 		"id: missing-flow-id",
 		"handle: registration-flow",
 		"name: Updated Registration Flow",
@@ -1202,6 +1215,7 @@ func TestImportResources_FlowUpsertDuplicateHandleFallsBackToHandleUpdate(t *tes
 	svc := newImportService(nil, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: flow",
 		"id: missing-flow-id",
 		"handle: registration-flow",
 		"name: Updated Registration Flow",
@@ -1242,7 +1256,7 @@ func TestImportResources_ApplicationFlowReferencesAreRemappedFromFlowAlias(t *te
 	svc := newImportService(appSvc, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
-		"# resource_type: flow",
+		"resource_type: flow",
 		"id: missing-registration-flow-id",
 		"handle: registration-flow",
 		"name: Updated Registration Flow",
@@ -1250,7 +1264,7 @@ func TestImportResources_ApplicationFlowReferencesAreRemappedFromFlowAlias(t *te
 		"nodes: []",
 		"",
 		"---",
-		"# resource_type: application",
+		"resource_type: application",
 		"name: My App",
 		"authFlowId: auth-flow-1",
 		"registrationFlowId: missing-registration-flow-id",
@@ -1277,6 +1291,7 @@ func TestImportResources_ThemeUpsertCreatePreservesID(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, themeSvc, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: theme",
 		"id: thm-123",
 		"handle: default-theme",
 		"displayName: Default Theme",
@@ -1309,6 +1324,7 @@ func TestImportResources_EntityTypeUpsertCreatePreservesID(t *testing.T) {
 	)
 
 	content := strings.Join([]string{
+		"resource_type: user_type",
 		"id: usrs-123",
 		"name: customer",
 		"ouId: ou-1",
@@ -1348,12 +1364,14 @@ func TestImportResources_UpsertCreatePreservesIDsAcrossResourceTypes(t *testing.
 	)
 
 	content := strings.Join([]string{
+		"resource_type: organization_unit",
 		"id: ou-123",
 		"handle: eng",
 		"name: Engineering",
 		"description: Engineering OU",
 		"",
 		"---",
+		"resource_type: theme",
 		"id: thm-123",
 		"handle: default-theme",
 		"displayName: Default Theme",
@@ -1362,6 +1380,7 @@ func TestImportResources_UpsertCreatePreservesIDsAcrossResourceTypes(t *testing.
 		"    light: {}",
 		"",
 		"---",
+		"resource_type: user_type",
 		"id: usrs-123",
 		"name: customer",
 		"ouId: ou-123",
@@ -1370,6 +1389,7 @@ func TestImportResources_UpsertCreatePreservesIDsAcrossResourceTypes(t *testing.
 		"  properties: {}",
 		"",
 		"---",
+		"resource_type: flow",
 		"id: flow-123",
 		"handle: registration-flow",
 		"name: Registration Flow",
@@ -1426,6 +1446,7 @@ func TestImportResources_EntityTypeOUHandlePassedToService(t *testing.T) {
 	)
 
 	content := strings.Join([]string{
+		"resource_type: user_type",
 		"id: usrs-123",
 		"name: customer",
 		"ouHandle: default",
@@ -1447,6 +1468,7 @@ func TestImportResources_EntityTypeOUHandlePassedToService(t *testing.T) {
 
 func TestImportResources_StripsClientSecretForPublicClientWithNoneAuthMethod(t *testing.T) {
 	content := strings.Join([]string{
+		"resource_type: application",
 		"id: app-1",
 		"name: My App",
 		"authFlowId: flow-1",
@@ -1479,6 +1501,7 @@ func TestImportResources_StripsClientSecretForPublicClientWithNoneAuthMethod(t *
 
 func TestImportResources_KeepsClientSecretForConfidentialClient(t *testing.T) {
 	content := strings.Join([]string{
+		"resource_type: application",
 		"id: app-1",
 		"name: My App",
 		"authFlowId: flow-1",
@@ -1534,7 +1557,7 @@ func TestImportResources_FileTargetReturnsError(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
+		Content: "resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n",
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetFile},
 	})
 
@@ -1559,7 +1582,7 @@ func TestDeleteResource_RemovesDeclarativeFile(t *testing.T) {
 	require.NoError(t, os.MkdirAll(resourceDir, 0o750))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(resourceDir, "app-1.yaml"),
-		[]byte("# resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n"),
+		[]byte("resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n"),
 		0o600,
 	))
 
@@ -1583,7 +1606,7 @@ func TestImportResources_ApplicationOUHandlePassedToService(t *testing.T) {
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: strings.Join([]string{
-			"# resource_type: application",
+			"resource_type: application",
 			"name: My App",
 			"ouHandle: default",
 			"",
@@ -1603,7 +1626,7 @@ func TestImportResources_ApplicationAuthFlowHandlePassedToService(t *testing.T) 
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: strings.Join([]string{
-			"# resource_type: application",
+			"resource_type: application",
 			"name: My App",
 			"authFlowHandle: login-flow",
 			"",
@@ -1623,7 +1646,7 @@ func TestImportResources_ApplicationRegistrationFlowHandlePassedToService(t *tes
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: strings.Join([]string{
-			"# resource_type: application",
+			"resource_type: application",
 			"name: My App",
 			"registrationFlowHandle: reg-flow",
 			"isRegistrationFlowEnabled: true",
@@ -1645,7 +1668,7 @@ func TestImportResources_ApplicationRecoveryFlowHandlePassedToService(t *testing
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: strings.Join([]string{
-			"# resource_type: application",
+			"resource_type: application",
 			"name: My App",
 			"recoveryFlowHandle: recovery-flow",
 			"isRecoveryFlowEnabled: true",
@@ -1668,7 +1691,7 @@ func TestImportResources_DryRunSkipsApplicationHandleResolution(t *testing.T) {
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: strings.Join([]string{
-			"# resource_type: application",
+			"resource_type: application",
 			"name: My App",
 			"ouHandle: nonexistent-ou",
 			"authFlowHandle: nonexistent-flow",
@@ -1731,7 +1754,7 @@ func (f *fakeAgentService) UpdateAgent(
 	return &agentmodel.AgentCompleteResponse{ID: agentID, Name: req.Name}, nil
 }
 
-const agentYAML = "# resource_type: agent\n" +
+const agentYAML = "resource_type: agent\n" +
 	"id: agent-1\ntype: default\nouId: root\nname: Test Agent\ndescription: desc\n"
 
 func TestImportAgent_Create(t *testing.T) {
@@ -1874,7 +1897,7 @@ func TestImportAgent_DecodeError(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil, nil, nil)
 
 	// ID field is a sequence, not a string — decode into AgentRequestWithID will fail.
-	invalidYAML := "# resource_type: agent\nid:\n  - bad\nname: Test\n"
+	invalidYAML := "resource_type: agent\nid:\n  - bad\nname: Test\n"
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{Content: invalidYAML})
 
 	require.Nil(t, svcErr)
@@ -2008,14 +2031,14 @@ func TestImportAgent_FlowAliasRemapsFlowIDs(t *testing.T) {
 			)
 
 			content := strings.Join([]string{
-				"# resource_type: flow",
+				"resource_type: flow",
 				"id: " + tc.flowID,
 				"handle: " + tc.flowHandle,
 				"name: " + tc.flowName,
 				"flowType: " + tc.flowType,
 				"nodes: []",
 				"---",
-				"# resource_type: agent",
+				"resource_type: agent",
 				"id: " + tc.agentID,
 				"type: default",
 				"ouId: root",
@@ -2040,7 +2063,7 @@ func TestImportAgent_StripsClientSecretForPublicAgentWithNoneAuthMethod(t *testi
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil, nil, nil)
 
 	content := strings.Join([]string{
-		"# resource_type: agent",
+		"resource_type: agent",
 		"id: agent-pub",
 		"type: default",
 		"ouId: root",
@@ -2133,6 +2156,7 @@ func TestImportRole_OUHandleResolved(t *testing.T) {
 	)
 
 	content := strings.Join([]string{
+		"resource_type: role",
 		"id: role-new",
 		"name: Viewer",
 		"ouHandle: default",
@@ -2161,6 +2185,7 @@ func TestImportRole_OUHandleNotFound(t *testing.T) {
 	)
 
 	content := strings.Join([]string{
+		"resource_type: role",
 		"id: role-new",
 		"name: Viewer",
 		"ouHandle: missing",
@@ -2188,6 +2213,7 @@ func TestImportRole_OUIDWinsOverHandle(t *testing.T) {
 	)
 
 	content := strings.Join([]string{
+		"resource_type: role",
 		"id: role-new",
 		"name: Viewer",
 		"ouId: ou-explicit",
@@ -2215,6 +2241,7 @@ func TestImportGroup_OUHandleResolved(t *testing.T) {
 	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: group",
 		"id: group-new",
 		"name: Engineers",
 		"ouHandle: default",
@@ -2238,6 +2265,7 @@ func TestImportGroup_OUHandleNotFound(t *testing.T) {
 	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: group",
 		"id: group-new",
 		"name: Engineers",
 		"ouHandle: missing",
@@ -2260,6 +2288,7 @@ func TestImportGroup_OUIDWinsOverHandle(t *testing.T) {
 	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: group",
 		"id: group-new",
 		"name: Engineers",
 		"ouId: ou-explicit",
@@ -2286,6 +2315,7 @@ func TestImportUser_OUHandleResolved(t *testing.T) {
 	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: user",
 		"id: user-new",
 		"type: person",
 		"ouHandle: default",
@@ -2314,6 +2344,7 @@ func TestImportUser_OUHandleNotFound(t *testing.T) {
 	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: user",
 		"id: user-new",
 		"type: person",
 		"ouHandle: missing",
@@ -2338,6 +2369,7 @@ func TestImportUser_OUIDWinsOverHandle(t *testing.T) {
 	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: user",
 		"id: user-new",
 		"type: person",
 		"ouId: ou-explicit",
@@ -2369,7 +2401,7 @@ func TestImportResourceServer_OUHandleResolved(t *testing.T) {
 	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
-		"# resource_type: resource_server",
+		"resource_type: resource_server",
 		"id: rs-new",
 		"name: Test RS",
 		"handle: test-rs",
@@ -2399,7 +2431,7 @@ func TestImportResourceServer_OUHandleNotFound(t *testing.T) {
 	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
-		"# resource_type: resource_server",
+		"resource_type: resource_server",
 		"id: rs-new",
 		"name: Test RS",
 		"handle: test-rs",
@@ -2425,7 +2457,7 @@ func TestImportResourceServer_OUIDWinsOverHandle(t *testing.T) {
 	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
-		"# resource_type: resource_server",
+		"resource_type: resource_server",
 		"id: rs-new",
 		"name: Test RS",
 		"handle: test-rs",
@@ -2454,6 +2486,7 @@ func TestImportResources_IDPPropertiesArePassedToService(t *testing.T) {
 
 	// is_secret with empty value avoids the encryption path while still verifying the flag is parsed.
 	content := strings.Join([]string{
+		"resource_type: identity_provider",
 		"name: google-idp",
 		"type: GOOGLE",
 		"properties:",
@@ -2495,6 +2528,7 @@ func TestImportResources_IDPUpsertUpdatePropertiesArePassedToService(t *testing.
 	svc := newImportService(nil, idpSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
+		"resource_type: identity_provider",
 		"id: idp-1",
 		"name: google-idp",
 		"type: GOOGLE",

--- a/build.sh
+++ b/build.sh
@@ -1057,7 +1057,7 @@ function run() {
     # the backend without manual configuration. Regenerated on every run and picked up by
     # the bootstrap one-shot; it is git-ignored and never packaged (see build()).
     cat > "$BACKEND_DIR/bootstrap/02-server-configurations.yaml" <<EOF
-# resource_type: server_config
+resource_type: server_config
 name: cors
 value:
   allowedOrigins:

--- a/docs/content/guides/declarative-configurations/import-resources.mdx
+++ b/docs/content/guides/declarative-configurations/import-resources.mdx
@@ -103,7 +103,7 @@ curl -X POST "https://localhost:8090/import" \
   -H "Authorization: Bearer <access_token>" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": "# resource_type: application\nname: Console\nauthFlowId: {{.AUTH_FLOW_ID}}\n",
+    "content": "resource_type: application\nname: Console\nauthFlowId: {{.AUTH_FLOW_ID}}\n",
     "variables": {
       "AUTH_FLOW_ID": "edc013d0-e893-4dc0-990c-3e1d203e005b"
     },
@@ -132,12 +132,12 @@ The following handle fields are supported:
 
 If you provide both a handle field and the corresponding ID field, the ID takes precedence and the handle is ignored.
 
-If a handle cannot be resolved — because the target resource does not exist or the required adapter is not configured — the import item fails with a descriptive error message. When `continueOnError` is `true`, the importer continues processing the remaining documents.
+If a handle cannot be resolved (because the target resource does not exist or the required adapter is not configured), the import item fails with a descriptive error message. When `continueOnError` is `true`, the importer continues processing the remaining documents.
 
 ### Example: Application with Handle References
 
 ```yaml
-# resource_type: application
+resource_type: application
 name: My App
 ouHandle: default
 authFlowHandle: default-basic-flow

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -484,7 +484,7 @@ With environment variable substitution:
 ./start.sh resources.yml --env my.env
 ```
 
-Each document in the file must declare its type with a `# resource_type: <type>` comment at the top. Supported types:
+Each document in the file must declare its type with a `resource_type: <type>` field. Supported types:
 
 ```text
 application, flow, group, identity_provider, layout, notification_sender,
@@ -494,12 +494,12 @@ organization_unit, resource_server, role, theme, translation, user, user_schema
 Example single file:
 
 ```yaml
-# resource_type: application
+resource_type: application
 name: My App
 ouHandle: default
 authFlowHandle: default-flow
 ---
-# resource_type: group
+resource_type: group
 name: admins
 description: Administrators
 ```
@@ -522,7 +522,7 @@ repository/
       admins.yaml
 ```
 
-The file must use the same `# resource_type: <type>` document headers as the single-file startup format. On startup, <ProductName /> scans all `*.yaml` and `*.yml` files at that root level and loads every document whose `resource_type` matches a configured declarative resource type.
+The file must use the same `resource_type: <type>` document fields as the single-file startup format. On startup, <ProductName /> scans all `*.yaml` and `*.yml` files at that root level and loads every document whose `resource_type` matches a configured declarative resource type.
 
 :::note
 If any `*.yaml` or `*.yml` file is found at the `config/resources/` root, per-type subdirectories (priority 3) are skipped entirely for that resource type.
@@ -536,7 +536,7 @@ Two mounting modes are available. Use the one that fits your resource layout.
 
 #### Combined File Mode
 
-Use `singleFile.keys` to mount one or more combined YAML files (multi-document format with `# resource_type: <type>` headers) directly under `config/resources`. Each key in your ConfigMap or Secret is mounted as `<key>.yaml` at that path. <ProductName /> scans the directory at startup and loads every document whose `resource_type` matches a configured declarative resource type.
+Use `singleFile.keys` to mount one or more combined YAML files (multi-document format with `resource_type: <type>` fields) directly under `config/resources`. Each key in your ConfigMap or Secret is mounted as `<key>.yaml` at that path. <ProductName /> scans the directory at startup and loads every document whose `resource_type` matches a configured declarative resource type.
 
 ```yaml
 declarativeResources:

--- a/frontend/apps/console/src/features/import-export/components/ConfigureExport.tsx
+++ b/frontend/apps/console/src/features/import-export/components/ConfigureExport.tsx
@@ -181,22 +181,15 @@ export default function ConfigureExport({
         if (!trimmedSection) return;
 
         const lines = trimmedSection.split(/\r?\n|\r/);
-        let resourceType = 'unknown';
         let fileName = 'unknown';
 
-        // Extract resource type and file name from comments
+        // Extract file name from comments
         for (const line of lines) {
           if (line.startsWith('#')) {
             const fileNameRegex = /File:\s*(.+\.ya?ml)/i;
             const fileNameMatch = fileNameRegex.exec(line);
             if (fileNameMatch) {
               fileName = fileNameMatch[1];
-            }
-
-            const resourceTypeRegex = /resource_type:\s*(\w+)/;
-            const resourceTypeMatch = resourceTypeRegex.exec(line);
-            if (resourceTypeMatch) {
-              resourceType = resourceTypeMatch[1];
             }
           }
         }
@@ -236,6 +229,7 @@ export default function ConfigureExport({
         try {
           const resource = yaml.parse(yamlContent) as unknown;
           if (resource && typeof resource === 'object') {
+            const resourceType = (resource as Record<string, unknown>).resource_type?.toString() ?? 'unknown';
             if (!resourcesByType[resourceType]) {
               resourcesByType[resourceType] = [];
             }
@@ -244,7 +238,6 @@ export default function ConfigureExport({
         } catch (error) {
           logger.warn('Failed to parse YAML section', {
             fileName,
-            resourceType,
             sectionIndex: idx,
             error: error instanceof Error ? error.message : String(error),
             yamlPreview: yamlContent.substring(0, 200),

--- a/frontend/apps/console/src/features/import-export/components/__tests__/ConfigureExport.test.tsx
+++ b/frontend/apps/console/src/features/import-export/components/__tests__/ConfigureExport.test.tsx
@@ -241,7 +241,7 @@ name: Valid Flow
     it('parses agent resources and renders agents section', () => {
       const agentYaml = `
 ---
-# resource_type: agent
+resource_type: agent
 id: agent-1
 name: Test Agent
 description: A test agent

--- a/samples/apps/react-api-based-sample/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/react-api-based-sample/thunderid-config/thunderid-config.yaml
@@ -1,4 +1,4 @@
-# resource_type: user_type
+resource_type: user_type
 id: 019e3a5c-04ea-7d18-8ae6-f828b1f3d60f
 category: user
 name: Customer
@@ -49,7 +49,7 @@ schema: {
   }
 
 ---
-# resource_type: server_config
+resource_type: server_config
 name: cors
 value:
   allowedOrigins:

--- a/samples/apps/react-sdk-sample/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/react-sdk-sample/thunderid-config/thunderid-config.yaml
@@ -1,4 +1,4 @@
-# resource_type: user_type
+resource_type: user_type
 id: 019e3a5c-04ea-7d18-8ae6-f828b1f3d60f
 category: user
 name: Customer
@@ -49,7 +49,7 @@ schema: {
   }
 
 ---
-# resource_type: application
+resource_type: application
 id: 019e3a5c-0532-7b06-aa66-ec42ad05784e
 ouHandle: default
 name: React SDK Sample
@@ -128,7 +128,7 @@ inboundAuthConfig:
           - picture
 
 ---
-# resource_type: server_config
+resource_type: server_config
 name: cors
 value:
   allowedOrigins:

--- a/samples/apps/react-vanilla-sample/thunderid-config/basic/thunderid-config.yaml
+++ b/samples/apps/react-vanilla-sample/thunderid-config/basic/thunderid-config.yaml
@@ -1,4 +1,4 @@
-# resource_type: user_type
+resource_type: user_type
 id: 019e3a5c-04ea-7d18-8ae6-f828b1f3d60f
 category: user
 name: Customer
@@ -49,7 +49,7 @@ schema: {
   }
 
 ---
-# resource_type: application
+resource_type: application
 id: 019e3a5c-0500-7f3e-a66e-66fc7918c3a7
 ouHandle: default
 name: Sample App

--- a/samples/apps/react-vanilla-sample/thunderid-config/multi-auth/thunderid-config.yaml
+++ b/samples/apps/react-vanilla-sample/thunderid-config/multi-auth/thunderid-config.yaml
@@ -8,7 +8,7 @@
 # - SAMPLE_APP_GITHUB_REDIRECT_URI
 # - SAMPLE_APP_SMS_SENDER_ID
 #
-# resource_type: user_type
+resource_type: user_type
 id: 019e3a5c-04ea-7d18-8ae6-f828b1f3d60f
 category: user
 name: Customer
@@ -65,7 +65,7 @@ schema: {
   }
 
 ---
-# resource_type: identity_provider
+resource_type: identity_provider
 id: 019e201d-5634-7533-a971-538b66914721
 name: Sample Vanilla Google
 description: Google identity provider for the sample vanilla flows
@@ -82,7 +82,7 @@ properties:
     value: "{{.SAMPLE_APP_GOOGLE_SCOPES}}"
 
 ---
-# resource_type: identity_provider
+resource_type: identity_provider
 id: 019e3a5e-2ff3-7bfb-ae19-27aada871b80
 name: Sample Vanilla GitHub
 description: GitHub identity provider for the sample vanilla flows
@@ -97,7 +97,7 @@ properties:
     value: "{{.SAMPLE_APP_GITHUB_REDIRECT_URI}}"
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 9b52a0a4-8c63-4b2d-9dc9-1e6c2befc0c0
 name: Sample Vanilla Multi Auth Single Step with SMS and Passkey
 handle: sample-vanilla-multi-auth-single-step-sms
@@ -474,7 +474,7 @@ nodes:
 - id: end
   type: END
 ---
-# resource_type: flow
+resource_type: flow
 id: 0a840a2f-daf7-476c-8f7f-40e100666d19
 name: Sample Vanilla Multi Auth Dual Step with SMS
 handle: sample-vanilla-multi-auth-dual-step-sms
@@ -698,7 +698,7 @@ nodes:
 - id: end
   type: END
 ---
-# resource_type: flow
+resource_type: flow
 id: 6b8aa940-e8e7-42d8-88b6-4411a09fad85
 name: Sample Vanilla Multi Auth Single Step Registration with SMS and Passkey
 handle: sample-vanilla-multi-auth-single-step-sms
@@ -1136,7 +1136,7 @@ nodes:
 - id: end
   type: END
 ---
-# resource_type: flow
+resource_type: flow
 id: 58bb4b15-700c-4114-a744-f55650990259
 name: Sample Vanilla Multi Auth Dual Step Registration with SMS
 handle: sample-vanilla-multi-auth-dual-step-sms
@@ -1402,7 +1402,7 @@ nodes:
   type: END
 
 ---
-# resource_type: application
+resource_type: application
 id: 019e3a5c-0500-7f3e-a66e-66fc7918c3a7
 ouHandle: default
 name: Sample App

--- a/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
@@ -1,4 +1,4 @@
-# resource_type: user_type
+resource_type: user_type
 id: wayfinder-customer-type
 category: user
 name: Customer
@@ -44,7 +44,7 @@ schema: {
   }
 
 ---
-# resource_type: user_type
+resource_type: user_type
 id: wayfinder-staff-type
 category: user
 name: Staff
@@ -80,7 +80,7 @@ schema: {
   }
 
 ---
-# resource_type: resource_server
+resource_type: resource_server
 id: wayfinder-agent-rs
 name: Wayfinder Agent
 description: Controls access to the Wayfinder Concierge agent
@@ -96,7 +96,7 @@ resources:
         description: Grants access to the Wayfinder Concierge agent
 
 ---
-# resource_type: resource_server
+resource_type: resource_server
 id: wayfinder-booking-rs
 name: Wayfinder Booking
 handle: wayfinder
@@ -138,7 +138,7 @@ resources:
         description: Allows the upgrade scheduler agent to execute a pending upgrade via CIBA user token
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000001
 name: Wayfinder Registration Flow
 handle: wayfinder-registration-flow
@@ -315,7 +315,7 @@ nodes:
     type: END
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000002
 name: Wayfinder Password Recovery Flow
 handle: wayfinder-recovery-flow
@@ -483,7 +483,7 @@ nodes:
     type: END
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000005
 name: Wayfinder Staff Onboarding Flow
 handle: wayfinder-onboarding-flow
@@ -843,7 +843,7 @@ nodes:
     type: END
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000008
 name: Wayfinder Registration with Auto Sign-In Flow
 handle: wayfinder-registration-autosignin-flow
@@ -994,7 +994,7 @@ nodes:
     type: END
 
 ---
-# resource_type: application
+resource_type: application
 id: wayfinder-app
 name: Wayfinder
 description: Wayfinder Travel sample application
@@ -1056,7 +1056,7 @@ inboundAuthConfig:
           - groups
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000006
 name: Default Wayfinder CIBA Email Notification Flow
 handle: wayfinder-ciba-email-flow
@@ -1260,7 +1260,7 @@ nodes:
 
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000007
 name: Default Wayfinder CIBA SMS Notification Flow
 handle: wayfinder-ciba-sms-flow
@@ -1464,7 +1464,7 @@ nodes:
     type: END
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000004
 name: Wayfinder Agent Authentication Flow
 handle: wayfinder-agent-auth-flow
@@ -1600,7 +1600,7 @@ nodes:
     type: END
 
 ---
-# resource_type: agent
+resource_type: agent
 id: wayfinder-concierge
 name: WAYFINDER-CONCIERGE
 description: Wayfinder Concierge AI agent for the Wayfinder Travel sample
@@ -1631,7 +1631,7 @@ inboundAuthConfig:
               - email
 
 ---
-# resource_type: agent
+resource_type: agent
 # CIBA-only client used by the upgrade scheduler to initiate backchannel
 # authentication for users who have a pending upgrade request.
 # Uses wayfinder-ciba-email-flow so ThunderID sends an email notification to the
@@ -1668,7 +1668,29 @@ inboundAuthConfig:
               - username
 
 ---
-# resource_type: application
+resource_type: application
+# Confidential OAuth client used by the Wayfinder backend to call the
+# ThunderID AuthZEN PDP. This client authenticates the backend and is not the
+# subject of the access evaluation.
+id: wayfinder-authzen-client
+name: Wayfinder AuthZEN Client
+description: Backend service that requests MCP tool authorization decisions from the ThunderID AuthZEN PDP.
+ouHandle: default
+inboundAuthConfig:
+  - type: oauth2
+    config:
+      clientId: "{{.AUTHZEN_CLIENT_ID}}"
+      clientSecret: "{{.AUTHZEN_CLIENT_SECRET}}"
+      grantTypes:
+        - client_credentials
+      tokenEndpointAuthMethod: client_secret_basic
+      publicClient: false
+      token:
+        accessToken:
+          validityPeriod: 3600
+
+---
+resource_type: application
 # Public OAuth client used by external MCP clients (e.g. MCP Inspector)
 # to call the Wayfinder MCP server on /mcp.
 # Used by the MCP Authorization tryout to demonstrate ThunderID-secured MCP
@@ -1706,7 +1728,7 @@ inboundAuthConfig:
             validityPeriod: 3600
 
 ---
-# resource_type: role
+resource_type: role
 id: wayfinder-traveler-role
 name: Traveler
 description: Consumer role with full booking permissions
@@ -1724,21 +1746,21 @@ assignments:
     type: user
 
 ---
-# resource_type: role
+resource_type: role
 id: wayfinder-support-role
 name: Support
 description: Staff role for consumer support workflows
 ouHandle: default
 
 ---
-# resource_type: role
+resource_type: role
 id: wayfinder-destinations-admin-role
 name: DestinationsAdmin
 description: Staff role for curating featured destinations
 ouHandle: default
 
 ---
-# resource_type: role
+resource_type: role
 id: wayfinder-ops-admin-role
 name: OpsAdmin
 description: Staff role for inviting and managing other staff
@@ -1748,7 +1770,7 @@ assignments:
     type: user
 
 ---
-# resource_type: role
+resource_type: role
 id: chat-user-role
 name: Chat User
 description: Grants access to use the Wayfinder Concierge agent and request flight upgrades through it
@@ -1766,7 +1788,21 @@ assignments:
     type: user
 
 ---
-# resource_type: role
+resource_type: role
+id: wayfinder-authzen-client-role
+name: Wayfinder AuthZEN Client
+description: Grants the Wayfinder backend permission to call the ThunderID AuthZEN PDP.
+ouHandle: default
+permissions:
+  - resourceServerId: 01900000-0000-7000-8000-000000000020
+    permissions:
+      - system
+assignments:
+  - id: wayfinder-authzen-client
+    type: app
+
+---
+resource_type: role
 id: booking-user-role
 name: Booking User
 description: Grants booking permissions for the Wayfinder sample
@@ -1784,7 +1820,7 @@ assignments:
     type: user
 
 ---
-# resource_type: role
+resource_type: role
 id: recommender-role
 name: Recommender
 description: Grants access to wayfinder:booking:recommend and wayfinder:upgrade:search permissions, assigned to the Wayfinder Concierge agent
@@ -1799,7 +1835,7 @@ assignments:
     type: agent
 
 ---
-# resource_type: role
+resource_type: role
 id: upgrade-scheduler-role
 name: Upgrade Scheduler
 description: Grants wayfinder:upgrade:read to the upgrade scheduler agent so its M2M token can list pending upgrade requests
@@ -1814,7 +1850,7 @@ assignments:
     type: agent
 
 ---
-# resource_type: user
+resource_type: user
 id: wayfinder-john-doe
 type: Customer
 ouHandle: default
@@ -1828,7 +1864,7 @@ credentials:
   password: "{{.JOHN_DOE_PASSWORD}}"
 
 ---
-# resource_type: user
+resource_type: user
 id: wayfinder-jane-smith
 type: Customer
 ouHandle: default
@@ -1842,7 +1878,7 @@ credentials:
   password: "{{.JANE_SMITH_PASSWORD}}"
 
 ---
-# resource_type: user
+resource_type: user
 id: wayfinder-alex-carter
 type: Staff
 ouHandle: default
@@ -1854,7 +1890,7 @@ credentials:
   password: "{{.ALEX_CARTER_PASSWORD}}"
 
 ---
-# resource_type: server_config
+resource_type: server_config
 # Allows the Wayfinder web app's browser origin to call the server
 name: cors
 value:

--- a/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
@@ -1,4 +1,4 @@
-# resource_type: user_type
+resource_type: user_type
 id: wayfinder-customer-type
 category: user
 name: Customer
@@ -59,7 +59,7 @@ schema: {
   }
 
 ---
-# resource_type: user_type
+resource_type: user_type
 id: wayfinder-staff-type
 category: user
 name: Staff
@@ -95,7 +95,7 @@ schema: {
   }
 
 ---
-# resource_type: resource_server
+resource_type: resource_server
 id: wayfinder-agent-rs
 name: Wayfinder Agent
 description: Controls access to the Wayfinder Concierge agent
@@ -111,7 +111,7 @@ resources:
         description: Grants access to the Wayfinder Concierge agent
 
 ---
-# resource_type: resource_server
+resource_type: resource_server
 id: wayfinder-booking-rs
 name: Wayfinder Booking
 handle: wayfinder
@@ -153,7 +153,7 @@ resources:
         description: Allows the upgrade scheduler agent to execute a pending upgrade via CIBA user token
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000001
 name: Wayfinder Registration Flow
 handle: wayfinder-registration-flow
@@ -331,7 +331,7 @@ nodes:
 
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000002
 name: Wayfinder Password Recovery Flow
 handle: wayfinder-recovery-flow
@@ -497,7 +497,7 @@ nodes:
     type: END
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000005
 name: Wayfinder Staff Onboarding Flow
 handle: wayfinder-onboarding-flow
@@ -857,7 +857,7 @@ nodes:
     type: END
 
 ---
-# resource_type: application
+resource_type: application
 id: wayfinder-app
 name: Wayfinder
 description: Wayfinder Travel sample application
@@ -918,7 +918,7 @@ inboundAuthConfig:
           - groups
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000006
 name: Default Wayfinder CIBA Email Notification Flow
 handle: wayfinder-ciba-email-flow
@@ -1121,7 +1121,7 @@ nodes:
     type: END
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000007
 name: Default Wayfinder CIBA SMS Notification Flow
 handle: wayfinder-ciba-sms-flow
@@ -1325,7 +1325,7 @@ nodes:
     type: END
 
 ---
-# resource_type: flow
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000004
 name: Wayfinder Agent Authentication Flow
 handle: wayfinder-agent-auth-flow
@@ -1461,7 +1461,7 @@ nodes:
     type: END
 
 ---
-# resource_type: agent
+resource_type: agent
 id: wayfinder-concierge
 name: WAYFINDER-CONCIERGE
 description: Wayfinder Concierge AI agent for the Wayfinder Travel sample
@@ -1492,13 +1492,13 @@ inboundAuthConfig:
               - email
 
 ---
-# resource_type: agent
 # CIBA-only client used by the upgrade scheduler to initiate backchannel
 # authentication for users who have a pending upgrade request.
 # Uses wayfinder-ciba-email-flow so ThunderID sends an email notification to the
 # user's registered address. Kept separate from wayfinder-concierge because
 # auth_flow_handle is shared between authorization_code and CIBA — they need
 # different flows (interactive vs backchannel notification).
+resource_type: agent
 id: wayfinder-upgrade-agent
 name: WAYFINDER-UPGRADE-AGENT
 description: Upgrade scheduler agent — initiates CIBA for users with pending flight upgrade requests
@@ -1529,7 +1529,29 @@ inboundAuthConfig:
               - username
 
 ---
-# resource_type: application
+resource_type: application
+# Confidential OAuth client used by the Wayfinder backend to call the
+# ThunderID AuthZEN PDP. This client authenticates the backend and is not the
+# subject of the access evaluation.
+id: wayfinder-authzen-client
+name: Wayfinder AuthZEN Client
+description: Backend service that requests MCP tool authorization decisions from the ThunderID AuthZEN PDP.
+ouHandle: default
+inboundAuthConfig:
+  - type: oauth2
+    config:
+      clientId: "{{.AUTHZEN_CLIENT_ID}}"
+      clientSecret: "{{.AUTHZEN_CLIENT_SECRET}}"
+      grantTypes:
+        - client_credentials
+      tokenEndpointAuthMethod: client_secret_basic
+      publicClient: false
+      token:
+        accessToken:
+          validityPeriod: 3600
+
+---
+resource_type: application
 # Public OAuth client used by external MCP clients (e.g. MCP Inspector)
 # to call the Wayfinder MCP server on /mcp.
 # Used by the MCP Authorization tryout to demonstrate ThunderID-secured MCP
@@ -1567,7 +1589,7 @@ inboundAuthConfig:
             validityPeriod: 3600
 
 ---
-# resource_type: role
+resource_type: role
 id: wayfinder-traveler-role
 name: Traveler
 description: Consumer role with full booking permissions
@@ -1585,21 +1607,21 @@ assignments:
     type: user
 
 ---
-# resource_type: role
+resource_type: role
 id: wayfinder-support-role
 name: Support
 description: Staff role for consumer support workflows
 ouHandle: default
 
 ---
-# resource_type: role
+resource_type: role
 id: wayfinder-destinations-admin-role
 name: DestinationsAdmin
 description: Staff role for curating featured destinations
 ouHandle: default
 
 ---
-# resource_type: role
+resource_type: role
 id: wayfinder-ops-admin-role
 name: OpsAdmin
 description: Staff role for inviting and managing other staff
@@ -1609,7 +1631,7 @@ assignments:
     type: user
 
 ---
-# resource_type: role
+resource_type: role
 id: chat-user-role
 name: Chat User
 description: Grants access to use the Wayfinder Concierge agent and request flight upgrades through it
@@ -1627,7 +1649,21 @@ assignments:
     type: user
 
 ---
-# resource_type: role
+resource_type: role
+id: wayfinder-authzen-client-role
+name: Wayfinder AuthZEN Client
+description: Grants the Wayfinder backend permission to call the ThunderID AuthZEN PDP.
+ouHandle: default
+permissions:
+  - resourceServerId: 01900000-0000-7000-8000-000000000020
+    permissions:
+      - system
+assignments:
+  - id: wayfinder-authzen-client
+    type: app
+
+---
+resource_type: role
 id: booking-user-role
 name: Booking User
 description: Grants booking permissions for the Wayfinder sample
@@ -1645,7 +1681,7 @@ assignments:
     type: user
 
 ---
-# resource_type: role
+resource_type: role
 id: recommender-role
 name: Recommender
 description: Grants access to wayfinder:booking:recommend and wayfinder:upgrade:search permissions, assigned to the Wayfinder Concierge agent
@@ -1660,7 +1696,7 @@ assignments:
     type: agent
 
 ---
-# resource_type: role
+resource_type: role
 id: upgrade-scheduler-role
 name: Upgrade Scheduler
 description: Grants wayfinder:upgrade:read to the upgrade scheduler agent so its M2M token can list pending upgrade requests
@@ -1675,7 +1711,7 @@ assignments:
     type: agent
 
 ---
-# resource_type: user
+resource_type: user
 id: wayfinder-john-doe
 type: Customer
 ouHandle: default
@@ -1692,7 +1728,7 @@ credentials:
   password: "{{.JOHN_DOE_PASSWORD}}"
 
 ---
-# resource_type: user
+resource_type: user
 id: wayfinder-jane-smith
 type: Customer
 ouHandle: default
@@ -1706,7 +1742,7 @@ credentials:
   password: "{{.JANE_SMITH_PASSWORD}}"
 
 ---
-# resource_type: user
+resource_type: user
 id: wayfinder-alex-carter
 type: Staff
 ouHandle: default
@@ -1718,7 +1754,7 @@ credentials:
   password: "{{.ALEX_CARTER_PASSWORD}}"
 
 ---
-# resource_type: credential_configuration
+resource_type: credential_configuration
 # The Wayfinder Sky Pass issued to the wallet via OID4VCI. handle =
 # credential_configuration_id (and the OAuth scope). Every claim is individually
 # disclosable (SD-JWT); the lounge requests only a subset at verification time.
@@ -1744,7 +1780,7 @@ claims:
     displayName: Tier
 
 ---
-# resource_type: presentation_definition
+resource_type: presentation_definition
 # The Skyline Lounge kiosk's OpenID4VP request. Selective disclosure: it asks only
 # for `tier` (to prove status) and optionally `full_name` (to greet the guest) —
 # the wallet discloses nothing else from the pass.
@@ -1759,7 +1795,7 @@ optionalClaims:
   - full_name
 
 ---
-# resource_type: application
+resource_type: application
 # The Heidi / Funke wallet's OAuth client for the OID4VCI issuance flow (its fixed
 # vendor client_id + redirect). Lets the Heidi wallet receive the Sky Pass.
 id: heidi-wallet-app
@@ -1789,7 +1825,7 @@ inboundAuthConfig:
       publicClient: true
 
 ---
-# resource_type: application
+resource_type: application
 # The Lissi wallet's OAuth client for the OID4VCI issuance flow (its fixed vendor
 # client_id + redirect). Lets the Lissi wallet receive the Sky Pass.
 id: lissi-wallet-app
@@ -1819,7 +1855,7 @@ inboundAuthConfig:
       publicClient: true
 
 ---
-# resource_type: server_config
+resource_type: server_config
 # Allows the Wayfinder web app's browser origin to call the server
 name: cors
 value:

--- a/tests/e2e/thunderid-config.yaml
+++ b/tests/e2e/thunderid-config.yaml
@@ -1,5 +1,5 @@
 ---
-# resource_type: application
+resource_type: application
 # Embedded server-side application used exclusively by E2E test infrastructure for admin API
 # authentication. It has no OAuth profile, so it initiates the admin authentication flow directly
 # via the Flow Execution API and is issued a Flow Secret.
@@ -15,7 +15,7 @@ allowedUserTypes:
   - Customer
 
 ---
-# resource_type: server_config
+resource_type: server_config
 # Allows the sample apps' browser origins to reach the API during E2E tests. CORS origins come only from
 # the server-config "cors" section (no default ships), so the E2E setup imports them here.
 name: cors

--- a/tests/integration/agent/agent_import_export_test.go
+++ b/tests/integration/agent/agent_import_export_test.go
@@ -158,7 +158,7 @@ func (s *AgentImportExportSuite) TestExportImportRoundTrip_EntityOnlyAgent() {
 	s.Require().NotEmpty(exportResp.Resources, "expected exported YAML")
 	yamlContent := exportResp.Resources
 
-	s.Assert().Contains(yamlContent, "# resource_type: agent")
+	s.Assert().Contains(yamlContent, "resource_type: agent")
 	s.Assert().Contains(yamlContent, "id: "+createdID)
 	s.Assert().Contains(yamlContent, "ouId: "+s.ouID)
 	s.Assert().Contains(yamlContent, "name: "+agentName)
@@ -223,7 +223,7 @@ func (s *AgentImportExportSuite) TestExportImportRoundTrip_AgentWithConfidential
 	s.Require().NoError(err)
 	yamlContent := exportResp.Resources
 
-	s.Assert().Contains(yamlContent, "# resource_type: agent")
+	s.Assert().Contains(yamlContent, "resource_type: agent")
 	// ClientID and ClientSecret are parameterized; the plaintext secret must not appear in YAML.
 	s.Assert().NotContains(yamlContent, clientSecret, "client secret must not appear in exported YAML")
 	s.Assert().Contains(yamlContent, "{{", "client_id should be a template variable")
@@ -337,7 +337,7 @@ func (s *AgentImportExportSuite) TestExportImportRoundTrip_AgentWithAllFields() 
 	yamlContent := exportResp.Resources
 
 	// Assert every significant field appears in the exported YAML.
-	s.Assert().Contains(yamlContent, "# resource_type: agent")
+	s.Assert().Contains(yamlContent, "resource_type: agent")
 	s.Assert().Contains(yamlContent, "id: "+createdID)
 	s.Assert().Contains(yamlContent, "ouId: "+s.ouID)
 	s.Assert().Contains(yamlContent, "name: "+agentName)

--- a/tests/integration/application/application_import_export_test.go
+++ b/tests/integration/application/application_import_export_test.go
@@ -205,7 +205,7 @@ func (s *ApplicationImportExportSuite) TestExportImportRoundTrip_ConfidentialOAu
 			"exported YAML must not contain a bare `:` key")
 	}
 
-	s.Assert().Contains(yamlContent, "# resource_type: application")
+	s.Assert().Contains(yamlContent, "resource_type: application")
 	s.Assert().Contains(yamlContent, "id: "+createdID)
 	s.Assert().Contains(yamlContent, "ouId: "+s.ouID)
 	s.Assert().Contains(yamlContent, "name: "+appName)

--- a/tests/integration/declarativesinglefile/single_file_mode_test.go
+++ b/tests/integration/declarativesinglefile/single_file_mode_test.go
@@ -56,13 +56,13 @@ import (
 // The {{ t(...) }} expression in the GitHub IDP description verifies that
 // non-Go-template expressions inside the file are preserved as-is and do not
 // cause parse errors during env-var substitution.
-const resourcesYAML = `# resource_type: organization_unit
+const resourcesYAML = `resource_type: organization_unit
 id: sf-decl-ou-1
 handle: sf-decl-ou-1
 name: Single File Declarative OU
 description: Organization unit loaded via single-file mode
 ---
-# resource_type: identity_provider
+resource_type: identity_provider
 id: sf-decl-idp-1
 name: Single File GitHub IDP
 description: "{{ t(idp.github.description) }}"
@@ -78,7 +78,7 @@ properties:
     value: https://localhost:8095/callback
     isSecret: false
 ---
-# resource_type: identity_provider
+resource_type: identity_provider
 id: sf-decl-idp-2
 name: Single File Google IDP
 description: IDP loaded via single-file mode

--- a/tests/integration/importexport/import_export_fresh_pack_test.go
+++ b/tests/integration/importexport/import_export_fresh_pack_test.go
@@ -759,7 +759,8 @@ func (s *GroupRoleResourceImportExportSuite) TestGroupExportMultipleGroups() {
 func (s *GroupRoleResourceImportExportSuite) TestImportGroupWithMembers() {
 	groupName := "Import Members Group " + s.handleSuffix
 
-	yamlContent := fmt.Sprintf(`name: %s
+	yamlContent := fmt.Sprintf(`resource_type: group
+name: %s
 description: Imported group with a member
 ouId: %s
 members:
@@ -801,7 +802,8 @@ members:
 func (s *GroupRoleResourceImportExportSuite) TestImportGroupWithoutMembers() {
 	groupName := "Import No Members Group " + s.handleSuffix
 
-	yamlContent := fmt.Sprintf(`name: %s
+	yamlContent := fmt.Sprintf(`resource_type: group
+name: %s
 description: Imported group without members
 ouId: %s
 `, groupName, s.ouID)
@@ -841,7 +843,8 @@ func (s *GroupRoleResourceImportExportSuite) TestImportGroupUpsertUpdateWithMemb
 	defer testutils.DeleteGroup(groupID)
 
 	// Second import (update path) with the same ID and members
-	yamlContent := fmt.Sprintf(`id: %s
+	yamlContent := fmt.Sprintf(`resource_type: group
+id: %s
 name: Upsert Members Group %s
 description: Updated via import
 ouId: %s
@@ -888,7 +891,8 @@ func (s *GroupRoleResourceImportExportSuite) TestImportRoleWithAssignmentsCreate
 
 	roleName := "Import Role With Assignments " + s.handleSuffix
 
-	yamlContent := fmt.Sprintf(`name: %s
+	yamlContent := fmt.Sprintf(`resource_type: role
+name: %s
 description: Imported role with group assignment
 ouId: %s
 permissions: []
@@ -948,7 +952,8 @@ func (s *GroupRoleResourceImportExportSuite) TestImportRoleWithAssignmentsUpdate
 	s.Require().NoError(err)
 	defer testutils.DeleteRole(roleID)
 
-	yamlContent := fmt.Sprintf(`id: %s
+	yamlContent := fmt.Sprintf(`resource_type: role
+id: %s
 name: Upsert Role %s
 description: Updated via import with assignment
 ouId: %s
@@ -994,7 +999,8 @@ assignments:
 func (s *GroupRoleResourceImportExportSuite) TestImportRoleNoAssignments() {
 	roleName := "Import Role No Assignments " + s.handleSuffix
 
-	yamlContent := fmt.Sprintf(`name: %s
+	yamlContent := fmt.Sprintf(`resource_type: role
+name: %s
 description: Imported role without assignments
 ouId: %s
 permissions: []
@@ -1030,7 +1036,7 @@ permissions: []
 func (s *GroupRoleResourceImportExportSuite) TestImportResourceServerWithNestedResources() {
 	handle := "nested-rs-" + s.handleSuffix
 
-	yamlContent := fmt.Sprintf(`# resource_type: resource_server
+	yamlContent := fmt.Sprintf(`resource_type: resource_server
 name: Nested Resource Server %s
 description: Resource server with nested resources
 handle: %s
@@ -1105,7 +1111,7 @@ func (s *GroupRoleResourceImportExportSuite) TestImportResourceServerUpsertNeste
 		if id != "" {
 			idLine = "id: " + id + "\n"
 		}
-		return fmt.Sprintf(`# resource_type: resource_server
+		return fmt.Sprintf(`resource_type: resource_server
 %sname: Upsert Resource Server %s
 description: Resource server for upsert test
 handle: %s

--- a/tests/integration/resources/declarative_resources/agents/agent-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/agents/agent-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: agent
 id: decl-agent-1
 ouId: decl-ou-1
 type: default

--- a/tests/integration/resources/declarative_resources/agents/agent-declarative-confidential.yaml
+++ b/tests/integration/resources/declarative_resources/agents/agent-declarative-confidential.yaml
@@ -1,3 +1,4 @@
+resource_type: agent
 id: decl-agent-confidential-1
 ouId: decl-ou-1
 type: default

--- a/tests/integration/resources/declarative_resources/applications/app-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/applications/app-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: application
 id: decl-app-1
 name: Declarative Test Application
 description: A declarative test application for integration testing

--- a/tests/integration/resources/declarative_resources/applications/app-declarative-confidential.yaml
+++ b/tests/integration/resources/declarative_resources/applications/app-declarative-confidential.yaml
@@ -1,3 +1,4 @@
+resource_type: application
 id: decl-app-confidential-1
 name: Declarative Test Confidential Application
 description: A declarative confidential test application for integration testing

--- a/tests/integration/resources/declarative_resources/flows/flow-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/flows/flow-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: flow
 id: decl-flow-1
 handle: decl-flow-1
 name: Declarative Test Flow

--- a/tests/integration/resources/declarative_resources/flows/flow-declarative-recovery-1.yaml
+++ b/tests/integration/resources/declarative_resources/flows/flow-declarative-recovery-1.yaml
@@ -1,3 +1,4 @@
+resource_type: flow
 id: decl-recovery-flow-1
 handle: decl-flow-1
 name: Declarative Test Recovery Flow

--- a/tests/integration/resources/declarative_resources/flows/flow-declarative-registration-1.yaml
+++ b/tests/integration/resources/declarative_resources/flows/flow-declarative-registration-1.yaml
@@ -1,3 +1,4 @@
+resource_type: flow
 id: decl-reg-flow-1
 handle: decl-reg-flow-1
 name: Declarative Test Registration Flow

--- a/tests/integration/resources/declarative_resources/identity_providers/idp-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/identity_providers/idp-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: identity_provider
 id: decl-idp-1
 name: Declarative Test IDP
 description: A declarative test identity provider

--- a/tests/integration/resources/declarative_resources/layouts/layout-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/layouts/layout-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: layout
 id: decl-layout-1
 displayName: Declarative Test Layout
 description: A declarative test layout

--- a/tests/integration/resources/declarative_resources/organization_units/ou-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/organization_units/ou-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: organization_unit
 id: decl-ou-1
 handle: decl-ou-1
 name: Declarative Test OU

--- a/tests/integration/resources/declarative_resources/resource_servers/resource-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/resource_servers/resource-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: resource_server
 id: decl-rs-1
 name: Declarative Resource Server
 description: A declarative test resource server

--- a/tests/integration/resources/declarative_resources/roles/role-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/roles/role-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: role
 id: decl-role-1
 name: Declarative Test Role
 description: A declarative test role for integration testing

--- a/tests/integration/resources/declarative_resources/server_configs/cors.yaml
+++ b/tests/integration/resources/declarative_resources/server_configs/cors.yaml
@@ -1,3 +1,4 @@
+resource_type: server_config
 name: cors
 value:
   allowedOrigins:

--- a/tests/integration/resources/declarative_resources/themes/theme-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/themes/theme-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: theme
 id: decl-theme-1
 displayName: Declarative Test Theme
 description: A declarative test theme

--- a/tests/integration/resources/declarative_resources/user_types/usertype-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/user_types/usertype-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: user_type
 id: decl-schema-1
 name: Declarative Test Schema
 ouId: decl-ou-1

--- a/tests/integration/resources/declarative_resources/users/user-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/users/user-declarative-1.yaml
@@ -1,3 +1,4 @@
+resource_type: user
 id: decl-user-1
 type: person
 ouId: decl-ou-1


### PR DESCRIPTION
### Purpose

Make the resource type an explicit, first-class attribute of every declarative resource document.

Previously the importer determined a document's resource type implicitly — first by looking for a `# resource_type:` **comment** header, and falling back to **structural heuristics** (guessing the type from which keys were present, e.g. `identifier` + `resources` → resource server). This was brittle: heuristics could misclassify look-alike resources, comment headers were easy to drop during edits, and the rules were hard to reason about.

This PR replaces all of that with a single, declarative `resource_type` **field** on each YAML document. The type is now read directly and unambiguously; documents without a recognized `resource_type` are rejected at import time instead of being silently misclassified.

```yaml
resource_type: role
id: booking-user-role
name: Booking User
ouHandle: default
```

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
`resource_type` is now a **required top-level field** on every declarative resource document. The two previous classification mechanisms are removed:
- `# resource_type: <type>` **comment** headers are no longer recognized.
- **Structure-based inference** (deriving the type from the set of keys present) is no longer performed.

#### 💥 Impact
Any existing declarative resource YAML (single-file or per-resource, used with `--resources`, the import API, or bootstrap) that relied on comment headers or automatic structural classification will fail to import with:

```json
{ "code": "IMP-1002", "description": { "defaultValue": "unable to determine resource type for document N" } }
```

#### 🔄 Migration Guide
Add a `resource_type` field as a top-level key to each document (one per `---`-separated document in multi-document files):

```diff
-# resource_type: user_type
+resource_type: user_type
 id: wayfinder-customer-type
 name: Customer
```

Recognized values: `organization_unit`, `user_type`, `resource_server`, `role`, `group`, `identity_provider`, `notification_sender`, `flow`, `theme`, `layout`, `application`, `user`, `translation`, `agent`, `presentation_definition`, `credential_configuration`, `server_config`.

---

### Approach

**Backend**
- `importer/parser.go` — removed comment-based classification (`classifyResourceTypeWithComments`, `parseResourceTypeFromComment`) and the structural heuristics (`classifyResourceType`, `hasAllKeys`, `hasAnyKey`). Documents are now classified by a single `resourceTypeFromField` that scans the top-level mapping for `resource_type`; an unrecognized/missing value returns "unknown" and the import fails fast.
- `declarative_resource/manager.go` & `loader.go` — document/resource-type matching now keys off the `resource_type` field.
- `export/service.go` — exported YAML now emits the `resource_type` field so an export → import round-trip is lossless.

**Frontend**
- `import-export/ConfigureExport.tsx` — export configuration uses the explicit resource type for filtering/classification.

**Resource definitions migrated to the field form**
- Default bootstrap resources (`backend/cmd/server/bootstrap/01-default-resources.yaml`).
- Sample app configs (`react-sdk`, `react-api-based`, `react-vanilla` basic/multi-auth, wayfinder `app-native`/`redirect`) and the e2e config.
- The dev-only CORS `server_config` seed staged by `build.sh` for `make run`.
- Also fixed a latent bug in the wayfinder `redirect` sample where two flows (`…0007` CIBA SMS and `…0004` Agent Auth) were fused into one document by a missing `---` separator.

**Tests** — unit and integration tests and their fixtures updated to declare `resource_type`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YAML resources now declare their type with an active `resource_type` field.
  * Imports and exports use explicit resource types for more reliable classification and filtering.
  * Invalid or missing resource types are rejected during import.
* **Bug Fixes**
  * Improved resource precedence and export categorization across supported resource types.
  * Updated sample and default configurations to use the new format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
