### PR TITLE
Surface implicit on-behalf-of act claim in the Wayfinder sample

### DIFF
--- a/samples/apps/wayfinder-sample/README.md
+++ b/samples/apps/wayfinder-sample/README.md
@@ -40,14 +40,14 @@ The sample uses two OAuth clients and three token types:
 |-------|-------------|-------|---------|
 | **User token** | `WAYFINDER` | `authorization_code` | Frontend sign-in, API calls, chat API auth (`agent:access` scope) |
 | **M2M token** | `WAYFINDER-CONCIERGE` | `client_credentials` | Agent's own identity for browsing tools (search flights, hotels) via MCP |
-| **OBO token** | `WAYFINDER-CONCIERGE` | `authorization_code` + PKCE | User-context token for mutating tools (booking, cancellation) via MCP |
+| **OBO token** | `WAYFINDER-CONCIERGE` | `authorization_code` + PKCE | Implicit on-behalf-of user-context token for mutating tools (booking, cancellation) via MCP. Because the client is an agent, the issued token automatically carries an `act` claim identifying the agent — no separate token exchange needed. |
 
 **How it works:**
 
 1. The user signs in to the Wayfinder web app via the `WAYFINDER` OAuth application. The issued token carries `agent:access` (from the Chat User role).
 2. When the user sends a chat message, the frontend calls `POST /chat` on the AI Agent API with the user's access token in the `Authorization` header. The AI Agent validates the token has the `agent:access` scope before processing the message.
 3. For browsing tools (search flights, search hotels), the AI Agent uses its own M2M token (obtained via `client_credentials` with the `WAYFINDER-CONCIERGE` credentials) to call the Wayfinder server's `/mcp` endpoint.
-4. For mutating tools (create booking, cancel booking), the AI Agent returns a `need_user_consent` response. The frontend opens a consent popup, the user signs in and picks which booking permissions to grant (`booking:read`, `booking:create`, `booking:cancel`), and the authorization code is submitted to `POST /chat/consent`. The agent exchanges it for a user-context token, and the frontend retries the original message.
+4. For mutating tools (create booking, cancel booking), the AI Agent returns a `need_user_consent` response. The frontend opens a consent popup, the user signs in and picks which booking permissions to grant (`booking:read`, `booking:create`, `booking:cancel`), and the authorization code is submitted to `POST /chat/consent`. The agent exchanges it for a user-context token, and the frontend retries the original message. Because `WAYFINDER-CONCIERGE` is a ThunderID *agent*, the issued user-context token automatically includes an `act` claim with the agent's entity ID — an implicit on-behalf-of token. The Wayfinder server logs this delegation (`sub` = the user, `act.sub` = the agent) without any explicit token-exchange step.
 5. The Wayfinder server validates the JWT on every request and enforces scopes per route — browsing endpoints/tools are open, booking endpoints/tools require the matching `booking:*` scope. The MCP layer and the REST layer share the same scope guards because they share the same service modules.
 
 ## What This Demonstrates
@@ -56,7 +56,7 @@ The sample uses two OAuth clients and three token types:
 - The agent's **machine-to-machine (M2M) token** used for read-only browsing tools (search flights, search hotels, recommend flights, etc.).
 - **Scope-based access control** on the AI Agent's HTTP API — only users with `agent:access` can use the chat. Users without this scope (e.g. `jane.smith`) can browse and book through the UI but cannot use the Wayfinder Concierge.
 - A **typed user model** — `Customer` user type for consumers, `Staff` user type for internal team — with self sign-up, password recovery, and staff invitation flows backing the B2C use-case story.
-- An **on-behalf-of (OBO)** flow triggered from inside a chat session: the agent returns a consent request, the frontend opens a popup where the user picks which booking permissions to grant, and the issued user-context token only carries the approved subset.
+- An **on-behalf-of (OBO)** flow triggered from inside a chat session: the agent returns a consent request, the frontend opens a popup where the user picks which booking permissions to grant, and the issued user-context token only carries the approved subset. The token is an **implicit OBO token** — it carries an `act` claim naming the agent that mediated the login, so the resource server sees both the user (`sub`) and the acting agent (`act.sub`) from a single token.
 - A REST API that **verifies the JWT** and **enforces scopes per route** (`booking:read`, `booking:create`, `booking:cancel`, `booking:recommend`).
 - A **self-service profile page** at `/profile` that calls Thunder's `/users/me` directly with the `WAYFINDER` user token to read account details, edit attributes, and change the password.
 - **Multi-LLM support** — the Wayfinder Concierge works with both **Anthropic Claude** and **Google Gemini**, selectable via an environment variable.

