### PR TITLE
Migrate backend log calls to context-aware logging method

### DIFF
--- a/backend/.mockery.public.yml
+++ b/backend/.mockery.public.yml
@@ -417,7 +417,7 @@ packages:
       pkgname: rolemock
       filename: "{{.InterfaceName}}_mock.go"
 
-  github.com/thunder-id/thunderid/internal/observability:
+  github.com/thunder-id/thunderid/internal/system/observability:
     config:
       all: true
       dir: tests/mocks/observability/observabilitymock
@@ -425,7 +425,7 @@ packages:
       pkgname: observabilitymock
       filename: "{{.InterfaceName}}_mock.go"
 
-  github.com/thunder-id/thunderid/internal/observability/adapter:
+  github.com/thunder-id/thunderid/internal/system/observability/adapter:
     config:
       all: true
       dir: tests/mocks/observability/adaptermock

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -55,22 +55,24 @@ var (
 )
 
 func main() {
+	// Server bootstrap/shutdown logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
 	startupStartedAt := time.Now()
 	logger := log.GetLogger()
 
 	flag.String("resources", "", "Path to declarative resources YAML file")
-	serverHome := getThunderHome(logger)
+	serverHome := getThunderHome(ctx, logger)
 
-	cfg := initThunderConfigurations(logger, serverHome)
+	cfg := initThunderConfigurations(ctx, logger, serverHome)
 	if cfg == nil {
-		logger.Fatal("Failed to initialize configurations")
+		logger.FatalWithContext(ctx, "Failed to initialize configurations")
 	}
 
 	// Install the CORS allowed-origins matcher used by the HTTP middleware.
 	// Compilation errors are already surfaced by config validation; this call
 	// rebuilds the rules and installs them as the cors package singleton.
 	if err := cors.InitializeMatcher(cfg.CORS.AllowedOrigins); err != nil {
-		logger.Fatal("Failed to initialize CORS matcher", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize CORS matcher", log.Error(err))
 	}
 
 	// Initialize the cache manager.
@@ -82,65 +84,66 @@ func main() {
 	// Create a new HTTP multiplexer.
 	mux := http.NewServeMux()
 	if mux == nil {
-		logger.Fatal("Failed to initialize multiplexer")
+		logger.FatalWithContext(ctx, "Failed to initialize multiplexer")
 	}
 
 	// Register the services.
 	jwtService, runtimeCryptoSvc := registerServices(mux, cacheManager)
 
 	// Register static file handlers for frontend applications.
-	registerStaticFileHandlers(logger, mux, serverHome)
+	registerStaticFileHandlers(ctx, logger, mux, serverHome)
 
 	// Setup signal handling for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	// Create the HTTP server.
-	server := createHTTPServer(logger, cfg, mux, jwtService)
+	server := createHTTPServer(ctx, logger, cfg, mux, jwtService)
 	var ln net.Listener
 	if cfg.Server.HTTPOnly {
-		logger.Info("TLS is not enabled, starting server without TLS")
-		ln = createListener(logger, server)
+		logger.InfoWithContext(ctx, "TLS is not enabled, starting server without TLS")
+		ln = createListener(ctx, logger, server)
 	} else {
-		tlsConfig := loadCertConfig(logger, runtimeCryptoSvc)
-		ln = createTLSListener(logger, server, tlsConfig)
+		tlsConfig := loadCertConfig(ctx, logger, runtimeCryptoSvc)
+		ln = createTLSListener(ctx, logger, server, tlsConfig)
 	}
 
 	serverURL := config.GetServerURL(&cfg.Server)
 	consoleURL := fmt.Sprintf("%s/console", strings.TrimSuffix(serverURL, "/"))
-	logger.Info("ThunderID Server URL", log.String("url", serverURL))
-	logger.Info("ThunderID Console URL", log.String("url", consoleURL))
+	logger.InfoWithContext(ctx, "ThunderID Server URL", log.String("url", serverURL))
+	logger.InfoWithContext(ctx, "ThunderID Console URL", log.String("url", consoleURL))
 
 	// Start server in a goroutine
 	go func() {
 		startupDuration := time.Since(startupStartedAt)
-		logger.Info("ThunderID Server started", log.String("startup_time", startupDuration.String()))
+		logger.InfoWithContext(ctx, "ThunderID Server started", log.String("startup_time", startupDuration.String()))
 		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
-			logger.Fatal("Failed to serve requests", log.Error(err))
+			logger.FatalWithContext(ctx, "Failed to serve requests", log.Error(err))
 		}
 	}()
 
 	// Wait for shutdown signal
 	<-sigChan
-	logger.Info("Shutting down server...")
-	gracefulShutdown(logger, server, cacheManager)
+	logger.InfoWithContext(ctx, "Shutting down server...")
+	gracefulShutdown(ctx, logger, server, cacheManager)
 }
 
 // getThunderHome retrieves and return the home directory.
-func getThunderHome(logger *log.Logger) string {
+func getThunderHome(ctx context.Context, logger *log.Logger) string {
 	// Parse project directory from command line arguments.
 	projectHome := ""
 	projectHomeFlag := flag.String("serverHome", "", "Path to ThunderID home directory")
 	flag.Parse()
 
 	if *projectHomeFlag != "" {
-		logger.Info("Using serverHome from command line argument", log.String("serverHome", *projectHomeFlag))
+		logger.InfoWithContext(ctx, "Using serverHome from command line argument",
+			log.String("serverHome", *projectHomeFlag))
 		projectHome = *projectHomeFlag
 	} else {
 		// If no command line argument is provided, use the current working directory.
 		dir, dirErr := os.Getwd()
 		if dirErr != nil {
-			logger.Fatal("Failed to get current working directory", log.Error(dirErr))
+			logger.FatalWithContext(ctx, "Failed to get current working directory", log.Error(dirErr))
 		}
 		projectHome = dir
 	}
@@ -149,28 +152,28 @@ func getThunderHome(logger *log.Logger) string {
 }
 
 // initThunderConfigurations initializes the configurations.
-func initThunderConfigurations(logger *log.Logger, serverHome string) *config.Config {
+func initThunderConfigurations(ctx context.Context, logger *log.Logger, serverHome string) *config.Config {
 	// Load the configurations.
 	configFilePath := path.Join(serverHome, "repository/conf/deployment.yaml")
 	defaultConfigPath := path.Join(serverHome, "repository/resources/conf/default.json")
 	cfg, err := config.LoadConfig(configFilePath, defaultConfigPath, serverHome)
 	if err != nil {
-		logger.Fatal("Failed to load configurations", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to load configurations", log.Error(err))
 	}
 
 	// Initialize runtime configurations.
 	if err := config.InitializeServerRuntime(serverHome, cfg); err != nil {
-		logger.Fatal("Failed to initialize server runtime", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize server runtime", log.Error(err))
 	}
 
 	return cfg
 }
 
 // loadCertConfig loads the TLS material via the runtime crypto provider.
-func loadCertConfig(logger *log.Logger, runtimeSvc kmprovider.RuntimeCryptoProvider) *tls.Config {
-	mat, err := runtimeSvc.GetTLSMaterial(context.Background())
+func loadCertConfig(ctx context.Context, logger *log.Logger, runtimeSvc kmprovider.RuntimeCryptoProvider) *tls.Config {
+	mat, err := runtimeSvc.GetTLSMaterial(ctx)
 	if err != nil {
-		logger.Fatal("Failed to load TLS material", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to load TLS material", log.Error(err))
 	}
 	// #nosec G402 -- MinVersion is set to TLS 1.2 or higher by GetTLSMaterial
 	return &tls.Config{
@@ -180,9 +183,9 @@ func loadCertConfig(logger *log.Logger, runtimeSvc kmprovider.RuntimeCryptoProvi
 }
 
 // createHTTPServer creates and configures an HTTP server with common settings.
-func createHTTPServer(logger *log.Logger, cfg *config.Config, mux *http.ServeMux,
+func createHTTPServer(ctx context.Context, logger *log.Logger, cfg *config.Config, mux *http.ServeMux,
 	jwtService jwt.JWTServiceInterface) *http.Server {
-	securityMiddleware := createSecurityMiddleware(logger, mux, jwtService)
+	securityMiddleware := createSecurityMiddleware(ctx, logger, mux, jwtService)
 
 	// Build the middleware chain with proper execution order.
 	// Request flow: CorrelationID (outermost) -> AccessLog -> Security -> Route Handler (innermost)
@@ -205,46 +208,48 @@ func createHTTPServer(logger *log.Logger, cfg *config.Config, mux *http.ServeMux
 }
 
 // createListener creates and returns a listener for the HTTP server.
-func createListener(logger *log.Logger, server *http.Server) net.Listener {
+func createListener(ctx context.Context, logger *log.Logger, server *http.Server) net.Listener {
 	ln, err := netListen("tcp", server.Addr)
 	if err != nil {
-		logger.Fatal("Failed to start HTTP listener", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to start HTTP listener", log.Error(err))
 	}
 	return ln
 }
 
 // createTLSListener creates and returns a TLS listener for the HTTPS server.
-func createTLSListener(logger *log.Logger, server *http.Server, tlsConfig *tls.Config) net.Listener {
+func createTLSListener(ctx context.Context, logger *log.Logger, server *http.Server,
+	tlsConfig *tls.Config) net.Listener {
 	ln, err := tlsListen("tcp", server.Addr, tlsConfig)
 	if err != nil {
-		logger.Fatal("Failed to start TLS listener", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to start TLS listener", log.Error(err))
 	}
 	return ln
 }
 
-func createSecurityMiddleware(logger *log.Logger, mux *http.ServeMux,
+func createSecurityMiddleware(ctx context.Context, logger *log.Logger, mux *http.ServeMux,
 	jwtService jwt.JWTServiceInterface) http.Handler {
 	middlewareFunc, err := security.Initialize(jwtService)
 	if err != nil {
-		logger.Fatal("Failed to initialize security middleware", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize security middleware", log.Error(err))
 	}
 	return middlewareFunc(mux)
 }
 
 // gracefulShutdown handles the graceful shutdown of all components.
 func gracefulShutdown(
+	ctx context.Context,
 	logger *log.Logger,
 	server *http.Server,
 	cacheManager cache.CacheManagerInterface,
 ) {
-	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	ctx, cancel := context.WithTimeout(ctx, shutdownTimeout)
 	defer cancel()
 
 	// Shutdown HTTP server
 	if err := server.Shutdown(ctx); err != nil {
-		logger.Error("Error during server shutdown", log.Error(err))
+		logger.ErrorWithContext(ctx, "Error during server shutdown", log.Error(err))
 	} else {
-		logger.Debug("HTTP server shutdown completed")
+		logger.DebugWithContext(ctx, "HTTP server shutdown completed")
 	}
 
 	// Shutdown services
@@ -253,21 +258,21 @@ func gracefulShutdown(
 	// Close database connections
 	dbCloser := provider.GetDBProviderCloser()
 	if err := dbCloser.Close(); err != nil {
-		logger.Error("Error closing database connections", log.Error(err))
+		logger.ErrorWithContext(ctx, "Error closing database connections", log.Error(err))
 	} else {
-		logger.Debug("Database connections closed successfully")
+		logger.DebugWithContext(ctx, "Database connections closed successfully")
 	}
 
 	if cacheManager != nil {
 		cacheManager.Close()
-		logger.Debug("Cache manager closed successfully")
+		logger.DebugWithContext(ctx, "Cache manager closed successfully")
 	}
 
-	logger.Info("Server shutdown completed")
+	logger.InfoWithContext(ctx, "Server shutdown completed")
 }
 
 // registerStaticFileHandlers registers static file handlers for frontend applications.
-func registerStaticFileHandlers(logger *log.Logger, mux *http.ServeMux, serverHome string) {
+func registerStaticFileHandlers(ctx context.Context, logger *log.Logger, mux *http.ServeMux, serverHome string) {
 	// Override the OS-level MIME mapping so .js/.mjs files are served as
 	// application/javascript. Most proxies (Envoy, NGINX, Cloudflare) only
 	// compress application/javascript in their default allowlists, not
@@ -278,21 +283,21 @@ func registerStaticFileHandlers(logger *log.Logger, mux *http.ServeMux, serverHo
 	// Serve gate application from /gate
 	gateDir := path.Join(serverHome, "apps", "gate")
 	if directoryExists(gateDir) {
-		logger.Debug("Registering static file handler for Gate application",
+		logger.DebugWithContext(ctx, "Registering static file handler for Gate application",
 			log.String("path", "/gate/"), log.String("directory", gateDir))
 		mux.Handle("/gate/", createStaticFileHandler("/gate/", gateDir, logger))
 	} else {
-		logger.Warn("Gate application directory not found", log.String("directory", gateDir))
+		logger.WarnWithContext(ctx, "Gate application directory not found", log.String("directory", gateDir))
 	}
 
 	// Serve console application from /console
 	consoleDir := path.Join(serverHome, "apps", "console")
 	if directoryExists(consoleDir) {
-		logger.Debug("Registering static file handler for Console application",
+		logger.DebugWithContext(ctx, "Registering static file handler for Console application",
 			log.String("path", "/console/"), log.String("directory", consoleDir))
 		mux.Handle("/console/", createStaticFileHandler("/console/", consoleDir, logger))
 	} else {
-		logger.Warn("Console application directory not found", log.String("directory", consoleDir))
+		logger.WarnWithContext(ctx, "Console application directory not found", log.String("directory", consoleDir))
 	}
 }
 
@@ -325,7 +330,7 @@ func createStaticFileHandler(routePrefix, directory string, logger *log.Logger) 
 			// For SPA routing, serve index.html for non-existent files
 			indexPath := path.Join(directory, "index.html")
 			if fileExists(indexPath) {
-				logger.Debug("Serving index.html for SPA routing",
+				logger.DebugWithContext(r.Context(), "Serving index.html for SPA routing",
 					log.String("requested_path", r.URL.Path),
 					log.String("route_prefix", routePrefix))
 				// Set no-cache headers for index.html

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -134,7 +135,7 @@ func (suite *CreateSecurityMiddlewareTestSuite) TestCreateSecurityMiddleware_Wit
 			}
 
 			// Execute
-			handler := createSecurityMiddleware(suite.logger, suite.mux, suite.mockJWTService)
+			handler := createSecurityMiddleware(context.Background(), suite.logger, suite.mux, suite.mockJWTService)
 
 			// Assert - handler is always returned now, regardless of skip security flag
 			assert.NotNil(suite.T(), handler, "Handler should always be non-nil")
@@ -148,9 +149,9 @@ func (suite *CreateSecurityMiddlewareTestSuite) TestCreateSecurityMiddleware_Wit
 // TestCreateSecurityMiddleware_MultipleInvocations tests that multiple calls work correctly
 func (suite *CreateSecurityMiddlewareTestSuite) TestCreateSecurityMiddleware_MultipleInvocations() {
 	// Execute multiple times
-	handler1 := createSecurityMiddleware(suite.logger, suite.mux, suite.mockJWTService)
-	handler2 := createSecurityMiddleware(suite.logger, suite.mux, suite.mockJWTService)
-	handler3 := createSecurityMiddleware(suite.logger, suite.mux, suite.mockJWTService)
+	handler1 := createSecurityMiddleware(context.Background(), suite.logger, suite.mux, suite.mockJWTService)
+	handler2 := createSecurityMiddleware(context.Background(), suite.logger, suite.mux, suite.mockJWTService)
+	handler3 := createSecurityMiddleware(context.Background(), suite.logger, suite.mux, suite.mockJWTService)
 
 	// Assert - each call should return a new handler instance
 	assert.NotNil(suite.T(), handler1)
@@ -161,17 +162,17 @@ func (suite *CreateSecurityMiddlewareTestSuite) TestCreateSecurityMiddleware_Mul
 // TestCreateSecurityMiddleware_RuntimeToggle tests toggling security at runtime by changing environment variable
 func (suite *CreateSecurityMiddlewareTestSuite) TestCreateSecurityMiddleware_RuntimeToggle() {
 	// First call with security enabled
-	handler1 := createSecurityMiddleware(suite.logger, suite.mux, suite.mockJWTService)
+	handler1 := createSecurityMiddleware(context.Background(), suite.logger, suite.mux, suite.mockJWTService)
 	assert.NotNil(suite.T(), handler1, "First handler should not be nil")
 
 	// Disable security
 	_ = os.Setenv("SKIP_SECURITY", "true")
-	handler2 := createSecurityMiddleware(suite.logger, suite.mux, suite.mockJWTService)
+	handler2 := createSecurityMiddleware(context.Background(), suite.logger, suite.mux, suite.mockJWTService)
 	assert.NotNil(suite.T(), handler2, "Second handler should not be nil (skipSecurity is handled internally)")
 
 	// Re-enable security
 	_ = os.Unsetenv("SKIP_SECURITY")
-	handler3 := createSecurityMiddleware(suite.logger, suite.mux, suite.mockJWTService)
+	handler3 := createSecurityMiddleware(context.Background(), suite.logger, suite.mux, suite.mockJWTService)
 	assert.NotNil(suite.T(), handler3, "Third handler should not be nil after re-enabling security")
 }
 
@@ -195,7 +196,7 @@ func TestCreateHTTPServer_WithHTTPOnly(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	server := createHTTPServer(logger, cfg, mux, nil)
+	server := createHTTPServer(context.Background(), logger, cfg, mux, nil)
 
 	assert.Equal(t, "localhost:0", server.Addr)
 	assert.NotNil(t, server.Handler)
@@ -227,7 +228,7 @@ func TestCreateListener_Success(t *testing.T) {
 		netListen = originalListen
 	})
 
-	ln := createListener(logger, server)
+	ln := createListener(context.Background(), logger, server)
 
 	assert.Equal(t, 1, callCount)
 	assert.Equal(t, stubListener, ln)
@@ -249,7 +250,7 @@ func TestCreateListener_ExitsOnError(t *testing.T) {
 			Addr:              "invalid-address",
 			ReadHeaderTimeout: time.Second,
 		}
-		createListener(logger, server)
+		createListener(context.Background(), logger, server)
 		return
 	}
 
@@ -281,7 +282,7 @@ func TestCreateTLSListener_Success(t *testing.T) {
 		tlsListen = originalTLSListen
 	})
 
-	ln := createTLSListener(logger, server, tlsConfig)
+	ln := createTLSListener(context.Background(), logger, server, tlsConfig)
 
 	assert.Equal(t, 1, callCount)
 	assert.Equal(t, stubListener, ln)
@@ -303,7 +304,7 @@ func TestCreateTLSListener_ExitsOnError(t *testing.T) {
 			Addr:              "invalid-address",
 			ReadHeaderTimeout: time.Second,
 		}
-		createTLSListener(logger, server, &tls.Config{MinVersion: tls.VersionTLS12})
+		createTLSListener(context.Background(), logger, server, &tls.Config{MinVersion: tls.VersionTLS12})
 		return
 	}
 
@@ -322,7 +323,7 @@ func TestGetThunderHome_UsesFlagValue(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	os.Args = []string{origArgs[0], "-serverHome", tmpDir}
 
-	got := getThunderHome(log.GetLogger())
+	got := getThunderHome(context.Background(), log.GetLogger())
 	assert.Equal(t, tmpDir, got)
 }
 
@@ -341,7 +342,7 @@ func TestGetThunderHome_DefaultsToCWD(t *testing.T) {
 	os.Args = []string{origArgs[0]}
 	_ = os.Chdir(tmpDir)
 
-	got := getThunderHome(log.GetLogger())
+	got := getThunderHome(context.Background(), log.GetLogger())
 	expectedResolved, err := filepath.EvalSymlinks(tmpDir)
 	assert.NoError(t, err)
 	gotResolved, err := filepath.EvalSymlinks(got)
@@ -567,7 +568,7 @@ func TestRegisterStaticFileHandlers(t *testing.T) {
 
 	t.Run("registers handlers for existing directories", func(t *testing.T) {
 		mux := http.NewServeMux()
-		registerStaticFileHandlers(logger, mux, tmpDir)
+		registerStaticFileHandlers(context.Background(), logger, mux, tmpDir)
 
 		// Test gate handler
 		req := httptest.NewRequest(http.MethodGet, "/gate/", nil)
@@ -589,7 +590,7 @@ func TestRegisterStaticFileHandlers(t *testing.T) {
 		requireWriteFile(t, filepath.Join(gateDir, "app.js"), jsContent)
 
 		mux := http.NewServeMux()
-		registerStaticFileHandlers(logger, mux, tmpDir)
+		registerStaticFileHandlers(context.Background(), logger, mux, tmpDir)
 
 		req := httptest.NewRequest(http.MethodGet, "/gate/app.js", nil)
 		rr := httptest.NewRecorder()
@@ -604,7 +605,7 @@ func TestRegisterStaticFileHandlers(t *testing.T) {
 		requireWriteFile(t, filepath.Join(consoleDir, "app.js"), jsContent)
 
 		mux := http.NewServeMux()
-		registerStaticFileHandlers(logger, mux, tmpDir)
+		registerStaticFileHandlers(context.Background(), logger, mux, tmpDir)
 
 		req := httptest.NewRequest(http.MethodGet, "/console/app.js", nil)
 		rr := httptest.NewRecorder()
@@ -619,7 +620,7 @@ func TestRegisterStaticFileHandlers(t *testing.T) {
 		requireWriteFile(t, filepath.Join(gateDir, "app.mjs"), mjsContent)
 
 		mux := http.NewServeMux()
-		registerStaticFileHandlers(logger, mux, tmpDir)
+		registerStaticFileHandlers(context.Background(), logger, mux, tmpDir)
 
 		req := httptest.NewRequest(http.MethodGet, "/gate/app.mjs", nil)
 		rr := httptest.NewRecorder()
@@ -633,7 +634,7 @@ func TestRegisterStaticFileHandlers(t *testing.T) {
 		emptyTmpDir := t.TempDir()
 		mux := http.NewServeMux()
 		// Should not panic
-		registerStaticFileHandlers(logger, mux, emptyTmpDir)
+		registerStaticFileHandlers(context.Background(), logger, mux, emptyTmpDir)
 	})
 }
 

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -94,20 +95,23 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	jwt.JWTServiceInterface, kmprovider.RuntimeCryptoProvider) {
 	logger := log.GetLogger()
 
+	// Service registration runs during application startup, outside any request.
+	ctx := context.Background()
+
 	// Load the server's private key for signing JWTs.
 	pkiService, err := pki.Initialize()
 	if err != nil {
-		logger.Fatal("Failed to initialize certificate service", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize certificate service", log.Error(err))
 	}
 
 	runtimeCryptoSvc, _, err := kmprovider.Initialize(pkiService)
 	if err != nil {
-		logger.Fatal("Failed to initialize key manager provider", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize key manager provider", log.Error(err))
 	}
 
 	jwtService, jweService, err := jose.Initialize(runtimeCryptoSvc)
 	if err != nil {
-		logger.Fatal("Failed to initialize JOSE services", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize JOSE services", log.Error(err))
 	}
 
 	observabilitySvc = observability.Initialize()
@@ -121,19 +125,19 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// Initialize i18n service for internationalization support.
 	i18nService, i18nExporter, err := i18nmgt.Initialize(mux, config.GetServerRuntime().Config.Translation)
 	if err != nil {
-		logger.Fatal("Failed to initialize i18n service", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize i18n service", log.Error(err))
 	}
 	// Add to exporters list (must be done after initializing list)
 	exporters = append(exporters, i18nExporter)
 
 	ouAuthzService, err := sysauthz.Initialize()
 	if err != nil {
-		logger.Fatal("Failed to initialize system authorization service", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize system authorization service", log.Error(err))
 	}
 
 	ouService, ouHierarchyResolver, ouExporter, err := ou.Initialize(mux, mcpServer, cacheManager, ouAuthzService)
 	if err != nil {
-		logger.Fatal("Failed to initialize OrganizationUnitService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize OrganizationUnitService", log.Error(err))
 	}
 	exporters = append(exporters, ouExporter)
 
@@ -144,11 +148,11 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	hashCfg, err := buildHashConfig()
 	if err != nil {
-		logger.Fatal("Failed to build HashService config", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to build HashService config", log.Error(err))
 	}
 	hashService, err := cryptolib.Initialize(hashCfg)
 	if err != nil {
-		logger.Fatal("Failed to initialize HashService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize HashService", log.Error(err))
 	}
 
 	// Initialize consent service
@@ -158,14 +162,14 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	entityTypeService, entityTypeExporter, err := entitytype.Initialize(
 		mux, mcpServer, cacheManager, ouService, ouAuthzService, consentService)
 	if err != nil {
-		logger.Fatal("Failed to initialize EntityTypeService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize EntityTypeService", log.Error(err))
 	}
 	exporters = append(exporters, entityTypeExporter)
 
 	// Initialize entity service
 	entityService, err := entity.Initialize(cacheManager, hashService, entityTypeService, ouService)
 	if err != nil {
-		logger.Fatal("Failed to initialize EntityService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize EntityService", log.Error(err))
 	}
 
 	// Initialize entity provider
@@ -175,7 +179,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		mux, entityService, ouService, entityTypeService, ouAuthzService,
 	)
 	if err != nil {
-		logger.Fatal("Failed to initialize UserService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize UserService", log.Error(err))
 	}
 	exporters = append(exporters, userExporter)
 
@@ -183,7 +187,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		mux, dbprovider.GetDBProvider(), ouService, entityService, entityTypeService, ouAuthzService,
 	)
 	if err != nil {
-		logger.Fatal("Failed to initialize GroupService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize GroupService", log.Error(err))
 	}
 	exporters = append(exporters, groupExporter)
 
@@ -193,33 +197,33 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	resourceService, resourceExporter, err := resource.Initialize(mux, ouService, consentService)
 	if err != nil {
-		logger.Fatal("Failed to initialize Resource Service", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize Resource Service", log.Error(err))
 	}
 	exporters = append(exporters, resourceExporter)
 	roleService, roleAssignmentService, roleExporter, err := role.Initialize(
 		mux, entityService, groupService, ouService, resourceService, entityTypeService,
 	)
 	if err != nil {
-		logger.Fatal("Failed to initialize RoleService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize RoleService", log.Error(err))
 	}
 	exporters = append(exporters, roleExporter)
 	authZService := authz.Initialize(roleService)
 
 	idpService, idpExporter, err := idp.Initialize(cacheManager, mux)
 	if err != nil {
-		logger.Fatal("Failed to initialize IDPService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize IDPService", log.Error(err))
 	}
 	exporters = append(exporters, idpExporter)
 
 	templateService, err := template.Initialize()
 	if err != nil {
-		logger.Fatal("Failed to initialize template service", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize template service", log.Error(err))
 	}
 
 	_, otpService, notifSenderSvc, notificationExporter, err := notification.Initialize(
 		mux, jwtService, templateService)
 	if err != nil {
-		logger.Fatal("Failed to initialize NotificationService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize NotificationService", log.Error(err))
 	}
 	exporters = append(exporters, notificationExporter)
 
@@ -263,7 +267,8 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	var emailClient email.EmailClientInterface
 	emailClient, err = email.Initialize()
 	if err != nil {
-		logger.Debug("Email client not configured. "+
+		// Service registration runs at startup, outside any request.
+		logger.DebugWithContext(context.Background(), "Email client not configured. "+
 			"EmailExecutor will be registered but will not send emails.", log.Error(err))
 		emailClient = nil
 	}
@@ -272,7 +277,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// the engine itself.
 	openid4vpVerifierSvc, err := openid4vp.Initialize(mux, runtimeCryptoSvc, cacheManager, jwtService)
 	if err != nil {
-		logger.Fatal("Failed to initialize OpenID4VP verifier service", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize OpenID4VP verifier service", log.Error(err))
 	}
 
 	execRegistry := executor.Initialize(flowFactory, ouService, idpService, notifSenderSvc, jwtService, authAssertGen,
@@ -284,24 +289,24 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	flowMgtService, flowMgtExporter, err := flowmgt.Initialize(
 		mux, mcpServer, cacheManager, flowFactory, execRegistry, graphCache)
 	if err != nil {
-		logger.Fatal("Failed to initialize FlowMgtService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize FlowMgtService", log.Error(err))
 	}
 	exporters = append(exporters, flowMgtExporter)
 	certservice, err := cert.Initialize(cacheManager, dbprovider.GetDBProvider())
 	if err != nil {
-		logger.Fatal("Failed to initialize CertificateService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize CertificateService", log.Error(err))
 	}
 
 	// Initialize theme and layout services
 	themeMgtService, themeExporter, err := thememgt.Initialize(mux, mcpServer)
 	if err != nil {
-		logger.Fatal("Failed to initialize ThemeMgtService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize ThemeMgtService", log.Error(err))
 	}
 	exporters = append(exporters, themeExporter)
 
 	layoutMgtService, layoutExporter, err := layoutmgt.Initialize(mux)
 	if err != nil {
-		logger.Fatal("Failed to initialize LayoutMgtService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize LayoutMgtService", log.Error(err))
 	}
 	exporters = append(exporters, layoutExporter)
 
@@ -309,20 +314,20 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		cacheManager, certservice, entityProvider,
 		themeMgtService, layoutMgtService, flowMgtService, entityTypeService, consentService)
 	if err != nil {
-		logger.Fatal("Failed to initialize InboundClientService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize InboundClientService", log.Error(err))
 	}
 
 	// TODO: Remove entityService dependency after finalizing declarative resource loading pattern
 	applicationService, applicationExporter, err := application.Initialize(
 		mux, mcpServer, entityProvider, entityService, inboundClientService, ouService, i18nService)
 	if err != nil {
-		logger.Fatal("Failed to initialize ApplicationService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize ApplicationService", log.Error(err))
 	}
 	exporters = append(exporters, applicationExporter)
 
 	agentService, agentExporter, err := agent.Initialize(mux, entityService, inboundClientService, ouService)
 	if err != nil {
-		logger.Fatal("Failed to initialize AgentService", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize AgentService", log.Error(err))
 	}
 	exporters = append(exporters, agentExporter)
 
@@ -357,7 +362,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	flowExecService, err := flowexec.Initialize(mux, flowMgtService, inboundClientService, entityProvider,
 		execRegistry, observabilitySvc, runtimeCryptoSvc)
 	if err != nil {
-		logger.Fatal("Failed to initialize flow execution service", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize flow execution service", log.Error(err))
 	}
 
 	// Initialize OAuth services.
@@ -365,13 +370,13 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		flowExecService, observabilitySvc, runtimeCryptoSvc, ouService, attributeCacheService, authZService,
 		entityProvider, resourceService, i18nService, idpService)
 	if err != nil {
-		logger.Fatal("Failed to initialize OAuth services", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize OAuth services", log.Error(err))
 	}
 
 	// Register OAuth2 DCR service.
 	err = dcr.Initialize(mux, applicationService, ouService, i18nService)
 	if err != nil {
-		logger.Fatal("Failed to initialize OAuth2 DCR service", log.Error(err))
+		logger.FatalWithContext(ctx, "Failed to initialize OAuth2 DCR service", log.Error(err))
 	}
 
 	// Register the health service.

--- a/backend/internal/agent/declarative_resource.go
+++ b/backend/internal/agent/declarative_resource.go
@@ -116,7 +116,7 @@ func (e *agentExporter) GetResourceByID(
 }
 
 // ValidateResource validates an agent resource prior to export.
-func (e *agentExporter) ValidateResource(
+func (e *agentExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	a, ok := resource.(*model.AgentGetResponse)
@@ -124,7 +124,7 @@ func (e *agentExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeAgent, id)
 	}
 
-	if err := declarativeresource.ValidateResourceName(
+	if err := declarativeresource.ValidateResourceName(ctx,
 		a.Name, resourceTypeAgent, id, "AGT_VALIDATION_ERROR", logger); err != nil {
 		return "", err
 	}

--- a/backend/internal/agent/declarative_resource_test.go
+++ b/backend/internal/agent/declarative_resource_test.go
@@ -163,14 +163,14 @@ func (s *AgentExporterTestSuite) TestGetResourceByID_Error() {
 func (s *AgentExporterTestSuite) TestValidateResource_Success() {
 	a := &model.AgentGetResponse{ID: "agent1", Name: "Valid Agent"}
 
-	name, err := s.exporter.ValidateResource(a, "agent1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), a, "agent1", s.logger)
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Valid Agent", name)
 }
 
 func (s *AgentExporterTestSuite) TestValidateResource_InvalidType() {
-	name, err := s.exporter.ValidateResource("not-an-agent", "agent1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), "not-an-agent", "agent1", s.logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), err)
@@ -182,7 +182,7 @@ func (s *AgentExporterTestSuite) TestValidateResource_InvalidType() {
 func (s *AgentExporterTestSuite) TestValidateResource_EmptyName() {
 	a := &model.AgentGetResponse{ID: "agent1", Name: ""}
 
-	name, err := s.exporter.ValidateResource(a, "agent1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), a, "agent1", s.logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), err)

--- a/backend/internal/agent/handler.go
+++ b/backend/internal/agent/handler.go
@@ -19,6 +19,7 @@
 package agent
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -48,13 +49,13 @@ func (h *agentHandler) HandleAgentListRequest(w http.ResponseWriter, r *http.Req
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		writeServiceError(w, svcErr)
+		writeServiceError(ctx, w, svcErr)
 		return
 	}
 
 	filters, svcErr := parseFilterParams(r.URL.Query())
 	if svcErr != nil {
-		writeServiceError(w, svcErr)
+		writeServiceError(ctx, w, svcErr)
 		return
 	}
 
@@ -62,11 +63,11 @@ func (h *agentHandler) HandleAgentListRequest(w http.ResponseWriter, r *http.Req
 
 	resp, svcErr := h.service.GetAgentList(ctx, limit, offset, filters, includeDisplay)
 	if svcErr != nil {
-		writeServiceError(w, svcErr)
+		writeServiceError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
 	logger.DebugWithContext(ctx, "Agent list returned",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", resp.TotalResults), log.Int("count", resp.Count))
@@ -78,7 +79,7 @@ func (h *agentHandler) HandleAgentPostRequest(w http.ResponseWriter, r *http.Req
 
 	req, err := sysutils.DecodeJSONBody[model.CreateAgentRequest](r)
 	if err != nil {
-		writeServiceError(w, &ErrorInvalidRequestFormat)
+		writeServiceError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -96,10 +97,10 @@ func (h *agentHandler) HandleAgentPostRequest(w http.ResponseWriter, r *http.Req
 
 	resp, svcErr := h.service.CreateAgent(ctx, agent)
 	if svcErr != nil {
-		writeServiceError(w, svcErr)
+		writeServiceError(ctx, w, svcErr)
 		return
 	}
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, resp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, resp)
 }
 
 // HandleAgentGetRequest handles GET /agents/{id}.
@@ -107,17 +108,17 @@ func (h *agentHandler) HandleAgentGetRequest(w http.ResponseWriter, r *http.Requ
 	ctx := r.Context()
 	id := r.PathValue("id")
 	if id == "" {
-		writeServiceError(w, &ErrorMissingAgentID)
+		writeServiceError(ctx, w, &ErrorMissingAgentID)
 		return
 	}
 	includeDisplay := r.URL.Query().Get(sysutils.QueryParamInclude) == sysutils.IncludeValueDisplay
 
 	resp, svcErr := h.service.GetAgent(ctx, id, includeDisplay)
 	if svcErr != nil {
-		writeServiceError(w, svcErr)
+		writeServiceError(ctx, w, svcErr)
 		return
 	}
-	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
 }
 
 // HandleAgentPutRequest handles PUT /agents/{id}.
@@ -125,22 +126,22 @@ func (h *agentHandler) HandleAgentPutRequest(w http.ResponseWriter, r *http.Requ
 	ctx := r.Context()
 	id := r.PathValue("id")
 	if id == "" {
-		writeServiceError(w, &ErrorMissingAgentID)
+		writeServiceError(ctx, w, &ErrorMissingAgentID)
 		return
 	}
 
 	req, err := sysutils.DecodeJSONBody[model.UpdateAgentRequest](r)
 	if err != nil {
-		writeServiceError(w, &ErrorInvalidRequestFormat)
+		writeServiceError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
 	resp, svcErr := h.service.UpdateAgent(ctx, id, req)
 	if svcErr != nil {
-		writeServiceError(w, svcErr)
+		writeServiceError(ctx, w, svcErr)
 		return
 	}
-	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
 }
 
 // HandleAgentDeleteRequest handles DELETE /agents/{id}.
@@ -148,14 +149,14 @@ func (h *agentHandler) HandleAgentDeleteRequest(w http.ResponseWriter, r *http.R
 	ctx := r.Context()
 	id := r.PathValue("id")
 	if id == "" {
-		writeServiceError(w, &ErrorMissingAgentID)
+		writeServiceError(ctx, w, &ErrorMissingAgentID)
 		return
 	}
 	if svcErr := h.service.DeleteAgent(ctx, id); svcErr != nil {
-		writeServiceError(w, svcErr)
+		writeServiceError(ctx, w, svcErr)
 		return
 	}
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 }
 
 // HandleAgentGroupsRequest handles GET /agents/{id}/groups.
@@ -163,21 +164,21 @@ func (h *agentHandler) HandleAgentGroupsRequest(w http.ResponseWriter, r *http.R
 	ctx := r.Context()
 	id := r.PathValue("id")
 	if id == "" {
-		writeServiceError(w, &ErrorMissingAgentID)
+		writeServiceError(ctx, w, &ErrorMissingAgentID)
 		return
 	}
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		writeServiceError(w, svcErr)
+		writeServiceError(ctx, w, svcErr)
 		return
 	}
 
 	resp, svcErr := h.service.GetAgentGroups(ctx, id, limit, offset)
 	if svcErr != nil {
-		writeServiceError(w, svcErr)
+		writeServiceError(ctx, w, svcErr)
 		return
 	}
-	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
 }
 
 // parsePaginationParams parses limit and offset query parameters.
@@ -228,7 +229,7 @@ func parseFilterParams(query url.Values) (map[string]interface{}, *serviceerror.
 }
 
 // writeServiceError converts a service error into the appropriate HTTP error response.
-func writeServiceError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func writeServiceError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
 		switch svcErr.Code {
@@ -250,5 +251,5 @@ func writeServiceError(w http.ResponseWriter, svcErr *serviceerror.ServiceError)
 		Message:     svcErr.Error,
 		Description: svcErr.ErrorDescription,
 	}
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }

--- a/backend/internal/agent/handler_test.go
+++ b/backend/internal/agent/handler_test.go
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package agent
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/tests/mocks/agentmock"
+)
+
+type AgentHandlerTestSuite struct {
+	suite.Suite
+	mockService *agentmock.AgentServiceInterfaceMock
+	handler     *agentHandler
+}
+
+func TestAgentHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(AgentHandlerTestSuite))
+}
+
+func (s *AgentHandlerTestSuite) SetupTest() {
+	s.mockService = agentmock.NewAgentServiceInterfaceMock(s.T())
+	s.handler = newAgentHandler(s.mockService)
+}
+
+func (s *AgentHandlerTestSuite) TestHandleAgentListRequest_InvalidFilter() {
+	req := httptest.NewRequest(http.MethodGet, "/agents?filter=invalidfilter", nil)
+	rr := httptest.NewRecorder()
+
+	s.handler.HandleAgentListRequest(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), ErrorInvalidFilter.Code)
+}
+
+func (s *AgentHandlerTestSuite) TestHandleAgentListRequest_ServiceError() {
+	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
+	rr := httptest.NewRecorder()
+
+	s.mockService.EXPECT().
+		GetAgentList(mock.Anything, mock.Anything, mock.Anything, mock.Anything, false).
+		Return(nil, &serviceerror.InternalServerError)
+
+	s.handler.HandleAgentListRequest(rr, req)
+
+	s.Equal(http.StatusInternalServerError, rr.Code)
+	s.Contains(rr.Body.String(), serviceerror.InternalServerError.Code)
+}
+
+func (s *AgentHandlerTestSuite) TestHandleAgentPostRequest_InvalidJSON() {
+	req := httptest.NewRequest(http.MethodPost, "/agents", bytes.NewReader([]byte("invalid json")))
+	rr := httptest.NewRecorder()
+
+	s.handler.HandleAgentPostRequest(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), ErrorInvalidRequestFormat.Code)
+}
+
+func (s *AgentHandlerTestSuite) TestHandleAgentGetRequest_MissingID() {
+	req := httptest.NewRequest(http.MethodGet, "/agents/", nil)
+	req.SetPathValue("id", "")
+	rr := httptest.NewRecorder()
+
+	s.handler.HandleAgentGetRequest(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), ErrorMissingAgentID.Code)
+}
+
+func (s *AgentHandlerTestSuite) TestHandleAgentPutRequest_MissingID() {
+	req := httptest.NewRequest(http.MethodPut, "/agents/", nil)
+	req.SetPathValue("id", "")
+	rr := httptest.NewRecorder()
+
+	s.handler.HandleAgentPutRequest(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), ErrorMissingAgentID.Code)
+}
+
+func (s *AgentHandlerTestSuite) TestHandleAgentPutRequest_InvalidJSON() {
+	req := httptest.NewRequest(http.MethodPut, "/agents/agent1", bytes.NewReader([]byte("invalid json")))
+	req.SetPathValue("id", "agent1")
+	rr := httptest.NewRecorder()
+
+	s.handler.HandleAgentPutRequest(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), ErrorInvalidRequestFormat.Code)
+}
+
+func (s *AgentHandlerTestSuite) TestHandleAgentDeleteRequest_MissingID() {
+	req := httptest.NewRequest(http.MethodDelete, "/agents/", nil)
+	req.SetPathValue("id", "")
+	rr := httptest.NewRecorder()
+
+	s.handler.HandleAgentDeleteRequest(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), ErrorMissingAgentID.Code)
+}
+
+func (s *AgentHandlerTestSuite) TestHandleAgentGroupsRequest_MissingID() {
+	req := httptest.NewRequest(http.MethodGet, "/agents//groups", nil)
+	req.SetPathValue("id", "")
+	rr := httptest.NewRecorder()
+
+	s.handler.HandleAgentGroupsRequest(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), ErrorMissingAgentID.Code)
+}
+
+func (s *AgentHandlerTestSuite) TestHandleAgentGroupsRequest_InvalidLimit() {
+	req := httptest.NewRequest(http.MethodGet, "/agents/agent1/groups?limit=abc", nil)
+	req.SetPathValue("id", "agent1")
+	rr := httptest.NewRecorder()
+
+	s.handler.HandleAgentGroupsRequest(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), ErrorInvalidLimit.Code)
+}
+
+func (s *AgentHandlerTestSuite) TestHandleAgentGroupsRequest_ServiceError() {
+	req := httptest.NewRequest(http.MethodGet, "/agents/agent1/groups", nil)
+	req.SetPathValue("id", "agent1")
+	rr := httptest.NewRecorder()
+
+	s.mockService.EXPECT().
+		GetAgentGroups(mock.Anything, "agent1", mock.Anything, mock.Anything).
+		Return(nil, &ErrorAgentNotFound)
+
+	s.handler.HandleAgentGroupsRequest(rr, req)
+
+	s.Equal(http.StatusNotFound, rr.Code)
+	s.Contains(rr.Body.String(), ErrorAgentNotFound.Code)
+}

--- a/backend/internal/agent/service.go
+++ b/backend/internal/agent/service.go
@@ -369,7 +369,7 @@ func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *service
 
 	if err := s.inboundClientService.DeleteInboundClient(ctx, agentID); err != nil &&
 		!errors.Is(err, inboundclient.ErrInboundClientNotFound) {
-		if svcErr := s.translateInboundClientError(err); svcErr != nil {
+		if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 			return svcErr
 		}
 		s.logger.ErrorWithContext(ctx, "Failed to delete inbound client for agent",
@@ -518,7 +518,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 		oauthProfile := buildOAuthProfile(agent.InboundAuthConfig)
 		hasSecret := clientSecret != ""
 		if err := s.inboundClientService.Validate(ctx, &client, oauthProfile, hasSecret); err != nil {
-			if svcErr := s.translateInboundClientError(err); svcErr != nil {
+			if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 				return "", "", inboundmodel.InboundClient{}, svcErr
 			}
 			s.logger.ErrorWithContext(ctx, "Inbound client validation failed", log.Error(err))
@@ -732,7 +732,7 @@ func (s *agentService) createInboundForAgent(ctx context.Context, agentID string
 	hasSecret := clientSecret != ""
 	if err := s.inboundClientService.CreateInboundClient(ctx, &client, agent.Certificate,
 		oauthProfile, hasSecret, agent.Name); err != nil {
-		if svcErr := s.translateInboundClientError(err); svcErr != nil {
+		if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 			return inboundmodel.InboundClient{}, nil, svcErr
 		}
 		s.logger.ErrorWithContext(ctx, "Failed to create inbound client for agent",
@@ -755,7 +755,7 @@ func (s *agentService) reconcileInboundForUpdate(ctx context.Context, agentID st
 		if hasExisting {
 			if err := s.inboundClientService.DeleteInboundClient(ctx, agentID); err != nil &&
 				!errors.Is(err, inboundclient.ErrInboundClientNotFound) {
-				if svcErr := s.translateInboundClientError(err); svcErr != nil {
+				if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 					return inboundmodel.InboundClient{}, nil, svcErr
 				}
 				s.logger.ErrorWithContext(ctx, "Failed to remove inbound client during update",
@@ -779,7 +779,7 @@ func (s *agentService) reconcileInboundForUpdate(ctx context.Context, agentID st
 		}
 		if err := s.inboundClientService.UpdateInboundClient(ctx, &client, req.Certificate,
 			oauthProfile, hasSecret, clientID, entityName); err != nil {
-			if svcErr := s.translateInboundClientError(err); svcErr != nil {
+			if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 				return inboundmodel.InboundClient{}, nil, svcErr
 			}
 			s.logger.ErrorWithContext(ctx, "Failed to update inbound client",
@@ -791,7 +791,7 @@ func (s *agentService) reconcileInboundForUpdate(ctx context.Context, agentID st
 
 	if err := s.inboundClientService.CreateInboundClient(ctx, &client, req.Certificate,
 		oauthProfile, hasSecret, newName); err != nil {
-		if svcErr := s.translateInboundClientError(err); svcErr != nil {
+		if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 			return inboundmodel.InboundClient{}, nil, svcErr
 		}
 		s.logger.ErrorWithContext(ctx, "Failed to create inbound client during update",
@@ -854,7 +854,7 @@ func (s *agentService) composeGetResponse(ctx context.Context, e *entity.Entity)
 
 	entityCert, certOpErr := s.inboundClientService.GetCertificate(ctx, cert.CertificateReferenceTypeApplication, e.ID)
 	if certOpErr != nil {
-		return nil, s.translateCertOperationError(certOpErr)
+		return nil, s.translateCertOperationError(ctx, certOpErr)
 	}
 	resp.Certificate = entityCert
 
@@ -862,7 +862,7 @@ func (s *agentService) composeGetResponse(ctx context.Context, e *entity.Entity)
 		oauthCert, oauthCertOpErr := s.inboundClientService.GetCertificate(
 			ctx, cert.CertificateReferenceTypeOAuthApp, clientID)
 		if oauthCertOpErr != nil {
-			return nil, s.translateCertOperationError(oauthCertOpErr)
+			return nil, s.translateCertOperationError(ctx, oauthCertOpErr)
 		}
 		if len(resp.InboundAuthConfig) > 0 && resp.InboundAuthConfig[0].OAuthConfig != nil {
 			resp.InboundAuthConfig[0].OAuthConfig.Certificate = oauthCert
@@ -1315,7 +1315,7 @@ func mapEntityError(err error) *serviceerror.ServiceError {
 }
 
 // translateInboundClientError maps inbound-client-layer errors to agent-service errors.
-func (s *agentService) translateInboundClientError(err error) *serviceerror.ServiceError {
+func (s *agentService) translateInboundClientError(ctx context.Context, err error) *serviceerror.ServiceError {
 	if err == nil {
 		return nil
 	}
@@ -1339,7 +1339,7 @@ func (s *agentService) translateInboundClientError(err error) *serviceerror.Serv
 	}
 	var opErr *inboundclient.CertOperationError
 	if errors.As(err, &opErr) {
-		return s.translateCertOperationError(opErr)
+		return s.translateCertOperationError(ctx, opErr)
 	}
 	var consentErr *inboundclient.ConsentSyncError
 	if errors.As(err, &consentErr) {
@@ -1600,9 +1600,10 @@ func translateCertValidationError(err error) *serviceerror.ServiceError {
 }
 
 // translateCertOperationError maps a typed CertOperationError to an agent-service error.
-func (s *agentService) translateCertOperationError(err *inboundclient.CertOperationError) *serviceerror.ServiceError {
+func (s *agentService) translateCertOperationError(
+	ctx context.Context, err *inboundclient.CertOperationError) *serviceerror.ServiceError {
 	if !err.IsClientError() {
-		s.logger.Error("Certificate operation failed",
+		s.logger.ErrorWithContext(ctx, "Certificate operation failed",
 			log.Any("operation", err.Operation),
 			log.Any("refType", err.RefType),
 			log.Any("serviceError", err.Underlying))

--- a/backend/internal/agent/service_test.go
+++ b/backend/internal/agent/service_test.go
@@ -984,21 +984,21 @@ func (suite *AgentServiceTestSuite) TestMapEntityError_Unknown() {
 
 func (suite *AgentServiceTestSuite) TestTranslateInboundClientError_InvalidRedirectURI() {
 	svc, _, _, _ := suite.setupService()
-	svcErr := svc.translateInboundClientError(inboundclient.ErrOAuthInvalidRedirectURI)
+	svcErr := svc.translateInboundClientError(context.Background(), inboundclient.ErrOAuthInvalidRedirectURI)
 	suite.Require().NotNil(svcErr)
 	assert.Equal(suite.T(), ErrorInvalidRedirectURI.Code, svcErr.Code)
 }
 
 func (suite *AgentServiceTestSuite) TestTranslateInboundClientError_InvalidGrantType() {
 	svc, _, _, _ := suite.setupService()
-	svcErr := svc.translateInboundClientError(inboundclient.ErrOAuthInvalidGrantType)
+	svcErr := svc.translateInboundClientError(context.Background(), inboundclient.ErrOAuthInvalidGrantType)
 	suite.Require().NotNil(svcErr)
 	assert.Equal(suite.T(), ErrorInvalidGrantType.Code, svcErr.Code)
 }
 
 func (suite *AgentServiceTestSuite) TestTranslateInboundClientError_Unknown() {
 	svc, _, _, _ := suite.setupService()
-	svcErr := svc.translateInboundClientError(errors.New("unknown error"))
+	svcErr := svc.translateInboundClientError(context.Background(), errors.New("unknown error"))
 	assert.Nil(suite.T(), svcErr)
 }
 
@@ -1245,7 +1245,7 @@ func (suite *AgentServiceTestSuite) TestTranslateCertOperationError() {
 			opErr := &inboundclient.CertOperationError{
 				Operation: tc.op, RefType: tc.refType, Underlying: tc.underlying,
 			}
-			svcErr := s.translateCertOperationError(opErr)
+			svcErr := s.translateCertOperationError(context.Background(), opErr)
 			suite.Require().NotNil(svcErr)
 			suite.Equal(tc.wantCode, svcErr.Code)
 			suite.Equal(tc.wantDescKey, svcErr.ErrorDescription.Key)
@@ -1259,14 +1259,18 @@ func (suite *AgentServiceTestSuite) TestTranslateCertOperationError() {
 		RefType:    cert.CertificateReferenceTypeApplication,
 		Underlying: &serviceerror.ServiceError{Type: serviceerror.ServerErrorType, Code: "X-S"},
 	}
-	suite.Equal(serviceerror.InternalServerError.Code, s.translateCertOperationError(serverErrOp).Code)
+	suite.Equal(
+		serviceerror.InternalServerError.Code,
+		s.translateCertOperationError(context.Background(), serverErrOp).Code)
 
 	// Unknown operation returns InternalServerError.
 	unknownOp := &inboundclient.CertOperationError{
 		Operation:  "weird",
 		Underlying: &serviceerror.ServiceError{Type: serviceerror.ClientErrorType, Code: "X-?"},
 	}
-	suite.Equal(serviceerror.InternalServerError.Code, s.translateCertOperationError(unknownOp).Code)
+	suite.Equal(
+		serviceerror.InternalServerError.Code,
+		s.translateCertOperationError(context.Background(), unknownOp).Code)
 }
 
 // --- translateConsentSyncError ---

--- a/backend/internal/application/declarative_resource.go
+++ b/backend/internal/application/declarative_resource.go
@@ -98,7 +98,7 @@ func (e *applicationExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates an application resource.
-func (e *applicationExporter) ValidateResource(
+func (e *applicationExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	app, ok := resource.(*model.Application)
@@ -106,7 +106,7 @@ func (e *applicationExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeApplication, id)
 	}
 
-	if err := declarativeresource.ValidateResourceName(
+	if err := declarativeresource.ValidateResourceName(ctx,
 		app.Name, resourceTypeApplication, id, "APP_VALIDATION_ERROR", logger); err != nil {
 		return "", err
 	}

--- a/backend/internal/application/declarative_resource_test.go
+++ b/backend/internal/application/declarative_resource_test.go
@@ -147,7 +147,7 @@ func (s *ApplicationExporterTestSuite) TestValidateResource_Success() {
 		Name: "Valid App",
 	}
 
-	name, err := s.exporter.ValidateResource(app, "app1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), app, "app1", s.logger)
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Valid App", name)
@@ -156,7 +156,7 @@ func (s *ApplicationExporterTestSuite) TestValidateResource_Success() {
 func (s *ApplicationExporterTestSuite) TestValidateResource_InvalidType() {
 	invalidResource := "not an application"
 
-	name, err := s.exporter.ValidateResource(invalidResource, "app1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), invalidResource, "app1", s.logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), err)
@@ -171,7 +171,7 @@ func (s *ApplicationExporterTestSuite) TestValidateResource_EmptyName() {
 		Name: "",
 	}
 
-	name, err := s.exporter.ValidateResource(app, "app1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), app, "app1", s.logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), err)

--- a/backend/internal/application/handler.go
+++ b/backend/internal/application/handler.go
@@ -55,7 +55,7 @@ func (ah *applicationHandler) HandleApplicationPostRequest(w http.ResponseWriter
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -89,7 +89,7 @@ func (ah *applicationHandler) HandleApplicationPostRequest(w http.ResponseWriter
 	// Create the app using the application service.
 	createdAppDTO, svcErr := ah.service.CreateApplication(ctx, &appDTO)
 	if svcErr != nil {
-		ah.handleError(w, r, svcErr)
+		ah.handleError(ctx, w, r, svcErr)
 		return
 	}
 
@@ -129,12 +129,12 @@ func (ah *applicationHandler) HandleApplicationPostRequest(w http.ResponseWriter
 				Message:     serviceerror.InternalServerError.Error,
 				Description: serviceerror.InternalServerError.ErrorDescription,
 			}
-			sysutils.WriteErrorResponse(w, http.StatusInternalServerError, errResp)
+			sysutils.WriteErrorResponse(ctx, w, http.StatusInternalServerError, errResp)
 			return
 		}
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, returnApp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, returnApp)
 }
 
 // HandleApplicationListRequest handles the application request.
@@ -142,11 +142,11 @@ func (ah *applicationHandler) HandleApplicationListRequest(w http.ResponseWriter
 	ctx := r.Context()
 	listResponse, svcErr := ah.service.GetApplicationList(ctx)
 	if svcErr != nil {
-		ah.handleError(w, r, svcErr)
+		ah.handleError(ctx, w, r, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, listResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, listResponse)
 }
 
 // HandleApplicationGetRequest handles the application request.
@@ -161,13 +161,13 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 			Message:     ErrorInvalidApplicationID.Error,
 			Description: ErrorInvalidApplicationID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	appDTO, svcErr := ah.service.GetApplication(ctx, id)
 	if svcErr != nil {
-		ah.handleError(w, r, svcErr)
+		ah.handleError(ctx, w, r, svcErr)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 				Message:     serviceerror.InternalServerError.Error,
 				Description: serviceerror.InternalServerError.ErrorDescription,
 			}
-			sysutils.WriteErrorResponse(w, http.StatusInternalServerError, errResp)
+			sysutils.WriteErrorResponse(ctx, w, http.StatusInternalServerError, errResp)
 			return
 		}
 
@@ -221,7 +221,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 				Message:     serviceerror.InternalServerError.Error,
 				Description: serviceerror.InternalServerError.ErrorDescription,
 			}
-			sysutils.WriteErrorResponse(w, http.StatusInternalServerError, errResp)
+			sysutils.WriteErrorResponse(ctx, w, http.StatusInternalServerError, errResp)
 			return
 		}
 
@@ -234,7 +234,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 					Message:     serviceerror.InternalServerError.Error,
 					Description: serviceerror.InternalServerError.ErrorDescription,
 				}
-				sysutils.WriteErrorResponse(w, http.StatusInternalServerError, errResp)
+				sysutils.WriteErrorResponse(ctx, w, http.StatusInternalServerError, errResp)
 				return
 			}
 			redirectURIs := config.OAuthConfig.RedirectURIs
@@ -276,7 +276,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 		returnApp.ClientID = appDTO.InboundAuthConfig[0].OAuthConfig.ClientID
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, returnApp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, returnApp)
 }
 
 // HandleApplicationPutRequest handles the application request.
@@ -291,7 +291,7 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 			Message:     ErrorInvalidApplicationID.Error,
 			Description: ErrorInvalidApplicationID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -302,7 +302,7 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -337,7 +337,7 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 	// Update the application using the application service.
 	updatedAppDTO, svcErr := ah.service.UpdateApplication(ctx, id, &updateReqAppDTO)
 	if svcErr != nil {
-		ah.handleError(w, r, svcErr)
+		ah.handleError(ctx, w, r, svcErr)
 		return
 	}
 
@@ -377,12 +377,12 @@ func (ah *applicationHandler) HandleApplicationPutRequest(w http.ResponseWriter,
 				Message:     serviceerror.InternalServerError.Error,
 				Description: serviceerror.InternalServerError.ErrorDescription,
 			}
-			sysutils.WriteErrorResponse(w, http.StatusInternalServerError, errResp)
+			sysutils.WriteErrorResponse(ctx, w, http.StatusInternalServerError, errResp)
 			return
 		}
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, returnApp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, returnApp)
 }
 
 // HandleApplicationDeleteRequest handles the application request.
@@ -395,17 +395,17 @@ func (ah *applicationHandler) HandleApplicationDeleteRequest(w http.ResponseWrit
 			Message:     ErrorInvalidApplicationID.Error,
 			Description: ErrorInvalidApplicationID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	svcErr := ah.service.DeleteApplication(ctx, id)
 	if svcErr != nil {
-		ah.handleError(w, r, svcErr)
+		ah.handleError(ctx, w, r, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 }
 
 // processInboundAuthConfig prepares the response for OAuth app configuration.
@@ -476,7 +476,7 @@ func (ah *applicationHandler) processInboundAuthConfig(
 
 // handleError handles service errors and returns appropriate HTTP responses.
 // When the resolved status is 500, the error is logged with request context.
-func (ah *applicationHandler) handleError(w http.ResponseWriter, r *http.Request,
+func (ah *applicationHandler) handleError(ctx context.Context, w http.ResponseWriter, r *http.Request,
 	svcErr *serviceerror.ServiceError) {
 	errResp := apierror.ErrorResponse{
 		Code:        svcErr.Code,
@@ -495,7 +495,7 @@ func (ah *applicationHandler) handleError(w http.ResponseWriter, r *http.Request
 
 	if statusCode == http.StatusInternalServerError {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationHandler"))
-		logger.ErrorWithContext(r.Context(), "Internal server error processing application request",
+		logger.ErrorWithContext(ctx, "Internal server error processing application request",
 			log.String("method", r.Method),
 			log.String("path", r.URL.Path),
 			log.String("error_code", svcErr.Code),
@@ -503,7 +503,7 @@ func (ah *applicationHandler) handleError(w http.ResponseWriter, r *http.Request
 		)
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }
 
 // processInboundAuthConfigFromRequest processes inbound auth config from request to DTO.

--- a/backend/internal/application/handler_test.go
+++ b/backend/internal/application/handler_test.go
@@ -1214,7 +1214,7 @@ func (suite *HandlerTestSuite) TestHandleError_ClientError() {
 
 	svcErr := &ErrorInvalidApplicationName
 
-	handler.handleError(w, r, svcErr)
+	handler.handleError(context.Background(), w, r, svcErr)
 
 	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
 	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
@@ -1234,7 +1234,7 @@ func (suite *HandlerTestSuite) TestHandleError_NotFoundError() {
 
 	svcErr := &ErrorApplicationNotFound
 
-	handler.handleError(w, r, svcErr)
+	handler.handleError(context.Background(), w, r, svcErr)
 
 	assert.Equal(suite.T(), http.StatusNotFound, w.Code)
 	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
@@ -1254,7 +1254,7 @@ func (suite *HandlerTestSuite) TestHandleError_ServerError() {
 
 	svcErr := &serviceerror.InternalServerError
 
-	handler.handleError(w, r, svcErr)
+	handler.handleError(context.Background(), w, r, svcErr)
 
 	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
 	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -1416,7 +1416,7 @@ func (as *applicationService) processInboundAuthConfig(ctx context.Context, app 
 		}
 
 		if clientID == "" {
-			if svcErr := generateAndAssignClientID(inboundAuthConfig); svcErr != nil {
+			if svcErr := generateAndAssignClientID(ctx, inboundAuthConfig); svcErr != nil {
 				return nil, svcErr
 			}
 		} else if clientID != existingClientID {
@@ -1428,7 +1428,7 @@ func (as *applicationService) processInboundAuthConfig(ctx context.Context, app 
 		}
 	} else { // For create operation
 		if clientID == "" {
-			if svcErr := generateAndAssignClientID(inboundAuthConfig); svcErr != nil {
+			if svcErr := generateAndAssignClientID(ctx, inboundAuthConfig); svcErr != nil {
 				return nil, svcErr
 			}
 		} else {
@@ -1440,7 +1440,7 @@ func (as *applicationService) processInboundAuthConfig(ctx context.Context, app 
 		}
 	}
 
-	if svcErr := resolveClientSecret(inboundAuthConfig, existingApp); svcErr != nil {
+	if svcErr := resolveClientSecret(ctx, inboundAuthConfig, existingApp); svcErr != nil {
 		return nil, svcErr
 	}
 
@@ -1448,10 +1448,12 @@ func (as *applicationService) processInboundAuthConfig(ctx context.Context, app 
 }
 
 // generateAndAssignClientID generates an OAuth 2.0 compliant client ID and assigns it to the inbound auth config.
-func generateAndAssignClientID(inboundAuthConfig *inboundmodel.InboundAuthConfigWithSecret) *serviceerror.ServiceError {
+func generateAndAssignClientID(
+	ctx context.Context, inboundAuthConfig *inboundmodel.InboundAuthConfigWithSecret,
+) *serviceerror.ServiceError {
 	generatedClientID, err := oauthutils.GenerateOAuth2ClientID()
 	if err != nil {
-		log.GetLogger().Error("Failed to generate OAuth client ID", log.Error(err))
+		log.GetLogger().ErrorWithContext(ctx, "Failed to generate OAuth client ID", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	inboundAuthConfig.OAuthConfig.ClientID = generatedClientID
@@ -1459,6 +1461,7 @@ func generateAndAssignClientID(inboundAuthConfig *inboundmodel.InboundAuthConfig
 }
 
 func resolveClientSecret(
+	ctx context.Context,
 	inboundAuthConfig *inboundmodel.InboundAuthConfigWithSecret,
 	existingApp *model.ApplicationProcessedDTO,
 ) *serviceerror.ServiceError {
@@ -1484,7 +1487,7 @@ func resolveClientSecret(
 
 	generatedClientSecret, err := oauthutils.GenerateOAuth2ClientSecret()
 	if err != nil {
-		log.GetLogger().Error("Failed to generate OAuth client secret", log.Error(err))
+		log.GetLogger().ErrorWithContext(ctx, "Failed to generate OAuth client secret", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -1967,7 +1967,7 @@ func TestResolveClientSecret_PublicClient(t *testing.T) {
 		},
 	}
 
-	err := resolveClientSecret(inboundAuthConfig, nil)
+	err := resolveClientSecret(context.Background(), inboundAuthConfig, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "", inboundAuthConfig.OAuthConfig.ClientSecret)
@@ -1984,7 +1984,7 @@ func TestResolveClientSecret_SecretAlreadyProvided(t *testing.T) {
 		},
 	}
 
-	err := resolveClientSecret(inboundAuthConfig, nil)
+	err := resolveClientSecret(context.Background(), inboundAuthConfig, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, providedSecret, inboundAuthConfig.OAuthConfig.ClientSecret)
@@ -2000,7 +2000,7 @@ func TestResolveClientSecret_GenerateForNewConfidentialClient(t *testing.T) {
 		},
 	}
 
-	err := resolveClientSecret(inboundAuthConfig, nil)
+	err := resolveClientSecret(context.Background(), inboundAuthConfig, nil)
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, inboundAuthConfig.OAuthConfig.ClientSecret)
@@ -2030,7 +2030,7 @@ func TestResolveClientSecret_PreserveExistingSecret(t *testing.T) {
 		},
 	}
 
-	err := resolveClientSecret(inboundAuthConfig, existingApp)
+	err := resolveClientSecret(context.Background(), inboundAuthConfig, existingApp)
 
 	assert.Nil(t, err)
 	// Secret should remain empty (not generated) because existing app has a secret
@@ -2047,7 +2047,7 @@ func TestResolveClientSecret_NoExistingApp(t *testing.T) {
 		},
 	}
 
-	err := resolveClientSecret(inboundAuthConfig, nil)
+	err := resolveClientSecret(context.Background(), inboundAuthConfig, nil)
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, inboundAuthConfig.OAuthConfig.ClientSecret)
@@ -2075,7 +2075,7 @@ func TestResolveClientSecret_ExistingAppWithoutSecret(t *testing.T) {
 		},
 	}
 
-	err := resolveClientSecret(inboundAuthConfig, existingApp)
+	err := resolveClientSecret(context.Background(), inboundAuthConfig, existingApp)
 
 	assert.Nil(t, err)
 	// Should generate a new secret since existing app doesn't have one

--- a/backend/internal/authn/github/service.go
+++ b/backend/internal/authn/github/service.go
@@ -92,7 +92,7 @@ func (g *githubOAuthAuthnService) FetchUserInfo(ctx context.Context, idpID, acce
 	}
 
 	// Fetch primary email from the GitHub user emails endpoint.
-	primaryEmail, svcErr := g.fetchPrimaryEmail(oAuthClientConfig, accessToken)
+	primaryEmail, svcErr := g.fetchPrimaryEmail(ctx, oAuthClientConfig, accessToken)
 	if svcErr != nil {
 		return nil, svcErr
 	}
@@ -110,18 +110,18 @@ func (g *githubOAuthAuthnService) shouldFetchEmail(scopes []string) bool {
 }
 
 // fetchPrimaryEmail fetches the primary email of the user from the GitHub user emails endpoint.
-func (g *githubOAuthAuthnService) fetchPrimaryEmail(
+func (g *githubOAuthAuthnService) fetchPrimaryEmail(ctx context.Context,
 	oAuthClientConfig *authnoauth.OAuthClientConfig, accessToken string) (
 	string, *serviceerror.ServiceError) {
 	logger := g.logger
-	logger.Debug("Fetching primary email from GitHub user emails endpoint")
+	logger.DebugWithContext(ctx, "Fetching primary email from GitHub user emails endpoint")
 
 	if oAuthClientConfig.OAuthEndpoints.UserEmailEndpoint == "" {
-		logger.Error("User email endpoint is not configured in OAuth client config")
+		logger.ErrorWithContext(ctx, "User email endpoint is not configured in OAuth client config")
 		return "", &serviceerror.InternalServerError
 	}
 
-	req, svcErr := buildUserEmailRequest(oAuthClientConfig.OAuthEndpoints.UserEmailEndpoint, accessToken, logger)
+	req, svcErr := buildUserEmailRequest(ctx, oAuthClientConfig.OAuthEndpoints.UserEmailEndpoint, accessToken, logger)
 	if svcErr != nil {
 		return "", svcErr
 	}

--- a/backend/internal/authn/github/service_test.go
+++ b/backend/internal/authn/github/service_test.go
@@ -420,7 +420,7 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchPrimaryEmailEdgeCases() 
 	gsvc, ok := suite.service.(*githubOAuthAuthnService)
 	suite.True(ok)
 
-	email, svcErr := gsvc.fetchPrimaryEmail(config, testAccessToken)
+	email, svcErr := gsvc.fetchPrimaryEmail(context.Background(), config, testAccessToken)
 	suite.Nil(svcErr)
 	suite.Equal("", email)
 
@@ -430,7 +430,7 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestFetchPrimaryEmailEdgeCases() 
 	resp2 := &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(badJSON))}
 
 	suite.mockHTTPClient.On("Do", mock.Anything).Return(resp2, nil).Once()
-	email2, svcErr2 := gsvc.fetchPrimaryEmail(config, testAccessToken)
+	email2, svcErr2 := gsvc.fetchPrimaryEmail(context.Background(), config, testAccessToken)
 	suite.Nil(svcErr2)
 	suite.Equal("", email2)
 }

--- a/backend/internal/authn/github/utils.go
+++ b/backend/internal/authn/github/utils.go
@@ -19,6 +19,7 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -30,11 +31,11 @@ import (
 )
 
 // buildUserEmailRequest constructs the HTTP request to fetch user emails from GitHub.
-func buildUserEmailRequest(userEmailEndpoint string, accessToken string, logger *log.Logger) (
+func buildUserEmailRequest(ctx context.Context, userEmailEndpoint string, accessToken string, logger *log.Logger) (
 	*http.Request, *serviceerror.ServiceError) {
 	req, err := http.NewRequest(http.MethodGet, userEmailEndpoint, nil)
 	if err != nil {
-		logger.Error("Failed to create user email request", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to create user email request", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/authn/github/utils_test.go
+++ b/backend/internal/authn/github/utils_test.go
@@ -20,6 +20,7 @@ package github
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -53,7 +54,7 @@ func (suite *GithubUtilsTestSuite) TestBuildUserEmailRequest() {
 	endpoint := "https://api.github.com/user/emails"
 	accessToken := "test_token"
 
-	req, err := buildUserEmailRequest(endpoint, accessToken, suite.logger)
+	req, err := buildUserEmailRequest(context.Background(), endpoint, accessToken, suite.logger)
 	suite.Nil(err)
 	suite.NotNil(req)
 
@@ -201,7 +202,7 @@ func (suite *GithubUtilsTestSuite) TestSendUserEmailRequestDoReturnsRespAndError
 func (suite *GithubUtilsTestSuite) TestBuildUserEmailRequestError() {
 	// Use an invalid URL containing a control character to force NewRequest to fail.
 	endpoint := "http://\x00"
-	req, err := buildUserEmailRequest(endpoint, "token", suite.logger)
+	req, err := buildUserEmailRequest(context.Background(), endpoint, "token", suite.logger)
 	suite.Nil(req)
 	suite.NotNil(err)
 }

--- a/backend/internal/authn/google/service.go
+++ b/backend/internal/authn/google/service.go
@@ -217,9 +217,9 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 }
 
 // GetIDTokenClaims extracts and returns the claims from the Google ID token.
-func (g *googleOIDCAuthnService) GetIDTokenClaims(idToken string) (
+func (g *googleOIDCAuthnService) GetIDTokenClaims(ctx context.Context, idToken string) (
 	map[string]interface{}, *serviceerror.ServiceError) {
-	return g.internal.GetIDTokenClaims(idToken)
+	return g.internal.GetIDTokenClaims(ctx, idToken)
 }
 
 // FetchUserInfo retrieves user information from Google, ensuring email resolution if necessary.
@@ -253,7 +253,7 @@ func (g *googleOIDCAuthnService) Authenticate(ctx context.Context, idpID, code s
 		return nil, svcErr
 	}
 
-	claims, svcErr := g.GetIDTokenClaims(tokenResp.IDToken)
+	claims, svcErr := g.GetIDTokenClaims(ctx, tokenResp.IDToken)
 	if svcErr != nil {
 		return nil, svcErr
 	}

--- a/backend/internal/authn/google/service_test.go
+++ b/backend/internal/authn/google/service_test.go
@@ -785,9 +785,9 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestGetIDTokenClaimsSuccess() {
 		"sub":  "1234567890",
 		"name": "John Doe",
 	}
-	suite.mockOIDCService.On("GetIDTokenClaims", idToken).Return(claims, nil)
+	suite.mockOIDCService.On("GetIDTokenClaims", mock.Anything, idToken).Return(claims, nil)
 
-	result, err := suite.service.GetIDTokenClaims(idToken)
+	result, err := suite.service.GetIDTokenClaims(context.Background(), idToken)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal("1234567890", result["sub"])

--- a/backend/internal/authn/handler.go
+++ b/backend/internal/authn/handler.go
@@ -19,6 +19,7 @@
 package authn
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/authn/common"
@@ -46,7 +47,7 @@ func (ah *authenticationHandler) HandleCredentialsAuthRequest(w http.ResponseWri
 	ctx := r.Context()
 	authRequestPtr, err := sysutils.DecodeJSONBody[AuthenticateWithCredentialsRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 	authRequest := *authRequestPtr
@@ -64,11 +65,11 @@ func (ah *authenticationHandler) HandleCredentialsAuthRequest(w http.ResponseWri
 	authResponse, svcErr := ah.authService.AuthenticateWithCredentials(
 		ctx, authRequest.Identifiers, authRequest.Credentials, skipAssertion, assertion)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
 }
 
 // HandleSendSMSOTPRequest handles the send SMS OTP authentication request.
@@ -76,14 +77,14 @@ func (ah *authenticationHandler) HandleSendSMSOTPRequest(w http.ResponseWriter, 
 	ctx := r.Context()
 	otpRequest, err := sysutils.DecodeJSONBody[SendOTPAuthRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
 	sessionToken, svcErr := ah.authService.SendOTP(ctx, otpRequest.SenderID, notifcommon.ChannelTypeSMS,
 		otpRequest.Recipient)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
@@ -91,7 +92,7 @@ func (ah *authenticationHandler) HandleSendSMSOTPRequest(w http.ResponseWriter, 
 		Status:       "SUCCESS",
 		SessionToken: sessionToken,
 	}
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleVerifySMSOTPRequest handles the verify SMS OTP authentication request.
@@ -99,18 +100,18 @@ func (ah *authenticationHandler) HandleVerifySMSOTPRequest(w http.ResponseWriter
 	ctx := r.Context()
 	otpRequest, err := sysutils.DecodeJSONBody[VerifyOTPAuthRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
 	authResponse, svcErr := ah.authService.VerifyOTP(ctx, otpRequest.SessionToken, otpRequest.SkipAssertion,
 		otpRequest.Assertion, otpRequest.OTP)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
 }
 
 // HandleGoogleAuthStartRequest handles the Google OAuth start authentication request.
@@ -118,18 +119,18 @@ func (ah *authenticationHandler) HandleGoogleAuthStartRequest(w http.ResponseWri
 	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
 	authResponse, svcErr := ah.authService.StartIDPAuthentication(ctx, idp.IDPTypeGoogle, authRequest.IDPID)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
 	response := IDPAuthInitResponseDTO(*authResponse)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleGoogleAuthFinishRequest handles the Google OAuth finish authentication request.
@@ -137,18 +138,18 @@ func (ah *authenticationHandler) HandleGoogleAuthFinishRequest(w http.ResponseWr
 	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
 	authResponse, svcErr := ah.authService.FinishIDPAuthentication(ctx, idp.IDPTypeGoogle, authRequest.SessionToken,
 		authRequest.SkipAssertion, authRequest.Assertion, authRequest.Code)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
 }
 
 // HandleGithubAuthStartRequest handles the GitHub OAuth start authentication request.
@@ -156,18 +157,18 @@ func (ah *authenticationHandler) HandleGithubAuthStartRequest(w http.ResponseWri
 	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
 	authResponse, svcErr := ah.authService.StartIDPAuthentication(ctx, idp.IDPTypeGitHub, authRequest.IDPID)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
 	responseDTO := IDPAuthInitResponseDTO(*authResponse)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, responseDTO)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, responseDTO)
 }
 
 // HandleGithubAuthFinishRequest handles the GitHub OAuth finish authentication request.
@@ -175,18 +176,18 @@ func (ah *authenticationHandler) HandleGithubAuthFinishRequest(w http.ResponseWr
 	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
 	authResponse, svcErr := ah.authService.FinishIDPAuthentication(ctx, idp.IDPTypeGitHub, authRequest.SessionToken,
 		authRequest.SkipAssertion, authRequest.Assertion, authRequest.Code)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
 }
 
 // HandleStandardOAuthStartRequest handles the standard OAuth start authentication request.
@@ -194,18 +195,18 @@ func (ah *authenticationHandler) HandleStandardOAuthStartRequest(w http.Response
 	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthInitRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
 	authResponse, svcErr := ah.authService.StartIDPAuthentication(ctx, idp.IDPTypeOAuth, authRequest.IDPID)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
 	responseDTO := IDPAuthInitResponseDTO(*authResponse)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, responseDTO)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, responseDTO)
 }
 
 // HandleStandardOAuthFinishRequest handles the standard OAuth finish authentication request.
@@ -213,18 +214,18 @@ func (ah *authenticationHandler) HandleStandardOAuthFinishRequest(w http.Respons
 	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[IDPAuthFinishRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
 	authResponse, svcErr := ah.authService.FinishIDPAuthentication(ctx, idp.IDPTypeOAuth, authRequest.SessionToken,
 		authRequest.SkipAssertion, authRequest.Assertion, authRequest.Code)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
 }
 
 // HandlePasskeyRegisterStartRequest handles the passkey start registration request.
@@ -232,7 +233,7 @@ func (ah *authenticationHandler) HandlePasskeyRegisterStartRequest(w http.Respon
 	ctx := r.Context()
 	regRequest, err := sysutils.DecodeJSONBody[PasskeyRegisterStartRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -245,11 +246,11 @@ func (ah *authenticationHandler) HandlePasskeyRegisterStartRequest(w http.Respon
 		regRequest.Attestation,
 	)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, regResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, regResponse)
 }
 
 // HandlePasskeyRegisterFinishRequest handles the passkey finish registration request.
@@ -257,7 +258,7 @@ func (ah *authenticationHandler) HandlePasskeyRegisterFinishRequest(w http.Respo
 	ctx := r.Context()
 	regRequest, err := sysutils.DecodeJSONBody[PasskeyRegisterFinishRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -268,11 +269,11 @@ func (ah *authenticationHandler) HandlePasskeyRegisterFinishRequest(w http.Respo
 		regRequest.CredentialName,
 	)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, regResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, regResponse)
 }
 
 // HandlePasskeyStartRequest handles the passkey start authentication request.
@@ -280,7 +281,7 @@ func (ah *authenticationHandler) HandlePasskeyStartRequest(w http.ResponseWriter
 	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[PasskeyStartRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -290,11 +291,11 @@ func (ah *authenticationHandler) HandlePasskeyStartRequest(w http.ResponseWriter
 		authRequest.RelyingPartyID,
 	)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, authResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, authResponse)
 }
 
 // HandlePasskeyFinishRequest handles the passkey finish authentication request.
@@ -302,7 +303,7 @@ func (ah *authenticationHandler) HandlePasskeyFinishRequest(w http.ResponseWrite
 	ctx := r.Context()
 	authRequest, err := sysutils.DecodeJSONBody[PasskeyFinishRequestDTO](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, common.APIErrorInvalidRequestFormat)
 		return
 	}
 
@@ -316,15 +317,18 @@ func (ah *authenticationHandler) HandlePasskeyFinishRequest(w http.ResponseWrite
 		authRequest.Assertion,
 	)
 	if svcErr != nil {
-		ah.handleServiceError(w, svcErr)
+		ah.handleServiceError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, AuthenticationResponseDTO(*authResponse))
 }
 
 // handleServiceError converts service errors to appropriate HTTP responses.
-func (ah *authenticationHandler) handleServiceError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func (
+	ah *authenticationHandler) handleServiceError(ctx context.Context,
+	w http.ResponseWriter,
+	svcErr *serviceerror.ServiceError) {
 	status := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
 		switch svcErr.Code {
@@ -342,5 +346,5 @@ func (ah *authenticationHandler) handleServiceError(w http.ResponseWriter, svcEr
 		Message:     svcErr.Error,
 		Description: svcErr.ErrorDescription,
 	}
-	sysutils.WriteErrorResponse(w, status, errorResp)
+	sysutils.WriteErrorResponse(ctx, w, status, errorResp)
 }

--- a/backend/internal/authn/magiclink/service.go
+++ b/backend/internal/authn/magiclink/service.go
@@ -115,7 +115,7 @@ func (s *magicLinkAuthnService) GenerateMagicLink(ctx context.Context,
 		return "", &ErrorTokenGenerationFailed
 	}
 
-	verifyURL := s.buildMagicLinkURL(magicLinkURL, token, queryParams)
+	verifyURL := s.buildMagicLinkURL(ctx, magicLinkURL, token, queryParams)
 	s.logger.DebugWithContext(ctx, "Magic link generated successfully",
 		log.MaskedString("subject", subject))
 
@@ -138,13 +138,13 @@ func (s *magicLinkAuthnService) Authenticate(ctx context.Context,
 		return nil, svcErr
 	}
 
-	subject, svcErr := s.extractSubject(token)
+	subject, svcErr := s.extractSubject(ctx, token)
 	if svcErr != nil {
 		return nil, svcErr
 	}
 
 	subjectAttribute = strings.TrimSpace(subjectAttribute)
-	user, resolveErr := s.resolveUserFromSubject(subject, subjectAttribute)
+	user, resolveErr := s.resolveUserFromSubject(ctx, subject, subjectAttribute)
 	if resolveErr != nil {
 		if resolveErr.Code == common.ErrorUserNotFound.Code {
 			identifiers := map[string]interface{}{}
@@ -175,16 +175,16 @@ func (s *magicLinkAuthnService) verifyToken(ctx context.Context, token string) *
 	return nil
 }
 
-func (s *magicLinkAuthnService) extractSubject(token string) (string, *serviceerror.ServiceError) {
+func (s *magicLinkAuthnService) extractSubject(ctx context.Context, token string) (string, *serviceerror.ServiceError) {
 	payload, decodeErr := jwt.DecodeJWTPayload(token)
 	if decodeErr != nil {
-		s.logger.Debug("Failed to decode magic link token payload", log.Error(decodeErr))
+		s.logger.DebugWithContext(ctx, "Failed to decode magic link token payload", log.Error(decodeErr))
 		return "", &ErrorInvalidToken
 	}
 
 	subject := utils.ConvertInterfaceValueToString(payload["sub"])
 	if subject == "" {
-		s.logger.Debug("Subject claim not found or invalid")
+		s.logger.DebugWithContext(ctx, "Subject claim not found or invalid")
 		return "", &ErrorMalformedTokenClaims
 	}
 
@@ -192,19 +192,19 @@ func (s *magicLinkAuthnService) extractSubject(token string) (string, *serviceer
 }
 
 // resolveUserFromSubject resolves the token subject either as a user ID or as a configured destination attribute.
-func (s *magicLinkAuthnService) resolveUserFromSubject(
+func (s *magicLinkAuthnService) resolveUserFromSubject(ctx context.Context,
 	subject string, subjectAttribute string) (*entityprovider.Entity, *serviceerror.ServiceError) {
 	if subjectAttribute == "" {
 		user, upErr := s.entityProvider.GetEntity(subject)
 		if upErr != nil {
-			return nil, s.handleEntityProviderError(upErr)
+			return nil, s.handleEntityProviderError(ctx, upErr)
 		}
 		return user, nil
 	}
 
 	userID, upErr := s.entityProvider.IdentifyEntity(map[string]interface{}{subjectAttribute: subject})
 	if upErr != nil {
-		return nil, s.handleEntityProviderError(upErr)
+		return nil, s.handleEntityProviderError(ctx, upErr)
 	}
 	if userID == nil || *userID == "" {
 		return nil, &common.ErrorUserNotFound
@@ -212,13 +212,13 @@ func (s *magicLinkAuthnService) resolveUserFromSubject(
 
 	user, upErr := s.entityProvider.GetEntity(*userID)
 	if upErr != nil {
-		return nil, s.handleEntityProviderError(upErr)
+		return nil, s.handleEntityProviderError(ctx, upErr)
 	}
 	return user, nil
 }
 
 // buildMagicLinkURL constructs a magic link URL by appending query parameters to a base URL or default configuration.
-func (s *magicLinkAuthnService) buildMagicLinkURL(magicLinkURL string, token string,
+func (s *magicLinkAuthnService) buildMagicLinkURL(ctx context.Context, magicLinkURL string, token string,
 	queryParams map[string]string) string {
 	var u *url.URL
 	var err error
@@ -226,7 +226,8 @@ func (s *magicLinkAuthnService) buildMagicLinkURL(magicLinkURL string, token str
 	if magicLinkURL != "" && strings.TrimSpace(magicLinkURL) != "" {
 		u, err = url.Parse(strings.TrimSpace(magicLinkURL))
 		if err != nil {
-			s.logger.Debug("Failed to parse custom magic link URL; falling back to default configuration",
+			s.logger.DebugWithContext(ctx,
+				"Failed to parse custom magic link URL; falling back to default configuration",
 				log.Error(err))
 		}
 	}
@@ -246,7 +247,7 @@ func (s *magicLinkAuthnService) buildMagicLinkURL(magicLinkURL string, token str
 }
 
 // handleEntityProviderError maps entity provider errors to appropriate service errors with localization support.
-func (s *magicLinkAuthnService) handleEntityProviderError(
+func (s *magicLinkAuthnService) handleEntityProviderError(ctx context.Context,
 	upErr *entityprovider.EntityProviderError,
 ) *serviceerror.ServiceError {
 	if upErr.Code == entityprovider.ErrorCodeEntityNotFound {
@@ -255,7 +256,7 @@ func (s *magicLinkAuthnService) handleEntityProviderError(
 	if upErr.Code == entityprovider.ErrorCodeSystemError {
 		return &serviceerror.InternalServerError
 	}
-	s.logger.Debug("User provider returned an error while resolving user",
+	s.logger.DebugWithContext(ctx, "User provider returned an error while resolving user",
 		log.String("description", upErr.Description))
 	return &ErrorClientErrorWhileResolvingUser
 }

--- a/backend/internal/authn/magiclink/service_test.go
+++ b/backend/internal/authn/magiclink/service_test.go
@@ -325,7 +325,7 @@ func (suite *MagicLinkServiceTestSuite) TestGetAuthenticatorMetadata() {
 func (suite *MagicLinkServiceTestSuite) TestBuildMagicLinkURLUsesQueryParams() {
 	service := suite.service.(*magicLinkAuthnService)
 
-	result := service.buildMagicLinkURL("", testToken, map[string]string{"id": testExecutionID})
+	result := service.buildMagicLinkURL(context.Background(), "", testToken, map[string]string{"id": testExecutionID})
 	parsedURL, err := url.Parse(result)
 
 	suite.Require().NoError(err)
@@ -336,7 +336,7 @@ func (suite *MagicLinkServiceTestSuite) TestBuildMagicLinkURLUsesQueryParams() {
 
 func (suite *MagicLinkServiceTestSuite) TestBuildMagicLinkURLUsesQueryParamsForCustomURL() {
 	service := suite.service.(*magicLinkAuthnService)
-	result := service.buildMagicLinkURL("https://example.com/signin?tenant=alpha", testToken,
+	result := service.buildMagicLinkURL(context.Background(), "https://example.com/signin?tenant=alpha", testToken,
 		map[string]string{"id": testExecutionID})
 	parsedURL, err := url.Parse(result)
 
@@ -349,8 +349,8 @@ func (suite *MagicLinkServiceTestSuite) TestBuildMagicLinkURLUsesQueryParamsForC
 func (suite *MagicLinkServiceTestSuite) TestBuildMagicLinkURLDefaultURLIsNotMutated() {
 	service := suite.service.(*magicLinkAuthnService)
 
-	result1 := service.buildMagicLinkURL("", "token-aaa", map[string]string{"id": "flow-aaa"})
-	result2 := service.buildMagicLinkURL("", "token-bbb", map[string]string{"id": "flow-bbb"})
+	result1 := service.buildMagicLinkURL(context.Background(), "", "token-aaa", map[string]string{"id": "flow-aaa"})
+	result2 := service.buildMagicLinkURL(context.Background(), "", "token-bbb", map[string]string{"id": "flow-bbb"})
 
 	parsedURL1, err1 := url.Parse(result1)
 	parsedURL2, err2 := url.Parse(result2)

--- a/backend/internal/authn/oidc/service.go
+++ b/backend/internal/authn/oidc/service.go
@@ -39,7 +39,7 @@ const (
 type OIDCAuthnCoreServiceInterface interface {
 	authnoauth.OAuthAuthnCoreServiceInterface
 	ValidateIDToken(ctx context.Context, idpID, idToken string) *serviceerror.ServiceError
-	GetIDTokenClaims(idToken string) (map[string]interface{}, *serviceerror.ServiceError)
+	GetIDTokenClaims(ctx context.Context, idToken string) (map[string]interface{}, *serviceerror.ServiceError)
 }
 
 // OIDCAuthnServiceInterface defines the contract for OIDC based authenticator services.
@@ -166,19 +166,19 @@ func (s *oidcAuthnService) ValidateIDToken(ctx context.Context, idpID, idToken s
 }
 
 // GetIDTokenClaims extracts and returns the claims from the ID token.
-func (s *oidcAuthnService) GetIDTokenClaims(idToken string) (
+func (s *oidcAuthnService) GetIDTokenClaims(ctx context.Context, idToken string) (
 	map[string]interface{}, *serviceerror.ServiceError) {
 	logger := s.logger
-	logger.Debug("Extracting claims from ID token")
+	logger.DebugWithContext(ctx, "Extracting claims from ID token")
 
 	if strings.TrimSpace(idToken) == "" {
-		logger.Debug("ID token is empty")
+		logger.DebugWithContext(ctx, "ID token is empty")
 		return nil, &ErrorInvalidIDToken
 	}
 
 	claims, err := jwt.DecodeJWTPayload(idToken)
 	if err != nil {
-		logger.Debug("Failed to decode ID token payload", log.Error(err))
+		logger.DebugWithContext(ctx, "Failed to decode ID token payload", log.Error(err))
 		return nil, &ErrorInvalidIDToken
 	}
 
@@ -210,7 +210,7 @@ func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID, code string)
 		return nil, svcErr
 	}
 
-	claims, svcErr := s.GetIDTokenClaims(tokenResp.IDToken)
+	claims, svcErr := s.GetIDTokenClaims(ctx, tokenResp.IDToken)
 	if svcErr != nil {
 		return nil, svcErr
 	}

--- a/backend/internal/authn/oidc/service_test.go
+++ b/backend/internal/authn/oidc/service_test.go
@@ -330,14 +330,14 @@ func (suite *OIDCAuthnServiceTestSuite) TestGetIDTokenClaimsSuccess() {
 		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
 		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 
-	claims, err := suite.service.GetIDTokenClaims(idToken)
+	claims, err := suite.service.GetIDTokenClaims(context.Background(), idToken)
 	suite.Nil(err)
 	suite.NotNil(claims)
 	suite.Equal("1234567890", claims["sub"])
 }
 
 func (suite *OIDCAuthnServiceTestSuite) TestGetIDTokenClaimsEmptyToken() {
-	claims, err := suite.service.GetIDTokenClaims("")
+	claims, err := suite.service.GetIDTokenClaims(context.Background(), "")
 	suite.Nil(claims)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidIDToken.Code, err.Code)
@@ -413,7 +413,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateTokenResponseValidateIDToken
 
 func (suite *OIDCAuthnServiceTestSuite) TestGetIDTokenClaimsMalformedToken() {
 	// Malformed token (not three parts) should return invalid token error
-	claims, err := suite.service.GetIDTokenClaims("not.a.valid.token")
+	claims, err := suite.service.GetIDTokenClaims(context.Background(), "not.a.valid.token")
 	suite.Nil(claims)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidIDToken.Code, err.Code)

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -141,7 +141,7 @@ func (as *authenticationService) AuthenticateWithCredentials(ctx context.Context
 	newAuthUser, basicResult, svcErr := as.authnProvider.AuthenticateUser(ctx, identifiers, credentials, nil, nil,
 		authnprovidermgr.AuthUser{})
 	if svcErr != nil {
-		return nil, as.mapCredentialsAuthnError(svcErr, logger)
+		return nil, as.mapCredentialsAuthnError(ctx, svcErr, logger)
 	}
 
 	if basicResult == nil {
@@ -151,7 +151,7 @@ func (as *authenticationService) AuthenticateWithCredentials(ctx context.Context
 
 	_, attrsResponse, svcErr := as.authnProvider.GetUserAttributes(ctx, nil, nil, newAuthUser)
 	if svcErr != nil {
-		return nil, as.mapCredentialsGetAttributesError(svcErr, logger)
+		return nil, as.mapCredentialsGetAttributesError(ctx, svcErr, logger)
 	}
 
 	authResponse := &common.AuthenticationResponse{
@@ -256,10 +256,10 @@ func (as *authenticationService) StartIDPAuthentication(ctx context.Context, req
 
 	identityProvider, svcErr := as.idpService.GetIdentityProvider(ctx, idpID)
 	if svcErr != nil {
-		return nil, as.handleIDPServiceError(idpID, svcErr, logger)
+		return nil, as.handleIDPServiceError(ctx, idpID, svcErr, logger)
 	}
 
-	if svcErr := as.validateIDPType(requestedType, identityProvider.Type, logger); svcErr != nil {
+	if svcErr := as.validateIDPType(ctx, requestedType, identityProvider.Type, logger); svcErr != nil {
 		return nil, svcErr
 	}
 
@@ -319,7 +319,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 		return nil, svcErr
 	}
 
-	if svcErr := as.validateIDPType(requestedType, sessionData.IDPType, logger); svcErr != nil {
+	if svcErr := as.validateIDPType(ctx, requestedType, sessionData.IDPType, logger); svcErr != nil {
 		return nil, svcErr
 	}
 
@@ -333,7 +333,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 	_, basicResult, svcErr := as.authnProvider.AuthenticateUser(
 		ctx, nil, credentials, nil, nil, authnprovidermgr.AuthUser{})
 	if svcErr != nil {
-		return nil, as.mapFederatedAuthnError(svcErr, logger)
+		return nil, as.mapFederatedAuthnError(ctx, svcErr, logger)
 	}
 	if basicResult == nil {
 		logger.ErrorWithContext(ctx, "Federated authenticate response is nil")
@@ -520,7 +520,7 @@ func (as *authenticationService) extractClaimsFromAssertion(ctx context.Context,
 }
 
 // mapFederatedAuthnError maps provider manager errors to federated-authentication-specific service errors.
-func (as *authenticationService) mapFederatedAuthnError(svcErr *serviceerror.ServiceError,
+func (as *authenticationService) mapFederatedAuthnError(ctx context.Context, svcErr *serviceerror.ServiceError,
 	logger *log.Logger) *serviceerror.ServiceError {
 	switch svcErr.Code {
 	case authnprovidermgr.ErrorAuthenticationFailed.Code:
@@ -530,14 +530,14 @@ func (as *authenticationService) mapFederatedAuthnError(svcErr *serviceerror.Ser
 	case authnprovidermgr.ErrorInvalidRequest.Code:
 		return &ErrorFederatedAuthenticationFailed
 	default:
-		logger.Error("Error occurred while performing federated authentication",
+		logger.ErrorWithContext(ctx, "Error occurred while performing federated authentication",
 			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return &serviceerror.InternalServerError
 	}
 }
 
 // mapCredentialsAuthnError maps provider manager errors to credentials-specific service errors.
-func (as *authenticationService) mapCredentialsAuthnError(svcErr *serviceerror.ServiceError,
+func (as *authenticationService) mapCredentialsAuthnError(ctx context.Context, svcErr *serviceerror.ServiceError,
 	logger *log.Logger) *serviceerror.ServiceError {
 	switch svcErr.Code {
 	case authnprovidermgr.ErrorAuthenticationFailed.Code:
@@ -547,27 +547,29 @@ func (as *authenticationService) mapCredentialsAuthnError(svcErr *serviceerror.S
 	case authnprovidermgr.ErrorInvalidRequest.Code:
 		return &ErrorEmptyAttributesOrCredentials
 	default:
-		logger.Error("Error occurred while authenticating with credentials",
+		logger.ErrorWithContext(ctx, "Error occurred while authenticating with credentials",
 			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return &serviceerror.InternalServerError
 	}
 }
 
 // mapCredentialsGetAttributesError maps provider manager errors from GetUserAttributes to credentials-specific errors.
-func (as *authenticationService) mapCredentialsGetAttributesError(svcErr *serviceerror.ServiceError,
+func (as *authenticationService) mapCredentialsGetAttributesError(
+	ctx context.Context, svcErr *serviceerror.ServiceError,
 	logger *log.Logger) *serviceerror.ServiceError {
 	switch svcErr.Code {
 	case authnprovidermgr.ErrorGetAttributesClientError.Code:
 		return &ErrorInvalidToken
 	default:
-		logger.Error("Error occurred while getting attributes for credentials authentication",
+		logger.ErrorWithContext(ctx, "Error occurred while getting attributes for credentials authentication",
 			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return &serviceerror.InternalServerError
 	}
 }
 
 // handleIDPServiceError handles errors from IDP service.
-func (as *authenticationService) handleIDPServiceError(idpID string, svcErr *serviceerror.ServiceError,
+func (as *authenticationService) handleIDPServiceError(
+	ctx context.Context, idpID string, svcErr *serviceerror.ServiceError,
 	logger *log.Logger) *serviceerror.ServiceError {
 	if svcErr.Type == serviceerror.ClientErrorType {
 		errDesc := fmt.Sprintf(
@@ -581,12 +583,13 @@ func (as *authenticationService) handleIDPServiceError(idpID string, svcErr *ser
 		})
 	}
 
-	logger.Error("Error occurred while retrieving IDP", log.String("idpId", idpID), log.Any("error", svcErr))
+	logger.ErrorWithContext(ctx, "Error occurred while retrieving IDP",
+		log.String("idpId", idpID), log.Any("error", svcErr))
 	return &serviceerror.InternalServerError
 }
 
 // validateIDPType validates that the requested IDP type matches the actual IDP type.
-func (as *authenticationService) validateIDPType(requestedType, actualType idp.IDPType,
+func (as *authenticationService) validateIDPType(ctx context.Context, requestedType, actualType idp.IDPType,
 	logger *log.Logger) *serviceerror.ServiceError {
 	if requestedType != "" && requestedType != actualType {
 		// Allow cross-type authentication for certain types
@@ -595,7 +598,7 @@ func (as *authenticationService) validateIDPType(requestedType, actualType idp.I
 			return nil
 		}
 
-		logger.Debug("IDP type mismatch", log.String("requested", string(requestedType)),
+		logger.DebugWithContext(ctx, "IDP type mismatch", log.String("requested", string(requestedType)),
 			log.String("actual", string(actualType)))
 		return &common.ErrorInvalidIDPType
 	}

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -1017,26 +1017,26 @@ func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationProvider
 }
 
 func (suite *AuthenticationServiceTestSuite) TestValidateIDPTypeExactMatch() {
-	err := suite.service.validateIDPType(idp.IDPTypeOAuth, idp.IDPTypeOAuth, nil)
+	err := suite.service.validateIDPType(context.Background(), idp.IDPTypeOAuth, idp.IDPTypeOAuth, nil)
 	suite.Nil(err)
 }
 
 func (suite *AuthenticationServiceTestSuite) TestValidateIDPTypeEmptyRequested() {
-	err := suite.service.validateIDPType("", idp.IDPTypeOAuth, nil)
+	err := suite.service.validateIDPType(context.Background(), "", idp.IDPTypeOAuth, nil)
 	suite.Nil(err)
 }
 
 func (suite *AuthenticationServiceTestSuite) TestValidateIDPTypeCrossAllowed() {
-	err := suite.service.validateIDPType(idp.IDPTypeOAuth, idp.IDPTypeOIDC, nil)
+	err := suite.service.validateIDPType(context.Background(), idp.IDPTypeOAuth, idp.IDPTypeOIDC, nil)
 	suite.Nil(err)
 
-	err = suite.service.validateIDPType(idp.IDPTypeOIDC, idp.IDPTypeOAuth, nil)
+	err = suite.service.validateIDPType(context.Background(), idp.IDPTypeOIDC, idp.IDPTypeOAuth, nil)
 	suite.Nil(err)
 }
 
 func (suite *AuthenticationServiceTestSuite) TestValidateIDPTypeMismatch() {
 	logger := log.GetLogger()
-	err := suite.service.validateIDPType(idp.IDPTypeGoogle, idp.IDPTypeGitHub, logger)
+	err := suite.service.validateIDPType(context.Background(), idp.IDPTypeGoogle, idp.IDPTypeGitHub, logger)
 	suite.NotNil(err)
 	suite.Equal(common.ErrorInvalidIDPType.Code, err.Code)
 }
@@ -1053,7 +1053,7 @@ func (suite *AuthenticationServiceTestSuite) TestHandleIDPServiceErrorServerErro
 	}
 	logger := log.GetLogger()
 
-	result := suite.service.handleIDPServiceError(idpID, svcErr, logger)
+	result := suite.service.handleIDPServiceError(context.Background(), idpID, svcErr, logger)
 
 	suite.NotNil(result)
 	suite.Equal(serviceerror.InternalServerError.Code, result.Code)

--- a/backend/internal/authnprovider/provider/default_authn_provider.go
+++ b/backend/internal/authnprovider/provider/default_authn_provider.go
@@ -85,14 +85,17 @@ func (p *defaultAuthnProvider) Authenticate(
 			return nil, newClientError(authnprovidercm.ErrorCodeUserNotFound,
 				"User not found", "The specified user does not exist")
 		}
-		return nil, p.logAndReturnServerError("Failed to get entity after authentication",
+		return nil, p.logAndReturnServerError(ctx, "Failed to get entity after authentication",
 			log.String("error", getErr.Error()))
 	}
 
 	var attributes map[string]interface{}
 	if len(entityResult.Attributes) > 0 {
 		if err := json.Unmarshal(entityResult.Attributes, &attributes); err != nil {
-			return nil, p.logAndReturnServerError("Failed to get allowed attributes", log.String("error", err.Error()))
+			return nil, p.logAndReturnServerError(
+				ctx,
+				"Failed to get allowed attributes",
+				log.String("error", err.Error()))
 		}
 	}
 
@@ -185,7 +188,7 @@ func (p *defaultAuthnProvider) authenticateWithOTP(
 			return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
 				authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
 		}
-		return nil, p.logAndReturnServerError("OTP authentication failed with server error",
+		return nil, p.logAndReturnServerError(ctx, "OTP authentication failed with server error",
 			log.String("error", authErr.Error.DefaultValue),
 			log.String("errorDescription", authErr.ErrorDescription.DefaultValue))
 	}
@@ -228,7 +231,7 @@ func (p *defaultAuthnProvider) authenticateWithFederated(
 			return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
 				authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
 		}
-		return nil, p.logAndReturnServerError("Federated authentication failed with server error",
+		return nil, p.logAndReturnServerError(ctx, "Federated authentication failed with server error",
 			log.String("error", authErr.Error.DefaultValue),
 			log.String("errorDescription", authErr.ErrorDescription.DefaultValue))
 	}
@@ -272,7 +275,7 @@ func (p *defaultAuthnProvider) authenticateWithMagicLink(
 			return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
 				authErr.Error.DefaultValue, authErr.ErrorDescription.DefaultValue)
 		}
-		return nil, p.logAndReturnServerError("Magic link authentication failed with server error",
+		return nil, p.logAndReturnServerError(ctx, "Magic link authentication failed with server error",
 			log.String("error", authErr.Error.DefaultValue),
 			log.String("errorDescription", authErr.ErrorDescription.DefaultValue))
 	}
@@ -298,7 +301,7 @@ func (p *defaultAuthnProvider) authenticateByUserID(
 	}
 	authResult, authErr := p.entitySvc.AuthenticateEntityByID(ctx, userIDStr, credentials)
 	if authErr != nil {
-		return nil, p.handleEntityAuthError(authErr, "Basic authentication by ID failed with server error")
+		return nil, p.handleEntityAuthError(ctx, authErr, "Basic authentication by ID failed with server error")
 	}
 	return &credentialOutcome{entityID: authResult.EntityID}, nil
 }
@@ -308,12 +311,13 @@ func (p *defaultAuthnProvider) authenticateByIdentifiers(
 ) (*credentialOutcome, *serviceerror.ServiceError) {
 	authResult, authErr := p.entitySvc.AuthenticateEntity(ctx, identifiers, credentials)
 	if authErr != nil {
-		return nil, p.handleEntityAuthError(authErr, "Basic authentication failed with server error")
+		return nil, p.handleEntityAuthError(ctx, authErr, "Basic authentication failed with server error")
 	}
 	return &credentialOutcome{entityID: authResult.EntityID}, nil
 }
 
-func (p *defaultAuthnProvider) handleEntityAuthError(err error, serverMsg string) *serviceerror.ServiceError {
+func (p *defaultAuthnProvider) handleEntityAuthError(
+	ctx context.Context, err error, serverMsg string) *serviceerror.ServiceError {
 	if errors.Is(err, entity.ErrEntityNotFound) {
 		return newClientError(authnprovidercm.ErrorCodeUserNotFound,
 			"User not found", "The specified user does not exist")
@@ -322,7 +326,7 @@ func (p *defaultAuthnProvider) handleEntityAuthError(err error, serverMsg string
 		return newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,
 			"Authentication failed", "Invalid credentials provided")
 	}
-	return p.logAndReturnServerError(serverMsg, log.String("error", err.Error()))
+	return p.logAndReturnServerError(ctx, serverMsg, log.String("error", err.Error()))
 }
 
 // GetAttributes retrieves the user attributes using the internal entity service.
@@ -340,14 +344,14 @@ func (p *defaultAuthnProvider) GetAttributes(
 			return nil, newClientError(authnprovidercm.ErrorCodeInvalidToken,
 				"Invalid token", "The specified token is invalid")
 		}
-		return nil, p.logAndReturnServerError("Failed to get entity attributes",
+		return nil, p.logAndReturnServerError(ctx, "Failed to get entity attributes",
 			log.String("error", getErr.Error()))
 	}
 
 	var allAttributes map[string]interface{}
 	if len(entityResult.Attributes) > 0 {
 		if err := json.Unmarshal(entityResult.Attributes, &allAttributes); err != nil {
-			return nil, p.logAndReturnServerError("Failed to unmarshal entity attributes",
+			return nil, p.logAndReturnServerError(ctx, "Failed to unmarshal entity attributes",
 				log.String("error", err.Error()))
 		}
 	}
@@ -423,8 +427,9 @@ func newClientError(code, msg, desc string) *serviceerror.ServiceError {
 	}
 }
 
-func (p *defaultAuthnProvider) logAndReturnServerError(msg string, fields ...log.Field) *serviceerror.ServiceError {
-	p.logger.Error(msg, fields...)
+func (p *defaultAuthnProvider) logAndReturnServerError(
+	ctx context.Context, msg string, fields ...log.Field) *serviceerror.ServiceError {
+	p.logger.ErrorWithContext(ctx, msg, fields...)
 	err := serviceerror.InternalServerError
 	return &err
 }

--- a/backend/internal/authnprovider/provider/init.go
+++ b/backend/internal/authnprovider/provider/init.go
@@ -19,6 +19,7 @@
 package provider
 
 import (
+	"context"
 	"time"
 
 	authncommon "github.com/thunder-id/thunderid/internal/authn/common"
@@ -67,7 +68,8 @@ func initializeRestAuthnProvider() AuthnProviderInterface {
 	apiKey := authnProviderConfig.Rest.Security.APIKey
 	timeout := time.Duration(authnProviderConfig.Rest.Timeout) * time.Second
 	if baseURL == "" {
-		log.GetLogger().Fatal("AuthnProvider Rest BaseURL is required but found empty")
+		// Provider initialization runs during application startup, outside any request.
+		log.GetLogger().FatalWithContext(context.Background(), "AuthnProvider Rest BaseURL is required but found empty")
 	}
 	if timeout == 0 {
 		timeout = 10 * time.Second

--- a/backend/internal/authnprovider/provider/rest_authn_provider.go
+++ b/backend/internal/authnprovider/provider/rest_authn_provider.go
@@ -99,12 +99,12 @@ func postAndDecode[T any](p *restAuthnProvider, ctx context.Context, url string,
 	reqBody interface{}) (*T, *serviceerror.ServiceError) {
 	jsonBody, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, p.logAndReturnServerError("Failed to marshal request", log.String("error", err.Error()))
+		return nil, p.logAndReturnServerError(ctx, "Failed to marshal request", log.String("error", err.Error()))
 	}
 
 	resp, err := p.doRequest(ctx, url, bytes.NewBuffer(jsonBody))
 	if err != nil {
-		return nil, p.logAndReturnServerError("Failed to send request", log.String("error", err.Error()))
+		return nil, p.logAndReturnServerError(ctx, "Failed to send request", log.String("error", err.Error()))
 	}
 	defer func() {
 		_ = resp.Body.Close()
@@ -113,16 +113,17 @@ func postAndDecode[T any](p *restAuthnProvider, ctx context.Context, url string,
 	if resp.StatusCode == http.StatusOK {
 		var result T
 		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return nil, p.logAndReturnServerError("Failed to decode response", log.String("error", err.Error()))
+			return nil, p.logAndReturnServerError(ctx, "Failed to decode response", log.String("error", err.Error()))
 		}
 		return &result, nil
 	}
 
-	return nil, p.decodeError(resp.Body, resp.StatusCode)
+	return nil, p.decodeError(ctx, resp.Body, resp.StatusCode)
 }
 
-func (p *restAuthnProvider) logAndReturnServerError(msg string, fields ...log.Field) *serviceerror.ServiceError {
-	p.logger.Error(msg, fields...)
+func (p *restAuthnProvider) logAndReturnServerError(
+	ctx context.Context, msg string, fields ...log.Field) *serviceerror.ServiceError {
+	p.logger.ErrorWithContext(ctx, msg, fields...)
 	err := serviceerror.InternalServerError
 	return &err
 }
@@ -135,10 +136,11 @@ func isClientError(statusCode int, code string) bool {
 		code == authnprovidercm.ErrorCodeInvalidRequest
 }
 
-func (p *restAuthnProvider) decodeError(body io.Reader, statusCode int) *serviceerror.ServiceError {
+func (p *restAuthnProvider) decodeError(
+	ctx context.Context, body io.Reader, statusCode int) *serviceerror.ServiceError {
 	var apiErr apiErrorResponse
 	if err := json.NewDecoder(body).Decode(&apiErr); err != nil {
-		return p.logAndReturnServerError("Failed to decode error response from authn provider",
+		return p.logAndReturnServerError(ctx, "Failed to decode error response from authn provider",
 			log.String("error", err.Error()))
 	}
 
@@ -148,7 +150,7 @@ func (p *restAuthnProvider) decodeError(body io.Reader, statusCode int) *service
 	}
 
 	if errorType == serviceerror.ServerErrorType {
-		return p.logAndReturnServerError("Authn provider returned server error",
+		return p.logAndReturnServerError(ctx, "Authn provider returned server error",
 			log.String("code", apiErr.Code), log.String("message", apiErr.Message),
 			log.String("description", apiErr.Description))
 	}

--- a/backend/internal/consent/service.go
+++ b/backend/internal/consent/service.go
@@ -38,7 +38,8 @@ type consentService struct {
 func newConsentService(client consentClientInterface) ConsentServiceInterface {
 	isEnabled := config.GetServerRuntime().Config.Consent.Enabled
 	if !isEnabled {
-		log.GetLogger().Debug("Consent service is disabled in the configuration")
+		// Service construction runs during application startup, outside any request.
+		log.GetLogger().DebugWithContext(context.Background(), "Consent service is disabled in the configuration")
 	}
 
 	return &consentService{

--- a/backend/internal/design/layout/mgt/declarative_resource.go
+++ b/backend/internal/design/layout/mgt/declarative_resource.go
@@ -98,7 +98,7 @@ func (e *layoutExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates a layout resource.
-func (e *layoutExporter) ValidateResource(
+func (e *layoutExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	layout, ok := resource.(*Layout)
@@ -106,7 +106,7 @@ func (e *layoutExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeLayout, id)
 	}
 
-	err := declarativeresource.ValidateResourceName(
+	err := declarativeresource.ValidateResourceName(ctx,
 		layout.DisplayName, resourceTypeLayout, id, "LAYOUT_VALIDATION_ERROR", logger,
 	)
 	if err != nil {
@@ -114,7 +114,7 @@ func (e *layoutExporter) ValidateResource(
 	}
 
 	if len(layout.Layout) == 0 {
-		logger.Warn("Layout has no layout configuration",
+		logger.WarnWithContext(ctx, "Layout has no layout configuration",
 			log.String("layoutID", id), log.String("displayName", layout.DisplayName))
 	}
 

--- a/backend/internal/design/layout/mgt/declarative_resource_test.go
+++ b/backend/internal/design/layout/mgt/declarative_resource_test.go
@@ -89,7 +89,7 @@ func (s *DeclarativeResourceTestSuite) TestLayoutExporter_GetResourceRules() {
 func (s *DeclarativeResourceTestSuite) TestLayoutExporter_ValidateResource_InvalidType() {
 	exporter := &layoutExporter{}
 
-	name, err := exporter.ValidateResource("not a layout", "layout1", nil)
+	name, err := exporter.ValidateResource(context.Background(), "not a layout", "layout1", nil)
 
 	s.NotNil(err)
 	s.Empty(name)
@@ -352,7 +352,7 @@ func (s *DeclarativeResourceTestSuite) TestLayoutExporter_ValidateResource_Empty
 	}
 
 	// Even with empty layout, validation should succeed (just logs warning)
-	name, err := exporter.ValidateResource(layout, "layout1", testLogger)
+	name, err := exporter.ValidateResource(context.Background(), layout, "layout1", testLogger)
 
 	// The empty layout should not cause validation error in ValidateResource
 	// (it logs a warning instead)

--- a/backend/internal/design/layout/mgt/handler.go
+++ b/backend/internal/design/layout/mgt/handler.go
@@ -19,6 +19,7 @@
 package layoutmgt
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -52,13 +53,13 @@ func (lh *layoutMgtHandler) HandleLayoutListRequest(w http.ResponseWriter, r *ht
 	ctx := r.Context()
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	layoutList, svcErr := lh.layoutMgtService.GetLayoutList(ctx, limit, offset)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -83,7 +84,7 @@ func (lh *layoutMgtHandler) HandleLayoutListRequest(w http.ResponseWriter, r *ht
 		Links:        toHTTPLinks(layoutList.Links),
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, layoutListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, layoutListResponse)
 
 	lh.logger.DebugWithContext(ctx, "Successfully listed layout configurations with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -96,13 +97,13 @@ func (lh *layoutMgtHandler) HandleLayoutPostRequest(w http.ResponseWriter, r *ht
 	ctx := r.Context()
 	createRequest, err := sysutils.DecodeJSONBody[CreateLayoutRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidLayoutData)
+		handleError(ctx, w, &ErrorInvalidLayoutData)
 		return
 	}
 
 	createdLayout, svcErr := lh.layoutMgtService.CreateLayout(ctx, *createRequest)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -117,7 +118,7 @@ func (lh *layoutMgtHandler) HandleLayoutPostRequest(w http.ResponseWriter, r *ht
 		IsReadOnly:  createdLayout.IsReadOnly,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, layoutResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, layoutResponse)
 
 	lh.logger.DebugWithContext(ctx, "Successfully created layout configuration",
 		log.String("id", createdLayout.ID))
@@ -129,7 +130,7 @@ func (lh *layoutMgtHandler) HandleLayoutGetRequest(w http.ResponseWriter, r *htt
 	id := r.PathValue("id")
 	layout, svcErr := lh.layoutMgtService.GetLayout(ctx, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -144,7 +145,7 @@ func (lh *layoutMgtHandler) HandleLayoutGetRequest(w http.ResponseWriter, r *htt
 		IsReadOnly:  layout.IsReadOnly,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, layoutResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, layoutResponse)
 
 	lh.logger.DebugWithContext(ctx, "Successfully retrieved layout configuration", log.String("id", id))
 }
@@ -155,13 +156,13 @@ func (lh *layoutMgtHandler) HandleLayoutPutRequest(w http.ResponseWriter, r *htt
 	id := r.PathValue("id")
 	updateRequest, err := sysutils.DecodeJSONBody[UpdateLayoutRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidLayoutData)
+		handleError(ctx, w, &ErrorInvalidLayoutData)
 		return
 	}
 
 	updatedLayout, svcErr := lh.layoutMgtService.UpdateLayout(ctx, id, *updateRequest)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -176,7 +177,7 @@ func (lh *layoutMgtHandler) HandleLayoutPutRequest(w http.ResponseWriter, r *htt
 		IsReadOnly:  updatedLayout.IsReadOnly,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, layoutResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, layoutResponse)
 
 	lh.logger.DebugWithContext(ctx, "Successfully updated layout configuration", log.String("id", id))
 }
@@ -187,11 +188,11 @@ func (lh *layoutMgtHandler) HandleLayoutDeleteRequest(w http.ResponseWriter, r *
 	id := r.PathValue("id")
 	svcErr := lh.layoutMgtService.DeleteLayout(ctx, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	lh.logger.DebugWithContext(ctx, "Successfully deleted layout configuration", log.String("id", id))
 }
 
@@ -233,7 +234,7 @@ func toHTTPLinks(links []Link) []LinkResponse {
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.
-func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
 		switch svcErr.Code {
@@ -254,5 +255,5 @@ func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }

--- a/backend/internal/design/layout/mgt/handler_test.go
+++ b/backend/internal/design/layout/mgt/handler_test.go
@@ -489,7 +489,7 @@ func (suite *LayoutHandlerTestSuite) TestHandleError_StatusCodeMapping() {
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
 			w := httptest.NewRecorder()
-			handleError(w, tc.svcErr)
+			handleError(context.Background(), w, tc.svcErr)
 			assert.Equal(suite.T(), tc.expectedStatus, w.Code)
 		})
 	}

--- a/backend/internal/design/resolve/handler.go
+++ b/backend/internal/design/resolve/handler.go
@@ -19,6 +19,7 @@
 package resolve
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -54,11 +55,11 @@ func (rh *designResolveHandler) HandleResolveRequest(w http.ResponseWriter, r *h
 
 	designResponse, svcErr := rh.resolveService.ResolveDesign(ctx, resolveType, id)
 	if svcErr != nil {
-		rh.handleError(w, svcErr)
+		rh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusOK, designResponse)
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, designResponse)
 
 	rh.logger.DebugWithContext(ctx, "Successfully resolved design configuration",
 		log.String("type", string(resolveType)),
@@ -66,7 +67,10 @@ func (rh *designResolveHandler) HandleResolveRequest(w http.ResponseWriter, r *h
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.
-func (rh *designResolveHandler) handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func (
+	rh *designResolveHandler) handleError(ctx context.Context,
+	w http.ResponseWriter,
+	svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
 		switch svcErr.Code {
@@ -88,5 +92,5 @@ func (rh *designResolveHandler) handleError(w http.ResponseWriter, svcErr *servi
 		Description: svcErr.ErrorDescription,
 	}
 
-	utils.WriteErrorResponse(w, statusCode, errResp)
+	utils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }

--- a/backend/internal/design/resolve/handler_test.go
+++ b/backend/internal/design/resolve/handler_test.go
@@ -288,7 +288,7 @@ func (suite *ResolveHandlerTestSuite) TestHandleError_StatusCodeMapping() {
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
 			w := httptest.NewRecorder()
-			handler.handleError(w, tc.svcErr)
+			handler.handleError(context.Background(), w, tc.svcErr)
 			assert.Equal(suite.T(), tc.expectedStatus, w.Code)
 		})
 	}

--- a/backend/internal/design/theme/mgt/declarative_resource.go
+++ b/backend/internal/design/theme/mgt/declarative_resource.go
@@ -98,7 +98,7 @@ func (e *themeExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates a theme resource.
-func (e *themeExporter) ValidateResource(
+func (e *themeExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	theme, ok := resource.(*Theme)
@@ -106,7 +106,7 @@ func (e *themeExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeTheme, id)
 	}
 
-	err := declarativeresource.ValidateResourceName(
+	err := declarativeresource.ValidateResourceName(ctx,
 		theme.DisplayName, resourceTypeTheme, id, "THEME_VALIDATION_ERROR", logger,
 	)
 	if err != nil {
@@ -114,7 +114,7 @@ func (e *themeExporter) ValidateResource(
 	}
 
 	if len(theme.Theme) == 0 {
-		logger.Warn("Theme has no theme configuration",
+		logger.WarnWithContext(ctx, "Theme has no theme configuration",
 			log.String("themeID", id), log.String("displayName", theme.DisplayName))
 	}
 

--- a/backend/internal/design/theme/mgt/declarative_resource_test.go
+++ b/backend/internal/design/theme/mgt/declarative_resource_test.go
@@ -89,7 +89,7 @@ func (s *ThemeDeclarativeSuite) TestThemeExporter_GetResourceRules() {
 func (s *ThemeDeclarativeSuite) TestThemeExporter_ValidateResource_InvalidType() {
 	exporter := &themeExporter{}
 
-	name, err := exporter.ValidateResource("not a theme", "theme1", nil)
+	name, err := exporter.ValidateResource(context.Background(), "not a theme", "theme1", nil)
 
 	s.NotNil(err)
 	s.Empty(name)
@@ -348,7 +348,7 @@ func (s *ThemeDeclarativeSuite) TestThemeExporter_ValidateResource_EmptyThemeWar
 	}
 
 	// Even with empty theme, validation should succeed (just logs warning)
-	name, err := exporter.ValidateResource(theme, "theme1", testLogger)
+	name, err := exporter.ValidateResource(context.Background(), theme, "theme1", testLogger)
 
 	// The empty theme should not cause validation error in ValidateResource
 	// (it logs a warning instead)

--- a/backend/internal/design/theme/mgt/handler.go
+++ b/backend/internal/design/theme/mgt/handler.go
@@ -19,6 +19,7 @@
 package thememgt
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -52,13 +53,13 @@ func (th *themeMgtHandler) HandleThemeListRequest(w http.ResponseWriter, r *http
 	ctx := r.Context()
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	themeList, svcErr := th.themeMgtService.GetThemeList(ctx, limit, offset)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -86,7 +87,7 @@ func (th *themeMgtHandler) HandleThemeListRequest(w http.ResponseWriter, r *http
 		Links:        toHTTPLinks(themeList.Links),
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, themeListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, themeListResponse)
 
 	th.logger.DebugWithContext(ctx, "Successfully listed theme configurations with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -99,7 +100,7 @@ func (th *themeMgtHandler) HandleThemePostRequest(w http.ResponseWriter, r *http
 	ctx := r.Context()
 	createRequest, err := sysutils.DecodeJSONBody[CreateThemeRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidThemeData)
+		handleError(ctx, w, &ErrorInvalidThemeData)
 		return
 	}
 
@@ -110,7 +111,7 @@ func (th *themeMgtHandler) HandleThemePostRequest(w http.ResponseWriter, r *http
 		Theme:       createRequest.Theme,
 	})
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -124,7 +125,7 @@ func (th *themeMgtHandler) HandleThemePostRequest(w http.ResponseWriter, r *http
 		UpdatedAt:   createdTheme.UpdatedAt,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, themeResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, themeResponse)
 
 	th.logger.DebugWithContext(ctx, "Successfully created theme configuration",
 		log.String("id", createdTheme.ID))
@@ -136,7 +137,7 @@ func (th *themeMgtHandler) HandleThemeGetRequest(w http.ResponseWriter, r *http.
 	id := r.PathValue("id")
 	theme, svcErr := th.themeMgtService.GetTheme(ctx, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -150,7 +151,7 @@ func (th *themeMgtHandler) HandleThemeGetRequest(w http.ResponseWriter, r *http.
 		UpdatedAt:   theme.UpdatedAt,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, themeResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, themeResponse)
 
 	th.logger.DebugWithContext(ctx, "Successfully retrieved theme configuration", log.String("id", id))
 }
@@ -161,13 +162,13 @@ func (th *themeMgtHandler) HandleThemePutRequest(w http.ResponseWriter, r *http.
 	id := r.PathValue("id")
 	updateRequest, err := sysutils.DecodeJSONBody[UpdateThemeRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidThemeData)
+		handleError(ctx, w, &ErrorInvalidThemeData)
 		return
 	}
 
 	updatedTheme, svcErr := th.themeMgtService.UpdateTheme(ctx, id, *updateRequest)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -181,7 +182,7 @@ func (th *themeMgtHandler) HandleThemePutRequest(w http.ResponseWriter, r *http.
 		UpdatedAt:   updatedTheme.UpdatedAt,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, themeResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, themeResponse)
 
 	th.logger.DebugWithContext(ctx, "Successfully updated theme configuration", log.String("id", id))
 }
@@ -192,11 +193,11 @@ func (th *themeMgtHandler) HandleThemeDeleteRequest(w http.ResponseWriter, r *ht
 	id := r.PathValue("id")
 	svcErr := th.themeMgtService.DeleteTheme(ctx, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	th.logger.DebugWithContext(ctx, "Successfully deleted theme configuration", log.String("id", id))
 }
 
@@ -238,7 +239,7 @@ func toHTTPLinks(links []Link) []LinkResponse {
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.
-func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	switch {
 	case svcErr == &ErrorThemeNotFound:
@@ -255,5 +256,5 @@ func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }

--- a/backend/internal/design/theme/mgt/handler_test.go
+++ b/backend/internal/design/theme/mgt/handler_test.go
@@ -554,7 +554,7 @@ func (suite *ThemeHandlerTestSuite) TestHandleError_StatusCodeMapping() {
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
 			w := httptest.NewRecorder()
-			handleError(w, tc.svcErr)
+			handleError(context.Background(), w, tc.svcErr)
 			assert.Equal(suite.T(), tc.expectedStatus, w.Code)
 		})
 	}

--- a/backend/internal/entity/cache_backed_store.go
+++ b/backend/internal/entity/cache_backed_store.go
@@ -266,7 +266,7 @@ func identifierCacheKey(filterKey, filterValue string) cache.CacheKey {
 
 // parseEntityAttributes unmarshals the entity's SystemAttributes and Attributes
 // into a single merged map. SystemAttributes take precedence on key collisions.
-func (s *cacheBackedEntityStore) parseEntityAttributes(entity *Entity) map[string]interface{} {
+func (s *cacheBackedEntityStore) parseEntityAttributes(ctx context.Context, entity *Entity) map[string]interface{} {
 	if entity == nil {
 		return nil
 	}
@@ -277,7 +277,7 @@ func (s *cacheBackedEntityStore) parseEntityAttributes(entity *Entity) map[strin
 		}
 		var attrs map[string]interface{}
 		if err := json.Unmarshal(raw, &attrs); err != nil {
-			s.logger.Warn("Failed to unmarshal entity attributes for cache key resolution",
+			s.logger.WarnWithContext(ctx, "Failed to unmarshal entity attributes for cache key resolution",
 				log.String("entityID", entity.ID), log.Error(err))
 			continue
 		}
@@ -292,7 +292,7 @@ func (s *cacheBackedEntityStore) cacheEntityIDByIdentifiers(ctx context.Context,
 	if entity == nil || entity.ID == "" {
 		return
 	}
-	attrs := s.parseEntityAttributes(entity)
+	attrs := s.parseEntityAttributes(ctx, entity)
 	for key := range s.cacheableIdentifiers {
 		val, _ := attrs[key].(string)
 		if val == "" {
@@ -322,7 +322,7 @@ func (s *cacheBackedEntityStore) invalidateIdentifierCache(ctx context.Context, 
 		}
 		entity = &fetched
 	}
-	attrs := s.parseEntityAttributes(entity)
+	attrs := s.parseEntityAttributes(ctx, entity)
 	for key := range s.cacheableIdentifiers {
 		val, _ := attrs[key].(string)
 		if val == "" {

--- a/backend/internal/entity/declarative_resource.go
+++ b/backend/internal/entity/declarative_resource.go
@@ -19,6 +19,7 @@
 package entity
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -105,7 +106,8 @@ func loadDeclarativeResources(
 	idExtractor := func(data interface{}) string {
 		resource, ok := data.(*entityStoreEntry)
 		if !ok {
-			logger.Error("IDExtractor: type assertion failed for entityStoreEntry")
+			// Declarative resource loading runs at startup, outside any request.
+			logger.ErrorWithContext(context.Background(), "IDExtractor: type assertion failed for entityStoreEntry")
 			return ""
 		}
 		if config.IDExtractor != nil {

--- a/backend/internal/entitytype/config.go
+++ b/backend/internal/entitytype/config.go
@@ -19,6 +19,7 @@
 package entitytype
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -51,7 +52,8 @@ func getEntityTypeStoreMode() serverconst.StoreMode {
 		default:
 			msg := fmt.Sprintf(
 				"Invalid entity type store mode: %s, falling back to global declarative resources setting", mode)
-			log.GetLogger().Warn(msg)
+			// Store-mode resolution runs during startup config loading, outside any request.
+			log.GetLogger().WarnWithContext(context.Background(), msg)
 		}
 	}
 

--- a/backend/internal/entitytype/declarative_resource.go
+++ b/backend/internal/entitytype/declarative_resource.go
@@ -91,7 +91,7 @@ func (e *entityTypeExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates a entity type resource.
-func (e *entityTypeExporter) ValidateResource(
+func (e *entityTypeExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	schema, ok := resource.(*EntityType)
@@ -99,7 +99,7 @@ func (e *entityTypeExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeEntityType, id)
 	}
 
-	err := declarativeresource.ValidateResourceName(
+	err := declarativeresource.ValidateResourceName(ctx,
 		schema.Name, resourceTypeEntityType, id, "SCHEMA_VALIDATION_ERROR", logger,
 	)
 	if err != nil {
@@ -107,7 +107,7 @@ func (e *entityTypeExporter) ValidateResource(
 	}
 
 	if len(schema.Schema) == 0 {
-		logger.Warn("Entity type has no schema definition",
+		logger.WarnWithContext(ctx, "Entity type has no schema definition",
 			log.String("schemaID", id), log.String("name", schema.Name))
 	}
 

--- a/backend/internal/entitytype/declarative_resource_test.go
+++ b/backend/internal/entitytype/declarative_resource_test.go
@@ -163,7 +163,7 @@ func (s *EntityTypeExporterTestSuite) TestValidateResource_Success() {
 		Schema: json.RawMessage(`{"field": "value"}`),
 	}
 
-	name, err := s.exporter.ValidateResource(schema, "schema1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), schema, "schema1", s.logger)
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Valid Schema", name)
@@ -172,7 +172,7 @@ func (s *EntityTypeExporterTestSuite) TestValidateResource_Success() {
 func (s *EntityTypeExporterTestSuite) TestValidateResource_InvalidType() {
 	invalidResource := "not a schema"
 
-	name, err := s.exporter.ValidateResource(invalidResource, "schema1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), invalidResource, "schema1", s.logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), err)
@@ -187,7 +187,7 @@ func (s *EntityTypeExporterTestSuite) TestValidateResource_EmptyName() {
 		Name: "",
 	}
 
-	name, err := s.exporter.ValidateResource(schema, "schema1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), schema, "schema1", s.logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), err)
@@ -204,7 +204,7 @@ func (s *EntityTypeExporterTestSuite) TestValidateResource_NoSchema() {
 		Schema: json.RawMessage(`{}`),
 	}
 
-	name, err := s.exporter.ValidateResource(schema, "schema1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), schema, "schema1", s.logger)
 
 	// Should still succeed but log a warning
 	assert.Nil(s.T(), err)

--- a/backend/internal/entitytype/handler.go
+++ b/backend/internal/entitytype/handler.go
@@ -57,7 +57,7 @@ func (h *entityTypeHandler) HandleEntityTypeListRequest(w http.ResponseWriter, r
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -70,11 +70,11 @@ func (h *entityTypeHandler) HandleEntityTypeListRequest(w http.ResponseWriter, r
 	entityTypeListResponse, svcErr := h.entityTypeService.GetEntityTypeList(
 		ctx, h.category, limit, offset, includeDisplay)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, entityTypeListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, entityTypeListResponse)
 
 	logger.DebugWithContext(ctx, "Successfully listed entity types with pagination",
 		log.String("category", string(h.category)),
@@ -98,7 +98,7 @@ func (h *entityTypeHandler) HandleEntityTypePostRequest(w http.ResponseWriter, r
 				DefaultValue: "Failed to parse request body"},
 		}
 
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -113,11 +113,11 @@ func (h *entityTypeHandler) HandleEntityTypePostRequest(w http.ResponseWriter, r
 			Schema:                sanitizedRequest.Schema,
 		})
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdEntityType)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdEntityType)
 
 	logger.DebugWithContext(ctx, "Successfully created entity type",
 		log.String("category", string(h.category)),
@@ -138,11 +138,11 @@ func (h *entityTypeHandler) HandleEntityTypeGetRequest(w http.ResponseWriter, r 
 
 	entityType, svcErr := h.entityTypeService.GetEntityType(ctx, h.category, schemaID, includeDisplay)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, entityType)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, entityType)
 
 	logger.DebugWithContext(ctx, "Successfully retrieved entity type",
 		log.String("category", string(h.category)), log.String("entityTypeID", schemaID))
@@ -166,11 +166,11 @@ func (h *entityTypeHandler) HandleEntityTypePutRequest(w http.ResponseWriter, r 
 	updatedEntityType, svcErr := h.entityTypeService.UpdateEntityType(
 		ctx, h.category, schemaID, sanitizedRequest)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, updatedEntityType)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, updatedEntityType)
 
 	logger.DebugWithContext(ctx, "Successfully updated entity type",
 		log.String("category", string(h.category)),
@@ -189,11 +189,11 @@ func (h *entityTypeHandler) HandleEntityTypeDeleteRequest(w http.ResponseWriter,
 
 	svcErr := h.entityTypeService.DeleteEntityType(ctx, h.category, schemaID)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	logger.DebugWithContext(ctx, "Successfully deleted entity type",
 		log.String("category", string(h.category)), log.String("entityTypeID", schemaID))
 }
@@ -223,7 +223,7 @@ func parsePaginationParams(query map[string][]string) (int, int, *serviceerror.S
 }
 
 // handleError handles service errors and converts them to appropriate HTTP responses.
-func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	var statusCode int
 	if svcErr.Type == serviceerror.ClientErrorType {
 		statusCode = http.StatusBadRequest
@@ -248,7 +248,7 @@ func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }
 
 // extractAndValidateSchemaID extracts and validates the schema ID from the URL path.
@@ -260,7 +260,7 @@ func extractAndValidateSchemaID(w http.ResponseWriter, r *http.Request) (string,
 			Message:     ErrorInvalidEntityTypeRequest.Error,
 			Description: ErrorInvalidEntityTypeRequest.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, errResp)
 		return "", true
 	}
 
@@ -279,7 +279,7 @@ func validateUpdateEntityTypeRequest(
 				Key:          "error.entitytypeservice.update_schema_request_parse_failed_description",
 				DefaultValue: "Failed to parse request body"},
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, errResp)
 		return UpdateEntityTypeRequest{}, true
 	}
 

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -19,6 +19,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"slices"
 	"strings"
@@ -135,7 +136,7 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 		}
 
 		if ctx.CurrentAction != "" {
-			if nextNode := n.getNextNodeForActionRef(ctx.CurrentAction); nextNode != "" {
+			if nextNode := n.getNextNodeForActionRef(ctx.Context, ctx.CurrentAction); nextNode != "" {
 				nodeResp.NextNodeID = nextNode
 			} else {
 				logger.DebugWithContext(ctx.Context, ErrInvalidActionProvided.Error.DefaultValue,
@@ -184,7 +185,7 @@ func (n *promptNode) applyValidationFailureRePrompt(ctx *NodeContext, nodeResp *
 		return false
 	}
 	n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID)).
-		Debug("Input validation failed", log.Int("errorCount", len(fieldErrors)))
+		DebugWithContext(ctx.Context, "Input validation failed", log.Int("errorCount", len(fieldErrors)))
 
 	matchingAction := n.findActionByRef(ctx.CurrentAction)
 
@@ -311,7 +312,7 @@ func (n *promptNode) executeLoginOptions(ctx *NodeContext,
 func (n *promptNode) finalizeLoginOptionsAction(ctx *NodeContext, nodeResp *common.NodeResponse,
 	authClassToAction map[string]string) (*common.NodeResponse, *serviceerror.ServiceError) {
 	logger := n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	nextNode := n.getNextNodeForActionRef(ctx.CurrentAction)
+	nextNode := n.getNextNodeForActionRef(ctx.Context, ctx.CurrentAction)
 	if nextNode == "" {
 		logger.DebugWithContext(ctx.Context, ErrInvalidActionProvided.Error.DefaultValue,
 			log.String("actionRef", ctx.CurrentAction))
@@ -634,11 +635,11 @@ func (n *promptNode) getAllActions() []common.Action {
 }
 
 // getNextNodeForActionRef finds the next node for the given action reference.
-func (n *promptNode) getNextNodeForActionRef(actionRef string) string {
+func (n *promptNode) getNextNodeForActionRef(ctx context.Context, actionRef string) string {
 	actions := n.getAllActions()
 	for i := range actions {
 		if actions[i].Ref == actionRef {
-			n.logger.Debug("Action selected successfully", log.String("actionRef", actions[i].Ref),
+			n.logger.DebugWithContext(ctx, "Action selected successfully", log.String("actionRef", actions[i].Ref),
 				log.String("nextNode", actions[i].NextNode))
 			return actions[i].NextNode
 		}

--- a/backend/internal/flow/core/prompt_node_test.go
+++ b/backend/internal/flow/core/prompt_node_test.go
@@ -19,6 +19,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -946,13 +947,13 @@ func (s *PromptOnlyNodeTestSuite) TestGetNextNodeForActionRef() {
 	})
 
 	// Test finding existing actions
-	nextNode := promptNode.getNextNodeForActionRef("login")
+	nextNode := promptNode.getNextNodeForActionRef(context.Background(), "login")
 	s.Equal("auth_node", nextNode)
 
-	nextNode = promptNode.getNextNodeForActionRef("signup")
+	nextNode = promptNode.getNextNodeForActionRef(context.Background(), "signup")
 	s.Equal("register_node", nextNode)
 
-	nextNode = promptNode.getNextNodeForActionRef("cancel")
+	nextNode = promptNode.getNextNodeForActionRef(context.Background(), "cancel")
 	s.Equal("exit_node", nextNode)
 }
 
@@ -971,7 +972,7 @@ func (s *PromptOnlyNodeTestSuite) TestGetNextNodeForActionRefNotFound() {
 	})
 
 	// Test finding non-existent action
-	nextNode := promptNode.getNextNodeForActionRef("nonexistent")
+	nextNode := promptNode.getNextNodeForActionRef(context.Background(), "nonexistent")
 	s.Equal("", nextNode, "Should return empty string when action not found")
 }
 
@@ -987,7 +988,7 @@ func (s *PromptOnlyNodeTestSuite) TestGetNextNodeForActionRefEmptyRef() {
 	})
 
 	// Test with empty action ref
-	nextNode := promptNode.getNextNodeForActionRef("")
+	nextNode := promptNode.getNextNodeForActionRef(context.Background(), "")
 	s.Equal("", nextNode, "Should return empty string for empty action ref")
 }
 

--- a/backend/internal/flow/executor/email_executor.go
+++ b/backend/internal/flow/executor/email_executor.go
@@ -142,7 +142,7 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 		IsHTML:  rendered.IsHTML,
 	}
 
-	if err := e.emailClient.Send(emailData); err != nil {
+	if err := e.emailClient.Send(ctx.Context, emailData); err != nil {
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrEmailSendFailed
 		return execResp, nil

--- a/backend/internal/flow/executor/email_executor_test.go
+++ b/backend/internal/flow/executor/email_executor_test.go
@@ -108,7 +108,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UserInviteTemplate_Suc
 		Body:    "<html><body>Complete Registration</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(nil)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -155,7 +155,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_Invit
 		Body:    "<html><body>Click to register</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(nil)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -204,7 +204,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UsesRuntimeRecipientOv
 		Body:    "<html><body>Complete Registration</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(nil)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -249,7 +249,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_EmailFromRuntimeData()
 		Body:    "<html><body>Complete Registration</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(nil)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -314,7 +314,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingInviteLink() {
 		Body:    "<html><body>Complete Registration</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(nil)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -356,7 +356,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_SelfRegistration_Missi
 		Body:    "<html><body>Click to register</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(nil)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -549,7 +549,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ClientError() {
 		Body:    "<html><body>Complete Registration</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(email.ErrorInvalidRecipient)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(email.ErrorInvalidRecipient)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -608,7 +608,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_KnownSMTPErrors() {
 				Body:    "<html><body>Complete Registration</body></html>",
 				IsHTML:  true,
 			}
-			suite.mockEmailClient.On("Send", expectedEmail).Return(tc.sendErr)
+			suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(tc.sendErr)
 
 			resp, err := suite.executor.Execute(ctx)
 
@@ -657,7 +657,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UnexpectedError() {
 		Body:    "<html><body>Complete Registration</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(fmt.Errorf("unexpected internal error"))
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(fmt.Errorf("unexpected internal error"))
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -767,8 +767,8 @@ func (suite *EmailExecutorTestSuite) assertExecuteSendSuccess(ctx *core.NodeCont
 	}, nil)
 
 	var sentEmail email.EmailData
-	suite.mockEmailClient.On("Send", mock.Anything).Run(func(args mock.Arguments) {
-		sentEmail = args.Get(0).(email.EmailData)
+	suite.mockEmailClient.On("Send", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		sentEmail = args.Get(1).(email.EmailData)
 	}).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -819,7 +819,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ResolvesEmailFromForwa
 		Body:    "<html><body>Complete Registration</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(nil)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -867,7 +867,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_UsesNodePropertiesAndF
 		Body:    "<html><body>Magic Link</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(nil)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -912,7 +912,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ResolvesEmailUsingConf
 		Body:    "<html><body>Complete Registration</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(nil)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -962,7 +962,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ResolvesEmailFromEntit
 		Body:    "<html><body>Complete Registration</body></html>",
 		IsHTML:  true,
 	}
-	suite.mockEmailClient.On("Send", expectedEmail).Return(nil)
+	suite.mockEmailClient.On("Send", mock.Anything, expectedEmail).Return(nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -1209,7 +1209,7 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ApplicationNameInTempl
 		IsHTML:  false,
 	}, nil)
 
-	suite.mockEmailClient.On("Send", mock.MatchedBy(func(d email.EmailData) bool {
+	suite.mockEmailClient.On("Send", mock.Anything, mock.MatchedBy(func(d email.EmailData) bool {
 		return len(d.To) == 1 && d.To[0] == "user@example.com"
 	})).Return(nil)
 

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -19,6 +19,7 @@
 package flowexec
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -136,7 +137,7 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 			continue
 		}
 
-		svcErr := fe.setNodeExecutor(currentNode, logger)
+		svcErr := fe.setNodeExecutor(ctx.Context, currentNode, logger)
 		if svcErr != nil {
 			return flowStep, svcErr
 		}
@@ -301,13 +302,14 @@ func getNodeInputs(node core.NodeInterface) []common.Input {
 }
 
 // setNodeExecutor sets the executor for the given node if it is not already set.
-func (fe *flowEngine) setNodeExecutor(node core.NodeInterface, logger *log.Logger) *serviceerror.ServiceError {
+func (fe *flowEngine) setNodeExecutor(
+	ctx context.Context, node core.NodeInterface, logger *log.Logger) *serviceerror.ServiceError {
 	if node.GetType() != common.NodeTypeTaskExecution {
 		return nil
 	}
 	executableNode, ok := node.(core.ExecutorBackedNodeInterface)
 	if !ok {
-		logger.Error("Task execution node does not implement ExecutorBackedNodeInterface",
+		logger.ErrorWithContext(ctx, "Task execution node does not implement ExecutorBackedNodeInterface",
 			log.String("nodeID", node.GetID()))
 		return &serviceerror.InternalServerError
 	}
@@ -317,17 +319,19 @@ func (fe *flowEngine) setNodeExecutor(node core.NodeInterface, logger *log.Logge
 		return nil
 	}
 
-	logger.Debug("Executor not set for the node. Constructing executor.", log.String("nodeID", node.GetID()))
+	logger.DebugWithContext(ctx, "Executor not set for the node. Constructing executor.",
+		log.String("nodeID", node.GetID()))
 
 	executorName := executableNode.GetExecutorName()
 	if executorName == "" {
-		logger.Error("Executor name not configured for executable node", log.String("nodeID", node.GetID()))
+		logger.ErrorWithContext(ctx, "Executor name not configured for executable node",
+			log.String("nodeID", node.GetID()))
 		return &serviceerror.InternalServerError
 	}
 
 	executor, err := fe.getExecutorByName(executorName)
 	if err != nil {
-		logger.Error("Error constructing executor for node", log.String("nodeID", node.GetID()),
+		logger.ErrorWithContext(ctx, "Error constructing executor for node", log.String("nodeID", node.GetID()),
 			log.String("executorName", executorName), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
@@ -833,7 +837,7 @@ func (fe *flowEngine) validateSegmentResumePolicy(ctx *EngineContext, logger *lo
 		return false
 	}
 
-	if svcErr := fe.setNodeExecutor(segStartNode, logger); svcErr != nil {
+	if svcErr := fe.setNodeExecutor(ctx.Context, segStartNode, logger); svcErr != nil {
 		return false
 	}
 
@@ -1011,7 +1015,7 @@ func publishNodeExecutionStartedEvent(
 		WithData(event.DataKey.AttemptNumber, fmt.Sprintf("%d", attemptNumber)).
 		WithData(event.DataKey.EntityID, ctx.AppID)
 
-	obsSvc.PublishEvent(evt)
+	obsSvc.PublishEvent(ctx.Context, evt)
 }
 
 // publishNodeExecutionCompletedEvent publishes an observability event when node execution completes or fails.
@@ -1096,7 +1100,7 @@ func publishNodeExecutionCompletedEvent(ctx *EngineContext, node core.NodeInterf
 		evt.WithData(event.DataKey.UserID, ctx.AuthenticatedUser.UserID)
 	}
 
-	obsSvc.PublishEvent(evt)
+	obsSvc.PublishEvent(ctx.Context, evt)
 }
 
 // publishFlowStartedEvent publishes an observability event when flow execution starts.
@@ -1120,7 +1124,7 @@ func publishFlowStartedEvent(ctx *EngineContext, obsSvc observability.Observabil
 		evt.WithData(event.DataKey.UserID, ctx.AuthenticatedUser.UserID)
 	}
 
-	obsSvc.PublishEvent(evt)
+	obsSvc.PublishEvent(ctx.Context, evt)
 }
 
 // publishFlowCompletedEvent publishes an observability event when flow execution completes successfully.
@@ -1153,7 +1157,7 @@ func publishFlowCompletedEvent(
 		evt.WithData(event.DataKey.UserID, ctx.AuthenticatedUser.UserID)
 	}
 
-	obsSvc.PublishEvent(evt)
+	obsSvc.PublishEvent(ctx.Context, evt)
 }
 
 // publishFlowFailedEvent publishes an observability event when flow execution fails.
@@ -1187,7 +1191,7 @@ func publishFlowFailedEvent(ctx *EngineContext, svcErr *serviceerror.ServiceErro
 		evt.WithData(event.DataKey.UserID, ctx.AuthenticatedUser.UserID)
 	}
 
-	obsSvc.PublishEvent(evt)
+	obsSvc.PublishEvent(ctx.Context, evt)
 }
 
 // processServiceErrorForEventPublish processes a service error to extract relevant information

--- a/backend/internal/flow/flowexec/engine_event_enabled_test.go
+++ b/backend/internal/flow/flowexec/engine_event_enabled_test.go
@@ -60,7 +60,7 @@ func setupMockObservability(t *testing.T) *observabilitymock.ObservabilityServic
 
 	// Setup common expectations - allow any number of calls
 	mockObs.On("IsEnabled").Return(true).Maybe()
-	mockObs.On("PublishEvent", mock.Anything).Return().Maybe()
+	mockObs.On("PublishEvent", mock.Anything, mock.Anything).Return().Maybe()
 	mockObs.On("Shutdown").Return().Maybe()
 
 	return mockObs
@@ -89,7 +89,7 @@ func TestPublishFlowStartedEvent(t *testing.T) {
 
 		// Verify mock was called
 		mockObs.AssertCalled(t, "IsEnabled")
-		mockObs.AssertCalled(t, "PublishEvent", mock.Anything)
+		mockObs.AssertCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 	})
 
 	t.Run("without_authenticated_user", func(t *testing.T) {
@@ -105,7 +105,7 @@ func TestPublishFlowStartedEvent(t *testing.T) {
 
 		// Verify mock was called
 		mockObs.AssertCalled(t, "IsEnabled")
-		mockObs.AssertCalled(t, "PublishEvent", mock.Anything)
+		mockObs.AssertCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 	})
 }
 
@@ -134,7 +134,7 @@ func TestPublishFlowCompletedEvent(t *testing.T) {
 
 	// Verify mock was called
 	mockObs.AssertCalled(t, "IsEnabled")
-	mockObs.AssertCalled(t, "PublishEvent", mock.Anything)
+	mockObs.AssertCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 }
 
 // TestPublishFlowFailedEvent tests the flow failed event publishing
@@ -165,7 +165,7 @@ func TestPublishFlowFailedEvent(t *testing.T) {
 
 		// Verify mock was called
 		mockObs.AssertCalled(t, "IsEnabled")
-		mockObs.AssertCalled(t, "PublishEvent", mock.Anything)
+		mockObs.AssertCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 	})
 
 	t.Run("without_error_description", func(t *testing.T) {
@@ -189,7 +189,7 @@ func TestPublishFlowFailedEvent(t *testing.T) {
 
 		// Verify mock was called
 		mockObs.AssertCalled(t, "IsEnabled")
-		mockObs.AssertCalled(t, "PublishEvent", mock.Anything)
+		mockObs.AssertCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 	})
 }
 
@@ -216,7 +216,7 @@ func TestPublishNodeExecutionStartedEvent(t *testing.T) {
 
 		// Verify mock was called
 		mockObs.AssertCalled(t, "IsEnabled")
-		mockObs.AssertCalled(t, "PublishEvent", mock.Anything)
+		mockObs.AssertCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 	})
 
 	t.Run("retry_node_execution", func(t *testing.T) {
@@ -246,7 +246,7 @@ func TestPublishNodeExecutionStartedEvent(t *testing.T) {
 
 		// Verify mock was called
 		mockObs.AssertCalled(t, "IsEnabled")
-		mockObs.AssertCalled(t, "PublishEvent", mock.Anything)
+		mockObs.AssertCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 	})
 }
 
@@ -290,7 +290,7 @@ func TestPublishNodeExecutionCompletedEvent(t *testing.T) {
 
 		// Verify mock was called
 		mockObs.AssertCalled(t, "IsEnabled")
-		mockObs.AssertCalled(t, "PublishEvent", mock.Anything)
+		mockObs.AssertCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 	})
 
 	t.Run("node_failed_with_error", func(t *testing.T) {
@@ -328,7 +328,7 @@ func TestPublishNodeExecutionCompletedEvent(t *testing.T) {
 
 		// Verify mock was called
 		mockObs.AssertCalled(t, "IsEnabled")
-		mockObs.AssertCalled(t, "PublishEvent", mock.Anything)
+		mockObs.AssertCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 	})
 
 	t.Run("node_incomplete_status", func(t *testing.T) {
@@ -361,7 +361,7 @@ func TestPublishNodeExecutionCompletedEvent(t *testing.T) {
 
 		// Verify mock was called
 		mockObs.AssertCalled(t, "IsEnabled")
-		mockObs.AssertCalled(t, "PublishEvent", mock.Anything)
+		mockObs.AssertCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 	})
 }
 
@@ -383,7 +383,7 @@ func TestObservabilityDisabled(t *testing.T) {
 
 	mockObs := &observabilitymock.ObservabilityServiceInterfaceMock{}
 	mockObs.On("IsEnabled").Return(false).Maybe()
-	mockObs.On("PublishEvent", mock.Anything).Return().Maybe()
+	mockObs.On("PublishEvent", mock.Anything, mock.Anything).Return().Maybe()
 
 	// Try to publish an event
 	ctx := &EngineContext{
@@ -397,5 +397,5 @@ func TestObservabilityDisabled(t *testing.T) {
 
 	// Verify IsEnabled was called but PublishEvent was NOT called
 	mockObs.AssertCalled(t, "IsEnabled")
-	mockObs.AssertNotCalled(t, "PublishEvent", mock.Anything)
+	mockObs.AssertNotCalled(t, "PublishEvent", mock.Anything, mock.Anything)
 }

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -2033,9 +2033,9 @@ func (s *EngineTestSuite) TestPublishNodeExecutionCompletedEvent_NodeRespErrorPu
 	mockObservability.On("IsEnabled").Return(true)
 
 	var capturedEvent *event.Event
-	mockObservability.On("PublishEvent", mock.AnythingOfType("*event.Event")).
+	mockObservability.On("PublishEvent", mock.Anything, mock.AnythingOfType("*event.Event")).
 		Run(func(args mock.Arguments) {
-			capturedEvent = args.Get(0).(*event.Event)
+			capturedEvent = args.Get(1).(*event.Event)
 		}).Return()
 
 	mockNode := coremock.NewNodeInterfaceMock(t)
@@ -2098,9 +2098,9 @@ func (s *EngineTestSuite) TestPublishNodeExecutionCompletedEvent_NodeErrTakesPre
 	mockObservability.On("IsEnabled").Return(true)
 
 	var capturedEvent *event.Event
-	mockObservability.On("PublishEvent", mock.AnythingOfType("*event.Event")).
+	mockObservability.On("PublishEvent", mock.Anything, mock.AnythingOfType("*event.Event")).
 		Run(func(args mock.Arguments) {
-			capturedEvent = args.Get(0).(*event.Event)
+			capturedEvent = args.Get(1).(*event.Event)
 		}).Return()
 
 	mockNode := coremock.NewNodeInterfaceMock(t)
@@ -2159,9 +2159,9 @@ func (s *EngineTestSuite) TestPublishNodeExecutionCompletedEvent_NoErrorPublishe
 	mockObservability.On("IsEnabled").Return(true)
 
 	var capturedEvent *event.Event
-	mockObservability.On("PublishEvent", mock.AnythingOfType("*event.Event")).
+	mockObservability.On("PublishEvent", mock.Anything, mock.AnythingOfType("*event.Event")).
 		Run(func(args mock.Arguments) {
-			capturedEvent = args.Get(0).(*event.Event)
+			capturedEvent = args.Get(1).(*event.Event)
 		}).Return()
 
 	mockNode := coremock.NewNodeInterfaceMock(t)

--- a/backend/internal/flow/flowexec/handler.go
+++ b/backend/internal/flow/flowexec/handler.go
@@ -19,6 +19,7 @@
 package flowexec
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
@@ -44,7 +45,7 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 
 	flowR, err := sysutils.DecodeJSONBody[FlowRequest](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, APIErrorFlowRequestJSONDecodeError)
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, APIErrorFlowRequestJSONDecodeError)
 		return
 	}
 
@@ -61,7 +62,7 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 		r.Context(), appID, executionID, flowTypeStr, verbose, action, inputs, challengeToken)
 
 	if flowErr != nil {
-		handleFlowError(w, flowErr)
+		handleFlowError(r.Context(), w, flowErr)
 		return
 	}
 
@@ -83,14 +84,14 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 		ChallengeToken: flowStep.ChallengeToken,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, flowResp)
+	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, flowResp)
 
 	logger.DebugWithContext(r.Context(), "Flow execution request handled successfully",
 		log.String(log.LoggerKeyExecutionID, flowResp.ExecutionID))
 }
 
 // handleFlowError handles errors that occur during flow execution as an API error response.
-func handleFlowError(w http.ResponseWriter, flowErr *serviceerror.ServiceError) {
+func handleFlowError(ctx context.Context, w http.ResponseWriter, flowErr *serviceerror.ServiceError) {
 	errResp := apierror.ErrorResponse{
 		Code:        flowErr.Code,
 		Message:     flowErr.Error,
@@ -102,7 +103,7 @@ func handleFlowError(w http.ResponseWriter, flowErr *serviceerror.ServiceError) 
 		statusCode = http.StatusBadRequest
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }
 
 // convertToAPIError converts service errors that occur during flow step execution as an API error response.

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -122,7 +122,7 @@ func (s *flowExecService) Execute(ctx context.Context,
 					WithData(event.DataKey.FlowType, flowType).
 					WithData(event.DataKey.Error, processServiceErrorForEventPublish(loadErr))
 
-				s.observabilitySvc.PublishEvent(evt)
+				s.observabilitySvc.PublishEvent(ctx, evt)
 			}
 			return nil, loadErr
 		}

--- a/backend/internal/flow/flowmeta/handler.go
+++ b/backend/internal/flow/flowmeta/handler.go
@@ -19,6 +19,7 @@
 package flowmeta
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
@@ -60,12 +61,12 @@ func (h *flowMetaHandler) HandleGetFlowMetadata(w http.ResponseWriter, r *http.R
 
 	// Validate parameter combinations: id requires type, and type requires id
 	if id != "" && metaType == "" {
-		handleServiceError(w, &ErrorMissingType)
+		handleServiceError(r.Context(), w, &ErrorMissingType)
 		return
 	}
 
 	if metaType != "" && id == "" {
-		handleServiceError(w, &ErrorMissingID)
+		handleServiceError(r.Context(), w, &ErrorMissingID)
 		return
 	}
 	if language != nil {
@@ -80,19 +81,19 @@ func (h *flowMetaHandler) HandleGetFlowMetadata(w http.ResponseWriter, r *http.R
 	// Call service
 	metadata, svcErr := h.flowMetaService.GetFlowMetadata(r.Context(), MetaType(metaType), id, language, namespace)
 	if svcErr != nil {
-		handleServiceError(w, svcErr)
+		handleServiceError(r.Context(), w, svcErr)
 		return
 	}
 
 	// Return success response
-	sysutils.WriteSuccessResponse(w, http.StatusOK, metadata)
+	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, metadata)
 	h.logger.DebugWithContext(r.Context(), "Flow metadata retrieved successfully",
 		log.String("type", metaType),
 		log.String("id", id))
 }
 
 // handleServiceError converts service errors to appropriate HTTP responses.
-func handleServiceError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func handleServiceError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	errResp := apierror.ErrorResponse{
 		Code:        svcErr.Code,
 		Message:     svcErr.Error,
@@ -109,5 +110,5 @@ func handleServiceError(w http.ResponseWriter, svcErr *serviceerror.ServiceError
 		}
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }

--- a/backend/internal/flow/flowmeta/service.go
+++ b/backend/internal/flow/flowmeta/service.go
@@ -284,7 +284,7 @@ func (fms *flowMetaService) populateI18nMetadata(
 	ctx context.Context, response *FlowMetadataResponse, lang string, ns string) {
 	i18nResp, i18nErr := fms.i18nService.ResolveTranslations(ctx, lang, ns)
 	if i18nErr != nil {
-		fms.logger.Debug("Failed to get i18n translations",
+		fms.logger.DebugWithContext(ctx, "Failed to get i18n translations",
 			log.String("language", lang),
 			log.String("namespace", ns),
 			log.String("error", i18nErr.Error.DefaultValue))
@@ -296,7 +296,7 @@ func (fms *flowMetaService) populateI18nMetadata(
 
 	languages, i18nErr := fms.i18nService.ListLanguages(ctx)
 	if i18nErr != nil {
-		fms.logger.Debug("Failed to list languages",
+		fms.logger.DebugWithContext(ctx, "Failed to list languages",
 			log.String("error", i18nErr.Error.DefaultValue))
 		response.I18n.Languages = []string{i18nmgt.SystemLanguage}
 		return

--- a/backend/internal/flow/mgt/declarative_resource.go
+++ b/backend/internal/flow/mgt/declarative_resource.go
@@ -85,7 +85,7 @@ func (e *flowGraphExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates a flow graph resource.
-func (e *flowGraphExporter) ValidateResource(
+func (e *flowGraphExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	flow, ok := resource.(*CompleteFlowDefinition)
@@ -93,7 +93,7 @@ func (e *flowGraphExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeFlow, id)
 	}
 
-	if err := declarativeresource.ValidateResourceName(
+	if err := declarativeresource.ValidateResourceName(ctx,
 		flow.Name, resourceTypeFlow, id, "FLOW_VALIDATION_ERROR", logger); err != nil {
 		return "", err
 	}

--- a/backend/internal/flow/mgt/declarative_resource_test.go
+++ b/backend/internal/flow/mgt/declarative_resource_test.go
@@ -281,7 +281,7 @@ func (s *DeclarativeResourceTestSuite) TestFlowGraphExporter_ValidateResource() 
 	}
 
 	logger := log.GetLogger()
-	name, exportErr := exporter.ValidateResource(flow, "flow-001", logger)
+	name, exportErr := exporter.ValidateResource(context.Background(), flow, "flow-001", logger)
 
 	assert.Nil(s.T(), exportErr)
 	assert.Equal(s.T(), "Valid Flow Name", name)
@@ -293,7 +293,7 @@ func (s *DeclarativeResourceTestSuite) TestFlowGraphExporter_ValidateResource_In
 	exporter := newFlowGraphExporter(mockService)
 
 	logger := log.GetLogger()
-	_, exportErr := exporter.ValidateResource("not a flow", "invalid", logger)
+	_, exportErr := exporter.ValidateResource(context.Background(), "not a flow", "invalid", logger)
 
 	assert.NotNil(s.T(), exportErr)
 	assert.Equal(s.T(), "flow", exportErr.ResourceType)
@@ -312,7 +312,7 @@ func (s *DeclarativeResourceTestSuite) TestFlowGraphExporter_ValidateResource_Em
 	}
 
 	logger := log.GetLogger()
-	name, exportErr := exporter.ValidateResource(flow, "flow-001", logger)
+	name, exportErr := exporter.ValidateResource(context.Background(), flow, "flow-001", logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), exportErr)
@@ -549,7 +549,7 @@ func (s *DeclarativeResourceTestSuite) TestFlowGraphExporterIntegration() {
 
 	// Validate resource
 	logger := log.GetLogger()
-	validName, exportErr := exporter.ValidateResource(resource, ids[0], logger)
+	validName, exportErr := exporter.ValidateResource(context.Background(), resource, ids[0], logger)
 	assert.Nil(s.T(), exportErr)
 	assert.Equal(s.T(), "Authentication Flow", validName)
 }

--- a/backend/internal/flow/mgt/handler.go
+++ b/backend/internal/flow/mgt/handler.go
@@ -19,6 +19,7 @@
 package flowmgt
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -68,7 +69,7 @@ func (h *flowMgtHandler) listFlows(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	limit, offset, svcErr := parsePaginationParams(r)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -77,11 +78,11 @@ func (h *flowMgtHandler) listFlows(w http.ResponseWriter, r *http.Request) {
 
 	flowList, svcErr := h.service.ListFlows(ctx, limit, offset, flowType)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusOK, flowList)
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, flowList)
 	h.logger.DebugWithContext(ctx, "Flows listed successfully", log.Int(logKeyCount, flowList.Count))
 }
 
@@ -90,18 +91,18 @@ func (h *flowMgtHandler) createFlow(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	flowDefRequest, err := utils.DecodeJSONBody[FlowDefinitionRequest](r)
 	if err != nil {
-		handleInvalidRequestError(w)
+		handleInvalidRequestError(ctx, w)
 		return
 	}
 
 	sanitized := sanitizeFlowDefinitionRequest(flowDefRequest)
 	createdFlow, svcErr := h.service.CreateFlow(ctx, sanitized)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusCreated, createdFlow)
+	utils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdFlow)
 	h.logger.DebugWithContext(ctx, "Flow created successfully", log.String(logKeyFlowID, createdFlow.ID))
 }
 
@@ -110,17 +111,17 @@ func (h *flowMgtHandler) getFlow(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	flowID := r.PathValue(pathParamFlowID)
 	if flowID == "" {
-		handleError(w, &ErrorMissingFlowID)
+		handleError(ctx, w, &ErrorMissingFlowID)
 		return
 	}
 
 	flow, svcErr := h.service.GetFlow(ctx, flowID)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusOK, flow)
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, flow)
 	h.logger.DebugWithContext(ctx, "Flow retrieved successfully", log.String(logKeyFlowID, flowID))
 }
 
@@ -129,24 +130,24 @@ func (h *flowMgtHandler) updateFlow(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	flowID := r.PathValue(pathParamFlowID)
 	if flowID == "" {
-		handleError(w, &ErrorMissingFlowID)
+		handleError(ctx, w, &ErrorMissingFlowID)
 		return
 	}
 
 	flowDefRequest, err := utils.DecodeJSONBody[FlowDefinitionRequest](r)
 	if err != nil {
-		handleInvalidRequestError(w)
+		handleInvalidRequestError(ctx, w)
 		return
 	}
 
 	sanitized := sanitizeFlowDefinitionRequest(flowDefRequest)
 	updatedFlow, svcErr := h.service.UpdateFlow(ctx, flowID, sanitized)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusOK, updatedFlow)
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, updatedFlow)
 	h.logger.DebugWithContext(ctx, "Flow updated successfully", log.String(logKeyFlowID, flowID))
 }
 
@@ -155,13 +156,13 @@ func (h *flowMgtHandler) deleteFlow(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	flowID := r.PathValue(pathParamFlowID)
 	if flowID == "" {
-		handleError(w, &ErrorMissingFlowID)
+		handleError(ctx, w, &ErrorMissingFlowID)
 		return
 	}
 
 	svcErr := h.service.DeleteFlow(ctx, flowID)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -176,17 +177,17 @@ func (h *flowMgtHandler) listFlowVersions(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	flowID := r.PathValue(pathParamFlowID)
 	if flowID == "" {
-		handleError(w, &ErrorMissingFlowID)
+		handleError(ctx, w, &ErrorMissingFlowID)
 		return
 	}
 
 	versionList, svcErr := h.service.ListFlowVersions(ctx, flowID)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusOK, versionList)
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, versionList)
 	h.logger.DebugWithContext(ctx, "Flow versions listed successfully", log.String(logKeyFlowID, flowID))
 }
 
@@ -197,23 +198,23 @@ func (h *flowMgtHandler) getFlowVersion(w http.ResponseWriter, r *http.Request) 
 	versionStr := r.PathValue(pathParamVersion)
 
 	if flowID == "" || versionStr == "" {
-		handleError(w, &ErrorMissingFlowID)
+		handleError(ctx, w, &ErrorMissingFlowID)
 		return
 	}
 
 	version, err := strconv.Atoi(versionStr)
 	if err != nil || version <= 0 {
-		handleError(w, &ErrorInvalidVersion)
+		handleError(ctx, w, &ErrorInvalidVersion)
 		return
 	}
 
 	flowVersion, svcErr := h.service.GetFlowVersion(ctx, flowID, version)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusOK, flowVersion)
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, flowVersion)
 	h.logger.DebugWithContext(ctx, "Flow version retrieved successfully",
 		log.String(logKeyFlowID, flowID), log.Int(logKeyVersion, version))
 }
@@ -223,23 +224,23 @@ func (h *flowMgtHandler) restoreFlowVersion(w http.ResponseWriter, r *http.Reque
 	ctx := r.Context()
 	flowID := r.PathValue(pathParamFlowID)
 	if flowID == "" {
-		handleError(w, &ErrorMissingFlowID)
+		handleError(ctx, w, &ErrorMissingFlowID)
 		return
 	}
 
 	request, err := utils.DecodeJSONBody[RestoreVersionRequest](r)
 	if err != nil {
-		handleInvalidRequestError(w)
+		handleInvalidRequestError(ctx, w)
 		return
 	}
 
 	flow, svcErr := h.service.RestoreFlowVersion(ctx, flowID, request.Version)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusOK, flow)
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, flow)
 	h.logger.DebugWithContext(ctx, "Flow version restored successfully",
 		log.String(logKeyFlowID, flowID), log.Int(logKeyVersion, request.Version))
 }
@@ -285,17 +286,17 @@ func sanitizeFlowDefinitionRequest(req *FlowDefinitionRequest) *FlowDefinition {
 }
 
 // handleInvalidRequestError writes a standardized error response for invalid requests.
-func handleInvalidRequestError(w http.ResponseWriter) {
+func handleInvalidRequestError(ctx context.Context, w http.ResponseWriter) {
 	errResp := apierror.ErrorResponse{
 		Code:        ErrorInvalidRequestFormat.Code,
 		Message:     ErrorInvalidRequestFormat.Error,
 		Description: ErrorInvalidRequestFormat.ErrorDescription,
 	}
-	utils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+	utils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 }
 
 // handleError writes an error response based on the provided ServiceError.
-func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	errResp := apierror.ErrorResponse{
 		Code:        svcErr.Code,
 		Message:     svcErr.Error,
@@ -310,11 +311,11 @@ func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 		statusCode = http.StatusConflict
 	case serviceerror.InternalServerError.Code:
 		statusCode = http.StatusInternalServerError
-		log.GetLogger().Error("Internal server error in flow handler",
+		log.GetLogger().ErrorWithContext(ctx, "Internal server error in flow handler",
 			log.String("code", svcErr.Code),
 			log.String("error", svcErr.Error.DefaultValue),
 			log.String("description", svcErr.ErrorDescription.DefaultValue))
 	}
 
-	utils.WriteErrorResponse(w, statusCode, errResp)
+	utils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }

--- a/backend/internal/group/declarative_resource.go
+++ b/backend/internal/group/declarative_resource.go
@@ -110,7 +110,7 @@ func (e *groupExporter) GetResourceByID(
 }
 
 // ValidateResource validates a group resource.
-func (e *groupExporter) ValidateResource(
+func (e *groupExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	grp, ok := resource.(*groupDeclarativeResource)
@@ -118,7 +118,7 @@ func (e *groupExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeGroup, id)
 	}
 
-	if err := declarativeresource.ValidateResourceName(
+	if err := declarativeresource.ValidateResourceName(ctx,
 		grp.Name, resourceTypeGroup, id, "GROUP_VALIDATION_ERROR", logger); err != nil {
 		return "", err
 	}
@@ -193,7 +193,9 @@ func loadDeclarativeResources(
 			if v, ok := data.(*groupDeclarativeResource); ok {
 				return v.ID
 			}
-			log.GetLogger().Error("IDExtractor: type assertion failed for groupDeclarativeResource")
+			// Declarative resource loading runs during startup, outside any request.
+			log.GetLogger().ErrorWithContext(context.Background(),
+				"IDExtractor: type assertion failed for groupDeclarativeResource")
 			return ""
 		},
 	}

--- a/backend/internal/group/declarative_resource_test.go
+++ b/backend/internal/group/declarative_resource_test.go
@@ -288,7 +288,7 @@ func (suite *GroupExporterTestSuite) TestValidateResource_Success() {
 	}
 	logger := log.GetLogger()
 
-	name, exportErr := suite.exporter.ValidateResource(resource, "group1", logger)
+	name, exportErr := suite.exporter.ValidateResource(context.Background(), resource, "group1", logger)
 
 	suite.Nil(exportErr)
 	assert.Equal(suite.T(), "Admins", name)
@@ -306,7 +306,7 @@ func (suite *GroupExporterTestSuite) TestValidateResource_WithMembers() {
 	}
 	logger := log.GetLogger()
 
-	name, exportErr := suite.exporter.ValidateResource(resource, "group1", logger)
+	name, exportErr := suite.exporter.ValidateResource(context.Background(), resource, "group1", logger)
 
 	suite.Nil(exportErr)
 	assert.Equal(suite.T(), "Admins", name)
@@ -316,7 +316,7 @@ func (suite *GroupExporterTestSuite) TestValidateResource_WithMembers() {
 func (suite *GroupExporterTestSuite) TestValidateResource_WrongType() {
 	logger := log.GetLogger()
 
-	name, exportErr := suite.exporter.ValidateResource("not a group", "group1", logger)
+	name, exportErr := suite.exporter.ValidateResource(context.Background(), "not a group", "group1", logger)
 
 	suite.NotNil(exportErr)
 	assert.Empty(suite.T(), name)
@@ -331,7 +331,7 @@ func (suite *GroupExporterTestSuite) TestValidateResource_EmptyName() {
 	}
 	logger := log.GetLogger()
 
-	name, exportErr := suite.exporter.ValidateResource(resource, "group1", logger)
+	name, exportErr := suite.exporter.ValidateResource(context.Background(), resource, "group1", logger)
 
 	suite.NotNil(exportErr)
 	assert.Empty(suite.T(), name)

--- a/backend/internal/group/file_based_store.go
+++ b/backend/internal/group/file_based_store.go
@@ -75,7 +75,7 @@ func (f *fileBasedGroupStore) GetGroupList(ctx context.Context, limit, offset in
 	for _, item := range list {
 		grpData, err := groupFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
-			log.GetLogger().Warn("Skipping malformed group in GetGroupList",
+			log.GetLogger().WarnWithContext(ctx, "Skipping malformed group in GetGroupList",
 				log.String("groupID", item.ID.ID),
 				log.Error(err))
 			continue
@@ -447,7 +447,7 @@ func (f *fileBasedGroupStore) GetGroupsByIDs(ctx context.Context, groupIDs []str
 		}
 		grpData, err := groupFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
-			log.GetLogger().Warn("Skipping malformed group in GetGroupsByIDs",
+			log.GetLogger().WarnWithContext(ctx, "Skipping malformed group in GetGroupsByIDs",
 				log.String("groupID", item.ID.ID),
 				log.Error(err))
 			continue

--- a/backend/internal/group/handler.go
+++ b/backend/internal/group/handler.go
@@ -19,6 +19,7 @@
 package group
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -53,7 +54,7 @@ func (gh *groupHandler) HandleGroupListRequest(w http.ResponseWriter, r *http.Re
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -61,11 +62,11 @@ func (gh *groupHandler) HandleGroupListRequest(w http.ResponseWriter, r *http.Re
 
 	groupListResponse, svcErr := gh.groupService.GetGroupList(ctx, limit, offset, includeDisplay)
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, groupListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, groupListResponse)
 
 	logger.DebugWithContext(ctx, "Successfully listed groups with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -86,7 +87,7 @@ func (gh *groupHandler) HandleGroupListByPathRequest(w http.ResponseWriter, r *h
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -94,11 +95,11 @@ func (gh *groupHandler) HandleGroupListByPathRequest(w http.ResponseWriter, r *h
 
 	groupListResponse, svcErr := gh.groupService.GetGroupsByPath(ctx, path, limit, offset, includeDisplay)
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, groupListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, groupListResponse)
 
 	logger.DebugWithContext(ctx, "Successfully listed groups by path", log.String("path", path),
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -121,18 +122,18 @@ func (gh *groupHandler) HandleGroupPostRequest(w http.ResponseWriter, r *http.Re
 				Key:          "error.groupservice.create_group_request_parse_failed_description",
 				DefaultValue: "Failed to parse request body: " + err.Error()},
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	sanitizedRequest := gh.sanitizeCreateGroupRequest(createRequest)
 	createdGroup, svcErr := gh.groupService.CreateGroup(ctx, sanitizedRequest)
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdGroup)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdGroup)
 
 	logger.DebugWithContext(ctx, "Successfully created group", log.String("group id", createdGroup.ID))
 }
@@ -157,17 +158,17 @@ func (gh *groupHandler) HandleGroupPostByPathRequest(w http.ResponseWriter, r *h
 				Key:          "error.groupservice.create_group_by_path_request_parse_failed_description",
 				DefaultValue: "Failed to parse request body: " + err.Error()},
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	group, svcErr := gh.groupService.CreateGroupByPath(ctx, path, *createRequest)
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, group)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, group)
 
 	logger.DebugWithContext(ctx, "Successfully created group by path",
 		log.String("path", path), log.String("groupName", group.Name))
@@ -186,7 +187,7 @@ func (gh *groupHandler) HandleGroupGetRequest(w http.ResponseWriter, r *http.Req
 			Message:     ErrorMissingGroupID.Error,
 			Description: ErrorMissingGroupID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -194,11 +195,11 @@ func (gh *groupHandler) HandleGroupGetRequest(w http.ResponseWriter, r *http.Req
 
 	group, svcErr := gh.groupService.GetGroup(ctx, id, includeDisplay)
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, group)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, group)
 
 	logger.DebugWithContext(ctx, "Successfully retrieved group", log.String("group id", id))
 }
@@ -216,7 +217,7 @@ func (gh *groupHandler) HandleGroupPutRequest(w http.ResponseWriter, r *http.Req
 			Message:     ErrorMissingGroupID.Error,
 			Description: ErrorMissingGroupID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -230,18 +231,18 @@ func (gh *groupHandler) HandleGroupPutRequest(w http.ResponseWriter, r *http.Req
 				DefaultValue: "Failed to parse request body: " + err.Error(),
 			},
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	sanitizedRequest := gh.sanitizeUpdateGroupRequest(updateRequest)
 	group, svcErr := gh.groupService.UpdateGroup(ctx, id, sanitizedRequest)
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, group)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, group)
 
 	logger.DebugWithContext(ctx, "Successfully updated group", log.String("group id", id))
 }
@@ -259,17 +260,17 @@ func (gh *groupHandler) HandleGroupDeleteRequest(w http.ResponseWriter, r *http.
 			Message:     ErrorMissingGroupID.Error,
 			Description: ErrorMissingGroupID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	svcErr := gh.groupService.DeleteGroup(ctx, id)
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	logger.DebugWithContext(ctx, "Successfully deleted group", log.String("group id", id))
 }
 
@@ -286,13 +287,13 @@ func (gh *groupHandler) HandleGroupMembersGetRequest(w http.ResponseWriter, r *h
 			Message:     ErrorMissingGroupID.Error,
 			Description: ErrorMissingGroupID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -300,11 +301,11 @@ func (gh *groupHandler) HandleGroupMembersGetRequest(w http.ResponseWriter, r *h
 
 	memberListResponse, svcErr := gh.groupService.GetGroupMembers(ctx, id, limit, offset, includeDisplay)
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, memberListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, memberListResponse)
 
 	logger.DebugWithContext(ctx, "Successfully retrieved group members", log.String("group id", id),
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -313,19 +314,21 @@ func (gh *groupHandler) HandleGroupMembersGetRequest(w http.ResponseWriter, r *h
 }
 
 // HandleGroupMembersAddRequest handles the add members to group request.
+//
+//nolint:dupl // Add/Remove member handlers share the same request-handling skeleton with method-specific service calls.
 func (gh *groupHandler) HandleGroupMembersAddRequest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
 	id := r.PathValue("id")
 	if id == "" {
-		gh.handleError(w, &ErrorMissingGroupID)
+		gh.handleError(ctx, w, &ErrorMissingGroupID)
 		return
 	}
 
 	membersRequest, err := sysutils.DecodeJSONBody[MembersRequest](r)
 	if err != nil {
-		gh.handleError(w, &ErrorInvalidRequestFormat)
+		gh.handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -333,28 +336,30 @@ func (gh *groupHandler) HandleGroupMembersAddRequest(w http.ResponseWriter, r *h
 
 	group, svcErr := gh.groupService.AddGroupMembers(ctx, id, sanitizedRequest.Members)
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, group)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, group)
 	logger.DebugWithContext(ctx, "Successfully added members to group", log.String("group id", id))
 }
 
 // HandleGroupMembersRemoveRequest handles the remove members from group request.
+//
+//nolint:dupl // Add/Remove member handlers share the same request-handling skeleton with method-specific service calls.
 func (gh *groupHandler) HandleGroupMembersRemoveRequest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
 
 	id := r.PathValue("id")
 	if id == "" {
-		gh.handleError(w, &ErrorMissingGroupID)
+		gh.handleError(ctx, w, &ErrorMissingGroupID)
 		return
 	}
 
 	membersRequest, err := sysutils.DecodeJSONBody[MembersRequest](r)
 	if err != nil {
-		gh.handleError(w, &ErrorInvalidRequestFormat)
+		gh.handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -362,16 +367,16 @@ func (gh *groupHandler) HandleGroupMembersRemoveRequest(w http.ResponseWriter, r
 
 	group, svcErr := gh.groupService.RemoveGroupMembers(ctx, id, sanitizedRequest.Members)
 	if svcErr != nil {
-		gh.handleError(w, svcErr)
+		gh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, group)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, group)
 	logger.DebugWithContext(ctx, "Successfully removed members from group", log.String("group id", id))
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.
-func (gh *groupHandler) handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func (gh *groupHandler) handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	var statusCode int
 	if svcErr.Type == serviceerror.ClientErrorType {
 		switch svcErr.Code {
@@ -399,7 +404,7 @@ func (gh *groupHandler) handleError(w http.ResponseWriter, svcErr *serviceerror.
 		Message:     svcErr.Error,
 		Description: svcErr.ErrorDescription,
 	}
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }
 
 // sanitizeCreateGroupRequest sanitizes the create group request input.
@@ -487,7 +492,7 @@ func extractAndValidatePath(w http.ResponseWriter, r *http.Request) (string, boo
 				DefaultValue: "Handle path is required",
 			},
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, errResp)
 		return "", true
 	}
 	return path, false

--- a/backend/internal/group/handler_test.go
+++ b/backend/internal/group/handler_test.go
@@ -19,6 +19,7 @@
 package group
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -1424,7 +1425,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleErrorInternalServer()
 	handler := newGroupHandler(nil)
 	rr := httptest.NewRecorder()
 
-	handler.handleError(rr, &serviceerror.ServiceError{
+	handler.handleError(context.Background(), rr, &serviceerror.ServiceError{
 		Type:             serviceerror.ServerErrorType,
 		Code:             "GRP-9999",
 		Error:            i18ncore.I18nMessage{DefaultValue: "boom"},
@@ -1700,7 +1701,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleErrorClientError() {
 	handler := newGroupHandler(nil)
 	rr := httptest.NewRecorder()
 
-	handler.handleError(rr, &ErrorGroupNameConflict)
+	handler.handleError(context.Background(), rr, &ErrorGroupNameConflict)
 
 	require.Equal(t, http.StatusConflict, rr.Code)
 

--- a/backend/internal/group/service.go
+++ b/backend/internal/group/service.go
@@ -273,7 +273,7 @@ func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequ
 	logger.DebugWithContext(ctx, "Creating group", log.String("name", request.Name))
 
 	if isGroupDeclarativeModeEnabled() {
-		logger.Debug("Cannot create group in declarative-only mode")
+		logger.DebugWithContext(ctx, "Cannot create group in declarative-only mode")
 		return nil, &ErrorDeclarativeModeGroupCreateNotAllowed
 	}
 
@@ -465,10 +465,11 @@ func (gs *groupService) UpdateGroup(
 	}
 
 	if isDeclarative, err := gs.groupStore.IsGroupDeclarative(ctx, groupID); err != nil {
-		logger.Warn("Failed to check if group is declarative", log.String("groupID", groupID), log.Error(err))
+		logger.WarnWithContext(ctx, "Failed to check if group is declarative",
+			log.String("groupID", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	} else if isDeclarative {
-		logger.Debug("Cannot update declarative group", log.String("id", groupID))
+		logger.DebugWithContext(ctx, "Cannot update declarative group", log.String("id", groupID))
 		return nil, &ErrorImmutableGroup
 	}
 
@@ -573,10 +574,11 @@ func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *servic
 	}
 
 	if isDeclarative, err := gs.groupStore.IsGroupDeclarative(ctx, groupID); err != nil {
-		logger.Warn("Failed to check if group is declarative", log.String("groupID", groupID), log.Error(err))
+		logger.WarnWithContext(ctx, "Failed to check if group is declarative",
+			log.String("groupID", groupID), log.Error(err))
 		return &serviceerror.InternalServerError
 	} else if isDeclarative {
-		logger.Debug("Cannot delete declarative group", log.String("id", groupID))
+		logger.DebugWithContext(ctx, "Cannot delete declarative group", log.String("id", groupID))
 		return &ErrorImmutableGroup
 	}
 
@@ -783,7 +785,7 @@ func (gs *groupService) resolveMembers(
 func (gs *groupService) AddGroupMembers(
 	ctx context.Context, groupID string, members []Member) (*Group, *serviceerror.ServiceError) {
 	log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)).
-		Debug("Adding members to group", log.String("id", groupID))
+		DebugWithContext(ctx, "Adding members to group", log.String("id", groupID))
 	return gs.modifyGroupMembers(ctx, groupID, members,
 		gs.groupStore.AddGroupMembers,
 		"Failed to add members to group",
@@ -795,7 +797,7 @@ func (gs *groupService) AddGroupMembers(
 func (gs *groupService) RemoveGroupMembers(
 	ctx context.Context, groupID string, members []Member) (*Group, *serviceerror.ServiceError) {
 	log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)).
-		Debug("Removing members from group", log.String("id", groupID))
+		DebugWithContext(ctx, "Removing members from group", log.String("id", groupID))
 	return gs.modifyGroupMembers(ctx, groupID, members,
 		gs.groupStore.RemoveGroupMembers,
 		"Failed to remove members from group",

--- a/backend/internal/idp/declarative_resource.go
+++ b/backend/internal/idp/declarative_resource.go
@@ -90,14 +90,14 @@ func (e *idpExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates an identity provider resource.
-func (e *idpExporter) ValidateResource(
+func (e *idpExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger) (string, *declarativeresource.ExportError) {
 	idpDTO, ok := resource.(*IDPDTO)
 	if !ok {
 		return "", declarativeresource.CreateTypeError(resourceTypeIdentityProvider, id)
 	}
 
-	err := declarativeresource.ValidateResourceName(
+	err := declarativeresource.ValidateResourceName(ctx,
 		idpDTO.Name, resourceTypeIdentityProvider, id, "IDP_VALIDATION_ERROR", logger,
 	)
 	if err != nil {
@@ -105,7 +105,7 @@ func (e *idpExporter) ValidateResource(
 	}
 
 	if len(idpDTO.Properties) == 0 {
-		logger.Warn("Identity provider has no properties",
+		logger.WarnWithContext(ctx, "Identity provider has no properties",
 			log.String("idpID", id), log.String("name", idpDTO.Name))
 	}
 

--- a/backend/internal/idp/declarative_resource_test.go
+++ b/backend/internal/idp/declarative_resource_test.go
@@ -144,7 +144,7 @@ func (s *IDPExporterTestSuite) TestValidateResource_Success() {
 		Properties: []cmodels.Property{*prop},
 	}
 
-	name, err := s.exporter.ValidateResource(idpDTO, "idp1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), idpDTO, "idp1", s.logger)
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Valid IDP", name)
@@ -153,7 +153,7 @@ func (s *IDPExporterTestSuite) TestValidateResource_Success() {
 func (s *IDPExporterTestSuite) TestValidateResource_InvalidType() {
 	invalidResource := "not an IDP"
 
-	name, err := s.exporter.ValidateResource(invalidResource, "idp1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), invalidResource, "idp1", s.logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), err)
@@ -168,7 +168,7 @@ func (s *IDPExporterTestSuite) TestValidateResource_EmptyName() {
 		Name: "",
 	}
 
-	name, err := s.exporter.ValidateResource(idpDTO, "idp1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), idpDTO, "idp1", s.logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), err)
@@ -185,7 +185,7 @@ func (s *IDPExporterTestSuite) TestValidateResource_NoProperties() {
 		Properties: []cmodels.Property{},
 	}
 
-	name, err := s.exporter.ValidateResource(idpDTO, "idp1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), idpDTO, "idp1", s.logger)
 
 	// Should still succeed but log a warning
 	assert.Nil(s.T(), err)

--- a/backend/internal/idp/handler.go
+++ b/backend/internal/idp/handler.go
@@ -19,6 +19,7 @@
 package idp
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -54,14 +55,14 @@ func (ih *idpHandler) HandleIDPPostRequest(w http.ResponseWriter, r *http.Reques
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	properties, err := getSanitizedProperties(createRequest.Properties)
 	if err != nil {
 		logger.ErrorWithContext(ctx, "Failed to sanitize properties", log.Error(err))
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
+		writeServiceErrorResponse(ctx, w, &serviceerror.InternalServerError)
 		return
 	}
 
@@ -73,7 +74,7 @@ func (ih *idpHandler) HandleIDPPostRequest(w http.ResponseWriter, r *http.Reques
 	}
 	createdIDP, svcErr := ih.idpService.CreateIdentityProvider(ctx, idpDTO)
 	if svcErr != nil {
-		writeServiceErrorResponse(w, svcErr)
+		writeServiceErrorResponse(ctx, w, svcErr)
 		return
 	}
 
@@ -81,11 +82,11 @@ func (ih *idpHandler) HandleIDPPostRequest(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		logger.ErrorWithContext(ctx, "Failed to convert IDP to response",
 			log.String("idp", createdIDP.Name), log.Error(err))
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
+		writeServiceErrorResponse(ctx, w, &serviceerror.InternalServerError)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, idpResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, idpResponse)
 }
 
 // HandleIDPListRequest handles the list identity providers request.
@@ -93,7 +94,7 @@ func (ih *idpHandler) HandleIDPListRequest(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	idpList, svcErr := ih.idpService.GetIdentityProviderList(ctx)
 	if svcErr != nil {
-		writeServiceErrorResponse(w, svcErr)
+		writeServiceErrorResponse(ctx, w, svcErr)
 		return
 	}
 
@@ -108,7 +109,7 @@ func (ih *idpHandler) HandleIDPListRequest(w http.ResponseWriter, r *http.Reques
 		})
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, idpListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, idpListResponse)
 }
 
 // HandleIDPGetRequest handles the get identity provider request.
@@ -123,24 +124,24 @@ func (ih *idpHandler) HandleIDPGetRequest(w http.ResponseWriter, r *http.Request
 			Message:     ErrorInvalidIDPID.Error,
 			Description: ErrorInvalidIDPID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	idp, svcErr := ih.idpService.GetIdentityProvider(ctx, id)
 	if svcErr != nil {
-		writeServiceErrorResponse(w, svcErr)
+		writeServiceErrorResponse(ctx, w, svcErr)
 		return
 	}
 
 	idpResponse, err := getIDPResponse(*idp)
 	if err != nil {
 		logger.ErrorWithContext(ctx, "Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
+		writeServiceErrorResponse(ctx, w, &serviceerror.InternalServerError)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, idpResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, idpResponse)
 }
 
 // HandleIDPPutRequest handles the update identity provider request.
@@ -154,7 +155,7 @@ func (ih *idpHandler) HandleIDPPutRequest(w http.ResponseWriter, r *http.Request
 			Message:     ErrorInvalidIDPID.Error,
 			Description: ErrorInvalidIDPID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -165,14 +166,14 @@ func (ih *idpHandler) HandleIDPPutRequest(w http.ResponseWriter, r *http.Request
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	properties, err := getSanitizedProperties(updateRequest.Properties)
 	if err != nil {
 		logger.ErrorWithContext(ctx, "Failed to sanitize properties", log.Error(err))
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
+		writeServiceErrorResponse(ctx, w, &serviceerror.InternalServerError)
 		return
 	}
 
@@ -186,18 +187,18 @@ func (ih *idpHandler) HandleIDPPutRequest(w http.ResponseWriter, r *http.Request
 
 	idp, svcErr := ih.idpService.UpdateIdentityProvider(ctx, id, idpDTO)
 	if svcErr != nil {
-		writeServiceErrorResponse(w, svcErr)
+		writeServiceErrorResponse(ctx, w, svcErr)
 		return
 	}
 
 	idpResponse, err := getIDPResponse(*idp)
 	if err != nil {
 		logger.ErrorWithContext(ctx, "Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
+		writeServiceErrorResponse(ctx, w, &serviceerror.InternalServerError)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, idpResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, idpResponse)
 }
 
 // HandleIDPDeleteRequest handles the delete identity provider request.
@@ -210,21 +211,21 @@ func (ih *idpHandler) HandleIDPDeleteRequest(w http.ResponseWriter, r *http.Requ
 			Message:     ErrorInvalidIDPID.Error,
 			Description: ErrorInvalidIDPID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	svcErr := ih.idpService.DeleteIdentityProvider(ctx, id)
 	if svcErr != nil {
-		writeServiceErrorResponse(w, svcErr)
+		writeServiceErrorResponse(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 }
 
 // writeServiceErrorResponse writes the appropriate HTTP error response based on the service error.
-func writeServiceErrorResponse(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func writeServiceErrorResponse(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	var statusCode int
 	if svcErr.Type == serviceerror.ClientErrorType {
 		statusCode = getClientErrorStatusCode(svcErr.Code)
@@ -238,7 +239,7 @@ func writeServiceErrorResponse(w http.ResponseWriter, svcErr *serviceerror.Servi
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }
 
 // getClientErrorStatusCode returns the appropriate HTTP status code for client errors.

--- a/backend/internal/idp/handler_test.go
+++ b/backend/internal/idp/handler_test.go
@@ -20,6 +20,7 @@ package idp
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -511,7 +512,7 @@ func (s *IDPHandlerTestSuite) TestWriteServiceErrorResponse() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			rr := httptest.NewRecorder()
-			writeServiceErrorResponse(rr, &tc.serviceError)
+			writeServiceErrorResponse(context.Background(), rr, &tc.serviceError)
 
 			s.Equal(tc.expectedStatus, rr.Code)
 		})

--- a/backend/internal/inboundclient/model/oauth.go
+++ b/backend/internal/inboundclient/model/oauth.go
@@ -22,6 +22,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"slices"
@@ -222,8 +223,8 @@ func (o *OAuthClient) IsAllowedTokenEndpointAuthMethod(method oauth2const.TokenE
 }
 
 // ValidateRedirectURI validates the given redirect URI against this client's registered URIs.
-func (o *OAuthClient) ValidateRedirectURI(redirectURI string) error {
-	return ValidateRedirectURI(o.RedirectURIs, redirectURI)
+func (o *OAuthClient) ValidateRedirectURI(ctx context.Context, redirectURI string) error {
+	return ValidateRedirectURI(ctx, o.RedirectURIs, redirectURI)
 }
 
 // RequiresPKCE reports whether PKCE is required for this client.
@@ -278,7 +279,7 @@ func IsAllowedResponseType(responseTypes []oauth2const.ResponseType, responseTyp
 }
 
 // ValidateRedirectURI validates the provided redirect URI against the registered list.
-func ValidateRedirectURI(redirectURIs []string, redirectURI string) error {
+func ValidateRedirectURI(ctx context.Context, redirectURIs []string, redirectURI string) error {
 	logger := log.GetLogger()
 
 	if redirectURI == "" {
@@ -302,7 +303,7 @@ func ValidateRedirectURI(redirectURIs []string, redirectURI string) error {
 
 	parsedRedirectURI, err := utils.ParseURL(redirectURI)
 	if err != nil {
-		logger.Error("Failed to parse redirect URI", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to parse redirect URI", log.Error(err))
 		return fmt.Errorf("invalid redirect URI: %s", err.Error())
 	}
 	if parsedRedirectURI.Fragment != "" {

--- a/backend/internal/inboundclient/model/oauth_test.go
+++ b/backend/internal/inboundclient/model/oauth_test.go
@@ -19,6 +19,7 @@
 package model_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -248,7 +249,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_ValidWithSingleRegist
 		RedirectURIs: []string{"https://example.com/callback"},
 	}
 
-	suite.NoError(c.ValidateRedirectURI("https://example.com/callback"))
+	suite.NoError(c.ValidateRedirectURI(context.Background(), "https://example.com/callback"))
 }
 
 func (suite *OAuthClientTestSuite) TestValidateRedirectURI_ValidHTTPLocalhostWithPort() {
@@ -256,7 +257,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_ValidHTTPLocalhostWit
 		RedirectURIs: []string{"http://localhost:3000/callback"},
 	}
 
-	suite.NoError(c.ValidateRedirectURI("http://localhost:3000/callback"))
+	suite.NoError(c.ValidateRedirectURI(context.Background(), "http://localhost:3000/callback"))
 }
 
 func (suite *OAuthClientTestSuite) TestValidateRedirectURI_ValidHTTPSWithPath() {
@@ -264,7 +265,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_ValidHTTPSWithPath() 
 		RedirectURIs: []string{"https://app.example.com/oauth/callback"},
 	}
 
-	suite.NoError(c.ValidateRedirectURI("https://app.example.com/oauth/callback"))
+	suite.NoError(c.ValidateRedirectURI(context.Background(), "https://app.example.com/oauth/callback"))
 }
 
 func (suite *OAuthClientTestSuite) TestValidateRedirectURI_ValidCustomScheme() {
@@ -272,7 +273,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_ValidCustomScheme() {
 		RedirectURIs: []string{"myapp://callback"},
 	}
 
-	suite.NoError(c.ValidateRedirectURI("myapp://callback"))
+	suite.NoError(c.ValidateRedirectURI(context.Background(), "myapp://callback"))
 }
 
 func (suite *OAuthClientTestSuite) TestValidateRedirectURI_ValidWithQueryParameters() {
@@ -280,7 +281,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_ValidWithQueryParamet
 		RedirectURIs: []string{"https://example.com/callback?param=value"},
 	}
 
-	suite.NoError(c.ValidateRedirectURI("https://example.com/callback?param=value"))
+	suite.NoError(c.ValidateRedirectURI(context.Background(), "https://example.com/callback?param=value"))
 }
 
 func (suite *OAuthClientTestSuite) TestValidateRedirectURI_InvalidWithFragment() {
@@ -288,7 +289,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_InvalidWithFragment()
 		RedirectURIs: []string{"https://example.com/callback#fragment"},
 	}
 
-	err := c.ValidateRedirectURI("https://example.com/callback#fragment")
+	err := c.ValidateRedirectURI(context.Background(), "https://example.com/callback#fragment")
 	suite.EqualError(err, errRedirectURIFragment)
 }
 
@@ -297,7 +298,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_NotRegistered() {
 		RedirectURIs: []string{"https://example.com/callback"},
 	}
 
-	err := c.ValidateRedirectURI("https://different.com/callback")
+	err := c.ValidateRedirectURI(context.Background(), "https://different.com/callback")
 	suite.EqualError(err, errRedirectURINotRegistered)
 }
 
@@ -306,7 +307,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_EmptyWithSingleFullyQ
 		RedirectURIs: []string{"https://example.com/callback"},
 	}
 
-	suite.NoError(c.ValidateRedirectURI(""))
+	suite.NoError(c.ValidateRedirectURI(context.Background(), ""))
 }
 
 func (suite *OAuthClientTestSuite) TestValidateRedirectURI_EmptyWithMultipleURIs() {
@@ -317,7 +318,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_EmptyWithMultipleURIs
 		},
 	}
 
-	err := c.ValidateRedirectURI("")
+	err := c.ValidateRedirectURI(context.Background(), "")
 	suite.EqualError(err, errRedirectURIRequired)
 }
 
@@ -326,7 +327,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_EmptyWithPartialRegis
 		RedirectURIs: []string{"/callback"},
 	}
 
-	err := c.ValidateRedirectURI("")
+	err := c.ValidateRedirectURI(context.Background(), "")
 	suite.EqualError(err, errRedirectURINotFullyQualified)
 }
 
@@ -335,7 +336,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_EmptyWithInvalidRegis
 		RedirectURIs: []string{"://invalid"},
 	}
 
-	err := c.ValidateRedirectURI("")
+	err := c.ValidateRedirectURI(context.Background(), "")
 	suite.EqualError(err, errRedirectURINotFullyQualified)
 }
 
@@ -344,7 +345,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_EmptyRedirectURIsList
 		RedirectURIs: []string{},
 	}
 
-	err := c.ValidateRedirectURI("")
+	err := c.ValidateRedirectURI(context.Background(), "")
 	suite.EqualError(err, errRedirectURIRequired)
 }
 
@@ -353,7 +354,7 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_NilRedirectURIsList()
 		RedirectURIs: nil,
 	}
 
-	err := c.ValidateRedirectURI("")
+	err := c.ValidateRedirectURI(context.Background(), "")
 	suite.EqualError(err, errRedirectURIRequired)
 }
 
@@ -457,7 +458,10 @@ func (suite *OAuthHelperTestSuite) TestIsAllowedResponseType_NilList() {
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_ValidSingleURI() {
-	err := model.ValidateRedirectURI([]string{"https://example.com/callback"}, "https://example.com/callback")
+	err := model.ValidateRedirectURI(
+		context.Background(),
+		[]string{"https://example.com/callback"},
+		"https://example.com/callback")
 	suite.NoError(err)
 }
 
@@ -467,23 +471,26 @@ func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_ValidMultipleURIs() {
 		"https://example.com/callback2",
 	}
 
-	err := model.ValidateRedirectURI(redirectURIs, "https://example.com/callback2")
+	err := model.ValidateRedirectURI(context.Background(), redirectURIs, "https://example.com/callback2")
 	suite.NoError(err)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_InvalidNotRegistered() {
-	err := model.ValidateRedirectURI([]string{"https://example.com/callback"}, "https://different.com/callback")
+	err := model.ValidateRedirectURI(
+		context.Background(),
+		[]string{"https://example.com/callback"},
+		"https://different.com/callback")
 	suite.EqualError(err, errRedirectURINotRegistered)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_InvalidWithFragment() {
 	uri := "https://example.com/callback#fragment"
-	err := model.ValidateRedirectURI([]string{uri}, uri)
+	err := model.ValidateRedirectURI(context.Background(), []string{uri}, uri)
 	suite.EqualError(err, errRedirectURIFragment)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_EmptyURIWithSingleFullyQualified() {
-	err := model.ValidateRedirectURI([]string{"https://example.com/callback"}, "")
+	err := model.ValidateRedirectURI(context.Background(), []string{"https://example.com/callback"}, "")
 	suite.NoError(err)
 }
 
@@ -493,63 +500,72 @@ func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_EmptyURIWithMultiple(
 		"https://example.com/callback2",
 	}
 
-	err := model.ValidateRedirectURI(redirectURIs, "")
+	err := model.ValidateRedirectURI(context.Background(), redirectURIs, "")
 	suite.EqualError(err, errRedirectURIRequired)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_EmptyURIWithPartialRegistered() {
-	err := model.ValidateRedirectURI([]string{"/callback"}, "")
+	err := model.ValidateRedirectURI(context.Background(), []string{"/callback"}, "")
 	suite.EqualError(err, errRedirectURINotFullyQualified)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_EmptyURIWithNoScheme() {
-	err := model.ValidateRedirectURI([]string{"example.com/callback"}, "")
+	err := model.ValidateRedirectURI(context.Background(), []string{"example.com/callback"}, "")
 	suite.EqualError(err, errRedirectURINotFullyQualified)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_EmptyURIWithNoHost() {
-	err := model.ValidateRedirectURI([]string{"https:///callback"}, "")
+	err := model.ValidateRedirectURI(context.Background(), []string{"https:///callback"}, "")
 	suite.EqualError(err, errRedirectURINotFullyQualified)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_EmptyURIList() {
-	err := model.ValidateRedirectURI([]string{}, "")
+	err := model.ValidateRedirectURI(context.Background(), []string{}, "")
 	suite.EqualError(err, errRedirectURIRequired)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_NilList() {
-	err := model.ValidateRedirectURI(nil, "")
+	err := model.ValidateRedirectURI(context.Background(), nil, "")
 	suite.EqualError(err, errRedirectURIRequired)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_CustomScheme() {
-	err := model.ValidateRedirectURI([]string{"myapp://callback"}, "myapp://callback")
+	err := model.ValidateRedirectURI(context.Background(), []string{"myapp://callback"}, "myapp://callback")
 	suite.NoError(err)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_LocalhostHTTP() {
-	err := model.ValidateRedirectURI([]string{"http://localhost:3000/callback"}, "http://localhost:3000/callback")
+	err := model.ValidateRedirectURI(
+		context.Background(),
+		[]string{"http://localhost:3000/callback"},
+		"http://localhost:3000/callback")
 	suite.NoError(err)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_WithQueryParams() {
 	uri := "https://example.com/callback?foo=bar"
-	suite.NoError(model.ValidateRedirectURI([]string{uri}, uri))
+	suite.NoError(model.ValidateRedirectURI(context.Background(), []string{uri}, uri))
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_IPAddress() {
-	err := model.ValidateRedirectURI([]string{"https://192.168.1.1/callback"}, "https://192.168.1.1/callback")
+	err := model.ValidateRedirectURI(
+		context.Background(),
+		[]string{"https://192.168.1.1/callback"},
+		"https://192.168.1.1/callback")
 	suite.NoError(err)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_Localhost127() {
-	err := model.ValidateRedirectURI([]string{"http://127.0.0.1:8080/callback"}, "http://127.0.0.1:8080/callback")
+	err := model.ValidateRedirectURI(
+		context.Background(),
+		[]string{"http://127.0.0.1:8080/callback"},
+		"http://127.0.0.1:8080/callback")
 	suite.NoError(err)
 }
 
 func (suite *OAuthHelperTestSuite) TestValidateRedirectURI_InvalidURLFormat() {
 	uri := "http://example.com/callback\x00invalid"
-	err := model.ValidateRedirectURI([]string{uri}, uri)
+	err := model.ValidateRedirectURI(context.Background(), []string{uri}, uri)
 	suite.Error(err)
 	assert.Contains(suite.T(), err.Error(), "invalid redirect URI")
 }
@@ -605,7 +621,7 @@ func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_WildcardEnable
 	cfg.OAuth.AllowWildcardRedirectURI = true
 	suite.Require().NoError(sysconfig.InitializeServerRuntime("/tmp/test", cfg))
 
-	err := model.ValidateRedirectURI(
+	err := model.ValidateRedirectURI(context.Background(),
 		[]string{"https://app.example.com/*"},
 		"https://app.example.com/cb",
 	)
@@ -613,7 +629,7 @@ func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_WildcardEnable
 }
 
 func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_WildcardDisabled_NoMatch() {
-	err := model.ValidateRedirectURI(
+	err := model.ValidateRedirectURI(context.Background(),
 		[]string{"https://app.example.com/*"},
 		"https://app.example.com/cb",
 	)
@@ -626,7 +642,7 @@ func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_HostWildcardEn
 	cfg.OAuth.AllowWildcardRedirectURI = true
 	suite.Require().NoError(sysconfig.InitializeServerRuntime("/tmp/test", cfg))
 
-	err := model.ValidateRedirectURI(
+	err := model.ValidateRedirectURI(context.Background(),
 		[]string{"https://tenant-app-*-*.gateway.example.com/cb"},
 		"https://tenant-app-019dfc78-f19ab4f2.gateway.example.com/cb",
 	)
@@ -640,7 +656,7 @@ func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_HostWildcardEn
 	suite.Require().NoError(sysconfig.InitializeServerRuntime("/tmp/test", cfg))
 
 	// Hyphen inside the dynamic part is not in [0-9a-zA-Z]+, so this must fail.
-	err := model.ValidateRedirectURI(
+	err := model.ValidateRedirectURI(context.Background(),
 		[]string{"https://app-*-prod.example.com/cb"},
 		"https://app-foo-bar-prod.example.com/cb",
 	)
@@ -650,7 +666,7 @@ func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_HostWildcardEn
 func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_HostWildcardDisabled_NoMatch() {
 	// Default: AllowWildcardRedirectURI = false. Note the pattern would never have made it
 	// past registration with the flag off, but we still verify the matcher returns no match.
-	err := model.ValidateRedirectURI(
+	err := model.ValidateRedirectURI(context.Background(),
 		[]string{"https://app-*.example.com/cb"},
 		"https://app-prod.example.com/cb",
 	)
@@ -663,7 +679,7 @@ func (suite *OAuthHelperTestSuite) TestMatchAnyRedirectURIPattern_HostWildcardDo
 	cfg.OAuth.AllowWildcardRedirectURI = true
 	suite.Require().NoError(sysconfig.InitializeServerRuntime("/tmp/test", cfg))
 
-	err := model.ValidateRedirectURI(
+	err := model.ValidateRedirectURI(context.Background(),
 		[]string{"https://app-*.example.com/cb"},
 		"https://app-foo.evil.example.com/cb",
 	)

--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -147,7 +147,7 @@ func (s *inboundClientService) CreateInboundClient(ctx context.Context, client *
 		}
 	}
 	applyInboundDefaults(client, oauthProfile)
-	oauthClientID := s.resolveClientID(client.ID)
+	oauthClientID := s.resolveClientID(ctx, client.ID)
 	return s.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if _, vErr, opErr := s.createCertificate(
 			txCtx, cert.CertificateReferenceTypeApplication, client.ID, appCert,
@@ -221,7 +221,7 @@ func (s *inboundClientService) UpdateInboundClient(ctx context.Context, client *
 	}
 	applyInboundDefaults(client, oauthProfile)
 	// Capture existing OAuth client_id before the caller updates entity system attributes.
-	oldOAuthClientID := s.resolveClientID(client.ID)
+	oldOAuthClientID := s.resolveClientID(ctx, client.ID)
 	return s.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if _, vErr, opErr := s.syncCertificate(
 			txCtx, cert.CertificateReferenceTypeApplication, client.ID, appCert,
@@ -322,13 +322,13 @@ func (s *inboundClientService) ResolveInboundAuthProfileHandles(
 }
 
 // resolveClientID returns the OAuth client_id from an entity's system attributes, or "" if absent.
-func (s *inboundClientService) resolveClientID(entityID string) string {
+func (s *inboundClientService) resolveClientID(ctx context.Context, entityID string) string {
 	if s.entityProvider == nil {
 		return ""
 	}
 	e, epErr := s.entityProvider.GetEntity(entityID)
 	if epErr != nil {
-		s.logger.Warn("Failed to resolve OAuth client_id from entity provider",
+		s.logger.WarnWithContext(ctx, "Failed to resolve OAuth client_id from entity provider",
 			log.String("entityID", entityID), log.Error(epErr))
 		return ""
 	}
@@ -349,7 +349,7 @@ func (s *inboundClientService) DeleteInboundClient(ctx context.Context, entityID
 		return ErrCannotModifyDeclarative
 	}
 	// Capture OAuth client_id before the caller deletes the entity itself.
-	oauthClientID := s.resolveClientID(entityID)
+	oauthClientID := s.resolveClientID(ctx, entityID)
 	return s.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if s.consentService != nil && s.consentService.IsEnabled() {
 			if err := s.syncConsentOnDelete(txCtx, entityID); err != nil {

--- a/backend/internal/inboundclient/store.go
+++ b/backend/internal/inboundclient/store.go
@@ -193,7 +193,7 @@ func (st *store) GetInboundClientByEntityID(ctx context.Context, entityID string
 	if len(results) == 0 {
 		return nil, ErrInboundClientNotFound
 	}
-	return buildInboundClientFromRow(results[0])
+	return buildInboundClientFromRow(ctx, results[0])
 }
 
 // GetOAuthProfileByEntityID retrieves an OAuth profile by entity ID.
@@ -227,7 +227,7 @@ func (st *store) GetInboundClientList(ctx context.Context, limit int) ([]inbound
 
 	clients := make([]inboundmodel.InboundClient, 0, len(results))
 	for _, row := range results {
-		c, err := buildInboundClientFromRow(row)
+		c, err := buildInboundClientFromRow(ctx, row)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build inbound client from result row: %w", err)
 		}
@@ -371,7 +371,7 @@ func (st *store) IsDeclarative(_ context.Context, _ string) bool {
 // --- Helper functions ---
 
 // buildInboundClientFromRow constructs an InboundClient from a database result row.
-func buildInboundClientFromRow(row map[string]interface{}) (*inboundmodel.InboundClient, error) {
+func buildInboundClientFromRow(ctx context.Context, row map[string]interface{}) (*inboundmodel.InboundClient, error) {
 	entityID, ok := row["entity_id"].(string)
 	if !ok {
 		return nil, fmt.Errorf("failed to parse entity_id as string")
@@ -407,7 +407,7 @@ func buildInboundClientFromRow(row map[string]interface{}) (*inboundmodel.Inboun
 	if blobStr := parseJSONColumnString(row, "properties"); blobStr != "" {
 		var blob inboundClientJSONBlob
 		if err := json.Unmarshal([]byte(blobStr), &blob); err != nil {
-			log.GetLogger().Debug("Failed to unmarshal properties", log.Error(err))
+			log.GetLogger().DebugWithContext(ctx, "Failed to unmarshal properties", log.Error(err))
 		} else {
 			client.Assertion = blob.Assertion
 			client.LoginConsent = blob.LoginConsent

--- a/backend/internal/inboundclient/store_test.go
+++ b/backend/internal/inboundclient/store_test.go
@@ -112,7 +112,7 @@ func (suite *InboundClientStoreTestSuite) TestBuildInboundClientFromRow_Success(
 		"properties":                   string(blobBytes),
 	}
 
-	result, err := buildInboundClientFromRow(row)
+	result, err := buildInboundClientFromRow(context.Background(), row)
 
 	suite.NoError(err)
 	suite.NotNil(result)
@@ -138,7 +138,7 @@ func (suite *InboundClientStoreTestSuite) TestBuildInboundClientFromRow_InvalidI
 		"entity_id": 123, // Invalid type
 	}
 
-	result, err := buildInboundClientFromRow(row)
+	result, err := buildInboundClientFromRow(context.Background(), row)
 
 	suite.Error(err)
 	suite.Nil(result)
@@ -158,7 +158,7 @@ func (suite *InboundClientStoreTestSuite) TestBuildInboundClientFromRow_MinimalR
 		"properties":                   nil,
 	}
 
-	result, err := buildInboundClientFromRow(row)
+	result, err := buildInboundClientFromRow(context.Background(), row)
 
 	suite.NoError(err)
 	suite.NotNil(result)

--- a/backend/internal/notification/declarative_resource.go
+++ b/backend/internal/notification/declarative_resource.go
@@ -91,7 +91,7 @@ func (e *notificationSenderExporter) GetResourceByID(ctx context.Context, id str
 }
 
 // ValidateResource validates a notification sender resource.
-func (e *notificationSenderExporter) ValidateResource(
+func (e *notificationSenderExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	sender, ok := resource.(*common.NotificationSenderDTO)
@@ -99,7 +99,7 @@ func (e *notificationSenderExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeNotificationSender, id)
 	}
 
-	err := declarativeresource.ValidateResourceName(
+	err := declarativeresource.ValidateResourceName(ctx,
 		sender.Name, resourceTypeNotificationSender, id, "SENDER_VALIDATION_ERROR", logger,
 	)
 	if err != nil {
@@ -107,7 +107,7 @@ func (e *notificationSenderExporter) ValidateResource(
 	}
 
 	if len(sender.Properties) == 0 {
-		logger.Warn("Notification sender has no properties",
+		logger.WarnWithContext(ctx, "Notification sender has no properties",
 			log.String("senderID", id), log.String("name", sender.Name))
 	}
 

--- a/backend/internal/notification/declarative_resource_test.go
+++ b/backend/internal/notification/declarative_resource_test.go
@@ -145,7 +145,7 @@ func (s *NotificationSenderExporterTestSuite) TestValidateResource_Success() {
 		Properties: []cmodels.Property{*prop},
 	}
 
-	name, err := s.exporter.ValidateResource(sender, "sender1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), sender, "sender1", s.logger)
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Valid Sender", name)
@@ -154,7 +154,7 @@ func (s *NotificationSenderExporterTestSuite) TestValidateResource_Success() {
 func (s *NotificationSenderExporterTestSuite) TestValidateResource_InvalidType() {
 	invalidResource := "not a sender"
 
-	name, err := s.exporter.ValidateResource(invalidResource, "sender1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), invalidResource, "sender1", s.logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), err)
@@ -169,7 +169,7 @@ func (s *NotificationSenderExporterTestSuite) TestValidateResource_EmptyName() {
 		Name: "",
 	}
 
-	name, err := s.exporter.ValidateResource(sender, "sender1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), sender, "sender1", s.logger)
 
 	assert.Empty(s.T(), name)
 	assert.NotNil(s.T(), err)
@@ -186,7 +186,7 @@ func (s *NotificationSenderExporterTestSuite) TestValidateResource_NoProperties(
 		Properties: []cmodels.Property{},
 	}
 
-	name, err := s.exporter.ValidateResource(sender, "sender1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), sender, "sender1", s.logger)
 
 	// Should still succeed but log a warning
 	assert.Nil(s.T(), err)

--- a/backend/internal/notification/init.go
+++ b/backend/internal/notification/init.go
@@ -19,6 +19,7 @@
 package notification
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
@@ -44,7 +45,9 @@ func Initialize(mux *http.ServeMux, jwtService jwt.JWTServiceInterface,
 		var err error
 		notificationStore, tx, err = newNotificationStore()
 		if err != nil {
-			log.GetLogger().Error("Failed to initialize notification store", log.Error(err))
+			// Service initialization runs during application startup, outside any request.
+			log.GetLogger().ErrorWithContext(context.Background(),
+				"Failed to initialize notification store", log.Error(err))
 			return nil, nil, nil, nil, err
 		}
 	}

--- a/backend/internal/notification/message_handler.go
+++ b/backend/internal/notification/message_handler.go
@@ -19,6 +19,7 @@
 package notification
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -54,7 +55,7 @@ func (h *messageNotificationSenderHandler) HandleSenderListRequest(w http.Respon
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationHandler"))
 	senders, svcErr := h.mgtService.ListSenders(ctx)
 	if svcErr != nil {
-		h.handleError(w, svcErr, "")
+		h.handleError(ctx, w, svcErr, "")
 		return
 	}
 
@@ -64,13 +65,17 @@ func (h *messageNotificationSenderHandler) HandleSenderListRequest(w http.Respon
 		if err != nil {
 			logger.ErrorWithContext(ctx, "Failed to convert sender to response",
 				log.String("sender", sender.Name), log.Error(err))
-			h.handleError(w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
+			h.handleError(
+				ctx,
+				w,
+				&serviceerror.InternalServerError,
+				"Failed to convert sender to response: "+err.Error())
 			return
 		}
 		senderResponses = append(senderResponses, senderResponse)
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, senderResponses)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, senderResponses)
 }
 
 // HandleSenderCreateRequest handles the request to create a new message notification sender
@@ -79,14 +84,14 @@ func (h *messageNotificationSenderHandler) HandleSenderCreateRequest(w http.Resp
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationHandler"))
 	sender, err := sysutils.DecodeJSONBody[common.NotificationSenderRequest](r)
 	if err != nil {
-		h.handleError(w, &ErrorInvalidRequestFormat, "Failed to parse request body: "+err.Error())
+		h.handleError(ctx, w, &ErrorInvalidRequestFormat, "Failed to parse request body: "+err.Error())
 		return
 	}
 
 	senderDTO, err := getDTOFromSenderRequest(sender)
 	if err != nil {
 		logger.ErrorWithContext(ctx, "Failed to process sender request", log.Error(err))
-		h.handleError(w, &serviceerror.InternalServerError, "Failed to process sender request: "+err.Error())
+		h.handleError(ctx, w, &serviceerror.InternalServerError, "Failed to process sender request: "+err.Error())
 		return
 	}
 
@@ -99,11 +104,11 @@ func (h *messageNotificationSenderHandler) HandleSenderCreateRequest(w http.Resp
 				Description: svcErr.ErrorDescription,
 			}
 
-			sysutils.WriteErrorResponse(w, http.StatusConflict, errResp)
+			sysutils.WriteErrorResponse(ctx, w, http.StatusConflict, errResp)
 			return
 		}
 
-		h.handleError(w, svcErr, "")
+		h.handleError(ctx, w, svcErr, "")
 		return
 	}
 
@@ -111,11 +116,11 @@ func (h *messageNotificationSenderHandler) HandleSenderCreateRequest(w http.Resp
 	if err != nil {
 		logger.ErrorWithContext(ctx, "Failed to convert sender to response",
 			log.String("sender", createdSender.Name), log.Error(err))
-		h.handleError(w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
+		h.handleError(ctx, w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, senderResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, senderResponse)
 }
 
 // HandleSenderGetRequest handles the request to get a message notification sender by ID
@@ -123,13 +128,13 @@ func (h *messageNotificationSenderHandler) HandleSenderGetRequest(w http.Respons
 	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationHandler"))
 	id := r.PathValue("id")
-	if !h.validateSenderID(w, id) {
+	if !h.validateSenderID(ctx, w, id) {
 		return
 	}
 
 	sender, svcErr := h.mgtService.GetSender(ctx, id)
 	if svcErr != nil {
-		h.handleError(w, svcErr, "")
+		h.handleError(ctx, w, svcErr, "")
 		return
 	}
 	if sender == nil {
@@ -138,7 +143,7 @@ func (h *messageNotificationSenderHandler) HandleSenderGetRequest(w http.Respons
 			Message:     ErrorSenderNotFound.Error,
 			Description: ErrorSenderNotFound.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusNotFound, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusNotFound, errResp)
 		return
 	}
 
@@ -146,11 +151,11 @@ func (h *messageNotificationSenderHandler) HandleSenderGetRequest(w http.Respons
 	if err != nil {
 		logger.ErrorWithContext(ctx, "Failed to convert sender to response",
 			log.String("sender", sender.Name), log.Error(err))
-		h.handleError(w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
+		h.handleError(ctx, w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, senderResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, senderResponse)
 }
 
 // HandleSenderUpdateRequest handles the request to update a message notification sender
@@ -158,26 +163,26 @@ func (h *messageNotificationSenderHandler) HandleSenderUpdateRequest(w http.Resp
 	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationHandler"))
 	id := r.PathValue("id")
-	if !h.validateSenderID(w, id) {
+	if !h.validateSenderID(ctx, w, id) {
 		return
 	}
 
 	sender, err := sysutils.DecodeJSONBody[common.NotificationSenderRequest](r)
 	if err != nil {
-		h.handleError(w, &ErrorInvalidRequestFormat, "Failed to parse request body: "+err.Error())
+		h.handleError(ctx, w, &ErrorInvalidRequestFormat, "Failed to parse request body: "+err.Error())
 		return
 	}
 
 	senderDTO, err := getDTOFromSenderRequest(sender)
 	if err != nil {
 		logger.ErrorWithContext(ctx, "Failed to process sender request", log.Error(err))
-		h.handleError(w, &serviceerror.InternalServerError, "Failed to process sender request: "+err.Error())
+		h.handleError(ctx, w, &serviceerror.InternalServerError, "Failed to process sender request: "+err.Error())
 		return
 	}
 
 	updatedSender, svcErr := h.mgtService.UpdateSender(ctx, id, *senderDTO)
 	if svcErr != nil {
-		h.handleError(w, svcErr, "")
+		h.handleError(ctx, w, svcErr, "")
 		return
 	}
 
@@ -185,28 +190,28 @@ func (h *messageNotificationSenderHandler) HandleSenderUpdateRequest(w http.Resp
 	if err != nil {
 		logger.ErrorWithContext(ctx, "Failed to convert sender to response",
 			log.String("sender", updatedSender.Name), log.Error(err))
-		h.handleError(w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
+		h.handleError(ctx, w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, senderResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, senderResponse)
 }
 
 // HandleSenderDeleteRequest handles the request to delete a message notification sender
 func (h *messageNotificationSenderHandler) HandleSenderDeleteRequest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id := r.PathValue("id")
-	if !h.validateSenderID(w, id) {
+	if !h.validateSenderID(ctx, w, id) {
 		return
 	}
 
 	svcErr := h.mgtService.DeleteSender(ctx, id)
 	if svcErr != nil {
-		h.handleError(w, svcErr, "")
+		h.handleError(ctx, w, svcErr, "")
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 }
 
 // HandleOTPSendRequest handles the request to send an OTP.
@@ -214,14 +219,14 @@ func (h *messageNotificationSenderHandler) HandleOTPSendRequest(w http.ResponseW
 	ctx := r.Context()
 	request, err := sysutils.DecodeJSONBody[common.SendOTPRequest](r)
 	if err != nil {
-		h.handleError(w, &ErrorInvalidRequestFormat, "Failed to parse request body: "+err.Error())
+		h.handleError(ctx, w, &ErrorInvalidRequestFormat, "Failed to parse request body: "+err.Error())
 		return
 	}
 
 	otpDTO := common.SendOTPDTO(*request)
 	resultDTO, svcErr := h.otpService.SendOTP(ctx, otpDTO)
 	if svcErr != nil {
-		h.handleError(w, svcErr, "")
+		h.handleError(ctx, w, svcErr, "")
 		return
 	}
 
@@ -230,7 +235,7 @@ func (h *messageNotificationSenderHandler) HandleOTPSendRequest(w http.ResponseW
 		SessionToken: resultDTO.SessionToken,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, otpResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, otpResponse)
 }
 
 // HandleOTPVerifyRequest handles the request to verify an OTP.
@@ -238,14 +243,14 @@ func (h *messageNotificationSenderHandler) HandleOTPVerifyRequest(w http.Respons
 	ctx := r.Context()
 	request, err := sysutils.DecodeJSONBody[common.VerifyOTPRequest](r)
 	if err != nil {
-		h.handleError(w, &ErrorInvalidRequestFormat, "Failed to parse request body: "+err.Error())
+		h.handleError(ctx, w, &ErrorInvalidRequestFormat, "Failed to parse request body: "+err.Error())
 		return
 	}
 
 	verifyDTO := common.VerifyOTPDTO(*request)
 	resultDTO, svcErr := h.otpService.VerifyOTP(ctx, verifyDTO)
 	if svcErr != nil {
-		h.handleError(w, svcErr, "")
+		h.handleError(ctx, w, svcErr, "")
 		return
 	}
 
@@ -253,11 +258,11 @@ func (h *messageNotificationSenderHandler) HandleOTPVerifyRequest(w http.Respons
 		Status: string(resultDTO.Status),
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.
-func (h *messageNotificationSenderHandler) handleError(w http.ResponseWriter,
+func (h *messageNotificationSenderHandler) handleError(ctx context.Context, w http.ResponseWriter,
 	svcErr *serviceerror.ServiceError, customErrDesc string) {
 	errDesc := svcErr.ErrorDescription
 	if customErrDesc != "" {
@@ -284,13 +289,16 @@ func (h *messageNotificationSenderHandler) handleError(w http.ResponseWriter,
 		}
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }
 
 // validateSenderID validates the sender ID and returns true if valid
-func (h *messageNotificationSenderHandler) validateSenderID(w http.ResponseWriter, id string) bool {
+func (
+	h *messageNotificationSenderHandler) validateSenderID(ctx context.Context,
+	w http.ResponseWriter,
+	id string) bool {
 	if strings.TrimSpace(id) == "" {
-		h.handleError(w, &ErrorInvalidSenderID, "Sender ID is required")
+		h.handleError(ctx, w, &ErrorInvalidSenderID, "Sender ID is required")
 		return false
 	}
 	return true

--- a/backend/internal/notification/message_handler_test.go
+++ b/backend/internal/notification/message_handler_test.go
@@ -20,6 +20,7 @@ package notification
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -344,7 +345,7 @@ func (suite *MessageHandlerTestSuite) TestValidateSenderID_EmptyID() {
 	handler := newMessageNotificationSenderHandler(nil, nil)
 
 	rr := httptest.NewRecorder()
-	ok := handler.validateSenderID(rr, "")
+	ok := handler.validateSenderID(context.Background(), rr, "")
 
 	suite.False(ok)
 	suite.Equal(400, rr.Code)
@@ -357,7 +358,7 @@ func (suite *MessageHandlerTestSuite) TestValidateSenderID_EmptyID() {
 func (suite *MessageHandlerTestSuite) TestValidateSenderID_NonEmptyID() {
 	handler := newMessageNotificationSenderHandler(nil, nil)
 	rr := httptest.NewRecorder()
-	ok := handler.validateSenderID(rr, "sender-1")
+	ok := handler.validateSenderID(context.Background(), rr, "sender-1")
 	suite.True(ok)
 	suite.Equal(0, rr.Body.Len())
 }
@@ -409,7 +410,7 @@ func (suite *MessageHandlerTestSuite) TestHandleError() {
 
 	for _, tc := range cases {
 		rr := httptest.NewRecorder()
-		handler.handleError(rr, tc.svcErr, tc.customDesc)
+		handler.handleError(context.Background(), rr, tc.svcErr, tc.customDesc)
 
 		suite.Equal(tc.expectedCode, rr.Code, tc.name)
 
@@ -425,6 +426,45 @@ func (suite *MessageHandlerTestSuite) TestHandleError() {
 	}
 }
 
+func (suite *MessageHandlerTestSuite) TestHandleSenderGetRequest_EmptyID() {
+	m := NewNotificationSenderMgtSvcInterfaceMock(suite.T())
+	handler := newMessageNotificationSenderHandler(m, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/senders/", nil)
+	req.SetPathValue("id", "")
+	rr := httptest.NewRecorder()
+
+	handler.HandleSenderGetRequest(rr, req)
+
+	suite.Equal(http.StatusBadRequest, rr.Code)
+}
+
+func (suite *MessageHandlerTestSuite) TestHandleSenderUpdateRequest_EmptyID() {
+	m := NewNotificationSenderMgtSvcInterfaceMock(suite.T())
+	handler := newMessageNotificationSenderHandler(m, nil)
+
+	req := httptest.NewRequest(http.MethodPut, "/senders/", nil)
+	req.SetPathValue("id", "")
+	rr := httptest.NewRecorder()
+
+	handler.HandleSenderUpdateRequest(rr, req)
+
+	suite.Equal(http.StatusBadRequest, rr.Code)
+}
+
+func (suite *MessageHandlerTestSuite) TestHandleSenderDeleteRequest_EmptyID() {
+	m := NewNotificationSenderMgtSvcInterfaceMock(suite.T())
+	handler := newMessageNotificationSenderHandler(m, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/senders/", nil)
+	req.SetPathValue("id", "")
+	rr := httptest.NewRecorder()
+
+	handler.HandleSenderDeleteRequest(rr, req)
+
+	suite.Equal(http.StatusBadRequest, rr.Code)
+}
+
 // writer that always errors when writing to exercise the encode error path
 type errWriter struct{}
 
@@ -435,7 +475,7 @@ func (e *errWriter) WriteHeader(statusCode int) {}
 func (suite *MessageHandlerTestSuite) TestHandleError_EncodeFailure() {
 	handler := newMessageNotificationSenderHandler(nil, nil)
 	ew := &errWriter{}
-	handler.handleError(ew, &serviceerror.InternalServerError, "boom")
+	handler.handleError(context.Background(), ew, &serviceerror.InternalServerError, "boom")
 }
 
 func (suite *MessageHandlerTestSuite) TestGetDTOFromSenderRequest() {

--- a/backend/internal/oauth/jwks/handler.go
+++ b/backend/internal/oauth/jwks/handler.go
@@ -19,6 +19,7 @@
 package jwks
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
@@ -46,21 +47,21 @@ func (h *jwksHandler) HandleJWKSRequest(w http.ResponseWriter, r *http.Request) 
 	ctx := r.Context()
 	jwksResponse, svcErr := h.jwksService.GetJWKS(ctx)
 	if svcErr != nil {
-		h.logAndWriteError(w, logger, svcErr)
+		h.logAndWriteError(ctx, w, logger, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, jwksResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, jwksResponse)
 	logger.DebugWithContext(ctx, "JWKS response successfully sent")
 }
 
 // logAndWriteError logs server errors and writes an appropriate error response to the HTTP response writer.
-func (h *jwksHandler) logAndWriteError(w http.ResponseWriter, logger *log.Logger,
+func (h *jwksHandler) logAndWriteError(ctx context.Context, w http.ResponseWriter, logger *log.Logger,
 	svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusBadRequest
 	if svcErr.Type == serviceerror.ServerErrorType {
 		statusCode = http.StatusInternalServerError
-		logger.Error("Failed to retrieve JWKS", log.String("error_code", svcErr.Code))
+		logger.ErrorWithContext(ctx, "Failed to retrieve JWKS", log.String("error_code", svcErr.Code))
 	}
 
 	errResp := apierror.ErrorResponse{
@@ -69,5 +70,5 @@ func (h *jwksHandler) logAndWriteError(w http.ResponseWriter, logger *log.Logger
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -107,17 +107,17 @@ func (ah *authorizeHandler) HandleAuthCallbackPostRequest(w http.ResponseWriter,
 				ah.writeAuthZResponseToClientRedirect(ctx, w, authErr)
 				return
 			}
-			ah.writeAuthZResponseToErrorPage(w, authErr.Code, authErr.Message, authErr.State)
+			ah.writeAuthZResponseToErrorPage(ctx, w, authErr.Code, authErr.Message, authErr.State)
 			return
 		}
-		ah.writeAuthZResponse(w, redirectURI)
+		ah.writeAuthZResponse(ctx, w, redirectURI)
 
 	case oauth2const.TypeConsentResponseFromUser:
 		// TODO: Handle the consent response from the user.
 		//  Verify whether we need separate session data key for consent flow.
 		//  Alternatively could add consent info also to the same session object.
 	default:
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
+		utils.WriteJSONError(ctx, w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
 			http.StatusBadRequest, nil)
 	}
 }
@@ -146,7 +146,7 @@ func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWrit
 
 	if err != nil {
 		ah.logger.DebugWithContext(r.Context(), "Invalid authorize request", log.Error(err))
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
+		utils.WriteJSONError(r.Context(), w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
 			http.StatusBadRequest, nil)
 	}
 
@@ -285,16 +285,21 @@ func (ah *authorizeHandler) redirectToErrorPage(w http.ResponseWriter, r *http.R
 }
 
 // writeAuthZResponse writes the authorization response to the HTTP response writer.
-func (ah *authorizeHandler) writeAuthZResponse(w http.ResponseWriter, redirectURI string) {
+func (ah *authorizeHandler) writeAuthZResponse(ctx context.Context, w http.ResponseWriter, redirectURI string) {
 	authZResp := AuthZPostResponse{
 		RedirectURI: redirectURI,
 	}
-	utils.WriteSuccessResponse(w, http.StatusOK, authZResp)
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, authZResp)
 }
 
 // writeAuthZResponseToErrorPage writes the authorization response redirecting to the error page.
 // The state parameter is included in the redirect if non-empty.
-func (ah *authorizeHandler) writeAuthZResponseToErrorPage(w http.ResponseWriter, code, msg, state string) {
+func (
+	ah *authorizeHandler) writeAuthZResponseToErrorPage(ctx context.Context,
+	w http.ResponseWriter,
+	code,
+	msg,
+	state string) {
 	redirectURI, err := getErrorPageRedirectURL(code, msg)
 	if err != nil {
 		http.Error(w, "Failed to redirect to error page", http.StatusInternalServerError)
@@ -312,7 +317,7 @@ func (ah *authorizeHandler) writeAuthZResponseToErrorPage(w http.ResponseWriter,
 		}
 	}
 
-	ah.writeAuthZResponse(w, redirectURI)
+	ah.writeAuthZResponse(ctx, w, redirectURI)
 }
 
 // writeAuthZResponseToClientRedirect writes the authorization error response redirecting to the
@@ -331,10 +336,10 @@ func (ah *authorizeHandler) writeAuthZResponseToClientRedirect(
 	redirectURI, err := oauth2utils.GetURIWithQueryParams(authErr.ClientRedirectURI, queryParams)
 	if err != nil {
 		ah.logger.ErrorWithContext(ctx, "Failed to construct client redirect URI", log.Error(err))
-		ah.writeAuthZResponseToErrorPage(w, oauth2const.ErrorServerError,
+		ah.writeAuthZResponseToErrorPage(ctx, w, oauth2const.ErrorServerError,
 			"Failed to process authorization request", authErr.State)
 		return
 	}
 
-	ah.writeAuthZResponse(w, redirectURI)
+	ah.writeAuthZResponse(ctx, w, redirectURI)
 }

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -20,6 +20,7 @@ package authz
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -547,7 +548,7 @@ func (suite *AuthorizeHandlerTestSuite) TestRedirectToErrorPage_NilRequest() {
 
 func (suite *AuthorizeHandlerTestSuite) TestWriteAuthZResponseToErrorPage_WithState() {
 	rr := httptest.NewRecorder()
-	suite.handler.writeAuthZResponseToErrorPage(rr, "error_code", "error message", "test-state")
+	suite.handler.writeAuthZResponseToErrorPage(context.Background(), rr, "error_code", "error message", "test-state")
 
 	assert.Equal(suite.T(), http.StatusOK, rr.Code)
 	var resp AuthZPostResponse
@@ -558,7 +559,7 @@ func (suite *AuthorizeHandlerTestSuite) TestWriteAuthZResponseToErrorPage_WithSt
 
 func (suite *AuthorizeHandlerTestSuite) TestWriteAuthZResponseToErrorPage_NoState() {
 	rr := httptest.NewRecorder()
-	suite.handler.writeAuthZResponseToErrorPage(rr, "error_code", "error message", "")
+	suite.handler.writeAuthZResponseToErrorPage(context.Background(), rr, "error_code", "error message", "")
 
 	assert.Equal(suite.T(), http.StatusOK, rr.Code)
 	var resp AuthZPostResponse
@@ -571,7 +572,7 @@ func (suite *AuthorizeHandlerTestSuite) TestWriteAuthZResponseToErrorPage_NoStat
 func (suite *AuthorizeHandlerTestSuite) TestWriteAuthZResponse() {
 	rr := httptest.NewRecorder()
 
-	suite.handler.writeAuthZResponse(rr, "https://example.com/callback?code=abc123")
+	suite.handler.writeAuthZResponse(context.Background(), rr, "https://example.com/callback?code=abc123")
 
 	assert.Equal(suite.T(), http.StatusOK, rr.Code)
 	assert.Equal(suite.T(), "application/json", rr.Header().Get("Content-Type"))

--- a/backend/internal/oauth/oauth2/authz/validator.go
+++ b/backend/internal/oauth/oauth2/authz/validator.go
@@ -54,7 +54,7 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(ctx contex
 		return false, constants.ErrorInvalidRequest, "Missing client_id parameter"
 	}
 
-	if err := oauthApp.ValidateRedirectURI(redirectURI); err != nil {
+	if err := oauthApp.ValidateRedirectURI(ctx, redirectURI); err != nil {
 		logger.DebugWithContext(ctx, "Validation failed for redirect URI", log.Error(err))
 		return false, constants.ErrorInvalidRequest, "Invalid redirect URI"
 	}

--- a/backend/internal/oauth/oauth2/callback/callback.go
+++ b/backend/internal/oauth/oauth2/callback/callback.go
@@ -23,6 +23,7 @@
 package callback
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -87,13 +88,13 @@ func (d *callbackDispatcher) handleFlowCallback(w http.ResponseWriter, r *http.R
 
 	req, err := utils.DecodeJSONBody[flowCallbackRequest](r)
 	if err != nil {
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest, "Invalid request body",
+		utils.WriteJSONError(ctx, w, oauth2const.ErrorInvalidRequest, "Invalid request body",
 			http.StatusBadRequest, nil)
 		return
 	}
 
 	if req.AuthID == "" || req.Assertion == "" {
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest, "authId and assertion are required",
+		utils.WriteJSONError(ctx, w, oauth2const.ErrorInvalidRequest, "authId and assertion are required",
 			http.StatusBadRequest, nil)
 		return
 	}
@@ -108,13 +109,13 @@ func (d *callbackDispatcher) handleFlowCallback(w http.ResponseWriter, r *http.R
 		redirectURI, authErr := d.authZService.HandleAuthorizationCallback(ctx, req.AuthID, req.Assertion)
 		if authErr != nil {
 			if authErr.SendErrorToClient {
-				d.writeRedirectWithError(w, authErr)
+				d.writeRedirectWithError(ctx, w, authErr)
 				return
 			}
-			d.writeErrorPageRedirect(w, authErr.Code, authErr.Message, authErr.State)
+			d.writeErrorPageRedirect(ctx, w, authErr.Code, authErr.Message, authErr.State)
 			return
 		}
-		utils.WriteSuccessResponse(w, http.StatusOK, oauth2authz.AuthZPostResponse{RedirectURI: redirectURI})
+		utils.WriteSuccessResponse(ctx, w, http.StatusOK, oauth2authz.AuthZPostResponse{RedirectURI: redirectURI})
 
 	case string(oauth2const.GrantTypeCIBA):
 		cibaErr := d.cibaService.HandleCallback(ctx, req.AuthID, req.Assertion)
@@ -123,18 +124,21 @@ func (d *callbackDispatcher) handleFlowCallback(w http.ResponseWriter, r *http.R
 			if cibaErr.Code == oauth2const.ErrorServerError {
 				statusCode = http.StatusInternalServerError
 			}
-			utils.WriteJSONError(w, cibaErr.Code, cibaErr.Message, statusCode, nil)
+			utils.WriteJSONError(ctx, w, cibaErr.Code, cibaErr.Message, statusCode, nil)
 			return
 		}
-		utils.WriteSuccessResponse(w, http.StatusOK, map[string]string{"status": "OK"})
+		utils.WriteSuccessResponse(ctx, w, http.StatusOK, map[string]string{"status": "OK"})
 
 	default:
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest,
+		utils.WriteJSONError(ctx, w, oauth2const.ErrorInvalidRequest,
 			"Unsupported callback type", http.StatusBadRequest, nil)
 	}
 }
 
-func (d *callbackDispatcher) writeRedirectWithError(w http.ResponseWriter, authErr *oauth2authz.AuthorizationError) {
+func (
+	d *callbackDispatcher) writeRedirectWithError(ctx context.Context,
+	w http.ResponseWriter,
+	authErr *oauth2authz.AuthorizationError) {
 	queryParams := map[string]string{
 		oauth2const.RequestParamError:            authErr.Code,
 		oauth2const.RequestParamErrorDescription: authErr.Message,
@@ -145,15 +149,20 @@ func (d *callbackDispatcher) writeRedirectWithError(w http.ResponseWriter, authE
 	}
 	redirectURI, err := oauth2utils.GetURIWithQueryParams(authErr.ClientRedirectURI, queryParams)
 	if err != nil {
-		d.logger.Error("Failed to construct client redirect URI", log.Error(err))
-		d.writeErrorPageRedirect(w, oauth2const.ErrorServerError,
+		d.logger.ErrorWithContext(ctx, "Failed to construct client redirect URI", log.Error(err))
+		d.writeErrorPageRedirect(ctx, w, oauth2const.ErrorServerError,
 			"Failed to process authorization request", authErr.State)
 		return
 	}
-	utils.WriteSuccessResponse(w, http.StatusOK, oauth2authz.AuthZPostResponse{RedirectURI: redirectURI})
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, oauth2authz.AuthZPostResponse{RedirectURI: redirectURI})
 }
 
-func (d *callbackDispatcher) writeErrorPageRedirect(w http.ResponseWriter, code, msg, state string) {
+func (
+	d *callbackDispatcher) writeErrorPageRedirect(ctx context.Context,
+	w http.ResponseWriter,
+	code,
+	msg,
+	state string) {
 	gateClientConfig := config.GetServerRuntime().Config.GateClient
 	errorPageURL := (&url.URL{
 		Scheme: gateClientConfig.Scheme,
@@ -172,5 +181,5 @@ func (d *callbackDispatcher) writeErrorPageRedirect(w http.ResponseWriter, code,
 		http.Error(w, "Failed to redirect to error page", http.StatusInternalServerError)
 		return
 	}
-	utils.WriteSuccessResponse(w, http.StatusOK, oauth2authz.AuthZPostResponse{RedirectURI: redirectURI})
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, oauth2authz.AuthZPostResponse{RedirectURI: redirectURI})
 }

--- a/backend/internal/oauth/oauth2/callback/callback_test.go
+++ b/backend/internal/oauth/oauth2/callback/callback_test.go
@@ -19,6 +19,7 @@
 package callback
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -272,7 +273,7 @@ func (suite *CallbackDispatcherTestSuite) TestWriteRedirectWithError_WithState()
 		State:             "abc123",
 	}
 	w := httptest.NewRecorder()
-	suite.dispatcher.writeRedirectWithError(w, authErr)
+	suite.dispatcher.writeRedirectWithError(context.Background(), w, authErr)
 
 	suite.Equal(http.StatusOK, w.Code)
 	var resp oauth2authz.AuthZPostResponse
@@ -290,7 +291,7 @@ func (suite *CallbackDispatcherTestSuite) TestWriteRedirectWithError_WithoutStat
 		State:             "",
 	}
 	w := httptest.NewRecorder()
-	suite.dispatcher.writeRedirectWithError(w, authErr)
+	suite.dispatcher.writeRedirectWithError(context.Background(), w, authErr)
 
 	suite.Equal(http.StatusOK, w.Code)
 	var resp oauth2authz.AuthZPostResponse
@@ -310,7 +311,7 @@ func (suite *CallbackDispatcherTestSuite) TestWriteRedirectWithError_URIConstruc
 		State:             "s1",
 	}
 	w := httptest.NewRecorder()
-	suite.dispatcher.writeRedirectWithError(w, authErr)
+	suite.dispatcher.writeRedirectWithError(context.Background(), w, authErr)
 
 	suite.Equal(http.StatusOK, w.Code)
 	var resp oauth2authz.AuthZPostResponse
@@ -322,7 +323,12 @@ func (suite *CallbackDispatcherTestSuite) TestWriteRedirectWithError_URIConstruc
 
 func (suite *CallbackDispatcherTestSuite) TestWriteErrorPageRedirect_WithState() {
 	w := httptest.NewRecorder()
-	suite.dispatcher.writeErrorPageRedirect(w, oauth2const.ErrorServerError, "something broke", "stateXYZ")
+	suite.dispatcher.writeErrorPageRedirect(
+		context.Background(),
+		w,
+		oauth2const.ErrorServerError,
+		"something broke",
+		"stateXYZ")
 
 	suite.Equal(http.StatusOK, w.Code)
 	var resp oauth2authz.AuthZPostResponse
@@ -333,7 +339,12 @@ func (suite *CallbackDispatcherTestSuite) TestWriteErrorPageRedirect_WithState()
 
 func (suite *CallbackDispatcherTestSuite) TestWriteErrorPageRedirect_WithoutState() {
 	w := httptest.NewRecorder()
-	suite.dispatcher.writeErrorPageRedirect(w, oauth2const.ErrorServerError, "something broke", "")
+	suite.dispatcher.writeErrorPageRedirect(
+		context.Background(),
+		w,
+		oauth2const.ErrorServerError,
+		"something broke",
+		"")
 
 	suite.Equal(http.StatusOK, w.Code)
 	var resp oauth2authz.AuthZPostResponse

--- a/backend/internal/oauth/oauth2/ciba/handler.go
+++ b/backend/internal/oauth/oauth2/ciba/handler.go
@@ -19,6 +19,7 @@
 package ciba
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/clientauth"
@@ -50,7 +51,7 @@ func newCIBAHandler(cibaService CIBAServiceInterface) CIBAHandlerInterface {
 // HandleBackchannelAuthRequest handles a POST /oauth2/bc-authorize request.
 func (h *cibaHandler) HandleBackchannelAuthRequest(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest, "Failed to parse request body",
+		utils.WriteJSONError(r.Context(), w, oauth2const.ErrorInvalidRequest, "Failed to parse request body",
 			http.StatusBadRequest, nil)
 		return
 	}
@@ -58,8 +59,9 @@ func (h *cibaHandler) HandleBackchannelAuthRequest(w http.ResponseWriter, r *htt
 	// Get authenticated client from context (set by ClientAuthMiddleware).
 	clientInfo := clientauth.GetOAuthClient(r.Context())
 	if clientInfo == nil {
-		h.logger.Error("OAuth client not found in context - ClientAuthMiddleware must be applied")
-		utils.WriteJSONError(w, oauth2const.ErrorServerError, "Something went wrong",
+		h.logger.ErrorWithContext(r.Context(),
+			"OAuth client not found in context - ClientAuthMiddleware must be applied")
+		utils.WriteJSONError(r.Context(), w, oauth2const.ErrorServerError, "Something went wrong",
 			http.StatusInternalServerError, nil)
 		return
 	}
@@ -73,13 +75,13 @@ func (h *cibaHandler) HandleBackchannelAuthRequest(w http.ResponseWriter, r *htt
 	// or login_hint_token. Zero or multiple hints are both invalid_request.
 	hintsProvided := countNonEmpty(loginHint, idTokenHint, loginHintToken)
 	if hintsProvided == 0 {
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest,
+		utils.WriteJSONError(r.Context(), w, oauth2const.ErrorInvalidRequest,
 			"One of login_hint, id_token_hint, or login_hint_token is required",
 			http.StatusBadRequest, nil)
 		return
 	}
 	if hintsProvided > 1 {
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest,
+		utils.WriteJSONError(r.Context(), w, oauth2const.ErrorInvalidRequest,
 			"Only one of login_hint, id_token_hint, or login_hint_token may be provided",
 			http.StatusBadRequest, nil)
 		return
@@ -89,14 +91,14 @@ func (h *cibaHandler) HandleBackchannelAuthRequest(w http.ResponseWriter, r *htt
 	// by this OP. Return invalid_request with a clear message so clients can adapt.
 	// TODO: implement id_token_hint — resolve user from a previously issued ID token
 	if idTokenHint != "" {
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest,
+		utils.WriteJSONError(r.Context(), w, oauth2const.ErrorInvalidRequest,
 			"id_token_hint is not supported, use login_hint",
 			http.StatusBadRequest, nil)
 		return
 	}
 	// TODO: implement login_hint_token — resolve user from a signed hint JWT
 	if loginHintToken != "" {
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest,
+		utils.WriteJSONError(r.Context(), w, oauth2const.ErrorInvalidRequest,
 			"login_hint_token is not supported, use login_hint",
 			http.StatusBadRequest, nil)
 		return
@@ -112,22 +114,22 @@ func (h *cibaHandler) HandleBackchannelAuthRequest(w http.ResponseWriter, r *htt
 
 	response, cibaErr := h.cibaService.InitiateBackchannelAuth(r.Context(), request, clientInfo.OAuthApp)
 	if cibaErr != nil {
-		writeCIBAError(w, cibaErr)
+		writeCIBAError(r.Context(), w, cibaErr)
 		return
 	}
 
 	w.Header().Set(sysconst.CacheControlHeaderName, sysconst.CacheControlNoStore)
 	w.Header().Set(sysconst.PragmaHeaderName, sysconst.PragmaNoCache)
-	utils.WriteSuccessResponse(w, http.StatusOK, response)
+	utils.WriteSuccessResponse(r.Context(), w, http.StatusOK, response)
 }
 
 // writeCIBAError maps a CIBAError to the appropriate HTTP status code and writes the JSON response.
-func writeCIBAError(w http.ResponseWriter, cibaErr *CIBAError) {
+func writeCIBAError(ctx context.Context, w http.ResponseWriter, cibaErr *CIBAError) {
 	statusCode := http.StatusBadRequest
 	if cibaErr.Code == oauth2const.ErrorServerError {
 		statusCode = http.StatusInternalServerError
 	}
-	utils.WriteJSONError(w, cibaErr.Code, cibaErr.Message, statusCode, nil)
+	utils.WriteJSONError(ctx, w, cibaErr.Code, cibaErr.Message, statusCode, nil)
 }
 
 // countNonEmpty returns the number of non-empty strings in the provided values.

--- a/backend/internal/oauth/oauth2/clientauth/middleware.go
+++ b/backend/internal/oauth/oauth2/clientauth/middleware.go
@@ -52,6 +52,7 @@ func ClientAuthMiddleware(inboundClient inboundclient.InboundClientServiceInterf
 				}
 				// Write error response
 				utils.WriteJSONError(
+					ctx,
 					w,
 					authErr.ErrorCode,
 					authErr.ErrorDescription,

--- a/backend/internal/oauth/oauth2/dcr/handler.go
+++ b/backend/internal/oauth/oauth2/dcr/handler.go
@@ -19,6 +19,7 @@
 package dcr
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
@@ -50,7 +51,7 @@ func (dh *dcrHandler) HandleDCRRegistration(w http.ResponseWriter, r *http.Reque
 
 	dcrRequest, err := sysutils.DecodeJSONBody[DCRRegistrationRequest](r)
 	if err != nil {
-		sysutils.WriteJSONError(w, ErrorInvalidRequestFormat.Code,
+		sysutils.WriteJSONError(ctx, w, ErrorInvalidRequestFormat.Code,
 			ErrorInvalidRequestFormat.ErrorDescription.DefaultValue, http.StatusBadRequest, nil)
 		return
 	}
@@ -65,11 +66,11 @@ func (dh *dcrHandler) HandleDCRRegistration(w http.ResponseWriter, r *http.Reque
 				log.String("error", svcErr.Error.DefaultValue),
 			)
 		}
-		dh.writeServiceErrorResponse(w, svcErr)
+		dh.writeServiceErrorResponse(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, dcrResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, dcrResponse)
 }
 
 // checkDCRAuthorization verifies that the caller holds required permission.
@@ -78,13 +79,16 @@ func (dh *dcrHandler) checkDCRAuthorization(r *http.Request, w http.ResponseWrit
 	if security.HasSystemPermission(security.GetPermissions(r.Context())) {
 		return true
 	}
-	sysutils.WriteJSONError(w, ErrorUnauthorized.Code,
+	sysutils.WriteJSONError(r.Context(), w, ErrorUnauthorized.Code,
 		ErrorUnauthorized.ErrorDescription.DefaultValue, http.StatusUnauthorized, nil)
 	return false
 }
 
 // writeServiceErrorResponse writes a service error response.
-func (dh *dcrHandler) writeServiceErrorResponse(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func (
+	dh *dcrHandler) writeServiceErrorResponse(ctx context.Context,
+	w http.ResponseWriter,
+	svcErr *serviceerror.ServiceError) {
 	var statusCode int
 
 	switch svcErr.Type {
@@ -96,5 +100,5 @@ func (dh *dcrHandler) writeServiceErrorResponse(w http.ResponseWriter, svcErr *s
 		statusCode = http.StatusBadRequest
 	}
 
-	sysutils.WriteJSONError(w, svcErr.Code, svcErr.ErrorDescription.DefaultValue, statusCode, nil)
+	sysutils.WriteJSONError(ctx, w, svcErr.Code, svcErr.ErrorDescription.DefaultValue, statusCode, nil)
 }

--- a/backend/internal/oauth/oauth2/dcr/handler_test.go
+++ b/backend/internal/oauth/oauth2/dcr/handler_test.go
@@ -284,7 +284,7 @@ func TestWriteServiceErrorResponse_DirectCall(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
-			handler.writeServiceErrorResponse(rr, tc.serviceError)
+			handler.writeServiceErrorResponse(context.Background(), rr, tc.serviceError)
 
 			assert.Equal(t, tc.expectedStatus, rr.Code)
 			var errorResponse map[string]interface{}

--- a/backend/internal/oauth/oauth2/dcr/init.go
+++ b/backend/internal/oauth/oauth2/dcr/init.go
@@ -20,6 +20,7 @@
 package dcr
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -42,7 +43,9 @@ func Initialize(
 	transactioner, err := provider.GetDBProvider().GetRuntimeDBTransactioner()
 	if err != nil {
 		wrappedErr := fmt.Errorf("failed to get runtime DB transactioner for DCR: %w", err)
-		log.GetLogger().Error("Failed to initialize DCR service", log.Error(wrappedErr))
+		// Service initialization runs during application startup, outside any request.
+		log.GetLogger().ErrorWithContext(context.Background(),
+			"Failed to initialize DCR service", log.Error(wrappedErr))
 		return wrappedErr
 	}
 	dcrService := newDCRService(appService, ouService, i18nService, transactioner)

--- a/backend/internal/oauth/oauth2/discovery/handler.go
+++ b/backend/internal/oauth/oauth2/discovery/handler.go
@@ -51,7 +51,7 @@ func (dh *discoveryHandler) HandleOAuth2AuthorizationServerMetadata(w http.Respo
 
 	metadata := dh.discoveryService.GetOAuth2AuthorizationServerMetadata(ctx)
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, metadata)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, metadata)
 	logger.DebugWithContext(ctx, "OAuth 2.0 Authorization Server Metadata response sent successfully")
 }
 
@@ -62,10 +62,10 @@ func (dh *discoveryHandler) HandleOIDCDiscovery(w http.ResponseWriter, r *http.R
 
 	metadata, err := dh.discoveryService.GetOIDCMetadata(ctx)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusInternalServerError, apierror.ErrorResponse{})
+		sysutils.WriteErrorResponse(ctx, w, http.StatusInternalServerError, apierror.ErrorResponse{})
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, metadata)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, metadata)
 	logger.DebugWithContext(ctx, "OIDC discovery response sent successfully")
 }

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -185,7 +185,8 @@ func (ds *discoveryService) getSupportedSubjectTypes() []string {
 func (ds *discoveryService) getSupportedSigningAlgorithms(ctx context.Context) ([]string, error) {
 	keys, err := ds.cryptoProvider.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
 	if err != nil {
-		log.GetLogger().Error("Failed to retrieve public keys for signing algorithm discovery", log.Error(err))
+		log.GetLogger().ErrorWithContext(ctx,
+			"Failed to retrieve public keys for signing algorithm discovery", log.Error(err))
 		return nil, err
 	}
 	result := make([]string, 0, len(keys))
@@ -198,7 +199,8 @@ func (ds *discoveryService) getSupportedSigningAlgorithms(ctx context.Context) (
 	}
 	if len(result) == 0 {
 		err = errors.New("no valid signing algorithms found")
-		log.GetLogger().Error("No valid signing algorithms found in registered public keys", log.Error(err))
+		log.GetLogger().ErrorWithContext(ctx,
+			"No valid signing algorithms found in registered public keys", log.Error(err))
 		return nil, err
 	}
 	return result, nil

--- a/backend/internal/oauth/oauth2/granthandlers/ciba.go
+++ b/backend/internal/oauth/oauth2/granthandlers/ciba.go
@@ -117,7 +117,7 @@ func (h *cibaGrantHandler) HandleGrant(ctx context.Context, tokenRequest *model.
 	if now.After(record.ExpiryTime) {
 		if record.State != ciba.CIBAStateExpired && record.State != ciba.CIBAStateConsumed {
 			if updateErr := h.cibaService.UpdateState(ctx, record.AuthReqID, ciba.CIBAStateExpired); updateErr != nil {
-				logger.Error("Failed to mark CIBA request as expired", log.Error(updateErr))
+				logger.ErrorWithContext(ctx, "Failed to mark CIBA request as expired", log.Error(updateErr))
 			}
 		}
 		return nil, &model.ErrorResponse{
@@ -156,7 +156,7 @@ func (h *cibaGrantHandler) handlePending(ctx context.Context, record *ciba.CIBAA
 		now.Sub(record.LastPolledAt) < time.Duration(constants.CIBADefaultIntervalSeconds)*time.Second
 
 	if updateErr := h.cibaService.UpdateLastPolled(ctx, record.AuthReqID, now); updateErr != nil {
-		logger.Error("Failed to update CIBA last polled time", log.Error(updateErr))
+		logger.ErrorWithContext(ctx, "Failed to update CIBA last polled time", log.Error(updateErr))
 	}
 
 	if tooFast {
@@ -186,7 +186,7 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 	if record.AttributeCacheID != "" {
 		cacheEntry, cacheErr := h.attributeCache.GetAttributeCache(ctx, record.AttributeCacheID)
 		if cacheErr != nil {
-			logger.Error("Failed to get user attributes from attribute cache",
+			logger.ErrorWithContext(ctx, "Failed to get user attributes from attribute cache",
 				log.String("error", cacheErr.ErrorDescription.DefaultValue))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
@@ -207,7 +207,7 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 		OAuthApp:         oauthApp,
 	})
 	if err != nil {
-		logger.Error("Failed to generate access token", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to generate access token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorServerError,
 			ErrorDescription: "Failed to generate token",
@@ -229,7 +229,7 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 			CompletedACR:   record.CompletedACR,
 		})
 		if idErr != nil {
-			logger.Error("Failed to generate ID token", log.Error(idErr))
+			logger.ErrorWithContext(ctx, "Failed to generate ID token", log.Error(idErr))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
 				ErrorDescription: "Failed to generate token",
@@ -242,7 +242,7 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 	// consumed it, reject this one with invalid_grant.
 	consumed, consumeErr := h.cibaService.MarkConsumed(ctx, record.AuthReqID)
 	if consumeErr != nil {
-		logger.Error("Failed to consume CIBA authentication request", log.Error(consumeErr))
+		logger.ErrorWithContext(ctx, "Failed to consume CIBA authentication request", log.Error(consumeErr))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorServerError,
 			ErrorDescription: "Failed to process token request",

--- a/backend/internal/oauth/oauth2/introspect/handler.go
+++ b/backend/internal/oauth/oauth2/introspect/handler.go
@@ -44,7 +44,7 @@ func newTokenIntrospectionHandler(introspectionService TokenIntrospectionService
 func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if err := r.ParseForm(); err != nil {
-		sysutils.WriteJSONError(w, constants.ErrorInvalidRequest, "Failed to decode request body",
+		sysutils.WriteJSONError(ctx, w, constants.ErrorInvalidRequest, "Failed to decode request body",
 			http.StatusBadRequest, nil)
 		return
 	}
@@ -52,7 +52,7 @@ func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *h
 	// Extract request parameters
 	token := r.FormValue(constants.RequestParamToken)
 	if token == "" {
-		sysutils.WriteJSONError(w, constants.ErrorInvalidRequest, "Token parameter is required",
+		sysutils.WriteJSONError(ctx, w, constants.ErrorInvalidRequest, "Token parameter is required",
 			http.StatusBadRequest, nil)
 		return
 	}
@@ -62,11 +62,11 @@ func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *h
 	response, err := h.service.IntrospectToken(ctx, token, tokenTypeHint)
 	if err != nil {
 		h.logger.ErrorWithContext(ctx, "Failed to introspect token", log.Error(err))
-		sysutils.WriteJSONError(w, constants.ErrorServerError,
+		sysutils.WriteJSONError(ctx, w, constants.ErrorServerError,
 			"An unexpected error occurred while processing the request",
 			http.StatusInternalServerError, nil)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }

--- a/backend/internal/oauth/oauth2/par/handler.go
+++ b/backend/internal/oauth/oauth2/par/handler.go
@@ -63,14 +63,14 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 	clientInfo := clientauth.GetOAuthClient(ctx)
 	if clientInfo == nil {
 		h.logger.ErrorWithContext(ctx, "OAuth client not found in context - ClientAuthMiddleware must be applied")
-		utils.WriteJSONError(w, oauth2const.ErrorServerError,
+		utils.WriteJSONError(ctx, w, oauth2const.ErrorServerError,
 			"Something went wrong", http.StatusInternalServerError, nil)
 		return
 	}
 
 	// Parse form-encoded body.
 	if err := r.ParseForm(); err != nil {
-		utils.WriteJSONError(w, oauth2const.ErrorInvalidRequest, "Failed to parse request body",
+		utils.WriteJSONError(ctx, w, oauth2const.ErrorInvalidRequest, "Failed to parse request body",
 			http.StatusBadRequest, nil)
 		return
 	}
@@ -93,7 +93,7 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 				log.String("error", errDesc))
 			errDesc = "Invalid DPoP proof"
 		}
-		utils.WriteJSONError(w, errCode, errDesc, statusCode, nil)
+		utils.WriteJSONError(ctx, w, errCode, errDesc, statusCode, nil)
 		return
 	}
 
@@ -117,11 +117,11 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 			)
 			statusCode = http.StatusInternalServerError
 		}
-		utils.WriteJSONError(w, errCode, errDesc, statusCode, nil)
+		utils.WriteJSONError(ctx, w, errCode, errDesc, statusCode, nil)
 		return
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusCreated, resp)
+	utils.WriteSuccessResponse(ctx, w, http.StatusCreated, resp)
 }
 
 // verifyDPoPHeader verifies the DPoP proof header if present and returns the JKT, error code, and error description.

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -79,7 +79,7 @@ func (s *parService) HandlePushedAuthorizationRequest(
 
 	// Validate the redirect URI.
 	redirectURI := params[oauth2const.RequestParamRedirectURI]
-	if err := oauthApp.ValidateRedirectURI(redirectURI); err != nil {
+	if err := oauthApp.ValidateRedirectURI(ctx, redirectURI); err != nil {
 		return nil, oauth2const.ErrorInvalidRequest, "Invalid redirect URI"
 	}
 

--- a/backend/internal/oauth/oauth2/token/handler.go
+++ b/backend/internal/oauth/oauth2/token/handler.go
@@ -65,7 +65,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 	if err := r.ParseForm(); err != nil {
 		publishTokenIssuanceFailedEvent(th.observabilitySvc, r.Context(), "", "", "",
 			http.StatusBadRequest, err.Error(), startTime)
-		utils.WriteJSONError(w, constants.ErrorInvalidRequest,
+		utils.WriteJSONError(r.Context(), w, constants.ErrorInvalidRequest,
 			"Failed to parse request body", http.StatusBadRequest, nil)
 		return
 	}
@@ -75,7 +75,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 	if len(dpopHeaders) > 1 {
 		publishTokenIssuanceFailedEvent(th.observabilitySvc, r.Context(), "", "", "",
 			http.StatusBadRequest, "Multiple DPoP headers", startTime)
-		utils.WriteJSONError(w, constants.ErrorInvalidDPoPProof,
+		utils.WriteJSONError(r.Context(), w, constants.ErrorInvalidDPoPProof,
 			"Multiple DPoP headers", http.StatusBadRequest, nil)
 		return
 	}
@@ -88,7 +88,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 	clientInfo := clientauth.GetOAuthClient(r.Context())
 	if clientInfo == nil {
 		logger.ErrorWithContext(ctx, "OAuth client not found in context - ClientAuthMiddleware must be applied")
-		utils.WriteJSONError(w, constants.ErrorServerError,
+		utils.WriteJSONError(r.Context(), w, constants.ErrorServerError,
 			"Something went wrong", http.StatusInternalServerError, nil)
 		return
 	}
@@ -131,9 +131,9 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 				logger.DebugWithContext(ctx, "DPoP proof rejected", log.String("error", description))
 				description = "Invalid DPoP proof"
 			}
-			utils.WriteJSONError(w, tokenError.Error, description, statusCode, nil)
+			utils.WriteJSONError(r.Context(), w, tokenError.Error, description, statusCode, nil)
 		} else {
-			utils.WriteJSONError(w, constants.ErrorServerError, "Something went wrong",
+			utils.WriteJSONError(r.Context(), w, constants.ErrorServerError, "Something went wrong",
 				http.StatusInternalServerError, nil)
 		}
 		return
@@ -145,5 +145,5 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 	w.Header().Set(sysconst.CacheControlHeaderName, sysconst.CacheControlNoStore)
 	w.Header().Set(sysconst.PragmaHeaderName, sysconst.PragmaNoCache)
 
-	utils.WriteSuccessResponse(w, http.StatusOK, tokenResponse)
+	utils.WriteSuccessResponse(r.Context(), w, http.StatusOK, tokenResponse)
 }

--- a/backend/internal/oauth/oauth2/token/service.go
+++ b/backend/internal/oauth/oauth2/token/service.go
@@ -323,7 +323,7 @@ func (ts *tokenService) publishTokenIssuanceStartedEvent(ctx context.Context, cl
 		WithData(event.DataKey.GrantType, grantType).
 		WithData(event.DataKey.Scope, scope)
 
-	ts.observabilitySvc.PublishEvent(evt)
+	ts.observabilitySvc.PublishEvent(ctx, evt)
 }
 
 func (ts *tokenService) publishTokenIssuedEvent(
@@ -346,7 +346,7 @@ func (ts *tokenService) publishTokenIssuedEvent(
 		WithData(event.DataKey.Scope, scope).
 		WithData(event.DataKey.DurationMs, fmt.Sprintf("%d", duration))
 
-	ts.observabilitySvc.PublishEvent(evt)
+	ts.observabilitySvc.PublishEvent(ctx, evt)
 }
 
 // publishTokenIssuanceFailedEvent is a package-level helper shared by tokenService and tokenHandler.
@@ -381,5 +381,5 @@ func publishTokenIssuanceFailedEvent(
 		}).
 		WithData(event.DataKey.DurationMs, fmt.Sprintf("%d", duration))
 
-	svc.PublishEvent(evt)
+	svc.PublishEvent(ctx, evt)
 }

--- a/backend/internal/oauth/oauth2/token/service_test.go
+++ b/backend/internal/oauth/oauth2/token/service_test.go
@@ -58,7 +58,7 @@ func (suite *TokenServiceTestSuite) SetupTest() {
 
 	suite.mockObsSvc = observabilitymock.NewObservabilityServiceInterfaceMock(suite.T())
 	suite.mockObsSvc.On("IsEnabled").Return(true).Maybe()
-	suite.mockObsSvc.On("PublishEvent", mock.Anything).Return().Maybe()
+	suite.mockObsSvc.On("PublishEvent", mock.Anything, mock.Anything).Return().Maybe()
 
 	suite.mockDPoPVerifier = dpopmock.NewVerifierInterfaceMock(suite.T())
 

--- a/backend/internal/oauth/oauth2/userinfo/handler.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler.go
@@ -80,7 +80,7 @@ func (h *userInfoHandler) handleBearerRequest(
 			w.Header().Set(serverconst.WWWAuthenticateHeaderName, serverconst.TokenTypeBearer)
 			w.WriteHeader(http.StatusUnauthorized)
 		} else {
-			h.writeBearerError(w, constants.ErrorInvalidRequest,
+			h.writeBearerError(r.Context(), w, constants.ErrorInvalidRequest,
 				"Invalid or malformed Bearer token", http.StatusBadRequest)
 		}
 		return
@@ -102,13 +102,13 @@ func (h *userInfoHandler) handleDPoPRequest(
 ) {
 	accessToken, err := dpop.ExtractDPoPToken(authHeader)
 	if err != nil {
-		h.writeDPoPError(w, "invalid_token", "Invalid or malformed DPoP token", http.StatusUnauthorized)
+		h.writeDPoPError(r.Context(), w, "invalid_token", "Invalid or malformed DPoP token", http.StatusUnauthorized)
 		return
 	}
 
 	dpopHeaders := r.Header.Values(constants.HeaderDPoP)
 	if len(dpopHeaders) != 1 {
-		h.writeDPoPError(w, "invalid_token",
+		h.writeDPoPError(r.Context(), w, "invalid_token",
 			"Exactly one DPoP header is required", http.StatusUnauthorized)
 		return
 	}
@@ -138,7 +138,7 @@ func (h *userInfoHandler) writeUserInfoResponse(ctx context.Context, w http.Resp
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(result.JWTBody))
 	default:
-		utils.WriteSuccessResponse(w, http.StatusOK, result.JSONBody)
+		utils.WriteSuccessResponse(ctx, w, http.StatusOK, result.JSONBody)
 	}
 
 	h.logger.DebugWithContext(ctx, "UserInfo response sent successfully")
@@ -168,34 +168,34 @@ func (h *userInfoHandler) writeServiceErrorResponse(ctx context.Context,
 		h.logger.ErrorWithContext(ctx, "Internal server error processing userinfo request",
 			log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
-		utils.WriteJSONError(w, constants.ErrorServerError,
+		utils.WriteJSONError(ctx, w, constants.ErrorServerError,
 			serviceerror.InternalServerError.Error.DefaultValue, statusCode, nil)
 		return
 	}
 
 	if dpop {
-		h.writeDPoPError(w, svcErr.Code, svcErr.ErrorDescription.DefaultValue, statusCode)
+		h.writeDPoPError(ctx, w, svcErr.Code, svcErr.ErrorDescription.DefaultValue, statusCode)
 	} else {
-		h.writeBearerError(w, svcErr.Code, svcErr.ErrorDescription.DefaultValue, statusCode)
+		h.writeBearerError(ctx, w, svcErr.Code, svcErr.ErrorDescription.DefaultValue, statusCode)
 	}
 }
 
 // writeBearerError writes a JSON error response with a WWW-Authenticate: Bearer header.
-func (h *userInfoHandler) writeBearerError(
+func (h *userInfoHandler) writeBearerError(ctx context.Context,
 	w http.ResponseWriter, errorCode, errorDescription string, statusCode int,
 ) {
 	wwwAuth := fmt.Sprintf("Bearer error=%q, error_description=%q", errorCode, errorDescription)
-	utils.WriteJSONError(w, errorCode, errorDescription, statusCode,
+	utils.WriteJSONError(ctx, w, errorCode, errorDescription, statusCode,
 		[]map[string]string{{serverconst.WWWAuthenticateHeaderName: wwwAuth}})
 }
 
 // writeDPoPError writes a JSON error response with a WWW-Authenticate: DPoP header
 // advertising the supported DPoP signing algorithms.
-func (h *userInfoHandler) writeDPoPError(
+func (h *userInfoHandler) writeDPoPError(ctx context.Context,
 	w http.ResponseWriter, errorCode, errorDescription string, statusCode int,
 ) {
 	wwwAuth := fmt.Sprintf("DPoP algs=%q, error=%q, error_description=%q",
 		strings.Join(h.dpopAllowedAlgs, " "), errorCode, errorDescription)
-	utils.WriteJSONError(w, errorCode, errorDescription, statusCode,
+	utils.WriteJSONError(ctx, w, errorCode, errorDescription, statusCode,
 		[]map[string]string{{serverconst.WWWAuthenticateHeaderName: wwwAuth}})
 }

--- a/backend/internal/openid4vp/handler.go
+++ b/backend/internal/openid4vp/handler.go
@@ -19,6 +19,7 @@
 package openid4vp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -82,13 +83,13 @@ func newOpenID4VPHandler(
 func (h *openID4VPHandler) HandleRequestObject(w http.ResponseWriter, r *http.Request) {
 	state := sysutils.SanitizeString(r.URL.Query().Get("state"))
 	if state == "" {
-		writeServiceErrorResponse(w, &ErrorInvalidRequest)
+		writeServiceErrorResponse(r.Context(), w, &ErrorInvalidRequest)
 		return
 	}
 
 	jar, err := h.service.RequestObject(r.Context(), state)
 	if err != nil {
-		writeServiceErrorResponse(w, toServiceError(err))
+		writeServiceErrorResponse(r.Context(), w, toServiceError(err))
 		return
 	}
 
@@ -96,26 +97,26 @@ func (h *openID4VPHandler) HandleRequestObject(w http.ResponseWriter, r *http.Re
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
 	if _, werr := w.Write([]byte(jar)); werr != nil {
-		log.GetLogger().Error("Failed to write request object response", log.Error(werr))
+		log.GetLogger().ErrorWithContext(r.Context(), "Failed to write request object response", log.Error(werr))
 	}
 }
 
 // HandleResponse ingests the wallet's encrypted VP response.
 func (h *openID4VPHandler) HandleResponse(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
-		writeServiceErrorResponse(w, &ErrorInvalidRequest)
+		writeServiceErrorResponse(r.Context(), w, &ErrorInvalidRequest)
 		return
 	}
 
 	state := sysutils.SanitizeString(r.FormValue("state"))
 	response := r.FormValue("response")
 	if state == "" || response == "" {
-		writeServiceErrorResponse(w, &ErrorInvalidRequest)
+		writeServiceErrorResponse(r.Context(), w, &ErrorInvalidRequest)
 		return
 	}
 
 	if _, err := h.service.SubmitResponse(r.Context(), state, []byte(response)); err != nil {
-		writeServiceErrorResponse(w, toServiceError(err))
+		writeServiceErrorResponse(r.Context(), w, toServiceError(err))
 		return
 	}
 
@@ -123,28 +124,28 @@ func (h *openID4VPHandler) HandleResponse(w http.ResponseWriter, r *http.Request
 	if redirect := h.service.ResultRedirectURI(state); redirect != "" {
 		body["redirect_uri"] = redirect
 	}
-	sysutils.WriteSuccessResponse(w, http.StatusOK, body)
+	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, body)
 }
 
 // HandleInitiate starts a verifier transaction on behalf of an RP.
 func (h *openID4VPHandler) HandleInitiate(w http.ResponseWriter, r *http.Request) {
 	var req initiateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeServiceErrorResponse(w, &ErrorInvalidRequest)
+		writeServiceErrorResponse(r.Context(), w, &ErrorInvalidRequest)
 		return
 	}
 	if strings.TrimSpace(req.DefinitionID) == "" || strings.TrimSpace(req.RPID) == "" {
-		writeServiceErrorResponse(w, &ErrorInvalidRequest)
+		writeServiceErrorResponse(r.Context(), w, &ErrorInvalidRequest)
 		return
 	}
 	init, err := h.service.InitiateForRP(r.Context(), req.DefinitionID, req.RPID)
 	if err != nil {
 		if isUnregisteredDefinition(err) {
-			writeServiceErrorResponse(w, &ErrorUnknownDefinition)
+			writeServiceErrorResponse(r.Context(), w, &ErrorUnknownDefinition)
 			return
 		}
-		log.GetLogger().Error("Failed to initiate OpenID4VP transaction", log.Error(err))
-		writeServiceErrorResponse(w, toServiceError(err))
+		log.GetLogger().ErrorWithContext(r.Context(), "Failed to initiate OpenID4VP transaction", log.Error(err))
+		writeServiceErrorResponse(r.Context(), w, toServiceError(err))
 		return
 	}
 
@@ -160,42 +161,42 @@ func (h *openID4VPHandler) HandleInitiate(w http.ResponseWriter, r *http.Request
 		StatusURL: h.rpStatusBase + init.State,
 		ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
 	}
-	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
+	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, resp)
 }
 
 // HandleStatus issues a result token on COMPLETED; FAILED/EXPIRED carry a diagnostic but no token.
 func (h *openID4VPHandler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	txnID := strings.TrimSpace(extractTxnID(r))
 	if txnID == "" {
-		writeServiceErrorResponse(w, &ErrorInvalidRequest)
+		writeServiceErrorResponse(r.Context(), w, &ErrorInvalidRequest)
 		return
 	}
 
 	rs, err := h.service.LookupState(r.Context(), txnID)
 	switch {
 	case errors.Is(err, ErrUnknownState):
-		writeServiceErrorResponse(w, &ErrorUnknownState)
+		writeServiceErrorResponse(r.Context(), w, &ErrorUnknownState)
 		return
 	case errors.Is(err, ErrExpiredState):
-		sysutils.WriteSuccessResponse(w, http.StatusOK, statusResponse{Status: "EXPIRED"})
+		sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, statusResponse{Status: "EXPIRED"})
 		return
 	case err != nil:
-		writeServiceErrorResponse(w, toServiceError(err))
+		writeServiceErrorResponse(r.Context(), w, toServiceError(err))
 		return
 	}
 
 	switch rs.Status {
 	case StatusPending:
-		sysutils.WriteSuccessResponse(w, http.StatusOK, statusResponse{Status: "PENDING"})
+		sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, statusResponse{Status: "PENDING"})
 	case StatusFailed:
-		sysutils.WriteSuccessResponse(w, http.StatusOK, statusResponse{
+		sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, statusResponse{
 			Status: "FAILED",
 			Error:  rs.FailureReason,
 		})
 	case StatusCompleted:
 		if h.issuer == nil {
-			log.GetLogger().Error("Result token issuer not configured")
-			writeServiceErrorResponse(w, &serviceerror.InternalServerError)
+			log.GetLogger().ErrorWithContext(r.Context(), "Result token issuer not configured")
+			writeServiceErrorResponse(r.Context(), w, &serviceerror.InternalServerError)
 			return
 		}
 		rpID := rs.RPID
@@ -205,16 +206,16 @@ func (h *openID4VPHandler) HandleStatus(w http.ResponseWriter, r *http.Request) 
 		token, tokenErr := h.issuer.issueResultToken(
 			r.Context(), rpID, rs, int64(h.resultTokenValidity.Seconds()))
 		if tokenErr != nil {
-			log.GetLogger().Error("Failed to issue result token", log.Error(tokenErr))
-			writeServiceErrorResponse(w, &serviceerror.InternalServerError)
+			log.GetLogger().ErrorWithContext(r.Context(), "Failed to issue result token", log.Error(tokenErr))
+			writeServiceErrorResponse(r.Context(), w, &serviceerror.InternalServerError)
 			return
 		}
-		sysutils.WriteSuccessResponse(w, http.StatusOK, statusResponse{
+		sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, statusResponse{
 			Status:      "COMPLETED",
 			ResultToken: token,
 		})
 	default:
-		writeServiceErrorResponse(w, &serviceerror.InternalServerError)
+		writeServiceErrorResponse(r.Context(), w, &serviceerror.InternalServerError)
 	}
 }
 
@@ -233,12 +234,12 @@ func extractTxnID(r *http.Request) string {
 	return strings.TrimPrefix(r.URL.Path, apiStatusPrefix)
 }
 
-func writeServiceErrorResponse(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func writeServiceErrorResponse(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
 		statusCode = clientErrorStatusCode(svcErr.Code)
 	}
-	sysutils.WriteErrorResponse(w, statusCode, apierror.ErrorResponse{
+	sysutils.WriteErrorResponse(ctx, w, statusCode, apierror.ErrorResponse{
 		Code:        svcErr.Code,
 		Message:     svcErr.Error,
 		Description: svcErr.ErrorDescription,

--- a/backend/internal/openid4vp/handler_test.go
+++ b/backend/internal/openid4vp/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -352,9 +353,172 @@ func TestAPIRegisterRoutesAddsInitiateAndStatus(t *testing.T) {
 	assert.Equal(t, "PENDING", sr.Status)
 }
 
+func TestHandleRequestObjectWriteError(t *testing.T) {
+	b := newPIDBuilder(t)
+	svc, _ := newTestService(t, b)
+	h := newOpenID4VPHandler(svc, nil, "", 0, 0)
+
+	init, err := svc.Initiate(context.Background(), testDefinitionID)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/openid4vp/request?state="+url.QueryEscape(init.State), nil)
+	rec := &failingResponseWriter{header: http.Header{}}
+	h.HandleRequestObject(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.status)
+	assert.True(t, rec.writeCalled)
+}
+
+func TestHandleResponseParseFormError(t *testing.T) {
+	b := newPIDBuilder(t)
+	svc, _ := newTestService(t, b)
+	h := newOpenID4VPHandler(svc, nil, "", 0, 0)
+
+	req := httptest.NewRequest(http.MethodPost, "/openid4vp/response", strings.NewReader("%zz"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h.HandleResponse(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, ErrorInvalidRequest.Code, decodeErrorCode(t, rec))
+}
+
+func TestAPIInitiateServiceError(t *testing.T) {
+	svc := &stubService{initiateErr: errors.New("boom")}
+	h := newOpenID4VPHandler(svc, &resultTokenIssuerFake{}, apiBaseURL, 0, 0)
+
+	body, _ := json.Marshal(initiateRequest{DefinitionID: testDefinitionID, RPID: "rp"})
+	rec := postJSON(h.HandleInitiate, body)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestAPIStatusLookupServiceError(t *testing.T) {
+	svc := &stubService{lookupErr: errors.New("boom")}
+	h := newOpenID4VPHandler(svc, &resultTokenIssuerFake{}, apiBaseURL, 0, 0)
+
+	rec := getStatus(h.HandleStatus, "txn")
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestAPIStatusEmptyTxn(t *testing.T) {
+	h, _ := newTestRPHandler(t)
+	rec := getStatus(h.HandleStatus, "")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, ErrorInvalidRequest.Code, decodeErrorCode(t, rec))
+}
+
+func TestAPIStatusCompletedIssuerNotConfigured(t *testing.T) {
+	b := newPIDBuilder(t)
+	svc, store := newTestService(t, b)
+	h := newOpenID4VPHandler(svc, nil, apiBaseURL, 300*time.Second, 0)
+
+	ir := initiateForTest(t, h, store)
+	rs := store.m[ir.TxnID]
+	rs.Status = StatusCompleted
+	rs.Result = &VerifiedPresentation{Subject: "sub"}
+
+	rec := getStatus(h.HandleStatus, ir.TxnID)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestAPIStatusCompletedIssuerError(t *testing.T) {
+	b := newPIDBuilder(t)
+	svc, store := newTestService(t, b)
+	issuer := &resultTokenIssuerFake{errToThrow: errors.New("sign failed")}
+	h := newOpenID4VPHandler(svc, issuer, apiBaseURL, 300*time.Second, 0)
+
+	ir := initiateForTest(t, h, store)
+	rs := store.m[ir.TxnID]
+	rs.Status = StatusCompleted
+	rs.Result = &VerifiedPresentation{Subject: "sub"}
+
+	rec := getStatus(h.HandleStatus, ir.TxnID)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestAPIStatusUnknownStatusValue(t *testing.T) {
+	b := newPIDBuilder(t)
+	svc, store := newTestService(t, b)
+	issuer := &resultTokenIssuerFake{}
+	h := newOpenID4VPHandler(svc, issuer, apiBaseURL, 300*time.Second, 0)
+
+	ir := initiateForTest(t, h, store)
+	store.m[ir.TxnID].Status = Status("BOGUS")
+
+	rec := getStatus(h.HandleStatus, ir.TxnID)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
 // =============================================================================
 // Shared test helpers
 // =============================================================================
+
+func initiateForTest(t *testing.T, h *openID4VPHandler, store *fakeStore) initiateResponse {
+	t.Helper()
+	rec := postJSON(h.HandleInitiate, mustJSON(t, initiateRequest{
+		DefinitionID: testDefinitionID, RPID: "rp",
+	}))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var ir initiateResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &ir))
+	require.NotNil(t, store.m[ir.TxnID])
+	return ir
+}
+
+// failingResponseWriter records the written status code and fails every Write.
+type failingResponseWriter struct {
+	header      http.Header
+	status      int
+	writeCalled bool
+}
+
+func (w *failingResponseWriter) Header() http.Header { return w.header }
+
+func (w *failingResponseWriter) Write([]byte) (int, error) {
+	w.writeCalled = true
+	return 0, errors.New("write failed")
+}
+
+func (w *failingResponseWriter) WriteHeader(code int) { w.status = code }
+
+// stubService implements OpenID4VPServiceInterface to drive handler error
+// branches that a real *service does not reach in unit tests.
+type stubService struct {
+	initiateErr error
+	lookupErr   error
+}
+
+func (s *stubService) Initiate(context.Context, string) (*Initiation, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubService) Result(context.Context, string) (*RequestState, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubService) RequestObject(context.Context, string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (s *stubService) SubmitResponse(context.Context, string, []byte) (*VerifiedPresentation, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubService) ResultRedirectURI(string) string { return "" }
+
+func (s *stubService) InitiateForRP(context.Context, string, string) (*Initiation, error) {
+	if s.initiateErr != nil {
+		return nil, s.initiateErr
+	}
+	return &Initiation{State: "stub-state"}, nil
+}
+
+func (s *stubService) LookupState(context.Context, string) (*RequestState, error) {
+	if s.lookupErr != nil {
+		return nil, s.lookupErr
+	}
+	return &RequestState{State: "stub-state", Status: StatusPending}, nil
+}
 
 func postForm(h *openID4VPHandler, form url.Values) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodPost, "/openid4vp/response", strings.NewReader(form.Encode()))

--- a/backend/internal/ou/declarative_resource.go
+++ b/backend/internal/ou/declarative_resource.go
@@ -140,7 +140,7 @@ func (e *ouExporter) GetResourceByID(
 }
 
 // ValidateResource validates an organization unit resource.
-func (e *ouExporter) ValidateResource(
+func (e *ouExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	ou, ok := resource.(*OrganizationUnit)
@@ -148,7 +148,7 @@ func (e *ouExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeOU, id)
 	}
 
-	if err := declarativeresource.ValidateResourceName(
+	if err := declarativeresource.ValidateResourceName(ctx,
 		ou.Name, resourceTypeOU, id, "OU_VALIDATION_ERROR", logger); err != nil {
 		return "", err
 	}

--- a/backend/internal/ou/declarative_resource_test.go
+++ b/backend/internal/ou/declarative_resource_test.go
@@ -86,7 +86,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateResource() {
 		Name:   "Test OU",
 	}
 
-	name, err := s.exporter.ValidateResource(ou, "test-ou-1", nil)
+	name, err := s.exporter.ValidateResource(context.Background(), ou, "test-ou-1", nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test OU", name)
 }
@@ -94,7 +94,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateResource() {
 func (s *DeclarativeResourceTestSuite) TestValidateResourceInvalidType() {
 	invalidResource := "not an OU"
 
-	name, err := s.exporter.ValidateResource(invalidResource, "test-id", nil)
+	name, err := s.exporter.ValidateResource(context.Background(), invalidResource, "test-id", nil)
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), name)
 	assert.Equal(s.T(), "INVALID_TYPE", err.Code)

--- a/backend/internal/ou/handler.go
+++ b/backend/internal/ou/handler.go
@@ -19,6 +19,7 @@
 package ou
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -52,7 +53,7 @@ func (ouh *organizationUnitHandler) HandleOUListRequest(w http.ResponseWriter, r
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -62,17 +63,17 @@ func (ouh *organizationUnitHandler) HandleOUListRequest(w http.ResponseWriter, r
 
 	f, err := filter.ParseFilterParam(r.URL.Query())
 	if err != nil {
-		ouh.handleError(w, &ErrorInvalidFilter)
+		ouh.handleError(ctx, w, &ErrorInvalidFilter)
 		return
 	}
 
 	ouListResponse, svcErr := ouh.service.GetOrganizationUnitList(ctx, limit, offset, f)
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, ouListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, ouListResponse)
 
 	logger.DebugWithContext(ctx, "Successfully listed organization units with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -87,7 +88,7 @@ func (ouh *organizationUnitHandler) HandleOUPostRequest(w http.ResponseWriter, r
 
 	createRequest, err := sysutils.DecodeJSONBody[OrganizationUnitRequest](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, apierror.ErrorResponse{
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, apierror.ErrorResponse{
 			Code:        ErrorInvalidRequestFormat.Code,
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
@@ -99,11 +100,11 @@ func (ouh *organizationUnitHandler) HandleOUPostRequest(w http.ResponseWriter, r
 
 	createdOU, svcErr := ouh.service.CreateOrganizationUnit(ctx, sanitizedRequest)
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdOU)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdOU)
 
 	logger.DebugWithContext(ctx, "Successfully created organization unit", log.String("ouId", createdOU.ID))
 }
@@ -120,11 +121,11 @@ func (ouh *organizationUnitHandler) HandleOUGetRequest(w http.ResponseWriter, r 
 
 	ou, svcErr := ouh.service.GetOrganizationUnit(ctx, id)
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, ou)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, ou)
 
 	logger.DebugWithContext(ctx, "Successfully retrieved organization unit", log.String("ouId", id))
 }
@@ -146,11 +147,11 @@ func (ouh *organizationUnitHandler) HandleOUPutRequest(w http.ResponseWriter, r 
 
 	ou, svcErr := ouh.service.UpdateOrganizationUnit(ctx, id, sanitizedRequest)
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, ou)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, ou)
 
 	logger.DebugWithContext(ctx, "Successfully updated organization unit", log.String("ouId", id))
 }
@@ -167,11 +168,11 @@ func (ouh *organizationUnitHandler) HandleOUDeleteRequest(w http.ResponseWriter,
 
 	svcErr := ouh.service.DeleteOrganizationUnit(ctx, id)
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	logger.DebugWithContext(ctx, "Successfully deleted organization unit", log.String("ouId", id))
 }
 
@@ -180,7 +181,7 @@ func (ouh *organizationUnitHandler) HandleOUChildrenListRequest(w http.ResponseW
 	ctx := r.Context()
 	f, err := filter.ParseFilterParam(r.URL.Query())
 	if err != nil {
-		ouh.handleError(w, &ErrorInvalidFilter)
+		ouh.handleError(ctx, w, &ErrorInvalidFilter)
 		return
 	}
 	ouh.handleResourceListRequest(w, r, "child organization units",
@@ -209,7 +210,10 @@ func (ouh *organizationUnitHandler) HandleOUGroupsListRequest(w http.ResponseWri
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.
-func (ouh *organizationUnitHandler) handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func (
+	ouh *organizationUnitHandler) handleError(ctx context.Context,
+	w http.ResponseWriter,
+	svcErr *serviceerror.ServiceError) {
 	var statusCode int
 	switch svcErr.Type {
 	case serviceerror.ClientErrorType:
@@ -231,7 +235,7 @@ func (ouh *organizationUnitHandler) handleError(w http.ResponseWriter, svcErr *s
 		statusCode = http.StatusInternalServerError
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, apierror.ErrorResponse{
+	sysutils.WriteErrorResponse(ctx, w, statusCode, apierror.ErrorResponse{
 		Code:        svcErr.Code,
 		Message:     svcErr.Error,
 		Description: svcErr.ErrorDescription,
@@ -259,7 +263,7 @@ func (ouh *organizationUnitHandler) sanitizeOrganizationUnitRequest(
 func extractAndValidateID(w http.ResponseWriter, r *http.Request) (string, bool) {
 	id := r.PathValue("id")
 	if id == "" {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, apierror.ErrorResponse{
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, apierror.ErrorResponse{
 			Code:        ErrorMissingOUID.Code,
 			Message:     ErrorMissingOUID.Error,
 			Description: ErrorMissingOUID.ErrorDescription,
@@ -274,7 +278,7 @@ func validateUpdateRequest(
 ) (OrganizationUnitRequestWithID, bool) {
 	updateRequest, err := sysutils.DecodeJSONBody[OrganizationUnitRequest](r)
 	if err != nil {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, apierror.ErrorResponse{
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, apierror.ErrorResponse{
 			Code:        ErrorInvalidRequestFormat.Code,
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
@@ -324,7 +328,7 @@ func (ouh *organizationUnitHandler) handleResourceListRequest(
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(r.Context(), w, svcErr)
 		return
 	}
 
@@ -334,11 +338,11 @@ func (ouh *organizationUnitHandler) handleResourceListRequest(
 
 	response, svcErr := serviceFunc(id, limit, offset)
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(r.Context(), w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, response)
 
 	// Extract pagination info for logging based on response type
 	var totalResults, count int
@@ -373,11 +377,11 @@ func (ouh *organizationUnitHandler) HandleOUGetByPathRequest(w http.ResponseWrit
 
 	ou, svcErr := ouh.service.GetOrganizationUnitByPath(ctx, path)
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, ou)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, ou)
 
 	logger.DebugWithContext(ctx, "Successfully retrieved organization unit by path", log.String("path", path))
 }
@@ -399,11 +403,11 @@ func (ouh *organizationUnitHandler) HandleOUPutByPathRequest(w http.ResponseWrit
 
 	ou, svcErr := ouh.service.UpdateOrganizationUnitByPath(ctx, path, sanitizedRequest)
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, ou)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, ou)
 
 	logger.DebugWithContext(ctx, "Successfully updated organization unit by path", log.String("path", path))
 }
@@ -420,11 +424,11 @@ func (ouh *organizationUnitHandler) HandleOUDeleteByPathRequest(w http.ResponseW
 
 	svcErr := ouh.service.DeleteOrganizationUnitByPath(ctx, path)
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	logger.DebugWithContext(ctx, "Successfully deleted organization unit by path", log.String("path", path))
 }
 
@@ -442,7 +446,7 @@ func (ouh *organizationUnitHandler) handleResourceListByPathRequest(
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(r.Context(), w, svcErr)
 		return
 	}
 
@@ -452,11 +456,11 @@ func (ouh *organizationUnitHandler) handleResourceListByPathRequest(
 
 	response, svcErr := serviceFunc(path, limit, offset)
 	if svcErr != nil {
-		ouh.handleError(w, svcErr)
+		ouh.handleError(r.Context(), w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, response)
 
 	if logger.IsDebugEnabled() {
 		var totalResults, count int
@@ -484,7 +488,7 @@ func (ouh *organizationUnitHandler) HandleOUChildrenListByPathRequest(w http.Res
 	ctx := r.Context()
 	f, err := filter.ParseFilterParam(r.URL.Query())
 	if err != nil {
-		ouh.handleError(w, &ErrorInvalidFilter)
+		ouh.handleError(ctx, w, &ErrorInvalidFilter)
 		return
 	}
 	ouh.handleResourceListByPathRequest(w, r, "child organization units",
@@ -515,7 +519,7 @@ func (ouh *organizationUnitHandler) HandleOUGroupsListByPathRequest(w http.Respo
 func extractAndValidatePath(w http.ResponseWriter, r *http.Request) (string, bool) {
 	path := r.PathValue("path")
 	if path == "" {
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, apierror.ErrorResponse{
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, apierror.ErrorResponse{
 			Code:        ErrorInvalidHandlePath.Code,
 			Message:     ErrorInvalidHandlePath.Error,
 			Description: ErrorInvalidHandlePath.ErrorDescription,

--- a/backend/internal/ou/handler_test.go
+++ b/backend/internal/ou/handler_test.go
@@ -19,6 +19,7 @@
 package ou
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -1968,7 +1969,7 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_handleErrorStatusMa
 		suite.Run(tc.name, func() {
 			recorder := httptest.NewRecorder()
 
-			handler.handleError(recorder, tc.err)
+			handler.handleError(context.Background(), recorder, tc.err)
 
 			suite.Equal(tc.wantStatus, recorder.Code)
 			var body apierror.ErrorResponse

--- a/backend/internal/resource/declarative_resource.go
+++ b/backend/internal/resource/declarative_resource.go
@@ -169,7 +169,7 @@ func (e *resourceServerExporter) GetResourceByID(ctx context.Context, id string)
 }
 
 // ValidateResource validates a resource server resource.
-func (e *resourceServerExporter) ValidateResource(
+func (e *resourceServerExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	server, ok := resource.(*ResourceServer)
@@ -177,7 +177,7 @@ func (e *resourceServerExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeResourceServer, id)
 	}
 
-	if err := declarativeresource.ValidateResourceName(
+	if err := declarativeresource.ValidateResourceName(ctx,
 		server.Name, resourceTypeResourceServer, id, "RS_VALIDATION_ERROR", logger); err != nil {
 		return "", err
 	}

--- a/backend/internal/resource/declarative_resource_test.go
+++ b/backend/internal/resource/declarative_resource_test.go
@@ -204,7 +204,7 @@ func (s *ResourceServerExporterTestSuite) TestValidateResource_Success() {
 		OUID:        "ou1",
 	}
 
-	name, err := s.exporter.ValidateResource(dto, "rs1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), dto, "rs1", s.logger)
 
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test Server", name)
@@ -213,7 +213,7 @@ func (s *ResourceServerExporterTestSuite) TestValidateResource_Success() {
 func (s *ResourceServerExporterTestSuite) TestValidateResource_InvalidType() {
 	invalidData := "not a resource server dto"
 
-	name, err := s.exporter.ValidateResource(invalidData, "rs1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), invalidData, "rs1", s.logger)
 
 	assert.Equal(s.T(), "", name)
 	assert.NotNil(s.T(), err)
@@ -226,7 +226,7 @@ func (s *ResourceServerExporterTestSuite) TestValidateResource_EmptyName() {
 		OUID: "ou1",
 	}
 
-	name, err := s.exporter.ValidateResource(dto, "rs1", s.logger)
+	name, err := s.exporter.ValidateResource(context.Background(), dto, "rs1", s.logger)
 
 	assert.Equal(s.T(), "", name)
 	assert.NotNil(s.T(), err)

--- a/backend/internal/resource/handler.go
+++ b/backend/internal/resource/handler.go
@@ -19,6 +19,7 @@
 package resource
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -48,18 +49,18 @@ func (h *resourceHandler) HandleResourceServerListRequest(w http.ResponseWriter,
 	ctx := r.Context()
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	result, svcErr := h.resourceService.GetResourceServerList(ctx, limit, offset)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toResourceServerListResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleResourceServerPostRequest handles creating a resource server.
@@ -67,7 +68,7 @@ func (h *resourceHandler) HandleResourceServerPostRequest(w http.ResponseWriter,
 	ctx := r.Context()
 	req, err := sysutils.DecodeJSONBody[CreateResourceServerRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -84,12 +85,12 @@ func (h *resourceHandler) HandleResourceServerPostRequest(w http.ResponseWriter,
 
 	result, svcErr := h.resourceService.CreateResourceServer(ctx, serviceReq)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toResourceServerResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, response)
 }
 
 // HandleResourceServerGetRequest handles getting a resource server.
@@ -98,12 +99,12 @@ func (h *resourceHandler) HandleResourceServerGetRequest(w http.ResponseWriter, 
 	id := r.PathValue("id")
 	result, svcErr := h.resourceService.GetResourceServer(ctx, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toResourceServerResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleResourceServerPutRequest handles updating a resource server.
@@ -112,7 +113,7 @@ func (h *resourceHandler) HandleResourceServerPutRequest(w http.ResponseWriter, 
 	id := r.PathValue("id")
 	req, err := sysutils.DecodeJSONBody[UpdateResourceServerRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -127,12 +128,12 @@ func (h *resourceHandler) HandleResourceServerPutRequest(w http.ResponseWriter, 
 
 	result, svcErr := h.resourceService.UpdateResourceServer(ctx, id, serviceReq)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toResourceServerResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleResourceServerDeleteRequest handles deleting a resource server.
@@ -141,7 +142,7 @@ func (h *resourceHandler) HandleResourceServerDeleteRequest(w http.ResponseWrite
 	id := r.PathValue("id")
 	svcErr := h.resourceService.DeleteResourceServer(ctx, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -156,7 +157,7 @@ func (h *resourceHandler) HandleResourceListRequest(w http.ResponseWriter, r *ht
 	rsID := r.PathValue("rsId")
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -170,12 +171,12 @@ func (h *resourceHandler) HandleResourceListRequest(w http.ResponseWriter, r *ht
 
 	result, svcErr := h.resourceService.GetResourceList(ctx, rsID, parentID, limit, offset)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toResourceListResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleResourcePostRequest handles creating a resource.
@@ -184,7 +185,7 @@ func (h *resourceHandler) HandleResourcePostRequest(w http.ResponseWriter, r *ht
 	rsID := r.PathValue("rsId")
 	req, err := sysutils.DecodeJSONBody[CreateResourceRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -201,12 +202,12 @@ func (h *resourceHandler) HandleResourcePostRequest(w http.ResponseWriter, r *ht
 
 	result, svcErr := h.resourceService.CreateResource(ctx, rsID, serviceReq)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toResourceResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, response)
 }
 
 // HandleResourceGetRequest handles getting a resource.
@@ -217,12 +218,12 @@ func (h *resourceHandler) HandleResourceGetRequest(w http.ResponseWriter, r *htt
 
 	result, svcErr := h.resourceService.GetResource(ctx, rsID, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toResourceResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleResourcePutRequest handles updating a resource.
@@ -233,7 +234,7 @@ func (h *resourceHandler) HandleResourcePutRequest(w http.ResponseWriter, r *htt
 
 	req, err := sysutils.DecodeJSONBody[UpdateResourceRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -245,12 +246,12 @@ func (h *resourceHandler) HandleResourcePutRequest(w http.ResponseWriter, r *htt
 
 	result, svcErr := h.resourceService.UpdateResource(ctx, rsID, id, serviceReq)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toResourceResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleResourceDeleteRequest handles deleting a resource.
@@ -261,7 +262,7 @@ func (h *resourceHandler) HandleResourceDeleteRequest(w http.ResponseWriter, r *
 
 	svcErr := h.resourceService.DeleteResource(ctx, rsID, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -276,18 +277,18 @@ func (h *resourceHandler) HandleActionListAtResourceServerRequest(w http.Respons
 	rsID := r.PathValue("rsId")
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	result, svcErr := h.resourceService.GetActionList(ctx, rsID, nil, limit, offset)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toActionListResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleActionPostAtResourceServerRequest handles creating an action at resource server level.
@@ -296,7 +297,7 @@ func (h *resourceHandler) HandleActionPostAtResourceServerRequest(w http.Respons
 	rsID := r.PathValue("rsId")
 	req, err := sysutils.DecodeJSONBody[CreateActionRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -309,12 +310,12 @@ func (h *resourceHandler) HandleActionPostAtResourceServerRequest(w http.Respons
 
 	result, svcErr := h.resourceService.CreateAction(ctx, rsID, nil, serviceReq)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toActionResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, response)
 }
 
 // HandleActionGetAtResourceServerRequest handles getting an action at resource server level.
@@ -325,12 +326,12 @@ func (h *resourceHandler) HandleActionGetAtResourceServerRequest(w http.Response
 
 	result, svcErr := h.resourceService.GetAction(ctx, rsID, nil, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toActionResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleActionPutAtResourceServerRequest handles updating an action at resource server level.
@@ -341,7 +342,7 @@ func (h *resourceHandler) HandleActionPutAtResourceServerRequest(w http.Response
 
 	req, err := sysutils.DecodeJSONBody[UpdateActionRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -353,12 +354,12 @@ func (h *resourceHandler) HandleActionPutAtResourceServerRequest(w http.Response
 
 	result, svcErr := h.resourceService.UpdateAction(ctx, rsID, nil, id, serviceReq)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toActionResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleActionDeleteAtResourceServerRequest handles deleting an action at resource server level.
@@ -369,7 +370,7 @@ func (h *resourceHandler) HandleActionDeleteAtResourceServerRequest(w http.Respo
 
 	svcErr := h.resourceService.DeleteAction(ctx, rsID, nil, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -385,18 +386,18 @@ func (h *resourceHandler) HandleActionListAtResourceRequest(w http.ResponseWrite
 	resourceID := r.PathValue("resourceId")
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	result, svcErr := h.resourceService.GetActionList(ctx, rsID, &resourceID, limit, offset)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toActionListResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleActionPostAtResourceRequest handles creating an action at resource level.
@@ -407,7 +408,7 @@ func (h *resourceHandler) HandleActionPostAtResourceRequest(w http.ResponseWrite
 
 	req, err := sysutils.DecodeJSONBody[CreateActionRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -420,12 +421,12 @@ func (h *resourceHandler) HandleActionPostAtResourceRequest(w http.ResponseWrite
 
 	result, svcErr := h.resourceService.CreateAction(ctx, rsID, &resourceID, serviceReq)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toActionResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, response)
 }
 
 // HandleActionGetAtResourceRequest handles getting an action at resource level.
@@ -437,12 +438,12 @@ func (h *resourceHandler) HandleActionGetAtResourceRequest(w http.ResponseWriter
 
 	result, svcErr := h.resourceService.GetAction(ctx, rsID, &resourceID, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toActionResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleActionPutAtResourceRequest handles updating an action at resource level.
@@ -454,7 +455,7 @@ func (h *resourceHandler) HandleActionPutAtResourceRequest(w http.ResponseWriter
 
 	req, err := sysutils.DecodeJSONBody[UpdateActionRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -466,12 +467,12 @@ func (h *resourceHandler) HandleActionPutAtResourceRequest(w http.ResponseWriter
 
 	result, svcErr := h.resourceService.UpdateAction(ctx, rsID, &resourceID, id, serviceReq)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	response := toActionResponse(result)
-	sysutils.WriteSuccessResponse(w, http.StatusOK, response)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
 }
 
 // HandleActionDeleteAtResourceRequest handles deleting an action at resource level.
@@ -483,7 +484,7 @@ func (h *resourceHandler) HandleActionDeleteAtResourceRequest(w http.ResponseWri
 
 	svcErr := h.resourceService.DeleteAction(ctx, rsID, &resourceID, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -517,7 +518,7 @@ func parsePaginationParams(query url.Values) (int, int, *serviceerror.ServiceErr
 }
 
 // handleError writes an error response based on the provided service error.
-func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
 		switch svcErr.Code {
@@ -536,7 +537,7 @@ func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }
 
 // Sanitization functions

--- a/backend/internal/resource/service.go
+++ b/backend/internal/resource/service.go
@@ -1551,7 +1551,7 @@ func (rs *resourceService) syncConsentOnPermissionCreate(
 
 	validNames, err := rs.consentService.ValidateConsentElements(ctx, ouID, []string{permission})
 	if err != nil {
-		return rs.wrapConsentServiceError(err)
+		return rs.wrapConsentServiceError(ctx, err)
 	}
 	for _, n := range validNames {
 		if n == permission {
@@ -1564,7 +1564,7 @@ func (rs *resourceService) syncConsentOnPermissionCreate(
 		Description: description,
 		Namespace:   consent.NamespacePermission,
 	}}); createErr != nil {
-		return rs.wrapConsentServiceError(createErr)
+		return rs.wrapConsentServiceError(ctx, createErr)
 	}
 	return nil
 }
@@ -1582,7 +1582,7 @@ func (rs *resourceService) syncConsentOnPermissionDelete(ctx context.Context, pe
 
 	existing, err := rs.consentService.ListConsentElements(ctx, ouID, consent.NamespacePermission, permission)
 	if err != nil {
-		return rs.wrapConsentServiceError(err)
+		return rs.wrapConsentServiceError(ctx, err)
 	}
 	if len(existing) == 0 {
 		return nil
@@ -1593,7 +1593,7 @@ func (rs *resourceService) syncConsentOnPermissionDelete(ctx context.Context, pe
 		if delErr.Code == consent.ErrorDeletingConsentElementWithAssociatedPurpose.Code {
 			return nil
 		}
-		return rs.wrapConsentServiceError(delErr)
+		return rs.wrapConsentServiceError(ctx, delErr)
 	}
 	return nil
 }
@@ -1612,7 +1612,7 @@ func (rs *resourceService) syncConsentOnPermissionUpdate(
 
 	existing, err := rs.consentService.ListConsentElements(ctx, ouID, consent.NamespacePermission, permission)
 	if err != nil {
-		return rs.wrapConsentServiceError(err)
+		return rs.wrapConsentServiceError(ctx, err)
 	}
 	if len(existing) == 0 {
 		return rs.syncConsentOnPermissionCreate(ctx, permission, description)
@@ -1627,7 +1627,7 @@ func (rs *resourceService) syncConsentOnPermissionUpdate(
 			Description: description,
 			Namespace:   consent.NamespacePermission,
 		}); updErr != nil {
-		return rs.wrapConsentServiceError(updErr)
+		return rs.wrapConsentServiceError(ctx, updErr)
 	}
 	return nil
 }
@@ -1636,12 +1636,12 @@ func (rs *resourceService) syncConsentOnPermissionUpdate(
 // distinguish consent-service failures from other store or service errors during resource CRUD.
 // Server-class failures are logged here so operators get a record even when the transaction
 // closure collapses the error to InternalServerError on the way out.
-func (rs *resourceService) wrapConsentServiceError(err *serviceerror.ServiceError) error {
+func (rs *resourceService) wrapConsentServiceError(ctx context.Context, err *serviceerror.ServiceError) error {
 	if err == nil {
 		return nil
 	}
 	if err.Type == serviceerror.ServerErrorType {
-		rs.logger.Error("Consent service returned a server-class error during resource sync",
+		rs.logger.ErrorWithContext(ctx, "Consent service returned a server-class error during resource sync",
 			log.String("code", err.Code),
 			log.String("description", err.ErrorDescription.DefaultValue))
 	}

--- a/backend/internal/resource/service_test.go
+++ b/backend/internal/resource/service_test.go
@@ -5107,7 +5107,7 @@ func (suite *ResourceServiceTestSuite) TestSyncHelpers_TolerateNilConsentService
 
 func (suite *ResourceServiceTestSuite) TestWrapConsentServiceError_NilPassthrough() {
 	svc := newSyncTestService(suite.T(), nil)
-	require.Nil(suite.T(), svc.wrapConsentServiceError(nil))
+	require.Nil(suite.T(), svc.wrapConsentServiceError(context.Background(), nil))
 }
 
 func (suite *ResourceServiceTestSuite) TestConsentSyncError_Error() {

--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -276,7 +276,8 @@ func (c *compositeRoleStore) getCompositeAssignmentsCount(
 
 	count := len(assignments)
 	if count > serverconst.MaxCompositeStoreRecords*9/10 {
-		log.GetLogger().Warn("Role assignment count approaches composite store limit; consider API pagination",
+		log.GetLogger().WarnWithContext(ctx,
+			"Role assignment count approaches composite store limit; consider API pagination",
 			log.String("id", id),
 			log.Int("count", count),
 			log.Int("limit", serverconst.MaxCompositeStoreRecords))
@@ -421,7 +422,8 @@ func (c *compositeRoleStore) crossStoreAuthorizedPermissions(
 			if errors.Is(err, ErrRoleNotFound) || errors.Is(err, ErrRoleDataCorrupted) {
 				continue
 			}
-			log.GetLogger().Error("Failed to load declarative role for cross-store permission resolution",
+			log.GetLogger().ErrorWithContext(ctx,
+				"Failed to load declarative role for cross-store permission resolution",
 				log.String("roleID", id), log.Error(err))
 			return nil, fmt.Errorf("composite role store: load declarative role %q: %w", id, err)
 		}

--- a/backend/internal/role/declarative_resource.go
+++ b/backend/internal/role/declarative_resource.go
@@ -121,7 +121,7 @@ func (e *roleExporter) GetResourceByID(
 }
 
 // ValidateResource validates a role resource.
-func (e *roleExporter) ValidateResource(
+func (e *roleExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	role, ok := resource.(*roleDeclarativeResource)
@@ -129,7 +129,7 @@ func (e *roleExporter) ValidateResource(
 		return "", declarativeresource.CreateTypeError(resourceTypeRole, id)
 	}
 
-	if err := declarativeresource.ValidateResourceName(
+	if err := declarativeresource.ValidateResourceName(ctx,
 		role.Name, resourceTypeRole, id, "ROLE_VALIDATION_ERROR", logger); err != nil {
 		return "", err
 	}
@@ -164,7 +164,9 @@ func loadDeclarativeResources(
 				return v.ID
 			}
 			// Log error and return empty string if type assertion fails
-			log.GetLogger().Error("IDExtractor: type assertion failed for RoleWithPermissionsAndAssignments")
+			// Declarative resource loading runs during startup, outside any request.
+			log.GetLogger().ErrorWithContext(context.Background(),
+				"IDExtractor: type assertion failed for RoleWithPermissionsAndAssignments")
 			return ""
 		},
 	}

--- a/backend/internal/role/declarative_resource_test.go
+++ b/backend/internal/role/declarative_resource_test.go
@@ -255,7 +255,7 @@ func (suite *RoleExporterTestSuite) TestValidateResource_Success() {
 	}
 	logger := log.GetLogger()
 
-	name, exportErr := suite.exporter.ValidateResource(resource, "role1", logger)
+	name, exportErr := suite.exporter.ValidateResource(context.Background(), resource, "role1", logger)
 
 	suite.Nil(exportErr)
 	assert.Equal(suite.T(), "Admin", name)
@@ -265,7 +265,7 @@ func (suite *RoleExporterTestSuite) TestValidateResource_Success() {
 func (suite *RoleExporterTestSuite) TestValidateResource_InvalidType() {
 	logger := log.GetLogger()
 
-	name, exportErr := suite.exporter.ValidateResource("not a role", "role1", logger)
+	name, exportErr := suite.exporter.ValidateResource(context.Background(), "not a role", "role1", logger)
 
 	suite.NotNil(exportErr)
 	assert.Empty(suite.T(), name)

--- a/backend/internal/role/file_based_store.go
+++ b/backend/internal/role/file_based_store.go
@@ -76,7 +76,7 @@ func (f *fileBasedStore) GetRoleList(ctx context.Context, limit, offset int) ([]
 		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
 			// Log warning for malformed declarative entry
-			log.GetLogger().Warn("Skipping malformed role in GetRoleList",
+			log.GetLogger().WarnWithContext(ctx, "Skipping malformed role in GetRoleList",
 				log.String("roleID", item.ID.ID),
 				log.Error(err))
 			continue
@@ -277,7 +277,7 @@ func (f *fileBasedStore) CheckRoleNameExists(ctx context.Context, ouID, name str
 		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
 			// Log warning for malformed declarative entry
-			log.GetLogger().Warn("Skipping malformed role in CheckRoleNameExists",
+			log.GetLogger().WarnWithContext(ctx, "Skipping malformed role in CheckRoleNameExists",
 				log.String("roleID", item.ID.ID),
 				log.Error(err))
 			continue
@@ -304,7 +304,7 @@ func (f *fileBasedStore) CheckRoleNameExistsExcludingID(
 		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
 			// Log warning for malformed declarative entry
-			log.GetLogger().Warn("Skipping malformed role in CheckRoleNameExistsExcludingID",
+			log.GetLogger().WarnWithContext(ctx, "Skipping malformed role in CheckRoleNameExistsExcludingID",
 				log.String("roleID", item.ID.ID),
 				log.Error(err))
 			continue
@@ -354,7 +354,7 @@ func (f *fileBasedStore) GetAuthorizedPermissions(
 		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
 			// Log warning for malformed declarative entry
-			log.GetLogger().Warn("Skipping malformed role in GetAuthorizedPermissions",
+			log.GetLogger().WarnWithContext(ctx, "Skipping malformed role in GetAuthorizedPermissions",
 				log.String("roleID", item.ID.ID),
 				log.Error(err))
 			continue
@@ -402,7 +402,7 @@ func (f *fileBasedStore) GetUserRoles(
 	for _, item := range list {
 		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
-			log.GetLogger().Warn("Skipping malformed role in GetUserRoles",
+			log.GetLogger().WarnWithContext(ctx, "Skipping malformed role in GetUserRoles",
 				log.String("roleID", item.ID.ID),
 				log.Error(err))
 			continue

--- a/backend/internal/role/handler.go
+++ b/backend/internal/role/handler.go
@@ -19,6 +19,7 @@
 package role
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -53,13 +54,13 @@ func (rh *roleHandler) HandleRoleListRequest(w http.ResponseWriter, r *http.Requ
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	roleList, svcErr := rh.roleService.GetRoleList(ctx, limit, offset)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -77,7 +78,7 @@ func (rh *roleHandler) HandleRoleListRequest(w http.ResponseWriter, r *http.Requ
 		Links:        roleList.Links,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, roleListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, roleListResponse)
 
 	logger.DebugWithContext(ctx, "Successfully listed roles with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -92,7 +93,7 @@ func (rh *roleHandler) HandleRolePostRequest(w http.ResponseWriter, r *http.Requ
 
 	createRequest, err := sysutils.DecodeJSONBody[CreateRoleRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -103,14 +104,14 @@ func (rh *roleHandler) HandleRolePostRequest(w http.ResponseWriter, r *http.Requ
 
 	serviceRole, svcErr := rh.roleService.CreateRole(ctx, serviceRequest)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	// Convert service response to HTTP response
 	createdRole := rh.toHTTPCreateRoleResponse(serviceRole)
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdRole)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdRole)
 
 	logger.DebugWithContext(ctx, "Successfully created role", log.String("roleId", createdRole.ID))
 }
@@ -123,14 +124,14 @@ func (rh *roleHandler) HandleRoleGetRequest(w http.ResponseWriter, r *http.Reque
 	id := r.PathValue("id")
 	serviceRole, svcErr := rh.roleService.GetRoleWithPermissions(ctx, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	// Convert service response to HTTP response
 	role := rh.toHTTPRoleResponse(serviceRole)
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, role)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, role)
 
 	logger.DebugWithContext(ctx, "Successfully retrieved role", log.String("role id", id))
 }
@@ -143,7 +144,7 @@ func (rh *roleHandler) HandleRolePutRequest(w http.ResponseWriter, r *http.Reque
 	id := r.PathValue("id")
 	updateRequest, err := sysutils.DecodeJSONBody[UpdateRoleRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -154,14 +155,14 @@ func (rh *roleHandler) HandleRolePutRequest(w http.ResponseWriter, r *http.Reque
 
 	serviceRole, svcErr := rh.roleService.UpdateRoleWithPermissions(ctx, id, serviceRequest)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
 	// Convert service response to HTTP response
 	role := rh.toHTTPRoleResponse(serviceRole)
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, role)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, role)
 
 	logger.DebugWithContext(ctx, "Successfully updated role", log.String("role id", id))
 }
@@ -174,11 +175,11 @@ func (rh *roleHandler) HandleRoleDeleteRequest(w http.ResponseWriter, r *http.Re
 	id := r.PathValue("id")
 	svcErr := rh.roleService.DeleteRole(ctx, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	logger.DebugWithContext(ctx, "Successfully deleted role", log.String("role id", id))
 }
 
@@ -190,7 +191,7 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 	id := r.PathValue("id")
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -201,7 +202,7 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 	assigneeType := r.URL.Query().Get("type")
 	if assigneeType != "" && assigneeType != string(AssigneeTypeUser) && assigneeType != string(AssigneeTypeGroup) &&
 		assigneeType != string(AssigneeTypeApp) && assigneeType != string(AssigneeTypeAgent) {
-		handleError(w, &ErrorInvalidAssigneeType)
+		handleError(ctx, w, &ErrorInvalidAssigneeType)
 		return
 	}
 
@@ -213,7 +214,7 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 		serviceResponse, svcErr = rh.assignmentService.GetRoleAssignments(ctx, id, limit, offset, includeDisplay)
 	}
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -231,7 +232,7 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 		Links:        serviceResponse.Links,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, assignmentListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, assignmentListResponse)
 
 	logger.DebugWithContext(ctx, "Successfully retrieved role assignments", log.String("role id", id),
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -249,7 +250,7 @@ func (rh *roleHandler) HandleRoleAddAssignmentsRequest(w http.ResponseWriter, r 
 	id := r.PathValue("id")
 	assignmentsRequest, err := sysutils.DecodeJSONBody[AssignmentsRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -260,11 +261,11 @@ func (rh *roleHandler) HandleRoleAddAssignmentsRequest(w http.ResponseWriter, r 
 
 	svcErr := rh.assignmentService.AddAssignments(ctx, id, serviceRequest)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	logger.DebugWithContext(ctx, "Successfully added assignments to role", log.String("role id", id))
 }
 
@@ -276,7 +277,7 @@ func (rh *roleHandler) HandleRoleRemoveAssignmentsRequest(w http.ResponseWriter,
 	id := r.PathValue("id")
 	assignmentsRequest, err := sysutils.DecodeJSONBody[AssignmentsRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -287,16 +288,16 @@ func (rh *roleHandler) HandleRoleRemoveAssignmentsRequest(w http.ResponseWriter,
 
 	svcErr := rh.assignmentService.RemoveAssignments(ctx, id, serviceRequest)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	logger.DebugWithContext(ctx, "Successfully removed assignments from role", log.String("role id", id))
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.
-func handleError(w http.ResponseWriter,
+func handleError(ctx context.Context, w http.ResponseWriter,
 	svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
@@ -322,7 +323,7 @@ func handleError(w http.ResponseWriter,
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }
 
 // sanitizeCreateRoleRequest sanitizes the create role request input.

--- a/backend/internal/role/handler_test.go
+++ b/backend/internal/role/handler_test.go
@@ -20,6 +20,7 @@ package role
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -739,7 +740,7 @@ func (suite *RoleHandlerTestSuite) TestHandleError_ClientAndServerErrors() {
 	suite.T().Run("Client_NotFound", func(t *testing.T) {
 		w := httptest.NewRecorder()
 
-		handleError(w, &ErrorRoleNotFound)
+		handleError(context.Background(), w, &ErrorRoleNotFound)
 
 		suite.Equal(http.StatusNotFound, w.Code)
 		var resp apierror.ErrorResponse
@@ -751,7 +752,7 @@ func (suite *RoleHandlerTestSuite) TestHandleError_ClientAndServerErrors() {
 	suite.T().Run("ServerError", func(t *testing.T) {
 		w := httptest.NewRecorder()
 
-		handleError(w, &serviceerror.InternalServerError)
+		handleError(context.Background(), w, &serviceerror.InternalServerError)
 
 		suite.Equal(http.StatusInternalServerError, w.Code)
 		var resp apierror.ErrorResponse

--- a/backend/internal/system/cache/inmemorycache.go
+++ b/backend/internal/system/cache/inmemorycache.go
@@ -116,7 +116,8 @@ func getEvictionPolicy(cacheConfig config.CacheConfig, cacheProperty config.Cach
 	case string(evictionPolicyLFU):
 		return evictionPolicyLFU
 	default:
-		log.GetLogger().Warn("Unknown eviction policy, defaulting to LRU")
+		// Cache infrastructure logging has no request scope, so context.Background() is used.
+		log.GetLogger().WarnWithContext(context.Background(), "Unknown eviction policy, defaulting to LRU")
 		return evictionPolicyLRU
 	}
 }
@@ -142,11 +143,13 @@ func getCacheSize(cacheConfig config.CacheConfig, cacheProperty config.CacheProp
 // newInMemoryCache creates a new instance of InMemoryCache.
 func newInMemoryCache[T any](name string, enabled bool,
 	cacheConfig config.CacheConfig, cacheProperty config.CacheProperty) CacheInterface[T] {
+	// Cache infrastructure logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InMemoryCache"),
 		log.String("name", name))
 
 	if !enabled {
-		logger.Warn("In-memory cache is disabled, returning empty cache")
+		logger.WarnWithContext(ctx, "In-memory cache is disabled, returning empty cache")
 		return &inMemoryCache[T]{
 			name:    name,
 			enabled: false,
@@ -157,7 +160,7 @@ func newInMemoryCache[T any](name string, enabled bool,
 	size := getCacheSize(cacheConfig, cacheProperty)
 	evictionPolicy := getEvictionPolicy(cacheConfig, cacheProperty)
 
-	logger.Debug("Initializing In-memory cache", log.String("evictionPolicy", string(evictionPolicy)),
+	logger.DebugWithContext(ctx, "Initializing In-memory cache", log.String("evictionPolicy", string(evictionPolicy)),
 		log.Int("size", size), log.Any("ttl", ttl))
 
 	lfuHeapInstance := &lfuHeap{}
@@ -395,7 +398,8 @@ func (c *inMemoryCache[T]) evictOldest() {
 		if entry, exists := c.cache[key]; exists {
 			c.deleteEntry(key, entry)
 			c.evictCount.Add(1)
-			logger.Debug("Cache entry evicted", log.String("key", key.ToString()))
+			// Cache eviction is infrastructure-scoped, not tied to a request.
+			logger.DebugWithContext(context.Background(), "Cache entry evicted", log.String("key", key.ToString()))
 		}
 	}
 }
@@ -415,7 +419,9 @@ func (c *inMemoryCache[T]) evictLeastFrequent() {
 	if entry, exists := c.cache[leastFrequentItem.key]; exists {
 		c.deleteEntry(leastFrequentItem.key, entry)
 		c.evictCount.Add(1)
-		logger.Debug("Cache entry evicted (LFU)", log.String("key", leastFrequentItem.key.ToString()),
+		// Cache eviction is infrastructure-scoped, not tied to a request.
+		logger.DebugWithContext(context.Background(), "Cache entry evicted (LFU)",
+			log.String("key", leastFrequentItem.key.ToString()),
 			log.Any("accessCount", leastFrequentItem.accessCount))
 	}
 }
@@ -433,13 +439,15 @@ func (c *inMemoryCache[T]) deleteEntry(key CacheKey, entry *inMemoryCacheEntry[T
 
 // CleanupExpired removes all expired entries from the cache.
 func (c *inMemoryCache[T]) CleanupExpired() {
+	// Cache infrastructure logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
 	if !c.enabled {
 		return
 	}
 
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InMemoryCache"),
 		log.String("name", c.GetName()))
-	logger.Debug("Cleaning up expired entries from the cache")
+	logger.DebugWithContext(ctx, "Cleaning up expired entries from the cache")
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -455,9 +463,9 @@ func (c *inMemoryCache[T]) CleanupExpired() {
 
 	if logger.IsDebugEnabled() {
 		if cleaned > 0 {
-			logger.Debug("Expired cache entries cleaned", log.Int("count", cleaned))
+			logger.DebugWithContext(ctx, "Expired cache entries cleaned", log.Int("count", cleaned))
 		} else {
-			logger.Debug("No expired entries found in the cache")
+			logger.DebugWithContext(ctx, "No expired entries found in the cache")
 		}
 	}
 }

--- a/backend/internal/system/cache/manager.go
+++ b/backend/internal/system/cache/manager.go
@@ -56,10 +56,16 @@ type CacheManager struct {
 	deploymentID    string
 }
 
+// Cache logging is infrastructure-scoped: initialization, shutdown, background
+// cleanup, construction, and eviction are not tied to any request, so
+// context.Background() is used (there is no request trace ID to propagate).
+
 // Initialize creates, configures, and returns a ready-to-use CacheManagerInterface.
 func Initialize(cacheConfig config.CacheConfig, deploymentID string) CacheManagerInterface {
+	// Cache infrastructure logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
-	logger.Debug("Initializing Cache Manager")
+	logger.DebugWithContext(ctx, "Initializing Cache Manager")
 
 	cm := &CacheManager{
 		cacheConfig:  cacheConfig,
@@ -68,7 +74,7 @@ func Initialize(cacheConfig config.CacheConfig, deploymentID string) CacheManage
 	}
 
 	if cacheConfig.Disabled {
-		logger.Debug("Caching is disabled. Skipping initialization")
+		logger.DebugWithContext(ctx, "Caching is disabled. Skipping initialization")
 		return cm
 	}
 
@@ -88,27 +94,30 @@ func Initialize(cacheConfig config.CacheConfig, deploymentID string) CacheManage
 			WriteTimeout:    time.Duration(cacheConfig.Redis.WriteTimeoutMS) * time.Millisecond,
 		})
 		if err := cm.redisClient.Ping(context.Background()).Err(); err != nil {
-			logger.Error("Failed to connect to Redis. Cache initialization aborted.", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to connect to Redis. Cache initialization aborted.", log.Error(err))
 			if closeErr := cm.redisClient.Close(); closeErr != nil {
-				logger.Warn("Failed to close Redis client after ping failure", log.Error(closeErr))
+				logger.WarnWithContext(ctx, "Failed to close Redis client after ping failure", log.Error(closeErr))
 			}
 			cm.redisClient = nil
 			cm.enabled = false
 			return cm
 		}
-		logger.Debug("Connected to Redis successfully", log.String("address", cacheConfig.Redis.Address))
+		logger.DebugWithContext(ctx, "Connected to Redis successfully",
+			log.String("address", cacheConfig.Redis.Address))
 	} else {
 		cm.cleanupInterval = getCleanupInterval(cacheConfig)
 		cm.startCleanupRoutine()
 	}
 
-	logger.Debug("Cache Manager initialized", log.Bool("enabled", cm.enabled),
+	logger.DebugWithContext(ctx, "Cache Manager initialized", log.Bool("enabled", cm.enabled),
 		log.Any("cleanupInterval", cm.cleanupInterval))
 	return cm
 }
 
 // Close shuts down the CacheManager and releases resources.
 func (cm *CacheManager) Close() {
+	// Cache infrastructure logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
 
 	cm.mu.Lock()
@@ -116,9 +125,9 @@ func (cm *CacheManager) Close() {
 
 	if cm.redisClient != nil {
 		if err := cm.redisClient.Close(); err != nil {
-			logger.Warn("Failed to close Redis client", log.Error(err))
+			logger.WarnWithContext(ctx, "Failed to close Redis client", log.Error(err))
 		} else {
-			logger.Debug("Redis client closed")
+			logger.DebugWithContext(ctx, "Redis client closed")
 		}
 		cm.redisClient = nil
 	}
@@ -147,7 +156,8 @@ func (cm *CacheManager) getCache(cacheKey string) (interface{}, bool) {
 func (cm *CacheManager) addCache(cacheKey string, cacheInstance interface{}) {
 	if _, exists := cm.caches[cacheKey]; !exists {
 		cm.caches[cacheKey] = cacheInstance
-		log.GetLogger().Debug("Cache added", log.String("cacheKey", cacheKey))
+		// Cache infrastructure logging has no request scope, so context.Background() is used.
+		log.GetLogger().DebugWithContext(context.Background(), "Cache added", log.String("cacheKey", cacheKey))
 	}
 }
 
@@ -168,12 +178,14 @@ func (cm *CacheManager) getRedisClient() *redis.Client {
 
 // startCleanupRoutine starts a background routine to clean up expired caches at regular intervals.
 func (cm *CacheManager) startCleanupRoutine() {
+	// Cache infrastructure logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
 	if cm.cleanupInterval <= 0 {
 		return
 	}
 
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
-	logger.Debug("Starting cleanup routine for caches")
+	logger.DebugWithContext(ctx, "Starting cleanup routine for caches")
 
 	go func() {
 		ticker := time.NewTicker(cm.cleanupInterval)
@@ -184,13 +196,15 @@ func (cm *CacheManager) startCleanupRoutine() {
 		}
 	}()
 
-	logger.Debug("Cleanup routine started", log.Any("interval", cm.cleanupInterval))
+	logger.DebugWithContext(ctx, "Cleanup routine started", log.Any("interval", cm.cleanupInterval))
 }
 
 // cleanupAllCaches cleans up expired entries in all caches.
 func (cm *CacheManager) cleanupAllCaches() {
+	// Cache infrastructure logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
-	logger.Debug("Cleaning up expired caches")
+	logger.DebugWithContext(ctx, "Cleaning up expired caches")
 
 	for _, cacheEntry := range cm.caches {
 		// Use type switch to handle different cache types
@@ -201,11 +215,11 @@ func (cm *CacheManager) cleanupAllCaches() {
 			CleanupExpired()
 		}:
 			if cache.IsEnabled() {
-				logger.Debug("Cleaning up cache", log.String("cacheName", cache.GetName()))
+				logger.DebugWithContext(ctx, "Cleaning up cache", log.String("cacheName", cache.GetName()))
 				cache.CleanupExpired()
 			}
 		default:
-			logger.Warn("Unknown cache type encountered", log.Any("type", reflect.TypeOf(cacheEntry)))
+			logger.WarnWithContext(ctx, "Unknown cache type encountered", log.Any("type", reflect.TypeOf(cacheEntry)))
 		}
 	}
 }
@@ -234,12 +248,14 @@ func buildRedisKeyPrefix(basePrefix, deploymentID string) string {
 
 // newCache creates a new cache instance.
 func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[T] {
+	// Cache infrastructure logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"),
 		log.String("cacheName", cacheName))
 
 	cacheConfig := cm.getCacheConfig()
 	if cacheConfig.Disabled {
-		logger.Debug("Caching is disabled, returning empty")
+		logger.DebugWithContext(ctx, "Caching is disabled, returning empty")
 		return &Cache[T]{
 			enabled:   false,
 			cacheName: cacheName,
@@ -250,7 +266,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 	cacheProperty := getCacheProperty(cacheConfig, cacheName)
 
 	if cacheProperty.Disabled {
-		logger.Debug("Individual cache is disabled, returning empty")
+		logger.DebugWithContext(ctx, "Individual cache is disabled, returning empty")
 		return &Cache[T]{
 			enabled:   false,
 			cacheName: cacheName,
@@ -258,7 +274,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 		}
 	}
 
-	logger.Debug("Initializing the cache")
+	logger.DebugWithContext(ctx, "Initializing the cache")
 
 	var internalCache CacheInterface[T]
 	switch getCacheType(cacheConfig) {
@@ -272,7 +288,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 	case cacheTypeRedis:
 		redisClient := cm.getRedisClient()
 		if redisClient == nil {
-			logger.Warn("Redis client not available, disabling cache")
+			logger.WarnWithContext(ctx, "Redis client not available, disabling cache")
 			return &Cache[T]{
 				enabled:   false,
 				cacheName: cacheName,
@@ -290,7 +306,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 			)
 		}
 	default:
-		logger.Warn("Unknown cache type, defaulting to in-memory cache")
+		logger.WarnWithContext(ctx, "Unknown cache type, defaulting to in-memory cache")
 		internalCache = newInMemoryCache[T](
 			cacheName,
 			!cacheProperty.Disabled,
@@ -335,7 +351,9 @@ func GetInMemoryCache[T any](cm CacheManagerInterface, cacheName string) CacheIn
 		}
 	}
 
-	logger.Debug("Creating new in-memory cache", log.String("cacheName", cacheName), log.String("type", typeName))
+	// Cache construction is infrastructure-scoped, not tied to a request.
+	logger.DebugWithContext(context.Background(), "Creating new in-memory cache",
+		log.String("cacheName", cacheName), log.String("type", typeName))
 
 	cacheConfig := cm.getCacheConfig()
 	cacheProperty := getCacheProperty(cacheConfig, cacheName)
@@ -358,6 +376,8 @@ func GetInMemoryCache[T any](cm CacheManagerInterface, cacheName string) CacheIn
 
 // GetCache returns a singleton cache instance for the given type and cache name.
 func GetCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[T] {
+	// Cache infrastructure logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
 
 	// Create unique key for the cache
@@ -372,7 +392,7 @@ func GetCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 		if retCache, ok := cache.(CacheInterface[T]); ok {
 			return retCache
 		}
-		logger.Warn("Type mismatch for cache", log.String("cacheName", cacheName),
+		logger.WarnWithContext(ctx, "Type mismatch for cache", log.String("cacheName", cacheName),
 			log.String("expectedType", typeName), log.String("actualType", reflect.TypeOf(cache).String()))
 
 		return nil
@@ -387,14 +407,14 @@ func GetCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 		if retCache, ok := cache.(CacheInterface[T]); ok {
 			return retCache
 		}
-		logger.Warn("Type mismatch for cache", log.String("cacheName", cacheName),
+		logger.WarnWithContext(ctx, "Type mismatch for cache", log.String("cacheName", cacheName),
 			log.String("expectedType", typeName), log.String("actualType", reflect.TypeOf(cache).String()))
 
 		return nil
 	}
 
 	// Create a new cache
-	logger.Debug("Creating new cache", log.String("cacheName", cacheName), log.String("type", typeName))
+	logger.DebugWithContext(ctx, "Creating new cache", log.String("cacheName", cacheName), log.String("type", typeName))
 	newCacheInst := newCache[T](cm, cacheName)
 	cm.addCache(cacheKey, newCacheInst)
 
@@ -412,7 +432,8 @@ func getCacheType(cacheConfig config.CacheConfig) cacheType {
 	case string(cacheTypeRedis):
 		return cacheTypeRedis
 	default:
-		log.GetLogger().Warn("Unknown cache type, defaulting to in-memory cache")
+		// Cache infrastructure logging has no request scope, so context.Background() is used.
+		log.GetLogger().WarnWithContext(context.Background(), "Unknown cache type, defaulting to in-memory cache")
 		return cacheTypeInMemory
 	}
 }

--- a/backend/internal/system/cache/redis_cache.go
+++ b/backend/internal/system/cache/redis_cache.go
@@ -45,11 +45,13 @@ type redisCache[T any] struct {
 // newRedisCache creates a new instance of redisCache.
 func newRedisCache[T any](name string, enabled bool, client *redis.Client, keyPrefix string,
 	cacheConfig config.CacheConfig, cacheProperty config.CacheProperty) CacheInterface[T] {
+	// Cache infrastructure logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "RedisCache"),
 		log.String("name", name))
 
 	if !enabled {
-		logger.Warn("Redis cache is disabled, returning empty cache")
+		logger.WarnWithContext(ctx, "Redis cache is disabled, returning empty cache")
 		return &redisCache[T]{
 			name:    name,
 			enabled: false,
@@ -58,7 +60,7 @@ func newRedisCache[T any](name string, enabled bool, client *redis.Client, keyPr
 
 	ttl := getCacheTTL(cacheConfig, cacheProperty)
 
-	logger.Debug("Initializing Redis cache", log.Any("ttl", ttl),
+	logger.DebugWithContext(ctx, "Initializing Redis cache", log.Any("ttl", ttl),
 		log.String("keyPrefix", keyPrefix))
 
 	return &redisCache[T]{
@@ -145,7 +147,7 @@ func (c *redisCache[T]) Delete(ctx context.Context, key CacheKey) error {
 	fullKey := c.buildKey(key)
 
 	if err := c.client.Del(ctx, fullKey).Err(); err != nil {
-		log.GetLogger().Warn("Failed to delete value from Redis cache",
+		log.GetLogger().WarnWithContext(ctx, "Failed to delete value from Redis cache",
 			log.Error(err))
 		return err
 	}

--- a/backend/internal/system/config/runtimeconfig.go
+++ b/backend/internal/system/config/runtimeconfig.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"context"
 	"net"
 	"net/url"
 	"strconv"
@@ -58,7 +59,8 @@ func InitializeServerRuntime(serverHome string, config *Config) error {
 
 		parsedPath, err := url.Parse(loginPath)
 		if err != nil || parsedPath == nil {
-			log.GetLogger().Warn(
+			// Runtime initialization runs during application startup, outside any request.
+			log.GetLogger().WarnWithContext(context.Background(),
 				"Invalid gate client login path configured. Falling back to default '/signin'",
 				log.String("configuredPath", loginPath),
 				log.Error(err),

--- a/backend/internal/system/cors/instance.go
+++ b/backend/internal/system/cors/instance.go
@@ -24,7 +24,11 @@
 // InitializeMatcher.
 package cors
 
-import "github.com/thunder-id/thunderid/internal/system/log"
+import (
+	"context"
+
+	"github.com/thunder-id/thunderid/internal/system/log"
+)
 
 // instance holds the process-wide compiled CORS matcher. It is populated once
 // at server start by InitializeMatcher (called from the server bootstrap
@@ -60,7 +64,9 @@ func InitializeMatcher(entries OriginEntries) error {
 		}
 		if !isRegexAnchored(rx.Pattern) {
 			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CORS"))
-			logger.Warn("cors.allowed_origins regex is not fully anchored; partial matches are likely",
+			// CORS matcher is initialized at startup, outside any request.
+			logger.WarnWithContext(context.Background(),
+				"cors.allowed_origins regex is not fully anchored; partial matches are likely",
 				log.Int("index", i),
 				log.String("pattern", rx.Pattern))
 		}

--- a/backend/internal/system/database/provider/dbprovider.go
+++ b/backend/internal/system/database/provider/dbprovider.go
@@ -20,6 +20,7 @@
 package provider
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -158,26 +159,28 @@ func (d *dbProvider) getTransactioner(
 
 // initializeAllClients initializes config, runtime, and user database clients at startup.
 func (d *dbProvider) initializeAllClients() {
+	// This runs outside any request, so context.Background() is used (no request trace ID).
+	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DBProvider"))
 
 	configDBConfig := config.GetServerRuntime().Config.Database.Config
 	err := d.initializeClient(&d.configClient, configDBConfig, dbNameConfig)
 	if err != nil {
-		logger.Error("Failed to initialize config database client", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to initialize config database client", log.Error(err))
 	}
 
 	runtimeDBConfig := config.GetServerRuntime().Config.Database.Runtime
 	if runtimeDBConfig.Type != DataSourceTypeRedis {
 		err = d.initializeClient(&d.runtimeClient, runtimeDBConfig, dbNameRuntime)
 		if err != nil {
-			logger.Error("Failed to initialize runtime database client", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to initialize runtime database client", log.Error(err))
 		}
 	}
 
 	userDBConfig := config.GetServerRuntime().Config.Database.User
 	err = d.initializeClient(&d.userClient, userDBConfig, dbNameUser)
 	if err != nil {
-		logger.Error("Failed to initialize user database client", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to initialize user database client", log.Error(err))
 	}
 }
 
@@ -310,7 +313,8 @@ func (d *dbProvider) getDBConfig(dataSource config.DataSource) dbConfig {
 // Close closes the database connections. This should only be called by the lifecycle manager during shutdown.
 func (d *dbProvider) Close() error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DBProvider"))
-	logger.Debug("Closing database connections")
+	// DB shutdown runs outside any request.
+	logger.DebugWithContext(context.Background(), "Closing database connections")
 
 	configErr := d.closeClient(&d.configClient, &d.configMutex, "config")
 	runtimeErr := d.closeClient(&d.runtimeClient, &d.runtimeMutex, "runtime")

--- a/backend/internal/system/database/provider/redisprovider.go
+++ b/backend/internal/system/database/provider/redisprovider.go
@@ -83,13 +83,16 @@ func initRedisProvider() {
 
 		if err := client.Ping(context.Background()).Err(); err != nil {
 			if closeErr := client.Close(); closeErr != nil {
-				logger.Fatal("Failed to connect to Redis runtime store; also failed to close client",
+				logger.FatalWithContext(context.Background(),
+					"Failed to connect to Redis runtime store; also failed to close client",
 					log.Error(err), log.String("closeError", closeErr.Error()))
 			}
-			logger.Fatal("Failed to connect to Redis runtime store", log.Error(err))
+			logger.FatalWithContext(context.Background(), "Failed to connect to Redis runtime store", log.Error(err))
 		}
 
-		logger.Info("Connected to Redis runtime store", log.String("address", r.Address))
+		// Redis client is initialized at startup, outside any request.
+		logger.InfoWithContext(context.Background(), "Connected to Redis runtime store",
+			log.String("address", r.Address))
 		redisInstance = &redisProvider{
 			client:    client,
 			keyPrefix: r.KeyPrefix,

--- a/backend/internal/system/declarative_resource/exporter.go
+++ b/backend/internal/system/declarative_resource/exporter.go
@@ -50,7 +50,7 @@ type ResourceExporter interface {
 
 	// ValidateResource validates the resource and extracts its name
 	// Returns: resource name, export error
-	ValidateResource(resource interface{}, id string, logger *log.Logger) (string, *ExportError)
+	ValidateResource(ctx context.Context, resource interface{}, id string, logger *log.Logger) (string, *ExportError)
 
 	// GetResourceRules returns the parameterization rules for this resource type
 	GetResourceRules() *ResourceRules
@@ -83,9 +83,10 @@ func CreateTypeError(resourceType, resourceID string) *ExportError {
 }
 
 // ValidateResourceName validates that a resource name is not empty and returns an error if it is.
-func ValidateResourceName(name, resourceType, resourceID, errorCode string, logger *log.Logger) *ExportError {
+func ValidateResourceName(
+	ctx context.Context, name, resourceType, resourceID, errorCode string, logger *log.Logger) *ExportError {
 	if name == "" {
-		logger.Warn(resourceType+" missing name, skipping export",
+		logger.WarnWithContext(ctx, resourceType+" missing name, skipping export",
 			log.String("resourceID", resourceID))
 		return &ExportError{
 			ResourceType: resourceType,

--- a/backend/internal/system/declarative_resource/exporter_test.go
+++ b/backend/internal/system/declarative_resource/exporter_test.go
@@ -19,6 +19,7 @@
 package declarativeresource
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -115,7 +116,8 @@ func TestValidateResourceName(t *testing.T) {
 			// Create a logger for testing
 			logger := log.GetLogger()
 
-			got := ValidateResourceName(tt.resourceName, tt.resourceType, tt.resourceID, tt.errorCode, logger)
+			got := ValidateResourceName(
+				context.Background(), tt.resourceName, tt.resourceType, tt.resourceID, tt.errorCode, logger)
 			assert.Equal(t, tt.wantError, got)
 		})
 	}

--- a/backend/internal/system/declarative_resource/manager.go
+++ b/backend/internal/system/declarative_resource/manager.go
@@ -20,6 +20,7 @@ package declarativeresource
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -45,7 +46,8 @@ func GetConfigsFromFile(filePath, resourceType string) ([][]byte, error) {
 	}
 	defer func() {
 		if cerr := file.Close(); cerr != nil {
-			log.GetLogger().Warn("Failed to close resources file", log.Error(cerr))
+			// Declarative resource files are loaded at startup, outside any request.
+			log.GetLogger().WarnWithContext(context.Background(), "Failed to close resources file", log.Error(cerr))
 		}
 	}()
 	fileContent, err := io.ReadAll(file)
@@ -153,6 +155,9 @@ func GetConfigsFromRootDir(resourceType string) ([][]byte, error) {
 
 // GetConfigs reads all configuration files from the specified directory within the resources directory.
 func GetConfigs(configDirectoryPath string) ([][]byte, error) {
+	// Declarative config files are loaded at startup, outside any request,
+	// so context.Background() is used (no request trace ID to propagate).
+	ctx := context.Background()
 	logger := log.GetLogger().With(log.String("component", "FileBasedRuntime"))
 	serverHome := config.GetServerRuntime().ServerHome
 	immutableConfigFilePath := path.Join(serverHome, "repository/resources/")
@@ -162,7 +167,7 @@ func GetConfigs(configDirectoryPath string) ([][]byte, error) {
 		if os.IsNotExist(err) {
 			return [][]byte{}, nil
 		}
-		logger.Error("Failed to read configuration directory",
+		logger.ErrorWithContext(ctx, "Failed to read configuration directory",
 			log.String("path", absoluteDirectoryPath), log.Error(err))
 		return nil, err
 	}
@@ -198,14 +203,15 @@ func GetConfigs(configDirectoryPath string) ([][]byte, error) {
 				// #nosec G304 -- File path is controlled and within a trusted directory
 				fileContent, err := os.ReadFile(filePath)
 				if err != nil {
-					logger.Warn("Failed to read configuration file", log.String("filePath", fileName), log.Error(err))
+					logger.WarnWithContext(ctx, "Failed to read configuration file",
+						log.String("filePath", fileName), log.Error(err))
 					configChan <- configResult{content: nil, err: err}
 					return
 				}
 				// Substitute environment variables
 				processedContent, err := utils.SubstituteEnvironmentVariables(fileContent)
 				if err != nil {
-					logger.Warn("Failed to substitute environment variables in configuration file",
+					logger.WarnWithContext(ctx, "Failed to substitute environment variables in configuration file",
 						log.String("filePath", fileName), log.Error(err))
 					configChan <- configResult{content: nil, err: err}
 					return

--- a/backend/internal/system/declarative_resource/store.go
+++ b/backend/internal/system/declarative_resource/store.go
@@ -19,6 +19,7 @@
 package declarativeresource
 
 import (
+	"context"
 	"errors"
 
 	"github.com/thunder-id/thunderid/internal/system/declarative_resource/entity"
@@ -119,7 +120,8 @@ func (s *GenericFileBasedStore) ClearByType() error {
 
 // LogTypeAssertionError logs a type assertion error.
 func LogTypeAssertionError(resourceType, id string) {
-	log.GetLogger().Error("Type assertion failed while retrieving resource",
+	// Declarative resource ID extraction runs during startup loading, outside any request.
+	log.GetLogger().ErrorWithContext(context.Background(), "Type assertion failed while retrieving resource",
 		log.String("resourceType", resourceType),
 		log.String("id", id))
 }

--- a/backend/internal/system/email/client.go
+++ b/backend/internal/system/email/client.go
@@ -20,8 +20,10 @@
 // It defines a common interface and implementations for sending emails via various transports.
 package email
 
+import "context"
+
 // EmailClientInterface defines the interface for sending emails.
 type EmailClientInterface interface {
 	// Send sends an email using the provided EmailData.
-	Send(emailData EmailData) error
+	Send(ctx context.Context, emailData EmailData) error
 }

--- a/backend/internal/system/email/smtp_client.go
+++ b/backend/internal/system/email/smtp_client.go
@@ -19,6 +19,7 @@
 package email
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"mime"
@@ -92,7 +93,7 @@ func NewSMTPClientFromConfig() (EmailClientInterface, error) {
 }
 
 // smtpClient implements the EmailClientInterface using SMTP.
-func (c *smtpClient) Send(emailData EmailData) error {
+func (c *smtpClient) Send(ctx context.Context, emailData EmailData) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, smtpLoggerComponentName))
 
 	// 1. Validate, sanitize in place, and extract the flat envelope list
@@ -101,7 +102,7 @@ func (c *smtpClient) Send(emailData EmailData) error {
 		return err
 	}
 
-	logger.Debug("Sending email via SMTP",
+	logger.DebugWithContext(ctx, "Sending email via SMTP",
 		log.MaskedString("from", c.config.from),
 		log.Int("recipientCount", len(emailData.To)))
 
@@ -111,11 +112,11 @@ func (c *smtpClient) Send(emailData EmailData) error {
 	message := c.buildMessage(emailData)
 
 	// 3. Send via SMTP
-	if err := c.sendViaSMTP(serverAddress, allRecipients, message); err != nil {
+	if err := c.sendViaSMTP(ctx, serverAddress, allRecipients, message); err != nil {
 		return err
 	}
 
-	logger.Debug("Email sent successfully")
+	logger.DebugWithContext(ctx, "Email sent successfully")
 	return nil
 }
 
@@ -198,7 +199,7 @@ func (c *smtpClient) buildMessage(emailData EmailData) string {
 
 // sendViaSMTP handles the low-level SMTP communication, connection setup,
 // optional TLS upgrade, authentication, and message transmission
-func (c *smtpClient) sendViaSMTP(serverAddress string, recipients []string, message string) error {
+func (c *smtpClient) sendViaSMTP(ctx context.Context, serverAddress string, recipients []string, message string) error {
 	conn, err := net.DialTimeout("tcp", serverAddress, smtpDialTimeout)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrorSMTPConnection, err)
@@ -256,7 +257,7 @@ func (c *smtpClient) sendViaSMTP(serverAddress string, recipients []string, mess
 
 	if err := client.Quit(); err != nil {
 		log.GetLogger().With(log.String(log.LoggerKeyComponentName, smtpLoggerComponentName)).
-			Error("Failed to gracefully close SMTP client", log.Error(err))
+			ErrorWithContext(ctx, "Failed to gracefully close SMTP client", log.Error(err))
 	}
 
 	return nil

--- a/backend/internal/system/email/smtp_client_test.go
+++ b/backend/internal/system/email/smtp_client_test.go
@@ -20,6 +20,7 @@ package email
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -167,7 +168,7 @@ func (suite *SMTPClientTestSuite) TestSendEmail_PlainText_Success() {
 		IsHTML:  false,
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Require().NoError(err)
 	suite.waitForDone(done)
@@ -193,7 +194,7 @@ func (suite *SMTPClientTestSuite) TestSendEmail_HTML_Success() {
 		IsHTML:  true,
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Require().NoError(err)
 	suite.waitForDone(done)
@@ -221,7 +222,7 @@ func (suite *SMTPClientTestSuite) TestSendEmail_MultipleRecipients_Success() {
 		IsHTML:  false,
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Require().NoError(err)
 	suite.waitForDone(done)
@@ -249,7 +250,7 @@ func (suite *SMTPClientTestSuite) TestSendEmail_EmptyToWithCC_Success() {
 		IsHTML:  false,
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Require().NoError(err)
 	suite.waitForDone(done)
@@ -266,7 +267,7 @@ func (suite *SMTPClientTestSuite) TestSendEmail_EmptyRecipients_Error() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorInvalidRecipient))
@@ -283,7 +284,7 @@ func (suite *SMTPClientTestSuite) TestSendEmail_EmptyRecipientString_Error() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorInvalidRecipient))
@@ -309,7 +310,7 @@ func (suite *SMTPClientTestSuite) TestSendEmail_ConnectionError() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorSMTPConnection))
@@ -326,7 +327,7 @@ func (suite *SMTPClientTestSuite) TestSendEmail_CRLFInjection_Error() {
 		Subject: "Test",
 		Body:    "Test body",
 	}
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorInvalidRecipient))
 
@@ -336,7 +337,7 @@ func (suite *SMTPClientTestSuite) TestSendEmail_CRLFInjection_Error() {
 		Subject: "Test\r\nBcc: evil@example.com",
 		Body:    "Test body",
 	}
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 	suite.Error(err)
 	suite.Contains(err.Error(), "invalid characters")
 	suite.True(errors.Is(err, ErrorInvalidSubject))
@@ -490,7 +491,7 @@ func (suite *SMTPClientTestSuite) TestSendViaSMTP_InvalidGreeting_Error() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorSMTPConnection))
@@ -518,7 +519,7 @@ func (suite *SMTPClientTestSuite) TestSendViaSMTP_TLSNotSupported_Error() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorSMTPConnection))
@@ -546,7 +547,7 @@ func (suite *SMTPClientTestSuite) TestSendViaSMTP_TLSError() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorSMTPConnection))
@@ -573,7 +574,7 @@ func (suite *SMTPClientTestSuite) TestSendViaSMTP_AuthError() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorSMTPAuth))
@@ -600,7 +601,7 @@ func (suite *SMTPClientTestSuite) TestSendViaSMTP_MailFromError() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorEmailSendFailed))
@@ -627,7 +628,7 @@ func (suite *SMTPClientTestSuite) TestSendViaSMTP_RcptToError() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorEmailSendFailed))
@@ -654,7 +655,7 @@ func (suite *SMTPClientTestSuite) TestSendViaSMTP_DataError() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorEmailSendFailed))
@@ -686,7 +687,7 @@ func (suite *SMTPClientTestSuite) TestSendViaSMTP_WriteError() {
 		Body:    largeBody,
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	// On Windows, this is often reported as a connection failure (SYS-EMAIL-5001)
@@ -716,7 +717,7 @@ func (suite *SMTPClientTestSuite) TestSendViaSMTP_DataTerminationError() {
 		Body:    "Test body",
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Error(err)
 	suite.True(errors.Is(err, ErrorEmailSendFailed))
@@ -848,7 +849,7 @@ func (suite *SMTPClientTestSuite) TestSendEmail_NoAuth_Success() {
 		IsHTML:  false,
 	}
 
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 
 	suite.Require().NoError(err)
 	suite.waitForDone(done)
@@ -878,7 +879,7 @@ func (suite *SMTPClientTestSuite) TestSendViaSMTP_QuitError_Ignored() {
 	}
 
 	// QUIT errors should be ignored since the message was already accepted.
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 	suite.NoError(err)
 	suite.waitForDone(done)
 }
@@ -1310,7 +1311,7 @@ func (suite *SMTPClientTestSuite) TestSendLiveEmail() {
 		IsHTML: true,
 	}
 	fmt.Printf("Sending test email to %s...\n", emailData.To[0])
-	err = client.Send(emailData)
+	err = client.Send(context.Background(), emailData)
 	suite.NoError(err, "Failed to send email")
 	fmt.Println("Email sent successfully!")
 }

--- a/backend/internal/system/export/handler.go
+++ b/backend/internal/system/export/handler.go
@@ -21,6 +21,7 @@ package export
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -54,7 +55,7 @@ func (eh *exportHandler) HandleExportRequest(w http.ResponseWriter, r *http.Requ
 			Message:     ErrorInvalidRequest.Error,
 			Description: ErrorInvalidRequest.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -64,7 +65,7 @@ func (eh *exportHandler) HandleExportRequest(w http.ResponseWriter, r *http.Requ
 		if svcErr.Type == serviceerror.ServerErrorType {
 			logger.ErrorWithContext(r.Context(), "Error exporting resources", log.Any("serviceError", svcErr))
 		}
-		eh.handleError(w, svcErr)
+		eh.handleError(r.Context(), w, svcErr)
 		return
 	}
 
@@ -76,7 +77,7 @@ func (eh *exportHandler) HandleExportRequest(w http.ResponseWriter, r *http.Requ
 		jsonResponse.EnvironmentVariables = exportResponse.EnvFile.Content
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, jsonResponse)
+	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, jsonResponse)
 }
 
 func buildCombinedResources(files []ExportFile) string {
@@ -107,35 +108,35 @@ func (eh *exportHandler) HandleExportZipRequest(w http.ResponseWriter, r *http.R
 			Message:     ErrorInvalidRequest.Error,
 			Description: ErrorInvalidRequest.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	// Export resources using the export service
-	exportResponse, svcErr := eh.service.ExportResources(r.Context(), exportRequest)
+	exportResponse, svcErr := eh.service.ExportResources(ctx, exportRequest)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
 			logger.ErrorWithContext(ctx, "Error exporting resources", log.Any("serviceError", svcErr))
 		}
-		eh.handleError(w, svcErr)
+		eh.handleError(ctx, w, svcErr)
 		return
 	}
 
 	// Generate ZIP file and send response
-	if err := eh.generateAndSendZipResponse(w, logger, exportResponse); err != nil {
+	if err := eh.generateAndSendZipResponse(ctx, w, logger, exportResponse); err != nil {
 		logger.ErrorWithContext(ctx, "Error generating ZIP response", log.Error(err))
 		errResp := apierror.ErrorResponse{
 			Code:        serviceerror.InternalServerError.Code,
 			Message:     serviceerror.InternalServerError.Error,
 			Description: serviceerror.InternalServerError.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusInternalServerError, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusInternalServerError, errResp)
 		return
 	}
 }
 
 // generateAndSendZipResponse creates a ZIP file from export files and sends it as HTTP response.
-func (eh *exportHandler) generateAndSendZipResponse(
+func (eh *exportHandler) generateAndSendZipResponse(ctx context.Context,
 	w http.ResponseWriter, logger *log.Logger, exportResponse *ExportResponse) error {
 	// Create ZIP file in memory
 	var zipBuffer bytes.Buffer
@@ -151,12 +152,13 @@ func (eh *exportHandler) generateAndSendZipResponse(
 
 		fileWriter, err := zipWriter.Create(zipPath)
 		if err != nil {
-			logger.Error("Error creating file in ZIP", log.String("zipPath", zipPath), log.Error(err))
+			logger.ErrorWithContext(ctx, "Error creating file in ZIP", log.String("zipPath", zipPath), log.Error(err))
 			return fmt.Errorf("failed to create file in ZIP: %w", err)
 		}
 
 		if _, err := fileWriter.Write([]byte(file.Content)); err != nil {
-			logger.Error("Error writing file content to ZIP", log.String("zipPath", zipPath), log.Error(err))
+			logger.ErrorWithContext(ctx, "Error writing file content to ZIP",
+				log.String("zipPath", zipPath), log.Error(err))
 			return fmt.Errorf("failed to write content to ZIP: %w", err)
 		}
 	}
@@ -164,13 +166,14 @@ func (eh *exportHandler) generateAndSendZipResponse(
 	if exportResponse.EnvFile != nil {
 		envWriter, err := zipWriter.Create(exportResponse.EnvFile.FileName)
 		if err != nil {
-			logger.Error("Error creating env file in ZIP", log.String("fileName", exportResponse.EnvFile.FileName),
+			logger.ErrorWithContext(ctx, "Error creating env file in ZIP",
+				log.String("fileName", exportResponse.EnvFile.FileName),
 				log.Error(err))
 			return fmt.Errorf("failed to create env file in ZIP: %w", err)
 		}
 
 		if _, err = envWriter.Write([]byte(exportResponse.EnvFile.Content)); err != nil {
-			logger.Error("Error writing env file content to ZIP",
+			logger.ErrorWithContext(ctx, "Error writing env file content to ZIP",
 				log.String("fileName", exportResponse.EnvFile.FileName),
 				log.Error(err))
 			return fmt.Errorf("failed to write env file content to ZIP: %w", err)
@@ -179,7 +182,7 @@ func (eh *exportHandler) generateAndSendZipResponse(
 
 	// Close the ZIP writer
 	if err := zipWriter.Close(); err != nil {
-		logger.Error("Error closing ZIP writer", log.Error(err))
+		logger.ErrorWithContext(ctx, "Error closing ZIP writer", log.Error(err))
 		return fmt.Errorf("failed to close ZIP writer: %w", err)
 	}
 
@@ -191,7 +194,7 @@ func (eh *exportHandler) generateAndSendZipResponse(
 
 	// Write the ZIP content
 	if _, err := w.Write(zipBuffer.Bytes()); err != nil {
-		logger.Error("Error writing ZIP response", log.Error(err))
+		logger.ErrorWithContext(ctx, "Error writing ZIP response", log.Error(err))
 		return fmt.Errorf("failed to write ZIP response: %w", err)
 	}
 
@@ -199,7 +202,7 @@ func (eh *exportHandler) generateAndSendZipResponse(
 }
 
 // handleError handles service errors and sends appropriate HTTP responses.
-func (eh *exportHandler) handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func (eh *exportHandler) handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
 		statusCode = http.StatusBadRequest
@@ -211,5 +214,5 @@ func (eh *exportHandler) handleError(w http.ResponseWriter, svcErr *serviceerror
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }

--- a/backend/internal/system/export/handler_test.go
+++ b/backend/internal/system/export/handler_test.go
@@ -19,16 +19,17 @@
 package export
 
 import (
-	"github.com/stretchr/testify/mock"
-
 	"archive/zip"
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 
 	"github.com/thunder-id/thunderid/internal/application"
 	"github.com/thunder-id/thunderid/internal/application/model"
@@ -135,7 +136,7 @@ func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_Success() {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TestHandler"))
 
 	// Execute
-	err := suite.handler.generateAndSendZipResponse(w, logger, exportResponse)
+	err := suite.handler.generateAndSendZipResponse(context.Background(), w, logger, exportResponse)
 
 	// Assert no error
 	assert.NoError(suite.T(), err)
@@ -197,7 +198,7 @@ func (suite *HandlerTestSuite) testZipResponse(
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TestHandler"))
 
 	// Execute
-	err := suite.handler.generateAndSendZipResponse(w, logger, exportResponse)
+	err := suite.handler.generateAndSendZipResponse(context.Background(), w, logger, exportResponse)
 
 	// Assert no error
 	assert.NoError(suite.T(), err)
@@ -260,7 +261,7 @@ func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_EmptyFiles() {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TestHandler"))
 
 	// Execute
-	err := suite.handler.generateAndSendZipResponse(w, logger, exportResponse)
+	err := suite.handler.generateAndSendZipResponse(context.Background(), w, logger, exportResponse)
 
 	// Assert no error (empty ZIP should be valid)
 	assert.NoError(suite.T(), err)
@@ -300,7 +301,7 @@ func (suite *HandlerTestSuite) TestGenerateAndSendZipResponse_LargeContent() {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TestHandler"))
 
 	// Execute
-	err := suite.handler.generateAndSendZipResponse(w, logger, exportResponse)
+	err := suite.handler.generateAndSendZipResponse(context.Background(), w, logger, exportResponse)
 
 	// Assert no error
 	assert.NoError(suite.T(), err)
@@ -418,7 +419,7 @@ func TestGenerateAndSendZipResponse_Standalone(t *testing.T) {
 
 	// Execute
 	w := httptest.NewRecorder()
-	err = handler.generateAndSendZipResponse(w, logger, exportResponse)
+	err = handler.generateAndSendZipResponse(context.Background(), w, logger, exportResponse)
 
 	// Assert
 	assert.NoError(t, err)
@@ -738,7 +739,7 @@ func (suite *HandlerTestSuite) TestHandleError_ClientError() {
 	clientErr := &ErrorNoResourcesFound
 
 	// Execute
-	suite.handler.handleError(w, clientErr)
+	suite.handler.handleError(context.Background(), w, clientErr)
 
 	// Assert response
 	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
@@ -761,7 +762,7 @@ func (suite *HandlerTestSuite) TestHandleError_ServerError() {
 	serverErr := &serviceerror.InternalServerError
 
 	// Execute
-	suite.handler.handleError(w, serverErr)
+	suite.handler.handleError(context.Background(), w, serverErr)
 
 	// Assert response
 	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
@@ -886,7 +887,7 @@ func BenchmarkGenerateAndSendZipResponse(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		w := httptest.NewRecorder()
-		_ = handler.generateAndSendZipResponse(w, logger, exportResponse)
+		_ = handler.generateAndSendZipResponse(context.Background(), w, logger, exportResponse)
 	}
 }
 

--- a/backend/internal/system/export/parameterizer.go
+++ b/backend/internal/system/export/parameterizer.go
@@ -20,6 +20,7 @@ package export
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -62,7 +63,7 @@ func newParameterizer(rules templatingRules) *parameterizer {
 
 // ToParameterizedYAML converts an object directly to parameterized YAML.
 // It returns the template string and a map of variable names to their original values.
-func (p *parameterizer) ToParameterizedYAML(obj interface{},
+func (p *parameterizer) ToParameterizedYAML(ctx context.Context, obj interface{},
 	resourceType string, resourceName string,
 	rules *declarativeresource.ResourceRules) (string, map[string]string, error) {
 	// Convert imported type to local type for compatibility
@@ -98,7 +99,7 @@ func (p *parameterizer) ToParameterizedYAML(obj interface{},
 	}
 
 	// Convert struct field paths to YAML field paths
-	rulesWithYAMLPaths := p.convertStructPathsToYAMLPaths(obj, localRules)
+	rulesWithYAMLPaths := p.convertStructPathsToYAMLPaths(ctx, obj, localRules)
 
 	// Capture original values before parameterization replaces them.
 	// Dynamic property values must be extracted from the original struct here because
@@ -1028,7 +1029,8 @@ func (p *parameterizer) convertFieldToInterface(v reflect.Value) interface{} {
 
 // convertStructPathsToYAMLPaths converts Go struct field paths to YAML field paths
 // e.g., "InboundAuthConfig[].OAuthConfig.ClientID" -> "inbound_auth_config[].config.client_id"
-func (p *parameterizer) convertStructPathsToYAMLPaths(obj interface{}, rules *resourceRules) *resourceRules {
+func (p *parameterizer) convertStructPathsToYAMLPaths(
+	ctx context.Context, obj interface{}, rules *resourceRules) *resourceRules {
 	logger := log.GetLogger().With(log.String("component", "Parameterizer"))
 
 	converted := &resourceRules{
@@ -1045,7 +1047,7 @@ func (p *parameterizer) convertStructPathsToYAMLPaths(obj interface{}, rules *re
 		yamlPath := p.convertPathToYAMLPath(objType, path)
 		converted.Variables[i] = yamlPath
 		// Debug log to help troubleshoot path resolution
-		logger.Debug("Converted variable path",
+		logger.DebugWithContext(ctx, "Converted variable path",
 			log.String("original", path),
 			log.String("yaml", yamlPath))
 	}
@@ -1054,7 +1056,7 @@ func (p *parameterizer) convertStructPathsToYAMLPaths(obj interface{}, rules *re
 		yamlPath := p.convertPathToYAMLPath(objType, path)
 		converted.ArrayVariables[i] = yamlPath
 		// Debug log to help troubleshoot path resolution
-		logger.Debug("Converted array variable path",
+		logger.DebugWithContext(ctx, "Converted array variable path",
 			log.String("original", path),
 			log.String("yaml", yamlPath))
 	}

--- a/backend/internal/system/export/parameterizer_test.go
+++ b/backend/internal/system/export/parameterizer_test.go
@@ -19,6 +19,7 @@
 package export
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -85,7 +86,7 @@ func TestToParameterizedYAML_WithOmitemptyFields(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -137,7 +138,7 @@ func TestToParameterizedYAML_WithPopulatedFields(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -189,7 +190,7 @@ func TestToParameterizedYAML_MixedEmptyAndPopulated(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -318,7 +319,7 @@ func TestOmitempty_EmptyFieldsWithoutRules(t *testing.T) {
 
 	// No parameterization rules - omitempty should work normally
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), app, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -345,7 +346,7 @@ func TestOmitempty_EmptyArraysOmitted(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), app, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	assert.NotContains(t, result, "grantTypes:", "Empty GrantTypes array should be omitted")
@@ -363,7 +364,7 @@ func TestOmitempty_NilSlicesOmitted(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), app, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	assert.NotContains(t, result, "grantTypes:", "Nil GrantTypes should be omitted")
@@ -378,7 +379,7 @@ func TestOmitempty_NilPointersOmitted(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), app, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	assert.NotContains(t, result, "oauth:", "Nil OAuth pointer should be omitted")
@@ -408,7 +409,7 @@ func TestParameterization_OverridesOmitemptyForVariables(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -438,7 +439,7 @@ func TestParameterization_OverridesOmitemptyForArrays(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -471,7 +472,7 @@ func TestParameterization_NestedFieldsWithOmitempty(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -508,7 +509,7 @@ func TestParameterization_MixedRulesAndOmitempty(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		app, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -548,7 +549,7 @@ func TestFieldOrder_TopLevelFieldsPreserved(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -576,7 +577,7 @@ func TestFieldOrder_WithOmittedFields(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -618,7 +619,7 @@ func TestFieldOrder_NestedFieldsPreserved(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -678,7 +679,7 @@ func TestEdgeCase_DeeplyNestedStructures(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	assert.Contains(t, result, "level1:")
@@ -710,7 +711,7 @@ func TestEdgeCase_ArraysOfStructs(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	assert.Contains(t, result, "items:")
@@ -733,7 +734,7 @@ func TestEdgeCase_EmptyStructWithOmitempty(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(app, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), app, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -800,7 +801,7 @@ func TestIsEmptyValue_IntegerTypes(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -823,7 +824,7 @@ func TestIsEmptyValue_UnsignedIntegerTypes(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -843,7 +844,7 @@ func TestIsEmptyValue_FloatTypes(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -859,7 +860,7 @@ func TestIsEmptyValue_BoolType(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -878,7 +879,7 @@ func TestIsEmptyValue_NonZeroValues(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -1030,7 +1031,7 @@ func TestRenderNode_ComplexTemplateStructures(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		obj, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -1053,7 +1054,7 @@ func TestRenderNode_ArrayOfMaps(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -1072,7 +1073,7 @@ func TestToParameterizedYAML_NilRules(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
@@ -1095,7 +1096,7 @@ func TestToParameterizedYAML_NilRulesWithOmitempty(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		obj, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -1145,7 +1146,7 @@ func TestRenderNode_NestedArraysInSequence(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -1165,7 +1166,7 @@ func TestFieldToNode_NilPointer(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(templatingRules{})
-	result, _, err := parameterizer.ToParameterizedYAML(obj, "Application", "TestApp", nil)
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(), obj, "Application", "TestApp", nil)
 
 	require.NoError(t, err)
 
@@ -1189,7 +1190,7 @@ func TestConvertPathToYAMLPath_NonStructType(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		obj, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -1212,7 +1213,7 @@ func TestFindFieldByNameCaseInsensitive_NotFound(t *testing.T) {
 	}
 
 	parameterizer := newParameterizer(rules)
-	result, _, err := parameterizer.ToParameterizedYAML(
+	result, _, err := parameterizer.ToParameterizedYAML(context.Background(),
 		obj, "Application", "TestApp", toDeclarativeResourceRules(rules.Application))
 
 	require.NoError(t, err)
@@ -1231,7 +1232,7 @@ func TestToParameterizedYAML_InvalidStruct(t *testing.T) {
 	// Pass non-struct type
 	var notAStruct int = 42
 
-	_, _, err := p.ToParameterizedYAML(notAStruct, "Application", "Test", nil)
+	_, _, err := p.ToParameterizedYAML(context.Background(), notAStruct, "Application", "Test", nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to convert object to node")
@@ -1644,7 +1645,7 @@ func TestToParameterizedYAML_JSONRawMessageInvalid(t *testing.T) {
 	}
 
 	// Should return an error
-	result, _, err := p.ToParameterizedYAML(schema, "EntityType", "TestSchema", nil)
+	result, _, err := p.ToParameterizedYAML(context.Background(), schema, "EntityType", "TestSchema", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid JSON in RawMessage")
@@ -1676,7 +1677,7 @@ func TestToParameterizedYAML_NestedStructWithInvalidJSON(t *testing.T) {
 	}
 
 	// Should return an error from the nested structure
-	result, _, err := p.ToParameterizedYAML(obj, "Config", "TestConfig", nil)
+	result, _, err := p.ToParameterizedYAML(context.Background(), obj, "Config", "TestConfig", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid JSON in RawMessage")
@@ -1721,7 +1722,7 @@ func TestEntityTypeImportExportSymmetry(t *testing.T) {
 
 	// Export using the parameterizer
 	p := newParameterizer(templatingRules{})
-	yamlOutput, _, err := p.ToParameterizedYAML(originalSchema, "EntityType", "Person", nil)
+	yamlOutput, _, err := p.ToParameterizedYAML(context.Background(), originalSchema, "EntityType", "Person", nil)
 	require.NoError(t, err)
 
 	t.Logf("Exported YAML:\n%s", yamlOutput)
@@ -1801,7 +1802,7 @@ func TestRenderNode_I18nRefsInSequenceItemAreQuoted(t *testing.T) {
 
 	p := newParameterizer(templatingRules{})
 	// Use empty (non-nil) rules to exercise the custom renderNode path (same as flows)
-	result, _, err := p.ToParameterizedYAML(
+	result, _, err := p.ToParameterizedYAML(context.Background(),
 		obj, "Flow", "User Onboarding Flow",
 		toDeclarativeResourceRules(&resourceRules{}))
 	require.NoError(t, err)
@@ -1840,7 +1841,7 @@ func TestRenderMappingValue_I18nRefsAreQuoted(t *testing.T) {
 	}
 
 	p := newParameterizer(templatingRules{})
-	result, _, err := p.ToParameterizedYAML(
+	result, _, err := p.ToParameterizedYAML(context.Background(),
 		obj, "Application", "Test",
 		toDeclarativeResourceRules(&resourceRules{Variables: []string{"Callback"}}))
 	require.NoError(t, err)
@@ -1869,7 +1870,7 @@ func TestEntityTypeExportFormat(t *testing.T) {
 	}
 
 	p := newParameterizer(templatingRules{})
-	yamlOutput, _, err := p.ToParameterizedYAML(schema, "EntityType", "TestSchema", nil)
+	yamlOutput, _, err := p.ToParameterizedYAML(context.Background(), schema, "EntityType", "TestSchema", nil)
 	require.NoError(t, err)
 
 	// Verify the schema field is a plain string in the YAML, not a structured object
@@ -1900,7 +1901,7 @@ func TestResourceServerExport_IdentifierAndOUIDNotParameterized(t *testing.T) {
 
 	p := newParameterizer(templatingRules{})
 	// nil rules mirrors what GetResourceRules() returns for resource servers
-	result, vars, err := p.ToParameterizedYAML(rs, "ResourceServer", "System", nil)
+	result, vars, err := p.ToParameterizedYAML(context.Background(), rs, "ResourceServer", "System", nil)
 	require.NoError(t, err)
 
 	// identifier must be the literal value, not a template variable
@@ -1931,7 +1932,7 @@ func TestResourceServerExport_DelimiterIsQuoted(t *testing.T) {
 	}
 
 	p := newParameterizer(templatingRules{})
-	result, _, err := p.ToParameterizedYAML(rs, "ResourceServer", "System", nil)
+	result, _, err := p.ToParameterizedYAML(context.Background(), rs, "ResourceServer", "System", nil)
 	require.NoError(t, err)
 
 	// delimiter must be quoted so bare ":" is not parsed as a YAML mapping indicator
@@ -1972,7 +1973,7 @@ func TestInlineEmbed_TopLevelFlattensFields(t *testing.T) {
 	}
 
 	p := newParameterizer(templatingRules{})
-	out, _, err := p.ToParameterizedYAML(obj, "Application", "MyApp", nil)
+	out, _, err := p.ToParameterizedYAML(context.Background(), obj, "Application", "MyApp", nil)
 	require.NoError(t, err)
 
 	// Bug signature: a bare-colon line (empty key holding the embedded struct).
@@ -1996,7 +1997,7 @@ type inlinePtrParent struct {
 func TestInlineEmbed_NilPointerSkipped(t *testing.T) {
 	obj := &inlinePtrParent{Name: "App", Inner: nil}
 	p := newParameterizer(templatingRules{})
-	out, _, err := p.ToParameterizedYAML(obj, "Application", "App", nil)
+	out, _, err := p.ToParameterizedYAML(context.Background(), obj, "Application", "App", nil)
 	require.NoError(t, err)
 
 	assert.Contains(t, out, "name: App")
@@ -2010,7 +2011,7 @@ func TestInlineEmbed_NilPointerSkipped(t *testing.T) {
 func TestInlineEmbed_PointerDereferenced(t *testing.T) {
 	obj := &inlinePtrParent{Name: "App", Inner: &inlineInner{A: "alpha"}}
 	p := newParameterizer(templatingRules{})
-	out, _, err := p.ToParameterizedYAML(obj, "Application", "App", nil)
+	out, _, err := p.ToParameterizedYAML(context.Background(), obj, "Application", "App", nil)
 	require.NoError(t, err)
 
 	assert.NotContains(t, out, "\n:\n")
@@ -2037,7 +2038,7 @@ type recParent struct {
 func TestInlineEmbed_RecursivelyFlattensNestedInline(t *testing.T) {
 	obj := &recParent{Name: "App", Mid: recMiddle{Inner: recInner{Deep: "value"}, Mid: "middle"}}
 	p := newParameterizer(templatingRules{})
-	out, _, err := p.ToParameterizedYAML(obj, "Application", "App", nil)
+	out, _, err := p.ToParameterizedYAML(context.Background(), obj, "Application", "App", nil)
 	require.NoError(t, err)
 
 	assert.NotContains(t, out, "\n:\n")
@@ -2054,7 +2055,12 @@ func TestInlineEmbed_RuleOverridesOmitemptyForInlineField(t *testing.T) {
 	rules := &resourceRules{Variables: []string{"A"}}
 
 	p := newParameterizer(templatingRules{Application: rules})
-	out, _, err := p.ToParameterizedYAML(obj, "Application", "App", toDeclarativeResourceRules(rules))
+	out, _, err := p.ToParameterizedYAML(
+		context.Background(),
+		obj,
+		"Application",
+		"App",
+		toDeclarativeResourceRules(rules))
 	require.NoError(t, err)
 
 	// A is empty but referenced by rules -> emitted (omitempty bypassed).
@@ -2077,7 +2083,7 @@ type inlineQuotedParent struct {
 func TestInlineEmbed_QuotedFieldHonored(t *testing.T) {
 	obj := &inlineQuotedParent{Name: "App", Inner: inlineQuotedInner{Delim: ":"}}
 	p := newParameterizer(templatingRules{})
-	out, _, err := p.ToParameterizedYAML(obj, "Application", "App", nil)
+	out, _, err := p.ToParameterizedYAML(context.Background(), obj, "Application", "App", nil)
 	require.NoError(t, err)
 
 	assert.Contains(t, out, `delim: ":"`)
@@ -2095,7 +2101,7 @@ type bogusInlineParent struct {
 func TestInlineEmbed_NonStructValueSkipped(t *testing.T) {
 	obj := &bogusInlineParent{Name: "App", Foo: 42}
 	p := newParameterizer(templatingRules{})
-	out, _, err := p.ToParameterizedYAML(obj, "Application", "App", nil)
+	out, _, err := p.ToParameterizedYAML(context.Background(), obj, "Application", "App", nil)
 	require.NoError(t, err)
 
 	assert.Contains(t, out, "name: App")
@@ -2121,7 +2127,7 @@ func TestInlineEmbed_HiddenAndUntaggedFieldsSkipped(t *testing.T) {
 		Inner: skipFieldInner{Visible: "yes", Skipped: "secret", NoTag: "untagged"},
 	}
 	p := newParameterizer(templatingRules{})
-	out, _, err := p.ToParameterizedYAML(obj, "Application", "App", nil)
+	out, _, err := p.ToParameterizedYAML(context.Background(), obj, "Application", "App", nil)
 	require.NoError(t, err)
 
 	assert.Contains(t, out, "visible: yes")
@@ -2148,7 +2154,7 @@ func TestInlineEmbed_InsideNestedStructFlattened(t *testing.T) {
 		Child: nestedInlineChild{Y: "outer", Inner: inlineInner{A: "alpha"}},
 	}
 	p := newParameterizer(templatingRules{})
-	out, _, err := p.ToParameterizedYAML(obj, "Application", "App", nil)
+	out, _, err := p.ToParameterizedYAML(context.Background(), obj, "Application", "App", nil)
 	require.NoError(t, err)
 
 	// No empty-key nesting inside the child mapping.

--- a/backend/internal/system/export/registry_test.go
+++ b/backend/internal/system/export/registry_test.go
@@ -130,7 +130,7 @@ func (m *mockResourceExporter) GetResourceByID(
 }
 
 func (m *mockResourceExporter) ValidateResource(
-	resource interface{}, id string, logger *log.Logger,
+	_ context.Context, resource interface{}, id string, logger *log.Logger,
 ) (string, *ExportError) {
 	return m.validateName, m.validateExportErr
 }

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -60,7 +60,7 @@ const (
 
 // parameterizerInterface defines the interface for template parameterization.
 type parameterizerInterface interface {
-	ToParameterizedYAML(obj interface{},
+	ToParameterizedYAML(ctx context.Context, obj interface{},
 		resourceType string, resourceName string,
 		rules *declarativeresource.ResourceRules) (string, map[string]string, error)
 }
@@ -152,7 +152,7 @@ func (es *exportService) ExportResources(
 
 		exporter, exists := es.registry.Get(resourceType)
 		if !exists {
-			log.GetLogger().Warn("No exporter registered for resource type",
+			log.GetLogger().WarnWithContext(ctx, "No exporter registered for resource type",
 				log.String("resourceType", resourceType))
 			continue
 		}
@@ -290,7 +290,7 @@ func (es *exportService) exportResourcesWithExporter(
 		}
 
 		// Validate resource
-		validatedName, exportErr := exporter.ValidateResource(resource, resourceID, logger)
+		validatedName, exportErr := exporter.ValidateResource(ctx, resource, resourceID, logger)
 		if exportErr != nil {
 			exportErrors = append(exportErrors, *exportErr)
 			continue
@@ -306,7 +306,7 @@ func (es *exportService) exportResourcesWithExporter(
 			options.Format = formatYAML
 		}
 
-		templateContent, vars, err := es.generateTemplateFromStruct(
+		templateContent, vars, err := es.generateTemplateFromStruct(ctx,
 			resource, exporter.GetParameterizerType(), validatedName, exporter)
 		if err != nil {
 			logger.WarnWithContext(ctx, "Failed to generate template from struct",
@@ -344,7 +344,7 @@ func (es *exportService) exportResourcesWithExporter(
 	return exportFiles, variableValues, exportErrors
 }
 
-func (es *exportService) generateTemplateFromStruct(data interface{},
+func (es *exportService) generateTemplateFromStruct(ctx context.Context, data interface{},
 	paramResourceType string, resourceName string,
 	exporter declarativeresource.ResourceExporter) (string, map[string]string, error) {
 	var rules *declarativeresource.ResourceRules
@@ -353,7 +353,7 @@ func (es *exportService) generateTemplateFromStruct(data interface{},
 	} else {
 		rules = exporter.GetResourceRules()
 	}
-	template, vars, err := es.parameterizer.ToParameterizedYAML(
+	template, vars, err := es.parameterizer.ToParameterizedYAML(ctx,
 		data, paramResourceType, resourceName, rules)
 	if err != nil {
 		return "", nil, err

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -1152,7 +1152,7 @@ type MockParameterizer struct {
 	errorMsg   string
 }
 
-func (m *MockParameterizer) ToParameterizedYAML(obj interface{},
+func (m *MockParameterizer) ToParameterizedYAML(_ context.Context, obj interface{},
 	resourceType string, resourceName string,
 	rules *declarativeresource.ResourceRules) (string, map[string]string, error) {
 	if m.shouldFail {

--- a/backend/internal/system/healthcheck/handler/healthcheckhandler.go
+++ b/backend/internal/system/healthcheck/handler/healthcheckhandler.go
@@ -52,7 +52,7 @@ func (hch *HealthCheckHandler) HandleReadinessRequest(w http.ResponseWriter, r *
 	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckHandler"))
 
-	serverstatus := hch.Service.CheckReadiness()
+	serverstatus := hch.Service.CheckReadiness(ctx)
 
 	statusCode := http.StatusOK
 	if serverstatus.Status != model.StatusUp {
@@ -64,7 +64,7 @@ func (hch *HealthCheckHandler) HandleReadinessRequest(w http.ResponseWriter, r *
 			log.String("serverstatus", string(serverstatus.Status)))
 	}
 
-	sysutils.WriteSuccessResponse(w, statusCode, serverstatus)
+	sysutils.WriteSuccessResponse(ctx, w, statusCode, serverstatus)
 
 	logger.DebugWithContext(ctx, "Health Check Readiness response sent")
 }

--- a/backend/internal/system/healthcheck/handler/healthcheckhandler_test.go
+++ b/backend/internal/system/healthcheck/handler/healthcheckhandler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/thunder-id/thunderid/tests/mocks/healthcheck/servicemock"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -83,7 +84,7 @@ func (suite *HealthCheckHandlerTestSuite) TestHandleReadinessRequest_AllUp() {
 		Status:        model.StatusUp,
 		ServiceStatus: serviceStatus,
 	}
-	suite.mockService.On("CheckReadiness").Return(serverStatus)
+	suite.mockService.On("CheckReadiness", mock.Anything).Return(serverStatus)
 
 	// Call handler method
 	suite.handler.HandleReadinessRequest(rec, req)
@@ -125,7 +126,7 @@ func (suite *HealthCheckHandlerTestSuite) TestHandleReadinessRequest_Down() {
 		Status:        model.StatusDown,
 		ServiceStatus: serviceStatus,
 	}
-	suite.mockService.On("CheckReadiness").Return(serverStatus)
+	suite.mockService.On("CheckReadiness", mock.Anything).Return(serverStatus)
 
 	// Call handler method
 	suite.handler.HandleReadinessRequest(rec, req)

--- a/backend/internal/system/healthcheck/service/healthcheckservice.go
+++ b/backend/internal/system/healthcheck/service/healthcheckservice.go
@@ -31,7 +31,7 @@ import (
 
 // HealthCheckServiceInterface defines the interface for the health check service.
 type HealthCheckServiceInterface interface {
-	CheckReadiness() model.ServerStatus
+	CheckReadiness(ctx context.Context) model.ServerStatus
 }
 
 // HealthCheckService is the default implementation of the HealthCheckServiceInterface.
@@ -50,20 +50,20 @@ func Initialize(dbProvider provider.DBProviderInterface,
 }
 
 // CheckReadiness checks the readiness of the server and its dependencies.
-func (hcs *HealthCheckService) CheckReadiness() model.ServerStatus {
+func (hcs *HealthCheckService) CheckReadiness(ctx context.Context) model.ServerStatus {
 	configDBStatus := model.ServiceStatus{
 		ServiceName: "ConfigDB",
-		Status:      hcs.checkConfigDatabaseStatus(queryConfigDBTable),
+		Status:      hcs.checkConfigDatabaseStatus(ctx, queryConfigDBTable),
 	}
 
 	runtimeDBStatus := model.ServiceStatus{
 		ServiceName: "RuntimeDB",
-		Status:      hcs.checkRuntimeDatabaseStatus(queryRuntimeDBTable),
+		Status:      hcs.checkRuntimeDatabaseStatus(ctx, queryRuntimeDBTable),
 	}
 
 	userDBStatus := model.ServiceStatus{
 		ServiceName: "UserDB",
-		Status:      hcs.checkUserDatabaseStatus(queryUserDBTable),
+		Status:      hcs.checkUserDatabaseStatus(ctx, queryUserDBTable),
 	}
 
 	status := model.StatusUp
@@ -83,54 +83,54 @@ func (hcs *HealthCheckService) CheckReadiness() model.ServerStatus {
 }
 
 // checkConfigDatabaseStatus checks the status of the config database with the specified query.
-func (hcs *HealthCheckService) checkConfigDatabaseStatus(query dbmodel.DBQuery) model.Status {
+func (hcs *HealthCheckService) checkConfigDatabaseStatus(ctx context.Context, query dbmodel.DBQuery) model.Status {
 	dbClient, err := hcs.DBProvider.GetConfigDBClient()
-	return hcs.executeDatabaseHealthCheck("ConfigDB", dbClient, err, query)
+	return hcs.executeDatabaseHealthCheck(ctx, "ConfigDB", dbClient, err, query)
 }
 
 // checkRuntimeDatabaseStatus checks the status of the runtime database with the specified query.
-func (hcs *HealthCheckService) checkRuntimeDatabaseStatus(query dbmodel.DBQuery) model.Status {
+func (hcs *HealthCheckService) checkRuntimeDatabaseStatus(ctx context.Context, query dbmodel.DBQuery) model.Status {
 	if config.GetServerRuntime().Config.Database.Runtime.Type == provider.DataSourceTypeRedis {
-		return hcs.checkRedisRuntimeStatus()
+		return hcs.checkRedisRuntimeStatus(ctx)
 	}
 	dbClient, err := hcs.DBProvider.GetRuntimeDBClient()
-	return hcs.executeDatabaseHealthCheck("RuntimeDB", dbClient, err, query)
+	return hcs.executeDatabaseHealthCheck(ctx, "RuntimeDB", dbClient, err, query)
 }
 
 // checkRedisRuntimeStatus checks the health of the Redis runtime store via Ping.
-func (hcs *HealthCheckService) checkRedisRuntimeStatus() model.Status {
+func (hcs *HealthCheckService) checkRedisRuntimeStatus(ctx context.Context) model.Status {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckService"))
 	if hcs.RedisProvider == nil {
-		logger.Error("Redis runtime provider is not initialized")
+		logger.ErrorWithContext(ctx, "Redis runtime provider is not initialized")
 		return model.StatusDown
 	}
 	if err := hcs.RedisProvider.GetRedisClient().Ping(context.Background()).Err(); err != nil {
-		logger.Error("Failed to ping Redis runtime store", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to ping Redis runtime store", log.Error(err))
 		return model.StatusDown
 	}
 	return model.StatusUp
 }
 
 // checkUserDatabaseStatus checks the status of the runtime database with the specified query.
-func (hcs *HealthCheckService) checkUserDatabaseStatus(query dbmodel.DBQuery) model.Status {
+func (hcs *HealthCheckService) checkUserDatabaseStatus(ctx context.Context, query dbmodel.DBQuery) model.Status {
 	dbClient, err := hcs.DBProvider.GetUserDBClient()
-	return hcs.executeDatabaseHealthCheck("UserDB", dbClient, err, query)
+	return hcs.executeDatabaseHealthCheck(ctx, "UserDB", dbClient, err, query)
 }
 
 // executeDatabaseHealthCheck runs the provided query on the given database client and reports its status.
-func (hcs *HealthCheckService) executeDatabaseHealthCheck(
+func (hcs *HealthCheckService) executeDatabaseHealthCheck(ctx context.Context,
 	dbName string, dbClient provider.DBClientInterface, err error, query dbmodel.DBQuery,
 ) model.Status {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckService"))
 
 	if err != nil {
-		logger.Error("Failed to get database client", log.String("dbname", dbName), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to get database client", log.String("dbname", dbName), log.Error(err))
 		return model.StatusDown
 	}
 
 	_, err = dbClient.Query(query)
 	if err != nil {
-		logger.Error("Failed to execute query", log.String("dbname", dbName), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to execute query", log.String("dbname", dbName), log.Error(err))
 		return model.StatusDown
 	}
 	return model.StatusUp

--- a/backend/internal/system/healthcheck/service/healthcheckservice_test.go
+++ b/backend/internal/system/healthcheck/service/healthcheckservice_test.go
@@ -19,6 +19,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -199,7 +200,7 @@ func (suite *HealthCheckServiceTestSuite) TestCheckReadiness() {
 			}
 
 			// Execute the method being tested
-			serverStatus := suite.service.CheckReadiness()
+			serverStatus := suite.service.CheckReadiness(context.Background())
 
 			// Assertions
 			assert.Equal(t, tc.expectedStatus, serverStatus.Status, "Server status should match expected")
@@ -257,7 +258,7 @@ func (suite *HealthCheckServiceTestSuite) TestCheckReadiness_DBRetrievalError() 
 	suite.mockDBProvider.On("GetUserDBClient").Return(nil, errors.New("failed to get user DB client"))
 
 	// Execute the method being tested
-	serverStatus := suite.service.CheckReadiness()
+	serverStatus := suite.service.CheckReadiness(context.Background())
 
 	// Assertions
 	assert.Equal(suite.T(), model.StatusDown, serverStatus.Status, "Server status should be DOWN")

--- a/backend/internal/system/i18n/mgt/declarative_resource.go
+++ b/backend/internal/system/i18n/mgt/declarative_resource.go
@@ -120,7 +120,7 @@ func (e *translationExporter) GetResourceByID(ctx context.Context, id string) (
 }
 
 // ValidateResource validates a translation resource.
-func (e *translationExporter) ValidateResource(
+func (e *translationExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	trans, ok := resource.(*LanguageTranslations)

--- a/backend/internal/system/i18n/mgt/declarative_resource_test.go
+++ b/backend/internal/system/i18n/mgt/declarative_resource_test.go
@@ -116,7 +116,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateResource() {
 		},
 	}
 
-	name, err := s.exporter.ValidateResource(trans, "en-US", nil)
+	name, err := s.exporter.ValidateResource(context.Background(), trans, "en-US", nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "en-US", name)
 }
@@ -124,7 +124,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateResource() {
 func (s *DeclarativeResourceTestSuite) TestValidateResourceInvalidType() {
 	invalidResource := "not a translation"
 
-	name, err := s.exporter.ValidateResource(invalidResource, "en-US", nil)
+	name, err := s.exporter.ValidateResource(context.Background(), invalidResource, "en-US", nil)
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), name)
 	assert.Equal(s.T(), "INVALID_TYPE", err.Code)
@@ -137,7 +137,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateResourceMissingLanguage() {
 		},
 	}
 
-	name, err := s.exporter.ValidateResource(trans, "en-US", nil)
+	name, err := s.exporter.ValidateResource(context.Background(), trans, "en-US", nil)
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), name)
 	assert.Equal(s.T(), "INVALID_TRANSLATION", err.Code)
@@ -148,7 +148,7 @@ func (s *DeclarativeResourceTestSuite) TestValidateResourceMissingTranslations()
 		Language: "en-US",
 	}
 
-	name, err := s.exporter.ValidateResource(trans, "en-US", nil)
+	name, err := s.exporter.ValidateResource(context.Background(), trans, "en-US", nil)
 	assert.NotNil(s.T(), err)
 	assert.Empty(s.T(), name)
 	assert.Equal(s.T(), "INVALID_TRANSLATION", err.Code)

--- a/backend/internal/system/i18n/mgt/handler.go
+++ b/backend/internal/system/i18n/mgt/handler.go
@@ -19,6 +19,7 @@
 package mgt
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
@@ -48,7 +49,7 @@ func (h *i18nHandler) HandleListLanguages(w http.ResponseWriter, r *http.Request
 
 	localeCodes, svcErr := h.i18nService.ListLanguages(ctx)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -56,7 +57,7 @@ func (h *i18nHandler) HandleListLanguages(w http.ResponseWriter, r *http.Request
 		Languages: localeCodes,
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
 	logger.DebugWithContext(ctx, "Successfully retrieved languages", log.Int("count", len(localeCodes)))
 }
 
@@ -73,11 +74,11 @@ func (h *i18nHandler) HandleResolveTranslationsByLanguage(w http.ResponseWriter,
 
 	resp, svcErr := h.i18nService.ResolveTranslations(ctx, sanitizedLanguage, sanitizedNamespace)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
 	logger.DebugWithContext(ctx, "Successfully resolved translations",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
@@ -94,17 +95,17 @@ func (h *i18nHandler) HandleSetOverrideTranslationsByLanguage(w http.ResponseWri
 
 	req, err := sysutils.DecodeJSONBody[SetTranslationsRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
 	resp, svcErr := h.i18nService.SetTranslationOverrides(ctx, sanitizedLanguage, req.Translations)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
 	logger.DebugWithContext(ctx, "Successfully set override translations",
 		log.String("language", sanitizedLanguage),
 		log.Int("totalResults", resp.TotalResults))
@@ -120,7 +121,7 @@ func (h *i18nHandler) HandleClearOverrideTranslationsByLanguage(w http.ResponseW
 
 	svcErr := h.i18nService.ClearTranslationOverrides(ctx, sanitizedLanguage)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -144,11 +145,11 @@ func (h *i18nHandler) HandleResolveTranslation(w http.ResponseWriter, r *http.Re
 
 	resp, svcErr := h.i18nService.ResolveTranslationsForKey(ctx, sanitizedLanguage, sanitizedNamespace, sanitizedKey)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
 	logger.DebugWithContext(ctx, "Successfully resolved translation",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
@@ -170,7 +171,7 @@ func (h *i18nHandler) HandleSetOverrideTranslation(w http.ResponseWriter, r *htt
 
 	req, err := sysutils.DecodeJSONBody[SetTranslationRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
@@ -179,11 +180,11 @@ func (h *i18nHandler) HandleSetOverrideTranslation(w http.ResponseWriter, r *htt
 	resp, svcErr := h.i18nService.SetTranslationOverrideForKey(ctx,
 		sanitizedLanguage, sanitizedNamespace, sanitizedKey, sanitizedValue)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, resp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
 	logger.DebugWithContext(ctx, "Successfully set override translation",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
@@ -206,7 +207,7 @@ func (h *i18nHandler) HandleClearOverrideTranslation(w http.ResponseWriter, r *h
 
 	svcErr := h.i18nService.ClearTranslationOverrideForKey(ctx, sanitizedLanguage, sanitizedNamespace, sanitizedKey)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -218,7 +219,7 @@ func (h *i18nHandler) HandleClearOverrideTranslation(w http.ResponseWriter, r *h
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.
-func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
 		statusCode = http.StatusBadRequest
@@ -234,5 +235,5 @@ func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }

--- a/backend/internal/system/i18n/mgt/handler_test.go
+++ b/backend/internal/system/i18n/mgt/handler_test.go
@@ -20,6 +20,7 @@ package mgt
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -220,6 +221,102 @@ func (suite *I18nHandlerTestSuite) TestHandleClearOverrideTranslation_Success() 
 	suite.Equal(http.StatusNoContent, w.Code)
 }
 
+func (suite *I18nHandlerTestSuite) TestHandleSetOverrideTranslationsByLanguage_ServiceError() {
+	inputTranslations := map[string]map[string]string{
+		"common": {"key": "value"},
+	}
+	request := SetTranslationsRequest{
+		Translations: inputTranslations,
+	}
+
+	suite.mockService.On("SetTranslationOverrides", mock.Anything, "en-US", inputTranslations).
+		Return(nil, &serviceerror.InternalServerError)
+
+	body, _ := json.Marshal(request)
+	req := httptest.NewRequest(http.MethodPost, "/i18n/languages/en-US/translations", bytes.NewBuffer(body))
+	req.SetPathValue("language", "en-US")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleSetOverrideTranslationsByLanguage(w, req)
+
+	suite.Equal(http.StatusInternalServerError, w.Code)
+}
+
+func (suite *I18nHandlerTestSuite) TestHandleClearOverrideTranslationsByLanguage_ServiceError() {
+	suite.mockService.On("ClearTranslationOverrides", mock.Anything, "en-US").
+		Return(&ErrorInvalidLanguage)
+
+	req := httptest.NewRequest(http.MethodDelete, "/i18n/languages/en-US/translations", nil)
+	req.SetPathValue("language", "en-US")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleClearOverrideTranslationsByLanguage(w, req)
+
+	suite.Equal(http.StatusBadRequest, w.Code)
+}
+
+func (suite *I18nHandlerTestSuite) TestHandleResolveTranslation_ServiceError() {
+	suite.mockService.On("ResolveTranslationsForKey", mock.Anything, "en-US", "ns", "key").
+		Return(nil, &serviceerror.InternalServerError)
+
+	req := httptest.NewRequest(http.MethodGet, "/i18n/languages/en-US/translations/ns/ns/keys/key/resolve", nil)
+	req.SetPathValue("language", "en-US")
+	req.SetPathValue("namespace", "ns")
+	req.SetPathValue("key", "key")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleResolveTranslation(w, req)
+
+	suite.Equal(http.StatusInternalServerError, w.Code)
+}
+
+func (suite *I18nHandlerTestSuite) TestHandleSetOverrideTranslation_InvalidJSON() {
+	req := httptest.NewRequest(http.MethodPost, "/i18n/languages/en-US/translations/ns/ns/keys/key",
+		bytes.NewBufferString("invalid"))
+	req.SetPathValue("language", "en-US")
+	req.SetPathValue("namespace", "ns")
+	req.SetPathValue("key", "key")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleSetOverrideTranslation(w, req)
+
+	suite.Equal(http.StatusBadRequest, w.Code)
+}
+
+func (suite *I18nHandlerTestSuite) TestHandleSetOverrideTranslation_ServiceError() {
+	request := SetTranslationRequest{Value: "new val"}
+
+	suite.mockService.On("SetTranslationOverrideForKey", mock.Anything, "en-US", "ns", "key", "new val").
+		Return(nil, &serviceerror.InternalServerError)
+
+	body, _ := json.Marshal(request)
+	req := httptest.NewRequest(http.MethodPost, "/i18n/languages/en-US/translations/ns/ns/keys/key",
+		bytes.NewBuffer(body))
+	req.SetPathValue("language", "en-US")
+	req.SetPathValue("namespace", "ns")
+	req.SetPathValue("key", "key")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleSetOverrideTranslation(w, req)
+
+	suite.Equal(http.StatusInternalServerError, w.Code)
+}
+
+func (suite *I18nHandlerTestSuite) TestHandleClearOverrideTranslation_ServiceError() {
+	suite.mockService.On("ClearTranslationOverrideForKey", mock.Anything, "en-US", "ns", "key").
+		Return(&ErrorInvalidLanguage)
+
+	req := httptest.NewRequest(http.MethodDelete, "/i18n/languages/en-US/translations/ns/ns/keys/key", nil)
+	req.SetPathValue("language", "en-US")
+	req.SetPathValue("namespace", "ns")
+	req.SetPathValue("key", "key")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleClearOverrideTranslation(w, req)
+
+	suite.Equal(http.StatusBadRequest, w.Code)
+}
+
 func (suite *I18nHandlerTestSuite) TestHandleError_NotFound() {
 	// Testing manual error construction/mapping in handleError
 	svcErr := &serviceerror.ServiceError{
@@ -228,7 +325,7 @@ func (suite *I18nHandlerTestSuite) TestHandleError_NotFound() {
 	}
 
 	w := httptest.NewRecorder()
-	handleError(w, svcErr)
+	handleError(context.Background(), w, svcErr)
 
 	suite.Equal(http.StatusNotFound, w.Code)
 }

--- a/backend/internal/system/importer/handler.go
+++ b/backend/internal/system/importer/handler.go
@@ -19,6 +19,7 @@
 package importer
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
@@ -47,17 +48,17 @@ func (ih *importHandler) HandleImportRequest(w http.ResponseWriter, r *http.Requ
 			Message:     ErrorInvalidImportRequest.Error,
 			Description: ErrorInvalidImportRequest.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	importResponse, svcErr := ih.service.ImportResources(r.Context(), importRequest)
 	if svcErr != nil {
-		ih.handleError(w, svcErr)
+		ih.handleError(r.Context(), w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, importResponse)
+	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, importResponse)
 }
 
 func (ih *importHandler) HandleDeleteImportRequest(w http.ResponseWriter, r *http.Request) {
@@ -68,27 +69,27 @@ func (ih *importHandler) HandleDeleteImportRequest(w http.ResponseWriter, r *htt
 			Message:     ErrorInvalidImportRequest.Error,
 			Description: ErrorInvalidImportRequest.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	deleteResponse, svcErr := ih.service.DeleteResource(r.Context(), deleteRequest)
 	if svcErr != nil {
-		ih.handleError(w, svcErr)
+		ih.handleError(r.Context(), w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, deleteResponse)
+	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, deleteResponse)
 }
 
-func (ih *importHandler) handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func (ih *importHandler) handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	statusCode := http.StatusInternalServerError
 	if svcErr.Type == serviceerror.ClientErrorType {
 		statusCode = http.StatusBadRequest
 	}
 
 	if statusCode == http.StatusInternalServerError {
-		ih.logger.Error(
+		ih.logger.ErrorWithContext(ctx,
 			"Import request failed with server error",
 			log.String("code", svcErr.Code),
 			log.String("error", svcErr.Error.DefaultValue),
@@ -102,5 +103,5 @@ func (ih *importHandler) handleError(w http.ResponseWriter, svcErr *serviceerror
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }

--- a/backend/internal/system/importer/handler_test.go
+++ b/backend/internal/system/importer/handler_test.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package importer
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/cors"
+	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+)
+
+type fakeImportService struct {
+	importFn func(context.Context, *ImportRequest) (*ImportResponse, *serviceerror.ServiceError)
+	deleteFn func(context.Context, *DeleteResourceRequest) (*DeleteResourceResponse, *serviceerror.ServiceError)
+}
+
+func (f *fakeImportService) ImportResources(
+	ctx context.Context, r *ImportRequest,
+) (*ImportResponse, *serviceerror.ServiceError) {
+	return f.importFn(ctx, r)
+}
+
+func (f *fakeImportService) DeleteResource(
+	ctx context.Context, r *DeleteResourceRequest,
+) (*DeleteResourceResponse, *serviceerror.ServiceError) {
+	return f.deleteFn(ctx, r)
+}
+
+type ImportHandlerTestSuite struct {
+	suite.Suite
+	service *fakeImportService
+	handler *importHandler
+}
+
+func (suite *ImportHandlerTestSuite) SetupTest() {
+	config.ResetServerRuntime()
+	var allowedOrigins cors.OriginEntries
+	suite.Require().NoError(yaml.Unmarshal([]byte(`
+- https://localhost:3000
+`), &allowedOrigins))
+	testConfig := &config.Config{
+		CORS: config.CORSConfig{AllowedOrigins: allowedOrigins},
+	}
+	suite.Require().NoError(cors.InitializeMatcher(testConfig.CORS.AllowedOrigins))
+	require.NoError(suite.T(), config.InitializeServerRuntime("/tmp/test", testConfig))
+
+	suite.service = &fakeImportService{}
+	suite.handler = newImportHandler(suite.service)
+}
+
+func (suite *ImportHandlerTestSuite) TearDownTest() {
+	config.ResetServerRuntime()
+}
+
+func TestImportHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(ImportHandlerTestSuite))
+}
+
+func (suite *ImportHandlerTestSuite) TestHandleImportRequest_InvalidJSON() {
+	req := httptest.NewRequest("POST", "/import", strings.NewReader("{"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleImportRequest(w, req)
+
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+}
+
+func (suite *ImportHandlerTestSuite) TestHandleImportRequest_ServerError() {
+	suite.service.importFn = func(
+		_ context.Context, _ *ImportRequest,
+	) (*ImportResponse, *serviceerror.ServiceError) {
+		return nil, &serviceerror.InternalServerError
+	}
+
+	req := httptest.NewRequest("POST", "/import", strings.NewReader(`{"content":"foo"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleImportRequest(w, req)
+
+	assert.Equal(suite.T(), http.StatusInternalServerError, w.Code)
+}
+
+func (suite *ImportHandlerTestSuite) TestHandleImportRequest_Success() {
+	suite.service.importFn = func(
+		_ context.Context, _ *ImportRequest,
+	) (*ImportResponse, *serviceerror.ServiceError) {
+		return &ImportResponse{Summary: &ImportSummary{}, Results: []ImportItemOutcome{}}, nil
+	}
+
+	req := httptest.NewRequest("POST", "/import", strings.NewReader(`{"content":"foo"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleImportRequest(w, req)
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+}
+
+func (suite *ImportHandlerTestSuite) TestHandleDeleteImportRequest_InvalidJSON() {
+	req := httptest.NewRequest("DELETE", "/import", strings.NewReader("{"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleDeleteImportRequest(w, req)
+
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+}
+
+func (suite *ImportHandlerTestSuite) TestHandleDeleteImportRequest_ClientError() {
+	suite.service.deleteFn = func(
+		_ context.Context, _ *DeleteResourceRequest,
+	) (*DeleteResourceResponse, *serviceerror.ServiceError) {
+		return nil, &ErrorInvalidImportRequest
+	}
+
+	req := httptest.NewRequest("DELETE", "/import", strings.NewReader(`{"resourceType":"application"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleDeleteImportRequest(w, req)
+
+	assert.Equal(suite.T(), http.StatusBadRequest, w.Code)
+}
+
+func (suite *ImportHandlerTestSuite) TestHandleDeleteImportRequest_Success() {
+	suite.service.deleteFn = func(
+		_ context.Context, _ *DeleteResourceRequest,
+	) (*DeleteResourceResponse, *serviceerror.ServiceError) {
+		return &DeleteResourceResponse{
+			ResourceType: "application",
+			ResourceKey:  "app1",
+			DeletedFile:  "app1.yaml",
+		}, nil
+	}
+
+	body := `{"resourceType":"application","resourceKey":"app1"}`
+	req := httptest.NewRequest("DELETE", "/import", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleDeleteImportRequest(w, req)
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+}

--- a/backend/internal/system/importer/service.go
+++ b/backend/internal/system/importer/service.go
@@ -284,14 +284,14 @@ func (s *importService) ImportResources(
 
 	resolvedContent, err := resolveTemplate(request.Content, request.Variables)
 	if err != nil {
-		log.GetLogger().Warn("Import template resolution failed", log.String("error", err.Error()))
+		log.GetLogger().WarnWithContext(ctx, "Import template resolution failed", log.String("error", err.Error()))
 		return nil, serviceerror.CustomServiceError(ErrorTemplateResolutionFailed,
 			core.I18nMessage{Key: "error.import.dynamic", DefaultValue: err.Error()})
 	}
 
 	docs, err := parseDocuments(resolvedContent)
 	if err != nil {
-		log.GetLogger().Warn("Import YAML parsing failed", log.String("error", err.Error()))
+		log.GetLogger().WarnWithContext(ctx, "Import YAML parsing failed", log.String("error", err.Error()))
 		return nil, serviceerror.CustomServiceError(ErrorInvalidYAMLContent,
 			core.I18nMessage{Key: "error.import.dynamic", DefaultValue: err.Error()})
 	}
@@ -711,7 +711,7 @@ func (s *importService) importApplication(
 	}
 
 	appDTO := applicationRequestToDTO(&req)
-	normalizeOAuthConfigForImport(appDTO)
+	normalizeOAuthConfigForImport(ctx, appDTO)
 	if dryRun {
 		if options.IsUpsertEnabled() && req.ID != "" {
 			_, svcErr := s.applicationService.GetApplication(ctx, req.ID)
@@ -780,10 +780,11 @@ func (s *importService) importApplication(
 			)
 		}
 
-		log.GetLogger().Warn("Application import create failed", failureLogFields...)
+		log.GetLogger().WarnWithContext(ctx, "Application import create failed", failureLogFields...)
 
 		if svcErr.Code == invalidOAuthConfigurationCode {
-			log.GetLogger().Debug("Application import failed due to invalid OAuth configuration", failureLogFields...)
+			log.GetLogger().DebugWithContext(ctx,
+				"Application import failed due to invalid OAuth configuration", failureLogFields...)
 		}
 
 		return ImportItemOutcome{
@@ -886,7 +887,7 @@ func getOAuthConfigForImportLog(appDTO *appmodel.ApplicationDTO) *inboundmodel.O
 	return nil
 }
 
-func normalizeOAuthConfigForImport(appDTO *appmodel.ApplicationDTO) {
+func normalizeOAuthConfigForImport(ctx context.Context, appDTO *appmodel.ApplicationDTO) {
 	oauthConfig := getOAuthConfigForImportLog(appDTO)
 	if oauthConfig == nil {
 		return
@@ -895,7 +896,8 @@ func normalizeOAuthConfigForImport(appDTO *appmodel.ApplicationDTO) {
 	if oauthConfig.PublicClient &&
 		oauthConfig.TokenEndpointAuthMethod == oauth2const.TokenEndpointAuthMethodNone &&
 		oauthConfig.ClientSecret != "" {
-		log.GetLogger().Debug("Dropping client_secret for public client import with token endpoint auth method 'none'",
+		log.GetLogger().DebugWithContext(ctx,
+			"Dropping client_secret for public client import with token endpoint auth method 'none'",
 			log.String("appID", appDTO.ID),
 			log.String("name", appDTO.Name),
 			log.String("clientID", oauthConfig.ClientID))

--- a/backend/internal/system/importer/service_adapters.go
+++ b/backend/internal/system/importer/service_adapters.go
@@ -914,7 +914,7 @@ func (s *importService) importAgent(
 		attributesJSON = raw
 	}
 
-	normalizeAgentOAuthConfigForImport(&req)
+	normalizeAgentOAuthConfigForImport(ctx, &req)
 
 	createReq := &agentmodel.Agent{
 		ID:                 req.ID,
@@ -991,7 +991,7 @@ func getAgentOAuthConfigForImport(req *agentmodel.AgentRequestWithID) *inboundmo
 	return nil
 }
 
-func normalizeAgentOAuthConfigForImport(req *agentmodel.AgentRequestWithID) {
+func normalizeAgentOAuthConfigForImport(ctx context.Context, req *agentmodel.AgentRequestWithID) {
 	oauthConfig := getAgentOAuthConfigForImport(req)
 	if oauthConfig == nil {
 		return
@@ -1000,7 +1000,8 @@ func normalizeAgentOAuthConfigForImport(req *agentmodel.AgentRequestWithID) {
 	if oauthConfig.PublicClient &&
 		oauthConfig.TokenEndpointAuthMethod == oauth2const.TokenEndpointAuthMethodNone &&
 		oauthConfig.ClientSecret != "" {
-		log.GetLogger().Debug("Dropping client_secret for public agent import with token endpoint auth method 'none'",
+		log.GetLogger().DebugWithContext(ctx,
+			"Dropping client_secret for public agent import with token endpoint auth method 'none'",
 			log.String("agentID", req.ID),
 			log.String("name", req.Name),
 			log.String("clientID", oauthConfig.ClientID))

--- a/backend/internal/system/log/accesslog.go
+++ b/backend/internal/system/log/accesslog.go
@@ -50,7 +50,7 @@ func AccessLogHandler(logger *Logger, next http.Handler) http.Handler {
 
 		// Apache CLF-style format with correlation ID and response time
 		// Format: host - - [timestamp] method uri protocol status size elapsed_ms correlation_id
-		logger.Info(fmt.Sprintf(
+		logger.InfoWithContext(r.Context(), fmt.Sprintf(
 			"%s - - [%s] %s %s %s %d %d %d %s",
 			host,
 			start.Format("02/Jan/2006:15:04:05 -0700"),

--- a/backend/internal/system/log/log.go
+++ b/backend/internal/system/log/log.go
@@ -196,8 +196,18 @@ func (l *Logger) ErrorWithContext(ctx context.Context, msg string, fields ...Fie
 }
 
 // Fatal logs a fatal message with custom fields and exits the application.
+//
+// Deprecated: Fatal does not propagate the request context, so log entries
+// miss the trace ID (correlation ID). Use FatalWithContext instead. Refs #2038.
 func (l *Logger) Fatal(msg string, fields ...Field) {
 	l.internal.Error(msg, convertFields(fields)...)
+	os.Exit(1)
+}
+
+// FatalWithContext logs a fatal message with custom fields and exits the application,
+// automatically including the trace ID (correlation ID) from the context if present.
+func (l *Logger) FatalWithContext(ctx context.Context, msg string, fields ...Field) {
+	l.internal.ErrorContext(ctx, msg, convertFields(fields)...)
 	os.Exit(1)
 }
 

--- a/backend/internal/system/log/log_test.go
+++ b/backend/internal/system/log/log_test.go
@@ -164,10 +164,11 @@ func (suite *LogTestSuite) TestLogMethods() {
 	}
 	log := logger
 
-	log.Debug("Debug message", Field{Key: "test", Value: "debug"})
-	log.Info("Info message", Field{Key: "test", Value: "info"})
-	log.Warn("Warning message", Field{Key: "test", Value: "warn"})
-	log.Error("Error message", Field{Key: "test", Value: "error"})
+	ctx := context.Background()
+	log.DebugWithContext(ctx, "Debug message", Field{Key: "test", Value: "debug"})
+	log.InfoWithContext(ctx, "Info message", Field{Key: "test", Value: "info"})
+	log.WarnWithContext(ctx, "Warning message", Field{Key: "test", Value: "warn"})
+	log.ErrorWithContext(ctx, "Error message", Field{Key: "test", Value: "error"})
 
 	output := buf.String()
 	assert.Contains(suite.T(), output, "Debug message")
@@ -199,7 +200,7 @@ func (suite *LogTestSuite) TestLoggerWith() {
 	contextLogger := log.With(Field{Key: "context", Value: "test"})
 	assert.NotNil(suite.T(), contextLogger)
 
-	contextLogger.Info("Context log message")
+	contextLogger.InfoWithContext(context.Background(), "Context log message")
 
 	output := buf.String()
 	assert.Contains(suite.T(), output, "context=test")

--- a/backend/internal/system/mcp/auth/token_verifier.go
+++ b/backend/internal/system/mcp/auth/token_verifier.go
@@ -44,14 +44,14 @@ func NewTokenVerifier(
 	return func(ctx context.Context, token string, req *http.Request) (*auth.TokenInfo, error) {
 		// Verify JWT signature and claims (iss, aud, exp, nbf)
 		if err := jwtService.VerifyJWT(ctx, token, mcpURL, issuer); err != nil {
-			logger.Error("JWT verification failed", log.String("error", err.Error.DefaultValue))
+			logger.ErrorWithContext(ctx, "JWT verification failed", log.String("error", err.Error.DefaultValue))
 			return nil, auth.ErrInvalidToken
 		}
 
 		// Decode payload to extract claims for TokenInfo
 		payload, err := jwt.DecodeJWTPayload(token)
 		if err != nil {
-			logger.Error("Failed to decode JWT payload", log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to decode JWT payload", log.Error(err))
 			return nil, auth.ErrInvalidToken
 		}
 
@@ -65,11 +65,11 @@ func NewTokenVerifier(
 		var scopes []string
 		if scopeStr, ok := payload["scope"].(string); ok && scopeStr != "" {
 			scopes = strings.Fields(scopeStr)
-			logger.Debug("Token scopes extracted",
+			logger.DebugWithContext(ctx, "Token scopes extracted",
 				log.String("scopes", strings.Join(scopes, ",")),
 				log.String("path", req.URL.Path))
 		} else {
-			logger.Warn("Token missing 'scope' claim", log.String("path", req.URL.Path))
+			logger.WarnWithContext(ctx, "Token missing 'scope' claim", log.String("path", req.URL.Path))
 		}
 
 		// Extract user ID from 'sub' claim

--- a/backend/internal/system/mcp/tool/utils.go
+++ b/backend/internal/system/mcp/tool/utils.go
@@ -20,6 +20,7 @@
 package tool
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -34,7 +35,8 @@ import (
 func GenerateSchema[T any](modifiers ...func(*jsonschema.Schema)) *jsonschema.Schema {
 	schema, err := jsonschema.For[T](&jsonschema.ForOptions{})
 	if err != nil {
-		log.GetLogger().Error("Failed to generate schema",
+		// Schema generation runs during MCP tool registration at startup, outside any request.
+		log.GetLogger().ErrorWithContext(context.Background(), "Failed to generate schema",
 			log.String("type", fmt.Sprintf("%T", *new(T))),
 			log.Error(err))
 		return nil

--- a/backend/internal/system/middleware/cors.go
+++ b/backend/internal/system/middleware/cors.go
@@ -83,7 +83,7 @@ func applyCORSHeaders(w http.ResponseWriter, r *http.Request, opts CORSOptions) 
 		return
 	}
 	if len(origins) > 1 {
-		logger().Debug("CORS: multiple Origin headers; refusing to evaluate")
+		logger().DebugWithContext(r.Context(), "CORS: multiple Origin headers; refusing to evaluate")
 		w.Header().Add("Vary", "Origin")
 		return
 	}
@@ -103,14 +103,14 @@ func applyCORSHeaders(w http.ResponseWriter, r *http.Request, opts CORSOptions) 
 
 	parsed, err := cors.ParseOrigin(requestOrigin)
 	if err != nil {
-		logger().Debug("CORS origin rejected by parser",
+		logger().DebugWithContext(r.Context(), "CORS origin rejected by parser",
 			log.String("origin", requestOrigin), log.Error(err))
 		return
 	}
 
 	allow, echo := matcher.Match(parsed)
 	if !allow {
-		logger().Debug("CORS origin rejected by matcher",
+		logger().DebugWithContext(r.Context(), "CORS origin rejected by matcher",
 			log.String("origin", requestOrigin))
 		return
 	}

--- a/backend/internal/system/observability/adapter/file_adapter.go
+++ b/backend/internal/system/observability/adapter/file_adapter.go
@@ -22,6 +22,7 @@ package adapter
 import (
 	"bufio"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -143,15 +144,17 @@ func NewFileAdapterWithConfig(config *Config) (*FileAdapter, error) {
 	go fa.periodicFlush()
 
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+	// Adapter construction runs during subscriber initialization, outside any request.
+	ctx := context.Background()
 	if fa.isRotationEnabled() {
-		logger.Info("File adapter initialized with rotation",
+		logger.InfoWithContext(ctx, "File adapter initialized with rotation",
 			log.String("filePath", config.Path),
 			log.Int("maxFileSizeMB", config.MaxFileSizeMB),
 			log.Int("maxBackups", config.MaxBackups),
 			log.Int("maxAgeDays", config.MaxAgeDays),
 			log.Bool("compress", config.Compress))
 	} else {
-		logger.Info("File adapter initialized",
+		logger.InfoWithContext(ctx, "File adapter initialized",
 			log.String("filePath", config.Path))
 	}
 
@@ -179,7 +182,9 @@ func (fa *FileAdapter) Write(data []byte) error {
 		if fa.currentSize+dataSize > maxSize {
 			if err := fa.rotate(); err != nil {
 				logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-				logger.Error("Failed to rotate file", log.Error(err))
+				// The file adapter is infrastructure with no request-scoped context.
+				ctx := context.Background()
+				logger.ErrorWithContext(ctx, "Failed to rotate file", log.Error(err))
 				// Continue writing to current file even if rotation fails
 			}
 		}
@@ -205,13 +210,15 @@ func (fa *FileAdapter) Write(data []byte) error {
 // rotate rotates the log file (must be called with lock held).
 func (fa *FileAdapter) rotate() error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+	// File rotation is internal infrastructure work, outside any request.
+	ctx := context.Background()
 
 	// Flush and close current writer and file
 	if err := fa.writer.Flush(); err != nil {
-		logger.Error("Failed to flush before rotation", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to flush before rotation", log.Error(err))
 	}
 	if err := fa.file.Close(); err != nil {
-		logger.Error("Failed to close file during rotation", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to close file during rotation", log.Error(err))
 	}
 
 	// Generate rotated filename with timestamp
@@ -220,7 +227,7 @@ func (fa *FileAdapter) rotate() error {
 
 	// Rename current file
 	if err := os.Rename(fa.config.Path, rotatedPath); err != nil {
-		logger.Error("Failed to rename file during rotation", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to rename file during rotation", log.Error(err))
 		// Try to reopen original file
 		file, err := os.OpenFile(fa.config.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, filePermissions)
 		if err != nil {
@@ -247,7 +254,7 @@ func (fa *FileAdapter) rotate() error {
 	fa.writer = bufio.NewWriterSize(file, defaultBufferSize)
 	fa.currentSize = 0
 
-	logger.Info("File rotated successfully", log.String("rotatedFile", rotatedPath))
+	logger.InfoWithContext(ctx, "File rotated successfully", log.String("rotatedFile", rotatedPath))
 
 	// Clean up old files
 	go fa.cleanup()
@@ -258,16 +265,19 @@ func (fa *FileAdapter) rotate() error {
 // compressFile compresses a log file using gzip.
 func (fa *FileAdapter) compressFile(filePath string) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+	// Compression runs in a detached goroutine with no request-scoped context.
+	ctx := context.Background()
 
 	// Open source file
 	src, err := os.Open(filePath) // #nosec G304 -- File path is controlled internally by rotation logic
 	if err != nil {
-		logger.Error("Failed to open file for compression", log.String("filePath", filePath), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to open file for compression",
+			log.String("filePath", filePath), log.Error(err))
 		return
 	}
 	defer func() {
 		if closeErr := src.Close(); closeErr != nil {
-			logger.Error("Failed to close source file", log.Error(closeErr))
+			logger.ErrorWithContext(ctx, "Failed to close source file", log.Error(closeErr))
 		}
 	}()
 
@@ -275,12 +285,13 @@ func (fa *FileAdapter) compressFile(filePath string) {
 	compressedPath := filePath + ".gz"
 	dst, err := os.Create(compressedPath) // #nosec G304 -- File path is derived from controlled internal path
 	if err != nil {
-		logger.Error("Failed to create compressed file", log.String("compressedPath", compressedPath), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to create compressed file",
+			log.String("compressedPath", compressedPath), log.Error(err))
 		return
 	}
 	defer func() {
 		if closeErr := dst.Close(); closeErr != nil {
-			logger.Error("Failed to close destination file", log.Error(closeErr))
+			logger.ErrorWithContext(ctx, "Failed to close destination file", log.Error(closeErr))
 		}
 	}()
 
@@ -288,35 +299,37 @@ func (fa *FileAdapter) compressFile(filePath string) {
 	gzWriter := gzip.NewWriter(dst)
 	defer func() {
 		if closeErr := gzWriter.Close(); closeErr != nil {
-			logger.Error("Failed to close gzip writer", log.Error(closeErr))
+			logger.ErrorWithContext(ctx, "Failed to close gzip writer", log.Error(closeErr))
 		}
 	}()
 
 	// Copy and compress
 	if _, err := io.Copy(gzWriter, src); err != nil {
-		logger.Error("Failed to compress file", log.String("filePath", filePath), log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to compress file", log.String("filePath", filePath), log.Error(err))
 		return
 	}
 
 	// Close gzip writer to flush
 	if err := gzWriter.Close(); err != nil {
-		logger.Error("Failed to close gzip writer", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to close gzip writer", log.Error(err))
 		return
 	}
 
 	// Remove original file
 	if err := os.Remove(filePath); err != nil {
-		logger.Error("Failed to remove original file after compression",
+		logger.ErrorWithContext(ctx, "Failed to remove original file after compression",
 			log.String("filePath", filePath), log.Error(err))
 		return
 	}
 
-	logger.Info("File compressed successfully", log.String("compressedPath", compressedPath))
+	logger.InfoWithContext(ctx, "File compressed successfully", log.String("compressedPath", compressedPath))
 }
 
 // cleanup removes old log files based on maxBackups and maxAge.
 func (fa *FileAdapter) cleanup() {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+	// Cleanup runs in a detached goroutine with no request-scoped context.
+	ctx := context.Background()
 
 	dir := filepath.Dir(fa.config.Path)
 	baseName := filepath.Base(fa.config.Path)
@@ -324,7 +337,7 @@ func (fa *FileAdapter) cleanup() {
 	// Find all rotated log files
 	files, err := filepath.Glob(filepath.Join(dir, baseName+".*"))
 	if err != nil {
-		logger.Error("Failed to list rotated files", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to list rotated files", log.Error(err))
 		return
 	}
 
@@ -367,7 +380,8 @@ func (fa *FileAdapter) cleanup() {
 
 		if shouldRemove {
 			if err := os.Remove(file); err != nil {
-				logger.Error("Failed to remove old log file", log.String("filePath", file), log.Error(err))
+				logger.ErrorWithContext(ctx, "Failed to remove old log file",
+					log.String("filePath", file), log.Error(err))
 			} else {
 				removed++
 			}
@@ -375,7 +389,7 @@ func (fa *FileAdapter) cleanup() {
 	}
 
 	if removed > 0 {
-		logger.Info("Cleaned up old log files", log.Int("removedCount", removed))
+		logger.InfoWithContext(ctx, "Cleaned up old log files", log.Int("removedCount", removed))
 	}
 }
 
@@ -404,12 +418,14 @@ func (fa *FileAdapter) periodicFlush() {
 	defer fa.wg.Done()
 
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+	// Periodic flushing runs in a background goroutine with no request-scoped context.
+	ctx := context.Background()
 
 	for {
 		select {
 		case <-fa.flushTicker.C:
 			if err := fa.Flush(); err != nil {
-				logger.Error("Failed to flush file", log.Error(err))
+				logger.ErrorWithContext(ctx, "Failed to flush file", log.Error(err))
 			}
 		case <-fa.stopFlush:
 			return
@@ -428,7 +444,9 @@ func (fa *FileAdapter) Close() error {
 	fa.mu.Unlock()
 
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.Info("Closing file adapter", log.String("filePath", fa.config.Path))
+	// Adapter shutdown runs during application teardown, outside any request.
+	ctx := context.Background()
+	logger.InfoWithContext(ctx, "Closing file adapter", log.String("filePath", fa.config.Path))
 
 	// Stop periodic flushing
 	fa.flushTicker.Stop()
@@ -437,7 +455,7 @@ func (fa *FileAdapter) Close() error {
 
 	// Final flush
 	if err := fa.Flush(); err != nil {
-		logger.Error("Failed to perform final flush", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to perform final flush", log.Error(err))
 	}
 
 	// Close file
@@ -445,7 +463,7 @@ func (fa *FileAdapter) Close() error {
 		return fmt.Errorf("failed to close file: %w", err)
 	}
 
-	logger.Info("File adapter closed")
+	logger.InfoWithContext(ctx, "File adapter closed")
 	return nil
 }
 

--- a/backend/internal/system/observability/init.go
+++ b/backend/internal/system/observability/init.go
@@ -19,6 +19,8 @@
 package observability
 
 import (
+	"context"
+
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
@@ -41,13 +43,16 @@ import (
 func Initialize() ObservabilityServiceInterface {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
-	logger.Debug("Initializing observability service")
+	// Service construction runs during application startup, outside any request.
+	ctx := context.Background()
+
+	logger.DebugWithContext(ctx, "Initializing observability service")
 
 	// Get configuration
 	cfg := config.GetServerRuntime().Config.Observability
 
 	if !cfg.Enabled {
-		logger.Debug("Observability is disabled in configuration")
+		logger.DebugWithContext(ctx, "Observability is disabled in configuration")
 		// Return a disabled service (handles all operations as no-ops)
 		return &Service{
 			logger: logger,
@@ -60,7 +65,7 @@ func Initialize() ObservabilityServiceInterface {
 
 	// Log initialization status
 	activeSubscribers := svc.GetActiveSubscribers()
-	logger.Debug("Observability service initialized successfully",
+	logger.DebugWithContext(ctx, "Observability service initialized successfully",
 		log.Int("activeSubscribers", len(activeSubscribers)))
 
 	return svc

--- a/backend/internal/system/observability/interface.go
+++ b/backend/internal/system/observability/interface.go
@@ -19,6 +19,8 @@
 package observability
 
 import (
+	"context"
+
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/observability/event"
 	"github.com/thunder-id/thunderid/internal/system/observability/publisher"
@@ -31,7 +33,8 @@ import (
 type ObservabilityServiceInterface interface {
 	// PublishEvent publishes an event to the observability system.
 	// This is a no-op if observability is disabled.
-	PublishEvent(evt *event.Event)
+	// The context carries the request trace ID used for correlated logging.
+	PublishEvent(ctx context.Context, evt *event.Event)
 
 	// IsEnabled returns true if observability is enabled and operational.
 	IsEnabled() bool

--- a/backend/internal/system/observability/publisher/category_publisher_test.go
+++ b/backend/internal/system/observability/publisher/category_publisher_test.go
@@ -1,6 +1,7 @@
 package publisher
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -70,7 +71,7 @@ func TestCategoryPublisher_SmartPublishing(t *testing.T) {
 	}
 
 	// Publish event with NO subscribers - should be skipped
-	pub.Publish(evt)
+	pub.Publish(context.Background(), evt)
 
 	// Give it time to process
 	time.Sleep(50 * time.Millisecond)
@@ -93,7 +94,7 @@ func TestCategoryPublisher_SmartPublishing(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 
-	pub.Publish(evt2)
+	pub.Publish(context.Background(), evt2)
 
 	// Give it time to process
 	time.Sleep(100 * time.Millisecond)
@@ -142,7 +143,7 @@ func TestCategoryPublisher_CategoryRouting(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 
-	pub.Publish(authEvent)
+	pub.Publish(context.Background(), authEvent)
 
 	// Publish token event
 	tokenEvent := &event.Event{
@@ -153,7 +154,7 @@ func TestCategoryPublisher_CategoryRouting(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 
-	pub.Publish(tokenEvent)
+	pub.Publish(context.Background(), tokenEvent)
 
 	// Give it time to process
 	time.Sleep(100 * time.Millisecond)
@@ -288,7 +289,7 @@ func TestCategoryPublisher_MultipleSubscribersPerCategory(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 
-	pub.Publish(evt)
+	pub.Publish(context.Background(), evt)
 
 	// Give it time to process
 	time.Sleep(100 * time.Millisecond)
@@ -310,7 +311,7 @@ func TestCategoryPublisher_PublishNilEvent(t *testing.T) {
 	defer pub.Shutdown()
 
 	// Should not panic
-	pub.Publish(nil)
+	pub.Publish(context.Background(), nil)
 }
 
 func TestCategoryPublisher_PublishInvalidEvent(t *testing.T) {
@@ -324,7 +325,7 @@ func TestCategoryPublisher_PublishInvalidEvent(t *testing.T) {
 	}
 
 	// Should not panic, should be rejected
-	pub.Publish(invalidEvt)
+	pub.Publish(context.Background(), invalidEvt)
 }
 
 func TestCategoryPublisher_PublishAfterShutdown(t *testing.T) {
@@ -349,7 +350,7 @@ func TestCategoryPublisher_PublishAfterShutdown(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 
-	pub.Publish(evt)
+	pub.Publish(context.Background(), evt)
 
 	// Give it time (should not process)
 	time.Sleep(50 * time.Millisecond)
@@ -397,7 +398,7 @@ func TestCategoryPublisher_SubscriberPanic(t *testing.T) {
 	}
 
 	// Should not crash the publisher
-	pub.Publish(evt)
+	pub.Publish(context.Background(), evt)
 
 	// Give it time to process
 	time.Sleep(100 * time.Millisecond)
@@ -426,7 +427,7 @@ func TestCategoryPublisher_SubscriberError(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 
-	pub.Publish(evt)
+	pub.Publish(context.Background(), evt)
 
 	// Give it time to process
 	time.Sleep(100 * time.Millisecond)
@@ -609,7 +610,7 @@ func TestCategoryPublisher_AsyncNonBlocking(t *testing.T) {
 
 	// Measure time taken for Publish to return
 	start := time.Now()
-	pub.Publish(evt)
+	pub.Publish(context.Background(), evt)
 	elapsed := time.Since(start)
 
 	// It should return almost instantly, definitely much faster than the 200ms sleep

--- a/backend/internal/system/observability/publisher/publisher.go
+++ b/backend/internal/system/observability/publisher/publisher.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"sync"
 
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/observability/event"
 	"github.com/thunder-id/thunderid/internal/system/observability/subscriber"
@@ -32,7 +33,8 @@ import (
 // Events are published synchronously to all interested subscribers.
 type CategoryPublisherInterface interface {
 	// Publish publishes an event immediately to all interested subscribers.
-	Publish(event *event.Event)
+	// The context carries the request trace ID used for correlated logging.
+	Publish(ctx context.Context, event *event.Event)
 
 	// Subscribe adds a subscriber (subscriber decides what categories it wants).
 	Subscribe(sub subscriber.SubscriberInterface)
@@ -83,21 +85,21 @@ func NewCategoryPublisher() CategoryPublisherInterface {
 // Publish publishes an event to all interested subscribers.
 // This method returns immediately without blocking the caller.
 // The entire publishing process (validation, routing, and dispatching) runs asynchronously.
-func (p *categoryEventPublisher) Publish(evt *event.Event) {
+func (p *categoryEventPublisher) Publish(ctx context.Context, evt *event.Event) {
 	if evt == nil {
 		return
 	}
 
 	// Validate event
 	if err := evt.Validate(); err != nil {
-		p.logger.Warn("Invalid event, skipping publish", log.Error(err))
+		p.logger.WarnWithContext(ctx, "Invalid event, skipping publish", log.Error(err))
 		return
 	}
 
 	p.mu.RLock()
 	if p.isShutdown {
 		p.mu.RUnlock()
-		p.logger.Warn("Attempted to publish event after shutdown",
+		p.logger.WarnWithContext(ctx, "Attempted to publish event after shutdown",
 			log.String("eventType", evt.Type))
 		return
 	}
@@ -106,12 +108,16 @@ func (p *categoryEventPublisher) Publish(evt *event.Event) {
 	// Increment WaitGroup for the dispatcher goroutine
 	p.wg.Add(1)
 
+	// Dispatch runs in a detached goroutine after the caller's context may be
+	// cancelled, so derive a logging context from the event's trace ID instead.
+	eventCtx := sysContext.WithTraceID(context.Background(), evt.TraceID)
+
 	// Process event asynchronously to avoid blocking the caller
 	go func() {
 		defer p.wg.Done()
 		defer func() {
 			if r := recover(); r != nil {
-				p.logger.Error("Panic in event publisher dispatcher",
+				p.logger.ErrorWithContext(eventCtx, "Panic in event publisher dispatcher",
 					log.String("eventType", evt.Type),
 					log.Any("panic", r))
 			}
@@ -120,7 +126,7 @@ func (p *categoryEventPublisher) Publish(evt *event.Event) {
 		// Get event category
 		category, err := evt.GetCategory()
 		if err != nil {
-			p.logger.Error("Failed to get event category, skipping publish",
+			p.logger.ErrorWithContext(eventCtx, "Failed to get event category, skipping publish",
 				log.String("eventType", evt.Type),
 				log.Error(err))
 			return
@@ -141,7 +147,7 @@ func (p *categoryEventPublisher) Publish(evt *event.Event) {
 			// No subscribers for this category - skip it!
 			p.mu.RUnlock()
 			if p.logger.IsDebugEnabled() {
-				p.logger.Debug("No subscribers for event category, skipping",
+				p.logger.DebugWithContext(eventCtx, "No subscribers for event category, skipping",
 					log.String("eventType", evt.Type),
 					log.String("category", string(category)))
 			}
@@ -164,7 +170,7 @@ func (p *categoryEventPublisher) Publish(evt *event.Event) {
 				defer p.wg.Done() // Ensure WaitGroup is decremented when goroutine completes
 				defer func() {
 					if r := recover(); r != nil {
-						p.logger.Error("Subscriber panicked while handling event",
+						p.logger.ErrorWithContext(eventCtx, "Subscriber panicked while handling event",
 							log.String("subscriberID", s.GetID()),
 							log.Any("panic", r))
 					}
@@ -172,7 +178,7 @@ func (p *categoryEventPublisher) Publish(evt *event.Event) {
 
 				// Subscriber will filter the event itself based on its interests
 				if err := s.OnEvent(evt); err != nil {
-					p.logger.Error("Subscriber failed to handle event",
+					p.logger.ErrorWithContext(eventCtx, "Subscriber failed to handle event",
 						log.String("subscriberID", s.GetID()),
 						log.String("eventType", evt.Type),
 						log.Error(err))
@@ -204,7 +210,8 @@ func (p *categoryEventPublisher) Subscribe(sub subscriber.SubscriberInterface) {
 		p.subscribersByCategory[category] = append(p.subscribersByCategory[category], subscriberID)
 	}
 
-	p.logger.Debug("Subscriber registered",
+	// Subscriber registration happens during service startup, outside any request.
+	p.logger.DebugWithContext(context.Background(), "Subscriber registered",
 		log.String("subscriberID", subscriberID),
 		log.Int("categoryCount", len(categories)),
 		log.Any("categories", categories))
@@ -240,7 +247,9 @@ func (p *categoryEventPublisher) Unsubscribe(sub subscriber.SubscriberInterface)
 		}
 	}
 
-	p.logger.Debug("Subscriber unregistered", log.String("subscriberID", subscriberID))
+	// Subscriber removal happens during service shutdown, outside any request.
+	p.logger.DebugWithContext(context.Background(), "Subscriber unregistered",
+		log.String("subscriberID", subscriberID))
 }
 
 // GetActiveCategories returns categories that have at least one subscriber.
@@ -281,7 +290,10 @@ func (p *categoryEventPublisher) Shutdown() {
 	}
 	p.isShutdown = true
 
-	p.logger.Debug("Shutting down event publisher")
+	// Shutdown runs during application teardown, outside any request.
+	ctx := context.Background()
+
+	p.logger.DebugWithContext(ctx, "Shutting down event publisher")
 
 	// Signal all goroutines to stop accepting new events
 	p.cancel()
@@ -294,18 +306,18 @@ func (p *categoryEventPublisher) Shutdown() {
 	p.mu.Unlock()
 
 	// Wait for all in-flight event processing to complete
-	p.logger.Debug("Waiting for in-flight event processing to complete")
+	p.logger.DebugWithContext(ctx, "Waiting for in-flight event processing to complete")
 	p.wg.Wait()
-	p.logger.Debug("All in-flight events processed")
+	p.logger.DebugWithContext(ctx, "All in-flight events processed")
 
 	// Close all subscribers
 	for _, sub := range subscribers {
 		if err := sub.Close(); err != nil {
-			p.logger.Error("Error closing subscriber",
+			p.logger.ErrorWithContext(ctx, "Error closing subscriber",
 				log.String("subscriberID", sub.GetID()),
 				log.Error(err))
 		}
 	}
 
-	p.logger.Debug("Event bus shutdown complete")
+	p.logger.DebugWithContext(ctx, "Event bus shutdown complete")
 }

--- a/backend/internal/system/observability/service.go
+++ b/backend/internal/system/observability/service.go
@@ -21,6 +21,7 @@
 package observability
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
@@ -56,12 +57,15 @@ var _ ObservabilityServiceInterface = (*Service)(nil)
 func newServiceWithConfig() *Service {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
+	// Service construction runs during application startup, outside any request.
+	ctx := context.Background()
+
 	// Check if observability is disabled
 
-	logger.Debug("Initializing observability service")
+	logger.DebugWithContext(ctx, "Initializing observability service")
 	config := config.GetServerRuntime().Config.Observability
 	if !config.Enabled {
-		logger.Debug("Observability is disabled in configuration")
+		logger.DebugWithContext(ctx, "Observability is disabled in configuration")
 		return &Service{
 			logger: logger,
 			config: config,
@@ -81,7 +85,7 @@ func newServiceWithConfig() *Service {
 	subscribers, err := subscriber.Initialize(config)
 	if err != nil {
 		// This only happens in strict mode
-		logger.Error("Failed to initialize subscribers in strict mode", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to initialize subscribers in strict mode", log.Error(err))
 		// In strict mode, we could return an error service, but for now we continue
 		// with no subscribers (observability will be disabled)
 		return svc
@@ -90,11 +94,11 @@ func newServiceWithConfig() *Service {
 	// Subscribe all initialized subscribers to the publisher
 	for _, sub := range subscribers {
 		pub.Subscribe(sub)
-		logger.Debug("Subscriber subscribed to publisher",
+		logger.DebugWithContext(ctx, "Subscriber subscribed to publisher",
 			log.String("subscriberID", sub.GetID()))
 	}
 
-	logger.Debug("Observability service initialized successfully",
+	logger.DebugWithContext(ctx, "Observability service initialized successfully",
 		log.Int("activeSubscribers", len(subscribers)))
 	return svc
 }
@@ -103,16 +107,19 @@ func newServiceWithConfig() *Service {
 // This is called by subscribers in their init() functions.
 // The subscriber will only be activated if IsEnabled returns true and Initialize succeeds.
 func (s *Service) RegisterSubscriber(sub subscriber.SubscriberInterface) {
+	// Subscriber self-registration runs during package init, outside any request.
+	ctx := context.Background()
+
 	// Skip registration if service is not enabled or has no publisher
 	if !s.config.Enabled || s.publisher == nil {
-		s.logger.Debug("Subscriber registration skipped - service not enabled",
+		s.logger.DebugWithContext(ctx, "Subscriber registration skipped - service not enabled",
 			log.String("subscriberType", fmt.Sprintf("%T", sub)))
 		return
 	}
 
 	// Check if subscriber is enabled in config
 	if !sub.IsEnabled() {
-		s.logger.Debug("Subscriber registration skipped - disabled by config",
+		s.logger.DebugWithContext(ctx, "Subscriber registration skipped - disabled by config",
 			log.String("subscriberType", fmt.Sprintf("%T", sub)))
 		return
 	}
@@ -120,12 +127,12 @@ func (s *Service) RegisterSubscriber(sub subscriber.SubscriberInterface) {
 	// Initialize the subscriber
 	if err := sub.Initialize(); err != nil {
 		if s.config.FailureMode == "strict" {
-			s.logger.Error("Failed to initialize subscriber in strict mode",
+			s.logger.ErrorWithContext(ctx, "Failed to initialize subscriber in strict mode",
 				log.String("subscriberType", fmt.Sprintf("%T", sub)),
 				log.Error(err))
 			// In strict mode, we could panic or store error for later retrieval
 		} else {
-			s.logger.Warn("Failed to initialize subscriber, skipping",
+			s.logger.WarnWithContext(ctx, "Failed to initialize subscriber, skipping",
 				log.String("subscriberType", fmt.Sprintf("%T", sub)),
 				log.Error(err))
 		}
@@ -135,7 +142,7 @@ func (s *Service) RegisterSubscriber(sub subscriber.SubscriberInterface) {
 	// Subscribe to publisher (publisher now owns the subscriber list)
 	s.publisher.Subscribe(sub)
 
-	s.logger.Debug("Subscriber registered and activated successfully",
+	s.logger.DebugWithContext(ctx, "Subscriber registered and activated successfully",
 		log.String("subscriberType", fmt.Sprintf("%T", sub)),
 		log.String("subscriberID", sub.GetID()))
 }
@@ -143,18 +150,18 @@ func (s *Service) RegisterSubscriber(sub subscriber.SubscriberInterface) {
 // PublishEvent publishes an event to the observability system.
 // This is a no-op if observability is disabled.
 // The publisher will validate the event, so no need to check here.
-func (s *Service) PublishEvent(evt *event.Event) {
+func (s *Service) PublishEvent(ctx context.Context, evt *event.Event) {
 	// Quick exit if observability is disabled
 	if !s.config.Enabled || s.publisher == nil {
 		return
 	}
 
 	// Publisher handles nil check and validation
-	s.publisher.Publish(evt)
+	s.publisher.Publish(ctx, evt)
 
 	// Only log if event is not nil (avoid panic on evt.Type access)
 	if evt != nil {
-		s.logger.Debug("Event published",
+		s.logger.DebugWithContext(ctx, "Event published",
 			log.String("eventType", evt.Type),
 			log.String("eventID", evt.EventID),
 			log.String("traceID", evt.TraceID))
@@ -195,7 +202,10 @@ func (s *Service) GetActiveSubscribers() []subscriber.SubscriberInterface {
 // Shutdown gracefully shuts down the observability service.
 // The publisher handles unsubscribing and closing all subscribers.
 func (s *Service) Shutdown() {
-	s.logger.Debug("Shutting down observability service")
+	// Shutdown runs during application teardown, outside any request.
+	ctx := context.Background()
+
+	s.logger.DebugWithContext(ctx, "Shutting down observability service")
 
 	if s.publisher != nil {
 		// Publisher handles all subscriber cleanup (unsubscribe, close)
@@ -204,5 +214,5 @@ func (s *Service) Shutdown() {
 		// Set publisher to nil to mark service as disabled
 		s.publisher = nil
 	}
-	s.logger.Debug("Observability service shutdown complete")
+	s.logger.DebugWithContext(ctx, "Observability service shutdown complete")
 }

--- a/backend/internal/system/observability/service_test.go
+++ b/backend/internal/system/observability/service_test.go
@@ -19,6 +19,7 @@
 package observability
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -127,7 +128,7 @@ func TestService_PublishEvent(t *testing.T) {
 	evt.WithStatus(event.StatusSuccess)
 
 	// Should not panic
-	svc.PublishEvent(evt)
+	svc.PublishEvent(context.Background(), evt)
 
 	// Give it time to process (async processing)
 	time.Sleep(100 * time.Millisecond)
@@ -145,7 +146,7 @@ func TestService_PublishEventDisabled(t *testing.T) {
 	evt := event.NewEvent("trace-123", string(event.EventTypeTokenIssuanceStarted), "test")
 
 	// Should not panic even when disabled
-	svc.PublishEvent(evt)
+	svc.PublishEvent(context.Background(), evt)
 }
 
 func TestService_PublishNilEvent(t *testing.T) {
@@ -153,7 +154,7 @@ func TestService_PublishNilEvent(t *testing.T) {
 	defer svc.Shutdown()
 
 	// Should not panic
-	svc.PublishEvent(nil)
+	svc.PublishEvent(context.Background(), nil)
 }
 
 func TestService_GetConfig(t *testing.T) {

--- a/backend/internal/system/observability/subscriber/console_subscriber.go
+++ b/backend/internal/system/observability/subscriber/console_subscriber.go
@@ -19,6 +19,8 @@
 package subscriber
 
 import (
+	"context"
+
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/observability/adapter"
@@ -79,9 +81,12 @@ func (cs *ConsoleSubscriber) Initialize() error {
 
 	cs.logger = log.GetLogger().With(log.String(log.LoggerKeyComponentName, consoleSubscriberComponentName))
 
+	// Subscriber initialization runs during application startup, outside any request.
+	ctx := context.Background()
+
 	id, err := utils.GenerateUUIDv7()
 	if err != nil {
-		cs.logger.Error("failed to generate UUID for console subscriber", log.Error(err))
+		cs.logger.ErrorWithContext(ctx, "failed to generate UUID for console subscriber", log.Error(err))
 		return err
 	}
 	cs.id = id
@@ -89,7 +94,7 @@ func (cs *ConsoleSubscriber) Initialize() error {
 	cs.formatter = fmtr
 	cs.adapter = adptr
 
-	cs.logger.Debug("Console subscriber initialized",
+	cs.logger.DebugWithContext(ctx, "Console subscriber initialized",
 		log.String("format", consoleConfig.Format),
 		log.Int("categories", len(cs.categories)))
 
@@ -117,20 +122,23 @@ func (cs *ConsoleSubscriber) OnEvent(evt *event.Event) error {
 
 // Close closes the subscriber and releases resources.
 func (cs *ConsoleSubscriber) Close() error {
-	cs.logger.Info("Closing console subscriber", log.String("subscriberID", cs.id))
+	// Subscriber shutdown runs during application teardown, outside any request.
+	ctx := context.Background()
+
+	cs.logger.InfoWithContext(ctx, "Closing console subscriber", log.String("subscriberID", cs.id))
 
 	// Flush and close adapter
 	if cs.adapter != nil {
 		if err := cs.adapter.Flush(); err != nil {
-			cs.logger.Error("Failed to flush console adapter", log.Error(err))
+			cs.logger.ErrorWithContext(ctx, "Failed to flush console adapter", log.Error(err))
 		}
 
 		if err := cs.adapter.Close(); err != nil {
-			cs.logger.Error("Failed to close console adapter", log.Error(err))
+			cs.logger.ErrorWithContext(ctx, "Failed to close console adapter", log.Error(err))
 			return err
 		}
 	}
 
-	cs.logger.Info("Console subscriber closed", log.String("subscriberID", cs.id))
+	cs.logger.InfoWithContext(ctx, "Console subscriber closed", log.String("subscriberID", cs.id))
 	return nil
 }

--- a/backend/internal/system/observability/subscriber/file_subscriber.go
+++ b/backend/internal/system/observability/subscriber/file_subscriber.go
@@ -19,6 +19,7 @@
 package subscriber
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -65,6 +66,9 @@ func (fs *FileSubscriber) IsEnabled() bool {
 
 // Initialize sets up the file subscriber with the provided configuration.
 func (fs *FileSubscriber) Initialize() error {
+	// Subscriber initialization runs during application startup, outside any request.
+	ctx := context.Background()
+
 	// Get config from observability service
 	fileConfig := config.GetServerRuntime().Config.Observability.Output.File
 
@@ -80,7 +84,7 @@ func (fs *FileSubscriber) Initialize() error {
 
 	if fs.adapter != nil {
 		if err := fs.adapter.Close(); err != nil {
-			fs.logger.Warn("failed to close existing file adapter", log.Error(err))
+			fs.logger.WarnWithContext(ctx, "failed to close existing file adapter", log.Error(err))
 		}
 	}
 	// Create file adapter using the Initialize pattern
@@ -105,7 +109,7 @@ func (fs *FileSubscriber) Initialize() error {
 	fs.adapter = adptr
 	fs.logger = log.GetLogger().With(log.String(log.LoggerKeyComponentName, fileSubscriberComponentName))
 
-	fs.logger.Debug("File subscriber initialized",
+	fs.logger.DebugWithContext(ctx, "File subscriber initialized",
 		log.String("filePath", filePath),
 		log.String("format", fileConfig.Format),
 		log.Int("categories", len(fs.categories)))
@@ -134,20 +138,23 @@ func (fs *FileSubscriber) OnEvent(evt *event.Event) error {
 
 // Close closes the subscriber and releases resources.
 func (fs *FileSubscriber) Close() error {
-	fs.logger.Info("Closing file subscriber", log.String("subscriberID", fs.id))
+	// Subscriber shutdown runs during application teardown, outside any request.
+	ctx := context.Background()
+
+	fs.logger.InfoWithContext(ctx, "Closing file subscriber", log.String("subscriberID", fs.id))
 
 	// Flush and close adapter
 	if fs.adapter != nil {
 		if err := fs.adapter.Flush(); err != nil {
-			fs.logger.Error("Failed to flush file adapter", log.Error(err))
+			fs.logger.ErrorWithContext(ctx, "Failed to flush file adapter", log.Error(err))
 		}
 
 		if err := fs.adapter.Close(); err != nil {
-			fs.logger.Error("Failed to close file adapter", log.Error(err))
+			fs.logger.ErrorWithContext(ctx, "Failed to close file adapter", log.Error(err))
 			return err
 		}
 	}
 
-	fs.logger.Info("File subscriber closed", log.String("subscriberID", fs.id))
+	fs.logger.InfoWithContext(ctx, "File subscriber closed", log.String("subscriberID", fs.id))
 	return nil
 }

--- a/backend/internal/system/observability/subscriber/init.go
+++ b/backend/internal/system/observability/subscriber/init.go
@@ -22,6 +22,7 @@
 package subscriber
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
@@ -59,15 +60,18 @@ const initComponentName = "SubscriberInit"
 func Initialize(observabilityConfig config.ObservabilityConfig) ([]SubscriberInterface, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, initComponentName))
 
+	// Subscriber initialization runs during application startup, outside any request.
+	ctx := context.Background()
+
 	// Get all registered factories
 	factories := getAllFactories()
 
 	if len(factories) == 0 {
-		logger.Warn("No subscriber factories registered, observability will have no outputs")
+		logger.WarnWithContext(ctx, "No subscriber factories registered, observability will have no outputs")
 		return []SubscriberInterface{}, nil
 	}
 
-	logger.Debug("Initializing subscribers from registry",
+	logger.DebugWithContext(ctx, "Initializing subscribers from registry",
 		log.Int("factoryCount", len(factories)))
 
 	activeSubscribers := make([]SubscriberInterface, 0, len(factories))
@@ -75,13 +79,13 @@ func Initialize(observabilityConfig config.ObservabilityConfig) ([]SubscriberInt
 
 	// Iterate through all registered factories
 	for name, factory := range factories {
-		logger.Debug("Processing subscriber factory",
+		logger.DebugWithContext(ctx, "Processing subscriber factory",
 			log.String("subscriberType", name))
 
 		// Create subscriber instance
 		instance := factory()
 		if instance == nil {
-			logger.Error("Factory returned nil instance",
+			logger.ErrorWithContext(ctx, "Factory returned nil instance",
 				log.String("subscriberType", name))
 			initErrors = append(initErrors, fmt.Errorf("factory %s returned nil instance", name))
 			continue
@@ -89,14 +93,14 @@ func Initialize(observabilityConfig config.ObservabilityConfig) ([]SubscriberInt
 
 		// Check if subscriber is enabled in configuration
 		if !instance.IsEnabled() {
-			logger.Debug("Subscriber disabled in configuration, skipping",
+			logger.DebugWithContext(ctx, "Subscriber disabled in configuration, skipping",
 				log.String("subscriberType", name))
 			continue
 		}
 
 		// Initialize the subscriber (setup resources, validate config, etc.)
 		if err := instance.Initialize(); err != nil {
-			logger.Error("Failed to initialize subscriber",
+			logger.ErrorWithContext(ctx, "Failed to initialize subscriber",
 				log.String("subscriberType", name),
 				log.Error(err))
 
@@ -108,26 +112,26 @@ func Initialize(observabilityConfig config.ObservabilityConfig) ([]SubscriberInt
 			}
 
 			// In lenient mode, log and continue
-			logger.Warn("Continuing subscriber initialization despite error (lenient mode)",
+			logger.WarnWithContext(ctx, "Continuing subscriber initialization despite error (lenient mode)",
 				log.String("subscriberType", name))
 			continue
 		}
 
 		// Successfully initialized - add to active list
 		activeSubscribers = append(activeSubscribers, instance)
-		logger.Debug("Subscriber initialized successfully",
+		logger.DebugWithContext(ctx, "Subscriber initialized successfully",
 			log.String("subscriberType", name),
 			log.String("subscriberID", instance.GetID()))
 	}
 
-	logger.Debug("Subscriber initialization complete",
+	logger.DebugWithContext(ctx, "Subscriber initialization complete",
 		log.Int("total", len(factories)),
 		log.Int("active", len(activeSubscribers)),
 		log.Int("errors", len(initErrors)))
 
 	// If we have errors but reached here, we're in lenient mode
 	if len(initErrors) > 0 && observabilityConfig.FailureMode != "strict" {
-		logger.Warn("Some subscribers failed to initialize but continuing in lenient mode",
+		logger.WarnWithContext(ctx, "Some subscribers failed to initialize but continuing in lenient mode",
 			log.Int("failedCount", len(initErrors)))
 	}
 

--- a/backend/internal/system/observability/subscriber/otel_subscriber.go
+++ b/backend/internal/system/observability/subscriber/otel_subscriber.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/observability/event"
 	otelconfig "github.com/thunder-id/thunderid/internal/system/observability/opentelemetry"
@@ -79,7 +80,10 @@ func (o *OTelSubscriber) Initialize() error {
 
 	o.logger = log.GetLogger().With(log.String(log.LoggerKeyComponentName, otelSubscriberComponentName))
 
-	o.logger.Debug("Initializing OpenTelemetry subscriber",
+	// Subscriber initialization runs during application startup, outside any request.
+	ctx := context.Background()
+
+	o.logger.DebugWithContext(ctx, "Initializing OpenTelemetry subscriber",
 		log.String("exporterType", otelConfig.ExporterType),
 		log.String("endpoint", otelConfig.OTLPEndpoint))
 
@@ -96,7 +100,6 @@ func (o *OTelSubscriber) Initialize() error {
 	}
 
 	// Create OTel tracer provider using the Initialize pattern
-	ctx := context.Background()
 	tracerProvider, err := otelconfig.Initialize(ctx, otelProviderCfg)
 	if err != nil {
 		return fmt.Errorf("failed to initialize OpenTelemetry provider: %w", err)
@@ -109,11 +112,11 @@ func (o *OTelSubscriber) Initialize() error {
 	o.tracer = otel.Tracer("thunderid-observability")
 	o.id, err = utils.GenerateUUIDv7()
 	if err != nil {
-		o.logger.Error("Failed to generate UUID", log.Error(err))
+		o.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
 		return fmt.Errorf("Failed to generate UUID: %w", err)
 	}
 
-	o.logger.Debug("OpenTelemetry subscriber initialized successfully",
+	o.logger.DebugWithContext(ctx, "OpenTelemetry subscriber initialized successfully",
 		log.String("exporterType", otelConfig.ExporterType),
 		log.String("serviceName", otelConfig.ServiceName))
 
@@ -153,7 +156,12 @@ func (o *OTelSubscriber) OnEvent(evt *event.Event) error {
 // createSpan creates a span with span events for the event data.
 // Following OTel best practices: event data becomes a span event (timestamp is meaningful).
 func (o *OTelSubscriber) createSpan(evt *event.Event) error {
-	ctx := context.Background()
+	// Subscribers run in detached goroutines after the request context may be
+	// cancelled, so derive a logging context from the event's trace ID.
+	ctx := sysContext.WithTraceID(context.Background(), evt.TraceID)
+
+	// Root context for the OTel span; the event's trace ID is injected below.
+	spanCtx := context.Background()
 
 	// Parse TraceID from event
 	// OTel expects 32-char hex string, but Event TraceID might be UUID (36 chars with hyphens)
@@ -161,7 +169,7 @@ func (o *OTelSubscriber) createSpan(evt *event.Event) error {
 	traceID, err := trace.TraceIDFromHex(cleanTraceID)
 	if err != nil {
 		// If invalid TraceID, log warning and let OTel generate a new one
-		o.logger.Warn("Invalid TraceID in event, generating new one",
+		o.logger.WarnWithContext(ctx, "Invalid TraceID in event, generating new one",
 			log.String("traceID", evt.TraceID),
 			log.Error(err))
 	} else {
@@ -188,7 +196,7 @@ func (o *OTelSubscriber) createSpan(evt *event.Event) error {
 		remoteSpanContext := trace.NewSpanContext(spanContextConfig)
 
 		// Inject into context
-		ctx = trace.ContextWithRemoteSpanContext(ctx, remoteSpanContext)
+		spanCtx = trace.ContextWithRemoteSpanContext(spanCtx, remoteSpanContext)
 	}
 
 	// Create span name from event type
@@ -209,7 +217,7 @@ func (o *OTelSubscriber) createSpan(evt *event.Event) error {
 	}
 
 	// Start span
-	_, span := o.tracer.Start(ctx, spanName,
+	_, span := o.tracer.Start(spanCtx, spanName,
 		trace.WithTimestamp(evt.Timestamp),
 		trace.WithSpanKind(spanKind),
 		trace.WithAttributes(spanAttrs...),
@@ -245,7 +253,7 @@ func (o *OTelSubscriber) createSpan(evt *event.Event) error {
 	// it took for the event to be processed by this subscriber.
 	span.End()
 
-	o.logger.Debug("Created span with event",
+	o.logger.DebugWithContext(ctx, "Created span with event",
 		log.String("spanName", spanName),
 		log.String("eventType", evt.Type),
 		log.String("status", evt.Status))
@@ -332,20 +340,23 @@ func (o *OTelSubscriber) extractErrorMessage(evt *event.Event) string {
 
 // Close shuts down the tracer provider.
 func (o *OTelSubscriber) Close() error {
-	o.logger.Info("Closing OTel subscriber", log.String("subscriberID", o.id))
+	// Subscriber shutdown runs during application teardown, outside any request.
+	ctx := context.Background()
+
+	o.logger.InfoWithContext(ctx, "Closing OTel subscriber", log.String("subscriberID", o.id))
 
 	if o.tracerProvider != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		if err := o.tracerProvider.Shutdown(ctx); err != nil {
-			o.logger.Error("Failed to shutdown OpenTelemetry provider", log.Error(err))
+		if err := o.tracerProvider.Shutdown(shutdownCtx); err != nil {
+			o.logger.ErrorWithContext(ctx, "Failed to shutdown OpenTelemetry provider", log.Error(err))
 			return err
 		}
-		o.logger.Debug("OpenTelemetry provider shutdown successfully")
+		o.logger.DebugWithContext(ctx, "OpenTelemetry provider shutdown successfully")
 		o.tracerProvider = nil
 	}
 
-	o.logger.Info("OTel subscriber closed successfully", log.String("subscriberID", o.id))
+	o.logger.InfoWithContext(ctx, "OTel subscriber closed successfully", log.String("subscriberID", o.id))
 	return nil
 }

--- a/backend/internal/system/observability/subscriber/registry.go
+++ b/backend/internal/system/observability/subscriber/registry.go
@@ -19,6 +19,7 @@
 package subscriber
 
 import (
+	"context"
 	"sync"
 
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -57,7 +58,8 @@ func RegisterSubscriberFactory(name string, factory SubscriberFactory) {
 
 	if _, exists := factoryRegistry[name]; exists {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "SubscriberRegistry"))
-		logger.Warn("Subscriber factory already registered, replacing",
+		// Factory registration runs during package init, outside any request.
+		logger.WarnWithContext(context.Background(), "Subscriber factory already registered, replacing",
 			log.String("subscriberType", name))
 	}
 

--- a/backend/internal/system/observability/subscriber/utils.go
+++ b/backend/internal/system/observability/subscriber/utils.go
@@ -19,8 +19,10 @@
 package subscriber
 
 import (
+	"context"
 	"fmt"
 
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/observability/event"
 	"github.com/thunder-id/thunderid/internal/system/observability/formatter"
@@ -60,10 +62,14 @@ func processEvent(
 		return fmt.Errorf("event is nil")
 	}
 
+	// Subscribers run in detached goroutines after the request context may be
+	// cancelled, so derive a logging context from the event's trace ID.
+	ctx := sysContext.WithTraceID(context.Background(), evt.TraceID)
+
 	// Format the event
 	formattedData, err := fmtr.Format(evt)
 	if err != nil {
-		logger.Error("Failed to format event",
+		logger.ErrorWithContext(ctx, "Failed to format event",
 			log.String("eventType", evt.Type),
 			log.String("eventID", evt.EventID),
 			log.Error(err))
@@ -72,14 +78,14 @@ func processEvent(
 
 	// Write using adapter
 	if err := adapter.Write(formattedData); err != nil {
-		logger.Error(fmt.Sprintf("Failed to write event to %s", outputType),
+		logger.ErrorWithContext(ctx, fmt.Sprintf("Failed to write event to %s", outputType),
 			log.String("eventType", evt.Type),
 			log.String("eventID", evt.EventID),
 			log.Error(err))
 		return fmt.Errorf("failed to write to %s: %w", outputType, err)
 	}
 
-	logger.Debug(fmt.Sprintf("Event processed successfully to %s", outputType),
+	logger.DebugWithContext(ctx, fmt.Sprintf("Event processed successfully to %s", outputType),
 		log.String("eventType", evt.Type),
 		log.String("eventID", evt.EventID),
 		log.String("traceID", evt.TraceID))

--- a/backend/internal/system/security/middleware.go
+++ b/backend/internal/system/security/middleware.go
@@ -19,6 +19,7 @@
 package security
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -38,7 +39,7 @@ func middleware(service SecurityServiceInterface) (func(http.Handler) http.Handl
 			ctx, err := service.Process(r)
 			if err != nil {
 				// Write error response and stop request processing
-				writeSecurityError(w, err)
+				writeSecurityError(ctx, w, err)
 				return
 			}
 
@@ -49,13 +50,13 @@ func middleware(service SecurityServiceInterface) (func(http.Handler) http.Handl
 }
 
 // writeSecurityError writes an appropriate HTTP error response based on the security error.
-func writeSecurityError(w http.ResponseWriter, err error) {
+func writeSecurityError(ctx context.Context, w http.ResponseWriter, err error) {
 	w.Header().Set(serverconst.WWWAuthenticateHeaderName, serverconst.TokenTypeBearer)
 
 	if errors.Is(err, errForbidden) || errors.Is(err, errInsufficientPermissions) {
-		utils.WriteErrorResponse(w, http.StatusForbidden, apierror.ErrForbidden)
+		utils.WriteErrorResponse(ctx, w, http.StatusForbidden, apierror.ErrForbidden)
 		return
 	}
 
-	utils.WriteErrorResponse(w, http.StatusUnauthorized, apierror.ErrUnauthorized)
+	utils.WriteErrorResponse(ctx, w, http.StatusUnauthorized, apierror.ErrUnauthorized)
 }

--- a/backend/internal/system/security/middleware_test.go
+++ b/backend/internal/system/security/middleware_test.go
@@ -403,7 +403,7 @@ func TestWriteSecurityError(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			writeSecurityError(w, tc.err)
+			writeSecurityError(context.Background(), w, tc.err)
 
 			assert.Equal(t, tc.expectedStatus, w.Code)
 			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))

--- a/backend/internal/system/security/service.go
+++ b/backend/internal/system/security/service.go
@@ -56,6 +56,9 @@ type securityService struct {
 //   - error: An error if any of the provided path patterns are invalid and cannot be compiled.
 func newSecurityService(authenticators []AuthenticatorInterface, publicPaths []string,
 	apiPermissions []apiPermissionEntry) (*securityService, error) {
+	// Security service is constructed at startup, outside any request,
+	// so context.Background() is used (no request trace ID to propagate).
+	ctx := context.Background()
 	compiledPaths, err := compilePathPatterns(publicPaths)
 	if err != nil {
 		return nil, err
@@ -72,14 +75,14 @@ func newSecurityService(authenticators []AuthenticatorInterface, publicPaths []s
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
 	if skipSecurity {
-		logger.Warn("============================================================")
-		logger.Warn("|       WARNING: SECURITY ENFORCEMENT DISABLED             |")
-		logger.Warn("|                                                          |")
-		logger.Warn("|        SKIP_SECURITY is set to 'true'            |")
-		logger.Warn("|  This is NOT RECOMMENDED for production environments!    |")
-		logger.Warn("| Endpoints accessible without auth, but tokens processed  |")
-		logger.Warn("|                                                          |")
-		logger.Warn("============================================================")
+		logger.WarnWithContext(ctx, "============================================================")
+		logger.WarnWithContext(ctx, "|       WARNING: SECURITY ENFORCEMENT DISABLED             |")
+		logger.WarnWithContext(ctx, "|                                                          |")
+		logger.WarnWithContext(ctx, "|        SKIP_SECURITY is set to 'true'            |")
+		logger.WarnWithContext(ctx, "|  This is NOT RECOMMENDED for production environments!    |")
+		logger.WarnWithContext(ctx, "| Endpoints accessible without auth, but tokens processed  |")
+		logger.WarnWithContext(ctx, "|                                                          |")
+		logger.WarnWithContext(ctx, "============================================================")
 	}
 
 	return &securityService{
@@ -94,7 +97,7 @@ func newSecurityService(authenticators []AuthenticatorInterface, publicPaths []s
 // Process handles the complete security flow: authentication and authorization.
 // Returns an enriched context on success, or an error if authentication or authorization fails.
 func (s *securityService) Process(r *http.Request) (context.Context, error) {
-	isPublic := s.isPublicPath(r.URL.Path)
+	isPublic := s.isPublicPath(r.Context(), r.URL.Path)
 
 	// Check if the request is options (CORS preflight)
 	if r.Method == http.MethodOptions {
@@ -170,9 +173,9 @@ func (s *securityService) getRequiredPermissionForAPI(method, path string) strin
 }
 
 // isPublicPath checks if the given request path matches any of the configured public path patterns.
-func (s *securityService) isPublicPath(requestPath string) bool {
+func (s *securityService) isPublicPath(ctx context.Context, requestPath string) bool {
 	if len(requestPath) > maxPublicPathLength {
-		s.logger.Warn("Path length exceeds maximum allowed length",
+		s.logger.WarnWithContext(ctx, "Path length exceeds maximum allowed length",
 			log.Int("limit", maxPublicPathLength),
 			log.Int("length", len(requestPath)))
 		return false

--- a/backend/internal/system/security/service_test.go
+++ b/backend/internal/system/security/service_test.go
@@ -19,6 +19,7 @@
 package security
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -329,7 +330,7 @@ func (suite *SecurityServiceTestSuite) TestIsPublicPath() {
 
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			result := suite.service.isPublicPath(tc.path)
+			result := suite.service.isPublicPath(context.Background(), tc.path)
 			assert.Equal(suite.T(), tc.expected, result, "Path: %s", tc.path)
 		})
 	}

--- a/backend/internal/system/transaction/transactioner.go
+++ b/backend/internal/system/transaction/transactioner.go
@@ -68,7 +68,7 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 	// 1. Begin transaction
 	tx, err := t.db.BeginTx(ctx, nil)
 	if err != nil {
-		log.GetLogger().Error("failed to begin transaction",
+		log.GetLogger().ErrorWithContext(ctx, "failed to begin transaction",
 			log.String("dbName", t.dbName),
 			log.Error(err),
 		)
@@ -80,7 +80,7 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 		if p := recover(); p != nil {
 			// Capture stack trace
 			stack := string(debug.Stack())
-			log.GetLogger().Error("panic occurred during transaction",
+			log.GetLogger().ErrorWithContext(ctx, "panic occurred during transaction",
 				log.String("dbName", t.dbName),
 				log.Any("panic", p),
 				log.String("stack", stack),
@@ -88,7 +88,7 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 
 			// Panic occurred - rollback and convert panic to error
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				log.GetLogger().Error("failed to rollback transaction after unexpected error",
+				log.GetLogger().ErrorWithContext(ctx, "failed to rollback transaction after unexpected error",
 					log.String("dbName", t.dbName),
 					log.Error(rollbackErr),
 				)
@@ -111,7 +111,7 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 		} else if err != nil {
 			// Error occurred - rollback
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				log.GetLogger().Error("failed to rollback transaction",
+				log.GetLogger().ErrorWithContext(ctx, "failed to rollback transaction",
 					log.String("dbName", t.dbName),
 					log.Error(rollbackErr),
 				)
@@ -121,7 +121,7 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 			// Success - commit
 			err = tx.Commit()
 			if err != nil {
-				log.GetLogger().Error("failed to commit transaction",
+				log.GetLogger().ErrorWithContext(ctx, "failed to commit transaction",
 					log.String("dbName", t.dbName),
 					log.Error(err),
 				)

--- a/backend/internal/system/utils/configutil.go
+++ b/backend/internal/system/utils/configutil.go
@@ -21,6 +21,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,6 +71,8 @@ var (
 //
 // If a file cannot be read, an error is returned.
 func SubstituteFilePaths(content []byte, baseDir string) ([]byte, error) {
+	// This runs outside any request, so context.Background() is used (no request trace ID).
+	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ConfigUtil"))
 	isError := false
 
@@ -85,7 +88,7 @@ func SubstituteFilePaths(content []byte, baseDir string) ([]byte, error) {
 			path = sub[2]
 		}
 		if path == "" {
-			logger.Warn("Empty file path in placeholder", log.String("placeholder", match))
+			logger.WarnWithContext(ctx, "Empty file path in placeholder", log.String("placeholder", match))
 			return ""
 		}
 
@@ -96,7 +99,7 @@ func SubstituteFilePaths(content []byte, baseDir string) ([]byte, error) {
 
 		data, err := readFileContent(path)
 		if err != nil {
-			logger.Error("Failed to read file content", log.String("filePath", path), log.Error(err))
+			logger.ErrorWithContext(ctx, "Failed to read file content", log.String("filePath", path), log.Error(err))
 			isError = true
 			return ""
 		}

--- a/backend/internal/system/utils/http_util.go
+++ b/backend/internal/system/utils/http_util.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"html"
@@ -36,9 +37,11 @@ import (
 )
 
 // WriteJSONError writes a JSON error response with the given details.
-func WriteJSONError(w http.ResponseWriter, code, desc string, statusCode int, respHeaders []map[string]string) {
+func WriteJSONError(ctx context.Context, w http.ResponseWriter, code, desc string, statusCode int,
+	respHeaders []map[string]string) {
 	logger := log.GetLogger()
-	logger.Error("Error in HTTP response", log.String("error", code), log.String("description", desc))
+	logger.ErrorWithContext(ctx, "Error in HTTP response",
+		log.String("error", code), log.String("description", desc))
 
 	// Set the response headers.
 	for _, header := range respHeaders {
@@ -54,7 +57,7 @@ func WriteJSONError(w http.ResponseWriter, code, desc string, statusCode int, re
 		"error_description": desc,
 	})
 	if err != nil {
-		logger.Error("Failed to write JSON error response", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to write JSON error response", log.Error(err))
 		return
 	}
 }
@@ -377,7 +380,7 @@ func ExtractBearerToken(authHeader string) (string, error) {
 }
 
 // WriteSuccessResponse writes a JSON success response with the given status code and data.
-func WriteSuccessResponse(w http.ResponseWriter, statusCode int, data interface{}) {
+func WriteSuccessResponse(ctx context.Context, w http.ResponseWriter, statusCode int, data interface{}) {
 	logger := log.GetLogger()
 
 	if statusCode == http.StatusNoContent {
@@ -388,7 +391,7 @@ func WriteSuccessResponse(w http.ResponseWriter, statusCode int, data interface{
 	// Encode to buffer first to ensure encoding succeeds before sending headers
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(data); err != nil {
-		logger.Error("Failed to encode response", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to encode response", log.Error(err))
 		errResp := apierror.ErrorResponse{
 			Code:        serviceerror.ErrorEncodingError.Code,
 			Message:     serviceerror.ErrorEncodingError.Error,
@@ -408,13 +411,13 @@ func WriteSuccessResponse(w http.ResponseWriter, statusCode int, data interface{
 }
 
 // WriteErrorResponse writes a JSON i18n error response with the given status code and error details.
-func WriteErrorResponse(w http.ResponseWriter, statusCode int, errorResp apierror.ErrorResponse) {
+func WriteErrorResponse(ctx context.Context, w http.ResponseWriter, statusCode int, errorResp apierror.ErrorResponse) {
 	logger := log.GetLogger()
 	w.Header().Set(constants.ContentTypeHeaderName, constants.ContentTypeJSON)
 	w.WriteHeader(statusCode)
 
 	if err := json.NewEncoder(w).Encode(errorResp); err != nil {
-		logger.Error("Failed to encode i18n error response", log.Error(err))
+		logger.ErrorWithContext(ctx, "Failed to encode i18n error response", log.Error(err))
 		errResp := apierror.ErrorResponse{
 			Code:        serviceerror.ErrorEncodingError.Code,
 			Message:     serviceerror.ErrorEncodingError.Error,

--- a/backend/internal/system/utils/http_util_test.go
+++ b/backend/internal/system/utils/http_util_test.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -84,7 +85,7 @@ func (suite *HTTPUtilTestSuite) TestWriteJSONError() {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 
-			WriteJSONError(w, tc.code, tc.desc, tc.statusCode, tc.respHeaders)
+			WriteJSONError(context.Background(), w, tc.code, tc.desc, tc.statusCode, tc.respHeaders)
 
 			// Verify status code
 			assert.Equal(t, tc.statusCode, w.Code)
@@ -629,7 +630,7 @@ func (suite *HTTPUtilTestSuite) TestWriteSuccessResponse() {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 
-			WriteSuccessResponse(w, tc.statusCode, tc.data)
+			WriteSuccessResponse(context.Background(), w, tc.statusCode, tc.data)
 
 			// Verify status code
 			assert.Equal(t, tc.statusCode, w.Code)
@@ -680,7 +681,7 @@ func (suite *HTTPUtilTestSuite) TestWriteSuccessResponse_EncodingError() {
 		w := httptest.NewRecorder()
 
 		// Channel cannot be JSON encoded, should trigger the encoding error fallback
-		WriteSuccessResponse(w, http.StatusOK, make(chan int))
+		WriteSuccessResponse(context.Background(), w, http.StatusOK, make(chan int))
 
 		// Encoding fails before headers are sent, so we get 500
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
@@ -723,7 +724,7 @@ func (suite *HTTPUtilTestSuite) TestWriteErrorResponse_EncodingFallback() {
 			Message:     core.I18nMessage{Key: "error.test", DefaultValue: "Test error"},
 			Description: core.I18nMessage{Key: "error.test_desc", DefaultValue: "A test error"},
 		}
-		WriteErrorResponse(w, http.StatusBadRequest, errorResp)
+		WriteErrorResponse(context.Background(), w, http.StatusBadRequest, errorResp)
 
 		// The fallback JSON must be valid and carry the encoding error fields
 		var resp apierror.ErrorResponse
@@ -792,7 +793,7 @@ func (suite *HTTPUtilTestSuite) TestWriteI18nErrorResponse() {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 
-			WriteErrorResponse(w, tc.statusCode, tc.errorResp)
+			WriteErrorResponse(context.Background(), w, tc.statusCode, tc.errorResp)
 
 			// Verify status code
 			assert.Equal(t, tc.statusCode, w.Code)

--- a/backend/internal/user/declarative_resource.go
+++ b/backend/internal/user/declarative_resource.go
@@ -143,7 +143,7 @@ func (e *userExporter) GetResourceByID(
 }
 
 // ValidateResource validates a user resource.
-func (e *userExporter) ValidateResource(
+func (e *userExporter) ValidateResource(ctx context.Context,
 	resource interface{}, id string, logger *log.Logger,
 ) (string, *declarativeresource.ExportError) {
 	user, ok := resource.(*userDeclarativeResource)
@@ -158,7 +158,7 @@ func (e *userExporter) ValidateResource(
 	}
 
 	if username == "" {
-		logger.Warn("USER_VALIDATION_ERROR: Missing username",
+		logger.WarnWithContext(ctx, "USER_VALIDATION_ERROR: Missing username",
 			log.MaskedString(log.LoggerKeyUserID, id))
 		return "", &declarativeresource.ExportError{
 			ResourceType: resourceTypeUser,

--- a/backend/internal/user/declarative_resource_test.go
+++ b/backend/internal/user/declarative_resource_test.go
@@ -273,7 +273,7 @@ func (suite *DeclarativeResourceTestSuite) TestValidateResource_MissingUsername(
 		Attributes: map[string]interface{}{},
 	}
 
-	_, err := exporter.ValidateResource(resource, "user-1", log.GetLogger())
+	_, err := exporter.ValidateResource(context.Background(), resource, "user-1", log.GetLogger())
 	suite.NotNil(err)
 }
 

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -19,6 +19,7 @@
 package user
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -56,7 +57,7 @@ func (uh *userHandler) HandleUserListRequest(w http.ResponseWriter, r *http.Requ
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -66,7 +67,7 @@ func (uh *userHandler) HandleUserListRequest(w http.ResponseWriter, r *http.Requ
 
 	filters, svcErr := parseFilterParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -76,11 +77,11 @@ func (uh *userHandler) HandleUserListRequest(w http.ResponseWriter, r *http.Requ
 	// Get the user list using the user service.
 	userListResponse, svcErr := uh.userService.GetUserList(ctx, limit, offset, filters, includeDisplay)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, userListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, userListResponse)
 
 	logger.DebugWithContext(ctx, "Successfully listed users with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -101,7 +102,7 @@ func (uh *userHandler) HandleUserPostRequest(w http.ResponseWriter, r *http.Requ
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -114,11 +115,11 @@ func (uh *userHandler) HandleUserPostRequest(w http.ResponseWriter, r *http.Requ
 	// Create the user using the user service.
 	createdUser, svcErr := uh.userService.CreateUser(ctx, user)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, createdUser)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdUser)
 
 	// Log the user creation response.
 	logger.DebugWithContext(ctx, "User POST response sent", log.MaskedString(log.LoggerKeyUserID, createdUser.ID))
@@ -136,7 +137,7 @@ func (uh *userHandler) HandleUserGetRequest(w http.ResponseWriter, r *http.Reque
 			Message:     ErrorMissingUserID.Error,
 			Description: ErrorMissingUserID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -146,11 +147,11 @@ func (uh *userHandler) HandleUserGetRequest(w http.ResponseWriter, r *http.Reque
 	// Get the user using the user service.
 	user, svcErr := uh.userService.GetUser(ctx, id, includeDisplay)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, user)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, user)
 
 	// Log the user response.
 	logger.DebugWithContext(ctx, "User GET response sent", log.MaskedString(log.LoggerKeyUserID, id))
@@ -163,13 +164,13 @@ func (ah *userHandler) HandleUserGroupsGetRequest(w http.ResponseWriter, r *http
 
 	id := r.PathValue("id")
 	if id == "" {
-		handleError(w, &ErrorMissingUserID)
+		handleError(ctx, w, &ErrorMissingUserID)
 		return
 	}
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -179,11 +180,11 @@ func (ah *userHandler) HandleUserGroupsGetRequest(w http.ResponseWriter, r *http
 
 	groupListResponse, svcErr := ah.userService.GetUserGroups(ctx, id, limit, offset)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, groupListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, groupListResponse)
 
 	logger.DebugWithContext(ctx, "Successfully retrieved user groups", log.MaskedString(log.LoggerKeyUserID, id),
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -203,7 +204,7 @@ func (uh *userHandler) HandleUserPutRequest(w http.ResponseWriter, r *http.Reque
 			Message:     ErrorMissingUserID.Error,
 			Description: ErrorMissingUserID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
@@ -214,7 +215,7 @@ func (uh *userHandler) HandleUserPutRequest(w http.ResponseWriter, r *http.Reque
 			Message:     ErrorInvalidRequestFormat.Error,
 			Description: ErrorInvalidRequestFormat.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 	updateRequest.ID = id
@@ -222,11 +223,11 @@ func (uh *userHandler) HandleUserPutRequest(w http.ResponseWriter, r *http.Reque
 	// Update the user using the user service.
 	user, svcErr := uh.userService.UpdateUser(ctx, id, updateRequest)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, user)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, user)
 
 	// Log the user response.
 	logger.DebugWithContext(ctx, "User PUT response sent", log.MaskedString(log.LoggerKeyUserID, id))
@@ -244,18 +245,18 @@ func (uh *userHandler) HandleUserDeleteRequest(w http.ResponseWriter, r *http.Re
 			Message:     ErrorMissingUserID.Error,
 			Description: ErrorMissingUserID.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	// Delete the user using the user service.
 	svcErr := uh.userService.DeleteUser(ctx, id)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 
 	// Log the user response.
 	logger.DebugWithContext(ctx, "User DELETE response sent", log.MaskedString(log.LoggerKeyUserID, id))
@@ -273,7 +274,7 @@ func (uh *userHandler) HandleUserListByPathRequest(w http.ResponseWriter, r *htt
 
 	limit, offset, svcErr := parsePaginationParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -283,7 +284,7 @@ func (uh *userHandler) HandleUserListByPathRequest(w http.ResponseWriter, r *htt
 
 	filters, svcErr := parseFilterParams(r.URL.Query())
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
@@ -292,11 +293,11 @@ func (uh *userHandler) HandleUserListByPathRequest(w http.ResponseWriter, r *htt
 
 	userListResponse, svcErr := uh.userService.GetUsersByPath(ctx, path, limit, offset, filters, includeDisplay)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, userListResponse)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, userListResponse)
 
 	logger.DebugWithContext(ctx, "Successfully listed users by path", log.String("path", path),
 		log.Int("limit", limit), log.Int("offset", offset),
@@ -325,17 +326,17 @@ func (uh *userHandler) HandleUserPostByPathRequest(w http.ResponseWriter, r *htt
 				DefaultValue: "Failed to parse request body: " + err.Error(),
 			},
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(ctx, w, http.StatusBadRequest, errResp)
 		return
 	}
 
 	user, svcErr := uh.userService.CreateUserByPath(ctx, path, *createRequest)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusCreated, user)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, user)
 
 	logger.DebugWithContext(ctx, "Successfully created user by path",
 		log.String("path", path), log.String("userType", user.Type))
@@ -348,7 +349,7 @@ func (uh *userHandler) HandleSelfUserGetRequest(w http.ResponseWriter, r *http.R
 
 	userID := security.GetSubject(ctx)
 	if strings.TrimSpace(userID) == "" {
-		handleError(w, &ErrorAuthenticationFailed)
+		handleError(ctx, w, &ErrorAuthenticationFailed)
 		return
 	}
 
@@ -357,11 +358,11 @@ func (uh *userHandler) HandleSelfUserGetRequest(w http.ResponseWriter, r *http.R
 
 	user, svcErr := uh.userService.GetUser(ctx, userID, includeDisplay)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, user)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, user)
 
 	logger.DebugWithContext(ctx, "Self user GET response sent", log.MaskedString(log.LoggerKeyUserID, userID))
 }
@@ -373,28 +374,28 @@ func (uh *userHandler) HandleSelfUserPutRequest(w http.ResponseWriter, r *http.R
 
 	userID := security.GetSubject(ctx)
 	if strings.TrimSpace(userID) == "" {
-		handleError(w, &ErrorAuthenticationFailed)
+		handleError(ctx, w, &ErrorAuthenticationFailed)
 		return
 	}
 
 	updateRequest, err := sysutils.DecodeJSONBody[UpdateSelfUserRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
 	if updateRequest == nil || len(updateRequest.Attributes) == 0 {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
 	updatedUser, svcErr := uh.userService.UpdateUserAttributes(ctx, userID, updateRequest.Attributes)
 	if svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusOK, updatedUser)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, updatedUser)
 
 	logger.DebugWithContext(ctx, "Self user PUT response sent", log.MaskedString(log.LoggerKeyUserID, userID))
 }
@@ -406,27 +407,27 @@ func (uh *userHandler) HandleSelfUserCredentialUpdateRequest(w http.ResponseWrit
 
 	userID := security.GetSubject(ctx)
 	if strings.TrimSpace(userID) == "" {
-		handleError(w, &ErrorAuthenticationFailed)
+		handleError(ctx, w, &ErrorAuthenticationFailed)
 		return
 	}
 
 	updateRequest, err := sysutils.DecodeJSONBody[UpdateSelfUserRequest](r)
 	if err != nil {
-		handleError(w, &ErrorInvalidRequestFormat)
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
 		return
 	}
 
 	if updateRequest == nil || len(updateRequest.Attributes) == 0 || string(updateRequest.Attributes) == "{}" {
-		handleError(w, &ErrorMissingCredentials)
+		handleError(ctx, w, &ErrorMissingCredentials)
 		return
 	}
 
 	if svcErr := uh.userService.UpdateUserCredentials(ctx, userID, updateRequest.Attributes); svcErr != nil {
-		handleError(w, svcErr)
+		handleError(ctx, w, svcErr)
 		return
 	}
 
-	sysutils.WriteSuccessResponse(w, http.StatusNoContent, nil)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	logger.DebugWithContext(ctx, "Self user credential update response sent",
 		log.MaskedString(log.LoggerKeyUserID, userID))
 }
@@ -460,7 +461,7 @@ func parsePaginationParams(query url.Values) (int, int, *serviceerror.ServiceErr
 }
 
 // handleError handles service errors and writes appropriate HTTP responses.
-func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
+func handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 	var statusCode int
 	if svcErr.Type == serviceerror.ClientErrorType {
 		switch svcErr.Code {
@@ -493,7 +494,7 @@ func handleError(w http.ResponseWriter, svcErr *serviceerror.ServiceError) {
 		Description: svcErr.ErrorDescription,
 	}
 
-	sysutils.WriteErrorResponse(w, statusCode, errResp)
+	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)
 }
 
 // extractAndValidatePath extracts and validates the path parameter from the request.
@@ -505,7 +506,7 @@ func extractAndValidatePath(w http.ResponseWriter, r *http.Request) (string, boo
 			Message:     ErrorHandlePathRequired.Error,
 			Description: ErrorHandlePathRequired.ErrorDescription,
 		}
-		sysutils.WriteErrorResponse(w, http.StatusBadRequest, errResp)
+		sysutils.WriteErrorResponse(r.Context(), w, http.StatusBadRequest, errResp)
 		return "", true
 	}
 	return path, false

--- a/backend/internal/user/handler_test.go
+++ b/backend/internal/user/handler_test.go
@@ -38,6 +38,7 @@ import (
 const (
 	testUserID789 = "user-789"
 	testUserID123 = "user-123"
+	testUserID456 = "user-456"
 )
 
 func TestHandleSelfUserGetRequest_Success(t *testing.T) {
@@ -102,7 +103,7 @@ func TestHandleSelfUserGetRequest_Unauthorized(t *testing.T) {
 }
 
 func TestHandleSelfUserPutRequest_Success(t *testing.T) {
-	userID := "user-456"
+	userID := testUserID456
 	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
 	attributes := json.RawMessage(`{"email":"alice@example.com"}`)
 
@@ -131,7 +132,7 @@ func TestHandleSelfUserPutRequest_Success(t *testing.T) {
 }
 
 func TestHandleSelfUserPutRequest_InvalidBody(t *testing.T) {
-	userID := "user-456"
+	userID := testUserID456
 	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
 
 	mockSvc := NewUserServiceInterfaceMock(t)
@@ -667,6 +668,241 @@ func TestHandleUserDeleteRequest_ErrorCases(t *testing.T) {
 		handler.HandleUserDeleteRequest(rr, req)
 		require.Equal(t, http.StatusInternalServerError, rr.Code)
 	})
+}
+
+func TestHandleUserListRequest_ServiceError(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	mockSvc.On("GetUserList", mock.Anything, 10, 0, mock.Anything, false).
+		Return(nil, &serviceerror.InternalServerError).Once()
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/users?limit=10&offset=0", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserListRequest(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, serviceerror.InternalServerError.Code, errResp.Code)
+}
+
+func TestHandleUserGroupsGetRequest_ErrorCases(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+	userID := testUserID123
+
+	t.Run("MissingID", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/users//groups", nil)
+		rr := httptest.NewRecorder()
+		handler.HandleUserGroupsGetRequest(rr, req)
+		require.Equal(t, http.StatusNotFound, rr.Code)
+
+		var errResp apierror.ErrorResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+		require.Equal(t, ErrorMissingUserID.Code, errResp.Code)
+	})
+
+	t.Run("InvalidPaginationParams", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/users/"+userID+"/groups?limit=abc", nil)
+		req.SetPathValue("id", userID)
+		rr := httptest.NewRecorder()
+		handler.HandleUserGroupsGetRequest(rr, req)
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var errResp apierror.ErrorResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+		require.Equal(t, ErrorInvalidLimit.Code, errResp.Code)
+	})
+}
+
+func TestHandleUserPutRequest_MissingID(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPut, "/users/", strings.NewReader(`{"attributes":{}}`))
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserPutRequest(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorMissingUserID.Code, errResp.Code)
+}
+
+func TestHandleUserListByPathRequest_ErrorCases(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+
+	t.Run("InvalidPaginationParams", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/users/path/root/engineering?limit=abc", nil)
+		req.SetPathValue("path", "root/engineering")
+		rr := httptest.NewRecorder()
+		handler.HandleUserListByPathRequest(rr, req)
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var errResp apierror.ErrorResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+		require.Equal(t, ErrorInvalidLimit.Code, errResp.Code)
+	})
+
+	t.Run("InvalidFilter", func(t *testing.T) {
+		req := httptest.NewRequest(
+			http.MethodGet, "/users/path/root/engineering?filter=username%20invalid%20%22alice%22", nil)
+		req.SetPathValue("path", "root/engineering")
+		rr := httptest.NewRecorder()
+		handler.HandleUserListByPathRequest(rr, req)
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var errResp apierror.ErrorResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+		require.Equal(t, ErrorInvalidFilter.Code, errResp.Code)
+	})
+
+	t.Run("MissingPath", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/users/path/", nil)
+		rr := httptest.NewRecorder()
+		handler.HandleUserListByPathRequest(rr, req)
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+
+		var errResp apierror.ErrorResponse
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+		require.Equal(t, ErrorHandlePathRequired.Code, errResp.Code)
+	})
+}
+
+func TestHandleUserPostByPathRequest_InvalidBody(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/users/path/root/sales", strings.NewReader("invalid"))
+	req.SetPathValue("path", "root/sales")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserPostByPathRequest(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorInvalidRequestFormat.Code, errResp.Code)
+}
+
+func TestHandleSelfUserGetRequest_ServiceError(t *testing.T) {
+	userID := testUserID123
+	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	mockSvc.On("GetUser", mock.Anything, userID, false).Return(nil, &ErrorUserNotFound).Once()
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/users/me", nil)
+	req = req.WithContext(security.WithSecurityContextTest(req.Context(), authCtx))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserGetRequest(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorUserNotFound.Code, errResp.Code)
+}
+
+func TestHandleSelfUserPutRequest_Unauthorized(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPut, "/users/me",
+		bytes.NewBufferString(`{"attributes":{"email":"alice@example.com"}}`))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserPutRequest(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorAuthenticationFailed.Code, errResp.Code)
+}
+
+func TestHandleSelfUserPutRequest_EmptyAttributes(t *testing.T) {
+	userID := testUserID456
+	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPut, "/users/me", bytes.NewBufferString(`{}`))
+	req = req.WithContext(security.WithSecurityContextTest(req.Context(), authCtx))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserPutRequest(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorInvalidRequestFormat.Code, errResp.Code)
+}
+
+func TestHandleSelfUserPutRequest_ServiceError(t *testing.T) {
+	userID := testUserID456
+	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
+	attributes := json.RawMessage(`{"email":"alice@example.com"}`)
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	mockSvc.On("UpdateUserAttributes", mock.Anything, userID, attributes).
+		Return(nil, &serviceerror.InternalServerError).Once()
+
+	handler := newUserHandler(mockSvc)
+	body := bytes.NewBufferString(`{"attributes":{"email":"alice@example.com"}}`)
+	req := httptest.NewRequest(http.MethodPut, "/users/me", body)
+	req = req.WithContext(security.WithSecurityContextTest(req.Context(), authCtx))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserPutRequest(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, serviceerror.InternalServerError.Code, errResp.Code)
+}
+
+func TestHandleSelfUserCredentialUpdateRequest_Unauthorized(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/users/me/update-credentials",
+		bytes.NewBufferString(`{"attributes":{"password":"Secret123!"}}`))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserCredentialUpdateRequest(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorAuthenticationFailed.Code, errResp.Code)
+}
+
+func TestHandleSelfUserCredentialUpdateRequest_InvalidBody(t *testing.T) {
+	userID := testUserID789
+	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/users/me/update-credentials",
+		bytes.NewBufferString(`{"attributes":`))
+	req = req.WithContext(security.WithSecurityContextTest(req.Context(), authCtx))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserCredentialUpdateRequest(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorInvalidRequestFormat.Code, errResp.Code)
 }
 
 func TestHandleError_ErrorUnauthorized_Returns403(t *testing.T) {

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -120,12 +120,12 @@ func (us *userService) listAllUsers(
 ) (*UserListResponse, *serviceerror.ServiceError) {
 	totalCount, err := us.entityService.GetEntityListCount(ctx, entity.EntityCategoryUser, filters)
 	if err != nil {
-		return nil, logErrorAndReturnServerError(logger, "Failed to get user list count", err)
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to get user list count", err)
 	}
 
 	entities, err := us.entityService.GetEntityList(ctx, entity.EntityCategoryUser, limit, offset, filters)
 	if err != nil {
-		return nil, logErrorAndReturnServerError(logger, "Failed to get user list", err)
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to get user list", err)
 	}
 
 	users := entitiesToUsers(entities)
@@ -150,13 +150,13 @@ func (us *userService) listUsersByOUIDs(
 
 	totalCount, err := us.entityService.GetEntityListCountByOUIDs(ctx, entity.EntityCategoryUser, ouIDs, filters)
 	if err != nil {
-		return nil, logErrorAndReturnServerError(logger, "Failed to get user list count", err)
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to get user list count", err)
 	}
 
 	entities, err := us.entityService.GetEntityListByOUIDs(
 		ctx, entity.EntityCategoryUser, ouIDs, limit, offset, filters)
 	if err != nil {
-		return nil, logErrorAndReturnServerError(logger, "Failed to get user list", err)
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to get user list", err)
 	}
 
 	users := entitiesToUsers(entities)
@@ -194,7 +194,7 @@ func (us *userService) GetUsersByPath(
 
 	ou, svcErr := us.ouService.GetOrganizationUnitByPath(ctx, handlePath)
 	if svcErr != nil {
-		return nil, mapOUServiceError(
+		return nil, mapOUServiceError(ctx,
 			svcErr,
 			logger,
 			"resolving organization unit by path",
@@ -218,7 +218,7 @@ func (us *userService) GetUsersByPath(
 
 	ouResponse, svcErr := us.ouService.GetOrganizationUnitUsers(ctx, oUID, limit, offset, false)
 	if svcErr != nil {
-		return nil, mapOUServiceError(
+		return nil, mapOUServiceError(ctx,
 			svcErr,
 			logger,
 			"listing organization unit users",
@@ -333,7 +333,7 @@ func (us *userService) CreateUser(ctx context.Context, user *User) (*User, *serv
 		if svcErr := mapEntityError(err); svcErr != nil {
 			return nil, svcErr
 		}
-		return nil, logErrorAndReturnServerError(logger, "Failed to create user", err)
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to create user", err)
 	}
 
 	// Sync cleaned attributes back — entity service removed credential fields from Attributes.
@@ -358,7 +358,7 @@ func (us *userService) CreateUserByPath(
 
 	ou, svcErr := us.ouService.GetOrganizationUnitByPath(ctx, handlePath)
 	if svcErr != nil {
-		return nil, mapOUServiceError(
+		return nil, mapOUServiceError(ctx,
 			svcErr,
 			logger,
 			"resolving organization unit by path",
@@ -396,7 +396,7 @@ func (us *userService) GetUser(
 			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
-		return nil, logErrorAndReturnServerError(logger, "Failed to retrieve user", err,
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 	if e.Category != entity.EntityCategoryUser {
@@ -448,7 +448,7 @@ func (as *userService) GetUserGroups(ctx context.Context, userID string, limit, 
 			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
-		return nil, logErrorAndReturnServerError(logger, "Failed to retrieve user", err,
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 	if userEntity.Category != entity.EntityCategoryUser {
@@ -509,7 +509,7 @@ func (us *userService) UpdateUser(
 			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
-		return nil, logErrorAndReturnServerError(logger, "Failed to retrieve user", err,
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 	if existingEntity.Category != entity.EntityCategoryUser {
@@ -554,7 +554,7 @@ func (us *userService) UpdateUser(
 		if svcErr := mapEntityError(err); svcErr != nil {
 			return nil, svcErr
 		}
-		return nil, logErrorAndReturnServerError(logger, "Failed to update user", err,
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to update user", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
@@ -584,7 +584,7 @@ func (us *userService) UpdateUserAttributes(
 			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
-		return nil, logErrorAndReturnServerError(logger, "Failed to get user", getErr,
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to get user", getErr,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 	if existingEntity.Category != entity.EntityCategoryUser {
@@ -604,7 +604,7 @@ func (us *userService) UpdateUserAttributes(
 		if svcErr.Code == entitytype.ErrorEntityTypeNotFound.Code {
 			return nil, &ErrorEntityTypeNotFound
 		}
-		return nil, logErrorAndReturnServerError(logger, "Failed to get credential attributes from schema",
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to get credential attributes from schema",
 			fmt.Errorf("schema service error: %s", svcErr.ErrorDescription.DefaultValue),
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
@@ -637,7 +637,7 @@ func (us *userService) UpdateUserAttributes(
 		if svcErr := mapEntityError(err); svcErr != nil {
 			return nil, svcErr
 		}
-		return nil, logErrorAndReturnServerError(logger, "Failed to update user attributes", err,
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to update user attributes", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
@@ -680,7 +680,7 @@ func (us *userService) UpdateUserCredentials(
 			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return &ErrorUserNotFound
 		}
-		return logErrorAndReturnServerError(logger, "Failed to retrieve user", err,
+		return logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 	if existingEntity.Category != entity.EntityCategoryUser {
@@ -715,14 +715,14 @@ func (us *userService) UpdateUserCredentials(
 
 	plaintextJSON, err := json.Marshal(plaintextCreds)
 	if err != nil {
-		return logErrorAndReturnServerError(logger, "Failed to marshal credentials", err,
+		return logErrorAndReturnServerError(ctx, logger, "Failed to marshal credentials", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 	if err = us.entityService.UpdateCredentials(ctx, userID, plaintextJSON); err != nil {
 		if svcErr := mapEntityError(err); svcErr != nil {
 			return svcErr
 		}
-		return logErrorAndReturnServerError(logger, "Failed to update user credentials", err,
+		return logErrorAndReturnServerError(ctx, logger, "Failed to update user credentials", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
@@ -748,7 +748,7 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *serviceer
 			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return &ErrorUserNotFound
 		}
-		return logErrorAndReturnServerError(logger, "Failed to retrieve user", err,
+		return logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 	if existingEntity.Category != entity.EntityCategoryUser {
@@ -773,7 +773,7 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *serviceer
 			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return &ErrorUserNotFound
 		}
-		return logErrorAndReturnServerError(logger, "Failed to delete user", err,
+		return logErrorAndReturnServerError(ctx, logger, "Failed to delete user", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
@@ -844,7 +844,7 @@ func (us *userService) validateOrganizationUnitForUserType(
 
 	exists, svcErr := us.ouService.IsOrganizationUnitExists(ctx, oUID)
 	if svcErr != nil {
-		return mapOUServiceError(
+		return mapOUServiceError(ctx,
 			svcErr,
 			logger,
 			"verifying organization unit existence",
@@ -887,7 +887,7 @@ func (us *userService) validateOrganizationUnitForUserType(
 
 	isParent, svcErr := us.ouService.IsParent(ctx, entityType.OUID, oUID)
 	if svcErr != nil {
-		return mapOUServiceError(
+		return mapOUServiceError(ctx,
 			svcErr,
 			logger,
 			"validating organization unit hierarchy",
@@ -942,7 +942,7 @@ func validatePaginationParams(limit, offset int) *serviceerror.ServiceError {
 }
 
 // logErrorAndReturnServerError logs the error and returns a server error.
-func logErrorAndReturnServerError(
+func logErrorAndReturnServerError(ctx context.Context,
 	logger *log.Logger,
 	message string,
 	err error,
@@ -952,7 +952,7 @@ func logErrorAndReturnServerError(
 	if err != nil {
 		fields = append(fields, log.Error(err))
 	}
-	logger.Error(message, fields...)
+	logger.ErrorWithContext(ctx, message, fields...)
 	return &serviceerror.InternalServerError
 }
 
@@ -976,7 +976,7 @@ func mapEntityError(err error) *serviceerror.ServiceError {
 }
 
 // mapOUServiceError converts organization unit service errors to user service errors.
-func mapOUServiceError(
+func mapOUServiceError(ctx context.Context,
 	svcErr *serviceerror.ServiceError,
 	logger *log.Logger,
 	context string,
@@ -994,13 +994,14 @@ func mapOUServiceError(
 	if svcErr.Type == serviceerror.ClientErrorType {
 		logFields := append([]log.Field{}, fields...)
 		logFields = append(logFields, log.Any("error", svcErr))
-		logger.Error(fmt.Sprintf("Unexpected organization unit client error while %s", context), logFields...)
+		logger.ErrorWithContext(ctx, fmt.Sprintf("Unexpected organization unit client error while %s", context),
+			logFields...)
 		return &serviceerror.InternalServerError
 	}
 
 	logFields := append([]log.Field{}, fields...)
 	logFields = append(logFields, log.Any("error", svcErr))
-	logger.Error(fmt.Sprintf("Organization unit service error while %s", context), logFields...)
+	logger.ErrorWithContext(ctx, fmt.Sprintf("Organization unit service error while %s", context), logFields...)
 	return &serviceerror.InternalServerError
 }
 

--- a/backend/tests/mocks/authn/googlemock/GoogleOIDCAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/googlemock/GoogleOIDCAuthnServiceInterface_mock.go
@@ -344,8 +344,8 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(r
 }
 
 // GetIDTokenClaims provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
-func (_mock *GoogleOIDCAuthnServiceInterfaceMock) GetIDTokenClaims(idToken string) (map[string]interface{}, *serviceerror.ServiceError) {
-	ret := _mock.Called(idToken)
+func (_mock *GoogleOIDCAuthnServiceInterfaceMock) GetIDTokenClaims(ctx context.Context, idToken string) (map[string]interface{}, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetIDTokenClaims")
@@ -353,18 +353,18 @@ func (_mock *GoogleOIDCAuthnServiceInterfaceMock) GetIDTokenClaims(idToken strin
 
 	var r0 map[string]interface{}
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
-		return returnFunc(idToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) map[string]interface{}); ok {
-		r0 = returnFunc(idToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]interface{}); ok {
+		r0 = returnFunc(ctx, idToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idToken)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -379,19 +379,25 @@ type GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call struct {
 }
 
 // GetIDTokenClaims is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idToken string
-func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) GetIDTokenClaims(idToken interface{}) *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
-	return &GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call{Call: _e.mock.On("GetIDTokenClaims", idToken)}
+func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) GetIDTokenClaims(ctx interface{}, idToken interface{}) *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
+	return &GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call{Call: _e.mock.On("GetIDTokenClaims", ctx, idToken)}
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call) Run(run func(idToken string)) *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call) Run(run func(ctx context.Context, idToken string)) *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -402,7 +408,7 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call) Return(stri
 	return _c
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call) RunAndReturn(run func(idToken string) (map[string]interface{}, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call) RunAndReturn(run func(ctx context.Context, idToken string) (map[string]interface{}, *serviceerror.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/oidcmock/OIDCAuthnCoreServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oidcmock/OIDCAuthnCoreServiceInterface_mock.go
@@ -344,8 +344,8 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run
 }
 
 // GetIDTokenClaims provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
-func (_mock *OIDCAuthnCoreServiceInterfaceMock) GetIDTokenClaims(idToken string) (map[string]interface{}, *serviceerror.ServiceError) {
-	ret := _mock.Called(idToken)
+func (_mock *OIDCAuthnCoreServiceInterfaceMock) GetIDTokenClaims(ctx context.Context, idToken string) (map[string]interface{}, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetIDTokenClaims")
@@ -353,18 +353,18 @@ func (_mock *OIDCAuthnCoreServiceInterfaceMock) GetIDTokenClaims(idToken string)
 
 	var r0 map[string]interface{}
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
-		return returnFunc(idToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) map[string]interface{}); ok {
-		r0 = returnFunc(idToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]interface{}); ok {
+		r0 = returnFunc(ctx, idToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idToken)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -379,19 +379,25 @@ type OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call struct {
 }
 
 // GetIDTokenClaims is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idToken string
-func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) GetIDTokenClaims(idToken interface{}) *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call {
-	return &OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call{Call: _e.mock.On("GetIDTokenClaims", idToken)}
+func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) GetIDTokenClaims(ctx interface{}, idToken interface{}) *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call {
+	return &OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call{Call: _e.mock.On("GetIDTokenClaims", ctx, idToken)}
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call) Run(run func(idToken string)) *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call) Run(run func(ctx context.Context, idToken string)) *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -402,7 +408,7 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call) Return(string
 	return _c
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call) RunAndReturn(run func(idToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call) RunAndReturn(run func(ctx context.Context, idToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_GetIDTokenClaims_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/oidcmock/OIDCAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oidcmock/OIDCAuthnServiceInterface_mock.go
@@ -344,8 +344,8 @@ func (_c *OIDCAuthnServiceInterfaceMock_FetchUserInfo_Call) RunAndReturn(run fun
 }
 
 // GetIDTokenClaims provides a mock function for the type OIDCAuthnServiceInterfaceMock
-func (_mock *OIDCAuthnServiceInterfaceMock) GetIDTokenClaims(idToken string) (map[string]interface{}, *serviceerror.ServiceError) {
-	ret := _mock.Called(idToken)
+func (_mock *OIDCAuthnServiceInterfaceMock) GetIDTokenClaims(ctx context.Context, idToken string) (map[string]interface{}, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, idToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetIDTokenClaims")
@@ -353,18 +353,18 @@ func (_mock *OIDCAuthnServiceInterfaceMock) GetIDTokenClaims(idToken string) (ma
 
 	var r0 map[string]interface{}
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
-		return returnFunc(idToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]interface{}, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, idToken)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) map[string]interface{}); ok {
-		r0 = returnFunc(idToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]interface{}); ok {
+		r0 = returnFunc(ctx, idToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(idToken)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, idToken)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -379,19 +379,25 @@ type OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call struct {
 }
 
 // GetIDTokenClaims is a helper method to define mock.On call
+//   - ctx context.Context
 //   - idToken string
-func (_e *OIDCAuthnServiceInterfaceMock_Expecter) GetIDTokenClaims(idToken interface{}) *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
-	return &OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call{Call: _e.mock.On("GetIDTokenClaims", idToken)}
+func (_e *OIDCAuthnServiceInterfaceMock_Expecter) GetIDTokenClaims(ctx interface{}, idToken interface{}) *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
+	return &OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call{Call: _e.mock.On("GetIDTokenClaims", ctx, idToken)}
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call) Run(run func(idToken string)) *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call) Run(run func(ctx context.Context, idToken string)) *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -402,7 +408,7 @@ func (_c *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call) Return(stringToIf
 	return _c
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call) RunAndReturn(run func(idToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call) RunAndReturn(run func(ctx context.Context, idToken string) (map[string]interface{}, *serviceerror.ServiceError)) *OIDCAuthnServiceInterfaceMock_GetIDTokenClaims_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/emailmock/EmailClientInterface_mock.go
+++ b/backend/tests/mocks/emailmock/EmailClientInterface_mock.go
@@ -5,6 +5,8 @@
 package emailmock
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/system/email"
 )
@@ -37,16 +39,16 @@ func (_m *EmailClientInterfaceMock) EXPECT() *EmailClientInterfaceMock_Expecter 
 }
 
 // Send provides a mock function for the type EmailClientInterfaceMock
-func (_mock *EmailClientInterfaceMock) Send(emailData email.EmailData) error {
-	ret := _mock.Called(emailData)
+func (_mock *EmailClientInterfaceMock) Send(ctx context.Context, emailData email.EmailData) error {
+	ret := _mock.Called(ctx, emailData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Send")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(email.EmailData) error); ok {
-		r0 = returnFunc(emailData)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, email.EmailData) error); ok {
+		r0 = returnFunc(ctx, emailData)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,19 +61,25 @@ type EmailClientInterfaceMock_Send_Call struct {
 }
 
 // Send is a helper method to define mock.On call
+//   - ctx context.Context
 //   - emailData email.EmailData
-func (_e *EmailClientInterfaceMock_Expecter) Send(emailData interface{}) *EmailClientInterfaceMock_Send_Call {
-	return &EmailClientInterfaceMock_Send_Call{Call: _e.mock.On("Send", emailData)}
+func (_e *EmailClientInterfaceMock_Expecter) Send(ctx interface{}, emailData interface{}) *EmailClientInterfaceMock_Send_Call {
+	return &EmailClientInterfaceMock_Send_Call{Call: _e.mock.On("Send", ctx, emailData)}
 }
 
-func (_c *EmailClientInterfaceMock_Send_Call) Run(run func(emailData email.EmailData)) *EmailClientInterfaceMock_Send_Call {
+func (_c *EmailClientInterfaceMock_Send_Call) Run(run func(ctx context.Context, emailData email.EmailData)) *EmailClientInterfaceMock_Send_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 email.EmailData
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(email.EmailData)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 email.EmailData
+		if args[1] != nil {
+			arg1 = args[1].(email.EmailData)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -82,7 +90,7 @@ func (_c *EmailClientInterfaceMock_Send_Call) Return(err error) *EmailClientInte
 	return _c
 }
 
-func (_c *EmailClientInterfaceMock_Send_Call) RunAndReturn(run func(emailData email.EmailData) error) *EmailClientInterfaceMock_Send_Call {
+func (_c *EmailClientInterfaceMock_Send_Call) RunAndReturn(run func(ctx context.Context, emailData email.EmailData) error) *EmailClientInterfaceMock_Send_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/healthcheck/servicemock/HealthCheckServiceInterface_mock.go
+++ b/backend/tests/mocks/healthcheck/servicemock/HealthCheckServiceInterface_mock.go
@@ -5,6 +5,8 @@
 package servicemock
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/system/healthcheck/model"
 )
@@ -37,16 +39,16 @@ func (_m *HealthCheckServiceInterfaceMock) EXPECT() *HealthCheckServiceInterface
 }
 
 // CheckReadiness provides a mock function for the type HealthCheckServiceInterfaceMock
-func (_mock *HealthCheckServiceInterfaceMock) CheckReadiness() model.ServerStatus {
-	ret := _mock.Called()
+func (_mock *HealthCheckServiceInterfaceMock) CheckReadiness(ctx context.Context) model.ServerStatus {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckReadiness")
 	}
 
 	var r0 model.ServerStatus
-	if returnFunc, ok := ret.Get(0).(func() model.ServerStatus); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) model.ServerStatus); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		r0 = ret.Get(0).(model.ServerStatus)
 	}
@@ -59,13 +61,20 @@ type HealthCheckServiceInterfaceMock_CheckReadiness_Call struct {
 }
 
 // CheckReadiness is a helper method to define mock.On call
-func (_e *HealthCheckServiceInterfaceMock_Expecter) CheckReadiness() *HealthCheckServiceInterfaceMock_CheckReadiness_Call {
-	return &HealthCheckServiceInterfaceMock_CheckReadiness_Call{Call: _e.mock.On("CheckReadiness")}
+//   - ctx context.Context
+func (_e *HealthCheckServiceInterfaceMock_Expecter) CheckReadiness(ctx interface{}) *HealthCheckServiceInterfaceMock_CheckReadiness_Call {
+	return &HealthCheckServiceInterfaceMock_CheckReadiness_Call{Call: _e.mock.On("CheckReadiness", ctx)}
 }
 
-func (_c *HealthCheckServiceInterfaceMock_CheckReadiness_Call) Run(run func()) *HealthCheckServiceInterfaceMock_CheckReadiness_Call {
+func (_c *HealthCheckServiceInterfaceMock_CheckReadiness_Call) Run(run func(ctx context.Context)) *HealthCheckServiceInterfaceMock_CheckReadiness_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -75,7 +84,7 @@ func (_c *HealthCheckServiceInterfaceMock_CheckReadiness_Call) Return(serverStat
 	return _c
 }
 
-func (_c *HealthCheckServiceInterfaceMock_CheckReadiness_Call) RunAndReturn(run func() model.ServerStatus) *HealthCheckServiceInterfaceMock_CheckReadiness_Call {
+func (_c *HealthCheckServiceInterfaceMock_CheckReadiness_Call) RunAndReturn(run func(ctx context.Context) model.ServerStatus) *HealthCheckServiceInterfaceMock_CheckReadiness_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/observability/observabilitymock/ObservabilityServiceInterface_mock.go
+++ b/backend/tests/mocks/observability/observabilitymock/ObservabilityServiceInterface_mock.go
@@ -5,11 +5,13 @@
 package observabilitymock
 
 import (
+	"context"
+
+	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/observability/event"
 	"github.com/thunder-id/thunderid/internal/system/observability/publisher"
 	"github.com/thunder-id/thunderid/internal/system/observability/subscriber"
-	mock "github.com/stretchr/testify/mock"
 )
 
 // NewObservabilityServiceInterfaceMock creates a new instance of ObservabilityServiceInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -222,8 +224,8 @@ func (_c *ObservabilityServiceInterfaceMock_IsEnabled_Call) RunAndReturn(run fun
 }
 
 // PublishEvent provides a mock function for the type ObservabilityServiceInterfaceMock
-func (_mock *ObservabilityServiceInterfaceMock) PublishEvent(evt *event.Event) {
-	_mock.Called(evt)
+func (_mock *ObservabilityServiceInterfaceMock) PublishEvent(ctx context.Context, evt *event.Event) {
+	_mock.Called(ctx, evt)
 	return
 }
 
@@ -233,19 +235,25 @@ type ObservabilityServiceInterfaceMock_PublishEvent_Call struct {
 }
 
 // PublishEvent is a helper method to define mock.On call
+//   - ctx context.Context
 //   - evt *event.Event
-func (_e *ObservabilityServiceInterfaceMock_Expecter) PublishEvent(evt interface{}) *ObservabilityServiceInterfaceMock_PublishEvent_Call {
-	return &ObservabilityServiceInterfaceMock_PublishEvent_Call{Call: _e.mock.On("PublishEvent", evt)}
+func (_e *ObservabilityServiceInterfaceMock_Expecter) PublishEvent(ctx interface{}, evt interface{}) *ObservabilityServiceInterfaceMock_PublishEvent_Call {
+	return &ObservabilityServiceInterfaceMock_PublishEvent_Call{Call: _e.mock.On("PublishEvent", ctx, evt)}
 }
 
-func (_c *ObservabilityServiceInterfaceMock_PublishEvent_Call) Run(run func(evt *event.Event)) *ObservabilityServiceInterfaceMock_PublishEvent_Call {
+func (_c *ObservabilityServiceInterfaceMock_PublishEvent_Call) Run(run func(ctx context.Context, evt *event.Event)) *ObservabilityServiceInterfaceMock_PublishEvent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *event.Event
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*event.Event)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *event.Event
+		if args[1] != nil {
+			arg1 = args[1].(*event.Event)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -256,7 +264,7 @@ func (_c *ObservabilityServiceInterfaceMock_PublishEvent_Call) Return() *Observa
 	return _c
 }
 
-func (_c *ObservabilityServiceInterfaceMock_PublishEvent_Call) RunAndReturn(run func(evt *event.Event)) *ObservabilityServiceInterfaceMock_PublishEvent_Call {
+func (_c *ObservabilityServiceInterfaceMock_PublishEvent_Call) RunAndReturn(run func(ctx context.Context, evt *event.Event)) *ObservabilityServiceInterfaceMock_PublishEvent_Call {
 	_c.Run(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose

Add correlation IDs (request trace IDs) to backend application logs by migrating the remaining deprecated, non-context log calls to the context-aware `*WithContext` logging methods. This is the follow-up to the foundation PR (#3196), which introduced the `contextHandler` and the `InfoWithContext` / `DebugWithContext` / `WarnWithContext` / `ErrorWithContext` methods. With this PR, **every** application log statement in the backend now propagates the request context, so each log entry is stamped with the `trace_id` when one is present. Refs #2038.

This change spans **186 files** (123 non-test source files, 56 test files, 6 auto-generated mocks) across effectively every backend subsystem (`system`, `oauth`, `flow`, `authn`, `design`, `role`, `group`, `application`, `resource`, `notification`, `inboundclient`, `agent`, `user`, `ou`, `idp`, `entitytype`, `openid4vp`, `consent`, `cmd/server`).

There are **no functional or external API changes** — only logging propagation and internal signature additions of `context.Context`. The previously deprecated methods are **not** deleted in this PR (that is reserved for a later lock-in PR); after this change there are simply zero call sites using them.

### Approach

The migration was applied per call site according to the context source available, and verified against the compiler rather than text search (see Verification).

**1. Method-for-method migration.** Deprecated `Info`/`Debug`/`Warn`/`Error` calls were replaced with their `*WithContext` equivalents. To complete the method set, this PR also adds `FatalWithContext` and deprecates `Fatal` (it was the only logging method without a context-aware variant).

**2. Context source selection (per call site).**
- **Request-scoped code** — used the in-scope `ctx context.Context`, `r.Context()` for HTTP handlers, or `NodeContext.Context` / `EngineContext.Context` for flow execution.
- **Private helpers whose callers already had a context** — threaded `context.Context` as a parameter (e.g. `http_util` response writers `WriteJSONError` / `WriteSuccessResponse` / `WriteErrorResponse`, email `sendViaSMTP`, importer `normalize*ConfigForImport`, application `generateAndAssignClientID` / `resolveClientSecret`, inboundclient `buildInboundClientFromRow`).
- **Startup / lifecycle / infrastructure code** — there is no request scope, so `context.Background()` is used, each with a short rationale comment explaining why (service construction, subscriber `Initialize`/`Close`, declarative-resource loading, cache management, file-adapter I/O and its detached goroutines, server bootstrap, etc.).

**3. Threading context into the observability package.** `observability.PublishEvent` and the publisher's `Publish` now accept `context.Context`, so the synchronous publish path logs with the request trace. Because event dispatch and subscribers run in **detached goroutines** (after the request context may be cancelled), the event already carries its `TraceID`, and the async/subscriber side derives a logging context from it (`sysContext.WithTraceID(context.Background(), evt.TraceID)`). This keeps subscriber and adapter logs correlated without binding them to a possibly-cancelled request context. `event.NewEvent` intentionally keeps its `traceID string` argument because the flow engine deliberately uses the `ExecutionID` as the trace for node-level events.

**4. Mocks.** Interface signature changes (e.g. `PublishEvent`, `http_util` writers, several service interfaces) were followed by regenerating the affected mocks with `make mockery`. This also fixes a stale path in `.mockery.public.yml` that still pointed at `internal/observability` after the package was moved to `internal/system/observability`, which had been silently skipping regeneration of those mocks.

### Related Issues
- Fixes #2038

### Related PRs
- Follow-up to #3196 (introduced the `contextHandler` and the base `*WithContext` methods)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. (Confirmed `trace_id` is stamped on application logs end-to-end via a `/flow/execute` request carrying a correlation ID.)
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests (existing unit tests updated for the new signatures; all pass)
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

