### PR TITLE
Fix application update issue with consent sync failure

### DIFF
--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -1372,11 +1372,13 @@ func (s *inboundClientService) syncConsentOnUpdate(ctx context.Context,
 			return err
 		}
 	}
+
 	allPurposes, err := s.consentService.ListConsentPurposes(ctx, ouID, entityID)
 	if err != nil {
 		return s.wrapConsentServiceError(err)
 	}
 	existing := consent.FilterAttributePurposes(allPurposes)
+
 	if len(existing) == 0 {
 		if len(newAttrs) > 0 {
 			purpose := consent.ConsentPurposeInput{
@@ -1392,6 +1394,7 @@ func (s *inboundClientService) syncConsentOnUpdate(ctx context.Context,
 		}
 		return nil
 	}
+
 	if len(newAttrs) == 0 {
 		// No attributes requested; remove only the attribute purpose. The permission purpose, if any,
 		// is left alone — it has an independent lifecycle bound to the resource service.
@@ -1405,6 +1408,11 @@ func (s *inboundClientService) syncConsentOnUpdate(ctx context.Context,
 		}
 		return nil
 	}
+
+	if isConsentAttributesUnchanged(existing[0].Elements, newAttrs) {
+		return nil
+	}
+
 	updated := consent.ConsentPurposeInput{
 		Name:        consent.AttributesPurposeName(entityID),
 		Description: "Consent purpose for application " + entityName,
@@ -1415,7 +1423,22 @@ func (s *inboundClientService) syncConsentOnUpdate(ctx context.Context,
 	if _, updateErr := s.consentService.UpdateConsentPurpose(ctx, ouID, existing[0].ID, &updated); updateErr != nil {
 		return s.wrapConsentServiceError(updateErr)
 	}
+
 	return nil
+}
+
+// isConsentAttributesUnchanged reports whether the elements on an existing attribute consent
+// purpose are the same set as the requested attributes (i.e. nothing to sync).
+func isConsentAttributesUnchanged(existing []consent.PurposeElement, requested map[string]bool) bool {
+	if len(existing) != len(requested) {
+		return false
+	}
+	for _, el := range existing {
+		if !requested[el.Name] {
+			return false
+		}
+	}
+	return true
 }
 
 // syncConsentOnDelete removes every consent purpose (attribute and permission) owned by the

--- a/backend/internal/inboundclient/service_test.go
+++ b/backend/internal/inboundclient/service_test.go
@@ -2307,3 +2307,70 @@ func (suite *InboundClientServiceTestSuite) TestSyncConsentOnUpdate_IgnoresPermi
 	err := svc.syncConsentOnUpdate(context.Background(), "app1", "App 1", client, nil)
 	assert.NoError(suite.T(), err)
 }
+
+func (suite *InboundClientServiceTestSuite) TestSyncConsentOnUpdate_SkipsUpdateWhenAttributeSetUnchanged() {
+	cm := consentmock.NewConsentServiceInterfaceMock(suite.T())
+	cm.EXPECT().ValidateConsentElements(mock.Anything, "default", mock.MatchedBy(func(names []string) bool {
+		if len(names) != 2 {
+			return false
+		}
+		got := map[string]bool{}
+		for _, n := range names {
+			got[n] = true
+		}
+		return got["email"] && got["given_name"]
+	})).Return([]string{"email", "given_name"}, nil)
+	cm.EXPECT().ListConsentPurposes(mock.Anything, "default", "app1").Return([]consent.ConsentPurpose{
+		{
+			ID:        "attr-p",
+			Namespace: consent.NamespaceAttribute,
+			// Elements returned by the consent service do not carry a per-element Namespace.
+			Elements: []consent.PurposeElement{
+				{Name: "email"},
+				{Name: "given_name"},
+			},
+		},
+	}, nil)
+	// Crucially, no UpdateConsentPurpose expectation — the mock would fail if it were called.
+
+	svc := newInboundClientServiceWithConsent(cm)
+	client := &inboundmodel.InboundClient{
+		Assertion: &inboundmodel.AssertionConfig{UserAttributes: []string{"email", "given_name"}},
+	}
+	err := svc.syncConsentOnUpdate(context.Background(), "app1", "App 1", client, nil)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *InboundClientServiceTestSuite) TestSyncConsentOnUpdate_UpdatesWhenAttributeSetChanged() {
+	cm := consentmock.NewConsentServiceInterfaceMock(suite.T())
+	cm.EXPECT().ValidateConsentElements(mock.Anything, "default", mock.Anything).
+		Return([]string{"email", "family_name"}, nil)
+	cm.EXPECT().ListConsentPurposes(mock.Anything, "default", "app1").Return([]consent.ConsentPurpose{
+		{
+			ID:        "attr-p",
+			Namespace: consent.NamespaceAttribute,
+			Elements: []consent.PurposeElement{
+				{Name: "email"},
+				{Name: "given_name"},
+			},
+		},
+	}, nil)
+	cm.EXPECT().UpdateConsentPurpose(mock.Anything, "default", "attr-p",
+		mock.MatchedBy(func(input *consent.ConsentPurposeInput) bool {
+			if input.GroupID != "app1" {
+				return false
+			}
+			names := map[string]bool{}
+			for _, el := range input.Elements {
+				names[el.Name] = true
+			}
+			return len(names) == 2 && names["email"] && names["family_name"]
+		})).Return(&consent.ConsentPurpose{ID: "attr-p"}, nil)
+
+	svc := newInboundClientServiceWithConsent(cm)
+	client := &inboundmodel.InboundClient{
+		Assertion: &inboundmodel.AssertionConfig{UserAttributes: []string{"email", "family_name"}},
+	}
+	err := svc.syncConsentOnUpdate(context.Background(), "app1", "App 1", client, nil)
+	assert.NoError(suite.T(), err)
+}


### PR DESCRIPTION
### Purpose
This pull request fixes the consent synchronization logic in the `inboundClientService`, specifically when updating attribute consent purposes. The main enhancement is that the service now detects when the set of consented attributes has not changed and avoids making unnecessary update calls. Additionally, new unit tests have been added to verify this behavior.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3176

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced consent attribute synchronization to eliminate redundant updates when attribute sets remain unchanged between operations.

* **Tests**
  * Added comprehensive tests validating consent attribute synchronization behavior, covering both unchanged and changed attribute scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->