### PR TITLE
Serve .js assets as application/javascript to enable proxy compression

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"mime"
 	"net"
 	"net/http"
 	"os"
@@ -267,6 +268,13 @@ func gracefulShutdown(
 
 // registerStaticFileHandlers registers static file handlers for frontend applications.
 func registerStaticFileHandlers(logger *log.Logger, mux *http.ServeMux, serverHome string) {
+	// Override the OS-level MIME mapping so .js/.mjs files are served as
+	// application/javascript. Most proxies (Envoy, NGINX, Cloudflare) only
+	// compress application/javascript in their default allowlists, not
+	// text/javascript, which is Go's default on some systems.
+	_ = mime.AddExtensionType(".js", "application/javascript; charset=utf-8")
+	_ = mime.AddExtensionType(".mjs", "application/javascript; charset=utf-8")
+
 	// Serve gate application from /gate
 	gateDir := path.Join(serverHome, "apps", "gate")
 	if directoryExists(gateDir) {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -584,6 +584,51 @@ func TestRegisterStaticFileHandlers(t *testing.T) {
 		assert.Contains(t, rr.Body.String(), "console app")
 	})
 
+	t.Run("serves js files as application/javascript", func(t *testing.T) {
+		jsContent := []byte("console.log('hello');")
+		requireWriteFile(t, filepath.Join(gateDir, "app.js"), jsContent)
+
+		mux := http.NewServeMux()
+		registerStaticFileHandlers(logger, mux, tmpDir)
+
+		req := httptest.NewRequest(http.MethodGet, "/gate/app.js", nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "application/javascript; charset=utf-8", rr.Header().Get("Content-Type"))
+	})
+
+	t.Run("serves console js files as application/javascript", func(t *testing.T) {
+		jsContent := []byte("console.log('hello');")
+		requireWriteFile(t, filepath.Join(consoleDir, "app.js"), jsContent)
+
+		mux := http.NewServeMux()
+		registerStaticFileHandlers(logger, mux, tmpDir)
+
+		req := httptest.NewRequest(http.MethodGet, "/console/app.js", nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "application/javascript; charset=utf-8", rr.Header().Get("Content-Type"))
+	})
+
+	t.Run("serves mjs files as application/javascript", func(t *testing.T) {
+		mjsContent := []byte("export default {};")
+		requireWriteFile(t, filepath.Join(gateDir, "app.mjs"), mjsContent)
+
+		mux := http.NewServeMux()
+		registerStaticFileHandlers(logger, mux, tmpDir)
+
+		req := httptest.NewRequest(http.MethodGet, "/gate/app.mjs", nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "application/javascript; charset=utf-8", rr.Header().Get("Content-Type"))
+	})
+
 	t.Run("handles missing directories gracefully", func(t *testing.T) {
 		emptyTmpDir := t.TempDir()
 		mux := http.NewServeMux()


### PR DESCRIPTION
### Purpose
`net/http`'s file server derives `Content-Type` from the OS MIME database. On many Linux environments (Alpine, Debian slim) `.js` resolves to `text/javascript`. Most reverse proxies (Envoy, Kgateway, NGINX, Cloudflare) gate compression on `application/javascript` in their default allowlists and skip `text/javascript`, so the gate SPA's ~3 MB bundle ships uncompressed even when the client sends `Accept-Encoding: gzip`. On bandwidth-constrained clients this causes a 20–30 s white screen on the OAuth redirect critical path.

### Approach
Call `mime.AddExtensionType` for `.js` and `.mjs` before wiring up the static file servers. This overrides the OS-level mapping in Go's global MIME table, making the behaviour deterministic across all deployment environments. `application/javascript` is the type expected by the deployed proxy ecosystem; RFC 9239 recommends `text/javascript` but the real-world proxy compression allowlists have not caught up (SPA toolchains — Vite, Webpack, esbuild — all default to `application/javascript` for this reason).

The override is a package-level call so it applies to both the gate (`/gate`) and console (`/console`) static file servers.

### Related Issues
- #2745

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Serve JavaScript assets (.js and .mjs) with Content-Type: application/javascript; charset=utf-8 to ensure consistent browser handling.

* **Tests**
  * Added tests confirming .js and .mjs static assets return 200 OK with the correct Content-Type header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->