### PR TITLE
Apply chunk splitting and lazy locale loading to gate app

### DIFF
--- a/frontend/apps/gate/src/hocs/withI18n.tsx
+++ b/frontend/apps/gate/src/hocs/withI18n.tsx
@@ -17,12 +17,13 @@
  */
 
 import {I18nDefaultConstants} from '@thunderid/i18n';
-import enUS from '@thunderid/i18n/locales/en-US';
 import {useThunderID} from '@thunderid/react';
 import i18next from 'i18next';
 import type {JSX, ComponentType} from 'react';
 import {useEffect} from 'react';
 import {initReactI18next, useTranslation} from 'react-i18next';
+
+const enUS = await import('@thunderid/i18n/locales/en-US').then((m) => m.default);
 
 interface I18nMeta {
   i18n?: {

--- a/frontend/apps/gate/vite.config.ts
+++ b/frontend/apps/gate/vite.config.ts
@@ -45,6 +45,33 @@ const prismjsGlobalFix = {
 // https://vite.dev/config/
 export default defineConfig({
   base: BASE_URL,
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (
+            id.includes('node_modules/@mui/material') ||
+            id.includes('node_modules/@mui/system') ||
+            id.includes('node_modules/@mui/styled-engine')
+          ) {
+            return 'vendor-mui';
+          }
+          if (id.includes('node_modules/@emotion/')) {
+            return 'vendor-emotion';
+          }
+          if (id.includes('node_modules/@wso2/oxygen-ui')) {
+            return 'vendor-oxygen';
+          }
+          if (id.includes('node_modules/react-i18next') || id.includes('node_modules/i18next')) {
+            return 'vendor-i18n';
+          }
+          if (id.includes('node_modules/react-dom') || id.includes('node_modules/react/')) {
+            return 'vendor-react';
+          }
+        },
+      },
+    },
+  },
   server: {
     port: PORT,
     host: HOST,


### PR DESCRIPTION
### Purpose

Extends the chunk-splitting and lazy locale-loading optimisations introduced for the Console app (411a7e55) to the Gate app.

**Gate app before:** vendor dependencies were not split, and the en-US locale was a static import that landed in the entry chunk.

**Gate app after:** vendor libraries are grouped into stable named chunks, and the locale data is deferred out of the entry chunk via a top-level `await import()`.

### Approach

Two changes, mirroring the Console implementation:

**1. `frontend/apps/gate/src/hocs/withI18n.tsx` — lazy locale loading**

Replaces the static top-level import of the en-US locale bundle with a dynamic `await import()` at module scope:

```ts
// before
import enUS from '@thunderid/i18n/locales/en-US';

// after
const enUS = await import('@thunderid/i18n/locales/en-US').then((m) => m.default);
```

This keeps the large translations JSON out of the entry chunk and defers it to its own async chunk.

**2. `frontend/apps/gate/vite.config.ts` — manual chunk splitting**

Adds `build.rollupOptions.output.manualChunks` to group vendor libraries into stable, content-addressed chunks:

| Chunk | Libraries |
|---|---|
| `vendor-mui` | `@mui/material`, `@mui/system`, `@mui/styled-engine` |
| `vendor-emotion` | `@emotion/*` |
| `vendor-oxygen` | `@wso2/oxygen-ui` |
| `vendor-i18n` | `react-i18next`, `i18next` |
| `vendor-react` | `react-dom`, `react` |

`vendor-mui-x` is intentionally omitted — the Gate app does not use `@mui/x-data-grid` or `@mui/x-virtualizer`.

### Related Issues

- N/A

### Related PRs

- #3152 (console chunk splitting — this PR extends that work to the gate)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized bundle splitting to separate vendor dependencies, improving application loading performance and caching efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->