--- a/samples/apps/wayfinder-sample/ai-agent/agent.ts
+++ b/samples/apps/wayfinder-sample/ai-agent/agent.ts
@@ -288,6 +288,7 @@ async function exchangeCodeForUserToken(code: string, codeVerifier: string): Pro
         const claims = JSON.parse(Buffer.from(payload.access_token.split(".")[1], "base64url").toString("utf8"));
         console.log("[obo] user token claims:", JSON.stringify({
             sub: claims.sub,
+            act: claims.act,
             authorized_permissions: claims.authorized_permissions,
             scope: claims.scope,
             aud: claims.aud,

--- a/samples/apps/wayfinder-sample/backend/src/auth.js
+++ b/samples/apps/wayfinder-sample/backend/src/auth.js
@@ -133,6 +133,7 @@ export async function getAuthenticatedUser(request) {
     givenName: parsedToken.payload.given_name,
     familyName: parsedToken.payload.family_name,
     scopes,
+    actor: parsedToken.payload.act?.sub || null,
     rawClaims: parsedToken.payload
   };
 }

--- a/samples/apps/wayfinder-sample/backend/src/mcp.js
+++ b/samples/apps/wayfinder-sample/backend/src/mcp.js
@@ -86,8 +86,10 @@ function callerTag(user) {
   }
 
   const type = user.rawClaims?.grant_type === "client_credentials" ? "m2m" : "user";
+  const base = `${type}:${user.id || "-"}`;
+  const actor = user.rawClaims?.act?.sub;
 
-  return `${type}:${user.id || "-"}`;
+  return actor ? `${base} (on-behalf-of agent ${actor})` : base;
 }
 
 function logMcpToolCall(body, user) {

--- a/samples/apps/wayfinder-sample/backend/src/server.js
+++ b/samples/apps/wayfinder-sample/backend/src/server.js
@@ -57,8 +57,9 @@ function logRequest(method, pathname, claims) {
   }
   const type = claims.grant_type === "client_credentials" ? "m2m" : "user";
   const aud = Array.isArray(claims.aud) ? claims.aud.join(",") : (claims.aud || "-");
+  const act = claims.act?.sub ? ` | act: ${claims.act.sub}` : "";
   console.log(
-    `${method} ${pathname} | type: ${type} | client_id: ${claims.client_id || "-"} | sub: ${claims.sub || "-"} | aud: ${aud} | scope: ${claims.scope || "-"}`
+    `${method} ${pathname} | type: ${type} | client_id: ${claims.client_id || "-"} | sub: ${claims.sub || "-"}${act} | aud: ${aud} | scope: ${claims.scope || "-"}`
   );
 }
 


### PR DESCRIPTION
### Purpose

Updates the **Wayfinder sample** to reflect the implicit on-behalf-of (`act`) claim introduced in https://github.com/thunder-id/thunderid/issues/3133.

The Wayfinder agent (`WAYFINDER-CONCIERGE`) obtains its user-context (OBO) token by logging the user into the agent's own OAuth client via the `authorization_code` flow. Because that client belongs to a ThunderID **agent**, the issued token now automatically carries `act: { sub: <agent-entity-id> }` — an **implicit OBO token**, with no separate token-exchange step. This PR surfaces and documents that actor identity in the sample.

There is no token-exchange in the sample to remove; the existing `authorization_code`-through-the-agent's-client flow is exactly what #3133 enriches. This change only makes the new `act` claim visible.

### Approach

- **Resource server (`backend/src/`)** — the authenticated principal now exposes the actor (`act.sub`); request logs append `| act: <agent-id>` when present; MCP tool-call logs read `user:<id> (on-behalf-of agent <id>)`. Direct user / M2M tokens (no `act`) log unchanged.
- **AI agent (`ai-agent/agent.ts`)** — logs the `act` claim on the issued OBO token.
- **README** — the token table, "How it works", and "What This Demonstrates" are reframed to describe the implicit OBO `act` claim (`sub` = user, `act.sub` = agent) and that no token-exchange ceremony is required.

No behavioural/enforcement change — the `act` claim is surfaced, not enforced.

### Verified end-to-end

Ran the full sample (Thunder + gate + the three sample services) and signed in as `john.doe`, browsed flights (M2M token, no `act`), then booked a flight (OBO consent). Observed:

```
# ai-agent — issued OBO token:
[obo] user token claims: {"sub":"wayfinder-john-doe","act":{"sub":"wayfinder-concierge"},...}

# wayfinder backend — surfaced actor:
POST /mcp | type: user | sub: wayfinder-john-doe | act: wayfinder-concierge | scope: booking:create booking:read booking:cancel
  → TOOL create_booking | caller: user:wayfinder-john-doe (on-behalf-of agent wayfinder-concierge)
```

Booking confirmed. M2M browsing tokens carried no `act`; OBO user tokens carried `act: wayfinder-concierge` — the intended contrast.

### Related Issues
- Refs #3133

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. (full end-to-end run, see above)
- [x] Documentation provided. (`samples/apps/wayfinder-sample/README.md`)
- [ ] Tests provided. (sample app — verified manually end-to-end; no automated test suite in the sample)
- [ ] Breaking changes. (Not applicable)

### Security checks
- [x] Followed secure coding standards. The `act` claim is read only from the validated, signed token and is surfaced for logging only — no authorization decision depends on it.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets. (`.env` and `wayfinder.sqlite` are git-ignored and excluded.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified on-behalf-of (OBO) token flow documentation for agent-issued tokens.

* **Improvements**
  * Enhanced debug logging to display acting agent information.
  * Authentication responses now track the acting agent for on-behalf-of requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->