### PR TITLE
Fix email executor with attribute resolution fallback

### DIFF
--- a/backend/internal/flow/executor/email_executor.go
+++ b/backend/internal/flow/executor/email_executor.go
@@ -157,16 +157,10 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 
 // resolveRecipientEmail retrieves the recipient email from user inputs, runtime data, or forwarded data.
 func (e *emailExecutor) resolveRecipientEmail(ctx *core.NodeContext, logger *log.Logger) (string, error) {
-	input, ok := findInputByType(ctx.NodeInputs, common.InputTypeEmail)
-	if !ok {
-		return "", errors.New("email input configuration is missing from node inputs")
-	}
-	emailAttr := input.Identifier
+	emailAttr := resolveInputIdentifierByType(ctx, common.InputTypeEmail, userAttributeEmail)
 
-	if recipientEmail, ok := ctx.ForwardedData[emailAttr]; ok {
-		if emailStr, isString := recipientEmail.(string); isString && emailStr != "" {
-			return emailStr, nil
-		}
+	if recipientEmail, ok := ctx.ForwardedData[emailAttr].(string); ok && recipientEmail != "" {
+		return recipientEmail, nil
 	}
 
 	if recipientEmail, ok := ctx.RuntimeData[emailAttr]; ok && recipientEmail != "" {

--- a/backend/internal/flow/executor/email_executor_test.go
+++ b/backend/internal/flow/executor/email_executor_test.go
@@ -1156,12 +1156,12 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_InvalidNodePropertySce
 	suite.Nil(resp)
 }
 
-func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingEmailInputConfig_Fails() {
+func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingEmailInputConfig_FallsBackToDefault() {
 	ctx := &core.NodeContext{
 		ExecutionID:  "test-execution-id",
 		FlowType:     common.FlowTypeUserOnboarding,
 		ExecutorMode: ExecutorModeSend,
-		NodeInputs:   []common.Input{}, // Missing EMAIL_INPUT
+		NodeInputs:   []common.Input{},
 		UserInputs: map[string]string{
 			"email": "user@example.com",
 		},
@@ -1170,11 +1170,26 @@ func (suite *EmailExecutorTestSuite) TestExecute_SendMode_MissingEmailInputConfi
 		},
 	}
 
+	suite.mockTemplateService.On("Render",
+		ctx.Context,
+		template.ScenarioType("USER_INVITE"),
+		template.TemplateTypeEmail,
+		template.TemplateData{},
+	).Return(&template.RenderedTemplate{
+		Subject: "Invite",
+		Body:    "Welcome",
+		IsHTML:  false,
+	}, nil)
+
+	suite.mockEmailClient.On("Send", mock.Anything, mock.MatchedBy(func(d email.EmailData) bool {
+		return len(d.To) == 1 && d.To[0] == "user@example.com"
+	})).Return(nil)
+
 	resp, err := suite.executor.Execute(ctx)
 
-	suite.Error(err)
-	suite.Contains(err.Error(), "email input configuration is missing from node inputs")
-	suite.Nil(resp)
+	suite.NoError(err)
+	suite.NotNil(resp)
+	suite.Equal(common.ExecComplete, resp.Status)
 }
 
 func (suite *EmailExecutorTestSuite) TestExecute_SendMode_ApplicationNameInTemplateData() {


### PR DESCRIPTION
### Purpose
This pull request updates the logic for resolving recipient email addresses in the email executor, allowing the system to fall back to a default identifier when the email input configuration is missing. The related unit test is also updated to reflect this new behavior, confirming that the executor will use the default and proceed successfully instead of failing.

### Approach
**Email recipient resolution improvements:**

* Modified `emailExecutor.resolveRecipientEmail` in `email_executor.go` to use `resolveInputIdentifierByType` for determining the email attribute, enabling fallback to a default identifier if the email input configuration is missing. The method now also simplifies the check for forwarded data by casting directly to a string.

**Test updates for new fallback behavior:**

* Updated the test `TestExecute_SendMode_MissingEmailInputConfig_FallsBackToDefault` in `email_executor_test.go` to expect successful execution when the email input config is missing, rather than an error. The test now mocks the template rendering and email sending, and asserts successful completion. [[1]](diffhunk://#diff-d1ffa0c7c0077f91feb399a7c146f23c97ef640c98ab16b6ae256eed1b9ad81eL1159-R1164) [[2]](diffhunk://#diff-d1ffa0c7c0077f91feb399a7c146f23c97ef640c98ab16b6ae256eed1b9ad81eR1173-R1192)

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3197

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email delivery now handles missing recipient configuration gracefully by falling back to defaults, preventing workflow failures.
* **Tests**
  * Updated tests to confirm fallback behavior and successful email sending with default recipient and template rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->