### PR TITLE
Add CodeRabbit labeling to skip changelog for docs-only changes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,6 +5,10 @@ reviews:
   request_changes_workflow: false
   high_level_summary: true
   poem: false
+  auto_apply_labels: true
+  labeling_instructions:
+    - label: skip-changelog
+      instructions: "All changed files are under docs/"
 
   path_instructions:
     - path: "**/*.go"


### PR DESCRIPTION
### Purpose
Automates the `skip-changelog` label for pull requests that contain only documentation changes, using CodeRabbit's `labeling_instructions` feature. This removes the need to manually label docs-only PRs.

### Approach
Added `auto_apply_labels: true` and a `labeling_instructions` entry to `.coderabbit.yaml`. CodeRabbit will apply the `skip-changelog` label when all changed files are under `docs/`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review automation configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->