### PR TITLE
Temporarily disable docs-only detection and revert codecov configs.

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -281,26 +281,29 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: 🔍 Detect non-docs file changes
         id: filter
-        env:
-          BASE_SHA: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+        # TODO: Temporarily always treat as code changes to unblock docs-only PRs hanging on the
+        # codecov/patch status check. Revisit once the workflow_run-based fix is in place.
+        # env:
+        #   BASE_SHA: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
         run: |
-          git fetch --depth=1 origin "$BASE_SHA"
-          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD)
-          echo "Changed files:"
-          echo "$CHANGED"
-          NON_DOCS=$(echo "$CHANGED" | grep -v '^docs/' | grep -v -i 'readme\.md' | grep -c . || true)
-          echo "Non-docs changed file count: $NON_DOCS"
-          if [ "$NON_DOCS" -gt 0 ]; then
-            echo "code=true" >> $GITHUB_OUTPUT
-          else
-            echo "code=false" >> $GITHUB_OUTPUT
-          fi
-      - name: ✅ Code changes detected
-        if: steps.filter.outputs.code == 'true'
-        run: echo "Non-documentation files changed - frontend and E2E tests will run"
-      - name: ⏭️ Docs-only changes
-        if: steps.filter.outputs.code != 'true'
-        run: echo "Only documentation changes detected - skipping frontend and E2E tests"
+          # git fetch --depth=1 origin "$BASE_SHA"
+          # CHANGED=$(git diff --name-only "$BASE_SHA" HEAD)
+          # echo "Changed files:"
+          # echo "$CHANGED"
+          # NON_DOCS=$(echo "$CHANGED" | grep -v '^docs/' | grep -v -i 'readme\.md' | grep -c . || true)
+          # echo "Non-docs changed file count: $NON_DOCS"
+          # if [ "$NON_DOCS" -gt 0 ]; then
+          #   echo "code=true" >> $GITHUB_OUTPUT
+          # else
+          #   echo "code=false" >> $GITHUB_OUTPUT
+          # fi
+          echo "code=true" >> $GITHUB_OUTPUT
+      # - name: ✅ Code changes detected
+      #   if: steps.filter.outputs.code == 'true'
+      #   run: echo "Non-documentation files changed - frontend and E2E tests will run"
+      # - name: ⏭️ Docs-only changes
+      #   if: steps.filter.outputs.code != 'true'
+      #   run: echo "Only documentation changes detected - skipping frontend and E2E tests"
 
   test-frontend-packages:
     name: 🧪 Frontend Packages Tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,30 +20,40 @@ codecov:
   require_ci_to_pass: true
   notify:
     wait_for_ci: true
+    # Wait for exactly 5 coverage uploads before reporting status:
+    #   1. backend-unit (from build job)
+    #   2. backend-integration-sqlite (from test-integration matrix)
+    #   3. backend-integration-postgres (from test-integration matrix)
+    #   4. frontend-apps-console-unit (from upload-frontend-coverage)
+    #   5. frontend-apps-gate-unit (from upload-frontend-coverage)
+    # Without this, Codecov status checks can intermittently hang at
+    # "Expected — Waiting for status to be reported" when CI signal is delayed.
+    # See: https://about.codecov.io/blog/delay-notifications-for-flags-with-after_n_builds/
+    after_n_builds: 6
 
 flags:
   backend-unit:
-    carryforward: true
+    carryforward: false
     paths:
       - backend/
   backend-integration-sqlite:
-    carryforward: true
+    carryforward: false
     paths:
       - backend/
   backend-integration-postgres:
-    carryforward: true
+    carryforward: false
     paths:
       - backend/
   backend-integration-redis:
-    carryforward: true
+    carryforward: false
     paths:
       - backend/
   frontend-apps-console-unit:
-    carryforward: true
+    carryforward: false
     paths:
       - frontend/apps/console/
   frontend-apps-gate-unit:
-    carryforward: true
+    carryforward: false
     paths:
       - frontend/apps/gate/
 


### PR DESCRIPTION
### Purpose
`codecov/patch` hangs indefinitely on docs-only PRs from forks. This temporarily disables the docs-only detection, always treating changes as code changes so all required checks run and report, unblocking the merge queue.

Additionally, reverts the codecov configuration changes introduced in #3067 — restoring `after_n_builds: 6` and setting all flags back to `carryforward: false`. The `after_n_builds` setting ensures Codecov waits for all coverage uploads before posting status, preventing premature failure when only unit tests have completed. Note: this means docs-only PRs where tests are skipped will leave the Codecov check in a pending state, which is the known tradeoff pending a longer-term fix.

This is a short-term fix.

### Related PRs
- Related to #3147 (reverted in #3153)
- Reverts codecov changes from #3067

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided.
- [ ] Tests provided.
- [ ] Breaking changes.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.