### PR TITLE
Set default system resource server identifier to MCP URL

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.ps1
+++ b/backend/cmd/server/bootstrap/01-default-resources.ps1
@@ -52,6 +52,7 @@ $ErrorActionPreference = 'Stop'
 Log-Info "Creating default $PRODUCT_NAME resources..."
 Write-Host ""
 
+$SystemRsIdentifier = "https://localhost:8090/mcp"
 
 # ============================================================================
 # Create Default Organization Unit
@@ -340,7 +341,7 @@ if (-not $DEFAULT_OU_ID) {
 $resourceServerData = @{
     name = "System"
     description = "System resource server"
-    identifier = "system"
+    identifier = $SystemRsIdentifier
     ouId = $DEFAULT_OU_ID
 } | ConvertTo-Json -Depth 10
 
@@ -400,7 +401,7 @@ Write-Host ""
 # ============================================================================
 #
 # Permission auto-derivation:
-#   Resource Server identifier "system"
+#   Resource Server identifier ($SystemRsIdentifier)
 #   └── Resource handle "system"           → permission "system"
 #       └── Resource handle "ou"           → permission "system:ou"
 #           └── Action handle "view"       → permission "system:ou:view"

--- a/backend/cmd/server/bootstrap/01-default-resources.sh
+++ b/backend/cmd/server/bootstrap/01-default-resources.sh
@@ -43,6 +43,7 @@ source "${SCRIPT_DIR}/common.sh"
 log_info "Creating default ${PRODUCT_NAME} resources..."
 echo ""
 
+SYSTEM_RS_IDENTIFIER="https://localhost:8090/mcp"
 
 # ============================================================================
 # Create Default Organization Unit
@@ -344,7 +345,7 @@ fi
 RESPONSE=$(api_call POST "/resource-servers" "{
   \"name\": \"System\",
   \"description\": \"System resource server\",
-  \"identifier\": \"system\",
+  \"identifier\": \"${SYSTEM_RS_IDENTIFIER}\",
   \"ouId\": \"${DEFAULT_OU_ID}\"
 }")
 
@@ -404,7 +405,7 @@ echo ""
 # ============================================================================
 #
 # Permission auto-derivation:
-#   Resource Server identifier "system"
+#   Resource Server identifier (SYSTEM_RS_IDENTIFIER)
 #   └── Resource handle "system"           → permission "system"
 #       └── Resource handle "ou"           → permission "system:ou"
 #           └── Action handle "view"       → permission "system:ou:view"

--- a/tests/integration/resource/resource_server_test.go
+++ b/tests/integration/resource/resource_server_test.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	testServerURL = "https://localhost:8095"
+	testServerURL                  = "https://localhost:8095"
+	systemResourceServerIdentifier = "https://localhost:8090/mcp"
 )
 
 var (
@@ -464,6 +465,22 @@ func (suite *ResourceServerAPITestSuite) TestCreateResourceServerWithVariousDeli
 		suite.Error(err, "Should reject %s delimiter", tc.description)
 		suite.Contains(err.Error(), "400", "Should return 400 for %s delimiter", tc.description)
 	}
+}
+
+func (suite *ResourceServerAPITestSuite) TestDefaultSystemResourceServerHasMCPIdentifier() {
+	list, err := listResourceServers(0, 100)
+	suite.Require().NoError(err)
+
+	var systemRS *ResourceServerResponse
+	for i := range list.ResourceServers {
+		if list.ResourceServers[i].Name == "System" {
+			systemRS = &list.ResourceServers[i]
+			break
+		}
+	}
+
+	suite.Require().NotNil(systemRS, "Default 'System' resource server should exist")
+	suite.Equal(systemResourceServerIdentifier, systemRS.Identifier)
 }
 
 // Helper functions


### PR DESCRIPTION
### Purpose

The bootstrap scripts created the default **system resource server** with identifier `system` instead of the MCP URL `https://localhost:8090/mcp`.

This was a **silent regression**: #2812 changed the default identifier to the MCP URL (merged 2026-05-19), but #2554 ("Treat system resource as a normal resource", merged 2026-05-29) was branched before #2812 landed and **rewrote the entire "Create System Resource Server" bootstrap block**, hardcoding `"identifier": "system"`. Because the surrounding lines were replaced wholesale, Git produced no merge conflict and #2812's change was silently reverted.

This breaks MCP authorization: the MCP token verifier (`backend/internal/system/mcp/init.go`) requires the access token's audience to equal the MCP resource URL (`GetServerURL() + "/mcp"`, advertised at `/.well-known/oauth-protected-resource`). Per RFC 8707 a token's audience is derived from the resource server identifier, so the system resource server's identifier must be `https://localhost:8090/mcp`.

### Approach

- Restore the MCP URL as the system resource server identifier in both bootstrap scripts (`01-default-resources.sh` and `.ps1`). #2554 deliberately decoupled `identifier` (audience/URL) from the permission prefix — permissions now derive from the fixed `system_permission_prefix` (default `system`) — so restoring the identifier is clean and does not affect permission validation.
- Add an integration regression test (`TestDefaultSystemResourceServerHasMCPIdentifier`) asserting the bootstrapped **System** resource server's identifier equals the MCP URL, so this can never silently regress again.

Verified locally:
- DB: `RESOURCE_SERVER.IDENTIFIER` for `System` = `https://localhost:8090/mcp`.
- Live `/.well-known/oauth-protected-resource` advertises `"resource":"https://localhost:8090/mcp"` — matching the identifier exactly.
- New integration test passes against a freshly built pack.

### Related Issues
- Fixes #3177

### Related PRs
- Reverts the regression introduced by #2554
- Restores the change from #2812

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized the default System resource server identifier to a consistent URL format for improved consistency.

* **Tests**
  * Added an integration test to verify the System resource server is configured with the expected identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->