### PR TITLE
Fix oauth certificate handling in frontend

### DIFF
--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/CertificateSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/CertificateSection.tsx
@@ -17,22 +17,21 @@
  */
 
 import {SettingsCard} from '@thunderid/components';
-import {Stack, TextField, FormControl, FormLabel, Autocomplete} from '@wso2/oxygen-ui';
+import {Stack, TextField, FormControl, FormLabel, Autocomplete, FormHelperText} from '@wso2/oxygen-ui';
 import {useTranslation} from 'react-i18next';
 import CertificateTypes from '../../../../applications/constants/certificate-types';
-import type {Agent} from '../../../models/agent';
 
 interface CertificateSectionProps {
-  agent: Agent;
-  editedAgent: Partial<Agent>;
-  onFieldChange: (field: keyof Agent, value: unknown) => void;
+  certificate?: {type?: string; value?: string} | null;
+  onCertificateChange: (cert: {type: string; value: string} | null) => void;
+  required?: boolean;
   disabled?: boolean;
 }
 
 export default function CertificateSection({
-  agent,
-  editedAgent,
-  onFieldChange,
+  certificate = undefined,
+  onCertificateChange,
+  required = false,
   disabled = false,
 }: CertificateSectionProps) {
   const {t} = useTranslation();
@@ -43,7 +42,8 @@ export default function CertificateSection({
     {value: CertificateTypes.JWKS_URI, label: t('applications:edit.advanced.certificate.type.jwksUri')},
   ];
 
-  const currentCertType = editedAgent.certificate?.type ?? agent.certificate?.type ?? CertificateTypes.NONE;
+  const currentCertType = certificate?.type ?? CertificateTypes.NONE;
+  const currentCertValue = certificate?.value ?? '';
 
   return (
     <SettingsCard
@@ -51,23 +51,36 @@ export default function CertificateSection({
       description={t('applications:edit.advanced.certificate.intro')}
     >
       <Stack spacing={2}>
-        <FormControl fullWidth>
+        <FormControl fullWidth error={required && currentCertType === CertificateTypes.NONE}>
           <FormLabel htmlFor="certificate-type">{t('applications:edit.advanced.labels.certificateType')}</FormLabel>
           <Autocomplete
             id="certificate-type"
             value={certificateTypeOptions.find((opt) => opt.value === currentCertType) ?? certificateTypeOptions[0]}
             onChange={(_, newValue) => {
-              const currentCert = editedAgent.certificate ??
-                agent.certificate ?? {type: CertificateTypes.NONE, value: ''};
-              onFieldChange('certificate', {...currentCert, type: newValue?.value || CertificateTypes.NONE});
+              const newType = newValue?.value ?? CertificateTypes.NONE;
+              if (newType === CertificateTypes.NONE) {
+                onCertificateChange(null);
+              } else {
+                onCertificateChange({type: newType, value: currentCertValue});
+              }
             }}
             options={certificateTypeOptions}
             getOptionLabel={(option) => option.label}
             isOptionEqualToValue={(option, value) => option.value === value.value}
-            renderInput={(params) => <TextField {...params} fullWidth />}
+            renderInput={(params) => (
+              <TextField {...params} fullWidth error={required && currentCertType === CertificateTypes.NONE} />
+            )}
             disableClearable
             disabled={disabled}
           />
+          {required && currentCertType === CertificateTypes.NONE && (
+            <FormHelperText>
+              {t(
+                'applications:edit.advanced.certificate.error.required',
+                'A certificate is required for private_key_jwt authentication.',
+              )}
+            </FormHelperText>
+          )}
         </FormControl>
 
         {currentCertType !== CertificateTypes.NONE && (
@@ -75,22 +88,26 @@ export default function CertificateSection({
             fullWidth
             multiline
             rows={3}
-            value={editedAgent.certificate?.value ?? agent.certificate?.value ?? ''}
+            value={currentCertValue}
             onChange={(e) => {
-              const currentCert = editedAgent.certificate ??
-                agent.certificate ?? {type: CertificateTypes.NONE, value: ''};
-              onFieldChange('certificate', {...currentCert, value: e.target.value});
+              onCertificateChange({type: currentCertType, value: e.target.value});
             }}
             disabled={disabled}
+            error={required && !currentCertValue}
             placeholder={
               currentCertType === CertificateTypes.JWKS_URI
                 ? t('applications:edit.advanced.certificate.placeholder.jwksUri')
                 : t('applications:edit.advanced.certificate.placeholder.jwks')
             }
             helperText={
-              currentCertType === CertificateTypes.JWKS_URI
-                ? t('applications:edit.advanced.certificate.hint.jwksUri')
-                : t('applications:edit.advanced.certificate.hint.jwks')
+              required && !currentCertValue
+                ? t(
+                    'applications:edit.advanced.certificate.error.valueRequired',
+                    'Please enter a value for the selected certificate type.',
+                  )
+                : currentCertType === CertificateTypes.JWKS_URI
+                  ? t('applications:edit.advanced.certificate.hint.jwksUri')
+                  : t('applications:edit.advanced.certificate.hint.jwks')
             }
           />
         )}

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/EditAdvancedSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/EditAdvancedSettings.tsx
@@ -63,9 +63,9 @@ export default function EditAdvancedSettings({
         disabled={agent.isReadOnly}
       />
       <CertificateSection
-        agent={agent}
-        editedAgent={editedAgent}
-        onFieldChange={onFieldChange}
+        certificate={oauth2Config?.certificate}
+        onCertificateChange={(cert) => handleOAuth2ConfigChange({certificate: cert})}
+        required={oauth2Config?.tokenEndpointAuthMethod === 'private_key_jwt'}
         disabled={agent.isReadOnly}
       />
     </Stack>

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/CertificateSection.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/CertificateSection.test.tsx
@@ -20,7 +20,6 @@ import {render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import CertificateTypes from '../../../../../applications/constants/certificate-types';
-import type {Agent} from '../../../../models/agent';
 import CertificateSection from '../CertificateSection';
 
 vi.mock('react-i18next', () => ({
@@ -30,36 +29,28 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('CertificateSection (agent)', () => {
-  const mockAgent: Agent = {
-    id: 'agent-1',
-    ouId: 'ou-1',
-    type: 'default',
-    name: 'Test Agent',
-    certificate: {type: CertificateTypes.NONE, value: ''},
-  };
-
-  const mockOnFieldChange = vi.fn();
+  const mockOnCertificateChange = vi.fn();
 
   beforeEach(() => {
-    mockOnFieldChange.mockClear();
+    mockOnCertificateChange.mockClear();
   });
 
   describe('Rendering', () => {
     it('renders the certificate section', () => {
-      render(<CertificateSection agent={mockAgent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
+      render(<CertificateSection onCertificateChange={mockOnCertificateChange} />);
 
       expect(screen.getByText('applications:edit.advanced.labels.certificate')).toBeInTheDocument();
       expect(screen.getByText('applications:edit.advanced.certificate.intro')).toBeInTheDocument();
     });
 
     it('renders the certificate type dropdown', () => {
-      render(<CertificateSection agent={mockAgent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
+      render(<CertificateSection onCertificateChange={mockOnCertificateChange} />);
 
       expect(screen.getByLabelText('applications:edit.advanced.labels.certificateType')).toBeInTheDocument();
     });
 
-    it('does not render the value field when type is NONE', () => {
-      render(<CertificateSection agent={mockAgent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
+    it('does not render the value field when certificate is null', () => {
+      render(<CertificateSection certificate={null} onCertificateChange={mockOnCertificateChange} />);
 
       expect(
         screen.queryByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks'),
@@ -67,8 +58,12 @@ describe('CertificateSection (agent)', () => {
     });
 
     it('renders the JWKS value field when type is JWKS', () => {
-      const agent = {...mockAgent, certificate: {type: CertificateTypes.JWKS, value: ''}};
-      render(<CertificateSection agent={agent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       expect(
         screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks'),
@@ -76,8 +71,12 @@ describe('CertificateSection (agent)', () => {
     });
 
     it('renders the JWKS URI value field when type is JWKS_URI', () => {
-      const agent = {...mockAgent, certificate: {type: CertificateTypes.JWKS_URI, value: ''}};
-      render(<CertificateSection agent={agent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS_URI, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       expect(
         screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwksUri'),
@@ -86,37 +85,42 @@ describe('CertificateSection (agent)', () => {
   });
 
   describe('Certificate Type Selection', () => {
-    it('reflects the certificate type from the agent', () => {
-      const agent = {...mockAgent, certificate: {type: CertificateTypes.JWKS, value: ''}};
-      render(<CertificateSection agent={agent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
-
-      expect(screen.getByRole('combobox')).toHaveValue('applications:edit.advanced.certificate.type.jwks');
-    });
-
-    it('prioritizes editedAgent.certificate.type over agent.certificate.type', () => {
-      const agent = {...mockAgent, certificate: {type: CertificateTypes.NONE, value: ''}};
+    it('reflects the certificate type from the certificate prop', () => {
       render(
         <CertificateSection
-          agent={agent}
-          editedAgent={{certificate: {type: CertificateTypes.JWKS, value: ''}}}
-          onFieldChange={mockOnFieldChange}
+          certificate={{type: CertificateTypes.JWKS, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
         />,
       );
 
       expect(screen.getByRole('combobox')).toHaveValue('applications:edit.advanced.certificate.type.jwks');
     });
 
-    it('calls onFieldChange when the certificate type changes', async () => {
+    it('calls onCertificateChange with null when NONE is selected', async () => {
       const user = userEvent.setup();
-      render(<CertificateSection agent={mockAgent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
-      const autocomplete = screen.getByRole('combobox');
-      await user.click(autocomplete);
+      await user.click(screen.getByRole('combobox'));
+      const listbox = screen.getByRole('listbox');
+      await user.click(within(listbox).getByText('applications:edit.advanced.certificate.type.none'));
 
+      expect(mockOnCertificateChange).toHaveBeenCalledWith(null);
+    });
+
+    it('calls onCertificateChange with certificate when JWKS is selected', async () => {
+      const user = userEvent.setup();
+      render(<CertificateSection certificate={null} onCertificateChange={mockOnCertificateChange} />);
+
+      await user.click(screen.getByRole('combobox'));
       const listbox = screen.getByRole('listbox');
       await user.click(within(listbox).getByText('applications:edit.advanced.certificate.type.jwks'));
 
-      expect(mockOnFieldChange).toHaveBeenCalledWith('certificate', {
+      expect(mockOnCertificateChange).toHaveBeenCalledWith({
         type: CertificateTypes.JWKS,
         value: '',
       });
@@ -124,14 +128,18 @@ describe('CertificateSection (agent)', () => {
 
     it('preserves certificate value when type changes', async () => {
       const user = userEvent.setup();
-      const agent = {...mockAgent, certificate: {type: CertificateTypes.JWKS, value: 'existing'}};
-      render(<CertificateSection agent={agent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS, value: 'existing'}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       await user.click(screen.getByRole('combobox'));
       const listbox = screen.getByRole('listbox');
       await user.click(within(listbox).getByText('applications:edit.advanced.certificate.type.jwksUri'));
 
-      expect(mockOnFieldChange).toHaveBeenCalledWith('certificate', {
+      expect(mockOnCertificateChange).toHaveBeenCalledWith({
         type: CertificateTypes.JWKS_URI,
         value: 'existing',
       });
@@ -139,56 +147,49 @@ describe('CertificateSection (agent)', () => {
   });
 
   describe('Certificate Value Input', () => {
-    it('reflects certificate value from the agent', () => {
-      const agent = {...mockAgent, certificate: {type: CertificateTypes.JWKS, value: 'jwks-value'}};
-      render(<CertificateSection agent={agent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
+    it('reflects certificate value from the certificate prop', () => {
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS, value: 'jwks-value'}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       expect(screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks')).toHaveValue(
         'jwks-value',
       );
     });
 
-    it('prioritizes editedAgent.certificate.value over agent value', () => {
-      const agent = {...mockAgent, certificate: {type: CertificateTypes.JWKS, value: 'old'}};
+    it('calls onCertificateChange when the value changes', async () => {
+      const user = userEvent.setup({delay: null});
       render(
         <CertificateSection
-          agent={agent}
-          editedAgent={{certificate: {type: CertificateTypes.JWKS, value: 'new'}}}
-          onFieldChange={mockOnFieldChange}
+          certificate={{type: CertificateTypes.JWKS, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
         />,
       );
-
-      expect(screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks')).toHaveValue('new');
-    });
-
-    it('calls onFieldChange when the value changes', async () => {
-      const user = userEvent.setup({delay: null});
-      const agent = {...mockAgent, certificate: {type: CertificateTypes.JWKS, value: ''}};
-      render(<CertificateSection agent={agent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
 
       const valueInput = screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks');
       await user.type(valueInput, 'X');
 
-      expect(mockOnFieldChange).toHaveBeenCalledWith(
-        'certificate',
-        expect.objectContaining({type: CertificateTypes.JWKS}),
-      );
+      expect(mockOnCertificateChange).toHaveBeenCalledWith(expect.objectContaining({type: CertificateTypes.JWKS}));
     });
   });
 
   describe('Edge Cases', () => {
-    it('handles missing certificate on the agent', () => {
-      const agent = {...mockAgent};
-      delete (agent as Partial<Agent>).certificate;
-
-      render(<CertificateSection agent={agent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
+    it('defaults to NONE when no certificate prop is provided', () => {
+      render(<CertificateSection onCertificateChange={mockOnCertificateChange} />);
 
       expect(screen.getByRole('combobox')).toHaveValue('applications:edit.advanced.certificate.type.none');
     });
 
     it('renders the JWKS value input as a multiline textarea with 3 rows', () => {
-      const agent = {...mockAgent, certificate: {type: CertificateTypes.JWKS, value: ''}};
-      render(<CertificateSection agent={agent} editedAgent={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       expect(screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks')).toHaveAttribute(
         'rows',

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/CertificateSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/CertificateSection.tsx
@@ -17,29 +17,29 @@
  */
 
 import {SettingsCard} from '@thunderid/components';
-import {Stack, TextField, FormControl, FormLabel, Autocomplete} from '@wso2/oxygen-ui';
+import {Stack, TextField, FormControl, FormLabel, Autocomplete, FormHelperText} from '@wso2/oxygen-ui';
 import {useTranslation} from 'react-i18next';
 import CertificateTypes from '../../../constants/certificate-types';
-import type {Application} from '../../../models/application';
 
 /**
  * Props for the {@link CertificateSection} component.
  */
 interface CertificateSectionProps {
   /**
-   * The application being edited
+   * The current certificate value (from the OAuth config).
+   * null or undefined means no certificate is configured.
    */
-  application: Application;
+  certificate?: {type?: string; value?: string} | null;
   /**
-   * Partial application object containing edited fields
+   * Called when the user changes the certificate type or value.
+   * Passes null when the user selects "None".
    */
-  editedApp: Partial<Application>;
+  onCertificateChange: (cert: {type: string; value: string} | null) => void;
   /**
-   * Callback function to handle field value changes
-   * @param field - The application field being updated
-   * @param value - The new value for the field
+   * When true, shows an inline error if no certificate is configured.
+   * Use when tokenEndpointAuthMethod is private_key_jwt.
    */
-  onFieldChange: (field: keyof Application, value: unknown) => void;
+  required?: boolean;
   /**
    * Whether inputs should be disabled (e.g. read-only resource).
    */
@@ -60,9 +60,9 @@ interface CertificateSectionProps {
  * @returns Certificate configuration UI within a SettingsCard
  */
 export default function CertificateSection({
-  application,
-  editedApp,
-  onFieldChange,
+  certificate = undefined,
+  onCertificateChange,
+  required = false,
   disabled = false,
 }: CertificateSectionProps) {
   const {t} = useTranslation();
@@ -73,10 +73,8 @@ export default function CertificateSection({
     {value: CertificateTypes.JWKS_URI, label: t('applications:edit.advanced.certificate.type.jwksUri')},
   ];
 
-  const currentCertType =
-    (editedApp.certificate as {type?: string})?.type ??
-    (application.certificate as {type?: string})?.type ??
-    CertificateTypes.NONE;
+  const currentCertType = certificate?.type ?? CertificateTypes.NONE;
+  const currentCertValue = certificate?.value ?? '';
 
   return (
     <SettingsCard
@@ -84,65 +82,63 @@ export default function CertificateSection({
       description={t('applications:edit.advanced.certificate.intro')}
     >
       <Stack spacing={2}>
-        <FormControl fullWidth>
+        <FormControl fullWidth error={required && currentCertType === CertificateTypes.NONE}>
           <FormLabel htmlFor="certificate-type">{t('applications:edit.advanced.labels.certificateType')}</FormLabel>
           <Autocomplete
             id="certificate-type"
             value={certificateTypeOptions.find((opt) => opt.value === currentCertType) ?? certificateTypeOptions[0]}
             onChange={(_, newValue) => {
-              const currentCert = (editedApp.certificate ??
-                application.certificate ?? {
-                  type: CertificateTypes.NONE,
-                  value: '',
-                }) as {
-                type: string;
-                value: string;
-              };
-              onFieldChange('certificate', {...currentCert, type: newValue?.value || CertificateTypes.NONE});
+              const newType = newValue?.value ?? CertificateTypes.NONE;
+              if (newType === CertificateTypes.NONE) {
+                onCertificateChange(null);
+              } else {
+                onCertificateChange({type: newType, value: currentCertValue});
+              }
             }}
             options={certificateTypeOptions}
             getOptionLabel={(option) => option.label}
             isOptionEqualToValue={(option, value) => option.value === value.value}
-            renderInput={(params) => <TextField {...params} fullWidth />}
+            renderInput={(params) => (
+              <TextField {...params} fullWidth error={required && currentCertType === CertificateTypes.NONE} />
+            )}
             disableClearable
             disabled={disabled}
           />
+          {required && currentCertType === CertificateTypes.NONE && (
+            <FormHelperText>
+              {t(
+                'applications:edit.advanced.certificate.error.required',
+                'A certificate is required for private_key_jwt authentication.',
+              )}
+            </FormHelperText>
+          )}
         </FormControl>
 
-        {((editedApp.certificate as {type?: string})?.type ?? (application.certificate as {type?: string})?.type) !==
-          CertificateTypes.NONE && (
+        {currentCertType !== CertificateTypes.NONE && (
           <TextField
             fullWidth
             multiline
             rows={3}
-            value={
-              (editedApp.certificate as {value?: string})?.value ??
-              (application.certificate as {value?: string})?.value ??
-              ''
-            }
+            value={currentCertValue}
             onChange={(e) => {
-              const currentCert = (editedApp.certificate ??
-                application.certificate ?? {
-                  type: CertificateTypes.NONE,
-                  value: '',
-                }) as {
-                type: string;
-                value: string;
-              };
-              onFieldChange('certificate', {...currentCert, value: e.target.value});
+              onCertificateChange({type: currentCertType, value: e.target.value});
             }}
             disabled={disabled}
+            error={required && !currentCertValue}
             placeholder={
-              ((editedApp.certificate as {type?: string})?.type ??
-                (application.certificate as {type?: string})?.type) === CertificateTypes.JWKS_URI
+              currentCertType === CertificateTypes.JWKS_URI
                 ? t('applications:edit.advanced.certificate.placeholder.jwksUri')
                 : t('applications:edit.advanced.certificate.placeholder.jwks')
             }
             helperText={
-              ((editedApp.certificate as {type?: string})?.type ??
-                (application.certificate as {type?: string})?.type) === CertificateTypes.JWKS_URI
-                ? t('applications:edit.advanced.certificate.hint.jwksUri')
-                : t('applications:edit.advanced.certificate.hint.jwks')
+              required && !currentCertValue
+                ? t(
+                    'applications:edit.advanced.certificate.error.valueRequired',
+                    'Please enter a value for the selected certificate type.',
+                  )
+                : currentCertType === CertificateTypes.JWKS_URI
+                  ? t('applications:edit.advanced.certificate.hint.jwksUri')
+                  : t('applications:edit.advanced.certificate.hint.jwks')
             }
           />
         )}

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/EditAdvancedSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/EditAdvancedSettings.tsx
@@ -53,6 +53,8 @@ interface EditAdvancedSettingsProps {
   onFieldChange: (field: keyof Application, value: unknown) => void;
 }
 
+type OAuthCertificate = {type: string; value?: string} | null;
+
 /**
  * Container component for advanced application settings.
  *
@@ -79,6 +81,10 @@ export default function EditAdvancedSettings({
     onFieldChange('inboundAuthConfig', updatedInboundAuth);
   };
 
+  const handleCertificateChange = (cert: OAuthCertificate) => {
+    handleOAuth2ConfigChange({certificate: cert});
+  };
+
   return (
     <Stack spacing={3}>
       <OAuth2ConfigSection
@@ -88,9 +94,9 @@ export default function EditAdvancedSettings({
         disabled={application.isReadOnly}
       />
       <CertificateSection
-        application={application}
-        editedApp={editedApp}
-        onFieldChange={onFieldChange}
+        certificate={oauth2Config?.certificate}
+        onCertificateChange={handleCertificateChange}
+        required={oauth2Config?.tokenEndpointAuthMethod === 'private_key_jwt'}
         disabled={application.isReadOnly}
       />
       <MetadataSection application={application} />

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/__tests__/CertificateSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/__tests__/CertificateSection.test.tsx
@@ -20,7 +20,6 @@ import {render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import CertificateTypes from '../../../../constants/certificate-types';
-import type {Application} from '../../../../models/application';
 import CertificateSection from '../CertificateSection';
 
 vi.mock('react-i18next', () => ({
@@ -30,39 +29,28 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('CertificateSection', () => {
-  const mockApplication: Application = {
-    id: 'test-app-id',
-    name: 'Test Application',
-    description: 'Test Description',
-    template: 'custom',
-    certificate: {
-      type: CertificateTypes.NONE,
-      value: '',
-    },
-  } as Application;
-
-  const mockOnFieldChange = vi.fn();
+  const mockOnCertificateChange = vi.fn();
 
   beforeEach(() => {
-    mockOnFieldChange.mockClear();
+    mockOnCertificateChange.mockClear();
   });
 
   describe('Rendering', () => {
     it('should render the certificate section', () => {
-      render(<CertificateSection application={mockApplication} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+      render(<CertificateSection onCertificateChange={mockOnCertificateChange} />);
 
       expect(screen.getByText('applications:edit.advanced.labels.certificate')).toBeInTheDocument();
       expect(screen.getByText('applications:edit.advanced.certificate.intro')).toBeInTheDocument();
     });
 
     it('should render certificate type dropdown', () => {
-      render(<CertificateSection application={mockApplication} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+      render(<CertificateSection onCertificateChange={mockOnCertificateChange} />);
 
       expect(screen.getByLabelText('applications:edit.advanced.labels.certificateType')).toBeInTheDocument();
     });
 
-    it('should not show value field when certificate type is NONE', () => {
-      render(<CertificateSection application={mockApplication} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+    it('should not show value field when certificate is null', () => {
+      render(<CertificateSection certificate={null} onCertificateChange={mockOnCertificateChange} />);
 
       expect(
         screen.queryByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks'),
@@ -73,12 +61,12 @@ describe('CertificateSection', () => {
     });
 
     it('should show JWKS value field when certificate type is JWKS', () => {
-      const appWithJwks = {
-        ...mockApplication,
-        certificate: {type: CertificateTypes.JWKS, value: ''},
-      };
-
-      render(<CertificateSection application={appWithJwks} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       expect(
         screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks'),
@@ -87,12 +75,12 @@ describe('CertificateSection', () => {
     });
 
     it('should show JWKS URI value field when certificate type is JWKS_URI', () => {
-      const appWithJwksUri = {
-        ...mockApplication,
-        certificate: {type: CertificateTypes.JWKS_URI, value: ''},
-      };
-
-      render(<CertificateSection application={appWithJwksUri} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS_URI, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       expect(
         screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwksUri'),
@@ -102,29 +90,11 @@ describe('CertificateSection', () => {
   });
 
   describe('Certificate Type Selection', () => {
-    it('should display current certificate type from application', () => {
-      const appWithJwks = {
-        ...mockApplication,
-        certificate: {type: CertificateTypes.JWKS, value: ''},
-      };
-
-      render(<CertificateSection application={appWithJwks} editedApp={{}} onFieldChange={mockOnFieldChange} />);
-
-      const input = screen.getByRole('combobox');
-      expect(input).toHaveValue('applications:edit.advanced.certificate.type.jwks');
-    });
-
-    it('should prioritize editedApp certificate type over application', () => {
-      const appWithNone = {
-        ...mockApplication,
-        certificate: {type: CertificateTypes.NONE, value: ''},
-      };
-
+    it('should display JWKS type from certificate prop', () => {
       render(
         <CertificateSection
-          application={appWithNone}
-          editedApp={{certificate: {type: CertificateTypes.JWKS, value: ''}}}
-          onFieldChange={mockOnFieldChange}
+          certificate={{type: CertificateTypes.JWKS, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
         />,
       );
 
@@ -132,9 +102,28 @@ describe('CertificateSection', () => {
       expect(input).toHaveValue('applications:edit.advanced.certificate.type.jwks');
     });
 
-    it('should call onFieldChange when certificate type changes', async () => {
+    it('should call onCertificateChange with null when NONE is selected', async () => {
       const user = userEvent.setup();
-      render(<CertificateSection application={mockApplication} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      const listbox = screen.getByRole('listbox');
+      const noneOption = within(listbox).getByText('applications:edit.advanced.certificate.type.none');
+      await user.click(noneOption);
+
+      expect(mockOnCertificateChange).toHaveBeenCalledWith(null);
+    });
+
+    it('should call onCertificateChange with certificate when JWKS is selected', async () => {
+      const user = userEvent.setup();
+      render(<CertificateSection certificate={null} onCertificateChange={mockOnCertificateChange} />);
 
       const autocomplete = screen.getByRole('combobox');
       await user.click(autocomplete);
@@ -143,7 +132,7 @@ describe('CertificateSection', () => {
       const jwksOption = within(listbox).getByText('applications:edit.advanced.certificate.type.jwks');
       await user.click(jwksOption);
 
-      expect(mockOnFieldChange).toHaveBeenCalledWith('certificate', {
+      expect(mockOnCertificateChange).toHaveBeenCalledWith({
         type: CertificateTypes.JWKS,
         value: '',
       });
@@ -151,12 +140,12 @@ describe('CertificateSection', () => {
 
     it('should preserve certificate value when changing type', async () => {
       const user = userEvent.setup();
-      const appWithValue = {
-        ...mockApplication,
-        certificate: {type: CertificateTypes.JWKS, value: 'existing-jwks'},
-      };
-
-      render(<CertificateSection application={appWithValue} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS, value: 'existing-jwks'}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       const autocomplete = screen.getByRole('combobox');
       await user.click(autocomplete);
@@ -165,7 +154,7 @@ describe('CertificateSection', () => {
       const jwksUriOption = within(listbox).getByText('applications:edit.advanced.certificate.type.jwksUri');
       await user.click(jwksUriOption);
 
-      expect(mockOnFieldChange).toHaveBeenCalledWith('certificate', {
+      expect(mockOnCertificateChange).toHaveBeenCalledWith({
         type: CertificateTypes.JWKS_URI,
         value: 'existing-jwks',
       });
@@ -173,52 +162,32 @@ describe('CertificateSection', () => {
   });
 
   describe('Certificate Value Input', () => {
-    it('should display current certificate value from application', () => {
-      const appWithValue = {
-        ...mockApplication,
-        certificate: {type: CertificateTypes.JWKS, value: 'test-jwks-value'},
-      };
-
-      render(<CertificateSection application={appWithValue} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+    it('should display current certificate value', () => {
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS, value: 'test-jwks-value'}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       const valueInput = screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks');
       expect(valueInput).toHaveValue('test-jwks-value');
     });
 
-    it('should prioritize editedApp certificate value over application', () => {
-      const appWithValue = {
-        ...mockApplication,
-        certificate: {type: CertificateTypes.JWKS, value: 'original-value'},
-      };
-
+    it('should call onCertificateChange when certificate value changes', async () => {
+      const user = userEvent.setup({delay: null});
       render(
         <CertificateSection
-          application={appWithValue}
-          editedApp={{certificate: {type: CertificateTypes.JWKS, value: 'edited-value'}}}
-          onFieldChange={mockOnFieldChange}
+          certificate={{type: CertificateTypes.JWKS, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
         />,
       );
 
       const valueInput = screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks');
-      expect(valueInput).toHaveValue('edited-value');
-    });
-
-    it('should call onFieldChange when certificate value changes', async () => {
-      const user = userEvent.setup({delay: null});
-      const appWithJwks = {
-        ...mockApplication,
-        certificate: {type: CertificateTypes.JWKS, value: ''},
-      };
-
-      render(<CertificateSection application={appWithJwks} editedApp={{}} onFieldChange={mockOnFieldChange} />);
-
-      const valueInput = screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks');
       await user.type(valueInput, 'new-value');
 
-      expect(mockOnFieldChange).toHaveBeenCalled();
-      // Check that the field was updated with the correct type
-      expect(mockOnFieldChange).toHaveBeenCalledWith(
-        'certificate',
+      expect(mockOnCertificateChange).toHaveBeenCalled();
+      expect(mockOnCertificateChange).toHaveBeenCalledWith(
         expect.objectContaining({
           type: CertificateTypes.JWKS,
         }),
@@ -227,20 +196,18 @@ describe('CertificateSection', () => {
 
     it('should preserve certificate type when changing value', async () => {
       const user = userEvent.setup({delay: null});
-      const appWithJwksUri = {
-        ...mockApplication,
-        certificate: {type: CertificateTypes.JWKS_URI, value: 'https://example.com'},
-      };
-
-      render(<CertificateSection application={appWithJwksUri} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS_URI, value: 'https://example.com'}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       const valueInput = screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwksUri');
       await user.clear(valueInput);
       await user.type(valueInput, 'https://new-url.com');
 
-      // Check that the field was updated with the correct type
-      expect(mockOnFieldChange).toHaveBeenCalledWith(
-        'certificate',
+      expect(mockOnCertificateChange).toHaveBeenCalledWith(
         expect.objectContaining({
           type: CertificateTypes.JWKS_URI,
         }),
@@ -249,23 +216,20 @@ describe('CertificateSection', () => {
   });
 
   describe('Edge Cases', () => {
-    it('should handle missing certificate in application', () => {
-      const appWithoutCert = {...mockApplication};
-      delete (appWithoutCert as Partial<Application>).certificate;
-
-      render(<CertificateSection application={appWithoutCert} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+    it('should default to NONE when no certificate prop is provided', () => {
+      render(<CertificateSection onCertificateChange={mockOnCertificateChange} />);
 
       const input = screen.getByRole('combobox');
       expect(input).toHaveValue('applications:edit.advanced.certificate.type.none');
     });
 
     it('should handle multiline JWKS input', () => {
-      const appWithJwks = {
-        ...mockApplication,
-        certificate: {type: CertificateTypes.JWKS, value: ''},
-      };
-
-      render(<CertificateSection application={appWithJwks} editedApp={{}} onFieldChange={mockOnFieldChange} />);
+      render(
+        <CertificateSection
+          certificate={{type: CertificateTypes.JWKS, value: ''}}
+          onCertificateChange={mockOnCertificateChange}
+        />,
+      );
 
       const valueInput = screen.getByPlaceholderText('applications:edit.advanced.certificate.placeholder.jwks');
       expect(valueInput).toHaveAttribute('rows', '3');

--- a/frontend/apps/console/src/features/applications/models/oauth.ts
+++ b/frontend/apps/console/src/features/applications/models/oauth.ts
@@ -384,6 +384,13 @@ export interface OAuth2Config {
    * @example { profile: ['name', 'given_name'], email: ['email', 'email_verified'] }
    */
   scopeClaims?: ScopeClaims;
+
+  /**
+   * OAuth client certificate (JWKS or JWKS URI).
+   * Required when tokenEndpointAuthMethod is 'private_key_jwt'.
+   * null means no certificate is configured.
+   */
+  certificate?: {type: string; value?: string} | null;
 }
 
 /**

--- a/frontend/apps/console/src/features/applications/utils/__tests__/oauth2Rules.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/oauth2Rules.test.ts
@@ -160,6 +160,36 @@ describe('applyTokenEndpointAuthMethodChange', () => {
     const updates = applyTokenEndpointAuthMethodChange(baseConfig(), TokenEndpointAuthMethods.CLIENT_SECRET_POST);
     expect(updates.publicClient).toBeUndefined();
   });
+
+  it('clears certificate when switching away from private_key_jwt', () => {
+    const updates = applyTokenEndpointAuthMethodChange(
+      baseConfig({
+        tokenEndpointAuthMethod: TokenEndpointAuthMethods.PRIVATE_KEY_JWT,
+        certificate: {type: 'JWKS_URI', value: 'https://example.com/jwks'},
+      }),
+      TokenEndpointAuthMethods.CLIENT_SECRET_BASIC,
+    );
+    expect(updates.certificate).toBeNull();
+  });
+
+  it('does not clear certificate when staying on private_key_jwt', () => {
+    const updates = applyTokenEndpointAuthMethodChange(
+      baseConfig({
+        tokenEndpointAuthMethod: TokenEndpointAuthMethods.PRIVATE_KEY_JWT,
+        certificate: {type: 'JWKS_URI', value: 'https://example.com/jwks'},
+      }),
+      TokenEndpointAuthMethods.PRIVATE_KEY_JWT,
+    );
+    expect(updates.certificate).toBeUndefined();
+  });
+
+  it('does not clear certificate when switching between non-private_key_jwt methods', () => {
+    const updates = applyTokenEndpointAuthMethodChange(
+      baseConfig({tokenEndpointAuthMethod: TokenEndpointAuthMethods.CLIENT_SECRET_BASIC}),
+      TokenEndpointAuthMethods.CLIENT_SECRET_POST,
+    );
+    expect(updates.certificate).toBeUndefined();
+  });
 });
 
 describe('isGrantItemDisabled', () => {

--- a/frontend/apps/console/src/features/applications/utils/oauth2Rules.ts
+++ b/frontend/apps/console/src/features/applications/utils/oauth2Rules.ts
@@ -109,6 +109,8 @@ export function applyPublicClientChange(current: OAuth2Config, checked: boolean)
  * Computes the set of config updates triggered by changing the token endpoint auth method.
  * Selecting 'none' promotes the client to public and forces PKCE on; switching away
  * from 'none' demotes it to confidential.
+ * Switching away from 'private_key_jwt' clears the certificate since the cert is only
+ * valid for that auth method in the current console configuration.
  */
 export function applyTokenEndpointAuthMethodChange(current: OAuth2Config, method: string): Partial<OAuth2Config> {
   const updates: Partial<OAuth2Config> = {tokenEndpointAuthMethod: method};
@@ -117,6 +119,12 @@ export function applyTokenEndpointAuthMethodChange(current: OAuth2Config, method
     updates.pkceRequired = true;
   } else if (current.publicClient) {
     updates.publicClient = false;
+  }
+  if (
+    current.tokenEndpointAuthMethod === TokenEndpointAuthMethods.PRIVATE_KEY_JWT &&
+    method !== TokenEndpointAuthMethods.PRIVATE_KEY_JWT
+  ) {
+    updates.certificate = null;
   }
   return updates;
 }


### PR DESCRIPTION


https://github.com/user-attachments/assets/9c584922-3b80-4036-8020-cc9affed8d63




* **Improvements**
  * Added UI for configuring OAuth2 certificates (type + value) with clear type selection and conditional value input.
  * Certificate is required and shows validation when using private_key_jwt; hints/placeholders adapt to the selected type.
  * Certificate is cleared automatically when switching away from private_key_jwt; switching certificate types preserves the existing value.
  
* **Tests**
  * Updated tests to cover the new certificate-driven behavior and validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->