### PR TITLE
Add import support for notification senders

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -216,7 +216,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		logger.Fatal("Failed to initialize template service", log.Error(err))
 	}
 
-	_, otpService, notifSenderSvc, notificationExporter, err := notification.Initialize(
+	notifSenderMgtSvc, otpService, notifSenderSvc, notificationExporter, err := notification.Initialize(
 		mux, jwtService, templateService)
 	if err != nil {
 		logger.Fatal("Failed to initialize NotificationService", log.Error(err))
@@ -352,6 +352,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		userService,
 		i18nService,
 		agentService,
+		notifSenderMgtSvc,
 	)
 
 	flowExecService, err := flowexec.Initialize(mux, flowMgtService, inboundClientService, entityProvider,

--- a/backend/internal/notification/declarative_resource.go
+++ b/backend/internal/notification/declarative_resource.go
@@ -159,6 +159,22 @@ func parseToNotificationSenderDTO(data []byte) (*common.NotificationSenderDTO, e
 		return nil, err
 	}
 
+	return buildNotificationSenderDTOFromRequest(senderRequest)
+}
+
+// ParseNotificationSenderDTOFromNode decodes a yaml.Node into a NotificationSenderDTO.
+func ParseNotificationSenderDTOFromNode(node *yaml.Node) (*common.NotificationSenderDTO, error) {
+	var senderRequest common.NotificationSenderRequestWithID
+	if err := node.Decode(&senderRequest); err != nil {
+		return nil, err
+	}
+
+	return buildNotificationSenderDTOFromRequest(senderRequest)
+}
+
+func buildNotificationSenderDTOFromRequest(
+	senderRequest common.NotificationSenderRequestWithID,
+) (*common.NotificationSenderDTO, error) {
 	senderDTO := &common.NotificationSenderDTO{
 		ID:          senderRequest.ID,
 		Name:        senderRequest.Name,

--- a/backend/internal/system/importer/error_constants.go
+++ b/backend/internal/system/importer/error_constants.go
@@ -28,6 +28,7 @@ import (
 	flowmgt "github.com/thunder-id/thunderid/internal/flow/mgt"
 	"github.com/thunder-id/thunderid/internal/group"
 	"github.com/thunder-id/thunderid/internal/idp"
+	"github.com/thunder-id/thunderid/internal/notification"
 	"github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/resource"
 	"github.com/thunder-id/thunderid/internal/role"
@@ -52,6 +53,7 @@ var notFoundErrorCodes = map[string]struct{}{
 	layoutmgt.ErrorLayoutNotFound.Code:        {},
 	user.ErrorUserNotFound.Code:               {},
 	agent.ErrorAgentNotFound.Code:             {},
+	notification.ErrorSenderNotFound.Code:     {},
 }
 
 var (

--- a/backend/internal/system/importer/init.go
+++ b/backend/internal/system/importer/init.go
@@ -29,6 +29,7 @@ import (
 	flowmgt "github.com/thunder-id/thunderid/internal/flow/mgt"
 	"github.com/thunder-id/thunderid/internal/group"
 	"github.com/thunder-id/thunderid/internal/idp"
+	"github.com/thunder-id/thunderid/internal/notification"
 	"github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/resource"
 	"github.com/thunder-id/thunderid/internal/role"
@@ -54,6 +55,7 @@ func Initialize(
 	userService user.UserServiceInterface,
 	translationService i18nmgt.I18nServiceInterface,
 	agentService agent.AgentServiceInterface,
+	notificationSenderService notification.NotificationSenderMgtSvcInterface,
 ) ImportServiceInterface {
 	importService := newImportService(
 		applicationService,
@@ -70,6 +72,7 @@ func Initialize(
 		userService,
 		translationService,
 		agentService,
+		notificationSenderService,
 	)
 	importHandler := newImportHandler(importService)
 

--- a/backend/internal/system/importer/service.go
+++ b/backend/internal/system/importer/service.go
@@ -36,6 +36,8 @@ import (
 	flowmgt "github.com/thunder-id/thunderid/internal/flow/mgt"
 	"github.com/thunder-id/thunderid/internal/group"
 	"github.com/thunder-id/thunderid/internal/idp"
+	"github.com/thunder-id/thunderid/internal/notification"
+	notificationcommon "github.com/thunder-id/thunderid/internal/notification/common"
 	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/resource"
@@ -178,6 +180,14 @@ type agentAdapter interface {
 		*agentmodel.AgentCompleteResponse, *serviceerror.ServiceError)
 }
 
+type notificationSenderAdapter interface {
+	CreateSender(ctx context.Context, sender notificationcommon.NotificationSenderDTO) (
+		*notificationcommon.NotificationSenderDTO, *serviceerror.ServiceError)
+	GetSender(ctx context.Context, id string) (*notificationcommon.NotificationSenderDTO, *serviceerror.ServiceError)
+	UpdateSender(ctx context.Context, id string, sender notificationcommon.NotificationSenderDTO) (
+		*notificationcommon.NotificationSenderDTO, *serviceerror.ServiceError)
+}
+
 // ImportServiceInterface defines runtime resource import and declarative resource deletion operations.
 type ImportServiceInterface interface {
 	ImportResources(ctx context.Context, request *ImportRequest) (*ImportResponse, *serviceerror.ServiceError)
@@ -194,20 +204,21 @@ const (
 )
 
 type importService struct {
-	applicationService    applicationAdapter
-	idpService            idpAdapter
-	flowService           flowAdapter
-	ouService             ouAdapter
-	entityTypeService     entityTypeAdapter
-	roleService           roleAdapter
-	roleAssignmentService roleAssignmentAdapter
-	groupService          groupAdapter
-	resourceService       resourceServerAdapter
-	themeService          themeAdapter
-	layoutService         layoutAdapter
-	userService           userAdapter
-	translationService    translationAdapter
-	agentService          agentAdapter
+	applicationService        applicationAdapter
+	idpService                idpAdapter
+	flowService               flowAdapter
+	ouService                 ouAdapter
+	entityTypeService         entityTypeAdapter
+	roleService               roleAdapter
+	roleAssignmentService     roleAssignmentAdapter
+	groupService              groupAdapter
+	resourceService           resourceServerAdapter
+	themeService              themeAdapter
+	layoutService             layoutAdapter
+	userService               userAdapter
+	translationService        translationAdapter
+	agentService              agentAdapter
+	notificationSenderService notificationSenderAdapter
 }
 
 func newImportService(
@@ -225,22 +236,24 @@ func newImportService(
 	userService userAdapter,
 	translationService translationAdapter,
 	agentService agentAdapter,
+	notificationSenderService notificationSenderAdapter,
 ) ImportServiceInterface {
 	return &importService{
-		applicationService:    applicationService,
-		idpService:            idpService,
-		flowService:           flowService,
-		ouService:             ouService,
-		entityTypeService:     entityTypeService,
-		roleService:           roleService,
-		roleAssignmentService: roleAssignmentService,
-		groupService:          groupService,
-		resourceService:       resourceService,
-		themeService:          themeService,
-		layoutService:         layoutService,
-		userService:           userService,
-		translationService:    translationService,
-		agentService:          agentService,
+		applicationService:        applicationService,
+		idpService:                idpService,
+		flowService:               flowService,
+		ouService:                 ouService,
+		entityTypeService:         entityTypeService,
+		roleService:               roleService,
+		roleAssignmentService:     roleAssignmentService,
+		groupService:              groupService,
+		resourceService:           resourceService,
+		themeService:              themeService,
+		layoutService:             layoutService,
+		userService:               userService,
+		translationService:        translationService,
+		agentService:              agentService,
+		notificationSenderService: notificationSenderService,
 	}
 }
 
@@ -394,6 +407,8 @@ func (s *importService) importDocument(
 		return s.importTranslation(doc, dryRun)
 	case resourceTypeAgent:
 		return s.importAgent(ctx, doc, options, dryRun, flowIDAliases)
+	case resourceTypeNotificationSender:
+		return s.importNotificationSender(ctx, doc, options, dryRun)
 	default:
 		return ImportItemOutcome{
 			ResourceType: doc.ResourceType,
@@ -401,6 +416,90 @@ func (s *importService) importDocument(
 			Code:         ErrorInvalidImportRequest.Code,
 			Message:      "unsupported resource document",
 		}
+	}
+}
+
+func (s *importService) importNotificationSender(
+	ctx context.Context, doc parsedDocument, options *ImportOptions, dryRun bool,
+) ImportItemOutcome {
+	if s.notificationSenderService == nil {
+		return ImportItemOutcome{
+			ResourceType: resourceTypeNotificationSender,
+			Status:       statusFailed,
+			Code:         ErrorInvalidImportRequest.Code,
+			Message:      "notification sender adapter is not configured",
+		}
+	}
+
+	req, err := notification.ParseNotificationSenderDTOFromNode(doc.Node)
+	if err != nil {
+		return ImportItemOutcome{
+			ResourceType: resourceTypeNotificationSender,
+			Status:       statusFailed,
+			Code:         ErrorInvalidYAMLContent.Code,
+			Message:      fmt.Sprintf("failed to decode notification sender document: %v", err),
+		}
+	}
+
+	if dryRun {
+		if options.IsUpsertEnabled() && req.ID != "" {
+			_, svcErr := s.notificationSenderService.GetSender(ctx, req.ID)
+			if svcErr == nil {
+				return successOutcome(resourceTypeNotificationSender, req.ID, req.Name, operationUpdate)
+			}
+
+			if !isNotFoundServiceError(svcErr) {
+				return serviceErrorOutcome(resourceTypeNotificationSender, req.ID, req.Name, operationUpdate, svcErr)
+			}
+		}
+
+		return successOutcome(resourceTypeNotificationSender, req.ID, req.Name, operationCreate)
+	}
+
+	if options.IsUpsertEnabled() && req.ID != "" {
+		updated, svcErr := s.notificationSenderService.UpdateSender(ctx, req.ID, *req)
+		if svcErr == nil {
+			return ImportItemOutcome{
+				ResourceType: resourceTypeNotificationSender,
+				ResourceID:   updated.ID,
+				ResourceName: updated.Name,
+				Operation:    operationUpdate,
+				Status:       statusSuccess,
+			}
+		}
+
+		if !isNotFoundServiceError(svcErr) {
+			return ImportItemOutcome{
+				ResourceType: resourceTypeNotificationSender,
+				ResourceID:   req.ID,
+				ResourceName: req.Name,
+				Operation:    operationUpdate,
+				Status:       statusFailed,
+				Code:         svcErr.Code,
+				Message:      svcErr.Error.DefaultValue,
+			}
+		}
+	}
+
+	created, svcErr := s.notificationSenderService.CreateSender(ctx, *req)
+	if svcErr != nil {
+		return ImportItemOutcome{
+			ResourceType: resourceTypeNotificationSender,
+			ResourceID:   req.ID,
+			ResourceName: req.Name,
+			Operation:    operationCreate,
+			Status:       statusFailed,
+			Code:         svcErr.Code,
+			Message:      svcErr.Error.DefaultValue,
+		}
+	}
+
+	return ImportItemOutcome{
+		ResourceType: resourceTypeNotificationSender,
+		ResourceID:   created.ID,
+		ResourceName: created.Name,
+		Operation:    operationCreate,
+		Status:       statusSuccess,
 	}
 }
 

--- a/backend/internal/system/importer/service_test.go
+++ b/backend/internal/system/importer/service_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/thunder-id/thunderid/internal/group"
 	"github.com/thunder-id/thunderid/internal/idp"
 	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
+	"github.com/thunder-id/thunderid/internal/notification"
+	notificationcommon "github.com/thunder-id/thunderid/internal/notification/common"
 	"github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/resource"
 	"github.com/thunder-id/thunderid/internal/role"
@@ -706,6 +708,7 @@ func newTestImportService(appSvc *fakeApplicationService) ImportServiceInterface
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }
 
@@ -882,7 +885,7 @@ func TestImportResources_PreservesExplicitFalseOptions(t *testing.T) {
 }
 
 func TestImportResources_ApplicationAdapterNotConfigured(t *testing.T) {
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: "id: app-1\nname: My App\nauth_flow_id: flow-1\n",
@@ -899,7 +902,7 @@ func TestImportResources_ApplicationAdapterNotConfigured(t *testing.T) {
 func TestImportResources_RoleImportIncludesAssignments(t *testing.T) {
 	roleSvc := &fakeRoleService{}
 	roleAssignmentSvc := &fakeRoleAssignmentService{}
-	svc := newImportService(nil, nil, nil, nil, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: role-1",
@@ -929,7 +932,7 @@ func TestImportResources_RoleImportIncludesAssignments(t *testing.T) {
 
 func TestImportResources_GroupImportIncludesMembers(t *testing.T) {
 	groupSvc := &fakeGroupService{}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: group-new",
@@ -956,7 +959,7 @@ func TestImportResources_GroupImportIncludesMembers(t *testing.T) {
 func TestImportResources_RoleImportNoAssignments(t *testing.T) {
 	roleSvc := &fakeRoleService{}
 	roleAssignmentSvc := &fakeRoleAssignmentService{}
-	svc := newImportService(nil, nil, nil, nil, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: role-new",
@@ -978,7 +981,7 @@ func TestImportResources_RoleImportNoAssignments(t *testing.T) {
 func TestImportResources_RoleUpsertUpdateIncludesAssignments(t *testing.T) {
 	roleSvc := &fakeRoleService{}
 	roleAssignmentSvc := &fakeRoleAssignmentService{}
-	svc := newImportService(nil, nil, nil, nil, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: role-1",
@@ -1011,7 +1014,7 @@ func TestImportResources_RoleAssignmentFailureReturnsError(t *testing.T) {
 		Code:  "ROLE-4001",
 		Error: core.I18nMessage{DefaultValue: "invalid assignee"},
 	}}
-	svc := newImportService(nil, nil, nil, nil, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	// role-1 exists in the fake → update path → AddAssignments is called separately → fails
 	content := strings.Join([]string{
@@ -1034,7 +1037,7 @@ func TestImportResources_RoleAssignmentFailureReturnsError(t *testing.T) {
 
 func TestImportResources_GroupImportNoMembers(t *testing.T) {
 	groupSvc := &fakeGroupService{}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: group-new",
@@ -1054,7 +1057,7 @@ func TestImportResources_GroupImportNoMembers(t *testing.T) {
 
 func TestImportResources_GroupUpsertUpdateIncludesMembers(t *testing.T) {
 	groupSvc := &fakeGroupService{}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: group-1",
@@ -1086,7 +1089,7 @@ func TestImportResources_GroupMemberFailureReturnsError(t *testing.T) {
 		Code:  "GRP-4001",
 		Error: core.I18nMessage{DefaultValue: "invalid member"},
 	}}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: group-new",
@@ -1107,7 +1110,7 @@ func TestImportResources_GroupMemberFailureReturnsError(t *testing.T) {
 
 func TestImportResources_UserCredentialFailureRollsBackCreate(t *testing.T) {
 	userSvc := &fakeUserService{updateCredentialsShouldFail: true}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: user-1",
@@ -1132,7 +1135,7 @@ func TestImportResources_UserCredentialFailureRollsBackCreate(t *testing.T) {
 
 func TestImportResources_OrganizationUnitUpsertCreatePreservesID(t *testing.T) {
 	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: ou-123",
@@ -1160,7 +1163,7 @@ func TestImportResources_FlowUpsertCreatePreservesID(t *testing.T) {
 		byKey: map[string]*flowmgt.CompleteFlowDefinition{},
 	}
 
-	svc := newImportService(nil, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: missing-flow-id",
@@ -1198,7 +1201,7 @@ func TestImportResources_FlowUpsertDuplicateHandleFallsBackToHandleUpdate(t *tes
 	}
 	flowSvc.byKey[string(common.FlowTypeRegistration)+":registration-flow"] = flowSvc.byID["existing-flow-id"]
 
-	svc := newImportService(nil, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: missing-flow-id",
@@ -1238,7 +1241,7 @@ func TestImportResources_ApplicationFlowReferencesAreRemappedFromFlowAlias(t *te
 		flowSvc.byID["existing-registration-flow-id"]
 
 	appSvc := &fakeApplicationService{existing: map[string]*model.Application{}}
-	svc := newImportService(appSvc, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(appSvc, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"# resource_type: flow",
@@ -1273,7 +1276,7 @@ func TestImportResources_ApplicationFlowReferencesAreRemappedFromFlowAlias(t *te
 //nolint:dupl // Test pattern repeated across resource types to verify ID preservation behavior
 func TestImportResources_ThemeUpsertCreatePreservesID(t *testing.T) {
 	themeSvc := &fakeThemeService{byID: map[string]*thememgt.Theme{}, byHandle: map[string]*thememgt.Theme{}}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, themeSvc, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, themeSvc, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: thm-123",
@@ -1303,7 +1306,7 @@ func TestImportResources_EntityTypeUpsertCreatePreservesID(t *testing.T) {
 		byID:   map[string]*entitytype.EntityType{},
 		byName: map[string]*entitytype.EntityType{},
 	}
-	svc := newImportService(nil, nil, nil, nil, entityTypeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, entityTypeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: usrs-123",
@@ -1339,7 +1342,9 @@ func TestImportResources_UpsertCreatePreservesIDsAcrossResourceTypes(t *testing.
 		byKey: map[string]*flowmgt.CompleteFlowDefinition{},
 	}
 
-	svc := newImportService(nil, nil, flowSvc, ouSvc, entityTypeSvc, nil, nil, nil, nil, themeSvc, nil, nil, nil, nil)
+	svc := newImportService(
+		nil, nil, flowSvc, ouSvc, entityTypeSvc, nil, nil, nil, nil, themeSvc, nil, nil, nil, nil, nil,
+	)
 
 	content := strings.Join([]string{
 		"id: ou-123",
@@ -1415,7 +1420,7 @@ func TestImportResources_EntityTypeOUHandlePassedToService(t *testing.T) {
 		byID:   map[string]*entitytype.EntityType{},
 		byName: map[string]*entitytype.EntityType{},
 	}
-	svc := newImportService(nil, nil, nil, nil, entityTypeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, entityTypeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: usrs-123",
@@ -1523,7 +1528,7 @@ func TestImportResources_FileTargetReturnsError(t *testing.T) {
 		DeclarativeResources: config.DeclarativeResources{Enabled: true},
 	}))
 
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: "id: app-1\nname: My App\nauth_flow_id: flow-1\n",
@@ -1545,7 +1550,7 @@ func TestDeleteResource_RemovesDeclarativeFile(t *testing.T) {
 		DeclarativeResources: config.DeclarativeResources{Enabled: true},
 	}))
 
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resourceDir := filepath.Join(tempHome, "repository", "resources", "applications")
 	require.NoError(t, os.MkdirAll(resourceDir, 0o750))
@@ -1571,7 +1576,7 @@ func TestDeleteResource_RemovesDeclarativeFile(t *testing.T) {
 
 func TestImportResources_ApplicationOUHandlePassedToService(t *testing.T) {
 	appSvc := &fakeApplicationService{existing: map[string]*model.Application{}}
-	svc := newImportService(appSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(appSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: strings.Join([]string{
@@ -1591,7 +1596,7 @@ func TestImportResources_ApplicationOUHandlePassedToService(t *testing.T) {
 
 func TestImportResources_ApplicationAuthFlowHandlePassedToService(t *testing.T) {
 	appSvc := &fakeApplicationService{existing: map[string]*model.Application{}}
-	svc := newImportService(appSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(appSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: strings.Join([]string{
@@ -1611,7 +1616,7 @@ func TestImportResources_ApplicationAuthFlowHandlePassedToService(t *testing.T) 
 
 func TestImportResources_ApplicationRegistrationFlowHandlePassedToService(t *testing.T) {
 	appSvc := &fakeApplicationService{existing: map[string]*model.Application{}}
-	svc := newImportService(appSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(appSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: strings.Join([]string{
@@ -1633,7 +1638,7 @@ func TestImportResources_ApplicationRegistrationFlowHandlePassedToService(t *tes
 
 func TestImportResources_ApplicationRecoveryFlowHandlePassedToService(t *testing.T) {
 	appSvc := &fakeApplicationService{existing: map[string]*model.Application{}}
-	svc := newImportService(appSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(appSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: strings.Join([]string{
@@ -1656,7 +1661,7 @@ func TestImportResources_ApplicationRecoveryFlowHandlePassedToService(t *testing
 func TestImportResources_DryRunSkipsApplicationHandleResolution(t *testing.T) {
 	// With dry-run, handle resolution is skipped — unknown handles must not cause failure.
 	appSvc := &fakeApplicationService{existing: map[string]*model.Application{}}
-	svc := newImportService(appSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(appSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: strings.Join([]string{
@@ -1728,7 +1733,7 @@ const agentYAML = "# resource_type: agent\n" +
 
 func TestImportAgent_Create(t *testing.T) {
 	agentSvc := &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{}}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{Content: agentYAML})
 
@@ -1745,7 +1750,7 @@ func TestImportAgent_UpsertUpdate(t *testing.T) {
 	agentSvc := &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{
 		"agent-1": {ID: "agent-1", Name: "Test Agent"},
 	}}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: agentYAML,
@@ -1762,7 +1767,7 @@ func TestImportAgent_UpsertUpdate(t *testing.T) {
 
 func TestImportAgent_UpsertFallbackCreate(t *testing.T) {
 	agentSvc := &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{}}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: agentYAML,
@@ -1779,7 +1784,7 @@ func TestImportAgent_UpsertFallbackCreate(t *testing.T) {
 
 func TestImportAgent_DryRunCreate(t *testing.T) {
 	agentSvc := &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{}}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: agentYAML,
@@ -1798,7 +1803,7 @@ func TestImportAgent_DryRunUpsert(t *testing.T) {
 	agentSvc := &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{
 		"agent-1": {ID: "agent-1", Name: "Test Agent"},
 	}}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: agentYAML,
@@ -1815,7 +1820,7 @@ func TestImportAgent_DryRunUpsert(t *testing.T) {
 }
 
 func TestImportAgent_NilAdapter(t *testing.T) {
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{Content: agentYAML})
 
@@ -1863,7 +1868,7 @@ func (e *errAgentService) UpdateAgent(
 
 func TestImportAgent_DecodeError(t *testing.T) {
 	agentSvc := &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{}}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	// ID field is a sequence, not a string — decode into AgentRequestWithID will fail.
 	invalidYAML := "# resource_type: agent\nid:\n  - bad\nname: Test\n"
@@ -1881,7 +1886,7 @@ func TestImportAgent_DryRunUpsertNonNotFoundError(t *testing.T) {
 		inner:  &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{}},
 		getErr: internalErr,
 	}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: agentYAML,
@@ -1903,7 +1908,7 @@ func TestImportAgent_UpsertUpdateError(t *testing.T) {
 		}},
 		updateErr: updateErr,
 	}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: agentYAML,
@@ -1922,7 +1927,7 @@ func TestImportAgent_UpsertGetNonNotFoundError(t *testing.T) {
 		inner:  &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{}},
 		getErr: internalErr,
 	}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
 		Content: agentYAML,
@@ -1941,7 +1946,7 @@ func TestImportAgent_CreateError(t *testing.T) {
 		inner:     &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{}},
 		createErr: createErr,
 	}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{Content: agentYAML})
 
@@ -1994,7 +1999,7 @@ func TestImportAgent_FlowAliasRemapsFlowIDs(t *testing.T) {
 				byKey: map[string]*flowmgt.CompleteFlowDefinition{},
 			}
 			agentSvc := &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{}}
-			svc := newImportService(nil, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+			svc := newImportService(nil, nil, flowSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 			content := strings.Join([]string{
 				"# resource_type: flow",
@@ -2026,7 +2031,7 @@ func TestImportAgent_FlowAliasRemapsFlowIDs(t *testing.T) {
 
 func TestImportAgent_StripsClientSecretForPublicAgentWithNoneAuthMethod(t *testing.T) {
 	agentSvc := &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{}}
-	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc)
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, agentSvc, nil)
 
 	content := strings.Join([]string{
 		"# resource_type: agent",
@@ -2116,7 +2121,9 @@ func TestImportRole_OUHandleResolved(t *testing.T) {
 	}}
 	roleSvc := &fakeRoleService{}
 	roleAssignmentSvc := &fakeRoleAssignmentService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(
+		nil, nil, nil, ouSvc, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
 
 	content := strings.Join([]string{
 		"id: role-new",
@@ -2141,7 +2148,9 @@ func TestImportRole_OUHandleNotFound(t *testing.T) {
 	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
 	roleSvc := &fakeRoleService{}
 	roleAssignmentSvc := &fakeRoleAssignmentService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(
+		nil, nil, nil, ouSvc, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
 
 	content := strings.Join([]string{
 		"id: role-new",
@@ -2165,7 +2174,9 @@ func TestImportRole_OUIDWinsOverHandle(t *testing.T) {
 	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
 	roleSvc := &fakeRoleService{}
 	roleAssignmentSvc := &fakeRoleAssignmentService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(
+		nil, nil, nil, ouSvc, nil, roleSvc, roleAssignmentSvc, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
 
 	content := strings.Join([]string{
 		"id: role-new",
@@ -2192,7 +2203,7 @@ func TestImportGroup_OUHandleResolved(t *testing.T) {
 		"ou-default": {ID: "ou-default", Handle: "default"},
 	}}
 	groupSvc := &fakeGroupService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: group-new",
@@ -2215,7 +2226,7 @@ func TestImportGroup_OUHandleResolved(t *testing.T) {
 func TestImportGroup_OUHandleNotFound(t *testing.T) {
 	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
 	groupSvc := &fakeGroupService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: group-new",
@@ -2237,7 +2248,7 @@ func TestImportGroup_OUHandleNotFound(t *testing.T) {
 func TestImportGroup_OUIDWinsOverHandle(t *testing.T) {
 	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
 	groupSvc := &fakeGroupService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, groupSvc, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: group-new",
@@ -2263,7 +2274,7 @@ func TestImportUser_OUHandleResolved(t *testing.T) {
 		"ou-default": {ID: "ou-default", Handle: "default"},
 	}}
 	userSvc := &fakeUserService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil)
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: user-new",
@@ -2291,7 +2302,7 @@ func TestImportUser_OUHandleResolved(t *testing.T) {
 func TestImportUser_OUHandleNotFound(t *testing.T) {
 	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
 	userSvc := &fakeUserService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil)
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: user-new",
@@ -2315,7 +2326,7 @@ func TestImportUser_OUHandleNotFound(t *testing.T) {
 func TestImportUser_OUIDWinsOverHandle(t *testing.T) {
 	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
 	userSvc := &fakeUserService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil)
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, nil, nil, nil, userSvc, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: user-new",
@@ -2346,7 +2357,7 @@ func TestImportResourceServer_OUHandleResolved(t *testing.T) {
 		"ou-default": {ID: "ou-default", Handle: "default"},
 	}}
 	rsSvc := &fakeResourceServerService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"# resource_type: resource_server",
@@ -2376,7 +2387,7 @@ func TestImportResourceServer_OUHandleResolved(t *testing.T) {
 func TestImportResourceServer_OUHandleNotFound(t *testing.T) {
 	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
 	rsSvc := &fakeResourceServerService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"# resource_type: resource_server",
@@ -2402,7 +2413,7 @@ func TestImportResourceServer_OUHandleNotFound(t *testing.T) {
 func TestImportResourceServer_OUIDWinsOverHandle(t *testing.T) {
 	ouSvc := &fakeOUService{existing: map[string]ou.OrganizationUnit{}}
 	rsSvc := &fakeResourceServerService{}
-	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, nil, nil, ouSvc, nil, nil, nil, nil, rsSvc, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"# resource_type: resource_server",
@@ -2430,7 +2441,7 @@ func TestImportResourceServer_OUIDWinsOverHandle(t *testing.T) {
 
 func TestImportResources_IDPPropertiesArePassedToService(t *testing.T) {
 	idpSvc := &fakeIDPService{byID: map[string]*idp.IDPDTO{}, byName: map[string]*idp.IDPDTO{}}
-	svc := newImportService(nil, idpSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, idpSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	// is_secret with empty value avoids the encryption path while still verifying the flag is parsed.
 	content := strings.Join([]string{
@@ -2472,7 +2483,7 @@ func TestImportResources_IDPUpsertUpdatePropertiesArePassedToService(t *testing.
 		byID:   map[string]*idp.IDPDTO{"idp-1": existing},
 		byName: map[string]*idp.IDPDTO{"google-idp": existing},
 	}
-	svc := newImportService(nil, idpSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := newImportService(nil, idpSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	content := strings.Join([]string{
 		"id: idp-1",
@@ -2501,4 +2512,275 @@ func TestImportResources_IDPUpsertUpdatePropertiesArePassedToService(t *testing.
 	plainValue, err2 := updated.Properties[0].GetValue()
 	require.NoError(t, err2)
 	assert.Equal(t, "updated-client-id", plainValue)
+}
+
+// fakeNotificationSenderService is a test double for the notificationSenderAdapter.
+type fakeNotificationSenderService struct {
+	created  []notificationcommon.NotificationSenderDTO
+	updated  []notificationcommon.NotificationSenderDTO
+	existing map[string]*notificationcommon.NotificationSenderDTO
+}
+
+func (f *fakeNotificationSenderService) CreateSender(
+	_ context.Context, sender notificationcommon.NotificationSenderDTO,
+) (*notificationcommon.NotificationSenderDTO, *serviceerror.ServiceError) {
+	if sender.ID == "" {
+		sender.ID = "generated-sender-id"
+	}
+	f.created = append(f.created, sender)
+	if f.existing == nil {
+		f.existing = map[string]*notificationcommon.NotificationSenderDTO{}
+	}
+	f.existing[sender.ID] = &sender
+	return &sender, nil
+}
+
+func (f *fakeNotificationSenderService) GetSender(
+	_ context.Context, id string,
+) (*notificationcommon.NotificationSenderDTO, *serviceerror.ServiceError) {
+	if s, ok := f.existing[id]; ok {
+		return s, nil
+	}
+	return nil, &serviceerror.ServiceError{
+		Type:  serviceerror.ClientErrorType,
+		Code:  notification.ErrorSenderNotFound.Code,
+		Error: core.I18nMessage{DefaultValue: "Sender not found"},
+	}
+}
+
+func (f *fakeNotificationSenderService) UpdateSender(
+	_ context.Context, id string, sender notificationcommon.NotificationSenderDTO,
+) (*notificationcommon.NotificationSenderDTO, *serviceerror.ServiceError) {
+	if _, ok := f.existing[id]; !ok {
+		return nil, &serviceerror.ServiceError{
+			Type:  serviceerror.ClientErrorType,
+			Code:  notification.ErrorSenderNotFound.Code,
+			Error: core.I18nMessage{DefaultValue: "Sender not found"},
+		}
+	}
+	sender.ID = id
+	f.updated = append(f.updated, sender)
+	f.existing[id] = &sender
+	return &sender, nil
+}
+
+const notificationSenderYAML = "# resource_type: notification_sender\n" +
+	"id: sender-1\nname: Test SMS Sender\nprovider: twilio\n" +
+	"properties:\n- name: account_sid\n  value: AC123\n"
+
+func TestImportNotificationSender_Create(t *testing.T) {
+	senderSvc := &fakeNotificationSenderService{existing: map[string]*notificationcommon.NotificationSenderDTO{}}
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, senderSvc)
+
+	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{Content: notificationSenderYAML})
+
+	require.Nil(t, svcErr)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.Equal(t, operationCreate, resp.Results[0].Operation)
+	assert.Equal(t, resourceTypeNotificationSender, resp.Results[0].ResourceType)
+	assert.Len(t, senderSvc.created, 1)
+	assert.Equal(t, "Test SMS Sender", senderSvc.created[0].Name)
+}
+
+func TestImportNotificationSender_UpsertUpdate(t *testing.T) {
+	existing := &notificationcommon.NotificationSenderDTO{ID: "sender-1", Name: "Test SMS Sender"}
+	senderSvc := &fakeNotificationSenderService{
+		existing: map[string]*notificationcommon.NotificationSenderDTO{"sender-1": existing},
+	}
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, senderSvc)
+
+	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: notificationSenderYAML,
+		Options: &ImportOptions{Upsert: boolPtr(true)},
+	})
+
+	require.Nil(t, svcErr)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.Equal(t, operationUpdate, resp.Results[0].Operation)
+	assert.Len(t, senderSvc.updated, 1)
+}
+
+// TestImportNotificationSender_UpsertFallsBackToCreate verifies the fix for the bug where
+// MNS-1001 was missing from notFoundErrorCodes, causing an update failure to surface instead
+// of falling through to create.
+func TestImportNotificationSender_UpsertFallsBackToCreate(t *testing.T) {
+	senderSvc := &fakeNotificationSenderService{existing: map[string]*notificationcommon.NotificationSenderDTO{}}
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, senderSvc)
+
+	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: notificationSenderYAML,
+		Options: &ImportOptions{Upsert: boolPtr(true)},
+	})
+
+	require.Nil(t, svcErr)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.Equal(t, operationCreate, resp.Results[0].Operation)
+	assert.Len(t, senderSvc.created, 1)
+}
+
+func TestImportNotificationSender_NilAdapter(t *testing.T) {
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{Content: notificationSenderYAML})
+
+	require.Nil(t, svcErr)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Equal(t, ErrorInvalidImportRequest.Code, resp.Results[0].Code)
+	assert.Equal(t, "notification sender adapter is not configured", resp.Results[0].Message)
+}
+
+func TestImportNotificationSender_DecodeError(t *testing.T) {
+	senderSvc := &fakeNotificationSenderService{existing: map[string]*notificationcommon.NotificationSenderDTO{}}
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, senderSvc)
+
+	// provider field is a sequence, not a string — node decode into NotificationSenderRequestWithID fails.
+	invalidYAML := "# resource_type: notification_sender\nid: s1\nname: Bad\nprovider:\n  - invalid\n"
+	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{Content: invalidYAML})
+
+	require.Nil(t, svcErr)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Equal(t, ErrorInvalidYAMLContent.Code, resp.Results[0].Code)
+	assert.Contains(t, resp.Results[0].Message, "failed to decode notification sender document")
+}
+
+func TestImportNotificationSender_DryRunCreate(t *testing.T) {
+	senderSvc := &fakeNotificationSenderService{existing: map[string]*notificationcommon.NotificationSenderDTO{}}
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, senderSvc)
+
+	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: notificationSenderYAML,
+		DryRun:  true,
+	})
+
+	require.Nil(t, svcErr)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.Equal(t, operationCreate, resp.Results[0].Operation)
+	assert.Empty(t, senderSvc.created)
+}
+
+func TestImportNotificationSender_DryRunUpsertExisting(t *testing.T) {
+	existing := &notificationcommon.NotificationSenderDTO{ID: "sender-1", Name: "Test SMS Sender"}
+	senderSvc := &fakeNotificationSenderService{
+		existing: map[string]*notificationcommon.NotificationSenderDTO{"sender-1": existing},
+	}
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, senderSvc)
+
+	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: notificationSenderYAML,
+		DryRun:  true,
+		Options: &ImportOptions{Upsert: boolPtr(true)},
+	})
+
+	require.Nil(t, svcErr)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.Equal(t, operationUpdate, resp.Results[0].Operation)
+	assert.Empty(t, senderSvc.updated)
+}
+
+func TestImportNotificationSender_DryRunUpsertNonNotFoundError(t *testing.T) {
+	internalErr := &serviceerror.ServiceError{
+		Code:  "MNS-9999",
+		Error: core.I18nMessage{DefaultValue: "internal error"},
+	}
+	senderSvc := &errNotificationSenderService{
+		inner:  &fakeNotificationSenderService{existing: map[string]*notificationcommon.NotificationSenderDTO{}},
+		getErr: internalErr,
+	}
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, senderSvc)
+
+	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: notificationSenderYAML,
+		DryRun:  true,
+		Options: &ImportOptions{Upsert: boolPtr(true)},
+	})
+
+	require.Nil(t, svcErr)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Equal(t, "MNS-9999", resp.Results[0].Code)
+}
+
+// errNotificationSenderService wraps fakeNotificationSenderService with injectable per-method errors.
+type errNotificationSenderService struct {
+	inner     *fakeNotificationSenderService
+	createErr *serviceerror.ServiceError
+	getErr    *serviceerror.ServiceError
+	updateErr *serviceerror.ServiceError
+}
+
+func (e *errNotificationSenderService) CreateSender(
+	ctx context.Context, sender notificationcommon.NotificationSenderDTO,
+) (*notificationcommon.NotificationSenderDTO, *serviceerror.ServiceError) {
+	if e.createErr != nil {
+		return nil, e.createErr
+	}
+	return e.inner.CreateSender(ctx, sender)
+}
+
+func (e *errNotificationSenderService) GetSender(
+	ctx context.Context, id string,
+) (*notificationcommon.NotificationSenderDTO, *serviceerror.ServiceError) {
+	if e.getErr != nil {
+		return nil, e.getErr
+	}
+	return e.inner.GetSender(ctx, id)
+}
+
+func (e *errNotificationSenderService) UpdateSender(
+	ctx context.Context, id string, sender notificationcommon.NotificationSenderDTO,
+) (*notificationcommon.NotificationSenderDTO, *serviceerror.ServiceError) {
+	if e.updateErr != nil {
+		return nil, e.updateErr
+	}
+	return e.inner.UpdateSender(ctx, id, sender)
+}
+
+func TestImportNotificationSender_UpsertUpdateError(t *testing.T) {
+	updateErr := &serviceerror.ServiceError{Code: "MNS-9998", Error: core.I18nMessage{DefaultValue: "update failed"}}
+	senderSvc := &errNotificationSenderService{
+		inner: &fakeNotificationSenderService{existing: map[string]*notificationcommon.NotificationSenderDTO{
+			"sender-1": {ID: "sender-1", Name: "Test SMS Sender"},
+		}},
+		updateErr: updateErr,
+	}
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, senderSvc)
+
+	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: notificationSenderYAML,
+		Options: &ImportOptions{Upsert: boolPtr(true)},
+	})
+
+	require.Nil(t, svcErr)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Equal(t, operationUpdate, resp.Results[0].Operation)
+	assert.Equal(t, "MNS-9998", resp.Results[0].Code)
+}
+
+func TestImportNotificationSender_CreateError(t *testing.T) {
+	createErr := &serviceerror.ServiceError{Code: "MNS-9997", Error: core.I18nMessage{DefaultValue: "create failed"}}
+	senderSvc := &errNotificationSenderService{
+		inner:     &fakeNotificationSenderService{existing: map[string]*notificationcommon.NotificationSenderDTO{}},
+		createErr: createErr,
+	}
+	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, senderSvc)
+
+	resp, svcErr := svc.ImportResources(context.Background(), &ImportRequest{Content: notificationSenderYAML})
+
+	require.Nil(t, svcErr)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Equal(t, operationCreate, resp.Results[0].Operation)
+	assert.Equal(t, "MNS-9997", resp.Results[0].Code)
 }

--- a/frontend/apps/console/src/features/import-export/constants/resource-types.ts
+++ b/frontend/apps/console/src/features/import-export/constants/resource-types.ts
@@ -33,6 +33,7 @@ export const ALLOWED_RESOURCE_TYPES = [
   'resource_server',
   'role',
   'agent',
+  'notification_sender',
 ] as const;
 
 export type ResourceType = (typeof ALLOWED_RESOURCE_TYPES)[number];

--- a/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationUploadPage.test.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationUploadPage.test.tsx
@@ -111,6 +111,27 @@ describe('ImportConfigurationUploadPage', () => {
     expect(screen.getByText('upload.errors.uploadYaml')).toBeInTheDocument();
   });
 
+  it('accepts notification_sender as a known resource type without error', async () => {
+    const user = userEvent.setup();
+    render(<ImportConfigurationUploadPage />);
+
+    const yamlContent = '# resource_type: notification_sender\nid: sms-sender\nname: SMS Sender\nprovider: twilio\n';
+    const yamlFile = new File([yamlContent], 'config.yaml', {type: 'text/yaml'});
+    Object.defineProperty(yamlFile, 'text', {value: () => Promise.resolve(yamlContent)});
+
+    await user.upload(document.getElementById('file-upload') as HTMLInputElement, yamlFile);
+    await user.click(screen.getByRole('button', {name: 'common:actions.continue'}));
+
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith('/welcome/open-project/validate', expect.anything());
+      },
+      {timeout: 5000},
+    );
+
+    expect(screen.queryByText(/upload.errors.unknownResourceType/)).not.toBeInTheDocument();
+  });
+
   it('shows file name after valid yaml file is selected', async () => {
     const user = userEvent.setup();
     render(<ImportConfigurationUploadPage />);


### PR DESCRIPTION
## Summary

- Add `notification_sender` to `ALLOWED_RESOURCE_TYPES` in the frontend import validation — previously any config file containing notification senders was rejected at the upload step with an "unknown resource type" error
- Add `MNS-1001` (`ErrorSenderNotFound`) to `notFoundErrorCodes` in the importer — previously the upsert path surfaced a failed `update` outcome instead of falling through to `create` when the sender did not yet exist
- Implement `importNotificationSender` in the backend importer with the standard upsert pattern (get → update if exists, create otherwise), wire it into `importDocument`, and thread the adapter through `Initialize` and `servicemanager`
- Export `ParseNotificationSenderDTOFromNode` from the notification package (refactored from the unexported `parseToNotificationSenderDTO`) to support node-based decoding in the importer
- Add backend tests: create, upsert-update, upsert-fallback-to-create (regression for the `MNS-1001` bug), and nil-adapter cases
- Add frontend test: `notification_sender` resource type is accepted without error by the upload page validation

Closes #3193

## Test plan

- [x] Upload a config YAML containing `notification_sender` resources — no unknown-type error, continue button enabled
- [x] Import a config with a notification sender that does not exist — operation is `create`, status `success`
- [ ] Import a config with a notification sender that already exists (upsert enabled) — operation is `update`, status `success`
- [ ] Backend unit tests: `TestImportNotificationSender_*` all pass
- [ ] Frontend unit test: `accepts notification_sender as a known resource type without error` passes
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import-export now supports notification sender resources, enabling create, update, and upsert during configuration imports.
  * Import behavior updated so missing senders are classified as "not found", enabling proper upsert-fallback create and clearer operation/status reporting.
* **Tests**
  * Expanded backend tests for notification-sender import (create, upsert, dry-run, error cases) and a frontend UI upload test for the new resource type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->