### PR TITLE
Remove deprecated logging methods and finalize the context-first logging methods

### DIFF
--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -192,3 +192,4 @@ rp_id
 EUDI
 [Vv]erifiable
 [Kk]rakenD
+[Gg]oroutines?

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -96,14 +96,6 @@ issues:
   exclude-use-default: false
   exclude-dirs:
     - tests/mocks
-  exclude-rules:
-    # Temporary during the correlation-ID log migration (issue #2038):
-    # suppress deprecation errors for the old non-context log methods until
-    # all call sites are migrated to the *Context variants. Remove this rule
-    # before deleting the deprecated methods so any stragglers fail loudly.
-    - linters:
-        - staticcheck
-      text: 'Use (Info|Debug|Warn|Error)WithContext instead\. Refs #2038'
 
 output:
   show-stats: true

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -65,14 +65,14 @@ func main() {
 
 	cfg := initThunderConfigurations(ctx, logger, serverHome)
 	if cfg == nil {
-		logger.FatalWithContext(ctx, "Failed to initialize configurations")
+		logger.Fatal(ctx, "Failed to initialize configurations")
 	}
 
 	// Install the CORS allowed-origins matcher used by the HTTP middleware.
 	// Compilation errors are already surfaced by config validation; this call
 	// rebuilds the rules and installs them as the cors package singleton.
 	if err := cors.InitializeMatcher(cfg.CORS.AllowedOrigins); err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize CORS matcher", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize CORS matcher", log.Error(err))
 	}
 
 	// Initialize the cache manager.
@@ -84,7 +84,7 @@ func main() {
 	// Create a new HTTP multiplexer.
 	mux := http.NewServeMux()
 	if mux == nil {
-		logger.FatalWithContext(ctx, "Failed to initialize multiplexer")
+		logger.Fatal(ctx, "Failed to initialize multiplexer")
 	}
 
 	// Register the services.
@@ -101,7 +101,7 @@ func main() {
 	server := createHTTPServer(ctx, logger, cfg, mux, jwtService)
 	var ln net.Listener
 	if cfg.Server.HTTPOnly {
-		logger.InfoWithContext(ctx, "TLS is not enabled, starting server without TLS")
+		logger.Info(ctx, "TLS is not enabled, starting server without TLS")
 		ln = createListener(ctx, logger, server)
 	} else {
 		tlsConfig := loadCertConfig(ctx, logger, runtimeCryptoSvc)
@@ -110,21 +110,21 @@ func main() {
 
 	serverURL := config.GetServerURL(&cfg.Server)
 	consoleURL := fmt.Sprintf("%s/console", strings.TrimSuffix(serverURL, "/"))
-	logger.InfoWithContext(ctx, "ThunderID Server URL", log.String("url", serverURL))
-	logger.InfoWithContext(ctx, "ThunderID Console URL", log.String("url", consoleURL))
+	logger.Info(ctx, "ThunderID Server URL", log.String("url", serverURL))
+	logger.Info(ctx, "ThunderID Console URL", log.String("url", consoleURL))
 
 	// Start server in a goroutine
 	go func() {
 		startupDuration := time.Since(startupStartedAt)
-		logger.InfoWithContext(ctx, "ThunderID Server started", log.String("startup_time", startupDuration.String()))
+		logger.Info(ctx, "ThunderID Server started", log.String("startup_time", startupDuration.String()))
 		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
-			logger.FatalWithContext(ctx, "Failed to serve requests", log.Error(err))
+			logger.Fatal(ctx, "Failed to serve requests", log.Error(err))
 		}
 	}()
 
 	// Wait for shutdown signal
 	<-sigChan
-	logger.InfoWithContext(ctx, "Shutting down server...")
+	logger.Info(ctx, "Shutting down server...")
 	gracefulShutdown(ctx, logger, server, cacheManager)
 }
 
@@ -136,14 +136,14 @@ func getThunderHome(ctx context.Context, logger *log.Logger) string {
 	flag.Parse()
 
 	if *projectHomeFlag != "" {
-		logger.InfoWithContext(ctx, "Using serverHome from command line argument",
+		logger.Info(ctx, "Using serverHome from command line argument",
 			log.String("serverHome", *projectHomeFlag))
 		projectHome = *projectHomeFlag
 	} else {
 		// If no command line argument is provided, use the current working directory.
 		dir, dirErr := os.Getwd()
 		if dirErr != nil {
-			logger.FatalWithContext(ctx, "Failed to get current working directory", log.Error(dirErr))
+			logger.Fatal(ctx, "Failed to get current working directory", log.Error(dirErr))
 		}
 		projectHome = dir
 	}
@@ -158,12 +158,12 @@ func initThunderConfigurations(ctx context.Context, logger *log.Logger, serverHo
 	defaultConfigPath := path.Join(serverHome, "repository/resources/conf/default.json")
 	cfg, err := config.LoadConfig(configFilePath, defaultConfigPath, serverHome)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to load configurations", log.Error(err))
+		logger.Fatal(ctx, "Failed to load configurations", log.Error(err))
 	}
 
 	// Initialize runtime configurations.
 	if err := config.InitializeServerRuntime(serverHome, cfg); err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize server runtime", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize server runtime", log.Error(err))
 	}
 
 	return cfg
@@ -173,7 +173,7 @@ func initThunderConfigurations(ctx context.Context, logger *log.Logger, serverHo
 func loadCertConfig(ctx context.Context, logger *log.Logger, runtimeSvc kmprovider.RuntimeCryptoProvider) *tls.Config {
 	mat, err := runtimeSvc.GetTLSMaterial(ctx)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to load TLS material", log.Error(err))
+		logger.Fatal(ctx, "Failed to load TLS material", log.Error(err))
 	}
 	// #nosec G402 -- MinVersion is set to TLS 1.2 or higher by GetTLSMaterial
 	return &tls.Config{
@@ -211,7 +211,7 @@ func createHTTPServer(ctx context.Context, logger *log.Logger, cfg *config.Confi
 func createListener(ctx context.Context, logger *log.Logger, server *http.Server) net.Listener {
 	ln, err := netListen("tcp", server.Addr)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to start HTTP listener", log.Error(err))
+		logger.Fatal(ctx, "Failed to start HTTP listener", log.Error(err))
 	}
 	return ln
 }
@@ -221,7 +221,7 @@ func createTLSListener(ctx context.Context, logger *log.Logger, server *http.Ser
 	tlsConfig *tls.Config) net.Listener {
 	ln, err := tlsListen("tcp", server.Addr, tlsConfig)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to start TLS listener", log.Error(err))
+		logger.Fatal(ctx, "Failed to start TLS listener", log.Error(err))
 	}
 	return ln
 }
@@ -230,7 +230,7 @@ func createSecurityMiddleware(ctx context.Context, logger *log.Logger, mux *http
 	jwtService jwt.JWTServiceInterface) http.Handler {
 	middlewareFunc, err := security.Initialize(jwtService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize security middleware", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize security middleware", log.Error(err))
 	}
 	return middlewareFunc(mux)
 }
@@ -247,9 +247,9 @@ func gracefulShutdown(
 
 	// Shutdown HTTP server
 	if err := server.Shutdown(ctx); err != nil {
-		logger.ErrorWithContext(ctx, "Error during server shutdown", log.Error(err))
+		logger.Error(ctx, "Error during server shutdown", log.Error(err))
 	} else {
-		logger.DebugWithContext(ctx, "HTTP server shutdown completed")
+		logger.Debug(ctx, "HTTP server shutdown completed")
 	}
 
 	// Shutdown services
@@ -258,17 +258,17 @@ func gracefulShutdown(
 	// Close database connections
 	dbCloser := provider.GetDBProviderCloser()
 	if err := dbCloser.Close(); err != nil {
-		logger.ErrorWithContext(ctx, "Error closing database connections", log.Error(err))
+		logger.Error(ctx, "Error closing database connections", log.Error(err))
 	} else {
-		logger.DebugWithContext(ctx, "Database connections closed successfully")
+		logger.Debug(ctx, "Database connections closed successfully")
 	}
 
 	if cacheManager != nil {
 		cacheManager.Close()
-		logger.DebugWithContext(ctx, "Cache manager closed successfully")
+		logger.Debug(ctx, "Cache manager closed successfully")
 	}
 
-	logger.InfoWithContext(ctx, "Server shutdown completed")
+	logger.Info(ctx, "Server shutdown completed")
 }
 
 // registerStaticFileHandlers registers static file handlers for frontend applications.
@@ -283,21 +283,21 @@ func registerStaticFileHandlers(ctx context.Context, logger *log.Logger, mux *ht
 	// Serve gate application from /gate
 	gateDir := path.Join(serverHome, "apps", "gate")
 	if directoryExists(gateDir) {
-		logger.DebugWithContext(ctx, "Registering static file handler for Gate application",
+		logger.Debug(ctx, "Registering static file handler for Gate application",
 			log.String("path", "/gate/"), log.String("directory", gateDir))
 		mux.Handle("/gate/", createStaticFileHandler("/gate/", gateDir, logger))
 	} else {
-		logger.WarnWithContext(ctx, "Gate application directory not found", log.String("directory", gateDir))
+		logger.Warn(ctx, "Gate application directory not found", log.String("directory", gateDir))
 	}
 
 	// Serve console application from /console
 	consoleDir := path.Join(serverHome, "apps", "console")
 	if directoryExists(consoleDir) {
-		logger.DebugWithContext(ctx, "Registering static file handler for Console application",
+		logger.Debug(ctx, "Registering static file handler for Console application",
 			log.String("path", "/console/"), log.String("directory", consoleDir))
 		mux.Handle("/console/", createStaticFileHandler("/console/", consoleDir, logger))
 	} else {
-		logger.WarnWithContext(ctx, "Console application directory not found", log.String("directory", consoleDir))
+		logger.Warn(ctx, "Console application directory not found", log.String("directory", consoleDir))
 	}
 }
 
@@ -330,7 +330,7 @@ func createStaticFileHandler(routePrefix, directory string, logger *log.Logger) 
 			// For SPA routing, serve index.html for non-existent files
 			indexPath := path.Join(directory, "index.html")
 			if fileExists(indexPath) {
-				logger.DebugWithContext(r.Context(), "Serving index.html for SPA routing",
+				logger.Debug(r.Context(), "Serving index.html for SPA routing",
 					log.String("requested_path", r.URL.Path),
 					log.String("route_prefix", routePrefix))
 				// Set no-cache headers for index.html

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -101,17 +101,17 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// Load the server's private key for signing JWTs.
 	pkiService, err := pki.Initialize()
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize certificate service", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize certificate service", log.Error(err))
 	}
 
 	runtimeCryptoSvc, _, err := kmprovider.Initialize(pkiService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize key manager provider", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize key manager provider", log.Error(err))
 	}
 
 	jwtService, jweService, err := jose.Initialize(runtimeCryptoSvc)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize JOSE services", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize JOSE services", log.Error(err))
 	}
 
 	observabilitySvc = observability.Initialize()
@@ -125,19 +125,19 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// Initialize i18n service for internationalization support.
 	i18nService, i18nExporter, err := i18nmgt.Initialize(mux, config.GetServerRuntime().Config.Translation)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize i18n service", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize i18n service", log.Error(err))
 	}
 	// Add to exporters list (must be done after initializing list)
 	exporters = append(exporters, i18nExporter)
 
 	ouAuthzService, err := sysauthz.Initialize()
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize system authorization service", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize system authorization service", log.Error(err))
 	}
 
 	ouService, ouHierarchyResolver, ouExporter, err := ou.Initialize(mux, mcpServer, cacheManager, ouAuthzService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize OrganizationUnitService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize OrganizationUnitService", log.Error(err))
 	}
 	exporters = append(exporters, ouExporter)
 
@@ -148,11 +148,11 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	hashCfg, err := buildHashConfig()
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to build HashService config", log.Error(err))
+		logger.Fatal(ctx, "Failed to build HashService config", log.Error(err))
 	}
 	hashService, err := cryptolib.Initialize(hashCfg)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize HashService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize HashService", log.Error(err))
 	}
 
 	// Initialize consent service
@@ -162,14 +162,14 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	entityTypeService, entityTypeExporter, err := entitytype.Initialize(
 		mux, mcpServer, cacheManager, ouService, ouAuthzService, consentService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize EntityTypeService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize EntityTypeService", log.Error(err))
 	}
 	exporters = append(exporters, entityTypeExporter)
 
 	// Initialize entity service
 	entityService, err := entity.Initialize(cacheManager, hashService, entityTypeService, ouService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize EntityService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize EntityService", log.Error(err))
 	}
 
 	// Initialize entity provider
@@ -179,7 +179,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		mux, entityService, ouService, entityTypeService, ouAuthzService,
 	)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize UserService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize UserService", log.Error(err))
 	}
 	exporters = append(exporters, userExporter)
 
@@ -187,7 +187,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		mux, dbprovider.GetDBProvider(), ouService, entityService, entityTypeService, ouAuthzService,
 	)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize GroupService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize GroupService", log.Error(err))
 	}
 	exporters = append(exporters, groupExporter)
 
@@ -197,33 +197,33 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	resourceService, resourceExporter, err := resource.Initialize(mux, ouService, consentService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize Resource Service", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize Resource Service", log.Error(err))
 	}
 	exporters = append(exporters, resourceExporter)
 	roleService, roleAssignmentService, roleExporter, err := role.Initialize(
 		mux, entityService, groupService, ouService, resourceService, entityTypeService,
 	)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize RoleService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize RoleService", log.Error(err))
 	}
 	exporters = append(exporters, roleExporter)
 	authZService := authz.Initialize(roleService)
 
 	idpService, idpExporter, err := idp.Initialize(cacheManager, mux)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize IDPService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize IDPService", log.Error(err))
 	}
 	exporters = append(exporters, idpExporter)
 
 	templateService, err := template.Initialize()
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize template service", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize template service", log.Error(err))
 	}
 
 	_, otpService, notifSenderSvc, notificationExporter, err := notification.Initialize(
 		mux, jwtService, templateService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize NotificationService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize NotificationService", log.Error(err))
 	}
 	exporters = append(exporters, notificationExporter)
 
@@ -268,7 +268,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	emailClient, err = email.Initialize()
 	if err != nil {
 		// Service registration runs at startup, outside any request.
-		logger.DebugWithContext(context.Background(), "Email client not configured. "+
+		logger.Debug(context.Background(), "Email client not configured. "+
 			"EmailExecutor will be registered but will not send emails.", log.Error(err))
 		emailClient = nil
 	}
@@ -277,7 +277,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// the engine itself.
 	openid4vpVerifierSvc, err := openid4vp.Initialize(mux, runtimeCryptoSvc, cacheManager, jwtService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize OpenID4VP verifier service", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize OpenID4VP verifier service", log.Error(err))
 	}
 
 	execRegistry := executor.Initialize(flowFactory, ouService, idpService, notifSenderSvc, jwtService, authAssertGen,
@@ -289,24 +289,24 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	flowMgtService, flowMgtExporter, err := flowmgt.Initialize(
 		mux, mcpServer, cacheManager, flowFactory, execRegistry, graphCache)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize FlowMgtService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize FlowMgtService", log.Error(err))
 	}
 	exporters = append(exporters, flowMgtExporter)
 	certservice, err := cert.Initialize(cacheManager, dbprovider.GetDBProvider())
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize CertificateService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize CertificateService", log.Error(err))
 	}
 
 	// Initialize theme and layout services
 	themeMgtService, themeExporter, err := thememgt.Initialize(mux, mcpServer)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize ThemeMgtService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize ThemeMgtService", log.Error(err))
 	}
 	exporters = append(exporters, themeExporter)
 
 	layoutMgtService, layoutExporter, err := layoutmgt.Initialize(mux)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize LayoutMgtService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize LayoutMgtService", log.Error(err))
 	}
 	exporters = append(exporters, layoutExporter)
 
@@ -314,20 +314,20 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		cacheManager, certservice, entityProvider,
 		themeMgtService, layoutMgtService, flowMgtService, entityTypeService, consentService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize InboundClientService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize InboundClientService", log.Error(err))
 	}
 
 	// TODO: Remove entityService dependency after finalizing declarative resource loading pattern
 	applicationService, applicationExporter, err := application.Initialize(
 		mux, mcpServer, entityProvider, entityService, inboundClientService, ouService, i18nService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize ApplicationService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize ApplicationService", log.Error(err))
 	}
 	exporters = append(exporters, applicationExporter)
 
 	agentService, agentExporter, err := agent.Initialize(mux, entityService, inboundClientService, ouService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize AgentService", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize AgentService", log.Error(err))
 	}
 	exporters = append(exporters, agentExporter)
 
@@ -362,7 +362,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	flowExecService, err := flowexec.Initialize(mux, flowMgtService, inboundClientService, entityProvider,
 		execRegistry, observabilitySvc, runtimeCryptoSvc)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize flow execution service", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize flow execution service", log.Error(err))
 	}
 
 	// Initialize OAuth services.
@@ -370,13 +370,13 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		flowExecService, observabilitySvc, runtimeCryptoSvc, ouService, attributeCacheService, authZService,
 		entityProvider, resourceService, i18nService, idpService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize OAuth services", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize OAuth services", log.Error(err))
 	}
 
 	// Register OAuth2 DCR service.
 	err = dcr.Initialize(mux, applicationService, ouService, i18nService)
 	if err != nil {
-		logger.FatalWithContext(ctx, "Failed to initialize OAuth2 DCR service", log.Error(err))
+		logger.Fatal(ctx, "Failed to initialize OAuth2 DCR service", log.Error(err))
 	}
 
 	// Register the health service.

--- a/backend/internal/agent/handler.go
+++ b/backend/internal/agent/handler.go
@@ -68,7 +68,7 @@ func (h *agentHandler) HandleAgentListRequest(w http.ResponseWriter, r *http.Req
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
-	logger.DebugWithContext(ctx, "Agent list returned",
+	logger.Debug(ctx, "Agent list returned",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", resp.TotalResults), log.Int("count", resp.Count))
 }

--- a/backend/internal/agent/service.go
+++ b/backend/internal/agent/service.go
@@ -95,7 +95,7 @@ func (s *agentService) CreateAgent(ctx context.Context, agent *model.Agent) (
 		var err error
 		agentID, err = sysutils.GenerateUUIDv7()
 		if err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to generate agent ID", log.Error(err))
+			s.logger.Error(ctx, "Failed to generate agent ID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -110,7 +110,7 @@ func (s *agentService) CreateAgent(ctx context.Context, agent *model.Agent) (
 	e, sysCredsJSON, buildErr := buildAgentEntity(agentID, agent.Type, agent.OUID, agent.Attributes,
 		agent.Name, agent.Description, owner, clientID, clientSecret)
 	if buildErr != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to build agent entity", log.Error(buildErr))
+		s.logger.Error(ctx, "Failed to build agent entity", log.Error(buildErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -119,7 +119,7 @@ func (s *agentService) CreateAgent(ctx context.Context, agent *model.Agent) (
 		if mapped := mapEntityError(entErr); mapped != nil {
 			return nil, mapped
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to create agent entity",
+		s.logger.Error(ctx, "Failed to create agent entity",
 			log.String("agentID", agentID), log.Error(entErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -168,7 +168,7 @@ func (s *agentService) GetAgent(ctx context.Context, agentID string, includeDisp
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return nil, &ErrorAgentNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to retrieve agent entity",
+		s.logger.Error(ctx, "Failed to retrieve agent entity",
 			log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -201,13 +201,13 @@ func (s *agentService) GetAgentList(ctx context.Context, limit, offset int,
 
 	totalCount, err := s.entityService.GetEntityListCount(ctx, entity.EntityCategoryAgent, filters)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to get agent list count", log.Error(err))
+		s.logger.Error(ctx, "Failed to get agent list count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	entities, err := s.entityService.GetEntityList(ctx, entity.EntityCategoryAgent, limit, offset, filters)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to get agent list", log.Error(err))
+		s.logger.Error(ctx, "Failed to get agent list", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -231,7 +231,7 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return nil, &ErrorAgentNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to retrieve agent entity for update",
+		s.logger.Error(ctx, "Failed to retrieve agent entity for update",
 			log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -254,7 +254,7 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 	var existingOAuthMethod string
 	existingOAuth, oauthErr := s.inboundClientService.GetOAuthProfileByEntityID(ctx, agentID)
 	if oauthErr != nil && !errors.Is(oauthErr, inboundclient.ErrInboundClientNotFound) {
-		s.logger.ErrorWithContext(ctx, "Failed to load existing OAuth profile",
+		s.logger.Error(ctx, "Failed to load existing OAuth profile",
 			log.String("agentID", agentID), log.Error(oauthErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -299,7 +299,7 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 	}
 	sysAttrsJSON, marshalErr := buildSystemAttributesJSON(req.Name, req.Description, owner, clientID)
 	if marshalErr != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to build system attributes for update", log.Error(marshalErr))
+		s.logger.Error(ctx, "Failed to build system attributes for update", log.Error(marshalErr))
 		return nil, &serviceerror.InternalServerError
 	}
 	updatedEntity.SystemAttributes = sysAttrsJSON
@@ -308,7 +308,7 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 		if mapped := mapEntityError(err); mapped != nil {
 			return nil, mapped
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to update agent entity", log.String("agentID", agentID), log.Error(err))
+		s.logger.Error(ctx, "Failed to update agent entity", log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -316,7 +316,7 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 		sysCredsJSON, credErr := buildSystemCredentialsJSON(clientSecret)
 		if credErr == nil && sysCredsJSON != nil {
 			if err := s.entityService.UpdateSystemCredentials(ctx, agentID, sysCredsJSON); err != nil {
-				s.logger.ErrorWithContext(ctx, "Failed to update agent system credentials",
+				s.logger.Error(ctx, "Failed to update agent system credentials",
 					log.String("agentID", agentID), log.Error(err))
 				return nil, &serviceerror.InternalServerError
 			}
@@ -356,7 +356,7 @@ func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *service
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return &ErrorAgentNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to retrieve agent for delete",
+		s.logger.Error(ctx, "Failed to retrieve agent for delete",
 			log.String("agentID", agentID), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
@@ -372,7 +372,7 @@ func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *service
 		if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 			return svcErr
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to delete inbound client for agent",
+		s.logger.Error(ctx, "Failed to delete inbound client for agent",
 			log.Error(err), log.String("agentID", agentID))
 		return &serviceerror.InternalServerError
 	}
@@ -381,7 +381,7 @@ func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *service
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return nil
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to delete agent entity", log.String("agentID", agentID), log.Error(err))
+		s.logger.Error(ctx, "Failed to delete agent entity", log.String("agentID", agentID), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil
@@ -405,7 +405,7 @@ func (s *agentService) GetAgentGroups(ctx context.Context, agentID string, limit
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return nil, &ErrorAgentNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to retrieve agent for groups",
+		s.logger.Error(ctx, "Failed to retrieve agent for groups",
 			log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -415,14 +415,14 @@ func (s *agentService) GetAgentGroups(ctx context.Context, agentID string, limit
 
 	totalCount, err := s.entityService.GetGroupCountForEntity(ctx, agentID)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to get agent group count",
+		s.logger.Error(ctx, "Failed to get agent group count",
 			log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	groups, err := s.entityService.GetEntityGroups(ctx, agentID, limit, offset)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to get agent groups", log.String("agentID", agentID), log.Error(err))
+		s.logger.Error(ctx, "Failed to get agent groups", log.String("agentID", agentID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -458,7 +458,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 			if svcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
 				return "", "", inboundmodel.InboundClient{}, &ErrorOrganizationUnitNotFound
 			}
-			s.logger.ErrorWithContext(ctx, "Failed to resolve OU handle", log.Any("error", svcErr))
+			s.logger.Error(ctx, "Failed to resolve OU handle", log.Any("error", svcErr))
 			return "", "", inboundmodel.InboundClient{}, &serviceerror.InternalServerError
 		}
 		agent.OUID = ou.ID
@@ -480,7 +480,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 		if clientID == "" {
 			generated, err := oauthutils.GenerateOAuth2ClientID()
 			if err != nil {
-				s.logger.ErrorWithContext(ctx, "Failed to generate client ID", log.Error(err))
+				s.logger.Error(ctx, "Failed to generate client ID", log.Error(err))
 				return "", "", inboundmodel.InboundClient{}, &serviceerror.InternalServerError
 			}
 			clientID = generated
@@ -493,7 +493,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 		if requiresClientSecret(oauthCfg) && oauthCfg.ClientSecret == "" {
 			generated, err := oauthutils.GenerateOAuth2ClientSecret()
 			if err != nil {
-				s.logger.ErrorWithContext(ctx, "Failed to generate client secret", log.Error(err))
+				s.logger.Error(ctx, "Failed to generate client secret", log.Error(err))
 				return "", "", inboundmodel.InboundClient{}, &serviceerror.InternalServerError
 			}
 			clientSecret = generated
@@ -506,7 +506,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 		if svcErr := translateInboundClientFKError(err); svcErr != nil {
 			return "", "", inboundmodel.InboundClient{}, svcErr
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to resolve inbound auth profile handles", log.Error(err))
+		s.logger.Error(ctx, "Failed to resolve inbound auth profile handles", log.Error(err))
 		return "", "", inboundmodel.InboundClient{}, &serviceerror.InternalServerError
 	}
 
@@ -521,7 +521,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 			if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 				return "", "", inboundmodel.InboundClient{}, svcErr
 			}
-			s.logger.ErrorWithContext(ctx, "Inbound client validation failed", log.Error(err))
+			s.logger.Error(ctx, "Inbound client validation failed", log.Error(err))
 			return "", "", inboundmodel.InboundClient{}, &serviceerror.InternalServerError
 		}
 	}
@@ -532,7 +532,7 @@ func (s *agentService) ValidateAgent(ctx context.Context, agent *model.Agent, ex
 // deleteEntityCompensation deletes the entity row as a best-effort rollback after a failed downstream operation.
 func (s *agentService) deleteEntityCompensation(ctx context.Context, agentID string) {
 	if err := s.entityService.DeleteEntity(ctx, agentID); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to delete entity during compensation",
+		s.logger.Error(ctx, "Failed to delete entity during compensation",
 			log.String("agentID", agentID), log.Error(err))
 	}
 }
@@ -547,7 +547,7 @@ func (s *agentService) validateOUExists(ctx context.Context, ouID string) *servi
 		if err.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
 			return &ErrorOrganizationUnitNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to verify OU existence", log.String("ouID", ouID), log.Any("error", err))
+		s.logger.Error(ctx, "Failed to verify OU existence", log.String("ouID", ouID), log.Any("error", err))
 		return &serviceerror.InternalServerError
 	}
 	if !exists {
@@ -567,7 +567,7 @@ func (s *agentService) resolveUpdateOUID(
 			if ouSvcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
 				return "", &ErrorOrganizationUnitNotFound
 			}
-			s.logger.ErrorWithContext(ctx, "Failed to resolve OU handle", log.Any("error", ouSvcErr))
+			s.logger.Error(ctx, "Failed to resolve OU handle", log.Any("error", ouSvcErr))
 			return "", &serviceerror.InternalServerError
 		}
 		req.OUID = ou.ID
@@ -609,7 +609,7 @@ func (s *agentService) validateOwnerExists(ctx context.Context, ownerID string) 
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return &ErrorOwnerNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to verify owner existence",
+		s.logger.Error(ctx, "Failed to verify owner existence",
 			log.String("ownerID", ownerID), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
@@ -629,7 +629,7 @@ func (s *agentService) validateNameUnique(ctx context.Context, name, excludeID s
 		if errors.Is(err, entity.ErrAmbiguousEntity) {
 			return &ErrorAgentAlreadyExistsWithName
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to verify agent name uniqueness", log.Error(err))
+		s.logger.Error(ctx, "Failed to verify agent name uniqueness", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if id == nil || *id == "" {
@@ -667,7 +667,7 @@ func (s *agentService) resolveOAuthCredentials(ctx context.Context,
 	if clientID == "" {
 		generated, err := oauthutils.GenerateOAuth2ClientID()
 		if err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to generate client ID", log.Error(err))
+			s.logger.Error(ctx, "Failed to generate client ID", log.Error(err))
 			return "", "", &serviceerror.InternalServerError
 		}
 		clientID = generated
@@ -689,7 +689,7 @@ func (s *agentService) resolveOAuthCredentials(ctx context.Context,
 		if !existingWasSecretBased {
 			generated, err := oauthutils.GenerateOAuth2ClientSecret()
 			if err != nil {
-				s.logger.ErrorWithContext(ctx, "Failed to generate client secret", log.Error(err))
+				s.logger.Error(ctx, "Failed to generate client secret", log.Error(err))
 				return "", "", &serviceerror.InternalServerError
 			}
 			clientSecret = generated
@@ -706,7 +706,7 @@ func (s *agentService) isClientIDTaken(
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return false, nil
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to check client ID availability", log.MaskedString("clientID", clientID),
+		s.logger.Error(ctx, "Failed to check client ID availability", log.MaskedString("clientID", clientID),
 			log.Error(err))
 		return false, &serviceerror.InternalServerError
 	}
@@ -735,7 +735,7 @@ func (s *agentService) createInboundForAgent(ctx context.Context, agentID string
 		if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 			return inboundmodel.InboundClient{}, nil, svcErr
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to create inbound client for agent",
+		s.logger.Error(ctx, "Failed to create inbound client for agent",
 			log.Error(err), log.String("agentID", agentID))
 		return inboundmodel.InboundClient{}, nil, &serviceerror.InternalServerError
 	}
@@ -758,7 +758,7 @@ func (s *agentService) reconcileInboundForUpdate(ctx context.Context, agentID st
 				if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 					return inboundmodel.InboundClient{}, nil, svcErr
 				}
-				s.logger.ErrorWithContext(ctx, "Failed to remove inbound client during update",
+				s.logger.Error(ctx, "Failed to remove inbound client during update",
 					log.Error(err), log.String("agentID", agentID))
 				return inboundmodel.InboundClient{}, nil, &serviceerror.InternalServerError
 			}
@@ -782,7 +782,7 @@ func (s *agentService) reconcileInboundForUpdate(ctx context.Context, agentID st
 			if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 				return inboundmodel.InboundClient{}, nil, svcErr
 			}
-			s.logger.ErrorWithContext(ctx, "Failed to update inbound client",
+			s.logger.Error(ctx, "Failed to update inbound client",
 				log.Error(err), log.String("agentID", agentID))
 			return inboundmodel.InboundClient{}, nil, &serviceerror.InternalServerError
 		}
@@ -794,7 +794,7 @@ func (s *agentService) reconcileInboundForUpdate(ctx context.Context, agentID st
 		if svcErr := s.translateInboundClientError(ctx, err); svcErr != nil {
 			return inboundmodel.InboundClient{}, nil, svcErr
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to create inbound client during update",
+		s.logger.Error(ctx, "Failed to create inbound client during update",
 			log.Error(err), log.String("agentID", agentID))
 		return inboundmodel.InboundClient{}, nil, &serviceerror.InternalServerError
 	}
@@ -821,7 +821,7 @@ func (s *agentService) composeGetResponse(ctx context.Context, e *entity.Entity)
 	inbound, err := s.inboundClientService.GetInboundClientByEntityID(ctx, e.ID)
 	if err != nil {
 		if !errors.Is(err, inboundclient.ErrInboundClientNotFound) {
-			s.logger.ErrorWithContext(ctx, "Failed to load inbound client for agent",
+			s.logger.Error(ctx, "Failed to load inbound client for agent",
 				log.String("agentID", e.ID), log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
@@ -839,7 +839,7 @@ func (s *agentService) composeGetResponse(ctx context.Context, e *entity.Entity)
 
 	oauth, oauthErr := s.inboundClientService.GetOAuthProfileByEntityID(ctx, e.ID)
 	if oauthErr != nil && !errors.Is(oauthErr, inboundclient.ErrInboundClientNotFound) {
-		s.logger.ErrorWithContext(ctx, "Failed to load OAuth profile for agent",
+		s.logger.Error(ctx, "Failed to load OAuth profile for agent",
 			log.String("agentID", e.ID), log.Error(oauthErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -911,7 +911,7 @@ func (s *agentService) buildListResponse(ctx context.Context, entities []entity.
 func (s *agentService) lookupOUHandle(ctx context.Context, ouID string) string {
 	handles, err := s.ouService.GetOrganizationUnitHandlesByIDs(ctx, []string{ouID})
 	if err != nil {
-		s.logger.DebugWithContext(ctx, "Failed to resolve OU handle for agent",
+		s.logger.Debug(ctx, "Failed to resolve OU handle for agent",
 			log.String("ouID", ouID), log.Any("error", err))
 		return ""
 	}
@@ -956,7 +956,7 @@ func (s *agentService) populateOUHandlesForList(ctx context.Context, agents []mo
 	}
 	handles, err := s.ouService.GetOrganizationUnitHandlesByIDs(ctx, ids)
 	if err != nil {
-		s.logger.DebugWithContext(ctx, "Failed to resolve OU handles for agent list", log.Any("error", err))
+		s.logger.Debug(ctx, "Failed to resolve OU handles for agent list", log.Any("error", err))
 		return
 	}
 	for i := range agents {
@@ -1603,7 +1603,7 @@ func translateCertValidationError(err error) *serviceerror.ServiceError {
 func (s *agentService) translateCertOperationError(
 	ctx context.Context, err *inboundclient.CertOperationError) *serviceerror.ServiceError {
 	if !err.IsClientError() {
-		s.logger.ErrorWithContext(ctx, "Certificate operation failed",
+		s.logger.Error(ctx, "Certificate operation failed",
 			log.Any("operation", err.Operation),
 			log.Any("refType", err.RefType),
 			log.Any("serviceError", err.Underlying))

--- a/backend/internal/agent/service_test.go
+++ b/backend/internal/agent/service_test.go
@@ -2126,3 +2126,314 @@ func (suite *AgentServiceTestSuite) TestUpdateAgent_ExplicitOUIDChanged_Validate
 	assert.Equal(suite.T(), ErrorOrganizationUnitNotFound.Code, svcErr.Code)
 	assert.Nil(suite.T(), resp)
 }
+
+// --- error-branch coverage ---
+
+func (suite *AgentServiceTestSuite) TestCreateAgent_EntityCreationFails_NonMappableError() {
+	svc, mockEntity, _, _ := suite.setupService()
+
+	clearMockCalls(mockEntity, "CreateEntity")
+	mockEntity.On("CreateEntity", mock.Anything, mock.Anything, mock.Anything).
+		Return((*entity.Entity)(nil), errors.New("db error"))
+
+	req := &model.Agent{Name: testAgentName, Type: testAgentType, OUID: testOUID}
+	resp, svcErr := svc.CreateAgent(context.Background(), req)
+	assert.Nil(suite.T(), resp)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestCreateAgent_InboundCreationFails_NonTranslatableError() {
+	svc, mockEntity, mockInbound, _ := suite.setupService()
+
+	createdEntity := buildAgentEntityFixture(testAgentName, "", "", "")
+	clearMockCalls(mockEntity, "CreateEntity")
+	mockEntity.On("CreateEntity", mock.Anything, mock.Anything, mock.Anything).
+		Return(createdEntity, nil)
+
+	clearMockCalls(mockInbound, "CreateInboundClient")
+	mockInbound.On("CreateInboundClient", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("inbound boom"))
+
+	clearMockCalls(mockEntity, "DeleteEntity")
+	mockEntity.On("DeleteEntity", mock.Anything, mock.Anything).Return(nil)
+
+	req := &model.Agent{
+		Name:               testAgentName,
+		Type:               testAgentType,
+		OUID:               testOUID,
+		InboundAuthProfile: inboundmodel.InboundAuthProfile{AuthFlowID: "flow-1"},
+	}
+	resp, svcErr := svc.CreateAgent(context.Background(), req)
+	assert.Nil(suite.T(), resp)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+	mockEntity.AssertCalled(suite.T(), "DeleteEntity", mock.Anything, mock.Anything)
+}
+
+func (suite *AgentServiceTestSuite) TestCreateAgent_InboundFails_CompensationDeleteFails() {
+	svc, mockEntity, mockInbound, _ := suite.setupService()
+
+	createdEntity := buildAgentEntityFixture(testAgentName, "", "", "")
+	clearMockCalls(mockEntity, "CreateEntity")
+	mockEntity.On("CreateEntity", mock.Anything, mock.Anything, mock.Anything).
+		Return(createdEntity, nil)
+
+	clearMockCalls(mockInbound, "CreateInboundClient")
+	mockInbound.On("CreateInboundClient", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("inbound boom"))
+
+	clearMockCalls(mockEntity, "DeleteEntity")
+	mockEntity.On("DeleteEntity", mock.Anything, mock.Anything).
+		Return(errors.New("compensation delete failed"))
+
+	req := &model.Agent{
+		Name:               testAgentName,
+		Type:               testAgentType,
+		OUID:               testOUID,
+		InboundAuthProfile: inboundmodel.InboundAuthProfile{AuthFlowID: "flow-1"},
+	}
+	resp, svcErr := svc.CreateAgent(context.Background(), req)
+	assert.Nil(suite.T(), resp)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+	mockEntity.AssertCalled(suite.T(), "DeleteEntity", mock.Anything, mock.Anything)
+}
+
+func (suite *AgentServiceTestSuite) TestUpdateAgent_ExistingOAuthProfileLoadError() {
+	svc, mockEntity, mockInbound, _ := suite.setupService()
+
+	agentEntity := buildAgentEntityFixture(testAgentName, "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	clearMockCalls(mockInbound, "GetOAuthProfileByEntityID")
+	mockInbound.On("GetOAuthProfileByEntityID", mock.Anything, testAgentID).
+		Return((*inboundmodel.OAuthProfile)(nil), errors.New("db error"))
+
+	resp, svcErr := svc.UpdateAgent(context.Background(), testAgentID, &model.UpdateAgentRequest{
+		Name: testAgentName, Type: testAgentType,
+	})
+	assert.Nil(suite.T(), resp)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestUpdateAgent_UpdateEntityFails_NonMappableError() {
+	svc, mockEntity, _, _ := suite.setupService()
+
+	agentEntity := buildAgentEntityFixture(testAgentName, "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	clearMockCalls(mockEntity, "UpdateEntity")
+	mockEntity.On("UpdateEntity", mock.Anything, testAgentID, mock.Anything).
+		Return((*entity.Entity)(nil), errors.New("db error"))
+
+	resp, svcErr := svc.UpdateAgent(context.Background(), testAgentID, &model.UpdateAgentRequest{
+		Name: testAgentName, Type: testAgentType,
+	})
+	assert.Nil(suite.T(), resp)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestUpdateAgent_UpdateSystemCredentialsFails() {
+	svc, mockEntity, mockInbound, _ := suite.setupService()
+
+	agentEntity := buildAgentEntityFixture("old-name", "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	clearMockCalls(mockEntity, "UpdateEntity")
+	mockEntity.On("UpdateEntity", mock.Anything, testAgentID, mock.Anything).
+		Return(&entity.Entity{}, nil)
+
+	clearMockCalls(mockEntity, "UpdateSystemCredentials")
+	mockEntity.On("UpdateSystemCredentials", mock.Anything, testAgentID, mock.Anything).
+		Return(errors.New("creds boom"))
+
+	clearMockCalls(mockInbound, "UpdateInboundClient")
+	mockInbound.On("UpdateInboundClient", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	clearMockCalls(mockInbound, "GetInboundClientByEntityID")
+	mockInbound.On("GetInboundClientByEntityID", mock.Anything, testAgentID).
+		Return(&inboundmodel.InboundClient{ID: testAgentID}, nil)
+
+	req := &model.UpdateAgentRequest{
+		Name: testAgentName,
+		Type: testAgentType,
+		InboundAuthConfig: []inboundmodel.InboundAuthConfigWithSecret{
+			{
+				Type: inboundmodel.OAuthInboundAuthType,
+				OAuthConfig: &inboundmodel.OAuthConfigWithSecret{
+					GrantTypes:              []oauth2const.GrantType{oauth2const.GrantTypeClientCredentials},
+					TokenEndpointAuthMethod: oauth2const.TokenEndpointAuthMethodClientSecretBasic,
+				},
+			},
+		},
+	}
+	resp, svcErr := svc.UpdateAgent(context.Background(), testAgentID, req)
+	assert.Nil(suite.T(), resp)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestUpdateAgent_ReconcileUpdateInboundFails_NonTranslatableError() {
+	svc, mockEntity, mockInbound, _ := suite.setupService()
+
+	agentEntity := buildAgentEntityFixture("old-name", "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	clearMockCalls(mockInbound, "GetInboundClientByEntityID")
+	mockInbound.On("GetInboundClientByEntityID", mock.Anything, testAgentID).
+		Return(&inboundmodel.InboundClient{ID: testAgentID}, nil)
+
+	clearMockCalls(mockInbound, "UpdateInboundClient")
+	mockInbound.On("UpdateInboundClient", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("update boom"))
+
+	req := &model.UpdateAgentRequest{
+		Name:               testAgentName,
+		Type:               testAgentType,
+		InboundAuthProfile: inboundmodel.InboundAuthProfile{AuthFlowID: "flow-1"},
+	}
+	resp, svcErr := svc.UpdateAgent(context.Background(), testAgentID, req)
+	assert.Nil(suite.T(), resp)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestUpdateAgent_ReconcileCreateInboundFails_NonTranslatableError() {
+	svc, mockEntity, mockInbound, _ := suite.setupService()
+
+	agentEntity := buildAgentEntityFixture("old-name", "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	clearMockCalls(mockInbound, "GetInboundClientByEntityID")
+	mockInbound.On("GetInboundClientByEntityID", mock.Anything, testAgentID).
+		Return((*inboundmodel.InboundClient)(nil), inboundclient.ErrInboundClientNotFound)
+
+	clearMockCalls(mockInbound, "CreateInboundClient")
+	mockInbound.On("CreateInboundClient", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("create boom"))
+
+	req := &model.UpdateAgentRequest{
+		Name:               testAgentName,
+		Type:               testAgentType,
+		InboundAuthProfile: inboundmodel.InboundAuthProfile{AuthFlowID: "flow-1"},
+	}
+	resp, svcErr := svc.UpdateAgent(context.Background(), testAgentID, req)
+	assert.Nil(suite.T(), resp)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestUpdateAgent_ReconcileDeleteInboundFails_NonTranslatableError() {
+	svc, mockEntity, mockInbound, _ := suite.setupService()
+
+	agentEntity := buildAgentEntityFixture("old-name", "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	clearMockCalls(mockInbound, "GetInboundClientByEntityID")
+	mockInbound.On("GetInboundClientByEntityID", mock.Anything, testAgentID).
+		Return(&inboundmodel.InboundClient{ID: testAgentID}, nil)
+
+	clearMockCalls(mockInbound, "DeleteInboundClient")
+	mockInbound.On("DeleteInboundClient", mock.Anything, testAgentID).
+		Return(errors.New("delete boom"))
+
+	req := &model.UpdateAgentRequest{Name: testAgentName, Type: testAgentType}
+	resp, svcErr := svc.UpdateAgent(context.Background(), testAgentID, req)
+	assert.Nil(suite.T(), resp)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestDeleteAgent_DeleteInboundClientFails_NonTranslatableError() {
+	svc, mockEntity, mockInbound, _ := suite.setupService()
+
+	agentEntity := buildAgentEntityFixture(testAgentName, "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	clearMockCalls(mockInbound, "DeleteInboundClient")
+	mockInbound.On("DeleteInboundClient", mock.Anything, testAgentID).
+		Return(errors.New("delete boom"))
+
+	svcErr := svc.DeleteAgent(context.Background(), testAgentID)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestDeleteAgent_DeleteEntityFails() {
+	svc, mockEntity, mockInbound, _ := suite.setupService()
+
+	agentEntity := buildAgentEntityFixture(testAgentName, "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	clearMockCalls(mockInbound, "DeleteInboundClient")
+	mockInbound.On("DeleteInboundClient", mock.Anything, testAgentID).
+		Return(inboundclient.ErrInboundClientNotFound)
+
+	clearMockCalls(mockEntity, "DeleteEntity")
+	mockEntity.On("DeleteEntity", mock.Anything, testAgentID).
+		Return(errors.New("delete entity boom"))
+
+	svcErr := svc.DeleteAgent(context.Background(), testAgentID)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestValidateAgent_ResolveHandlesFails_NonFKError() {
+	svc, _, mockInbound, _ := suite.setupService()
+
+	clearMockCalls(mockInbound, "ResolveInboundAuthProfileHandles")
+	mockInbound.On("ResolveInboundAuthProfileHandles", mock.Anything, mock.Anything).
+		Return(errors.New("resolve boom"))
+
+	req := &model.Agent{Name: testAgentName, Type: testAgentType, OUID: testOUID}
+	_, _, _, svcErr := svc.ValidateAgent(context.Background(), req, "")
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestValidateAgent_InboundValidateFails_NonTranslatableError() {
+	svc, _, mockInbound, _ := suite.setupService()
+
+	clearMockCalls(mockInbound, "Validate")
+	mockInbound.On("Validate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("validate boom"))
+
+	req := &model.Agent{
+		Name:               testAgentName,
+		Type:               testAgentType,
+		OUID:               testOUID,
+		InboundAuthProfile: inboundmodel.InboundAuthProfile{AuthFlowID: "flow-1"},
+	}
+	_, _, _, svcErr := svc.ValidateAgent(context.Background(), req, "")
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestValidateOUExists_StoreError_NonNotFound() {
+	svc, _, _, mockOU := suite.setupService()
+
+	otherErr := &serviceerror.ServiceError{Code: "SOME_OTHER_ERROR"}
+	clearMockCalls(mockOU, "IsOrganizationUnitExists")
+	mockOU.On("IsOrganizationUnitExists", mock.Anything, testOUID).
+		Return(false, otherErr)
+
+	svcErr := svc.validateOUExists(context.Background(), testOUID)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), serviceerror.InternalServerError.Code, svcErr.Code)
+}

--- a/backend/internal/application/handler.go
+++ b/backend/internal/application/handler.go
@@ -201,7 +201,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 	// TODO: Need to refactor when supporting other/multiple inbound auth types.
 	if len(appDTO.InboundAuthConfig) > 0 {
 		if appDTO.InboundAuthConfig[0].Type != inboundmodel.OAuthInboundAuthType {
-			logger.ErrorWithContext(ctx, "Unsupported inbound authentication type returned",
+			logger.Error(ctx, "Unsupported inbound authentication type returned",
 				log.String("type", string(appDTO.InboundAuthConfig[0].Type)))
 
 			errResp := apierror.ErrorResponse{
@@ -214,7 +214,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 		}
 
 		if appDTO.InboundAuthConfig[0].OAuthConfig == nil {
-			logger.ErrorWithContext(ctx, "OAuth application configuration is nil")
+			logger.Error(ctx, "OAuth application configuration is nil")
 
 			errResp := apierror.ErrorResponse{
 				Code:        serviceerror.InternalServerError.Code,
@@ -228,7 +228,7 @@ func (ah *applicationHandler) HandleApplicationGetRequest(w http.ResponseWriter,
 		returnInboundAuthConfigs := make([]inboundmodel.InboundAuthConfig, 0, len(appDTO.InboundAuthConfig))
 		for _, config := range appDTO.InboundAuthConfig {
 			if config.OAuthConfig == nil {
-				logger.ErrorWithContext(ctx, "OAuth application configuration is nil")
+				logger.Error(ctx, "OAuth application configuration is nil")
 				errResp := apierror.ErrorResponse{
 					Code:        serviceerror.InternalServerError.Code,
 					Message:     serviceerror.InternalServerError.Error,
@@ -414,21 +414,21 @@ func (ah *applicationHandler) processInboundAuthConfig(
 	returnApp *model.ApplicationCompleteResponse) bool {
 	if len(appDTO.InboundAuthConfig) > 0 {
 		if appDTO.InboundAuthConfig[0].Type != inboundmodel.OAuthInboundAuthType {
-			logger.ErrorWithContext(ctx, "Unsupported inbound authentication type returned",
+			logger.Error(ctx, "Unsupported inbound authentication type returned",
 				log.String("type", string(appDTO.InboundAuthConfig[0].Type)))
 
 			return false
 		}
 
 		if appDTO.InboundAuthConfig[0].OAuthConfig == nil {
-			logger.ErrorWithContext(ctx, "OAuth application configuration is nil")
+			logger.Error(ctx, "OAuth application configuration is nil")
 			return false
 		}
 
 		returnInboundAuthConfigs := make([]inboundmodel.InboundAuthConfigWithSecret, 0, len(appDTO.InboundAuthConfig))
 		for _, config := range appDTO.InboundAuthConfig {
 			if config.OAuthConfig == nil {
-				logger.ErrorWithContext(ctx, "OAuth application configuration is nil")
+				logger.Error(ctx, "OAuth application configuration is nil")
 				return false
 			}
 			redirectURIs := config.OAuthConfig.RedirectURIs
@@ -495,7 +495,7 @@ func (ah *applicationHandler) handleError(ctx context.Context, w http.ResponseWr
 
 	if statusCode == http.StatusInternalServerError {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ApplicationHandler"))
-		logger.ErrorWithContext(ctx, "Internal server error processing application request",
+		logger.Error(ctx, "Internal server error processing application request",
 			log.String("method", r.Method),
 			log.String("path", r.URL.Path),
 			log.String("error_code", svcErr.Code),

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -87,7 +87,7 @@ func newApplicationService(
 
 func (as *applicationService) deleteEntityCompensation(ctx context.Context, appID string) {
 	if delErr := as.entityProvider.DeleteEntity(appID); delErr != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to delete entity during compensation", log.Error(delErr),
+		as.logger.Error(ctx, "Failed to delete entity during compensation", log.Error(delErr),
 			log.String("appID", appID))
 	}
 }
@@ -128,7 +128,7 @@ func (as *applicationService) CreateApplication(ctx context.Context, app *model.
 
 	appEntity, sysCredsJSON, buildErr := buildAppEntity(appID, app, clientID, clientSecret)
 	if buildErr != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to build entity for create", log.Error(buildErr))
+		as.logger.Error(ctx, "Failed to build entity for create", log.Error(buildErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -137,7 +137,7 @@ func (as *applicationService) CreateApplication(ctx context.Context, app *model.
 		if svcErr := mapEntityProviderError(epErr); svcErr != nil {
 			return nil, svcErr
 		}
-		as.logger.ErrorWithContext(ctx, "Failed to create application entity",
+		as.logger.Error(ctx, "Failed to create application entity",
 			log.String("appID", appID), log.Error(epErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -150,7 +150,7 @@ func (as *applicationService) CreateApplication(ctx context.Context, app *model.
 		if svcErr := as.translateInboundClientError(ctx, err); svcErr != nil {
 			return nil, svcErr
 		}
-		as.logger.ErrorWithContext(ctx, "Failed to create application", log.Error(err), log.String("appID", appID))
+		as.logger.Error(ctx, "Failed to create application", log.Error(err), log.String("appID", appID))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -209,7 +209,7 @@ func (as *applicationService) ValidateApplication(ctx context.Context, app *mode
 		var err error
 		appID, err = sysutils.GenerateUUIDv7()
 		if err != nil {
-			as.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+			as.logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, nil, &serviceerror.InternalServerError
 		}
 	}
@@ -234,7 +234,7 @@ func (as *applicationService) ValidateApplication(ctx context.Context, app *mode
 		if svcErr := as.translateInboundClientError(ctx, err); svcErr != nil {
 			return nil, nil, svcErr
 		}
-		as.logger.ErrorWithContext(ctx, "Inbound client validation failed", log.Error(err))
+		as.logger.Error(ctx, "Inbound client validation failed", log.Error(err))
 		return nil, nil, &serviceerror.InternalServerError
 	}
 	processedDTO.AuthFlowID = inboundClient.AuthFlowID
@@ -249,14 +249,14 @@ func (as *applicationService) GetApplicationList(
 	ctx context.Context) (*model.ApplicationListResponse, *serviceerror.ServiceError) {
 	totalResults, epErr := as.entityProvider.GetEntityListCount(entityprovider.EntityCategoryApp, nil)
 	if epErr != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to count application entities", log.Error(epErr))
+		as.logger.Error(ctx, "Failed to count application entities", log.Error(epErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	entities, epErr := as.entityProvider.GetEntityList(
 		entityprovider.EntityCategoryApp, serverconst.MaxCompositeStoreRecords, 0, nil)
 	if epErr != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to list application entities", log.Error(epErr))
+		as.logger.Error(ctx, "Failed to list application entities", log.Error(epErr))
 		return nil, &serviceerror.InternalServerError
 	}
 	if len(entities) == 0 {
@@ -273,7 +273,7 @@ func (as *applicationService) GetApplicationList(
 		if errors.Is(err, inboundclient.ErrCompositeResultLimitExceeded) {
 			return nil, &ErrorResultLimitExceeded
 		}
-		as.logger.ErrorWithContext(ctx, "Failed to list inbound clients", log.Error(err))
+		as.logger.Error(ctx, "Failed to list inbound clients", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -292,7 +292,7 @@ func (as *applicationService) GetApplicationList(
 	for i := range entities {
 		cfg := configMap[entities[i].ID]
 		if cfg == nil {
-			as.logger.WarnWithContext(ctx, "Application entity has no inbound-client row; skipping in list",
+			as.logger.Warn(ctx, "Application entity has no inbound-client row; skipping in list",
 				log.String("appID", entities[i].ID))
 			continue
 		}
@@ -315,7 +315,7 @@ func (as *applicationService) GetOAuthApplication(
 
 	client, err := as.inboundClientService.GetOAuthClientByClientID(ctx, clientID)
 	if err != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to retrieve OAuth client", log.Error(err),
+		as.logger.Error(ctx, "Failed to retrieve OAuth client", log.Error(err),
 			log.MaskedString("clientID", clientID))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -325,7 +325,7 @@ func (as *applicationService) GetOAuthApplication(
 
 	entity, epErr := as.entityProvider.GetEntity(client.ID)
 	if epErr != nil && epErr.Code != entityprovider.ErrorCodeEntityNotFound {
-		as.logger.ErrorWithContext(ctx, "Failed to load entity for OAuth client",
+		as.logger.Error(ctx, "Failed to load entity for OAuth client",
 			log.String("entityID", client.ID), log.Error(epErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -385,7 +385,7 @@ func (as *applicationService) UpdateApplication(ctx context.Context, appID strin
 		if svcErr := as.translateInboundClientError(ctx, err); svcErr != nil {
 			return nil, svcErr
 		}
-		as.logger.ErrorWithContext(ctx, "Failed to update application", log.Error(err), log.String("appID", appID))
+		as.logger.Error(ctx, "Failed to update application", log.Error(err), log.String("appID", appID))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -434,7 +434,7 @@ func (as *applicationService) updateEntityDataForApplicationUpdate(ctx context.C
 
 	sysAttrsJSON, marshalErr := buildSystemAttributes(app, clientID)
 	if marshalErr != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to build entity system attributes for update", log.Error(marshalErr))
+		as.logger.Error(ctx, "Failed to build entity system attributes for update", log.Error(marshalErr))
 		return &serviceerror.InternalServerError
 	}
 
@@ -442,7 +442,7 @@ func (as *applicationService) updateEntityDataForApplicationUpdate(ctx context.C
 		if svcErr := mapEntityProviderError(epErr); svcErr != nil {
 			return svcErr
 		}
-		as.logger.ErrorWithContext(ctx, "Failed to update entity system attributes",
+		as.logger.Error(ctx, "Failed to update entity system attributes",
 			log.String("appID", appID), log.Error(epErr))
 		return &serviceerror.InternalServerError
 	}
@@ -457,7 +457,7 @@ func (as *applicationService) updateEntityDataForApplicationUpdate(ctx context.C
 			if svcErr := mapEntityProviderError(epErr); svcErr != nil {
 				return svcErr
 			}
-			as.logger.ErrorWithContext(ctx, "Failed to clear entity system credentials",
+			as.logger.Error(ctx, "Failed to clear entity system credentials",
 				log.String("appID", appID), log.Error(epErr))
 			return &serviceerror.InternalServerError
 		}
@@ -469,7 +469,7 @@ func (as *applicationService) updateEntityDataForApplicationUpdate(ctx context.C
 
 	sysCredsJSON, marshalErr := buildSystemCredentials(inboundAuthConfig.OAuthConfig.ClientSecret)
 	if marshalErr != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to build entity system credentials for update", log.Error(marshalErr))
+		as.logger.Error(ctx, "Failed to build entity system credentials for update", log.Error(marshalErr))
 		return &serviceerror.InternalServerError
 	}
 
@@ -477,7 +477,7 @@ func (as *applicationService) updateEntityDataForApplicationUpdate(ctx context.C
 		if svcErr := mapEntityProviderError(epErr); svcErr != nil {
 			return svcErr
 		}
-		as.logger.ErrorWithContext(ctx, "Failed to update entity system credentials",
+		as.logger.Error(ctx, "Failed to update entity system credentials",
 			log.String("appID", appID), log.Error(epErr))
 		return &serviceerror.InternalServerError
 	}
@@ -513,7 +513,7 @@ func (as *applicationService) DeleteApplication(ctx context.Context, appID strin
 
 	if existing, epErr := as.entityProvider.GetEntity(appID); epErr != nil {
 		if epErr.Code != entityprovider.ErrorCodeEntityNotFound {
-			as.logger.ErrorWithContext(ctx, "Failed to load entity before delete",
+			as.logger.Error(ctx, "Failed to load entity before delete",
 				log.String("appID", appID), log.Error(epErr))
 			return &serviceerror.InternalServerError
 		}
@@ -529,7 +529,7 @@ func (as *applicationService) DeleteApplication(ctx context.Context, appID strin
 		if svcErr := as.translateInboundClientError(ctx, appErr); svcErr != nil {
 			return svcErr
 		}
-		as.logger.ErrorWithContext(ctx, "Failed to delete application", log.Error(appErr), log.String("appID", appID))
+		as.logger.Error(ctx, "Failed to delete application", log.Error(appErr), log.String("appID", appID))
 		return &serviceerror.InternalServerError
 	}
 
@@ -538,7 +538,7 @@ func (as *applicationService) DeleteApplication(ctx context.Context, appID strin
 		if svcErr := mapEntityProviderError(epErr); svcErr != nil {
 			return svcErr
 		}
-		as.logger.ErrorWithContext(ctx, "Failed to delete application entity",
+		as.logger.Error(ctx, "Failed to delete application entity",
 			log.String("appID", appID), log.Error(epErr))
 		return &serviceerror.InternalServerError
 	}
@@ -556,7 +556,7 @@ func (as *applicationService) isIdentifierTaken(
 		if epErr.Code == entityprovider.ErrorCodeEntityNotFound {
 			return false, nil
 		}
-		as.logger.ErrorWithContext(ctx, "Failed to check identifier availability",
+		as.logger.Error(ctx, "Failed to check identifier availability",
 			log.String("key", key), log.String("value", value), log.Error(epErr))
 		return false, &serviceerror.InternalServerError
 	}
@@ -586,7 +586,7 @@ func (as *applicationService) getApplication(
 		if epErr.Code == entityprovider.ErrorCodeEntityNotFound {
 			entity = nil
 		} else {
-			as.logger.ErrorWithContext(ctx, "Failed to get entity for application",
+			as.logger.Error(ctx, "Failed to get entity for application",
 				log.String("appID", appID), log.Error(epErr))
 			return nil, &serviceerror.InternalServerError
 		}
@@ -598,7 +598,7 @@ func (as *applicationService) getApplication(
 
 	oauthProfile, err := as.inboundClientService.GetOAuthProfileByEntityID(ctx, appID)
 	if err != nil && !errors.Is(err, inboundclient.ErrInboundClientNotFound) {
-		as.logger.ErrorWithContext(ctx, "Failed to get OAuth profile for application",
+		as.logger.Error(ctx, "Failed to get OAuth profile for application",
 			log.String("appID", appID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -925,7 +925,7 @@ func (as *applicationService) validateApplicationFields(
 	// Resolve ou_handle to an ID when the direct ID is absent.
 	// If both are provided, ou_id wins and a warning is logged.
 	if app.OUID != "" && app.OUHandle != "" {
-		as.logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided for application; ou_handle ignored",
+		as.logger.Warn(ctx, "Both ou_id and ou_handle provided for application; ou_handle ignored",
 			log.String("appID", app.ID), log.String("name", app.Name))
 	} else if app.OUID == "" && app.OUHandle != "" {
 		ou, svcErr := as.ouService.GetOrganizationUnitByPath(ctx, app.OUHandle)
@@ -1342,7 +1342,7 @@ func translateCertValidationError(err error) *serviceerror.ServiceError {
 func (as *applicationService) translateCertOperationError(ctx context.Context,
 	err *inboundclient.CertOperationError) *serviceerror.ServiceError {
 	if !err.IsClientError() {
-		as.logger.ErrorWithContext(ctx, "Certificate operation failed",
+		as.logger.Error(ctx, "Certificate operation failed",
 			log.Any("operation", err.Operation),
 			log.Any("refType", err.RefType),
 			log.Any("serviceError", err.Underlying))
@@ -1453,7 +1453,7 @@ func generateAndAssignClientID(
 ) *serviceerror.ServiceError {
 	generatedClientID, err := oauthutils.GenerateOAuth2ClientID()
 	if err != nil {
-		log.GetLogger().ErrorWithContext(ctx, "Failed to generate OAuth client ID", log.Error(err))
+		log.GetLogger().Error(ctx, "Failed to generate OAuth client ID", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	inboundAuthConfig.OAuthConfig.ClientID = generatedClientID
@@ -1487,7 +1487,7 @@ func resolveClientSecret(
 
 	generatedClientSecret, err := oauthutils.GenerateOAuth2ClientSecret()
 	if err != nil {
-		log.GetLogger().ErrorWithContext(ctx, "Failed to generate OAuth client secret", log.Error(err))
+		log.GetLogger().Error(ctx, "Failed to generate OAuth client secret", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -1775,7 +1775,7 @@ func (as *applicationService) mapStoreError(ctx context.Context, err error) *ser
 	if errors.Is(err, inboundclient.ErrInboundClientNotFound) {
 		return &ErrorApplicationNotFound
 	}
-	as.logger.ErrorWithContext(ctx, "Failed to retrieve application", log.Error(err))
+	as.logger.Error(ctx, "Failed to retrieve application", log.Error(err))
 	return &serviceerror.InternalServerError
 }
 
@@ -1789,7 +1789,7 @@ func (as *applicationService) deleteLocalizedVariants(ctx context.Context, appID
 	for _, field := range []string{"name", "logo_uri", "tos_uri", "policy_uri"} {
 		if svcErr := as.i18nService.DeleteTranslationsByKey(
 			ctx, AppI18nNamespace(), AppI18nKey(appID, field)); svcErr != nil {
-			as.logger.ErrorWithContext(ctx, "Failed to delete localized variant on app deletion",
+			as.logger.Error(ctx, "Failed to delete localized variant on app deletion",
 				log.String("appID", appID),
 				log.String("field", field),
 				log.String("namespace", AppI18nNamespace()))
@@ -1823,7 +1823,7 @@ func (as *applicationService) cleanupStaleI18nKeys(
 		if isI18nRef(f.old) && !isI18nRef(f.updated) {
 			if svcErr := as.i18nService.DeleteTranslationsByKey(
 				ctx, AppI18nNamespace(), AppI18nKey(appID, f.field)); svcErr != nil {
-				as.logger.ErrorWithContext(ctx, "Failed to delete stale i18n key",
+				as.logger.Error(ctx, "Failed to delete stale i18n key",
 					log.String("appID", appID),
 					log.String("field", f.field),
 					log.String("namespace", AppI18nNamespace()))

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -41,6 +41,7 @@ import (
 	i18ncore "github.com/thunder-id/thunderid/internal/system/i18n/core"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/entityprovidermock"
+	"github.com/thunder-id/thunderid/tests/mocks/i18n/mgtmock"
 	"github.com/thunder-id/thunderid/tests/mocks/inboundclientmock"
 	"github.com/thunder-id/thunderid/tests/mocks/oumock"
 )
@@ -3406,4 +3407,250 @@ func (suite *ServiceTestSuite) TestValidateApplicationFields_FlowHandleResolutio
 
 	assert.NotNil(suite.T(), svcErr)
 	assert.Equal(suite.T(), ErrorInvalidRequestFormat.Code, svcErr.Code)
+}
+
+func (suite *ServiceTestSuite) TestCreateApplication_CreateInboundClientFailsAndCompensationFails() {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: false,
+		},
+	}
+	config.ResetServerRuntime()
+	err := config.InitializeServerRuntime("/tmp/test", testConfig)
+	require.NoError(suite.T(), err)
+	defer config.ResetServerRuntime()
+
+	service, mockStore := suite.setupTestService()
+
+	app := &model.ApplicationDTO{
+		Name: "Test App",
+		OUID: testOUID,
+		InboundAuthProfile: inboundmodel.InboundAuthProfile{
+			AuthFlowID:         "edc013d0-e893-4dc0-990c-3e1d203e005b",
+			RegistrationFlowID: "80024fb3-29ed-4c33-aa48-8aee5e96d522",
+		},
+	}
+
+	mockStore.On("CreateInboundClient",
+		mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(errors.New("internal server error"))
+
+	ep := resetEntityProviderMethod(service, "DeleteEntity")
+	ep.On("DeleteEntity", mock.Anything).
+		Return(entityprovider.NewEntityProviderError(
+			entityprovider.ErrorCodeSystemError, "delete failed", ""))
+
+	result, svcErr := service.CreateApplication(context.Background(), app)
+
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestValidateApplication_InboundClientValidateError() {
+	service, mockStore := suite.setupTestService()
+
+	for i, c := range mockStore.ExpectedCalls {
+		if c.Method == "Validate" {
+			mockStore.ExpectedCalls = append(mockStore.ExpectedCalls[:i], mockStore.ExpectedCalls[i+1:]...)
+			break
+		}
+	}
+	mockStore.On("Validate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("validation failed"))
+
+	app := &model.ApplicationDTO{
+		Name: "Test App",
+		OUID: testOUID,
+	}
+
+	processed, inboundAuthConfig, svcErr := service.ValidateApplication(context.Background(), app)
+
+	assert.Nil(suite.T(), processed)
+	assert.Nil(suite.T(), inboundAuthConfig)
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestGetApplicationList_CountError() {
+	service, _ := suite.setupTestService()
+
+	resetEntityProviderMethod(service, "GetEntityListCount").
+		On("GetEntityListCount", entityprovider.EntityCategoryApp, mock.Anything).
+		Return(0, entityprovider.NewEntityProviderError(
+			entityprovider.ErrorCodeSystemError, "count failed", ""))
+
+	result, svcErr := service.GetApplicationList(context.Background())
+
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestGetApplicationList_EntityWithoutInboundClient() {
+	service, mockStore := suite.setupTestService()
+
+	entities := []entityprovider.Entity{
+		{ID: "app1", Category: entityprovider.EntityCategoryApp},
+	}
+	resetEntityProviderMethod(service, "GetEntityListCount").
+		On("GetEntityListCount", entityprovider.EntityCategoryApp, mock.Anything).
+		Return(1, (*entityprovider.EntityProviderError)(nil))
+	ep := resetEntityProviderMethod(service, "GetEntityList")
+	ep.On("GetEntityList", entityprovider.EntityCategoryApp,
+		mock.AnythingOfType("int"), mock.AnythingOfType("int"), mock.Anything).
+		Return(entities, (*entityprovider.EntityProviderError)(nil))
+
+	mockStore.On("GetInboundClientList", mock.Anything).
+		Return([]inboundmodel.InboundClient{}, nil)
+
+	result, svcErr := service.GetApplicationList(context.Background())
+
+	assert.Nil(suite.T(), svcErr)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), 0, result.Count)
+}
+
+func (suite *ServiceTestSuite) TestUpdateEntityDataForApplicationUpdate_UpdateSystemAttributesError() {
+	service, _ := suite.setupTestService()
+
+	app := &model.ApplicationDTO{Name: "Test App", OUID: testOUID}
+
+	ep := resetEntityProviderMethod(service, "UpdateSystemAttributes")
+	ep.On("UpdateSystemAttributes", mock.Anything, mock.Anything).
+		Return(entityprovider.NewEntityProviderError(
+			entityprovider.ErrorCodeSystemError, "update failed", ""))
+
+	svcErr := service.updateEntityDataForApplicationUpdate(context.Background(), testServiceAppID, app, nil)
+
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestUpdateEntityDataForApplicationUpdate_ClearCredentialsError() {
+	service, _ := suite.setupTestService()
+
+	app := &model.ApplicationDTO{Name: "Test App", OUID: testOUID}
+
+	ep := resetEntityProviderMethod(service, "UpdateSystemCredentials")
+	ep.On("UpdateSystemCredentials", mock.Anything, mock.Anything).
+		Return(entityprovider.NewEntityProviderError(
+			entityprovider.ErrorCodeSystemError, "clear failed", ""))
+
+	svcErr := service.updateEntityDataForApplicationUpdate(context.Background(), testServiceAppID, app, nil)
+
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestUpdateEntityDataForApplicationUpdate_UpdateCredentialsError() {
+	service, _ := suite.setupTestService()
+
+	app := &model.ApplicationDTO{Name: "Test App", OUID: testOUID}
+	inboundAuthConfig := &inboundmodel.InboundAuthConfigWithSecret{
+		OAuthConfig: &inboundmodel.OAuthConfigWithSecret{
+			ClientID:                testClientID,
+			ClientSecret:            "secret-value",
+			TokenEndpointAuthMethod: oauth2const.TokenEndpointAuthMethodClientSecretBasic,
+		},
+	}
+
+	ep := resetEntityProviderMethod(service, "UpdateSystemCredentials")
+	ep.On("UpdateSystemCredentials", mock.Anything, mock.Anything).
+		Return(entityprovider.NewEntityProviderError(
+			entityprovider.ErrorCodeSystemError, "update creds failed", ""))
+
+	svcErr := service.updateEntityDataForApplicationUpdate(
+		context.Background(), testServiceAppID, app, inboundAuthConfig)
+
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestDeleteApplication_DeleteEntityError() {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{
+			Enabled: false,
+		},
+	}
+	config.ResetServerRuntime()
+	err := config.InitializeServerRuntime("/tmp/test", testConfig)
+	require.NoError(suite.T(), err)
+	defer config.ResetServerRuntime()
+
+	service, mockStore := suite.setupTestService()
+
+	mockStore.On("DeleteInboundClient", mock.Anything, testServiceAppID).Return(nil)
+	ep := resetEntityProviderMethod(service, "DeleteEntity")
+	ep.On("DeleteEntity", testServiceAppID).
+		Return(entityprovider.NewEntityProviderError(
+			entityprovider.ErrorCodeSystemError, "delete failed", ""))
+
+	svcErr := service.DeleteApplication(context.Background(), testServiceAppID)
+
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestGetApplication_GetEntityError() {
+	service, mockStore := suite.setupTestService()
+
+	inboundClient := &inboundmodel.InboundClient{ID: testServiceAppID}
+	mockStore.On("GetInboundClientByEntityID", mock.Anything, testServiceAppID).Return(inboundClient, nil)
+
+	ep := resetEntityProviderMethod(service, "GetEntity")
+	ep.On("GetEntity", testServiceAppID).
+		Return((*entityprovider.Entity)(nil), entityprovider.NewEntityProviderError(
+			entityprovider.ErrorCodeSystemError, "get failed", ""))
+
+	result, svcErr := service.getApplication(context.Background(), testServiceAppID)
+
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestGetApplication_GetOAuthProfileError() {
+	service, mockStore := suite.setupTestService()
+
+	inboundClient := &inboundmodel.InboundClient{ID: testServiceAppID}
+	mockStore.On("GetInboundClientByEntityID", mock.Anything, testServiceAppID).Return(inboundClient, nil)
+	mockStore.On("GetOAuthProfileByEntityID", mock.Anything, testServiceAppID).
+		Return((*inboundmodel.OAuthProfile)(nil), errors.New("oauth profile load failed"))
+
+	ep := resetEntityProviderMethod(service, "GetEntity")
+	ep.On("GetEntity", testServiceAppID).
+		Return(&entityprovider.Entity{ID: testServiceAppID, Category: entityprovider.EntityCategoryApp},
+			(*entityprovider.EntityProviderError)(nil))
+
+	result, svcErr := service.getApplication(context.Background(), testServiceAppID)
+
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestDeleteLocalizedVariants_DeleteError() {
+	service, _ := suite.setupTestService()
+
+	i18nMock := mgtmock.NewI18nServiceInterfaceMock(suite.T())
+	i18nMock.On("DeleteTranslationsByKey", mock.Anything, mock.Anything, mock.Anything).
+		Return(&serviceerror.InternalServerError)
+	service.i18nService = i18nMock
+
+	svcErr := service.deleteLocalizedVariants(context.Background(), testServiceAppID)
+
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestCleanupStaleI18nKeys_DeleteError() {
+	service, _ := suite.setupTestService()
+
+	i18nMock := mgtmock.NewI18nServiceInterfaceMock(suite.T())
+	i18nMock.On("DeleteTranslationsByKey", mock.Anything, mock.Anything, mock.Anything).
+		Return(&serviceerror.InternalServerError)
+	service.i18nService = i18nMock
+
+	existing := &model.ApplicationProcessedDTO{
+		ID:   testServiceAppID,
+		Name: AppI18nRef(testServiceAppID, "name"),
+	}
+	updated := &model.ApplicationDTO{
+		Name: "Plain Name",
+	}
+
+	svcErr := service.cleanupStaleI18nKeys(context.Background(), testServiceAppID, existing, updated)
+
+	assert.Equal(suite.T(), &serviceerror.InternalServerError, svcErr)
 }

--- a/backend/internal/attributecache/service.go
+++ b/backend/internal/attributecache/service.go
@@ -72,7 +72,7 @@ func (s *attributeCacheService) CreateAttributeCache(
 	ctx context.Context, cache *AttributeCache,
 ) (*AttributeCache, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Creating attribute cache entry")
+	logger.Debug(ctx, "Creating attribute cache entry")
 
 	if cache == nil {
 		return nil, &ErrorInvalidRequestFormat
@@ -89,17 +89,17 @@ func (s *attributeCacheService) CreateAttributeCache(
 	var err error
 	cache.ID, err = utils.GenerateUUIDv7()
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+		logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	err = s.store.CreateAttributeCache(ctx, *cache)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create attribute cache", log.Error(err), log.String("id", cache.ID))
+		logger.Error(ctx, "Failed to create attribute cache", log.Error(err), log.String("id", cache.ID))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully created attribute cache", log.String("id", cache.ID))
+	logger.Debug(ctx, "Successfully created attribute cache", log.String("id", cache.ID))
 	return cache, nil
 }
 
@@ -108,7 +108,7 @@ func (s *attributeCacheService) GetAttributeCache(
 	ctx context.Context, id string,
 ) (*AttributeCache, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Retrieving attribute cache", log.String("id", id))
+	logger.Debug(ctx, "Retrieving attribute cache", log.String("id", id))
 
 	if strings.TrimSpace(id) == "" {
 		return nil, &ErrorMissingCacheID
@@ -117,14 +117,14 @@ func (s *attributeCacheService) GetAttributeCache(
 	cache, err := s.store.GetAttributeCache(ctx, id)
 	if err != nil {
 		if errors.Is(err, errAttributeCacheNotFound) {
-			logger.DebugWithContext(ctx, "Attribute cache not found", log.String("id", id))
+			logger.Debug(ctx, "Attribute cache not found", log.String("id", id))
 			return nil, &ErrorAttributeCacheNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to retrieve attribute cache", log.Error(err), log.String("id", id))
+		logger.Error(ctx, "Failed to retrieve attribute cache", log.Error(err), log.String("id", id))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully retrieved attribute cache", log.String("id", id))
+	logger.Debug(ctx, "Successfully retrieved attribute cache", log.String("id", id))
 	return &cache, nil
 }
 
@@ -133,7 +133,7 @@ func (s *attributeCacheService) ExtendAttributeCacheTTL(
 	ctx context.Context, id string, ttlSeconds int,
 ) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Extending attribute cache TTL", log.String("id", id))
+	logger.Debug(ctx, "Extending attribute cache TTL", log.String("id", id))
 
 	if strings.TrimSpace(id) == "" {
 		return &ErrorMissingCacheID
@@ -146,14 +146,14 @@ func (s *attributeCacheService) ExtendAttributeCacheTTL(
 	err := s.store.ExtendAttributeCacheTTL(ctx, id, ttlSeconds)
 	if err != nil {
 		if errors.Is(err, errAttributeCacheNotFound) {
-			logger.DebugWithContext(ctx, "Attribute cache not found", log.String("id", id))
+			logger.Debug(ctx, "Attribute cache not found", log.String("id", id))
 			return &ErrorAttributeCacheNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to extend attribute cache TTL", log.Error(err), log.String("id", id))
+		logger.Error(ctx, "Failed to extend attribute cache TTL", log.Error(err), log.String("id", id))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully extended attribute cache TTL", log.String("id", id))
+	logger.Debug(ctx, "Successfully extended attribute cache TTL", log.String("id", id))
 	return nil
 }
 
@@ -162,7 +162,7 @@ func (s *attributeCacheService) DeleteAttributeCache(
 	ctx context.Context, id string,
 ) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Deleting attribute cache", log.String("id", id))
+	logger.Debug(ctx, "Deleting attribute cache", log.String("id", id))
 
 	if strings.TrimSpace(id) == "" {
 		return &ErrorMissingCacheID
@@ -171,13 +171,13 @@ func (s *attributeCacheService) DeleteAttributeCache(
 	err := s.store.DeleteAttributeCache(ctx, id)
 	if err != nil {
 		if errors.Is(err, errAttributeCacheNotFound) {
-			logger.DebugWithContext(ctx, "Attribute cache not found", log.String("id", id))
+			logger.Debug(ctx, "Attribute cache not found", log.String("id", id))
 			return &ErrorAttributeCacheNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to delete attribute cache", log.Error(err), log.String("id", id))
+		logger.Error(ctx, "Failed to delete attribute cache", log.Error(err), log.String("id", id))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully deleted attribute cache", log.String("id", id))
+	logger.Debug(ctx, "Successfully deleted attribute cache", log.String("id", id))
 	return nil
 }

--- a/backend/internal/authn/assert/generator.go
+++ b/backend/internal/authn/assert/generator.go
@@ -55,10 +55,10 @@ func newAuthAssertGenerator() AuthAssertGeneratorInterface {
 func (ag *authAssertGenerator) GenerateAssertion(ctx context.Context,
 	authenticators []authncm.AuthenticatorReference) (*AssertionResult, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Generating authentication assertion")
+	logger.Debug(ctx, "Generating authentication assertion")
 
 	if len(authenticators) == 0 {
-		logger.DebugWithContext(ctx, "No authenticators provided for assertion generation")
+		logger.Debug(ctx, "No authenticators provided for assertion generation")
 		return nil, &ErrorNoAuthenticators
 	}
 
@@ -79,16 +79,16 @@ func (ag *authAssertGenerator) GenerateAssertion(ctx context.Context,
 func (ag *authAssertGenerator) UpdateAssertion(ctx context.Context, context *AssuranceContext,
 	authenticator authncm.AuthenticatorReference) (*AssertionResult, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Updating authentication assertion with new authenticator")
+	logger.Debug(ctx, "Updating authentication assertion with new authenticator")
 
 	if context == nil {
-		logger.DebugWithContext(ctx, "No existing assurance context found, generating new assertion")
+		logger.Debug(ctx, "No existing assurance context found, generating new assertion")
 		return ag.GenerateAssertion(ctx, []authncm.AuthenticatorReference{authenticator})
 	}
 
 	// Validate authenticator name is present
 	if authenticator.Authenticator == "" {
-		logger.DebugWithContext(ctx, "Invalid authenticator: missing authenticator name")
+		logger.Debug(ctx, "Invalid authenticator: missing authenticator name")
 		return nil, &ErrorInvalidAuthenticator
 	}
 
@@ -106,20 +106,20 @@ func (ag *authAssertGenerator) VerifyAssurance(
 	ctx context.Context, context *AssuranceContext, requiredAAL AssuranceLevel,
 	requiredIAL AssuranceLevel) (bool, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Verifying assurance levels")
+	logger.Debug(ctx, "Verifying assurance levels")
 
 	if context == nil {
-		logger.DebugWithContext(ctx, "Nil assurance context provided")
+		logger.Debug(ctx, "Nil assurance context provided")
 		return false, &ErrorNilAssuranceContext
 	}
 	if requiredAAL == "" && requiredIAL == "" {
-		logger.DebugWithContext(ctx, "No assurance levels specified for verification")
+		logger.Debug(ctx, "No assurance levels specified for verification")
 		return false, &ErrorNoAssuranceRequirements
 	}
 
 	// Check AAL level
 	if requiredAAL != "" && !ag.meetsAssuranceLevel(context.AAL, requiredAAL) {
-		logger.DebugWithContext(ctx, "Actual AAL does not meet required AAL",
+		logger.Debug(ctx, "Actual AAL does not meet required AAL",
 			log.String("actualAAL", string(context.AAL)),
 			log.String("requiredAAL", string(requiredAAL)))
 		return false, nil
@@ -127,7 +127,7 @@ func (ag *authAssertGenerator) VerifyAssurance(
 
 	// Check IAL level
 	if requiredIAL != "" && !ag.meetsAssuranceLevel(context.IAL, requiredIAL) {
-		logger.DebugWithContext(ctx, "Actual IAL does not meet required IAL",
+		logger.Debug(ctx, "Actual IAL does not meet required IAL",
 			log.String("actualIAL", string(context.IAL)),
 			log.String("requiredIAL", string(requiredIAL)))
 		return false, nil
@@ -149,7 +149,7 @@ func (ag *authAssertGenerator) extractUniqueAuthenticators(
 
 		factors := authncm.GetAuthenticatorFactors(auth.Authenticator)
 		if len(factors) == 0 {
-			logger.DebugWithContext(ctx, "No factors found for authenticator. Skipping",
+			logger.Debug(ctx, "No factors found for authenticator. Skipping",
 				log.String("authenticator", auth.Authenticator))
 			continue
 		}
@@ -194,7 +194,7 @@ func (ag *authAssertGenerator) calculateAAL(ctx context.Context, factorSet []aut
 		aal = AALLevel3
 	}
 
-	logger.DebugWithContext(ctx, "Calculated AAL from authentication factors", log.Any("factors", factorSet),
+	logger.Debug(ctx, "Calculated AAL from authentication factors", log.Any("factors", factorSet),
 		log.String("aal", string(aal)))
 
 	return aal

--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -78,10 +78,10 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 	availableAttributes *authnprovidercm.AttributesResponse) (
 	*ConsentPromptData, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID))
-	logger.DebugWithContext(ctx, "Resolving consent for user")
+	logger.Debug(ctx, "Resolving consent for user")
 
 	if !s.consentService.IsEnabled() {
-		logger.DebugWithContext(ctx, "Consent service is not enabled; skipping consent check")
+		logger.Debug(ctx, "Consent service is not enabled; skipping consent check")
 		return nil, nil
 	}
 
@@ -89,11 +89,11 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 	purposes, svcErr := s.consentService.ListConsentPurposes(ctx, ouID, appID)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx, "Client error from consent service when listing purposes",
+			logger.Debug(ctx, "Client error from consent service when listing purposes",
 				log.Any("error", svcErr))
 			return nil, &ErrorConsentPurposeFetchFailed
 		}
-		logger.ErrorWithContext(ctx, "Failed to list consent purposes", log.Any("error", svcErr))
+		logger.Error(ctx, "Failed to list consent purposes", log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 	purposes, svcErr = s.applyPermissionsPurpose(ctx, purposes, ouID, appID, appName, authorizedPermissions)
@@ -101,7 +101,7 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 		return nil, svcErr
 	}
 	if len(purposes) == 0 {
-		logger.DebugWithContext(ctx, "No consent purposes configured for application; skipping consent")
+		logger.Debug(ctx, "No consent purposes configured for application; skipping consent")
 		return nil, nil
 	}
 
@@ -114,11 +114,11 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 	existingConsents, svcErr := s.consentService.SearchConsents(ctx, ouID, filter)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx, "Client error from consent service when searching consents",
+			logger.Debug(ctx, "Client error from consent service when searching consents",
 				log.Any("error", svcErr))
 			return nil, &ErrorConsentSearchFailed
 		}
-		logger.ErrorWithContext(ctx, "Failed to search existing consents", log.Any("error", svcErr))
+		logger.Error(ctx, "Failed to search existing consents", log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -131,7 +131,7 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 	promptPurposes := buildPurposePrompts(purposes, essentialAttributes, optionalAttributes,
 		consentedElements, userAttributeSet, authorizedPermissions)
 	if len(promptPurposes) == 0 {
-		logger.DebugWithContext(ctx, "All required consents are active; no prompt needed")
+		logger.Debug(ctx, "All required consents are active; no prompt needed")
 		return nil, nil
 	}
 
@@ -141,12 +141,12 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 	// This token should be verified in RecordConsent to ensure the user's decisions match what was prompted
 	sessionToken, err := s.createConsentSessionToken(ctx, promptData)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create consent session token", log.Error(err))
+		logger.Error(ctx, "Failed to create consent session token", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	promptData.SessionToken = sessionToken
 
-	logger.DebugWithContext(ctx, "Consent prompt required", log.Int("purposeCount", len(promptPurposes)))
+	logger.Debug(ctx, "Consent prompt required", log.Int("purposeCount", len(promptPurposes)))
 	return promptData, nil
 }
 
@@ -157,12 +157,12 @@ func (s *consentEnforcerService) RecordConsent(ctx context.Context, ouID, appID,
 	decisions *ConsentDecisions, sessionToken string,
 	validityPeriod int64) (*consent.Consent, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID))
-	logger.DebugWithContext(ctx, "Recording consent for user")
+	logger.Debug(ctx, "Recording consent for user")
 
 	// Verify and decode the consent session token to retrieve the prompted purposes
 	sessionData, err := s.verifyAndDecodeConsentSession(ctx, sessionToken)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Failed to verify consent session token", log.Error(err))
+		logger.Debug(ctx, "Failed to verify consent session token", log.Error(err))
 		return nil, &ErrorConsentSessionInvalid
 	}
 
@@ -190,11 +190,11 @@ func (s *consentEnforcerService) RecordConsent(ctx context.Context, ouID, appID,
 	})
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx, "Client error from consent service when searching consents for upsert",
+			logger.Debug(ctx, "Client error from consent service when searching consents for upsert",
 				log.Any("error", svcErr))
 			return nil, &ErrorConsentSearchFailed
 		}
-		logger.ErrorWithContext(ctx, "Failed to search existing consents for upsert", log.Any("error", svcErr))
+		logger.Error(ctx, "Failed to search existing consents for upsert", log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -211,7 +211,7 @@ func (s *consentEnforcerService) RecordConsent(ctx context.Context, ouID, appID,
 
 	// If the user denied any essential attribute, return an error after persisting
 	if hasEssentialDenial {
-		logger.DebugWithContext(ctx, "User denied essential attribute(s)", log.String("consentID", consentRecord.ID))
+		logger.Debug(ctx, "User denied essential attribute(s)", log.String("consentID", consentRecord.ID))
 		return nil, &ErrorEssentialConsentDenied
 	}
 
@@ -226,7 +226,7 @@ func (s *consentEnforcerService) updateExistingConsent(ctx context.Context, ouID
 ) (*consent.Consent, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID),
 		log.Int("existingConsentCount", len(existingConsents)))
-	logger.DebugWithContext(ctx, "Existing consent record found; updating with new decisions")
+	logger.Debug(ctx, "Existing consent record found; updating with new decisions")
 
 	// Build the consent request payload
 	req := &consent.ConsentRequest{
@@ -249,15 +249,15 @@ func (s *consentEnforcerService) updateExistingConsent(ctx context.Context, ouID
 	updated, svcErr := s.consentService.UpdateConsent(ctx, ouID, existing.ID, req)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx, "Client error from consent service when updating consent record",
+			logger.Debug(ctx, "Client error from consent service when updating consent record",
 				log.Any("error", svcErr))
 			return nil, &ErrorConsentUpdateFailed
 		}
-		logger.ErrorWithContext(ctx, "Failed to update consent record", log.Any("error", svcErr))
+		logger.Error(ctx, "Failed to update consent record", log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Consent record updated successfully", log.String("consentID", updated.ID))
+	logger.Debug(ctx, "Consent record updated successfully", log.String("consentID", updated.ID))
 	return updated, nil
 }
 
@@ -266,7 +266,7 @@ func (s *consentEnforcerService) createNewConsent(ctx context.Context, ouID, app
 	newPurposeItems []consent.ConsentPurposeItem, validityTime int64) (
 	*consent.Consent, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID))
-	logger.DebugWithContext(ctx, "Creating new consent record")
+	logger.Debug(ctx, "Creating new consent record")
 
 	// Build the consent request payload
 	req := &consent.ConsentRequest{
@@ -286,15 +286,15 @@ func (s *consentEnforcerService) createNewConsent(ctx context.Context, ouID, app
 	created, svcErr := s.consentService.CreateConsent(ctx, ouID, req)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx, "Client error from consent service when creating consent record",
+			logger.Debug(ctx, "Client error from consent service when creating consent record",
 				log.Any("error", svcErr))
 			return nil, &ErrorConsentCreateFailed
 		}
-		logger.ErrorWithContext(ctx, "Failed to create consent record", log.Any("error", svcErr))
+		logger.Error(ctx, "Failed to create consent record", log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Consent recorded successfully", log.String("consentID", created.ID))
+	logger.Debug(ctx, "Consent recorded successfully", log.String("consentID", created.ID))
 	return created, nil
 }
 
@@ -755,11 +755,11 @@ func (s *consentEnforcerService) applyPermissionsPurpose(ctx context.Context,
 		created, createErr := s.consentService.CreateConsentPurpose(ctx, ouID, &input)
 		if createErr != nil {
 			if createErr.Type == serviceerror.ClientErrorType {
-				logger.DebugWithContext(ctx, "Client error from consent service when creating permission purpose",
+				logger.Debug(ctx, "Client error from consent service when creating permission purpose",
 					log.Any("error", createErr))
 				return nil, &ErrorConsentPurposeCreateFailed
 			}
-			logger.ErrorWithContext(ctx, "Failed to create permission consent purpose", log.Any("error", createErr))
+			logger.Error(ctx, "Failed to create permission consent purpose", log.Any("error", createErr))
 			return nil, &serviceerror.InternalServerError
 		}
 		return append(allPurposes, *created), nil
@@ -781,11 +781,11 @@ func (s *consentEnforcerService) applyPermissionsPurpose(ctx context.Context,
 	updated, updErr := s.consentService.UpdateConsentPurpose(ctx, ouID, current.ID, &input)
 	if updErr != nil {
 		if updErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx, "Client error from consent service when updating permission purpose",
+			logger.Debug(ctx, "Client error from consent service when updating permission purpose",
 				log.Any("error", updErr))
 			return nil, &ErrorConsentPurposeUpdateFailed
 		}
-		logger.ErrorWithContext(ctx, "Failed to update permission consent purpose", log.Any("error", updErr))
+		logger.Error(ctx, "Failed to update permission consent purpose", log.Any("error", updErr))
 		return nil, &serviceerror.InternalServerError
 	}
 	for i := range allPurposes {

--- a/backend/internal/authn/github/service.go
+++ b/backend/internal/authn/github/service.go
@@ -86,7 +86,7 @@ func (g *githubOAuthAuthnService) FetchUserInfo(ctx context.Context, idpID, acce
 	// If email is already present in the user info or email scope is not requested, return it directly.
 	email := authnoauth.GetStringUserClaimValue(userInfo, "email")
 	if email != "" || !g.shouldFetchEmail(oAuthClientConfig.Scopes) {
-		logger.DebugWithContext(ctx, "Email is already present in the user info or email scope not requested")
+		logger.Debug(ctx, "Email is already present in the user info or email scope not requested")
 		authnoauth.ProcessSubClaim(userInfo)
 		return userInfo, nil
 	}
@@ -114,10 +114,10 @@ func (g *githubOAuthAuthnService) fetchPrimaryEmail(ctx context.Context,
 	oAuthClientConfig *authnoauth.OAuthClientConfig, accessToken string) (
 	string, *serviceerror.ServiceError) {
 	logger := g.logger
-	logger.DebugWithContext(ctx, "Fetching primary email from GitHub user emails endpoint")
+	logger.Debug(ctx, "Fetching primary email from GitHub user emails endpoint")
 
 	if oAuthClientConfig.OAuthEndpoints.UserEmailEndpoint == "" {
-		logger.ErrorWithContext(ctx, "User email endpoint is not configured in OAuth client config")
+		logger.Error(ctx, "User email endpoint is not configured in OAuth client config")
 		return "", &serviceerror.InternalServerError
 	}
 
@@ -160,7 +160,7 @@ func (g *githubOAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpI
 func (g *githubOAuthAuthnService) Authenticate(ctx context.Context, idpID, code string) (
 	*authncm.FederatedAuthResult, *serviceerror.ServiceError) {
 	logger := g.logger.With(log.String("idpId", idpID))
-	logger.DebugWithContext(ctx, "Performing federated GitHub OAuth authentication")
+	logger.Debug(ctx, "Performing federated GitHub OAuth authentication")
 
 	tokenResp, svcErr := g.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
@@ -179,7 +179,7 @@ func (g *githubOAuthAuthnService) Authenticate(ctx context.Context, idpID, code 
 		}
 	}
 	if sub == "" {
-		logger.DebugWithContext(ctx, "sub claim not found in user info")
+		logger.Debug(ctx, "sub claim not found in user info")
 		return nil, &authncm.ErrorSubClaimNotFound
 	}
 

--- a/backend/internal/authn/github/utils.go
+++ b/backend/internal/authn/github/utils.go
@@ -35,7 +35,7 @@ func buildUserEmailRequest(ctx context.Context, userEmailEndpoint string, access
 	*http.Request, *serviceerror.ServiceError) {
 	req, err := http.NewRequest(http.MethodGet, userEmailEndpoint, nil)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create user email request", log.Error(err))
+		logger.Error(ctx, "Failed to create user email request", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -51,25 +51,25 @@ func sendUserEmailRequest(httpReq *http.Request, httpClient syshttp.HTTPClientIn
 	ctx := httpReq.Context()
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "User email request to GitHub failed", log.Error(err))
+		logger.Error(ctx, "User email request to GitHub failed", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to close user email response body", log.Error(closeErr))
+			logger.Error(ctx, "Failed to close user email response body", log.Error(closeErr))
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		logger.ErrorWithContext(ctx, "User email endpoint returned an error response",
+		logger.Error(ctx, "User email endpoint returned an error response",
 			log.Int("statusCode", resp.StatusCode), log.String("response", string(body)))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	var emails []map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to decode user email response", log.Error(err))
+		logger.Error(ctx, "Failed to decode user email response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/authn/google/service.go
+++ b/backend/internal/authn/google/service.go
@@ -106,10 +106,10 @@ func (g *googleOIDCAuthnService) ValidateTokenResponse(ctx context.Context, idpI
 func (g *googleOIDCAuthnService) ValidateIDToken(
 	ctx context.Context, idpID, idToken string) *serviceerror.ServiceError {
 	logger := g.logger.With(log.String("idpId", idpID))
-	logger.DebugWithContext(ctx, "Validating ID token")
+	logger.Debug(ctx, "Validating ID token")
 
 	if strings.TrimSpace(idToken) == "" {
-		logger.DebugWithContext(ctx, "ID token is empty")
+		logger.Debug(ctx, "ID token is empty")
 		return &authnoidc.ErrorInvalidIDToken
 	}
 
@@ -123,15 +123,15 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 	if oAuthClientConfig.OAuthEndpoints.JwksEndpoint != "" {
 		err := g.jwtService.VerifyJWTSignatureWithJWKS(ctx, idToken, oAuthClientConfig.OAuthEndpoints.JwksEndpoint)
 		if err != nil {
-			logger.DebugWithContext(ctx, "ID token signature validation failed",
+			logger.Debug(ctx, "ID token signature validation failed",
 				log.String("error", err.Error.DefaultValue))
 			return &authnoidc.ErrorInvalidIDTokenSignature
 		}
 	} else {
-		logger.DebugWithContext(ctx, "Skipping ID token signature validation as JWKS endpoint is not configured")
+		logger.Debug(ctx, "Skipping ID token signature validation as JWKS endpoint is not configured")
 	}
 
-	logger.DebugWithContext(ctx, "Validating Google specific ID token claims")
+	logger.Debug(ctx, "Validating Google specific ID token claims")
 
 	// Extract ID token claims for Google-specific validation
 	claims, err := jwt.DecodeJWTPayload(idToken)
@@ -142,7 +142,7 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 	// Validate issuer
 	iss, ok := claims["iss"].(string)
 	if !ok || (iss != Issuer1 && iss != Issuer2) {
-		logger.DebugWithContext(ctx, "Invalid ID token issuer", log.String("issuer", iss))
+		logger.Debug(ctx, "Invalid ID token issuer", log.String("issuer", iss))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_issuer_description",
 			DefaultValue: "The issuer of the ID token is not a valid Google issuer",
@@ -152,7 +152,7 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 	// Validate audience
 	aud, ok := claims["aud"].(string)
 	if !ok || aud != oAuthClientConfig.ClientID {
-		logger.DebugWithContext(ctx, "Invalid ID token audience", log.String("audience", aud),
+		logger.Debug(ctx, "Invalid ID token audience", log.String("audience", aud),
 			log.MaskedString("clientId", oAuthClientConfig.ClientID))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_audience_description",
@@ -166,14 +166,14 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 	// Validate expiration time
 	exp, ok := claims["exp"].(float64)
 	if !ok {
-		logger.DebugWithContext(ctx, "Invalid ID token expiration claim", log.Any("exp", claims["exp"]))
+		logger.Debug(ctx, "Invalid ID token expiration claim", log.Any("exp", claims["exp"]))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_exp_claim_description",
 			DefaultValue: "The ID token expiration claim is missing or invalid",
 		})
 	}
 	if time.Now().Unix() >= int64(exp)+leeway {
-		logger.DebugWithContext(ctx, "ID token has expired", log.Int("exp", int(exp)))
+		logger.Debug(ctx, "ID token has expired", log.Int("exp", int(exp)))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_expired_description",
 			DefaultValue: "The ID token has expired",
@@ -183,14 +183,14 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 	// Check if token was issued in the future (with leeway for clock skew)
 	iat, ok := claims["iat"].(float64)
 	if !ok {
-		logger.DebugWithContext(ctx, "Invalid ID token issued-at claim", log.Any("iat", claims["iat"]))
+		logger.Debug(ctx, "Invalid ID token issued-at claim", log.Any("iat", claims["iat"]))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_iat_claim_description",
 			DefaultValue: "The ID token issued-at (iat) claim is missing or invalid",
 		})
 	}
 	if time.Now().Unix() < int64(iat)-leeway {
-		logger.DebugWithContext(ctx, "ID token was issued in the future", log.Int("iat", int(iat)))
+		logger.Debug(ctx, "ID token was issued in the future", log.Int("iat", int(iat)))
 		return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 			Key:          "error.authnservice.google.invalid_id_token_future_iat_description",
 			DefaultValue: "The ID token was issued in the future",
@@ -199,11 +199,11 @@ func (g *googleOIDCAuthnService) ValidateIDToken(
 
 	// Check for specific domain if configured in additional params
 	if hd, found := claims["hd"]; found {
-		logger.DebugWithContext(ctx, "hd claim found in ID token")
+		logger.Debug(ctx, "hd claim found in ID token")
 		if domain, exists := oAuthClientConfig.AdditionalParams["hd"]; exists && domain != "" {
-			logger.DebugWithContext(ctx, "Validating hosted domain (hd) claim")
+			logger.Debug(ctx, "Validating hosted domain (hd) claim")
 			if hdStr, ok := hd.(string); !ok || hdStr != domain {
-				logger.DebugWithContext(ctx, "Invalid hosted domain (hd) claim", log.String("hd", hdStr),
+				logger.Debug(ctx, "Invalid hosted domain (hd) claim", log.String("hd", hdStr),
 					log.String("expectedDomain", domain))
 				return serviceerror.CustomServiceError(authnoidc.ErrorInvalidIDToken, core.I18nMessage{
 					Key:          "error.authnservice.google.invalid_id_token_hosted_domain_description",
@@ -246,7 +246,7 @@ func (g *googleOIDCAuthnService) GetOAuthClientConfig(ctx context.Context, idpID
 func (g *googleOIDCAuthnService) Authenticate(ctx context.Context, idpID, code string) (
 	*common.FederatedAuthResult, *serviceerror.ServiceError) {
 	logger := g.logger.With(log.String("idpId", idpID))
-	logger.DebugWithContext(ctx, "Performing federated Google OIDC authentication")
+	logger.Debug(ctx, "Performing federated Google OIDC authentication")
 
 	tokenResp, svcErr := g.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
@@ -265,7 +265,7 @@ func (g *googleOIDCAuthnService) Authenticate(ctx context.Context, idpID, code s
 		}
 	}
 	if sub == "" {
-		logger.DebugWithContext(ctx, "sub claim not found in ID token")
+		logger.Debug(ctx, "sub claim not found in ID token")
 		return nil, &common.ErrorSubClaimNotFound
 	}
 

--- a/backend/internal/authn/magiclink/service.go
+++ b/backend/internal/authn/magiclink/service.go
@@ -84,7 +84,7 @@ func (s *magicLinkAuthnService) GenerateMagicLink(ctx context.Context,
 	queryParams map[string]string,
 	additionalClaims map[string]interface{},
 	magicLinkURL string) (string, *serviceerror.ServiceError) {
-	s.logger.DebugWithContext(ctx, "Generating magic link", log.MaskedString("subject", subject))
+	s.logger.Debug(ctx, "Generating magic link", log.MaskedString("subject", subject))
 
 	if subject == "" {
 		return "", &ErrorTokenGenerationFailed
@@ -116,7 +116,7 @@ func (s *magicLinkAuthnService) GenerateMagicLink(ctx context.Context,
 	}
 
 	verifyURL := s.buildMagicLinkURL(ctx, magicLinkURL, token, queryParams)
-	s.logger.DebugWithContext(ctx, "Magic link generated successfully",
+	s.logger.Debug(ctx, "Magic link generated successfully",
 		log.MaskedString("subject", subject))
 
 	return verifyURL, nil
@@ -127,7 +127,7 @@ func (s *magicLinkAuthnService) GenerateMagicLink(ctx context.Context,
 // allowing callers to handle registration flows.
 func (s *magicLinkAuthnService) Authenticate(ctx context.Context,
 	token string, subjectAttribute string) (*MagicLinkAuthnResult, *serviceerror.ServiceError) {
-	s.logger.DebugWithContext(ctx, "Authenticating with magic link token")
+	s.logger.Debug(ctx, "Authenticating with magic link token")
 
 	token = strings.TrimSpace(token)
 	if token == "" {
@@ -158,7 +158,7 @@ func (s *magicLinkAuthnService) Authenticate(ctx context.Context,
 		return nil, resolveErr
 	}
 
-	s.logger.DebugWithContext(ctx, "Magic link authentication successful", log.String("userId", user.ID))
+	s.logger.Debug(ctx, "Magic link authentication successful", log.String("userId", user.ID))
 	return &MagicLinkAuthnResult{InternalEntity: user}, nil
 }
 
@@ -170,7 +170,7 @@ func (s *magicLinkAuthnService) verifyToken(ctx context.Context, token string) *
 		if verifyErr.Code == jwt.ErrorTokenExpired.Code {
 			return &ErrorExpiredToken
 		}
-		s.logger.DebugWithContext(ctx, "Invalid magic link token", log.String("errorCode", verifyErr.Code))
+		s.logger.Debug(ctx, "Invalid magic link token", log.String("errorCode", verifyErr.Code))
 		return &ErrorInvalidToken
 	}
 	return nil
@@ -181,13 +181,13 @@ func (s *magicLinkAuthnService) verifyToken(ctx context.Context, token string) *
 func (s *magicLinkAuthnService) extractSubject(ctx context.Context, token string) (string, *serviceerror.ServiceError) {
 	payload, decodeErr := jwt.DecodeJWTPayload(token)
 	if decodeErr != nil {
-		s.logger.DebugWithContext(ctx, "Failed to decode magic link token payload", log.Error(decodeErr))
+		s.logger.Debug(ctx, "Failed to decode magic link token payload", log.Error(decodeErr))
 		return "", &ErrorInvalidToken
 	}
 
 	subject := utils.ConvertInterfaceValueToString(payload["sub"])
 	if subject == "" {
-		s.logger.DebugWithContext(ctx, "Subject claim not found or invalid")
+		s.logger.Debug(ctx, "Subject claim not found or invalid")
 		return "", &ErrorMalformedTokenClaims
 	}
 
@@ -229,7 +229,7 @@ func (s *magicLinkAuthnService) buildMagicLinkURL(ctx context.Context, magicLink
 	if magicLinkURL != "" && strings.TrimSpace(magicLinkURL) != "" {
 		u, err = url.Parse(strings.TrimSpace(magicLinkURL))
 		if err != nil {
-			s.logger.DebugWithContext(ctx,
+			s.logger.Debug(ctx,
 				"Failed to parse custom magic link URL; falling back to default configuration",
 				log.Error(err))
 		}
@@ -259,7 +259,7 @@ func (s *magicLinkAuthnService) handleEntityProviderError(ctx context.Context,
 	if upErr.Code == entityprovider.ErrorCodeSystemError {
 		return &serviceerror.InternalServerError
 	}
-	s.logger.DebugWithContext(ctx, "User provider returned an error while resolving user",
+	s.logger.Debug(ctx, "User provider returned an error while resolving user",
 		log.String("description", upErr.Description))
 	return &ErrorClientErrorWhileResolvingUser
 }

--- a/backend/internal/authn/oauth/service.go
+++ b/backend/internal/authn/oauth/service.go
@@ -94,7 +94,7 @@ func (s *oAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpID stri
 				DefaultValue: "Error while retrieving identity provider: " + svcErr.ErrorDescription.DefaultValue,
 			})
 		}
-		logger.ErrorWithContext(ctx, "Error while retrieving identity provider", log.String("errorCode", svcErr.Code),
+		logger.Error(ctx, "Error while retrieving identity provider", log.String("errorCode", svcErr.Code),
 			log.String("description", svcErr.ErrorDescription.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -104,7 +104,7 @@ func (s *oAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpID stri
 
 	oAuthClientConfig, err := parseIDPConfig(idp)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to parse identity provider configurations", log.Error(err))
+		logger.Error(ctx, "Failed to parse identity provider configurations", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -115,14 +115,14 @@ func (s *oAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpID stri
 func (s *oAuthAuthnService) BuildAuthorizeURL(
 	ctx context.Context, idpID string) (string, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.DebugWithContext(ctx, "Building authorize URL")
+	logger.Debug(ctx, "Building authorize URL")
 
 	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(ctx, idpID)
 	if svcErr != nil {
 		return "", svcErr
 	}
 	if oAuthClientConfig.OAuthEndpoints.AuthorizationEndpoint == "" {
-		logger.ErrorWithContext(ctx, "Authorization endpoint is not configured for the identity provider")
+		logger.Error(ctx, "Authorization endpoint is not configured for the identity provider")
 		return "", &serviceerror.InternalServerError
 	}
 
@@ -145,7 +145,7 @@ func (s *oAuthAuthnService) BuildAuthorizeURL(
 	authZURL, err := sysutils.GetURIWithQueryParams(oAuthClientConfig.OAuthEndpoints.AuthorizationEndpoint,
 		queryParams)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to build authorize URL", log.Error(err))
+		logger.Error(ctx, "Failed to build authorize URL", log.Error(err))
 		return "", &serviceerror.InternalServerError
 	}
 
@@ -157,7 +157,7 @@ func (s *oAuthAuthnService) BuildAuthorizeURL(
 func (s *oAuthAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, code string, validateResponse bool) (
 	*TokenResponse, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.DebugWithContext(ctx, "Exchanging authorization code for token")
+	logger.Debug(ctx, "Exchanging authorization code for token")
 
 	if strings.TrimSpace(code) == "" {
 		return nil, &ErrorEmptyAuthorizationCode
@@ -168,7 +168,7 @@ func (s *oAuthAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, cod
 		return nil, svcErr
 	}
 	if oAuthClientConfig.OAuthEndpoints.TokenEndpoint == "" {
-		logger.ErrorWithContext(ctx, "Token endpoint is not configured for the identity provider")
+		logger.Error(ctx, "Token endpoint is not configured for the identity provider")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -198,14 +198,14 @@ func (s *oAuthAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, cod
 func (s *oAuthAuthnService) ValidateTokenResponse(ctx context.Context,
 	idpID string, tokenResp *TokenResponse) *serviceerror.ServiceError {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.DebugWithContext(ctx, "Validating token response")
+	logger.Debug(ctx, "Validating token response")
 
 	if tokenResp == nil {
-		logger.DebugWithContext(ctx, "Empty token response received from identity provider")
+		logger.Debug(ctx, "Empty token response received from identity provider")
 		return &ErrorInvalidTokenResponse
 	}
 	if tokenResp.AccessToken == "" {
-		logger.DebugWithContext(ctx, "Access token is empty in the token response")
+		logger.Debug(ctx, "Access token is empty in the token response")
 		return &ErrorInvalidTokenResponse
 	}
 
@@ -227,14 +227,14 @@ func (s *oAuthAuthnService) FetchUserInfo(ctx context.Context, idpID, accessToke
 func (s *oAuthAuthnService) FetchUserInfoWithClientConfig(ctx context.Context, oAuthClientConfig *OAuthClientConfig,
 	accessToken string) (map[string]interface{}, *serviceerror.ServiceError) {
 	logger := s.logger
-	logger.DebugWithContext(ctx, "Fetching user info")
+	logger.Debug(ctx, "Fetching user info")
 
 	if strings.TrimSpace(accessToken) == "" {
 		return nil, &ErrorEmptyAccessToken
 	}
 
 	if oAuthClientConfig.OAuthEndpoints.UserInfoEndpoint == "" {
-		logger.ErrorWithContext(ctx, "User info endpoint is not configured for the identity provider")
+		logger.Error(ctx, "User info endpoint is not configured for the identity provider")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -257,7 +257,7 @@ func (s *oAuthAuthnService) FetchUserInfoWithClientConfig(ctx context.Context, o
 func (s *oAuthAuthnService) GetInternalUser(
 	ctx context.Context, sub string) (*entityprovider.Entity, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.MaskedString("sub", sub))
-	logger.DebugWithContext(ctx, "Retrieving internal user for the given sub claim")
+	logger.Debug(ctx, "Retrieving internal user for the given sub claim")
 
 	if strings.TrimSpace(sub) == "" {
 		return nil, &ErrorEmptySubClaim
@@ -269,20 +269,20 @@ func (s *oAuthAuthnService) GetInternalUser(
 	userID, upErr := s.entityProvider.IdentifyEntity(filters)
 	if upErr != nil {
 		if upErr.Code == entityprovider.ErrorCodeEntityNotFound {
-			logger.DebugWithContext(ctx, "No user found for the provided sub claim")
+			logger.Debug(ctx, "No user found for the provided sub claim")
 			return nil, &common.ErrorUserNotFound
 		}
 		if upErr.Code == entityprovider.ErrorCodeAmbiguousEntity {
-			logger.DebugWithContext(ctx, "Multiple users found for the provided sub claim")
+			logger.Debug(ctx, "Multiple users found for the provided sub claim")
 			return nil, &common.ErrorAmbiguousUser
 		}
-		logger.ErrorWithContext(ctx, "Error while identifying user", log.String("errorCode", string(upErr.Code)),
+		logger.Error(ctx, "Error while identifying user", log.String("errorCode", string(upErr.Code)),
 			log.String("description", upErr.Description))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	if userID == nil {
-		logger.DebugWithContext(ctx, "User id is nil, no user found for the provided sub claim")
+		logger.Debug(ctx, "User id is nil, no user found for the provided sub claim")
 		return nil, &common.ErrorUserNotFound
 	}
 
@@ -291,7 +291,7 @@ func (s *oAuthAuthnService) GetInternalUser(
 		if upErr.Code == entityprovider.ErrorCodeEntityNotFound {
 			return nil, &common.ErrorUserNotFound
 		}
-		logger.ErrorWithContext(ctx, "Error while retrieving user", log.String("errorCode", string(upErr.Code)),
+		logger.Error(ctx, "Error while retrieving user", log.String("errorCode", string(upErr.Code)),
 			log.String("description", upErr.Description))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -305,7 +305,7 @@ func (s *oAuthAuthnService) GetInternalUser(
 func (s *oAuthAuthnService) Authenticate(ctx context.Context, idpID, code string) (
 	*common.FederatedAuthResult, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.DebugWithContext(ctx, "Performing federated OAuth authentication")
+	logger.Debug(ctx, "Performing federated OAuth authentication")
 
 	tokenResp, svcErr := s.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
@@ -324,7 +324,7 @@ func (s *oAuthAuthnService) Authenticate(ctx context.Context, idpID, code string
 		}
 	}
 	if sub == "" {
-		logger.DebugWithContext(ctx, "sub claim not found in user info")
+		logger.Debug(ctx, "sub claim not found in user info")
 		return nil, &common.ErrorSubClaimNotFound
 	}
 

--- a/backend/internal/authn/oauth/utils.go
+++ b/backend/internal/authn/oauth/utils.go
@@ -103,7 +103,7 @@ func buildTokenRequest(ctx context.Context, oAuthClientConfig *OAuthClientConfig
 	httpReq, err := http.NewRequest(http.MethodPost, oAuthClientConfig.OAuthEndpoints.TokenEndpoint,
 		strings.NewReader(form.Encode()))
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create token request", log.Error(err))
+		logger.Error(ctx, "Failed to create token request", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -119,25 +119,25 @@ func sendTokenRequest(httpReq *http.Request, httpClient httpservice.HTTPClientIn
 	ctx := httpReq.Context()
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Token request to identity provider failed", log.Error(err))
+		logger.Error(ctx, "Token request to identity provider failed", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to close token response body", log.Error(closeErr))
+			logger.Error(ctx, "Failed to close token response body", log.Error(closeErr))
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		logger.ErrorWithContext(ctx, "Token endpoint returned an error response",
+		logger.Error(ctx, "Token endpoint returned an error response",
 			log.Int("statusCode", resp.StatusCode), log.String("response", string(body)))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	var tokenResp TokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to parse token response", log.Error(err))
+		logger.Error(ctx, "Failed to parse token response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -149,7 +149,7 @@ func buildUserInfoRequest(ctx context.Context, userInfoEndpoint string, accessTo
 	*http.Request, *serviceerror.ServiceError) {
 	req, err := http.NewRequest(http.MethodGet, userInfoEndpoint, nil)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create userinfo request", log.Error(err))
+		logger.Error(ctx, "Failed to create userinfo request", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -165,31 +165,31 @@ func sendUserInfoRequest(httpReq *http.Request, httpClient httpservice.HTTPClien
 	ctx := httpReq.Context()
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Userinfo request to identity provider failed", log.Error(err))
+		logger.Error(ctx, "Userinfo request to identity provider failed", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to close userinfo response body", log.Error(closeErr))
+			logger.Error(ctx, "Failed to close userinfo response body", log.Error(closeErr))
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		logger.ErrorWithContext(ctx, "Userinfo endpoint returned an error response",
+		logger.Error(ctx, "Userinfo endpoint returned an error response",
 			log.Int("statusCode", resp.StatusCode), log.String("response", string(body)))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to read userinfo response body", log.Error(err))
+		logger.Error(ctx, "Failed to read userinfo response body", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	var userInfo map[string]interface{}
 	if err := json.Unmarshal(body, &userInfo); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to parse userinfo response", log.Error(err))
+		logger.Error(ctx, "Failed to parse userinfo response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/authn/oidc/service.go
+++ b/backend/internal/authn/oidc/service.go
@@ -103,18 +103,18 @@ func (s *oidcAuthnService) ExchangeCodeForToken(ctx context.Context, idpID, code
 func (s *oidcAuthnService) ValidateTokenResponse(ctx context.Context, idpID string,
 	tokenResp *authnoauth.TokenResponse, validateIDToken bool) *serviceerror.ServiceError {
 	logger := s.logger
-	logger.DebugWithContext(ctx, "Validating token response")
+	logger.Debug(ctx, "Validating token response")
 
 	if tokenResp == nil {
-		logger.DebugWithContext(ctx, "Empty token response received from identity provider")
+		logger.Debug(ctx, "Empty token response received from identity provider")
 		return &authnoauth.ErrorInvalidTokenResponse
 	}
 	if tokenResp.AccessToken == "" {
-		logger.DebugWithContext(ctx, "Access token is empty in the token response")
+		logger.Debug(ctx, "Access token is empty in the token response")
 		return &authnoauth.ErrorInvalidTokenResponse
 	}
 	if tokenResp.IDToken == "" {
-		logger.DebugWithContext(ctx, "ID token is empty in the token response")
+		logger.Debug(ctx, "ID token is empty in the token response")
 		return &authnoauth.ErrorInvalidTokenResponse
 	}
 
@@ -134,10 +134,10 @@ func (s *oidcAuthnService) ValidateTokenResponse(ctx context.Context, idpID stri
 // is called with validateResponse set to true.
 func (s *oidcAuthnService) ValidateIDToken(ctx context.Context, idpID, idToken string) *serviceerror.ServiceError {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.DebugWithContext(ctx, "Validating ID token")
+	logger.Debug(ctx, "Validating ID token")
 
 	if strings.TrimSpace(idToken) == "" {
-		logger.DebugWithContext(ctx, "ID token is empty")
+		logger.Debug(ctx, "ID token is empty")
 		return &ErrorInvalidIDToken
 	}
 
@@ -150,12 +150,12 @@ func (s *oidcAuthnService) ValidateIDToken(ctx context.Context, idpID, idToken s
 	if oAuthClientConfig.OAuthEndpoints.JwksEndpoint != "" {
 		err := s.jwtService.VerifyJWTWithJWKS(ctx, idToken, oAuthClientConfig.OAuthEndpoints.JwksEndpoint, "", "")
 		if err != nil {
-			logger.DebugWithContext(ctx, "ID token signature validation failed",
+			logger.Debug(ctx, "ID token signature validation failed",
 				log.String("error", err.Error.DefaultValue))
 			return &ErrorInvalidIDTokenSignature
 		}
 	} else {
-		logger.DebugWithContext(ctx, "Skipping ID token signature validation as JWKS endpoint is not configured")
+		logger.Debug(ctx, "Skipping ID token signature validation as JWKS endpoint is not configured")
 	}
 
 	// TODO: Should mandate ID token validation when the support is available through a IDP configuration.
@@ -169,16 +169,16 @@ func (s *oidcAuthnService) ValidateIDToken(ctx context.Context, idpID, idToken s
 func (s *oidcAuthnService) GetIDTokenClaims(ctx context.Context, idToken string) (
 	map[string]interface{}, *serviceerror.ServiceError) {
 	logger := s.logger
-	logger.DebugWithContext(ctx, "Extracting claims from ID token")
+	logger.Debug(ctx, "Extracting claims from ID token")
 
 	if strings.TrimSpace(idToken) == "" {
-		logger.DebugWithContext(ctx, "ID token is empty")
+		logger.Debug(ctx, "ID token is empty")
 		return nil, &ErrorInvalidIDToken
 	}
 
 	claims, err := jwt.DecodeJWTPayload(idToken)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Failed to decode ID token payload", log.Error(err))
+		logger.Debug(ctx, "Failed to decode ID token payload", log.Error(err))
 		return nil, &ErrorInvalidIDToken
 	}
 
@@ -203,7 +203,7 @@ func (s *oidcAuthnService) GetInternalUser(
 func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID, code string) (
 	*authncm.FederatedAuthResult, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
-	logger.DebugWithContext(ctx, "Performing federated OIDC authentication")
+	logger.Debug(ctx, "Performing federated OIDC authentication")
 
 	tokenResp, svcErr := s.ExchangeCodeForToken(ctx, idpID, code, true)
 	if svcErr != nil {
@@ -223,7 +223,7 @@ func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID, code string)
 		}
 	}
 	if sub == "" {
-		logger.DebugWithContext(ctx, "sub claim not found in ID token")
+		logger.Debug(ctx, "sub claim not found in ID token")
 		return nil, &authncm.ErrorSubClaimNotFound
 	}
 
@@ -239,7 +239,7 @@ func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID, code string)
 					}
 				}
 			} else {
-				logger.DebugWithContext(ctx, "UserInfo sub mismatch, skipping attribute merge")
+				logger.Debug(ctx, "UserInfo sub mismatch, skipping attribute merge")
 			}
 		}
 	}

--- a/backend/internal/authn/otp/service.go
+++ b/backend/internal/authn/otp/service.go
@@ -78,7 +78,7 @@ func newOTPAuthnService(otpSvc notification.OTPServiceInterface,
 func (s *otpAuthnService) SendOTP(ctx context.Context, senderID string, channel notifcommon.ChannelType,
 	recipient string) (string, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Sending OTP for authentication", log.MaskedString("recipient", recipient),
+	logger.Debug(ctx, "Sending OTP for authentication", log.MaskedString("recipient", recipient),
 		log.String("channel", string(channel)))
 
 	if svcErr := s.validateOTPSendRequest(senderID, channel, recipient); svcErr != nil {
@@ -95,7 +95,7 @@ func (s *otpAuthnService) SendOTP(ctx context.Context, senderID string, channel 
 		return "", s.handleOTPServiceError(ctx, svcErr, false, logger)
 	}
 
-	logger.DebugWithContext(ctx, "OTP sent successfully, session token generated")
+	logger.Debug(ctx, "OTP sent successfully, session token generated")
 	return result.SessionToken, nil
 }
 
@@ -103,7 +103,7 @@ func (s *otpAuthnService) SendOTP(ctx context.Context, senderID string, channel 
 func (s *otpAuthnService) Authenticate(ctx context.Context, sessionToken,
 	otp string) (*OTPAuthnResult, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Verifying OTP for authentication")
+	logger.Debug(ctx, "Verifying OTP for authentication")
 
 	if svcErr := s.validateOTPVerifyRequest(sessionToken, otp); svcErr != nil {
 		return nil, svcErr
@@ -154,9 +154,9 @@ func (s *otpAuthnService) handleOTPServiceError(ctx context.Context, svcErr *ser
 	}
 
 	if isVerify {
-		logger.ErrorWithContext(ctx, "Error occurred while verifying OTP", log.Any("error", svcErr))
+		logger.Error(ctx, "Error occurred while verifying OTP", log.Any("error", svcErr))
 	} else {
-		logger.ErrorWithContext(ctx, "Error occurred while sending OTP", log.Any("error", svcErr))
+		logger.Error(ctx, "Error occurred while sending OTP", log.Any("error", svcErr))
 	}
 	return &serviceerror.InternalServerError
 }
@@ -180,7 +180,7 @@ func (s *otpAuthnService) handleVerifyOTPResponse(ctx context.Context, result *n
 	}
 
 	if result.Recipient == "" {
-		logger.ErrorWithContext(ctx, "Recipient not found in OTP verification result")
+		logger.Error(ctx, "Recipient not found in OTP verification result")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -201,7 +201,7 @@ func (s *otpAuthnService) handleVerifyOTPResponse(ctx context.Context, result *n
 // resolveUser retrieves a user by their recipient identifier (e.g., mobile number).
 func (s *otpAuthnService) resolveUser(ctx context.Context, recipient string, channel notifcommon.ChannelType,
 	logger *log.Logger) (*entityprovider.Entity, *serviceerror.ServiceError) {
-	logger.DebugWithContext(ctx, "Resolving user from recipient", log.MaskedString("recipient", recipient),
+	logger.Debug(ctx, "Resolving user from recipient", log.MaskedString("recipient", recipient),
 		log.String("channel", string(channel)))
 
 	// Build filter based on channel type
@@ -218,7 +218,7 @@ func (s *otpAuthnService) resolveUser(ctx context.Context, recipient string, cha
 		return nil, s.handleUserProviderError(ctx, upErr, logger)
 	}
 	if userID == nil || *userID == "" {
-		logger.DebugWithContext(ctx, "No user found for recipient", log.MaskedString("recipient", recipient))
+		logger.Debug(ctx, "No user found for recipient", log.MaskedString("recipient", recipient))
 		return nil, &common.ErrorUserNotFound
 	}
 
@@ -227,7 +227,7 @@ func (s *otpAuthnService) resolveUser(ctx context.Context, recipient string, cha
 		return nil, s.handleUserProviderError(ctx, upErr, logger)
 	}
 
-	logger.DebugWithContext(ctx, "User resolved from recipient", log.MaskedString(log.LoggerKeyUserID, user.ID))
+	logger.Debug(ctx, "User resolved from recipient", log.MaskedString(log.LoggerKeyUserID, user.ID))
 	return user, nil
 }
 
@@ -238,7 +238,7 @@ func (s *otpAuthnService) handleUserProviderError(ctx context.Context, upErr *en
 		return &common.ErrorUserNotFound
 	}
 	if upErr.Code == entityprovider.ErrorCodeSystemError {
-		logger.ErrorWithContext(ctx, "Error occurred while retrieving user", log.Any("error", upErr))
+		logger.Error(ctx, "Error occurred while retrieving user", log.Any("error", upErr))
 		return &serviceerror.InternalServerError
 	}
 	return serviceerror.CustomServiceError(ErrorClientErrorWhileResolvingUser, core.I18nMessage{

--- a/backend/internal/authn/passkey/service.go
+++ b/backend/internal/authn/passkey/service.go
@@ -88,7 +88,7 @@ func (w *passkeyService) StartRegistration(
 	}
 
 	logger := w.logger.With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Starting passkey credential registration",
+	logger.Debug(ctx, "Starting passkey credential registration",
 		log.MaskedString("userID", req.UserID),
 		log.String("relyingPartyID", req.RelyingPartyID))
 
@@ -116,7 +116,7 @@ func (w *passkeyService) StartRegistration(
 		rpDisplayName = req.RelyingPartyID
 	}
 
-	logger.DebugWithContext(ctx, "Retrieved existing credentials",
+	logger.Debug(ctx, "Retrieved existing credentials",
 		log.MaskedString("entityID", req.UserID),
 		log.Int("credentialCount", len(credentials)))
 
@@ -127,7 +127,7 @@ func (w *passkeyService) StartRegistration(
 	rpOrigins := getConfiguredOrigins()
 	webAuthnService, err := newDefaultWebAuthnService(req.RelyingPartyID, rpDisplayName, rpOrigins)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
+		logger.Error(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -138,18 +138,18 @@ func (w *passkeyService) StartRegistration(
 	// The WebAuthn service will generate challenge and set timeout automatically
 	options, sessionData, err := webAuthnService.BeginRegistration(webAuthnUser, registrationOptions)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to begin passkey registration", log.String("error", err.Error()))
+		logger.Error(ctx, "Failed to begin passkey registration", log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	// Store session data in cache with TTL
 	sessionToken, svcErr := w.storeSessionData(ctx, sessionData)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to store session data", log.String("error", svcErr.Error.DefaultValue))
+		logger.Error(ctx, "Failed to store session data", log.String("error", svcErr.Error.DefaultValue))
 		return nil, svcErr
 	}
 
-	logger.DebugWithContext(ctx, "Passkey credential creation options generated successfully",
+	logger.Debug(ctx, "Passkey credential creation options generated successfully",
 		log.MaskedString("userID", req.UserID),
 		log.Int("credentialsCount", len(credentials)))
 
@@ -176,11 +176,11 @@ func (w *passkeyService) StartRegistration(
 func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyRegistrationFinishRequest) (
 	*PasskeyRegistrationFinishData, *serviceerror.ServiceError) {
 	logger := w.logger.With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Finishing passkey credential registration")
+	logger.Debug(ctx, "Finishing passkey credential registration")
 
 	// Validate input
 	if svcErr := validateRegistrationFinishRequest(req); svcErr != nil {
-		logger.DebugWithContext(ctx, "Registration finish request validation failed")
+		logger.Debug(ctx, "Registration finish request validation failed")
 		return nil, svcErr
 	}
 
@@ -190,7 +190,7 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 		credentialType = "public-key"
 	}
 
-	logger.DebugWithContext(ctx, "Parsing attestation response",
+	logger.Debug(ctx, "Parsing attestation response",
 		log.String("credentialID", req.CredentialID),
 		log.String("credentialType", credentialType),
 		log.Int("clientDataJSONLen", len(req.ClientDataJSON)),
@@ -205,21 +205,21 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 		req.AttestationObject,
 	)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Failed to parse attestation response",
+		logger.Debug(ctx, "Failed to parse attestation response",
 			log.String("error", err.Error()),
 			log.String("credentialID", req.CredentialID),
 			log.String("credentialType", credentialType))
 		return nil, &ErrorInvalidAttestationResponse
 	}
 
-	logger.DebugWithContext(ctx, "Successfully parsed attestation response",
+	logger.Debug(ctx, "Successfully parsed attestation response",
 		log.String("credentialID", parsedCredential.ID),
 		log.String("credentialType", parsedCredential.Type))
 
 	// Retrieve session data from cache
 	sessionData, userID, relyingPartyID, svcErr := w.retrieveSessionData(ctx, req.SessionToken)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to retrieve session data", log.String("error", svcErr.Error.DefaultValue))
+		logger.Error(ctx, "Failed to retrieve session data", log.String("error", svcErr.Error.DefaultValue))
 		return nil, svcErr
 	}
 
@@ -236,7 +236,7 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 	}
 	credentials := w.decodePasskeyCredentials(ctx, userID, entries)
 
-	logger.DebugWithContext(ctx, "Retrieved existing credentials for entity",
+	logger.Debug(ctx, "Retrieved existing credentials for entity",
 		log.MaskedString("entityID", userID),
 		log.Int("credentialCount", len(credentials)))
 
@@ -247,14 +247,14 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 	rpOrigins := getConfiguredOrigins()
 	webAuthnService, err := newDefaultWebAuthnService(relyingPartyID, relyingPartyID, rpOrigins)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
+		logger.Error(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	// Verify the credential using WebAuthn service
 	credential, err := webAuthnService.CreateCredential(webAuthnUser, *sessionData, parsedCredential)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to verify and create credential", log.String("error", err.Error()))
+		logger.Error(ctx, "Failed to verify and create credential", log.String("error", err.Error()))
 		return nil, &ErrorInvalidAttestationResponse
 	}
 
@@ -269,7 +269,7 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 
 	// Store credential in database using user service
 	if err := w.storePasskeyCredential(ctx, userID, credential); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to store credential in database", log.Error(err))
+		logger.Error(ctx, "Failed to store credential in database", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -296,10 +296,10 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 	isUsernameless := strings.TrimSpace(req.UserID) == ""
 
 	if isUsernameless {
-		logger.DebugWithContext(ctx, "Starting usernameless passkey authentication",
+		logger.Debug(ctx, "Starting usernameless passkey authentication",
 			log.String("relyingPartyID", req.RelyingPartyID))
 	} else {
-		logger.DebugWithContext(ctx, "Starting passkey authentication",
+		logger.Debug(ctx, "Starting passkey authentication",
 			log.MaskedString("userID", req.UserID),
 			log.String("relyingPartyID", req.RelyingPartyID))
 	}
@@ -313,7 +313,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 	rpOrigins := getConfiguredOrigins()
 	webAuthnService, err := newDefaultWebAuthnService(req.RelyingPartyID, req.RelyingPartyID, rpOrigins)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
+		logger.Error(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -324,7 +324,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 		// Usernameless flow: Use discoverable credentials
 		options, sessionData, err = webAuthnService.BeginDiscoverableLogin()
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to begin usernameless passkey login", log.String("error", err.Error()))
+			logger.Error(ctx, "Failed to begin usernameless passkey login", log.String("error", err.Error()))
 			return nil, &serviceerror.InternalServerError
 		}
 	} else {
@@ -340,12 +340,12 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 		}
 		credentials := w.decodePasskeyCredentials(ctx, req.UserID, entries)
 
-		logger.DebugWithContext(ctx, "Retrieved credentials for authentication",
+		logger.Debug(ctx, "Retrieved credentials for authentication",
 			log.MaskedString("entityID", req.UserID),
 			log.Int("credentialCount", len(credentials)))
 
 		if len(credentials) == 0 {
-			logger.DebugWithContext(ctx, "No credentials found for entity", log.MaskedString("entityID", req.UserID))
+			logger.Debug(ctx, "No credentials found for entity", log.MaskedString("entityID", req.UserID))
 			return nil, &ErrorNoCredentialsFound
 		}
 
@@ -356,7 +356,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 		// The WebAuthn service will generate challenge and set timeout automatically
 		options, sessionData, err = webAuthnService.BeginLogin(webAuthnUser)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to begin passkey login", log.String("error", err.Error()))
+			logger.Error(ctx, "Failed to begin passkey login", log.String("error", err.Error()))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -364,7 +364,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 	// Store session data in cache with TTL
 	sessionToken, svcErr := w.storeSessionData(ctx, sessionData)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to store session data", log.String("error", svcErr.Error.DefaultValue))
+		logger.Error(ctx, "Failed to store session data", log.String("error", svcErr.Error.DefaultValue))
 		return nil, svcErr
 	}
 
@@ -388,7 +388,7 @@ func (w *passkeyService) StartAuthentication(ctx context.Context, req *PasskeyAu
 func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyAuthenticationFinishRequest) (
 	*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := w.logger.With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Finishing passkey authentication")
+	logger.Debug(ctx, "Finishing passkey authentication")
 
 	// Validate input
 	if svcErr := validateAuthenticationFinishRequest(req); svcErr != nil {
@@ -398,7 +398,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	// Retrieve session data from cache
 	sessionData, sessionUserID, relyingPartyID, svcErr := w.retrieveSessionData(ctx, req.SessionToken)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to retrieve session data", log.String("error", svcErr.Error.DefaultValue))
+		logger.Error(ctx, "Failed to retrieve session data", log.String("error", svcErr.Error.DefaultValue))
 		return nil, svcErr
 	}
 
@@ -410,7 +410,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	if isUsernameless {
 		// Usernameless flow: Resolve user from userHandle in the authentication response
 		if req.UserHandle == "" {
-			logger.ErrorWithContext(ctx, "UserHandle is required for usernameless authentication")
+			logger.Error(ctx, "UserHandle is required for usernameless authentication")
 			return nil, &ErrorInvalidAuthenticatorResponse
 		}
 
@@ -420,18 +420,18 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 			// Try RawURLEncoding if standard encoding fails
 			userHandleBytes, err = base64.RawURLEncoding.DecodeString(req.UserHandle)
 			if err != nil {
-				logger.ErrorWithContext(ctx, "Failed to decode userHandle", log.Error(err))
+				logger.Error(ctx, "Failed to decode userHandle", log.Error(err))
 				return nil, &ErrorInvalidAuthenticatorResponse
 			}
 		}
 
 		userID = string(userHandleBytes)
-		logger.DebugWithContext(ctx, "Resolved userID from userHandle for usernameless authentication",
+		logger.Debug(ctx, "Resolved userID from userHandle for usernameless authentication",
 			log.MaskedString("userID", userID))
 	} else {
 		// Username-based flow: Use userID from session
 		userID = sessionUserID
-		logger.DebugWithContext(ctx, "Processing passkey authentication",
+		logger.Debug(ctx, "Processing passkey authentication",
 			log.MaskedString("userID", userID),
 			log.String("relyingPartyID", relyingPartyID))
 	}
@@ -448,12 +448,12 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	}
 	credentials := w.decodePasskeyCredentials(ctx, userID, entries)
 
-	logger.DebugWithContext(ctx, "Retrieved credentials for authentication verification",
+	logger.Debug(ctx, "Retrieved credentials for authentication verification",
 		log.MaskedString("entityID", userID),
 		log.Int("credentialCount", len(credentials)))
 
 	if len(credentials) == 0 {
-		logger.DebugWithContext(ctx, "No credentials found for entity", log.MaskedString("entityID", userID))
+		logger.Debug(ctx, "No credentials found for entity", log.MaskedString("entityID", userID))
 		return nil, &ErrorNoCredentialsFound
 	}
 
@@ -464,7 +464,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	rpOrigins := getConfiguredOrigins()
 	webAuthnService, err := newDefaultWebAuthnService(relyingPartyID, relyingPartyID, rpOrigins)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
+		logger.Error(ctx, "Failed to initialize WebAuthn service", log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -472,7 +472,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 	parsedResponse, err := parseAssertionResponse(req.CredentialID, req.CredentialType,
 		req.ClientDataJSON, req.AuthenticatorData, req.Signature, req.UserHandle)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Failed to parse assertion response", log.String("error", err.Error()))
+		logger.Debug(ctx, "Failed to parse assertion response", log.String("error", err.Error()))
 		return nil, &ErrorInvalidAuthenticatorResponse
 	}
 
@@ -487,29 +487,29 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 
 		_, credential, err = webAuthnService.ValidatePasskeyLogin(userHandler, *sessionData, parsedResponse)
 		if err != nil {
-			logger.DebugWithContext(ctx, "Failed to validate passkey assertion", log.String("error", err.Error()))
+			logger.Debug(ctx, "Failed to validate passkey assertion", log.String("error", err.Error()))
 			return nil, &ErrorInvalidSignature
 		}
 	} else {
 		// Username-based flow: Use ValidateLogin with specific user
 		credential, err = webAuthnService.ValidateLogin(webAuthnUser, *sessionData, parsedResponse)
 		if err != nil {
-			logger.DebugWithContext(ctx, "Failed to validate WebAuthn assertion", log.String("error", err.Error()))
+			logger.Debug(ctx, "Failed to validate WebAuthn assertion", log.String("error", err.Error()))
 			return nil, &ErrorInvalidSignature
 		}
 	}
 
-	logger.DebugWithContext(ctx, "Passkey authentication verified successfully",
+	logger.Debug(ctx, "Passkey authentication verified successfully",
 		log.String("credentialID", base64.StdEncoding.EncodeToString(credential.ID)),
 		log.Any("signCount", credential.Authenticator.SignCount))
 
 	// Update credential in database to prevent replay attacks
 	if err := w.updatePasskeyCredential(ctx, userID, credential); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to update credential sign count in database", log.Error(err))
+		logger.Error(ctx, "Failed to update credential sign count in database", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Updated credential sign count in database",
+	logger.Debug(ctx, "Updated credential sign count in database",
 		log.MaskedString("userID", userID),
 		log.String("credentialID", base64.StdEncoding.EncodeToString(credential.ID)),
 		log.Any("newSignCount", credential.Authenticator.SignCount))
@@ -524,7 +524,7 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 		OUID: coreEntity.OUID,
 	}
 
-	logger.DebugWithContext(ctx, "Passkey authentication completed successfully",
+	logger.Debug(ctx, "Passkey authentication completed successfully",
 		log.MaskedString("entityID", userID))
 
 	return authResponse, nil
@@ -539,10 +539,10 @@ func (w *passkeyService) getEntity(
 	e, err := w.entityService.GetEntity(ctx, entityID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.DebugWithContext(ctx, "Entity not found", log.MaskedString("entityID", entityID))
+			logger.Debug(ctx, "Entity not found", log.MaskedString("entityID", entityID))
 			return nil, &ErrorUserNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to retrieve entity", log.Error(err))
+		logger.Error(ctx, "Failed to retrieve entity", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return e, nil
@@ -558,10 +558,10 @@ func (w *passkeyService) getStoredPasskeyEntries(
 	entries, err := w.entityService.GetCredentialsByType(ctx, entityID, passkeyCredentialType)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.DebugWithContext(ctx, "Entity not found", log.MaskedString("entityID", entityID))
+			logger.Debug(ctx, "Entity not found", log.MaskedString("entityID", entityID))
 			return nil, &ErrorUserNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to retrieve passkey credentials", log.Error(err))
+		logger.Error(ctx, "Failed to retrieve passkey credentials", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return entries, nil
@@ -577,12 +577,12 @@ func (w *passkeyService) decodePasskeyCredentials(ctx context.Context,
 	credentials := make([]webauthnCredential, 0, len(entries))
 	for _, entry := range entries {
 		if entry.Value == "" {
-			logger.ErrorWithContext(ctx, "Empty credential value", log.MaskedString("entityID", entityID))
+			logger.Error(ctx, "Empty credential value", log.MaskedString("entityID", entityID))
 			continue
 		}
 		var credential webauthnCredential
 		if err := json.Unmarshal([]byte(entry.Value), &credential); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to unmarshal passkey credential",
+			logger.Error(ctx, "Failed to unmarshal passkey credential",
 				log.MaskedString("entityID", entityID),
 				log.Error(err))
 			continue
@@ -600,7 +600,7 @@ func (w *passkeyService) storePasskeyCredential(
 
 	credentialJSON, err := json.Marshal(credential)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to marshal credential",
+		logger.Error(ctx, "Failed to marshal credential",
 			log.MaskedString("entityID", entityID),
 			log.Error(err))
 		return fmt.Errorf("failed to marshal credential: %w", err)
@@ -622,13 +622,13 @@ func (w *passkeyService) storePasskeyCredential(
 		return fmt.Errorf("failed to marshal passkey credentials: %w", err)
 	}
 	if err := w.entityService.UpdateSystemCredentials(ctx, entityID, payload); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to update passkey credentials",
+		logger.Error(ctx, "Failed to update passkey credentials",
 			log.MaskedString("entityID", entityID),
 			log.Error(err))
 		return fmt.Errorf("failed to update passkey credentials: %w", err)
 	}
 
-	logger.DebugWithContext(ctx, "Successfully stored passkey credential in database",
+	logger.Debug(ctx, "Successfully stored passkey credential in database",
 		log.MaskedString("entityID", entityID),
 		log.String("credentialID", base64.StdEncoding.EncodeToString(credential.ID)))
 
@@ -653,7 +653,7 @@ func (w *passkeyService) updatePasskeyCredential(
 	for _, entry := range existingEntries {
 		var credential webauthnCredential
 		if err := json.Unmarshal([]byte(entry.Value), &credential); err != nil {
-			logger.WarnWithContext(ctx, "Failed to unmarshal credential, keeping original",
+			logger.Warn(ctx, "Failed to unmarshal credential, keeping original",
 				log.MaskedString("entityID", entityID),
 				log.Error(err))
 			updatedEntries = append(updatedEntries, entry)
@@ -663,7 +663,7 @@ func (w *passkeyService) updatePasskeyCredential(
 		if string(credential.ID) == string(updatedCredential.ID) {
 			credentialJSON, marshalErr := json.Marshal(updatedCredential)
 			if marshalErr != nil {
-				logger.ErrorWithContext(ctx, "Failed to marshal updated credential",
+				logger.Error(ctx, "Failed to marshal updated credential",
 					log.MaskedString("entityID", entityID),
 					log.Error(marshalErr))
 				return fmt.Errorf("failed to marshal updated credential: %w", marshalErr)
@@ -675,7 +675,7 @@ func (w *passkeyService) updatePasskeyCredential(
 			})
 			found = true
 
-			logger.DebugWithContext(ctx, "Updated credential in memory",
+			logger.Debug(ctx, "Updated credential in memory",
 				log.MaskedString("entityID", entityID),
 				log.String("credentialID", base64.StdEncoding.EncodeToString(updatedCredential.ID)),
 				log.Any("newSignCount", updatedCredential.Authenticator.SignCount))
@@ -685,7 +685,7 @@ func (w *passkeyService) updatePasskeyCredential(
 	}
 
 	if !found {
-		logger.WarnWithContext(ctx, "Passkey credential not found for update",
+		logger.Warn(ctx, "Passkey credential not found for update",
 			log.MaskedString("entityID", entityID),
 			log.String("credentialID", base64.StdEncoding.EncodeToString(updatedCredential.ID)))
 		return fmt.Errorf("credential not found for update")
@@ -698,13 +698,13 @@ func (w *passkeyService) updatePasskeyCredential(
 		return fmt.Errorf("failed to marshal passkey credentials: %w", err)
 	}
 	if err := w.entityService.UpdateSystemCredentials(ctx, entityID, payload); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to update credentials",
+		logger.Error(ctx, "Failed to update credentials",
 			log.MaskedString("entityID", entityID),
 			log.Error(err))
 		return fmt.Errorf("failed to update passkey credentials: %w", err)
 	}
 
-	logger.DebugWithContext(ctx, "Successfully updated passkey credential in database",
+	logger.Debug(ctx, "Successfully updated passkey credential in database",
 		log.MaskedString("entityID", entityID),
 		log.String("credentialID", base64.StdEncoding.EncodeToString(updatedCredential.ID)),
 		log.Any("newSignCount", updatedCredential.Authenticator.SignCount))

--- a/backend/internal/authn/passkey/service_test.go
+++ b/backend/internal/authn/passkey/service_test.go
@@ -1405,3 +1405,274 @@ func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_ValidateLogin_Re
 	suite.NotNil(err)
 	suite.True(err.Code == ErrorInvalidSignature.Code || err.Code == ErrorInvalidAuthenticatorResponse.Code)
 }
+
+// validAttestationCredentialID is a real credential ID matching validAttestationObject below.
+//
+//nolint:gosec,lll // Test fixture credential identifier, not a real credential.
+const validAttestationCredentialID = "6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g"
+
+// validAttestationObject is a real "none" attestation object that parses successfully.
+//
+//nolint:lll // Real WebAuthn attestation fixture.
+const validAttestationObject = "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEdKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOsa7QYSUFukFOLTmgeK6x2ktirNMgwy_6vIwwtegxI2flS1X-JAkZL5dsadg-9bEz2J7PnsbB0B08txvsyUSvKlAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNciWCDHwin8Zdkr56iSIh0MrB5qZiEzYLQpEOREhMUkY6q4Vw"
+
+// validAttestationClientDataJSON is the clientDataJSON matching validAttestationObject.
+//
+//nolint:lll // Real WebAuthn clientDataJSON fixture.
+const validAttestationClientDataJSON = "eyJjaGFsbGVuZ2UiOiJXOEd6RlU4cEdqaG9SYldyTERsYW1BZnFfeTRTMUNaRzFWdW9lUkxBUnJFIiwib3JpZ2luIjoiaHR0cHM6Ly93ZWJhdXRobi5pbyIsInR5cGUiOiJ3ZWJhdXRobi5jcmVhdGUifQ"
+
+func (suite *WebAuthnServiceTestSuite) TestStartRegistration_WebAuthnInitError() {
+	req := &PasskeyRegistrationStartRequest{
+		UserID:         testUserID,
+		RelyingPartyID: "%zz",
+	}
+
+	testEntity := &entity.Entity{
+		ID:       testUserID,
+		Category: entity.EntityCategoryUser,
+		Type:     "person",
+	}
+
+	suite.mockEntityService.On("GetEntity", mock.Anything, testUserID).
+		Return(testEntity, nil).Once()
+	suite.mockEntityService.On("GetCredentialsByType", mock.Anything, testUserID, "passkey").
+		Return(nil, nil).Once()
+
+	result, svcErr := suite.service.StartRegistration(context.Background(), req)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_WebAuthnInitError() {
+	req := &PasskeyAuthenticationStartRequest{
+		UserID:         testUserID,
+		RelyingPartyID: "%zz",
+	}
+
+	result, svcErr := suite.service.StartAuthentication(context.Background(), req)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *WebAuthnServiceTestSuite) TestStartAuthentication_UsernameStoreSessionError() {
+	mockCredential := webauthnCredential{
+		ID:        []byte("credential123"),
+		PublicKey: []byte("publickey123"),
+		Authenticator: authenticator{
+			AAGUID:    []byte("aaguid123"),
+			SignCount: 5,
+		},
+	}
+	credentialJSON, _ := json.Marshal(mockCredential)
+
+	testEntity := &entity.Entity{
+		ID:       testUserID,
+		Category: entity.EntityCategoryUser,
+		Type:     "person",
+	}
+
+	suite.mockEntityService.On("GetEntity", mock.Anything, testUserID).
+		Return(testEntity, nil).Once()
+	suite.mockEntityService.On("GetCredentialsByType", mock.Anything, testUserID, "passkey").
+		Return([]entity.StoredCredential{{Value: string(credentialJSON)}}, nil).Once()
+
+	suite.mockSessionStore.On("storeSession",
+		mock.Anything, mock.AnythingOfType("string"),
+		mock.Anything,
+		mock.AnythingOfType("int64")).
+		Return(assert.AnError).Once()
+
+	req := &PasskeyAuthenticationStartRequest{
+		UserID:         testUserID,
+		RelyingPartyID: testRelyingPartyID,
+	}
+	result, svcErr := suite.service.StartAuthentication(context.Background(), req)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *WebAuthnServiceTestSuite) TestFinishRegistration_WebAuthnInitError() {
+	sessionData := &sessionData{
+		Challenge:      "W8GzFU8pGjhoRbWrLDlamAfq_y4S1CZG1VuoeRLARrE",
+		UserID:         []byte(testUserID),
+		RelyingPartyID: "%zz",
+	}
+
+	testEntity := &entity.Entity{
+		ID:       testUserID,
+		Category: entity.EntityCategoryUser,
+		Type:     "person",
+	}
+
+	suite.mockSessionStore.On("retrieveSession", mock.Anything, testSessionToken).
+		Return(sessionData, nil).Once()
+	suite.mockEntityService.On("GetEntity", mock.Anything, testUserID).
+		Return(testEntity, nil).Once()
+	suite.mockEntityService.On("GetCredentialsByType", mock.Anything, testUserID, "passkey").
+		Return(nil, nil).Once()
+
+	req := &PasskeyRegistrationFinishRequest{
+		SessionToken:      testSessionToken,
+		CredentialID:      validAttestationCredentialID,
+		CredentialType:    "public-key",
+		ClientDataJSON:    validAttestationClientDataJSON,
+		AttestationObject: validAttestationObject,
+	}
+	result, svcErr := suite.service.FinishRegistration(context.Background(), req)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *WebAuthnServiceTestSuite) TestFinishRegistration_RetrieveSessionStoreError() {
+	suite.mockSessionStore.On("retrieveSession", mock.Anything, testSessionToken).
+		Return(nil, assert.AnError).Once()
+
+	req := &PasskeyRegistrationFinishRequest{
+		SessionToken:      testSessionToken,
+		CredentialID:      validAttestationCredentialID,
+		CredentialType:    "public-key",
+		ClientDataJSON:    validAttestationClientDataJSON,
+		AttestationObject: validAttestationObject,
+	}
+	result, svcErr := suite.service.FinishRegistration(context.Background(), req)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *WebAuthnServiceTestSuite) TestFinishRegistration_CreateCredentialError() {
+	sessionData := &sessionData{
+		Challenge:      "W8GzFU8pGjhoRbWrLDlamAfq_y4S1CZG1VuoeRLARrE",
+		UserID:         []byte(testUserID),
+		RelyingPartyID: testRelyingPartyID,
+	}
+
+	testEntity := &entity.Entity{
+		ID:       testUserID,
+		Category: entity.EntityCategoryUser,
+		Type:     "person",
+	}
+
+	suite.mockSessionStore.On("retrieveSession", mock.Anything, testSessionToken).
+		Return(sessionData, nil).Once()
+	suite.mockEntityService.On("GetEntity", mock.Anything, testUserID).
+		Return(testEntity, nil).Once()
+	suite.mockEntityService.On("GetCredentialsByType", mock.Anything, testUserID, "passkey").
+		Return(nil, nil).Once()
+
+	req := &PasskeyRegistrationFinishRequest{
+		SessionToken:      testSessionToken,
+		CredentialID:      validAttestationCredentialID,
+		CredentialType:    "public-key",
+		ClientDataJSON:    validAttestationClientDataJSON,
+		AttestationObject: validAttestationObject,
+	}
+	result, svcErr := suite.service.FinishRegistration(context.Background(), req)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(ErrorInvalidAttestationResponse.Code, svcErr.Code)
+}
+
+func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_UsernamelessMissingUserHandle() {
+	sessionData := &sessionData{
+		Challenge:      "challenge123",
+		UserID:         nil,
+		RelyingPartyID: testRelyingPartyID,
+	}
+
+	suite.mockSessionStore.On("retrieveSession", mock.Anything, testSessionToken).
+		Return(sessionData, nil).Once()
+
+	req := &PasskeyAuthenticationFinishRequest{
+		CredentialID:      testCredentialID,
+		CredentialType:    "public-key",
+		ClientDataJSON:    "clientDataJSON",
+		AuthenticatorData: "authenticatorData",
+		Signature:         "signature",
+		UserHandle:        "",
+		SessionToken:      testSessionToken,
+	}
+	result, svcErr := suite.service.FinishAuthentication(context.Background(), req)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(ErrorInvalidAuthenticatorResponse.Code, svcErr.Code)
+}
+
+func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_UsernamelessInvalidUserHandle() {
+	sessionData := &sessionData{
+		Challenge:      "challenge123",
+		UserID:         nil,
+		RelyingPartyID: testRelyingPartyID,
+	}
+
+	suite.mockSessionStore.On("retrieveSession", mock.Anything, testSessionToken).
+		Return(sessionData, nil).Once()
+
+	req := &PasskeyAuthenticationFinishRequest{
+		CredentialID:      testCredentialID,
+		CredentialType:    "public-key",
+		ClientDataJSON:    "clientDataJSON",
+		AuthenticatorData: "authenticatorData",
+		Signature:         "signature",
+		UserHandle:        "!!!@@@",
+		SessionToken:      testSessionToken,
+	}
+	result, svcErr := suite.service.FinishAuthentication(context.Background(), req)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(ErrorInvalidAuthenticatorResponse.Code, svcErr.Code)
+}
+
+func (suite *WebAuthnServiceTestSuite) TestFinishAuthentication_WebAuthnInitError() {
+	sessionData := &sessionData{
+		Challenge:      "challenge123",
+		UserID:         []byte(testUserID),
+		RelyingPartyID: "%zz",
+	}
+
+	mockCredential := webauthnCredential{
+		ID:        []byte("credential123"),
+		PublicKey: []byte("publickey123"),
+	}
+	credentialJSON, _ := json.Marshal(mockCredential)
+
+	testEntity := &entity.Entity{
+		ID:       testUserID,
+		Category: entity.EntityCategoryUser,
+		Type:     "person",
+	}
+
+	suite.mockSessionStore.On("retrieveSession", mock.Anything, testSessionToken).
+		Return(sessionData, nil).Once()
+	suite.mockEntityService.On("GetEntity", mock.Anything, testUserID).
+		Return(testEntity, nil).Once()
+	suite.mockEntityService.On("GetCredentialsByType", mock.Anything, testUserID, "passkey").
+		Return([]entity.StoredCredential{{Value: string(credentialJSON)}}, nil).Once()
+
+	req := &PasskeyAuthenticationFinishRequest{
+		CredentialID:      testCredentialID,
+		CredentialType:    "public-key",
+		ClientDataJSON:    "clientDataJSON",
+		AuthenticatorData: "authenticatorData",
+		Signature:         "signature",
+		UserHandle:        "",
+		SessionToken:      testSessionToken,
+	}
+	result, svcErr := suite.service.FinishAuthentication(context.Background(), req)
+
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}

--- a/backend/internal/authn/passkey/session.go
+++ b/backend/internal/authn/passkey/session.go
@@ -69,7 +69,7 @@ func (w *passkeyService) retrieveSessionData(ctx context.Context,
 	// Retrieve session data from database
 	session, err := w.sessionStore.retrieveSession(ctx, sessionKey)
 	if err != nil {
-		w.logger.DebugWithContext(ctx, "Failed to retrieve passkey session", log.Error(err))
+		w.logger.Debug(ctx, "Failed to retrieve passkey session", log.Error(err))
 		return nil, "", "", &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/authn/passkey/store.go
+++ b/backend/internal/authn/passkey/store.go
@@ -65,19 +65,19 @@ func (s *sessionStore) storeSession(
 	ctx context.Context, sessionKey string, session *sessionData, expirySeconds int64) error {
 	dbClient, err := s.dbProvider.GetRuntimeDBClient()
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to get database client", log.Error(err))
+		s.logger.Error(ctx, "Failed to get database client", log.Error(err))
 		return err
 	}
 
 	// Serialize session data to JSON
 	jsonDataBytes, err := s.serializeSessionData(session)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to marshal session data to JSON", log.Error(err))
+		s.logger.Error(ctx, "Failed to marshal session data to JSON", log.Error(err))
 		return err
 	}
 
 	if s.logger.IsDebugEnabled() {
-		s.logger.DebugWithContext(ctx, "Storing session data",
+		s.logger.Debug(ctx, "Storing session data",
 			log.MaskedString("sessionKey", sessionKey),
 			log.String("jsonDataLength", fmt.Sprintf("%d bytes", len(jsonDataBytes))))
 	}
@@ -85,11 +85,11 @@ func (s *sessionStore) storeSession(
 	expiryTime := time.Now().UTC().Add(time.Duration(expirySeconds) * time.Second)
 	_, err = dbClient.Execute(queryInsertSession, sessionKey, jsonDataBytes, expiryTime, s.deploymentID)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to insert WebAuthn session", log.Error(err))
+		s.logger.Error(ctx, "Failed to insert WebAuthn session", log.Error(err))
 		return err
 	}
 
-	s.logger.DebugWithContext(ctx, "WebAuthn session stored successfully",
+	s.logger.Debug(ctx, "WebAuthn session stored successfully",
 		log.MaskedString("sessionKey", sessionKey))
 
 	return nil
@@ -103,7 +103,7 @@ func (s *sessionStore) retrieveSession(ctx context.Context, sessionKey string) (
 
 	dbClient, err := s.dbProvider.GetRuntimeDBClient()
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to get database client", log.Error(err))
+		s.logger.Error(ctx, "Failed to get database client", log.Error(err))
 		return nil, err
 	}
 
@@ -111,12 +111,12 @@ func (s *sessionStore) retrieveSession(ctx context.Context, sessionKey string) (
 	now := time.Now().UTC()
 	results, err := dbClient.Query(queryGetSession, sessionKey, now, s.deploymentID)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to query WebAuthn session", log.Error(err))
+		s.logger.Error(ctx, "Failed to query WebAuthn session", log.Error(err))
 		return nil, err
 	}
 
 	if len(results) == 0 {
-		s.logger.DebugWithContext(ctx, "WebAuthn session not found or expired",
+		s.logger.Debug(ctx, "WebAuthn session not found or expired",
 			log.MaskedString("sessionKey", sessionKey))
 		return nil, nil
 	}
@@ -124,18 +124,18 @@ func (s *sessionStore) retrieveSession(ctx context.Context, sessionKey string) (
 	row := results[0]
 
 	if s.logger.IsDebugEnabled() {
-		s.logger.DebugWithContext(ctx, "Retrieved session row from database",
+		s.logger.Debug(ctx, "Retrieved session row from database",
 			log.MaskedString("sessionKey", sessionKey),
 			log.String("rowKeys", fmt.Sprintf("%v", getMapKeys(row))))
 	}
 
 	sessionData, err := s.buildSessionDataFromResultRow(ctx, row)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to build session data from result", log.Error(err))
+		s.logger.Error(ctx, "Failed to build session data from result", log.Error(err))
 		return nil, err
 	}
 
-	s.logger.DebugWithContext(ctx, "WebAuthn session retrieved successfully",
+	s.logger.Debug(ctx, "WebAuthn session retrieved successfully",
 		log.MaskedString("sessionKey", sessionKey))
 
 	return sessionData, nil
@@ -149,17 +149,17 @@ func (s *sessionStore) deleteSession(ctx context.Context, sessionKey string) err
 
 	dbClient, err := s.dbProvider.GetRuntimeDBClient()
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to get database client", log.Error(err))
+		s.logger.Error(ctx, "Failed to get database client", log.Error(err))
 		return err
 	}
 
 	_, err = dbClient.Execute(queryDeleteSession, sessionKey, s.deploymentID)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to delete WebAuthn session", log.Error(err))
+		s.logger.Error(ctx, "Failed to delete WebAuthn session", log.Error(err))
 		return err
 	}
 
-	s.logger.DebugWithContext(ctx, "WebAuthn session deleted successfully",
+	s.logger.Debug(ctx, "WebAuthn session deleted successfully",
 		log.MaskedString("sessionKey", sessionKey))
 
 	return nil
@@ -225,14 +225,14 @@ func (s *sessionStore) buildSessionDataFromResultRow(ctx context.Context,
 	} else if val, ok := row[dbColumnSessionData].([]byte); ok && len(val) > 0 {
 		payloadJSON = string(val)
 	} else {
-		s.logger.ErrorWithContext(ctx, "SESSION_DATA is missing or of unexpected type",
+		s.logger.Error(ctx, "SESSION_DATA is missing or of unexpected type",
 			log.String("type", fmt.Sprintf("%T", row[dbColumnSessionData])))
 		return nil, fmt.Errorf("SESSION_DATA is missing or invalid")
 	}
 
 	var jsonData map[string]interface{}
 	if err := json.Unmarshal([]byte(payloadJSON), &jsonData); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to unmarshal session payload JSON",
+		s.logger.Error(ctx, "Failed to unmarshal session payload JSON",
 			log.Error(err))
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (s *sessionStore) buildSessionDataFromResultRow(ctx context.Context,
 	if userIDStr, ok := jsonData[jsonKeyUserID].(string); ok && userIDStr != "" {
 		userIDBytes, err := base64.StdEncoding.DecodeString(userIDStr)
 		if err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to decode UserID from session data", log.Error(err))
+			s.logger.Error(ctx, "Failed to decode UserID from session data", log.Error(err))
 			return nil, err
 		}
 		sessionData.UserID = userIDBytes

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -132,7 +132,7 @@ func (as *authenticationService) AuthenticateWithCredentials(ctx context.Context
 	credentials map[string]interface{}, skipAssertion bool, existingAssertion string) (
 	*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.DebugWithContext(ctx, "Authenticating with credentials")
+	logger.Debug(ctx, "Authenticating with credentials")
 
 	if len(identifiers) == 0 || len(credentials) == 0 {
 		return nil, &ErrorEmptyAttributesOrCredentials
@@ -145,7 +145,7 @@ func (as *authenticationService) AuthenticateWithCredentials(ctx context.Context
 	}
 
 	if basicResult == nil {
-		logger.ErrorWithContext(ctx, "Credentials authenticate response is nil")
+		logger.Error(ctx, "Credentials authenticate response is nil")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -170,7 +170,7 @@ func (as *authenticationService) AuthenticateWithCredentials(ctx context.Context
 		}
 		authUserAttributesJSON, err := json.Marshal(authUserAttributes)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to marshal user attributes")
+			logger.Error(ctx, "Failed to marshal user attributes")
 			return nil, &serviceerror.InternalServerError
 		}
 
@@ -200,7 +200,7 @@ func (as *authenticationService) SendOTP(ctx context.Context, senderID string, c
 func (as *authenticationService) VerifyOTP(ctx context.Context, sessionToken string, skipAssertion bool,
 	existingAssertion, otpCode string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.DebugWithContext(ctx, "Verifying OTP for authentication")
+	logger.Debug(ctx, "Verifying OTP for authentication")
 
 	credentials := map[string]interface{}{
 		"otp": map[string]interface{}{
@@ -248,7 +248,7 @@ func (as *authenticationService) VerifyOTP(ctx context.Context, sessionToken str
 func (as *authenticationService) StartIDPAuthentication(ctx context.Context, requestedType idp.IDPType, idpID string) (
 	*IDPAuthInitData, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.DebugWithContext(ctx, "Starting IDP authentication", log.String("idpId", idpID))
+	logger.Debug(ctx, "Starting IDP authentication", log.String("idpId", idpID))
 
 	if strings.TrimSpace(idpID) == "" {
 		return nil, &common.ErrorInvalidIDPID
@@ -276,7 +276,7 @@ func (as *authenticationService) StartIDPAuthentication(ctx context.Context, req
 	case idp.IDPTypeGitHub:
 		redirectURL, buildURLErr = as.githubService.BuildAuthorizeURL(ctx, idpID)
 	default:
-		logger.ErrorWithContext(ctx, "Unsupported IDP type", log.String("idpId", idpID),
+		logger.Error(ctx, "Unsupported IDP type", log.String("idpId", idpID),
 			log.String("type", string(identityProvider.Type)))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -288,7 +288,7 @@ func (as *authenticationService) StartIDPAuthentication(ctx context.Context, req
 	// Generate session token
 	sessionToken, err := as.createSessionToken(ctx, idpID, identityProvider.Type)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create session token", log.String("idpId", idpID),
+		logger.Error(ctx, "Failed to create session token", log.String("idpId", idpID),
 			log.String("error", err.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -304,7 +304,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 	sessionToken string, skipAssertion bool, existingAssertion, code string) (
 	*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.DebugWithContext(ctx, "Finishing IDP authentication")
+	logger.Debug(ctx, "Finishing IDP authentication")
 
 	if strings.TrimSpace(sessionToken) == "" {
 		return nil, &common.ErrorEmptySessionToken
@@ -336,7 +336,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 		return nil, as.mapFederatedAuthnError(ctx, svcErr, logger)
 	}
 	if basicResult == nil {
-		logger.ErrorWithContext(ctx, "Federated authenticate response is nil")
+		logger.Error(ctx, "Federated authenticate response is nil")
 		return nil, &serviceerror.InternalServerError
 	}
 	if basicResult.IsAmbiguousUser {
@@ -362,7 +362,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 	if !skipAssertion {
 		authenticatorName, err := common.GetAuthenticatorNameForIDPType(sessionData.IDPType)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to get authenticator name for IDP type",
+			logger.Error(ctx, "Failed to get authenticator name for IDP type",
 				log.String("idpType", string(sessionData.IDPType)), log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
@@ -382,7 +382,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(
 	ctx context.Context, authResponse *common.AuthenticationResponse, user *entityprovider.Entity, authenticator string,
 	existingAssertion string, logger *log.Logger,
 ) *serviceerror.ServiceError {
-	logger.DebugWithContext(ctx, "Generating auth assertion", log.MaskedString(log.LoggerKeyUserID, user.ID))
+	logger.Debug(ctx, "Generating auth assertion", log.MaskedString(log.LoggerKeyUserID, user.ID))
 
 	authenticatorRef := &common.AuthenticatorReference{
 		Authenticator: authenticator,
@@ -401,7 +401,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(
 
 		// Validate that the assertion subject matches the current user
 		if assertionSub != user.ID {
-			logger.DebugWithContext(ctx, "Assertion subject mismatch", log.MaskedString("assertionSub", assertionSub),
+			logger.Debug(ctx, "Assertion subject mismatch", log.MaskedString("assertionSub", assertionSub),
 				log.MaskedString(log.LoggerKeyUserID, user.ID))
 			return &common.ErrorAssertionSubjectMismatch
 		}
@@ -440,7 +440,7 @@ func (as *authenticationService) validateAndAppendAuthAssertion(
 	token, _, err := as.jwtService.GenerateJWT(ctx, user.ID, jwtConfig.Issuer,
 		jwtConfig.ValidityPeriod, jwtClaims, jwt.TokenTypeJWT, "")
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to generate auth assertion", log.String("error", err.Error.DefaultValue))
+		logger.Error(ctx, "Failed to generate auth assertion", log.String("error", err.Error.DefaultValue))
 		return &serviceerror.InternalServerError
 	}
 
@@ -473,46 +473,46 @@ func (as *authenticationService) extractClaimsFromAssertion(ctx context.Context,
 	jwtConfig := config.GetServerRuntime().Config.JWT
 
 	if err := as.jwtService.VerifyJWT(ctx, assertion, "", jwtConfig.Issuer); err != nil {
-		logger.DebugWithContext(ctx, "Failed to verify JWT signature of the assertion",
+		logger.Debug(ctx, "Failed to verify JWT signature of the assertion",
 			log.String("error", err.Error.DefaultValue))
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
 	payload, err := jwt.DecodeJWTPayload(assertion)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Failed to decode JWT assertion", log.Error(err))
+		logger.Debug(ctx, "Failed to decode JWT assertion", log.Error(err))
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
 	// Extract subject claim
 	subClaim, ok := payload["sub"]
 	if !ok {
-		logger.DebugWithContext(ctx, "No 'sub' claim found in JWT assertion")
+		logger.Debug(ctx, "No 'sub' claim found in JWT assertion")
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 	sub, ok := subClaim.(string)
 	if !ok || strings.TrimSpace(sub) == "" {
-		logger.DebugWithContext(ctx, "Invalid 'sub' claim in JWT assertion")
+		logger.Debug(ctx, "Invalid 'sub' claim in JWT assertion")
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
 	// Extract assurance claim
 	assuranceClaim, ok := payload["assurance"]
 	if !ok {
-		logger.DebugWithContext(ctx, "No assurance claim found in JWT assertion")
+		logger.Debug(ctx, "No assurance claim found in JWT assertion")
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
 	// Convert assurance claim to AssuranceContext
 	assuranceBytes, err := json.Marshal(assuranceClaim)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Failed to marshal assurance claim", log.Error(err))
+		logger.Debug(ctx, "Failed to marshal assurance claim", log.Error(err))
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
 	var assuranceCtx assert.AssuranceContext
 	if err := json.Unmarshal(assuranceBytes, &assuranceCtx); err != nil {
-		logger.DebugWithContext(ctx, "Failed to unmarshal assurance claim to AssuranceContext", log.Error(err))
+		logger.Debug(ctx, "Failed to unmarshal assurance claim to AssuranceContext", log.Error(err))
 		return nil, "", &common.ErrorInvalidAssertion
 	}
 
@@ -530,7 +530,7 @@ func (as *authenticationService) mapFederatedAuthnError(ctx context.Context, svc
 	case authnprovidermgr.ErrorInvalidRequest.Code:
 		return &ErrorFederatedAuthenticationFailed
 	default:
-		logger.ErrorWithContext(ctx, "Error occurred while performing federated authentication",
+		logger.Error(ctx, "Error occurred while performing federated authentication",
 			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return &serviceerror.InternalServerError
 	}
@@ -547,7 +547,7 @@ func (as *authenticationService) mapCredentialsAuthnError(ctx context.Context, s
 	case authnprovidermgr.ErrorInvalidRequest.Code:
 		return &ErrorEmptyAttributesOrCredentials
 	default:
-		logger.ErrorWithContext(ctx, "Error occurred while authenticating with credentials",
+		logger.Error(ctx, "Error occurred while authenticating with credentials",
 			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return &serviceerror.InternalServerError
 	}
@@ -561,7 +561,7 @@ func (as *authenticationService) mapCredentialsGetAttributesError(
 	case authnprovidermgr.ErrorGetAttributesClientError.Code:
 		return &ErrorInvalidToken
 	default:
-		logger.ErrorWithContext(ctx, "Error occurred while getting attributes for credentials authentication",
+		logger.Error(ctx, "Error occurred while getting attributes for credentials authentication",
 			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return &serviceerror.InternalServerError
 	}
@@ -583,7 +583,7 @@ func (as *authenticationService) handleIDPServiceError(
 		})
 	}
 
-	logger.ErrorWithContext(ctx, "Error occurred while retrieving IDP",
+	logger.Error(ctx, "Error occurred while retrieving IDP",
 		log.String("idpId", idpID), log.Any("error", svcErr))
 	return &serviceerror.InternalServerError
 }
@@ -598,7 +598,7 @@ func (as *authenticationService) validateIDPType(ctx context.Context, requestedT
 			return nil
 		}
 
-		logger.DebugWithContext(ctx, "IDP type mismatch", log.String("requested", string(requestedType)),
+		logger.Debug(ctx, "IDP type mismatch", log.String("requested", string(requestedType)),
 			log.String("actual", string(actualType)))
 		return &common.ErrorInvalidIDPType
 	}
@@ -634,33 +634,33 @@ func (as *authenticationService) verifyAndDecodeSessionToken(ctx context.Context
 	jwtConfig := config.GetServerRuntime().Config.JWT
 	svcErr := as.jwtService.VerifyJWT(ctx, token, "auth-svc", jwtConfig.Issuer)
 	if svcErr != nil {
-		logger.DebugWithContext(ctx, "Error verifying session token", log.String("error", svcErr.Error.DefaultValue))
+		logger.Debug(ctx, "Error verifying session token", log.String("error", svcErr.Error.DefaultValue))
 		return nil, &common.ErrorInvalidSessionToken
 	}
 
 	// Parse and extract authentication session data
 	payload, err := jwt.DecodeJWTPayload(token)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Error decoding session token payload", log.Error(err))
+		logger.Debug(ctx, "Error decoding session token payload", log.Error(err))
 		return nil, &common.ErrorInvalidSessionToken
 	}
 
 	authDataClaim, ok := payload["auth_data"]
 	if !ok {
-		logger.DebugWithContext(ctx, "auth_data claim not found in session token")
+		logger.Debug(ctx, "auth_data claim not found in session token")
 		return nil, &common.ErrorInvalidSessionToken
 	}
 
 	authDataBytes, err := json.Marshal(authDataClaim)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Error marshaling auth_data claim", log.Error(err))
+		logger.Debug(ctx, "Error marshaling auth_data claim", log.Error(err))
 		return nil, &common.ErrorInvalidSessionToken
 	}
 
 	var sessionData AuthSessionData
 	err = json.Unmarshal(authDataBytes, &sessionData)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Error marshaling auth_data claim", log.Error(err))
+		logger.Debug(ctx, "Error marshaling auth_data claim", log.Error(err))
 		return nil, &common.ErrorInvalidSessionToken
 	}
 
@@ -673,7 +673,7 @@ func (as *authenticationService) StartPasskeyRegistration(
 	authSelection *PasskeyAuthenticatorSelectionDTO, attestation string,
 ) (interface{}, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.DebugWithContext(ctx, "Starting Passkey registration")
+	logger.Debug(ctx, "Starting Passkey registration")
 
 	var passkeyAuthSel *passkey.AuthenticatorSelection
 	if authSelection != nil {
@@ -702,7 +702,7 @@ func (as *authenticationService) FinishPasskeyRegistration(
 	sessionToken, credentialName string,
 ) (interface{}, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.DebugWithContext(ctx, "Finishing Passkey registration")
+	logger.Debug(ctx, "Finishing Passkey registration")
 
 	req := &passkey.PasskeyRegistrationFinishRequest{
 		CredentialID:      credential.ID,
@@ -720,7 +720,7 @@ func (as *authenticationService) FinishPasskeyRegistration(
 func (as *authenticationService) StartPasskeyAuthentication(ctx context.Context, userID, relyingPartyID string) (
 	interface{}, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.DebugWithContext(ctx, "Starting Passkey authentication")
+	logger.Debug(ctx, "Starting Passkey authentication")
 
 	req := &passkey.PasskeyAuthenticationStartRequest{
 		UserID:         userID,
@@ -734,7 +734,7 @@ func (as *authenticationService) FinishPasskeyAuthentication(ctx context.Context
 	response PasskeyCredentialResponseDTO, sessionToken string, skipAssertion bool,
 	existingAssertion string) (*common.AuthenticationResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
-	logger.DebugWithContext(ctx, "Finishing Passkey authentication")
+	logger.Debug(ctx, "Finishing Passkey authentication")
 
 	passkeyCredential := &passkey.PasskeyAuthenticationFinishRequest{
 		CredentialID:      credentialID,

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -1932,6 +1932,180 @@ func (suite *AuthenticationServiceTestSuite) TestFinishPasskeyAuthentication_Ser
 	suite.mockPasskeyService.AssertExpectations(suite.T())
 }
 
+func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsNilBasicResult() {
+	identifiers := map[string]interface{}{
+		"username": "testuser",
+	}
+	authnCredentials := map[string]interface{}{
+		"password": "testpass",
+	}
+
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, identifiers,
+		authnCredentials, mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, (*authnprovidermgr.AuthnBasicResult)(nil), nil).Once()
+
+	result, err := suite.service.AuthenticateWithCredentials(context.Background(), identifiers,
+		authnCredentials, true, "")
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsMarshalError() {
+	identifiers := map[string]interface{}{
+		"username": "testuser",
+	}
+	authnCredentials := map[string]interface{}{
+		"password": "testpass",
+	}
+
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, identifiers,
+		authnCredentials, mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			UserID:   testUserID,
+			UserType: testUserType,
+			OUID:     testOrgUnit,
+		}, nil).Once()
+	suite.mockAuthnProvider.On("GetUserAttributes", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidercm.AttributesResponse{
+			Attributes: map[string]*authnprovidercm.AttributeResponse{
+				"bad": {Value: make(chan int)},
+			},
+		}, nil).Once()
+
+	result, err := suite.service.AuthenticateWithCredentials(context.Background(), identifiers,
+		authnCredentials, false, "")
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsGetAttributesDefaultError() {
+	identifiers := map[string]interface{}{
+		"username": "testuser",
+	}
+	authnCredentials := map[string]interface{}{
+		"password": "testpass",
+	}
+
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, identifiers,
+		authnCredentials, mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			UserID:   testUserID,
+			UserType: testUserType,
+			OUID:     testOrgUnit,
+		}, nil).Once()
+	suite.mockAuthnProvider.On("GetUserAttributes", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, (*authnprovidercm.AttributesResponse)(nil),
+			&serviceerror.ServiceError{
+				Type:             serviceerror.ServerErrorType,
+				Code:             "UNMATCHED_ATTR_ERROR",
+				Error:            core.I18nMessage{Key: "error.test.attr", DefaultValue: "attr error"},
+				ErrorDescription: core.I18nMessage{Key: "error.test.attr_desc", DefaultValue: "attr desc"},
+			}).Once()
+
+	result, err := suite.service.AuthenticateWithCredentials(context.Background(), identifiers,
+		authnCredentials, false, "")
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *AuthenticationServiceTestSuite) TestMapCredentialsAuthnErrorDefault() {
+	logger := log.GetLogger()
+	svcErr := &serviceerror.ServiceError{
+		Type:             serviceerror.ServerErrorType,
+		Code:             "UNMATCHED_CREDENTIALS_ERROR",
+		Error:            core.I18nMessage{Key: "error.test.cred", DefaultValue: "cred error"},
+		ErrorDescription: core.I18nMessage{Key: "error.test.cred_desc", DefaultValue: "cred desc"},
+	}
+
+	result := suite.service.mapCredentialsAuthnError(context.Background(), svcErr, logger)
+
+	suite.NotNil(result)
+	suite.Equal(serviceerror.InternalServerError.Code, result.Code)
+}
+
+func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationUnsupportedType() {
+	idpID := testIDPID
+	identityProvider := &idp.IDPDTO{
+		ID:   idpID,
+		Type: idp.IDPType("UNSUPPORTED"),
+	}
+
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
+
+	result, err := suite.service.StartIDPAuthentication(context.Background(), "", idpID)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationNilBasicResult() {
+	sessionToken := suite.createSessionToken(idp.IDPTypeOAuth)
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, sessionToken, "auth-svc", mock.Anything).Return(nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(creds map[string]interface{}) bool {
+			_, ok := creds["federated"]
+			return ok
+		}), mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, (*authnprovidermgr.AuthnBasicResult)(nil), nil).Once()
+
+	result, err := suite.service.FinishIDPAuthentication(
+		context.Background(), idp.IDPTypeOAuth, sessionToken, true, "", testAuthCode)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *AuthenticationServiceTestSuite) TestFinishIDPAuthenticationAuthenticatorNameError() {
+	sessionToken := suite.createSessionToken("")
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, sessionToken, "auth-svc", mock.Anything).Return(nil)
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(creds map[string]interface{}) bool {
+			_, ok := creds["federated"]
+			return ok
+		}), mock.Anything, mock.Anything, mock.Anything).
+		Return(authnprovidermgr.AuthUser{}, &authnprovidermgr.AuthnBasicResult{
+			UserID:         testUserID,
+			UserType:       "person",
+			OUID:           testOrgUnit,
+			IsExistingUser: true,
+		}, nil).Once()
+
+	result, err := suite.service.FinishIDPAuthentication(
+		context.Background(), "", sessionToken, false, "", testAuthCode)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *AuthenticationServiceTestSuite) TestVerifyAndDecodeSessionTokenUnmarshalError() {
+	logger := log.GetLogger()
+	payload := map[string]interface{}{
+		"auth_data": "not-an-object",
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	encoded := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	token := "header." + encoded + ".signature"
+
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "auth-svc", mock.Anything).Return(nil)
+
+	result, err := suite.service.verifyAndDecodeSessionToken(context.Background(), token, logger)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(common.ErrorInvalidSessionToken.Code, err.Code)
+}
+
 func (suite *AuthenticationServiceTestSuite) createTestAssertion(subject string) string {
 	assuranceCtx := map[string]interface{}{
 		"aal": "aal1",

--- a/backend/internal/authnprovider/manager/manager.go
+++ b/backend/internal/authnprovider/manager/manager.go
@@ -51,7 +51,7 @@ func (m *authnProviderManager) AuthenticateUser(ctx context.Context, identifiers
 	result, svcErr := m.provider.Authenticate(ctx, identifiers, credentials, metadata)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
-			m.logger.ErrorWithContext(ctx, "provider returned server error during authentication",
+			m.logger.Error(ctx, "provider returned server error during authentication",
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			return AuthUser{}, nil, &serviceerror.InternalServerError
 		}
@@ -105,12 +105,12 @@ func (m *authnProviderManager) AuthenticateUser(ctx context.Context, identifiers
 func (m *authnProviderManager) GetUserAvailableAttributes(ctx context.Context,
 	authUser AuthUser) (*authnprovidercm.AttributesResponse, *serviceerror.ServiceError) {
 	if !authUser.IsAuthenticated() {
-		m.logger.ErrorWithContext(ctx, "GetUserAvailableAttributes called with unauthenticated authUser")
+		m.logger.Error(ctx, "GetUserAvailableAttributes called with unauthenticated authUser")
 		return nil, &serviceerror.InternalServerError
 	}
 	data, ok := authUser.getProviderData(defaultProvider)
 	if !ok {
-		m.logger.ErrorWithContext(ctx, "GetUserAvailableAttributes: no provider data found for default provider")
+		m.logger.Error(ctx, "GetUserAvailableAttributes: no provider data found for default provider")
 		return nil, &serviceerror.InternalServerError
 	}
 	return data.attributes, nil
@@ -122,12 +122,12 @@ func (m *authnProviderManager) GetUserAttributes(ctx context.Context,
 	metadata *authnprovidercm.GetAttributesMetadata,
 	authUser AuthUser) (AuthUser, *authnprovidercm.AttributesResponse, *serviceerror.ServiceError) {
 	if !authUser.IsAuthenticated() {
-		m.logger.ErrorWithContext(ctx, "GetUserAttributes called with unauthenticated authUser")
+		m.logger.Error(ctx, "GetUserAttributes called with unauthenticated authUser")
 		return AuthUser{}, nil, &serviceerror.InternalServerError
 	}
 	data, ok := authUser.getProviderData(defaultProvider)
 	if !ok {
-		m.logger.ErrorWithContext(ctx, "GetUserAttributes: no provider data found for default provider")
+		m.logger.Error(ctx, "GetUserAttributes: no provider data found for default provider")
 		return AuthUser{}, nil, &serviceerror.InternalServerError
 	}
 	if data.isAttributeValuesIncluded {
@@ -136,7 +136,7 @@ func (m *authnProviderManager) GetUserAttributes(ctx context.Context,
 	result, svcErr := m.provider.GetAttributes(ctx, data.token, requestedAttributes, metadata)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
-			m.logger.ErrorWithContext(ctx, "provider returned server error while fetching attributes",
+			m.logger.Error(ctx, "provider returned server error while fetching attributes",
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			return AuthUser{}, nil, &serviceerror.InternalServerError
 		}

--- a/backend/internal/authnprovider/provider/default_authn_provider.go
+++ b/backend/internal/authnprovider/provider/default_authn_provider.go
@@ -429,7 +429,7 @@ func newClientError(code, msg, desc string) *serviceerror.ServiceError {
 
 func (p *defaultAuthnProvider) logAndReturnServerError(
 	ctx context.Context, msg string, fields ...log.Field) *serviceerror.ServiceError {
-	p.logger.ErrorWithContext(ctx, msg, fields...)
+	p.logger.Error(ctx, msg, fields...)
 	err := serviceerror.InternalServerError
 	return &err
 }

--- a/backend/internal/authnprovider/provider/init.go
+++ b/backend/internal/authnprovider/provider/init.go
@@ -69,7 +69,7 @@ func initializeRestAuthnProvider() AuthnProviderInterface {
 	timeout := time.Duration(authnProviderConfig.Rest.Timeout) * time.Second
 	if baseURL == "" {
 		// Provider initialization runs during application startup, outside any request.
-		log.GetLogger().FatalWithContext(context.Background(), "AuthnProvider Rest BaseURL is required but found empty")
+		log.GetLogger().Fatal(context.Background(), "AuthnProvider Rest BaseURL is required but found empty")
 	}
 	if timeout == 0 {
 		timeout = 10 * time.Second

--- a/backend/internal/authnprovider/provider/rest_authn_provider.go
+++ b/backend/internal/authnprovider/provider/rest_authn_provider.go
@@ -123,7 +123,7 @@ func postAndDecode[T any](p *restAuthnProvider, ctx context.Context, url string,
 
 func (p *restAuthnProvider) logAndReturnServerError(
 	ctx context.Context, msg string, fields ...log.Field) *serviceerror.ServiceError {
-	p.logger.ErrorWithContext(ctx, msg, fields...)
+	p.logger.Error(ctx, msg, fields...)
 	err := serviceerror.InternalServerError
 	return &err
 }

--- a/backend/internal/authz/service.go
+++ b/backend/internal/authz/service.go
@@ -58,7 +58,7 @@ func (s *authorizationService) GetAuthorizedPermissions(
 	request GetAuthorizedPermissionsRequest,
 ) (*GetAuthorizedPermissionsResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Evaluating authorization request",
+	logger.Debug(ctx, "Evaluating authorization request",
 		log.MaskedString(log.LoggerKeyUserID, request.EntityID),
 		log.Int("groupCount", len(request.GroupIDs)),
 		log.Int("requestedPermissionCount", len(request.RequestedPermissions)))
@@ -83,14 +83,14 @@ func (s *authorizationService) GetAuthorizedPermissions(
 		request.RequestedPermissions,
 	)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Authorization evaluation failed",
+		logger.Error(ctx, "Authorization evaluation failed",
 			log.MaskedString(log.LoggerKeyUserID, request.EntityID),
 			log.Int("groupCount", len(request.GroupIDs)),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Authorization evaluation completed",
+	logger.Debug(ctx, "Authorization evaluation completed",
 		log.MaskedString(log.LoggerKeyUserID, request.EntityID),
 		log.Int("groupCount", len(request.GroupIDs)),
 		log.Int("requestedCount", len(request.RequestedPermissions)),

--- a/backend/internal/cert/cache_backed_store.go
+++ b/backend/internal/cert/cache_backed_store.go
@@ -198,10 +198,10 @@ func (s *cacheBackedStore) cacheCertificate(ctx context.Context, cert *Certifica
 			Key: cert.ID,
 		}
 		if err := s.certByIDCache.Set(ctx, idCacheKey, cert); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to cache certificate by ID", log.Error(err),
+			logger.Error(ctx, "Failed to cache certificate by ID", log.Error(err),
 				log.String("certID", cert.ID))
 		} else {
-			logger.DebugWithContext(ctx, "Certificate cached by ID", log.String("certID", cert.ID))
+			logger.Debug(ctx, "Certificate cached by ID", log.String("certID", cert.ID))
 		}
 	}
 
@@ -209,10 +209,10 @@ func (s *cacheBackedStore) cacheCertificate(ctx context.Context, cert *Certifica
 	if cert.RefType != "" && cert.RefID != "" {
 		refCacheKey := getCertByReferenceCacheKey(cert.RefType, cert.RefID)
 		if err := s.certByReferenceCache.Set(ctx, refCacheKey, cert); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to cache certificate by reference", log.Error(err),
+			logger.Error(ctx, "Failed to cache certificate by reference", log.Error(err),
 				log.String("refType", string(cert.RefType)), log.String("refID", cert.RefID))
 		} else {
-			logger.DebugWithContext(ctx, "Certificate cached by reference", log.String("refType", string(cert.RefType)),
+			logger.Debug(ctx, "Certificate cached by reference", log.String("refType", string(cert.RefType)),
 				log.String("refID", cert.RefID))
 		}
 	}
@@ -229,10 +229,10 @@ func (s *cacheBackedStore) invalidateCertificateCache(ctx context.Context, id st
 			Key: id,
 		}
 		if err := s.certByIDCache.Delete(ctx, idCacheKey); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to invalidate certificate cache by ID", log.Error(err),
+			logger.Error(ctx, "Failed to invalidate certificate cache by ID", log.Error(err),
 				log.String("certID", id))
 		} else {
-			logger.DebugWithContext(ctx, "Certificate cache invalidated by ID", log.String("certID", id))
+			logger.Debug(ctx, "Certificate cache invalidated by ID", log.String("certID", id))
 		}
 	}
 
@@ -240,10 +240,10 @@ func (s *cacheBackedStore) invalidateCertificateCache(ctx context.Context, id st
 	if refType != "" && refID != "" {
 		refCacheKey := getCertByReferenceCacheKey(refType, refID)
 		if err := s.certByReferenceCache.Delete(ctx, refCacheKey); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to invalidate certificate cache by reference", log.Error(err),
+			logger.Error(ctx, "Failed to invalidate certificate cache by reference", log.Error(err),
 				log.String("refType", string(refType)), log.String("refID", refID))
 		} else {
-			logger.DebugWithContext(ctx, "Certificate cache invalidated by reference",
+			logger.Debug(ctx, "Certificate cache invalidated by reference",
 				log.String("refType", string(refType)),
 				log.String("refID", refID))
 		}

--- a/backend/internal/cert/service.go
+++ b/backend/internal/cert/service.go
@@ -75,11 +75,11 @@ func (s *certificateService) GetCertificateByID(ctx context.Context,
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get certificate by ID", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to get certificate by ID", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if certObj == nil {
-		logger.DebugWithContext(ctx, "Certificate not found for ID", log.String("id", id))
+		logger.Debug(ctx, "Certificate not found for ID", log.String("id", id))
 		return nil, &ErrorCertificateNotFound
 	}
 
@@ -103,12 +103,12 @@ func (s *certificateService) GetCertificateByReference(ctx context.Context, refT
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get certificate by reference", log.String("refType", string(refType)),
+		logger.Error(ctx, "Failed to get certificate by reference", log.String("refType", string(refType)),
 			log.String("refID", refID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if certObj == nil {
-		logger.DebugWithContext(ctx, "Certificate not found for reference", log.String("refType", string(refType)),
+		logger.Debug(ctx, "Certificate not found for reference", log.String("refType", string(refType)),
 			log.String("refID", refID))
 		return nil, &ErrorCertificateNotFound
 	}
@@ -128,7 +128,7 @@ func (s *certificateService) CreateCertificate(ctx context.Context, cert *Certif
 	// Check if a certificate with the same reference already exists
 	existingCert, err := s.store.GetCertificateByReference(ctx, cert.RefType, cert.RefID)
 	if err != nil && !errors.Is(err, ErrCertificateNotFound) {
-		logger.ErrorWithContext(ctx, "Failed to check existing certificate",
+		logger.Error(ctx, "Failed to check existing certificate",
 			log.String("refType", string(cert.RefType)),
 			log.String("refID", cert.RefID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -139,7 +139,7 @@ func (s *certificateService) CreateCertificate(ctx context.Context, cert *Certif
 
 	cert.ID, err = sysutils.GenerateUUIDv7()
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+		logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -147,7 +147,7 @@ func (s *certificateService) CreateCertificate(ctx context.Context, cert *Certif
 		return s.store.CreateCertificate(txCtx, cert)
 	})
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create certificate", log.Error(err))
+		logger.Error(ctx, "Failed to create certificate", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -172,11 +172,11 @@ func (s *certificateService) UpdateCertificateByID(ctx context.Context, id strin
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get existing certificate", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to get existing certificate", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if existingCert == nil {
-		logger.DebugWithContext(ctx, "Certificate not found for update", log.String("id", id))
+		logger.Debug(ctx, "Certificate not found for update", log.String("id", id))
 		return nil, &ErrorCertificateNotFound
 	}
 
@@ -192,7 +192,7 @@ func (s *certificateService) UpdateCertificateByID(ctx context.Context, id strin
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to update certificate by ID", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to update certificate by ID", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -220,12 +220,12 @@ func (s *certificateService) UpdateCertificateByReference(ctx context.Context, r
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get existing certificate", log.String("refType", string(refType)),
+		logger.Error(ctx, "Failed to get existing certificate", log.String("refType", string(refType)),
 			log.String("refID", refID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if existingCert == nil {
-		logger.DebugWithContext(ctx, "Certificate not found for update", log.String("refType", string(refType)),
+		logger.Debug(ctx, "Certificate not found for update", log.String("refType", string(refType)),
 			log.String("refID", refID))
 		return nil, &ErrorCertificateNotFound
 	}
@@ -243,7 +243,7 @@ func (s *certificateService) UpdateCertificateByReference(ctx context.Context, r
 		if errors.Is(err, ErrCertificateNotFound) {
 			return nil, &ErrorCertificateNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to update certificate by reference",
+		logger.Error(ctx, "Failed to update certificate by reference",
 			log.String("refType", string(refType)),
 			log.String("refID", refID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -264,7 +264,7 @@ func (s *certificateService) DeleteCertificateByID(ctx context.Context, id strin
 		return s.store.DeleteCertificateByID(txCtx, id)
 	})
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to delete certificate by ID", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to delete certificate by ID", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -287,7 +287,7 @@ func (s *certificateService) DeleteCertificateByReference(ctx context.Context, r
 		return s.store.DeleteCertificateByReference(txCtx, refType, refID)
 	})
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to delete certificate by reference",
+		logger.Error(ctx, "Failed to delete certificate by reference",
 			log.String("refType", string(refType)),
 			log.String("refID", refID), log.Error(err))
 		return &serviceerror.InternalServerError

--- a/backend/internal/consent/default_client.go
+++ b/backend/internal/consent/default_client.go
@@ -262,7 +262,7 @@ func (c *defaultClient) createConsentElements(ctx context.Context, ouID string, 
 
 	result, err := sysutils.DecodeJSONResponse[elementsCreateResponseDTO](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode create-elements response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode create-elements response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -294,7 +294,7 @@ func (c *defaultClient) listConsentElements(ctx context.Context, ouID string, ns
 
 	result, err := sysutils.DecodeJSONResponse[elementListResponseDTO](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode list-elements response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode list-elements response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -336,7 +336,7 @@ func (c *defaultClient) updateConsentElement(ctx context.Context, ouID, elementI
 
 	result, err := sysutils.DecodeJSONResponse[elementResponseDTO](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode update-element response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode update-element response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	el := c.dtoToConsentElement(result)
@@ -391,7 +391,7 @@ func (c *defaultClient) validateConsentElements(ctx context.Context, ouID string
 
 	result, err := sysutils.DecodeJSONResponse[[]string](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode validate-elements response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode validate-elements response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -430,7 +430,7 @@ func (c *defaultClient) createConsentPurpose(ctx context.Context, ouID string, p
 
 	result, err := sysutils.DecodeJSONResponse[purposeResponseDTO](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode create-purpose response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode create-purpose response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	p := c.dtoToConsentPurpose(result)
@@ -463,7 +463,7 @@ func (c *defaultClient) listConsentPurposes(ctx context.Context, ouID, groupID s
 
 	result, err := sysutils.DecodeJSONResponse[purposeListResponseDTO](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode list-purposes response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode list-purposes response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -505,7 +505,7 @@ func (c *defaultClient) updateConsentPurpose(ctx context.Context, ouID, purposeI
 
 	result, err := sysutils.DecodeJSONResponse[purposeResponseDTO](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode update-purpose response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode update-purpose response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	p := c.dtoToConsentPurpose(result)
@@ -565,7 +565,7 @@ func (c *defaultClient) createConsent(ctx context.Context, ouID string, req *Con
 
 	result, err := sysutils.DecodeJSONResponse[consentResponseDTO](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode create-consent response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode create-consent response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	out := c.dtoToConsent(result)
@@ -597,7 +597,7 @@ func (c *defaultClient) searchConsents(ctx context.Context, ouID string, filter 
 
 	result, err := sysutils.DecodeJSONResponse[consentSearchResponseDTO](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode search-consents response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode search-consents response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -663,7 +663,7 @@ func (c *defaultClient) validateConsent(ctx context.Context, ouID, consentID str
 
 	result, err := sysutils.DecodeJSONResponse[consentValidateResponseDTO](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode validate-consent response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode validate-consent response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -698,7 +698,7 @@ func (c *defaultClient) updateConsent(ctx context.Context, ouID, consentID strin
 
 	result, err := sysutils.DecodeJSONResponse[consentResponseDTO](resp)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode update-consent response", log.Error(err))
+		c.logger.Error(ctx, "Failed to decode update-consent response", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	out := c.dtoToConsent(result)
@@ -760,7 +760,7 @@ func (c *defaultClient) buildServiceEndpoint(
 	ctx context.Context, pathSegments ...string) (string, *serviceerror.ServiceError) {
 	u, err := url.JoinPath(c.clientConfig.baseURL, pathSegments...)
 	if err != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to construct endpoint URL for consent operation", log.Error(err))
+		c.logger.Error(ctx, "Failed to construct endpoint URL for consent operation", log.Error(err))
 		return "", &serviceerror.InternalServerError
 	}
 
@@ -1066,7 +1066,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		var merr error
 		encodedBody, merr = json.Marshal(body)
 		if merr != nil {
-			c.logger.DebugWithContext(ctx, "Failed to marshal request body", log.Error(merr))
+			c.logger.Debug(ctx, "Failed to marshal request body", log.Error(merr))
 			return nil, &ErrorInvalidRequestFormat
 		}
 	}
@@ -1079,7 +1079,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
-				c.logger.WarnWithContext(ctx, "Consent request cancelled during retry", log.Error(ctx.Err()))
+				c.logger.Warn(ctx, "Consent request cancelled during retry", log.Error(ctx.Err()))
 				return nil, &serviceerror.InternalServerError
 			case <-time.After(backoff):
 			}
@@ -1097,7 +1097,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		req, err := http.NewRequestWithContext(reqCtx, method, url, bodyReader)
 		if err != nil {
 			cancel()
-			c.logger.ErrorWithContext(ctx, "Failed to create HTTP request", log.Error(err))
+			c.logger.Error(ctx, "Failed to create HTTP request", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 
@@ -1110,7 +1110,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		if err != nil {
 			cancel()
 			lastErr = err
-			c.logger.WarnWithContext(ctx, "Error reaching consent service, will retry if attempts remain",
+			c.logger.Warn(ctx, "Error reaching consent service, will retry if attempts remain",
 				log.Error(err), log.Int("attempt", attempt+1), log.Int("maxAttempts", maxAttempts))
 			continue
 		}
@@ -1118,7 +1118,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		// For 5xx responses, retry if attempts remain; on the last attempt return the
 		// response so checkStatus can inspect the final status code and body.
 		if resp.StatusCode >= http.StatusInternalServerError {
-			c.logger.WarnWithContext(ctx, "Consent service returned server error, will retry if attempts remain",
+			c.logger.Warn(ctx, "Consent service returned server error, will retry if attempts remain",
 				log.Int("status", resp.StatusCode), log.Int("attempt", attempt+1),
 				log.Int("maxAttempts", maxAttempts))
 
@@ -1140,7 +1140,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		return resp, nil
 	}
 
-	c.logger.ErrorWithContext(ctx, "All retry attempts exceeded for consent service request",
+	c.logger.Error(ctx, "All retry attempts exceeded for consent service request",
 		log.String("method", method), log.Error(lastErr))
 
 	return nil, &serviceerror.InternalServerError
@@ -1161,18 +1161,18 @@ func (c *defaultClient) checkStatus(ctx context.Context, resp *http.Response) *s
 	// Decode the error response body to extract details for logging
 	apiErr, decodeErr := sysutils.DecodeJSONResponse[consentBackendErrorDTO](resp)
 	if decodeErr != nil {
-		c.logger.ErrorWithContext(ctx, "Failed to decode error response from consent service", log.Error(decodeErr))
+		c.logger.Error(ctx, "Failed to decode error response from consent service", log.Error(decodeErr))
 	}
 
 	if resp.StatusCode >= 500 {
 		if decodeErr != nil {
-			c.logger.ErrorWithContext(ctx, "Consent service returned server error",
+			c.logger.Error(ctx, "Consent service returned server error",
 				log.Int("statusCode", resp.StatusCode))
 		} else {
 			// Handle conflict error for consent element deletion due to it's being associated with a purpose
 			// as a client error
 			if apiErr.Code == "CE-5009" {
-				c.logger.DebugWithContext(ctx,
+				c.logger.Debug(ctx,
 					"Consent service rejected request due to element being associated with a purpose",
 					log.Int("statusCode", resp.StatusCode),
 					log.String("code", apiErr.Code),
@@ -1180,7 +1180,7 @@ func (c *defaultClient) checkStatus(ctx context.Context, resp *http.Response) *s
 				return &ErrorDeletingConsentElementWithAssociatedPurpose
 			}
 
-			c.logger.ErrorWithContext(ctx, "Consent service returned server error",
+			c.logger.Error(ctx, "Consent service returned server error",
 				log.Int("statusCode", resp.StatusCode),
 				log.String("code", apiErr.Code),
 				log.String("description", apiErr.Description))
@@ -1196,9 +1196,9 @@ func (c *defaultClient) checkStatus(ctx context.Context, resp *http.Response) *s
 		return &ErrorConsentServiceReturnedForbidden
 	default:
 		if decodeErr != nil {
-			c.logger.DebugWithContext(ctx, "Consent service rejected request", log.Int("statusCode", resp.StatusCode))
+			c.logger.Debug(ctx, "Consent service rejected request", log.Int("statusCode", resp.StatusCode))
 		} else {
-			c.logger.DebugWithContext(ctx, "Consent service rejected request",
+			c.logger.Debug(ctx, "Consent service rejected request",
 				log.Int("statusCode", resp.StatusCode),
 				log.String("code", apiErr.Code),
 				log.String("description", apiErr.Description))
@@ -1211,7 +1211,7 @@ func (c *defaultClient) checkStatus(ctx context.Context, resp *http.Response) *s
 func (c *defaultClient) closeBody(ctx context.Context, resp *http.Response) {
 	if resp != nil && resp.Body != nil {
 		if err := resp.Body.Close(); err != nil {
-			c.logger.WarnWithContext(ctx, "Failed to close response body", log.Error(err))
+			c.logger.Warn(ctx, "Failed to close response body", log.Error(err))
 		}
 	}
 }
@@ -1221,9 +1221,9 @@ func (c *defaultClient) handleClientError(ctx context.Context, resp *http.Respon
 	svcErr *serviceerror.ServiceError) *serviceerror.ServiceError {
 	apiErr, err := sysutils.DecodeJSONResponse[consentBackendErrorDTO](resp)
 	if err != nil {
-		c.logger.DebugWithContext(ctx, "Consent service rejected request", log.Int("statusCode", resp.StatusCode))
+		c.logger.Debug(ctx, "Consent service rejected request", log.Int("statusCode", resp.StatusCode))
 	} else {
-		c.logger.DebugWithContext(ctx, "Consent service rejected request",
+		c.logger.Debug(ctx, "Consent service rejected request",
 			log.Int("statusCode", resp.StatusCode),
 			log.String("code", apiErr.Code),
 			log.String("description", apiErr.Description))

--- a/backend/internal/consent/service.go
+++ b/backend/internal/consent/service.go
@@ -39,7 +39,7 @@ func newConsentService(client consentClientInterface) ConsentServiceInterface {
 	isEnabled := config.GetServerRuntime().Config.Consent.Enabled
 	if !isEnabled {
 		// Service construction runs during application startup, outside any request.
-		log.GetLogger().DebugWithContext(context.Background(), "Consent service is disabled in the configuration")
+		log.GetLogger().Debug(context.Background(), "Consent service is disabled in the configuration")
 	}
 
 	return &consentService{
@@ -86,7 +86,7 @@ func (s *consentService) DeleteConsentElement(ctx context.Context, ouID string,
 	elementID string) *serviceerror.ServiceError {
 	svcErr := s.client.deleteConsentElement(ctx, ouID, elementID)
 	if svcErr != nil && svcErr.Code == ErrorConsentElementNotFound.Code {
-		s.logger.DebugWithContext(ctx, "Consent element not found during delete, skipping",
+		s.logger.Debug(ctx, "Consent element not found during delete, skipping",
 			log.String("elementID", elementID))
 		return nil
 	}
@@ -132,7 +132,7 @@ func (s *consentService) DeleteConsentPurpose(ctx context.Context, ouID string,
 	purposeID string) *serviceerror.ServiceError {
 	svcErr := s.client.deleteConsentPurpose(ctx, ouID, purposeID)
 	if svcErr != nil && svcErr.Code == ErrorConsentPurposeNotFound.Code {
-		s.logger.DebugWithContext(ctx, "Consent purpose not found during delete, skipping",
+		s.logger.Debug(ctx, "Consent purpose not found during delete, skipping",
 			log.String("purposeID", purposeID))
 		return nil
 	}

--- a/backend/internal/design/layout/mgt/config.go
+++ b/backend/internal/design/layout/mgt/config.go
@@ -51,7 +51,7 @@ func getLayoutStoreMode() serverconst.StoreMode {
 			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "LayoutMgtConfig"))
 			// Store mode is resolved at server startup, outside any request,
 			// so there is no request context (or trace ID) to propagate.
-			logger.WarnWithContext(context.Background(), "Unrecognized layout store configuration value",
+			logger.Warn(context.Background(), "Unrecognized layout store configuration value",
 				log.String("raw_value", cfg.Layout.Store),
 				log.String("normalized_value", string(mode)),
 				log.String("fallback", "global declarative_resources setting"))

--- a/backend/internal/design/layout/mgt/declarative_resource.go
+++ b/backend/internal/design/layout/mgt/declarative_resource.go
@@ -114,7 +114,7 @@ func (e *layoutExporter) ValidateResource(ctx context.Context,
 	}
 
 	if len(layout.Layout) == 0 {
-		logger.WarnWithContext(ctx, "Layout has no layout configuration",
+		logger.Warn(ctx, "Layout has no layout configuration",
 			log.String("layoutID", id), log.String("displayName", layout.DisplayName))
 	}
 

--- a/backend/internal/design/layout/mgt/handler.go
+++ b/backend/internal/design/layout/mgt/handler.go
@@ -86,7 +86,7 @@ func (lh *layoutMgtHandler) HandleLayoutListRequest(w http.ResponseWriter, r *ht
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, layoutListResponse)
 
-	lh.logger.DebugWithContext(ctx, "Successfully listed layout configurations with pagination",
+	lh.logger.Debug(ctx, "Successfully listed layout configurations with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", layoutListResponse.TotalResults),
 		log.Int("count", layoutListResponse.Count))
@@ -120,7 +120,7 @@ func (lh *layoutMgtHandler) HandleLayoutPostRequest(w http.ResponseWriter, r *ht
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, layoutResponse)
 
-	lh.logger.DebugWithContext(ctx, "Successfully created layout configuration",
+	lh.logger.Debug(ctx, "Successfully created layout configuration",
 		log.String("id", createdLayout.ID))
 }
 
@@ -147,7 +147,7 @@ func (lh *layoutMgtHandler) HandleLayoutGetRequest(w http.ResponseWriter, r *htt
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, layoutResponse)
 
-	lh.logger.DebugWithContext(ctx, "Successfully retrieved layout configuration", log.String("id", id))
+	lh.logger.Debug(ctx, "Successfully retrieved layout configuration", log.String("id", id))
 }
 
 // HandleLayoutPutRequest handles the update layout configuration request.
@@ -179,7 +179,7 @@ func (lh *layoutMgtHandler) HandleLayoutPutRequest(w http.ResponseWriter, r *htt
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, layoutResponse)
 
-	lh.logger.DebugWithContext(ctx, "Successfully updated layout configuration", log.String("id", id))
+	lh.logger.Debug(ctx, "Successfully updated layout configuration", log.String("id", id))
 }
 
 // HandleLayoutDeleteRequest handles the delete layout configuration request.
@@ -193,7 +193,7 @@ func (lh *layoutMgtHandler) HandleLayoutDeleteRequest(w http.ResponseWriter, r *
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
-	lh.logger.DebugWithContext(ctx, "Successfully deleted layout configuration", log.String("id", id))
+	lh.logger.Debug(ctx, "Successfully deleted layout configuration", log.String("id", id))
 }
 
 // parsePaginationParams parses limit and offset query parameters from the request.

--- a/backend/internal/design/layout/mgt/service.go
+++ b/backend/internal/design/layout/mgt/service.go
@@ -68,13 +68,13 @@ func (ls *layoutMgtService) GetLayoutList(
 
 	totalCount, err := ls.layoutMgtStore.GetLayoutListCount()
 	if err != nil {
-		ls.logger.ErrorWithContext(ctx, "Failed to get layout count", log.Error(err))
+		ls.logger.Error(ctx, "Failed to get layout count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	layouts, err := ls.layoutMgtStore.GetLayoutList(limit, offset)
 	if err != nil {
-		ls.logger.ErrorWithContext(ctx, "Failed to list layouts", log.Error(err))
+		ls.logger.Error(ctx, "Failed to list layouts", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -92,7 +92,7 @@ func (ls *layoutMgtService) GetLayoutList(
 // CreateLayout creates a new layout configuration.
 func (ls *layoutMgtService) CreateLayout(
 	ctx context.Context, layout CreateLayoutRequest) (*Layout, *serviceerror.ServiceError) {
-	ls.logger.DebugWithContext(ctx, "Creating layout configuration")
+	ls.logger.Debug(ctx, "Creating layout configuration")
 
 	if layout.DisplayName == "" {
 		return nil, &ErrorMissingDisplayName
@@ -109,7 +109,7 @@ func (ls *layoutMgtService) CreateLayout(
 
 	conflict, err := ls.layoutMgtStore.IsLayoutHandleConflict(layout.Handle, "")
 	if err != nil {
-		ls.logger.ErrorWithContext(ctx, "Failed to check layout handle conflict", log.Error(err))
+		ls.logger.Error(ctx, "Failed to check layout handle conflict", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if conflict {
@@ -122,12 +122,12 @@ func (ls *layoutMgtService) CreateLayout(
 
 	id, err := utils.GenerateUUIDv7()
 	if err != nil {
-		ls.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+		ls.logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	if err := ls.layoutMgtStore.CreateLayout(id, layout); err != nil {
-		ls.logger.ErrorWithContext(ctx, "Failed to create layout", log.Error(err))
+		ls.logger.Error(ctx, "Failed to create layout", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -139,13 +139,13 @@ func (ls *layoutMgtService) CreateLayout(
 		Layout:      layout.Layout,
 	}
 
-	ls.logger.DebugWithContext(ctx, "Successfully created layout", log.String("id", id))
+	ls.logger.Debug(ctx, "Successfully created layout", log.String("id", id))
 	return createdLayout, nil
 }
 
 // GetLayout retrieves a specific layout configuration by its id.
 func (ls *layoutMgtService) GetLayout(ctx context.Context, id string) (*Layout, *serviceerror.ServiceError) {
-	ls.logger.DebugWithContext(ctx, "Retrieving layout", log.String("id", id))
+	ls.logger.Debug(ctx, "Retrieving layout", log.String("id", id))
 
 	if id == "" {
 		return nil, &ErrorInvalidLayoutID
@@ -154,21 +154,21 @@ func (ls *layoutMgtService) GetLayout(ctx context.Context, id string) (*Layout, 
 	layout, err := ls.layoutMgtStore.GetLayout(id)
 	if err != nil {
 		if errors.Is(err, errLayoutNotFound) {
-			ls.logger.DebugWithContext(ctx, "Layout not found", log.String("id", id))
+			ls.logger.Debug(ctx, "Layout not found", log.String("id", id))
 			return nil, &ErrorLayoutNotFound
 		}
-		ls.logger.ErrorWithContext(ctx, "Failed to retrieve layout", log.String("id", id), log.Error(err))
+		ls.logger.Error(ctx, "Failed to retrieve layout", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	ls.logger.DebugWithContext(ctx, "Successfully retrieved layout", log.String("id", layout.ID))
+	ls.logger.Debug(ctx, "Successfully retrieved layout", log.String("id", layout.ID))
 	return &layout, nil
 }
 
 // UpdateLayout updates an existing layout configuration.
 func (ls *layoutMgtService) UpdateLayout(ctx context.Context,
 	id string, layout UpdateLayoutRequest) (*Layout, *serviceerror.ServiceError) {
-	ls.logger.DebugWithContext(ctx, "Updating layout", log.String("id", id))
+	ls.logger.Debug(ctx, "Updating layout", log.String("id", id))
 
 	if id == "" {
 		return nil, &ErrorInvalidLayoutID
@@ -189,7 +189,7 @@ func (ls *layoutMgtService) UpdateLayout(ctx context.Context,
 		if errors.Is(err, errLayoutNotFound) {
 			return nil, &ErrorLayoutNotFound
 		}
-		ls.logger.ErrorWithContext(ctx, "Failed to retrieve layout", log.String("id", id), log.Error(err))
+		ls.logger.Error(ctx, "Failed to retrieve layout", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -203,7 +203,7 @@ func (ls *layoutMgtService) UpdateLayout(ctx context.Context,
 	}
 
 	if err := ls.layoutMgtStore.UpdateLayout(id, layout); err != nil {
-		ls.logger.ErrorWithContext(ctx, "Failed to update layout", log.String("id", id), log.Error(err))
+		ls.logger.Error(ctx, "Failed to update layout", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -215,13 +215,13 @@ func (ls *layoutMgtService) UpdateLayout(ctx context.Context,
 		Layout:      layout.Layout,
 	}
 
-	ls.logger.DebugWithContext(ctx, "Successfully updated layout", log.String("id", id))
+	ls.logger.Debug(ctx, "Successfully updated layout", log.String("id", id))
 	return updatedLayout, nil
 }
 
 // DeleteLayout deletes a layout configuration.
 func (ls *layoutMgtService) DeleteLayout(ctx context.Context, id string) *serviceerror.ServiceError {
-	ls.logger.DebugWithContext(ctx, "Deleting layout", log.String("id", id))
+	ls.logger.Debug(ctx, "Deleting layout", log.String("id", id))
 
 	if id == "" {
 		return &ErrorInvalidLayoutID
@@ -235,19 +235,19 @@ func (ls *layoutMgtService) DeleteLayout(ctx context.Context, id string) *servic
 	// Check if layout exists. Return success for non-existing layouts (idempotent delete).
 	exists, err := ls.layoutMgtStore.IsLayoutExist(id)
 	if err != nil {
-		ls.logger.ErrorWithContext(ctx, "Failed to check layout existence", log.String("id", id), log.Error(err))
+		ls.logger.Error(ctx, "Failed to check layout existence", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
 	if !exists {
-		ls.logger.DebugWithContext(ctx, "Layout not found for deletion, returning success", log.String("id", id))
+		ls.logger.Debug(ctx, "Layout not found for deletion, returning success", log.String("id", id))
 		return nil
 	}
 
 	// Check if layout is used by any applications
 	count, err := ls.layoutMgtStore.GetApplicationsCountByLayoutID(id)
 	if err != nil {
-		ls.logger.ErrorWithContext(ctx, "Failed to check applications using layout",
+		ls.logger.Error(ctx, "Failed to check applications using layout",
 			log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
@@ -260,11 +260,11 @@ func (ls *layoutMgtService) DeleteLayout(ctx context.Context, id string) *servic
 	}
 
 	if err := ls.layoutMgtStore.DeleteLayout(id); err != nil {
-		ls.logger.ErrorWithContext(ctx, "Failed to delete layout", log.String("id", id), log.Error(err))
+		ls.logger.Error(ctx, "Failed to delete layout", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
-	ls.logger.DebugWithContext(ctx, "Successfully deleted layout", log.String("id", id))
+	ls.logger.Debug(ctx, "Successfully deleted layout", log.String("id", id))
 	return nil
 }
 
@@ -276,7 +276,7 @@ func (ls *layoutMgtService) IsLayoutExist(ctx context.Context, id string) (bool,
 
 	exists, err := ls.layoutMgtStore.IsLayoutExist(id)
 	if err != nil {
-		ls.logger.ErrorWithContext(ctx, "Failed to check layout existence", log.String("id", id), log.Error(err))
+		ls.logger.Error(ctx, "Failed to check layout existence", log.String("id", id), log.Error(err))
 		return false, &serviceerror.InternalServerError
 	}
 
@@ -292,7 +292,7 @@ func (ls *layoutMgtService) validateLayoutPreferences(
 
 	var result map[string]interface{}
 	if err := json.Unmarshal(layout, &result); err != nil {
-		ls.logger.DebugWithContext(ctx, "Invalid layout JSON", log.Error(err))
+		ls.logger.Debug(ctx, "Invalid layout JSON", log.Error(err))
 		return &ErrorInvalidLayoutFormat
 	}
 

--- a/backend/internal/design/resolve/handler.go
+++ b/backend/internal/design/resolve/handler.go
@@ -61,7 +61,7 @@ func (rh *designResolveHandler) HandleResolveRequest(w http.ResponseWriter, r *h
 
 	utils.WriteSuccessResponse(ctx, w, http.StatusOK, designResponse)
 
-	rh.logger.DebugWithContext(ctx, "Successfully resolved design configuration",
+	rh.logger.Debug(ctx, "Successfully resolved design configuration",
 		log.String("type", string(resolveType)),
 		log.String("id", id))
 }

--- a/backend/internal/design/resolve/service.go
+++ b/backend/internal/design/resolve/service.go
@@ -82,7 +82,7 @@ func (drs *designResolveService) ResolveDesign(
 
 	// Get the application by ID
 	if drs.applicationService == nil {
-		drs.logger.ErrorWithContext(ctx, "Application service is not available")
+		drs.logger.Error(ctx, "Application service is not available")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -108,14 +108,14 @@ func (drs *designResolveService) ResolveDesign(
 	// Get theme configuration if available
 	if app.ThemeID != "" {
 		if drs.themeMgtService == nil {
-			drs.logger.ErrorWithContext(ctx, "Theme management service is not available")
+			drs.logger.Error(ctx, "Theme management service is not available")
 			return nil, &serviceerror.InternalServerError
 		}
 
 		themeConfig, svcErr := drs.themeMgtService.GetTheme(ctx, app.ThemeID)
 		if svcErr != nil {
 			if svcErr.Code == thememgt.ErrorThemeNotFound.Code {
-				drs.logger.ErrorWithContext(ctx, "Data integrity issue: application references non-existent theme",
+				drs.logger.Error(ctx, "Data integrity issue: application references non-existent theme",
 					log.String("applicationId", id),
 					log.String("themeId", app.ThemeID))
 				return nil, &serviceerror.InternalServerError
@@ -129,14 +129,14 @@ func (drs *designResolveService) ResolveDesign(
 	// Get layout configuration if available
 	if app.LayoutID != "" {
 		if drs.layoutMgtService == nil {
-			drs.logger.ErrorWithContext(ctx, "Layout management service is not available")
+			drs.logger.Error(ctx, "Layout management service is not available")
 			return nil, &serviceerror.InternalServerError
 		}
 
 		layoutConfig, svcErr := drs.layoutMgtService.GetLayout(ctx, app.LayoutID)
 		if svcErr != nil {
 			if svcErr.Code == layoutmgt.ErrorLayoutNotFound.Code {
-				drs.logger.ErrorWithContext(ctx, "Data integrity issue: application references non-existent layout",
+				drs.logger.Error(ctx, "Data integrity issue: application references non-existent layout",
 					log.String("applicationId", id),
 					log.String("layoutId", app.LayoutID))
 				return nil, &serviceerror.InternalServerError
@@ -147,7 +147,7 @@ func (drs *designResolveService) ResolveDesign(
 		designResponse.Layout = layoutConfig.Layout
 	}
 
-	drs.logger.DebugWithContext(ctx, "Successfully resolved design configuration",
+	drs.logger.Debug(ctx, "Successfully resolved design configuration",
 		log.String("type", string(resolveType)),
 		log.String("id", id),
 		log.String("themeId", app.ThemeID),

--- a/backend/internal/design/theme/mgt/config.go
+++ b/backend/internal/design/theme/mgt/config.go
@@ -51,7 +51,7 @@ func getThemeStoreMode() serverconst.StoreMode {
 			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ThemeMgtConfig"))
 			// Store mode is resolved at server startup, outside any request,
 			// so there is no request context (or trace ID) to propagate.
-			logger.WarnWithContext(context.Background(), "Unrecognized theme store configuration value",
+			logger.Warn(context.Background(), "Unrecognized theme store configuration value",
 				log.String("raw_value", cfg.Theme.Store),
 				log.String("normalized_value", string(mode)),
 				log.String("fallback", "global declarative_resources setting"))

--- a/backend/internal/design/theme/mgt/declarative_resource.go
+++ b/backend/internal/design/theme/mgt/declarative_resource.go
@@ -114,7 +114,7 @@ func (e *themeExporter) ValidateResource(ctx context.Context,
 	}
 
 	if len(theme.Theme) == 0 {
-		logger.WarnWithContext(ctx, "Theme has no theme configuration",
+		logger.Warn(ctx, "Theme has no theme configuration",
 			log.String("themeID", id), log.String("displayName", theme.DisplayName))
 	}
 

--- a/backend/internal/design/theme/mgt/handler.go
+++ b/backend/internal/design/theme/mgt/handler.go
@@ -89,7 +89,7 @@ func (th *themeMgtHandler) HandleThemeListRequest(w http.ResponseWriter, r *http
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, themeListResponse)
 
-	th.logger.DebugWithContext(ctx, "Successfully listed theme configurations with pagination",
+	th.logger.Debug(ctx, "Successfully listed theme configurations with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", themeListResponse.TotalResults),
 		log.Int("count", themeListResponse.Count))
@@ -127,7 +127,7 @@ func (th *themeMgtHandler) HandleThemePostRequest(w http.ResponseWriter, r *http
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, themeResponse)
 
-	th.logger.DebugWithContext(ctx, "Successfully created theme configuration",
+	th.logger.Debug(ctx, "Successfully created theme configuration",
 		log.String("id", createdTheme.ID))
 }
 
@@ -153,7 +153,7 @@ func (th *themeMgtHandler) HandleThemeGetRequest(w http.ResponseWriter, r *http.
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, themeResponse)
 
-	th.logger.DebugWithContext(ctx, "Successfully retrieved theme configuration", log.String("id", id))
+	th.logger.Debug(ctx, "Successfully retrieved theme configuration", log.String("id", id))
 }
 
 // HandleThemePutRequest handles the update theme configuration request.
@@ -184,7 +184,7 @@ func (th *themeMgtHandler) HandleThemePutRequest(w http.ResponseWriter, r *http.
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, themeResponse)
 
-	th.logger.DebugWithContext(ctx, "Successfully updated theme configuration", log.String("id", id))
+	th.logger.Debug(ctx, "Successfully updated theme configuration", log.String("id", id))
 }
 
 // HandleThemeDeleteRequest handles the delete theme configuration request.
@@ -198,7 +198,7 @@ func (th *themeMgtHandler) HandleThemeDeleteRequest(w http.ResponseWriter, r *ht
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
-	th.logger.DebugWithContext(ctx, "Successfully deleted theme configuration", log.String("id", id))
+	th.logger.Debug(ctx, "Successfully deleted theme configuration", log.String("id", id))
 }
 
 // parsePaginationParams parses limit and offset query parameters from the request.

--- a/backend/internal/design/theme/mgt/service.go
+++ b/backend/internal/design/theme/mgt/service.go
@@ -68,13 +68,13 @@ func (ts *themeMgtService) GetThemeList(
 
 	totalCount, err := ts.themeMgtStore.GetThemeListCount()
 	if err != nil {
-		ts.logger.ErrorWithContext(ctx, "Failed to get theme count", log.Error(err))
+		ts.logger.Error(ctx, "Failed to get theme count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	themes, err := ts.themeMgtStore.GetThemeList(limit, offset)
 	if err != nil {
-		ts.logger.ErrorWithContext(ctx, "Failed to list themes", log.Error(err))
+		ts.logger.Error(ctx, "Failed to list themes", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -92,7 +92,7 @@ func (ts *themeMgtService) GetThemeList(
 // CreateTheme creates a new theme configuration.
 func (ts *themeMgtService) CreateTheme(
 	ctx context.Context, theme CreateThemeRequestWithID) (*Theme, *serviceerror.ServiceError) {
-	ts.logger.DebugWithContext(ctx, "Creating theme configuration")
+	ts.logger.Debug(ctx, "Creating theme configuration")
 
 	if theme.DisplayName == "" {
 		return nil, &ErrorMissingDisplayName
@@ -109,7 +109,7 @@ func (ts *themeMgtService) CreateTheme(
 
 	conflict, err := ts.themeMgtStore.IsThemeHandleConflict(theme.Handle, "")
 	if err != nil {
-		ts.logger.ErrorWithContext(ctx, "Failed to check theme handle conflict", log.Error(err))
+		ts.logger.Error(ctx, "Failed to check theme handle conflict", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if conflict {
@@ -125,7 +125,7 @@ func (ts *themeMgtService) CreateTheme(
 		var err error
 		id, err = utils.GenerateUUIDv7()
 		if err != nil {
-			ts.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+			ts.logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -138,7 +138,7 @@ func (ts *themeMgtService) CreateTheme(
 	}
 
 	if err := ts.themeMgtStore.CreateTheme(id, storeReq); err != nil {
-		ts.logger.ErrorWithContext(ctx, "Failed to create theme", log.Error(err))
+		ts.logger.Error(ctx, "Failed to create theme", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -150,13 +150,13 @@ func (ts *themeMgtService) CreateTheme(
 		Theme:       theme.Theme,
 	}
 
-	ts.logger.DebugWithContext(ctx, "Successfully created theme", log.String("id", id))
+	ts.logger.Debug(ctx, "Successfully created theme", log.String("id", id))
 	return createdTheme, nil
 }
 
 // GetTheme retrieves a specific theme configuration by its id.
 func (ts *themeMgtService) GetTheme(ctx context.Context, id string) (*Theme, *serviceerror.ServiceError) {
-	ts.logger.DebugWithContext(ctx, "Retrieving theme", log.String("id", id))
+	ts.logger.Debug(ctx, "Retrieving theme", log.String("id", id))
 
 	if id == "" {
 		return nil, &ErrorInvalidThemeID
@@ -165,21 +165,21 @@ func (ts *themeMgtService) GetTheme(ctx context.Context, id string) (*Theme, *se
 	theme, err := ts.themeMgtStore.GetTheme(id)
 	if err != nil {
 		if errors.Is(err, errThemeNotFound) {
-			ts.logger.DebugWithContext(ctx, "Theme not found", log.String("id", id))
+			ts.logger.Debug(ctx, "Theme not found", log.String("id", id))
 			return nil, &ErrorThemeNotFound
 		}
-		ts.logger.ErrorWithContext(ctx, "Failed to retrieve theme", log.String("id", id), log.Error(err))
+		ts.logger.Error(ctx, "Failed to retrieve theme", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	ts.logger.DebugWithContext(ctx, "Successfully retrieved theme", log.String("id", theme.ID))
+	ts.logger.Debug(ctx, "Successfully retrieved theme", log.String("id", theme.ID))
 	return &theme, nil
 }
 
 // UpdateTheme updates an existing theme configuration.
 func (ts *themeMgtService) UpdateTheme(
 	ctx context.Context, id string, theme UpdateThemeRequest) (*Theme, *serviceerror.ServiceError) {
-	ts.logger.DebugWithContext(ctx, "Updating theme", log.String("id", id))
+	ts.logger.Debug(ctx, "Updating theme", log.String("id", id))
 
 	if id == "" {
 		return nil, &ErrorInvalidThemeID
@@ -200,7 +200,7 @@ func (ts *themeMgtService) UpdateTheme(
 		if errors.Is(err, errThemeNotFound) {
 			return nil, &ErrorThemeNotFound
 		}
-		ts.logger.ErrorWithContext(ctx, "Failed to retrieve theme", log.String("id", id), log.Error(err))
+		ts.logger.Error(ctx, "Failed to retrieve theme", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -214,7 +214,7 @@ func (ts *themeMgtService) UpdateTheme(
 	}
 
 	if err := ts.themeMgtStore.UpdateTheme(id, theme); err != nil {
-		ts.logger.ErrorWithContext(ctx, "Failed to update theme", log.String("id", id), log.Error(err))
+		ts.logger.Error(ctx, "Failed to update theme", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -226,13 +226,13 @@ func (ts *themeMgtService) UpdateTheme(
 		Theme:       theme.Theme,
 	}
 
-	ts.logger.DebugWithContext(ctx, "Successfully updated theme", log.String("id", id))
+	ts.logger.Debug(ctx, "Successfully updated theme", log.String("id", id))
 	return updatedTheme, nil
 }
 
 // DeleteTheme deletes a theme configuration.
 func (ts *themeMgtService) DeleteTheme(ctx context.Context, id string) *serviceerror.ServiceError {
-	ts.logger.DebugWithContext(ctx, "Deleting theme", log.String("id", id))
+	ts.logger.Debug(ctx, "Deleting theme", log.String("id", id))
 
 	if id == "" {
 		return &ErrorInvalidThemeID
@@ -246,19 +246,19 @@ func (ts *themeMgtService) DeleteTheme(ctx context.Context, id string) *servicee
 	// Check if theme exists. Return success for non-existing themes (idempotent delete).
 	exists, err := ts.themeMgtStore.IsThemeExist(id)
 	if err != nil {
-		ts.logger.ErrorWithContext(ctx, "Failed to check theme existence", log.String("id", id), log.Error(err))
+		ts.logger.Error(ctx, "Failed to check theme existence", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
 	if !exists {
-		ts.logger.DebugWithContext(ctx, "Theme not found for deletion, returning success", log.String("id", id))
+		ts.logger.Debug(ctx, "Theme not found for deletion, returning success", log.String("id", id))
 		return nil
 	}
 
 	// Check if theme is used by any applications
 	count, err := ts.themeMgtStore.GetApplicationsCountByThemeID(id)
 	if err != nil {
-		ts.logger.ErrorWithContext(ctx, "Failed to check applications using theme",
+		ts.logger.Error(ctx, "Failed to check applications using theme",
 			log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
@@ -268,11 +268,11 @@ func (ts *themeMgtService) DeleteTheme(ctx context.Context, id string) *servicee
 	}
 
 	if err := ts.themeMgtStore.DeleteTheme(id); err != nil {
-		ts.logger.ErrorWithContext(ctx, "Failed to delete theme", log.String("id", id), log.Error(err))
+		ts.logger.Error(ctx, "Failed to delete theme", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
-	ts.logger.DebugWithContext(ctx, "Successfully deleted theme", log.String("id", id))
+	ts.logger.Debug(ctx, "Successfully deleted theme", log.String("id", id))
 	return nil
 }
 
@@ -284,7 +284,7 @@ func (ts *themeMgtService) IsThemeExist(ctx context.Context, id string) (bool, *
 
 	exists, err := ts.themeMgtStore.IsThemeExist(id)
 	if err != nil {
-		ts.logger.ErrorWithContext(ctx, "Failed to check theme existence", log.String("id", id), log.Error(err))
+		ts.logger.Error(ctx, "Failed to check theme existence", log.String("id", id), log.Error(err))
 		return false, &serviceerror.InternalServerError
 	}
 
@@ -300,7 +300,7 @@ func (ts *themeMgtService) validateThemePreferences(
 
 	var result map[string]interface{}
 	if err := json.Unmarshal(theme, &result); err != nil {
-		ts.logger.DebugWithContext(ctx, "Invalid theme JSON", log.Error(err))
+		ts.logger.Debug(ctx, "Invalid theme JSON", log.Error(err))
 		return &ErrorInvalidThemeFormat
 	}
 

--- a/backend/internal/entity/cache_backed_store.go
+++ b/backend/internal/entity/cache_backed_store.go
@@ -178,7 +178,7 @@ func (s *cacheBackedEntityStore) IdentifyEntity(ctx context.Context,
 
 			if err := s.entityIDByIdentifierCache.Set(ctx,
 				compositeKey, entityID); err != nil {
-				s.logger.ErrorWithContext(ctx, "Failed to cache entity ID by identifier",
+				s.logger.Error(ctx, "Failed to cache entity ID by identifier",
 					log.String("key", filterKey), log.String("value", val), log.Error(err))
 			}
 			return entityID, nil
@@ -277,7 +277,7 @@ func (s *cacheBackedEntityStore) parseEntityAttributes(ctx context.Context, enti
 		}
 		var attrs map[string]interface{}
 		if err := json.Unmarshal(raw, &attrs); err != nil {
-			s.logger.WarnWithContext(ctx, "Failed to unmarshal entity attributes for cache key resolution",
+			s.logger.Warn(ctx, "Failed to unmarshal entity attributes for cache key resolution",
 				log.String("entityID", entity.ID), log.Error(err))
 			continue
 		}
@@ -300,7 +300,7 @@ func (s *cacheBackedEntityStore) cacheEntityIDByIdentifiers(ctx context.Context,
 		}
 		if err := s.entityIDByIdentifierCache.Set(ctx,
 			identifierCacheKey(key, val), &entity.ID); err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to cache entity ID by identifier",
+			s.logger.Error(ctx, "Failed to cache entity ID by identifier",
 				log.String("key", key), log.String("value", val), log.Error(err))
 		}
 	}
@@ -316,7 +316,7 @@ func (s *cacheBackedEntityStore) invalidateIdentifierCache(ctx context.Context, 
 	} else {
 		fetched, err := s.store.GetEntity(ctx, entityID)
 		if err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to fetch entity for identifier cache invalidation",
+			s.logger.Error(ctx, "Failed to fetch entity for identifier cache invalidation",
 				log.String("entityID", entityID), log.Error(err))
 			return
 		}
@@ -330,7 +330,7 @@ func (s *cacheBackedEntityStore) invalidateIdentifierCache(ctx context.Context, 
 		}
 		if err := s.entityIDByIdentifierCache.Delete(ctx,
 			identifierCacheKey(key, val)); err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to invalidate identifier cache",
+			s.logger.Error(ctx, "Failed to invalidate identifier cache",
 				log.String("key", key), log.String("value", val), log.Error(err))
 		}
 	}
@@ -341,7 +341,7 @@ func (s *cacheBackedEntityStore) cacheEntityByID(ctx context.Context, entity *En
 		return
 	}
 	if err := s.entityByIDCache.Set(ctx, cache.CacheKey{Key: entity.ID}, entity); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to cache entity by ID",
+		s.logger.Error(ctx, "Failed to cache entity by ID",
 			log.String("entityID", entity.ID), log.Error(err))
 	}
 }
@@ -353,7 +353,7 @@ func (s *cacheBackedEntityStore) cacheEntityWithCredentialsByID(ctx context.Cont
 	}
 	if err := s.entityWithCredentialsByIDCache.Set(ctx,
 		cache.CacheKey{Key: ewc.Entity.ID}, ewc); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to cache entity with credentials by ID",
+		s.logger.Error(ctx, "Failed to cache entity with credentials by ID",
 			log.String("entityID", ewc.Entity.ID), log.Error(err))
 	}
 }
@@ -363,11 +363,11 @@ func (s *cacheBackedEntityStore) invalidateEntityByID(ctx context.Context, entit
 		return
 	}
 	if err := s.entityByIDCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to invalidate entity cache by ID",
+		s.logger.Error(ctx, "Failed to invalidate entity cache by ID",
 			log.String("entityID", entityID), log.Error(err))
 	}
 	if err := s.entityWithCredentialsByIDCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to invalidate entity with credentials cache by ID",
+		s.logger.Error(ctx, "Failed to invalidate entity with credentials cache by ID",
 			log.String("entityID", entityID), log.Error(err))
 	}
 }

--- a/backend/internal/entity/declarative_resource.go
+++ b/backend/internal/entity/declarative_resource.go
@@ -107,7 +107,7 @@ func loadDeclarativeResources(
 		resource, ok := data.(*entityStoreEntry)
 		if !ok {
 			// Declarative resource loading runs at startup, outside any request.
-			logger.ErrorWithContext(context.Background(), "IDExtractor: type assertion failed for entityStoreEntry")
+			logger.Error(context.Background(), "IDExtractor: type assertion failed for entityStoreEntry")
 			return ""
 		}
 		if config.IDExtractor != nil {

--- a/backend/internal/entity/service.go
+++ b/backend/internal/entity/service.go
@@ -139,7 +139,7 @@ func (s *entityService) CreateEntity(ctx context.Context, entity *Entity,
 		}
 		entity.ID = id
 	}
-	s.logger.DebugWithContext(ctx, "Creating entity", log.MaskedString("id", entity.ID))
+	s.logger.Debug(ctx, "Creating entity", log.MaskedString("id", entity.ID))
 
 	// Validate entity attributes and uniqueness via schema.
 	if err := s.validateEntityType(ctx, entity.Category, entity.Type, entity.Attributes, "", false); err != nil {
@@ -224,7 +224,7 @@ func (s *entityService) UpdateEntity(ctx context.Context, entityID string, entit
 	if entity == nil {
 		return nil, ErrEntityNotFound
 	}
-	s.logger.DebugWithContext(ctx, "Updating entity", log.MaskedString("id", entityID))
+	s.logger.Debug(ctx, "Updating entity", log.MaskedString("id", entityID))
 
 	// Validate entity attributes and uniqueness via schema (excludes self for uniqueness).
 	if err := s.validateEntityType(ctx, entity.Category, entity.Type, entity.Attributes, entityID, true); err != nil {
@@ -275,7 +275,7 @@ func (s *entityService) UpdateEntity(ctx context.Context, entityID string, entit
 // DeleteEntity deletes an entity.
 // Uses a transaction to ensure the entity row and its indexed identifiers are deleted atomically.
 func (s *entityService) DeleteEntity(ctx context.Context, entityID string) error {
-	s.logger.DebugWithContext(ctx, "Deleting entity", log.MaskedString("id", entityID))
+	s.logger.Debug(ctx, "Deleting entity", log.MaskedString("id", entityID))
 	err := s.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		return s.store.DeleteEntity(txCtx, entityID)
 	})
@@ -286,7 +286,7 @@ func (s *entityService) DeleteEntity(ctx context.Context, entityID string) error
 // Any credential fields present in the attributes are extracted, hashed, and merged
 // with the existing credentials atomically.
 func (s *entityService) UpdateAttributes(ctx context.Context, entityID string, attributes json.RawMessage) error {
-	s.logger.DebugWithContext(ctx, "Updating entity attributes", log.MaskedString("id", entityID))
+	s.logger.Debug(ctx, "Updating entity attributes", log.MaskedString("id", entityID))
 
 	// Load entity to get its category and type for schema validation and credential extraction.
 	existing, err := s.store.GetEntity(ctx, entityID)
@@ -334,7 +334,7 @@ func (s *entityService) UpdateAttributes(ctx context.Context, entityID string, a
 // UpdateSystemAttributes updates the system-managed attributes of an entity.
 func (s *entityService) UpdateSystemAttributes(ctx context.Context, entityID string,
 	attrs json.RawMessage) error {
-	s.logger.DebugWithContext(ctx, "Updating entity system attributes", log.MaskedString("id", entityID))
+	s.logger.Debug(ctx, "Updating entity system attributes", log.MaskedString("id", entityID))
 	return s.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		return s.store.UpdateSystemAttributes(txCtx, entityID, attrs)
 	})
@@ -739,7 +739,7 @@ func (s *entityService) populateOUHandles(ctx context.Context, entities []Entity
 	}
 	handleMap, svcErr := s.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
 	if svcErr != nil {
-		s.logger.WarnWithContext(ctx, "Failed to resolve OU handles, skipping", log.Any("error", svcErr))
+		s.logger.Warn(ctx, "Failed to resolve OU handles, skipping", log.Any("error", svcErr))
 		return
 	}
 	for i := range entities {

--- a/backend/internal/entity/store.go
+++ b/backend/internal/entity/store.go
@@ -506,7 +506,7 @@ func (es *entityDBStore) IdentifyEntity(ctx context.Context,
 
 	if len(results) == 0 {
 		if es.logger.IsDebugEnabled() {
-			es.logger.DebugWithContext(ctx, "Entity not found with the provided filters",
+			es.logger.Debug(ctx, "Entity not found with the provided filters",
 				log.MaskedMap("filters", filters))
 		}
 		return nil, ErrEntityNotFound
@@ -514,7 +514,7 @@ func (es *entityDBStore) IdentifyEntity(ctx context.Context,
 
 	if len(results) != 1 {
 		if es.logger.IsDebugEnabled() {
-			es.logger.DebugWithContext(ctx,
+			es.logger.Debug(ctx,
 				"Unexpected number of results for the provided filters",
 				log.MaskedMap("filters", filters),
 				log.Int("result_count", len(results)),

--- a/backend/internal/entitytype/cache_backed_store.go
+++ b/backend/internal/entitytype/cache_backed_store.go
@@ -207,7 +207,7 @@ func (s *cachedBackedEntityTypeStore) cacheEntityType(ctx context.Context, schem
 	if schema.ID != "" {
 		key := cacheKeyForID(schema.Category, schema.ID)
 		if err := s.schemaByIDCache.Set(ctx, key, schema); err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to cache entity type by ID",
+			s.logger.Error(ctx, "Failed to cache entity type by ID",
 				log.String("schemaID", schema.ID), log.Error(err))
 		}
 	}
@@ -215,7 +215,7 @@ func (s *cachedBackedEntityTypeStore) cacheEntityType(ctx context.Context, schem
 	if schema.Name != "" {
 		key := cacheKeyForName(schema.Category, schema.Name)
 		if err := s.schemaByNameCache.Set(ctx, key, schema); err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to cache entity type by name",
+			s.logger.Error(ctx, "Failed to cache entity type by name",
 				log.String("schemaName", schema.Name), log.Error(err))
 		}
 	}
@@ -227,7 +227,7 @@ func (s *cachedBackedEntityTypeStore) invalidateEntityTypeCache(ctx context.Cont
 	if schemaID != "" {
 		key := cacheKeyForID(category, schemaID)
 		if err := s.schemaByIDCache.Delete(ctx, key); err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to invalidate entity type cache by ID",
+			s.logger.Error(ctx, "Failed to invalidate entity type cache by ID",
 				log.String("schemaID", schemaID), log.Error(err))
 		}
 	}
@@ -235,7 +235,7 @@ func (s *cachedBackedEntityTypeStore) invalidateEntityTypeCache(ctx context.Cont
 	if schemaName != "" {
 		key := cacheKeyForName(category, schemaName)
 		if err := s.schemaByNameCache.Delete(ctx, key); err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to invalidate entity type cache by name",
+			s.logger.Error(ctx, "Failed to invalidate entity type cache by name",
 				log.String("schemaName", schemaName), log.Error(err))
 		}
 	}

--- a/backend/internal/entitytype/config.go
+++ b/backend/internal/entitytype/config.go
@@ -53,7 +53,7 @@ func getEntityTypeStoreMode() serverconst.StoreMode {
 			msg := fmt.Sprintf(
 				"Invalid entity type store mode: %s, falling back to global declarative resources setting", mode)
 			// Store-mode resolution runs during startup config loading, outside any request.
-			log.GetLogger().WarnWithContext(context.Background(), msg)
+			log.GetLogger().Warn(context.Background(), msg)
 		}
 	}
 

--- a/backend/internal/entitytype/declarative_resource.go
+++ b/backend/internal/entitytype/declarative_resource.go
@@ -107,7 +107,7 @@ func (e *entityTypeExporter) ValidateResource(ctx context.Context,
 	}
 
 	if len(schema.Schema) == 0 {
-		logger.WarnWithContext(ctx, "Entity type has no schema definition",
+		logger.Warn(ctx, "Entity type has no schema definition",
 			log.String("schemaID", id), log.String("name", schema.Name))
 	}
 

--- a/backend/internal/entitytype/handler.go
+++ b/backend/internal/entitytype/handler.go
@@ -76,7 +76,7 @@ func (h *entityTypeHandler) HandleEntityTypeListRequest(w http.ResponseWriter, r
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, entityTypeListResponse)
 
-	logger.DebugWithContext(ctx, "Successfully listed entity types with pagination",
+	logger.Debug(ctx, "Successfully listed entity types with pagination",
 		log.String("category", string(h.category)),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", entityTypeListResponse.TotalResults),
@@ -119,7 +119,7 @@ func (h *entityTypeHandler) HandleEntityTypePostRequest(w http.ResponseWriter, r
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdEntityType)
 
-	logger.DebugWithContext(ctx, "Successfully created entity type",
+	logger.Debug(ctx, "Successfully created entity type",
 		log.String("category", string(h.category)),
 		log.String("entityTypeID", createdEntityType.ID), log.String("name", createdEntityType.Name))
 }
@@ -144,7 +144,7 @@ func (h *entityTypeHandler) HandleEntityTypeGetRequest(w http.ResponseWriter, r 
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, entityType)
 
-	logger.DebugWithContext(ctx, "Successfully retrieved entity type",
+	logger.Debug(ctx, "Successfully retrieved entity type",
 		log.String("category", string(h.category)), log.String("entityTypeID", schemaID))
 }
 
@@ -172,7 +172,7 @@ func (h *entityTypeHandler) HandleEntityTypePutRequest(w http.ResponseWriter, r 
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, updatedEntityType)
 
-	logger.DebugWithContext(ctx, "Successfully updated entity type",
+	logger.Debug(ctx, "Successfully updated entity type",
 		log.String("category", string(h.category)),
 		log.String("entityTypeID", schemaID), log.String("name", updatedEntityType.Name))
 }
@@ -194,7 +194,7 @@ func (h *entityTypeHandler) HandleEntityTypeDeleteRequest(w http.ResponseWriter,
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
-	logger.DebugWithContext(ctx, "Successfully deleted entity type",
+	logger.Debug(ctx, "Successfully deleted entity type",
 		log.String("category", string(h.category)), log.String("entityTypeID", schemaID))
 }
 
@@ -314,7 +314,7 @@ func (h *entityTypeHandler) sanitizeUpdateEntityTypeRequest(ctx context.Context,
 	sanitizedOUID := sysutils.SanitizeString(request.OUID)
 
 	if originalName != sanitizedName {
-		logger.DebugWithContext(ctx, "Sanitized entity type name in update request",
+		logger.Debug(ctx, "Sanitized entity type name in update request",
 			log.MaskedString("original", originalName),
 			log.MaskedString("sanitized", sanitizedName))
 	}

--- a/backend/internal/entitytype/model/array.go
+++ b/backend/internal/entitytype/model/array.go
@@ -56,13 +56,13 @@ func (p *array) isUnique() bool {
 func (p *array) validateValue(ctx context.Context, value interface{}, path string, logger *log.Logger) (bool, error) {
 	arrayValue, ok := value.([]interface{})
 	if !ok {
-		logger.DebugWithContext(ctx, "Expected array but got different type",
+		logger.Debug(ctx, "Expected array but got different type",
 			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
 		return false, nil
 	}
 
 	if p.required && len(arrayValue) == 0 {
-		logger.DebugWithContext(ctx, "Array property is required but empty", log.String("property", path))
+		logger.Debug(ctx, "Array property is required but empty", log.String("property", path))
 		return false, nil
 	}
 

--- a/backend/internal/entitytype/model/boolean.go
+++ b/backend/internal/entitytype/model/boolean.go
@@ -55,7 +55,7 @@ func (p *boolean) isUnique() bool {
 func (p *boolean) validateValue(ctx context.Context, value interface{}, path string, logger *log.Logger) (bool, error) {
 	_, ok := value.(bool)
 	if !ok {
-		logger.DebugWithContext(ctx, "Expected boolean but got different type",
+		logger.Debug(ctx, "Expected boolean but got different type",
 			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
 		return false, nil
 	}

--- a/backend/internal/entitytype/model/number.go
+++ b/backend/internal/entitytype/model/number.go
@@ -57,14 +57,14 @@ func (p *number) getDisplayName() string {
 func (p *number) validateValue(ctx context.Context, value interface{}, path string, logger *log.Logger) (bool, error) {
 	numberValue, ok := convertToFloat64(value)
 	if !ok {
-		logger.DebugWithContext(ctx, "Expected number but got different type",
+		logger.Debug(ctx, "Expected number but got different type",
 			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
 		return false, nil
 	}
 
 	if p.enum != nil {
 		if _, exists := p.enum[numberValue]; !exists {
-			logger.DebugWithContext(ctx, "Value not in enum", log.String("property", path),
+			logger.Debug(ctx, "Value not in enum", log.String("property", path),
 				log.String("value", fmt.Sprintf("%v", value)))
 			return false, nil
 		}

--- a/backend/internal/entitytype/model/object.go
+++ b/backend/internal/entitytype/model/object.go
@@ -55,7 +55,7 @@ func (p *object) isUnique() bool {
 func (p *object) validateValue(ctx context.Context, value interface{}, path string, logger *log.Logger) (bool, error) {
 	valueMap, ok := value.(map[string]interface{})
 	if !ok {
-		logger.DebugWithContext(ctx, "Expected object but got different type",
+		logger.Debug(ctx, "Expected object but got different type",
 			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
 		return false, nil
 	}
@@ -87,7 +87,7 @@ func (p *object) validateValue(ctx context.Context, value interface{}, path stri
 	// Reject any nested keys not declared in the object schema.
 	for key := range valueMap {
 		if _, declared := p.properties[key]; !declared {
-			logger.DebugWithContext(ctx, "Attribute not defined in schema",
+			logger.Debug(ctx, "Attribute not defined in schema",
 				log.String("attribute", path+"."+key))
 			return false, nil
 		}
@@ -104,7 +104,7 @@ func (p *object) validateUniqueness(ctx context.Context,
 ) (bool, error) {
 	valueMap, ok := value.(map[string]interface{})
 	if !ok {
-		logger.DebugWithContext(ctx, "Expected object but got different type",
+		logger.Debug(ctx, "Expected object but got different type",
 			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
 		return false, nil
 	}

--- a/backend/internal/entitytype/model/schema.go
+++ b/backend/internal/entitytype/model/schema.go
@@ -169,7 +169,7 @@ func (cs *Schema) GetUniqueAttributes() []string {
 func (cs *Schema) Validate(
 	ctx context.Context, attributes json.RawMessage, logger *log.Logger, skipCredentialRequired bool) (bool, error) {
 	if len(attributes) == 0 {
-		logger.DebugWithContext(ctx, "User has no attributes to validate")
+		logger.Debug(ctx, "User has no attributes to validate")
 		return true, nil
 	}
 
@@ -203,7 +203,7 @@ func (cs *Schema) Validate(
 	// Reject any user attributes not declared in the schema.
 	for key := range userAttrs {
 		if _, declared := cs.properties[key]; !declared {
-			logger.DebugWithContext(ctx, "Attribute not defined in schema", log.String("attribute", key))
+			logger.Debug(ctx, "Attribute not defined in schema", log.String("attribute", key))
 			return false, nil
 		}
 	}

--- a/backend/internal/entitytype/model/string.go
+++ b/backend/internal/entitytype/model/string.go
@@ -59,21 +59,21 @@ func (p *str) getDisplayName() string {
 func (p *str) validateValue(ctx context.Context, value interface{}, path string, logger *log.Logger) (bool, error) {
 	strValue, ok := value.(string)
 	if !ok {
-		logger.DebugWithContext(ctx, "Expected string but got different type",
+		logger.Debug(ctx, "Expected string but got different type",
 			log.String("property", path), log.String("value", fmt.Sprintf("%v", value)))
 		return false, nil
 	}
 
 	if p.enum != nil {
 		if _, exists := p.enum[strValue]; !exists {
-			logger.DebugWithContext(ctx, "Value not in enum",
+			logger.Debug(ctx, "Value not in enum",
 				log.String("property", path), log.String("value", strValue))
 			return false, nil
 		}
 	}
 
 	if p.pattern != nil && !p.pattern.MatchString(strValue) {
-		logger.DebugWithContext(ctx, "Regex pattern mismatch",
+		logger.Debug(ctx, "Regex pattern mismatch",
 			log.String("property", path), log.String("value", strValue))
 		return false, nil
 	}

--- a/backend/internal/entitytype/service.go
+++ b/backend/internal/entitytype/service.go
@@ -133,7 +133,7 @@ func (us *entityTypeService) GetEntityTypeList(ctx context.Context, category Typ
 	}
 
 	if accessible.AllAllowed {
-		logger.DebugWithContext(ctx, "Caller has access to all entity types, retrieving without OU filtering",
+		logger.Debug(ctx, "Caller has access to all entity types, retrieving without OU filtering",
 			log.String("category", string(category)))
 		return us.listAllEntityTypes(ctx, category, limit, offset, includeDisplay, logger)
 	}
@@ -241,7 +241,7 @@ func (us *entityTypeService) CreateEntityType(
 		Schema:           request.Schema,
 	}
 	if validationErr := validateEntityTypeDefinition(ctx, category, schemaToValidate); validationErr != nil {
-		logger.DebugWithContext(ctx, "Entity type validation failed", log.String("name", request.Name))
+		logger.Debug(ctx, "Entity type validation failed", log.String("name", request.Name))
 		return nil, validationErr
 	}
 
@@ -266,7 +266,7 @@ func (us *entityTypeService) CreateEntityType(
 	if id == "" {
 		id, err = utils.GenerateUUIDv7()
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+			logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -291,7 +291,7 @@ func (us *entityTypeService) CreateEntityType(
 		if svcErr := us.syncConsentElementsOnCreate(ctx, category, entityType.Schema, logger); svcErr != nil {
 			if delErr := us.entityTypeStore.DeleteEntityTypeByID(ctx, category,
 				entityType.ID); delErr != nil {
-				logger.ErrorWithContext(ctx, "Failed to compensate schema creation after consent sync failure",
+				logger.Error(ctx, "Failed to compensate schema creation after consent sync failure",
 					log.String("schemaID", entityType.ID), log.Error(delErr))
 			}
 
@@ -333,7 +333,7 @@ func (us *entityTypeService) GetEntityType(
 		handleMap, svcErr := us.ouService.GetOrganizationUnitHandlesByIDs(
 			ctx, []string{entityType.OUID})
 		if svcErr != nil {
-			logger.WarnWithContext(ctx, "Failed to resolve OU handle for entity type, skipping",
+			logger.Warn(ctx, "Failed to resolve OU handle for entity type, skipping",
 				log.String("id", schemaID), log.Any("error", svcErr))
 		} else if handle, ok := handleMap[entityType.OUID]; ok {
 			entityType.OUHandle = handle
@@ -409,7 +409,7 @@ func (us *entityTypeService) UpdateEntityType(ctx context.Context, category Type
 		Schema:           request.Schema,
 	}
 	if validationErr := validateEntityTypeDefinition(ctx, category, schemaToValidate); validationErr != nil {
-		logger.DebugWithContext(ctx, "Entity type validation failed", log.String("id", schemaID))
+		logger.Debug(ctx, "Entity type validation failed", log.String("id", schemaID))
 		return nil, validationErr
 	}
 
@@ -468,7 +468,7 @@ func (us *entityTypeService) UpdateEntityType(ctx context.Context, category Type
 			entityType.Schema, logger); svcErr != nil {
 			if revertErr := us.entityTypeStore.UpdateEntityTypeByID(ctx, category, schemaID,
 				existingSchema); revertErr != nil {
-				logger.ErrorWithContext(ctx, "Failed to compensate schema update after consent sync failure",
+				logger.Error(ctx, "Failed to compensate schema update after consent sync failure",
 					log.String("schemaID", schemaID), log.Error(revertErr))
 			}
 
@@ -521,7 +521,7 @@ func (us *entityTypeService) DeleteEntityType(ctx context.Context, category Type
 	if us.consentService.IsEnabled() {
 		attrNames, err := extractAttributeNames(category, existingSchema.Schema)
 		if err != nil {
-			logger.ErrorWithContext(ctx,
+			logger.Error(ctx,
 				"Failed to extract attribute names for consent cleanup; proceeding with schema deletion",
 				log.String("schemaID", schemaID), log.Any("error", err))
 			attributeNames = []string{}
@@ -541,7 +541,7 @@ func (us *entityTypeService) DeleteEntityType(ctx context.Context, category Type
 	// since orphaned consent elements are safe and won't cause active harm.
 	if us.consentService.IsEnabled() && len(attributeNames) > 0 {
 		if svcErr := us.deleteConsentElements(ctx, attributeNames, logger); svcErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to delete consent elements for removed schema attributes; "+
+			logger.Error(ctx, "Failed to delete consent elements for removed schema attributes; "+
 				"orphaned consent elements may remain but schema deletion succeeded",
 				log.Any("attributeNames", attributeNames), log.Any("error", svcErr))
 		}
@@ -574,12 +574,12 @@ func (us *entityTypeService) ValidateEntity(
 		return false, logAndReturnServerError(ctx, logger, "Failed to validate entity attributes against schema", err)
 	}
 	if !isValid {
-		logger.DebugWithContext(ctx, "Schema validation failed", log.String("category", string(category)),
+		logger.Debug(ctx, "Schema validation failed", log.String("category", string(category)),
 			log.String("entityType", entityType))
 		return false, nil
 	}
 
-	logger.DebugWithContext(ctx, "Schema validation successful", log.String("category", string(category)),
+	logger.Debug(ctx, "Schema validation successful", log.String("category", string(category)),
 		log.String("entityType", entityType))
 	return true, nil
 }
@@ -620,7 +620,7 @@ func (us *entityTypeService) ValidateEntityUniqueness(
 		return false, logAndReturnServerError(ctx, logger, "Failed during uniqueness validation", err)
 	}
 	if !isValid {
-		logger.DebugWithContext(ctx, "Entity attribute failed uniqueness validation",
+		logger.Debug(ctx, "Entity attribute failed uniqueness validation",
 			log.String("category", string(category)), log.String("entityType", entityType))
 		return false, nil
 	}
@@ -712,7 +712,7 @@ func (us *entityTypeService) getCompiledSchemaForEntityType(
 
 	compiled, err := model.CompileSchema(found.Schema)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to compile stored entity type", log.String("category", string(category)),
+		logger.Error(ctx, "Failed to compile stored entity type", log.String("category", string(category)),
 			log.String("entityType", entityType), log.Error(err))
 		return nil, fmt.Errorf("failed to compile stored entity type: %w", err)
 	}
@@ -778,7 +778,7 @@ func (us *entityTypeService) resolveEntityTypeOUHandle(
 ) *serviceerror.ServiceError {
 	if entityType.OUID != "" && entityType.OUHandle != "" {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, entityTypeLoggerComponentName))
-		logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided for entity type; ou_handle ignored",
+		logger.Warn(ctx, "Both ou_id and ou_handle provided for entity type; ou_handle ignored",
 			log.String("entityTypeID", entityType.ID), log.String("name", entityType.Name))
 		return nil
 	}
@@ -803,19 +803,19 @@ func (us *entityTypeService) ensureOrganizationUnitExists(
 	logger *log.Logger,
 ) *serviceerror.ServiceError {
 	if us.ouService == nil {
-		logger.ErrorWithContext(ctx, "Organization unit service is not configured for entity type operations")
+		logger.Error(ctx, "Organization unit service is not configured for entity type operations")
 		return &serviceerror.InternalServerError
 	}
 
 	exists, svcErr := us.ouService.IsOrganizationUnitExists(ctx, oUID)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to verify organization unit existence",
+		logger.Error(ctx, "Failed to verify organization unit existence",
 			log.String("oUID", oUID), log.Any("error", svcErr))
 		return &serviceerror.InternalServerError
 	}
 
 	if !exists {
-		logger.DebugWithContext(ctx, "Organization unit does not exist",
+		logger.Debug(ctx, "Organization unit does not exist",
 			log.String("oUID", oUID))
 		return invalidEntityTypeRequestErr(category, "organization unit id does not exist")
 	}
@@ -849,7 +849,7 @@ func (us *entityTypeService) populateEntityTypeOUHandles(
 
 	handleMap, svcErr := us.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
 	if svcErr != nil {
-		logger.WarnWithContext(ctx, "Failed to resolve OU handles for entity types, skipping", log.Any("error", svcErr))
+		logger.Warn(ctx, "Failed to resolve OU handles for entity types, skipping", log.Any("error", svcErr))
 		return
 	}
 
@@ -971,7 +971,7 @@ func logAndReturnServerError(ctx context.Context,
 	message string,
 	err error,
 ) *serviceerror.ServiceError {
-	logger.ErrorWithContext(ctx, message, log.Error(err))
+	logger.Error(ctx, message, log.Error(err))
 	return &serviceerror.InternalServerError
 }
 
@@ -982,23 +982,23 @@ func validateEntityTypeDefinition(
 	logger := log.GetLogger()
 
 	if schema.Name == "" {
-		logger.DebugWithContext(ctx, "Entity type validation failed: name is empty")
+		logger.Debug(ctx, "Entity type validation failed: name is empty")
 		return invalidEntityTypeRequestErr(category, "entity type name must not be empty")
 	}
 
 	if schema.OUID == "" {
-		logger.DebugWithContext(ctx, "Entity type validation failed: organization unit ID is empty")
+		logger.Debug(ctx, "Entity type validation failed: organization unit ID is empty")
 		return invalidEntityTypeRequestErr(category, "organization unit id must not be empty")
 	}
 
 	if len(schema.Schema) == 0 {
-		logger.DebugWithContext(ctx, "Entity type validation failed: schema definition is empty")
+		logger.Debug(ctx, "Entity type validation failed: schema definition is empty")
 		return invalidEntityTypeRequestErr(category, "schema definition must not be empty")
 	}
 
 	compiledSchema, err := model.CompileSchema(schema.Schema)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Entity type validation failed: schema compilation error",
+		logger.Debug(ctx, "Entity type validation failed: schema compilation error",
 			log.Error(err))
 		return invalidEntityTypeRequestErr(category, err.Error())
 	}
@@ -1045,7 +1045,7 @@ func (us *entityTypeService) syncConsentElementsOnCreate(ctx context.Context,
 	// TODO: Replace "default" with the schema's actual OU when applications are associated with OUs.
 	const ouID = "default"
 
-	logger.DebugWithContext(ctx, "Synchronizing consent elements for the new schema", log.String("ouID", ouID))
+	logger.Debug(ctx, "Synchronizing consent elements for the new schema", log.String("ouID", ouID))
 
 	names, err := extractAttributeNames(category, schema)
 	if err != nil {
@@ -1053,7 +1053,7 @@ func (us *entityTypeService) syncConsentElementsOnCreate(ctx context.Context,
 	}
 
 	if len(names) > 0 {
-		logger.DebugWithContext(ctx, "Creating missing consent elements for the new schema",
+		logger.Debug(ctx, "Creating missing consent elements for the new schema",
 			log.String("ouID", ouID), log.Int("elementCount", len(names)))
 		if svcErr := us.createMissingConsentElements(ctx, ouID, names, logger); svcErr != nil {
 			return svcErr
@@ -1070,7 +1070,7 @@ func (us *entityTypeService) syncConsentElementsOnUpdate(ctx context.Context,
 	// TODO: Replace "default" with the schema's actual OU when applications are associated with OUs.
 	const ouID = "default"
 
-	logger.DebugWithContext(ctx, "Synchronizing consent elements for the updated schema", log.String("ouID", ouID))
+	logger.Debug(ctx, "Synchronizing consent elements for the updated schema", log.String("ouID", ouID))
 
 	oldAttrs, err := extractAttributeNamesAsMap(category, oldSchema)
 	if err != nil {
@@ -1092,7 +1092,7 @@ func (us *entityTypeService) syncConsentElementsOnUpdate(ctx context.Context,
 	}
 
 	if len(requiredNames) > 0 {
-		logger.DebugWithContext(ctx, "Ensuring consent elements exist for all requested attributes",
+		logger.Debug(ctx, "Ensuring consent elements exist for all requested attributes",
 			log.String("ouID", ouID), log.Int("requiredAttributesCount", len(requiredNames)))
 		if err := us.createMissingConsentElements(ctx, ouID, requiredNames, logger); err != nil {
 			return err
@@ -1116,11 +1116,11 @@ func (us *entityTypeService) syncConsentElementsOnUpdate(ctx context.Context,
 func (us *entityTypeService) createMissingConsentElements(ctx context.Context,
 	ouID string, names []string, logger *log.Logger) *serviceerror.ServiceError {
 	if len(names) == 0 {
-		logger.DebugWithContext(ctx, "No consent elements to create for the schema", log.String("ouID", ouID))
+		logger.Debug(ctx, "No consent elements to create for the schema", log.String("ouID", ouID))
 		return nil
 	}
 
-	logger.DebugWithContext(ctx, "Validating consent elements for the schema attributes",
+	logger.Debug(ctx, "Validating consent elements for the schema attributes",
 		log.String("ouID", ouID), log.Int("elementCount", len(names)))
 
 	validNames, err := us.consentService.ValidateConsentElements(ctx, ouID, names)
@@ -1146,7 +1146,7 @@ func (us *entityTypeService) createMissingConsentElements(ctx context.Context,
 	}
 
 	if len(elementsToCreate) > 0 {
-		logger.DebugWithContext(ctx, "Creating new consent elements for the schema attributes",
+		logger.Debug(ctx, "Creating new consent elements for the schema attributes",
 			log.String("ouID", ouID), log.Int("elementCount", len(elementsToCreate)))
 		if _, err := us.consentService.CreateConsentElements(ctx, ouID, elementsToCreate); err != nil {
 			return wrapConsentServiceError(ctx, err, logger)
@@ -1162,11 +1162,11 @@ func (us *entityTypeService) deleteConsentElements(ctx context.Context,
 	// TODO: Replace "default" with the schema's actual OU when applications are associated with OUs.
 	const ouID = "default"
 
-	logger.DebugWithContext(ctx, "Deleting consent elements for the removed schema attributes",
+	logger.Debug(ctx, "Deleting consent elements for the removed schema attributes",
 		log.String("ouID", ouID), log.Int("elementCount", len(attributeNames)))
 
 	if len(attributeNames) == 0 {
-		logger.DebugWithContext(ctx, "No consent elements to delete for the schema", log.String("ouID", ouID))
+		logger.Debug(ctx, "No consent elements to delete for the schema", log.String("ouID", ouID))
 		return nil
 	}
 
@@ -1181,7 +1181,7 @@ func (us *entityTypeService) deleteConsentElements(ctx context.Context,
 		// We assume there is only one consent element per attribute name.
 		// TODO: This should be revisited when user type separation is onboarded to consent elements.
 		if len(existing) > 0 {
-			logger.DebugWithContext(ctx, "Deleting consent element for the removed schema attribute",
+			logger.Debug(ctx, "Deleting consent element for the removed schema attribute",
 				log.String("ouID", ouID), log.String("attribute", attrName), log.String("elementID", existing[0].ID))
 			if err := us.consentService.DeleteConsentElement(ctx, ouID, existing[0].ID); err != nil {
 				// Silently ignore the error if it's due to associated purposes, but log a warning.
@@ -1190,7 +1190,7 @@ func (us *entityTypeService) deleteConsentElements(ctx context.Context,
 				// If it's not associated with a purpose, but exists in a different schema, we still delete it,
 				// as the consent element can be created again when configuring attribute for a application.
 				if err.Code == consent.ErrorDeletingConsentElementWithAssociatedPurpose.Code {
-					logger.WarnWithContext(ctx,
+					logger.Warn(ctx,
 						"Cannot delete consent element for removed attribute due to associated purposes",
 						log.String("attribute", attrName), log.String("elementID", existing[0].ID),
 						log.String("error", err.ErrorDescription.DefaultValue))
@@ -1255,13 +1255,13 @@ func wrapConsentServiceError(
 	}
 
 	if err.Type == serviceerror.ClientErrorType {
-		logger.DebugWithContext(ctx, "Failed to sync consent elements for the schema changes", log.Any("error", err))
+		logger.Debug(ctx, "Failed to sync consent elements for the schema changes", log.Any("error", err))
 		return serviceerror.CustomServiceError(ErrorConsentSyncFailed, core.I18nMessage{
 			Key:          "error.entitytypeservice.consent_sync_failed_description",
 			DefaultValue: fmt.Sprintf("%s : code - %s", ErrorConsentSyncFailed.ErrorDescription.DefaultValue, err.Code),
 		})
 	}
 
-	logger.ErrorWithContext(ctx, "Failed to sync consent elements for the schema changes", log.Any("error", err))
+	logger.Error(ctx, "Failed to sync consent elements for the schema changes", log.Any("error", err))
 	return &serviceerror.InternalServerError
 }

--- a/backend/internal/entitytype/service_consent_test.go
+++ b/backend/internal/entitytype/service_consent_test.go
@@ -21,6 +21,7 @@ package entitytype
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -616,5 +617,148 @@ func (s *EntityTypeServiceConsentTestSuite) TestDeleteEntityType_ConsentEnabled_
 
 	s.Nil(svcErr)
 	storeMock.AssertCalled(s.T(), "DeleteEntityTypeByID", mock.Anything, mock.Anything, "schema-id")
+	cMock.AssertCalled(s.T(), "ListConsentElements", mock.Anything, "default", consent.NamespaceAttribute, "email")
+}
+
+// TestCreateEntityType_ConsentSyncFails_CompensationDeleteFails verifies that when the
+// compensating schema deletion also fails after a consent sync failure, the failure is logged
+// and the original consent error is still returned.
+func (s *EntityTypeServiceConsentTestSuite) TestCreateEntityType_ConsentSyncFails_CompensationDeleteFails() {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{Enabled: false},
+	}
+	config.ResetServerRuntime()
+	err := config.InitializeServerRuntime("/tmp/test", testConfig)
+	require.NoError(s.T(), err)
+	defer config.ResetServerRuntime()
+
+	storeMock := newEntityTypeStoreInterfaceMock(s.T())
+	ouMock := oumock.NewOrganizationUnitServiceInterfaceMock(s.T())
+	cMock := consentmock.NewConsentServiceInterfaceMock(s.T())
+
+	svc := &entityTypeService{
+		entityTypeStore: storeMock,
+		ouService:       ouMock,
+		transactioner:   &mockTransactioner{},
+		consentService:  cMock,
+	}
+
+	ouMock.On("IsOrganizationUnitExists", mock.Anything, testOUID1).Return(true, (*serviceerror.ServiceError)(nil))
+	storeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, "test-schema").
+		Return(EntityType{}, ErrEntityTypeNotFound)
+	storeMock.On("CreateEntityType", mock.Anything, mock.Anything).Return(nil)
+	cMock.On("IsEnabled").Return(true)
+	cMock.On("ValidateConsentElements", mock.Anything, "default", mock.Anything).
+		Return(nil, &serviceerror.InternalServerError)
+	// Compensation deletion itself fails.
+	storeMock.On("DeleteEntityTypeByID", mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("delete failed"))
+
+	request := CreateEntityTypeRequestWithID{
+		Name:   "test-schema",
+		OUID:   testOUID1,
+		Schema: json.RawMessage(`{"email":{"type":"string"}}`),
+	}
+
+	result, svcErr := svc.CreateEntityType(context.Background(), TypeCategoryUser, request)
+
+	s.Nil(result)
+	s.NotNil(svcErr)
+	storeMock.AssertCalled(s.T(), "DeleteEntityTypeByID", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestUpdateEntityType_ConsentSyncFails_CompensationRevertFails verifies that when the
+// compensating schema revert also fails after a consent sync failure, the failure is logged
+// and the original consent error is still returned.
+func (s *EntityTypeServiceConsentTestSuite) TestUpdateEntityType_ConsentSyncFails_CompensationRevertFails() {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{Enabled: false},
+	}
+	config.ResetServerRuntime()
+	err := config.InitializeServerRuntime("/tmp/test", testConfig)
+	require.NoError(s.T(), err)
+	defer config.ResetServerRuntime()
+
+	storeMock := newEntityTypeStoreInterfaceMock(s.T())
+	ouMock := oumock.NewOrganizationUnitServiceInterfaceMock(s.T())
+	cMock := consentmock.NewConsentServiceInterfaceMock(s.T())
+
+	svc := &entityTypeService{
+		entityTypeStore: storeMock,
+		ouService:       ouMock,
+		transactioner:   &mockTransactioner{},
+		consentService:  cMock,
+	}
+
+	existingSchema := EntityType{
+		ID:     "schema-id",
+		Name:   "test-schema",
+		OUID:   testOUID1,
+		Schema: json.RawMessage(`{"email":{"type":"string"}}`),
+	}
+
+	storeMock.On("IsEntityTypeDeclarative", TypeCategoryUser, "schema-id").Return(false)
+	ouMock.On("IsOrganizationUnitExists", mock.Anything, testOUID1).Return(true, (*serviceerror.ServiceError)(nil))
+	storeMock.On("GetEntityTypeByID", mock.Anything, mock.Anything, "schema-id").Return(existingSchema, nil)
+	// First call (in-tx update) succeeds; second call (compensation revert) fails.
+	storeMock.On("UpdateEntityTypeByID", mock.Anything, mock.Anything, "schema-id", mock.Anything).
+		Return(nil).Once()
+	storeMock.On("UpdateEntityTypeByID", mock.Anything, mock.Anything, "schema-id", mock.Anything).
+		Return(errors.New("revert failed")).Once()
+	cMock.On("IsEnabled").Return(true)
+	cMock.On("ValidateConsentElements", mock.Anything, "default", mock.Anything).
+		Return(nil, &serviceerror.InternalServerError)
+
+	request := UpdateEntityTypeRequest{
+		Name:   "test-schema",
+		OUID:   testOUID1,
+		Schema: json.RawMessage(`{"email":{"type":"string"}}`),
+	}
+
+	result, svcErr := svc.UpdateEntityType(context.Background(), TypeCategoryUser, "schema-id", request)
+
+	s.Nil(result)
+	s.NotNil(svcErr)
+	storeMock.AssertNumberOfCalls(s.T(), "UpdateEntityTypeByID", 2)
+}
+
+// TestDeleteEntityType_ConsentCleanupFails verifies that a failure while deleting consent
+// elements after schema deletion is logged but the overall delete still succeeds.
+func (s *EntityTypeServiceConsentTestSuite) TestDeleteEntityType_ConsentCleanupFails() {
+	testConfig := &config.Config{
+		DeclarativeResources: config.DeclarativeResources{Enabled: false},
+	}
+	config.ResetServerRuntime()
+	err := config.InitializeServerRuntime("/tmp/test", testConfig)
+	require.NoError(s.T(), err)
+	defer config.ResetServerRuntime()
+
+	storeMock := newEntityTypeStoreInterfaceMock(s.T())
+	cMock := consentmock.NewConsentServiceInterfaceMock(s.T())
+
+	svc := &entityTypeService{
+		entityTypeStore: storeMock,
+		transactioner:   &mockTransactioner{},
+		consentService:  cMock,
+	}
+
+	existingSchema := EntityType{
+		ID:     "schema-id",
+		Name:   "test-schema",
+		OUID:   testOUID1,
+		Schema: json.RawMessage(`{"email":{"type":"string"}}`),
+	}
+
+	storeMock.On("GetEntityTypeByID", mock.Anything, mock.Anything, "schema-id").Return(existingSchema, nil)
+	storeMock.On("IsEntityTypeDeclarative", TypeCategoryUser, "schema-id").Return(false)
+	cMock.On("IsEnabled").Return(true)
+	storeMock.On("DeleteEntityTypeByID", mock.Anything, mock.Anything, "schema-id").Return(nil)
+	// Consent cleanup fails when listing elements for the removed attribute.
+	cMock.On("ListConsentElements", mock.Anything, "default", consent.NamespaceAttribute, "email").
+		Return(nil, &serviceerror.InternalServerError)
+
+	svcErr := svc.DeleteEntityType(context.Background(), TypeCategoryUser, "schema-id")
+
+	s.Nil(svcErr)
 	cMock.AssertCalled(s.T(), "ListConsentElements", mock.Anything, "default", consent.NamespaceAttribute, "email")
 }

--- a/backend/internal/entitytype/service_test.go
+++ b/backend/internal/entitytype/service_test.go
@@ -33,6 +33,7 @@ import (
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/tests/mocks/consentmock"
@@ -1975,4 +1976,55 @@ func (s *EntityTypeServiceTestSuite) TestGetAttributes_NonCredential_StoreError_
 	s.Require().NotNil(svcErr)
 	s.Require().Equal(serviceerror.InternalServerError, *svcErr)
 	s.Require().Nil(attrs)
+}
+
+// TestGetCompiledSchemaForEntityType_CompileError verifies that a stored schema which fails to
+// compile surfaces as an internal server error through ValidateEntity.
+func TestGetCompiledSchemaForEntityType_CompileError(t *testing.T) {
+	storeMock := newEntityTypeStoreInterfaceMock(t)
+	storeMock.
+		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "employee").
+		Return(EntityType{
+			Name:   "employee",
+			Schema: json.RawMessage(`{"email":{"type":"banana"}}`),
+		}, nil).
+		Once()
+
+	service := &entityTypeService{
+		entityTypeStore: storeMock,
+		transactioner:   &mockTransactioner{},
+	}
+
+	ok, svcErr := service.ValidateEntity(
+		context.Background(), TypeCategoryUser, "employee", json.RawMessage(`{}`), false)
+
+	require.False(t, ok)
+	require.NotNil(t, svcErr)
+	require.Equal(t, serviceerror.InternalServerError, *svcErr)
+}
+
+// TestEnsureOrganizationUnitExists_NilOUService verifies that a missing OU service yields an
+// internal server error.
+func TestEnsureOrganizationUnitExists_NilOUService(t *testing.T) {
+	service := &entityTypeService{ouService: nil}
+
+	svcErr := service.ensureOrganizationUnitExists(
+		context.Background(), testOUID1, TypeCategoryUser, log.GetLogger())
+
+	require.NotNil(t, svcErr)
+	require.Equal(t, serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// TestPopulateEntityTypeOUHandles_HandleResolutionError verifies that populateEntityTypeOUHandles
+// returns early without setting handles when the OU service fails.
+func TestPopulateEntityTypeOUHandles_HandleResolutionError(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("GetOrganizationUnitHandlesByIDs", mock.Anything, []string{testOUID1}).
+		Return(map[string]string(nil), &serviceerror.InternalServerError).Once()
+
+	service := &entityTypeService{ouService: ouServiceMock}
+	schemas := []EntityTypeListItem{{ID: "s1", Name: "Schema1", OUID: testOUID1}}
+
+	service.populateEntityTypeOUHandles(context.Background(), schemas, log.GetLogger())
+	require.Empty(t, schemas[0].OUHandle)
 }

--- a/backend/internal/entitytype/store.go
+++ b/backend/internal/entitytype/store.go
@@ -151,7 +151,7 @@ func (s *entityTypeStore) GetEntityTypeList(ctx context.Context, category TypeCa
 	for _, row := range results {
 		entityType, err := parseEntityTypeListItemFromRow(row)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to parse entity type list item from row", log.Error(err))
+			logger.Error(ctx, "Failed to parse entity type list item from row", log.Error(err))
 			continue
 		}
 		entityTypes = append(entityTypes, entityType)
@@ -190,7 +190,7 @@ func (s *entityTypeStore) GetEntityTypeListByOUIDs(ctx context.Context, category
 	for _, row := range results {
 		entityType, err := parseEntityTypeListItemFromRow(row)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to parse entity type list item from row", log.Error(err))
+			logger.Error(ctx, "Failed to parse entity type list item from row", log.Error(err))
 			continue
 		}
 		entityTypes = append(entityTypes, entityType)
@@ -355,7 +355,7 @@ func (s *entityTypeStore) DeleteEntityTypeByID(ctx context.Context, category Typ
 	}
 
 	if rowsAffected == 0 {
-		logger.DebugWithContext(ctx, "entity type not found with id: "+schemaID)
+		logger.Debug(ctx, "entity type not found with id: "+schemaID)
 	}
 
 	return nil
@@ -396,13 +396,13 @@ func (s *entityTypeStore) GetDisplayAttributesByNames(ctx context.Context, categ
 	for _, row := range results {
 		name, ok := row["name"].(string)
 		if !ok {
-			logger.ErrorWithContext(ctx, "Failed to parse name from display attributes query")
+			logger.Error(ctx, "Failed to parse name from display attributes query")
 			continue
 		}
 
 		sysAttrs, err := parseSystemAttributes(row["system_attributes"])
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to parse system attributes",
+			logger.Error(ctx, "Failed to parse system attributes",
 				log.String("schemaName", name), log.Error(err))
 			continue
 		}

--- a/backend/internal/flow/core/executor.go
+++ b/backend/internal/flow/core/executor.go
@@ -97,7 +97,7 @@ func (e *executor) HasRequiredInputs(ctx *NodeContext, execResp *common.Executor
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "Executor"),
 		log.String(log.LoggerKeyExecutorName, e.GetName()),
 		log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Checking inputs for the executor")
+	logger.Debug(ctx.Context, "Checking inputs for the executor")
 
 	requiredData := e.GetRequiredInputs(ctx)
 
@@ -140,7 +140,7 @@ func (e *executor) ValidatePrerequisites(ctx *NodeContext, execResp *common.Exec
 		if _, ok := ctx.UserInputs[prerequisite.Identifier]; !ok {
 			if _, ok := ctx.RuntimeData[prerequisite.Identifier]; !ok {
 				if value, ok := ctx.ForwardedData[prerequisite.Identifier]; !ok {
-					logger.DebugWithContext(ctx.Context, "Prerequisite not met for the executor",
+					logger.Debug(ctx.Context, "Prerequisite not met for the executor",
 						log.String("identifier", prerequisite.Identifier))
 					execResp.Status = common.ExecFailure
 					execResp.Error = serviceerror.CustomServiceError(ErrExecutorPrerequisiteNotMet,
@@ -152,7 +152,7 @@ func (e *executor) ValidatePrerequisites(ctx *NodeContext, execResp *common.Exec
 				} else {
 					// ForwardedData found but verify it's a string value
 					if _, isString := value.(string); !isString {
-						logger.DebugWithContext(ctx.Context,
+						logger.Debug(ctx.Context,
 							"Prerequisite not met for the executor (non-string in ForwardedData)",
 							log.String("identifier", prerequisite.Identifier))
 						execResp.Status = common.ExecFailure

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -78,7 +78,7 @@ func newPromptNode(id string, properties map[string]interface{},
 // Execute executes the prompt node logic based on the current context.
 func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceerror.ServiceError) {
 	logger := n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing prompt node")
+	logger.Debug(ctx.Context, "Executing prompt node")
 
 	nodeResp := &common.NodeResponse{
 		Inputs:         make([]common.Input, 0),
@@ -93,7 +93,7 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 			var errResp serviceerror.ServiceError
 			if err := json.Unmarshal([]byte(jsonStr), &errResp); err == nil {
 				nodeResp.Error = &errResp
-				logger.DebugWithContext(ctx.Context, "Prompt node is handling a failure",
+				logger.Debug(ctx.Context, "Prompt node is handling a failure",
 					log.String("errorCode", errResp.Code))
 			}
 			delete(ctx.RuntimeData, "failureReasonJSON")
@@ -107,7 +107,7 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 
 	// Check if this is a display-only prompt node
 	if n.IsDisplayOnly() {
-		logger.DebugWithContext(ctx.Context, "Display-only prompt node, returning display content")
+		logger.Debug(ctx.Context, "Display-only prompt node, returning display content")
 
 		if ctx.Verbose && n.GetMeta() != nil {
 			nodeResp.Meta = n.GetMeta()
@@ -130,7 +130,7 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 	}
 
 	if n.resolvePromptInputs(ctx, nodeResp) {
-		logger.DebugWithContext(ctx.Context, "All required inputs and actions are available")
+		logger.Debug(ctx.Context, "All required inputs and actions are available")
 		if n.applyValidationFailureRePrompt(ctx, nodeResp) {
 			return nodeResp, nil
 		}
@@ -139,7 +139,7 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 			if nextNode := n.getNextNodeForActionRef(ctx.Context, ctx.CurrentAction); nextNode != "" {
 				nodeResp.NextNodeID = nextNode
 			} else {
-				logger.DebugWithContext(ctx.Context, ErrInvalidActionProvided.Error.DefaultValue,
+				logger.Debug(ctx.Context, ErrInvalidActionProvided.Error.DefaultValue,
 					log.String("actionRef", ctx.CurrentAction))
 				nodeResp.Status = common.NodeStatusFailure
 				nodeResp.Error = &ErrInvalidActionProvided
@@ -161,7 +161,7 @@ func (n *promptNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceer
 	}
 
 	// If required inputs or action is not yet available, prompt for user interaction
-	logger.DebugWithContext(ctx.Context, "Required inputs or action not available, prompting user",
+	logger.Debug(ctx.Context, "Required inputs or action not available, prompting user",
 		log.Any("inputs", nodeResp.Inputs), log.Any("actions", nodeResp.Actions))
 
 	// Include meta in the response if verbose mode is enabled
@@ -185,7 +185,7 @@ func (n *promptNode) applyValidationFailureRePrompt(ctx *NodeContext, nodeResp *
 		return false
 	}
 	n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID)).
-		DebugWithContext(ctx.Context, "Input validation failed", log.Int("errorCount", len(fieldErrors)))
+		Debug(ctx.Context, "Input validation failed", log.Int("errorCount", len(fieldErrors)))
 
 	matchingAction := n.findActionByRef(ctx.CurrentAction)
 
@@ -254,7 +254,7 @@ func (n *promptNode) executeLoginOptions(ctx *NodeContext,
 	if ctx.CurrentAction != "" {
 		if allowedRaw := ctx.RuntimeData[common.RuntimeKeyAllowedLoginOptions]; allowedRaw != "" {
 			if !slices.Contains(strings.Fields(allowedRaw), ctx.CurrentAction) {
-				logger.DebugWithContext(ctx.Context, "Selected action is not in allowed login options",
+				logger.Debug(ctx.Context, "Selected action is not in allowed login options",
 					log.String("actionRef", ctx.CurrentAction))
 				nodeResp.Status = common.NodeStatusFailure
 				nodeResp.Error = &ErrInvalidActionProvided
@@ -285,7 +285,7 @@ func (n *promptNode) executeLoginOptions(ctx *NodeContext,
 	// Auto-select the sole remaining option so the user skips a single-choice chooser.
 	if len(actions) == 1 && len(requestedAuthClasses) > 0 {
 		ctx.CurrentAction = actions[0].Ref
-		logger.DebugWithContext(ctx.Context, "Auto-selected single login option",
+		logger.Debug(ctx.Context, "Auto-selected single login option",
 			log.String("actionRef", ctx.CurrentAction))
 		if n.resolvePromptInputs(ctx, nodeResp) {
 			if n.applyValidationFailureRePrompt(ctx, nodeResp) {
@@ -314,7 +314,7 @@ func (n *promptNode) finalizeLoginOptionsAction(ctx *NodeContext, nodeResp *comm
 	logger := n.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	nextNode := n.getNextNodeForActionRef(ctx.Context, ctx.CurrentAction)
 	if nextNode == "" {
-		logger.DebugWithContext(ctx.Context, ErrInvalidActionProvided.Error.DefaultValue,
+		logger.Debug(ctx.Context, ErrInvalidActionProvided.Error.DefaultValue,
 			log.String("actionRef", ctx.CurrentAction))
 		nodeResp.Status = common.NodeStatusFailure
 		nodeResp.Error = &ErrInvalidActionProvided
@@ -455,10 +455,10 @@ func (n *promptNode) hasRequiredInputs(ctx *NodeContext, nodeResp *common.NodeRe
 				return !n.appendMissingInputs(ctx, nodeResp, prompt.Inputs)
 			}
 		}
-		logger.DebugWithContext(ctx.Context, "Selected action not found in prompts, treating as no action selected",
+		logger.Debug(ctx.Context, "Selected action not found in prompts, treating as no action selected",
 			log.String("action", ctx.CurrentAction))
 	} else {
-		logger.DebugWithContext(ctx.Context, "No action selected, checking inputs from all prompts")
+		logger.Debug(ctx.Context, "No action selected, checking inputs from all prompts")
 	}
 
 	// If no action selected or action not found, validate inputs from all prompts
@@ -493,7 +493,7 @@ func (n *promptNode) enrichInputsFromForwardedData(ctx *NodeContext, nodeResp *c
 	// Type assert to []common.Input.
 	forwardedInputs, ok := forwardedInputsData.([]common.Input)
 	if !ok {
-		n.logger.DebugWithContext(ctx.Context,
+		n.logger.Debug(ctx.Context,
 			"ForwardedData contains 'inputs' key but value is not []common.Input, skipping enrichment")
 		return
 	}
@@ -510,20 +510,20 @@ func (n *promptNode) enrichInputsFromForwardedData(ctx *NodeContext, nodeResp *c
 		if idx, exists := existingIndexMap[fwdInput.Identifier]; exists {
 			if fwdInput.Required && !nodeResp.Inputs[idx].Required {
 				nodeResp.Inputs[idx].Required = true
-				n.logger.DebugWithContext(ctx.Context, "Updated input required flag from ForwardedData",
+				n.logger.Debug(ctx.Context, "Updated input required flag from ForwardedData",
 					log.String("identifier", fwdInput.Identifier))
 			}
 			if fwdInput.Type == common.InputTypePassword &&
 				nodeResp.Inputs[idx].Type != common.InputTypePassword {
 				nodeResp.Inputs[idx].Type = common.InputTypePassword
-				n.logger.DebugWithContext(ctx.Context, "Updated input type to password from ForwardedData",
+				n.logger.Debug(ctx.Context, "Updated input type to password from ForwardedData",
 					log.String("identifier", fwdInput.Identifier))
 			}
 			if fwdInput.Type == common.InputTypeSelect &&
 				nodeResp.Inputs[idx].Type == common.InputTypeSelect &&
 				len(fwdInput.Options) > 0 {
 				nodeResp.Inputs[idx].Options = fwdInput.Options
-				n.logger.DebugWithContext(ctx.Context, "Enriched input with options from ForwardedData",
+				n.logger.Debug(ctx.Context, "Enriched input with options from ForwardedData",
 					log.String("identifier", fwdInput.Identifier),
 					log.Int("optionsCount", len(fwdInput.Options)))
 			}
@@ -542,7 +542,7 @@ func (n *promptNode) enrichInputsFromForwardedData(ctx *NodeContext, nodeResp *c
 		}
 		nodeResp.Inputs = append(nodeResp.Inputs, fwdInput)
 		existingIndexMap[fwdInput.Identifier] = len(nodeResp.Inputs) - 1
-		n.logger.DebugWithContext(ctx.Context, "Added dynamically-derived input from ForwardedData",
+		n.logger.Debug(ctx.Context, "Added dynamically-derived input from ForwardedData",
 			log.String("identifier", fwdInput.Identifier))
 	}
 }
@@ -583,7 +583,7 @@ func (n *promptNode) tryAutoSelectSingleAction(ctx *NodeContext) bool {
 	// Skip auto-select for confirmation prompts (no inputs) - they should wait for explicit action
 	if len(actions) == 1 && ctx.CurrentAction == "" && len(allInputs) > 0 {
 		ctx.CurrentAction = actions[0].Ref
-		n.logger.DebugWithContext(ctx.Context, "Auto-selected single action",
+		n.logger.Debug(ctx.Context, "Auto-selected single action",
 			log.String(log.LoggerKeyExecutionID, ctx.ExecutionID),
 			log.String("actionRef", actions[0].Ref))
 		return true
@@ -639,7 +639,7 @@ func (n *promptNode) getNextNodeForActionRef(ctx context.Context, actionRef stri
 	actions := n.getAllActions()
 	for i := range actions {
 		if actions[i].Ref == actionRef {
-			n.logger.DebugWithContext(ctx, "Action selected successfully", log.String("actionRef", actions[i].Ref),
+			n.logger.Debug(ctx, "Action selected successfully", log.String("actionRef", actions[i].Ref),
 				log.String("nextNode", actions[i].NextNode))
 			return actions[i].NextNode
 		}

--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -86,10 +86,10 @@ func newTaskExecutionNode(id string, properties map[string]interface{}, isStartN
 // Execute executes the node's executor.
 func (n *taskExecutionNode) Execute(ctx *NodeContext) (*common.NodeResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing task execution node")
+	logger.Debug(ctx.Context, "Executing task execution node")
 
 	if n.executor == nil {
-		logger.ErrorWithContext(ctx.Context, "No executor configured for the node")
+		logger.Error(ctx.Context, "No executor configured for the node")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -158,7 +158,7 @@ func (n *taskExecutionNode) Execute(ctx *NodeContext) (*common.NodeResponse, *se
 		len(nodeResp.Inputs) == 0 {
 		// Executor returned INCOMPLETE+VIEW with no inputs — broken executor implementation.
 		// There is nothing for the client to act on; surface as a server error.
-		logger.ErrorWithContext(ctx.Context, "Executor returned INCOMPLETE with VIEW type but no inputs")
+		logger.Error(ctx.Context, "Executor returned INCOMPLETE with VIEW type but no inputs")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -190,11 +190,11 @@ func (n *taskExecutionNode) triggerExecutor(ctx *NodeContext, logger *log.Logger
 	*common.ExecutorResponse, *serviceerror.ServiceError) {
 	execResp, err := n.executor.Execute(ctx)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Error executing node executor", log.Error(err))
+		logger.Error(ctx.Context, "Error executing node executor", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if execResp == nil {
-		logger.ErrorWithContext(ctx.Context, "Executor returned a nil response")
+		logger.Error(ctx.Context, "Executor returned a nil response")
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/flow/core/utils.go
+++ b/backend/internal/flow/core/utils.go
@@ -131,23 +131,23 @@ func collectMissingInputs(ctx *NodeContext, presentedOptionalInputs map[string]s
 			continue
 		}
 		if _, ok := ctx.RuntimeData[input.Identifier]; ok {
-			logger.DebugWithContext(ctx.Context, "Input available in runtime data, skipping",
+			logger.Debug(ctx.Context, "Input available in runtime data, skipping",
 				log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
 			continue
 		}
 		if value, ok := ctx.ForwardedData[input.Identifier]; ok {
 			if _, isString := value.(string); isString {
-				logger.DebugWithContext(ctx.Context, "Input available in forwarded data, skipping",
+				logger.Debug(ctx.Context, "Input available in forwarded data, skipping",
 					log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
 				continue
 			}
 		}
 		if !input.Required && IsOptionalInputPrompted(presentedOptionalInputs, input.Identifier) {
-			logger.DebugWithContext(ctx.Context, "Optional input already prompted, skipping",
+			logger.Debug(ctx.Context, "Optional input already prompted, skipping",
 				log.String("identifier", input.Identifier))
 			continue
 		}
-		logger.DebugWithContext(ctx.Context, "Input not available in the context",
+		logger.Debug(ctx.Context, "Input not available in the context",
 			log.String("identifier", input.Identifier), log.Bool("isRequired", input.Required))
 		missing = append(missing, input)
 	}

--- a/backend/internal/flow/executor/attribute_collector.go
+++ b/backend/internal/flow/executor/attribute_collector.go
@@ -73,7 +73,7 @@ func newAttributeCollector(
 // Execute executes the attribute collection logic.
 func (a *attributeCollector) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing attribute collect executor")
+	logger.Debug(ctx.Context, "Executing attribute collect executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -81,39 +81,39 @@ func (a *attributeCollector) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 	}
 
 	if ctx.FlowType == common.FlowTypeRegistration {
-		logger.DebugWithContext(ctx.Context, "Flow type is registration, skipping attribute collection")
+		logger.Debug(ctx.Context, "Flow type is registration, skipping attribute collection")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
 
 	if !ctx.AuthenticatedUser.IsAuthenticated {
-		logger.DebugWithContext(ctx.Context, "User is not authenticated, cannot collect attributes")
+		logger.Debug(ctx.Context, "User is not authenticated, cannot collect attributes")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserNotAuthenticated
 		return execResp, nil
 	}
 
 	if !a.ValidatePrerequisites(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Prerequisites validation failed for attribute collector")
+		logger.Debug(ctx.Context, "Prerequisites validation failed for attribute collector")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrPrerequisitesFailed
 		return execResp, nil
 	}
 
 	if !a.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required inputs for attribute collector is not provided")
+		logger.Debug(ctx.Context, "Required inputs for attribute collector is not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
 
 	if err := a.updateUserInStore(ctx); err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to update user attributes", log.Error(err))
+		logger.Error(ctx.Context, "Failed to update user attributes", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrAttributeCollectFailed
 		return execResp, nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "User attributes updated successfully")
+	logger.Debug(ctx.Context, "User attributes updated successfully")
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }
@@ -123,7 +123,7 @@ func (a *attributeCollector) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) bool {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Checking inputs for the attribute collector")
+	logger.Debug(ctx.Context, "Checking inputs for the attribute collector")
 
 	if a.ExecutorInterface.HasRequiredInputs(ctx, execResp) {
 		return true
@@ -135,7 +135,7 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 	// Update the executor response with the required inputs retrieved from authenticated user attributes.
 	authnUserAttrs := ctx.AuthenticatedUser.Attributes
 	if len(authnUserAttrs) > 0 {
-		logger.DebugWithContext(ctx.Context,
+		logger.Debug(ctx.Context,
 			"Authenticated user attributes found, updating executor response required inputs")
 
 		// Clear the required data in the executor response to avoid duplicates.
@@ -155,13 +155,13 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 
 				attributeStr, ok := attribute.(string)
 				if ok {
-					logger.DebugWithContext(ctx.Context,
+					logger.Debug(ctx.Context,
 						"Input exists in authenticated user attributes, adding to runtime data",
 						log.String("attributeName", input.Identifier))
 					execResp.RuntimeData[input.Identifier] = attributeStr
 				}
 			} else {
-				logger.DebugWithContext(ctx.Context,
+				logger.Debug(ctx.Context,
 					"Input does not exist in authenticated user attributes, adding to required inputs",
 					log.String("attributeName", input.Identifier))
 				execResp.Inputs = append(execResp.Inputs, input)
@@ -169,7 +169,7 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 		}
 
 		if len(execResp.Inputs) == 0 {
-			logger.DebugWithContext(ctx.Context, "All required inputs are available in authenticated user attributes, "+
+			logger.Debug(ctx.Context, "All required inputs are available in authenticated user attributes, "+
 				"no further action needed")
 			return true
 		}
@@ -179,11 +179,11 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 	userAttributes, err := a.getUserAttributes(ctx)
 	if err != nil {
 		// Silently log the error and proceed with prompting for required inputs.
-		logger.ErrorWithContext(ctx.Context, "Failed to retrieve user attributes", log.Error(err))
+		logger.Error(ctx.Context, "Failed to retrieve user attributes", log.Error(err))
 		return false
 	}
 	if userAttributes == nil {
-		logger.DebugWithContext(ctx.Context,
+		logger.Debug(ctx.Context,
 			"No user attributes found in the user profile, proceeding with required inputs")
 		return false
 	}
@@ -202,7 +202,7 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 			if input.Identifier == userAttributePassword {
 				continue
 			}
-			logger.DebugWithContext(ctx.Context, "Input exists in user profile, adding to runtime data",
+			logger.Debug(ctx.Context, "Input exists in user profile, adding to runtime data",
 				log.String("attributeName", input.Identifier))
 
 			// TODO: This conversion should be modified according to the storage mechanism of the
@@ -213,14 +213,14 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 				execResp.RuntimeData[input.Identifier] = fmt.Sprintf("%v", attribute)
 			}
 		} else {
-			logger.DebugWithContext(ctx.Context, "Input does not exist in user profile, adding to required inputs",
+			logger.Debug(ctx.Context, "Input does not exist in user profile, adding to required inputs",
 				log.String("attributeName", input.Identifier))
 			execResp.Inputs = append(execResp.Inputs, input)
 		}
 	}
 
 	if len(execResp.Inputs) == 0 {
-		logger.DebugWithContext(ctx.Context,
+		logger.Debug(ctx.Context,
 			"All required inputs are available in the user profile, no further action needed")
 		return true
 	}
@@ -231,7 +231,7 @@ func (a *attributeCollector) HasRequiredInputs(ctx *core.NodeContext,
 // getUserAttributes retrieves the user attributes from the user profile.
 func (a *attributeCollector) getUserAttributes(ctx *core.NodeContext) (map[string]interface{}, error) {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Retrieving user attributes from the user profile")
+	logger.Debug(ctx.Context, "Retrieving user attributes from the user profile")
 
 	user, err := a.getUserFromStore(ctx)
 	if err != nil {
@@ -250,7 +250,7 @@ func (a *attributeCollector) getUserAttributes(ctx *core.NodeContext) (map[strin
 	} else {
 		userAttributes = make(map[string]interface{})
 	}
-	logger.DebugWithContext(ctx.Context, "User attributes retrieved successfully")
+	logger.Debug(ctx.Context, "User attributes retrieved successfully")
 
 	return userAttributes, nil
 }
@@ -258,7 +258,7 @@ func (a *attributeCollector) getUserAttributes(ctx *core.NodeContext) (map[strin
 // updateUserInStore updates the user profile with the collected attributes.
 func (a *attributeCollector) updateUserInStore(ctx *core.NodeContext) error {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Updating user attributes")
+	logger.Debug(ctx.Context, "Updating user attributes")
 
 	user, err := a.getUserFromStore(ctx)
 	if err != nil {
@@ -274,7 +274,7 @@ func (a *attributeCollector) updateUserInStore(ctx *core.NodeContext) error {
 		return fmt.Errorf("failed to get updated user object: %w", err)
 	}
 	if !updateRequired {
-		logger.DebugWithContext(ctx.Context, "No updates required for user attributes, skipping update")
+		logger.Debug(ctx.Context, "No updates required for user attributes, skipping update")
 		return nil
 	}
 	if updatedUser == nil {
@@ -284,7 +284,7 @@ func (a *attributeCollector) updateUserInStore(ctx *core.NodeContext) error {
 	if err := a.entityProvider.UpdateAttributes(userID, updatedUser.Attributes); err != nil {
 		return fmt.Errorf("failed to update user attributes: %s", err.Message)
 	}
-	logger.DebugWithContext(ctx.Context, "User attributes updated successfully",
+	logger.Debug(ctx.Context, "User attributes updated successfully",
 		log.MaskedString(log.LoggerKeyUserID, userID))
 
 	return nil
@@ -331,7 +331,7 @@ func (a *attributeCollector) getUpdatedUserObject(ctx *core.NodeContext,
 	// Get new attributes from input
 	newAttrs := a.getInputAttributes(ctx)
 	if len(newAttrs) == 0 {
-		logger.DebugWithContext(ctx.Context, "No new attributes provided, returning existing user")
+		logger.Debug(ctx.Context, "No new attributes provided, returning existing user")
 		return false, userData, nil
 	}
 

--- a/backend/internal/flow/executor/attribute_uniqueness_validator.go
+++ b/backend/internal/flow/executor/attribute_uniqueness_validator.go
@@ -70,7 +70,7 @@ func newAttributeUniquenessValidator(
 // named in the structured error when a conflict is detected, or ExecComplete when all values are free.
 func (e *attributeUniquenessValidator) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing uniqueness checker executor")
+	logger.Debug(ctx.Context, "Executing uniqueness checker executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -105,7 +105,7 @@ func (e *attributeUniquenessValidator) Execute(ctx *core.NodeContext) (*common.E
 		}
 
 		if userID != nil {
-			logger.DebugWithContext(ctx.Context, "Unique attribute conflict detected", log.String("attribute", attr))
+			logger.Debug(ctx.Context, "Unique attribute conflict detected", log.String("attribute", attr))
 			execResp.Status = common.ExecUserInputRequired
 			execResp.Error = errAttributeNotUniqueFor(attr)
 			return execResp, nil

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -96,7 +96,7 @@ func newAuthAssertExecutor(
 // Execute executes the authentication assertion logic.
 func (a *authAssertExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing authentication assertion executor")
+	logger.Debug(ctx.Context, "Executing authentication assertion executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -109,7 +109,7 @@ func (a *authAssertExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 			return nil, err
 		}
 
-		logger.DebugWithContext(ctx.Context, "Generated JWT token for authentication assertion")
+		logger.Debug(ctx.Context, "Generated JWT token for authentication assertion")
 
 		execResp.Status = common.ExecComplete
 		execResp.Assertion = token
@@ -121,7 +121,7 @@ func (a *authAssertExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 		execResp.Error = &ErrUserNotAuthenticated
 	}
 
-	logger.DebugWithContext(ctx.Context, "Authentication assertion executor execution completed",
+	logger.Debug(ctx.Context, "Authentication assertion executor execution completed",
 		log.String("status", string(execResp.Status)))
 
 	return execResp, nil
@@ -153,7 +153,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 		assertionResult, svcErr := a.authAssertGenerator.GenerateAssertion(ctx.Context, authenticatorRefs)
 		if svcErr != nil {
 			if svcErr.Type == serviceerror.ServerErrorType {
-				logger.ErrorWithContext(ctx.Context, "Failed to generate auth assertion",
+				logger.Error(ctx.Context, "Failed to generate auth assertion",
 					log.String("error", svcErr.Error.DefaultValue))
 				return "", errors.New("something went wrong while generating auth assertion")
 			}
@@ -191,7 +191,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 		if len(resolvedAttributes) > 0 {
 			ttlSeconds, err := strconv.Atoi(ttlSecondsStr)
 			if err != nil {
-				logger.ErrorWithContext(ctx.Context, "Failed to parse TTL seconds from runtime data",
+				logger.Error(ctx.Context, "Failed to parse TTL seconds from runtime data",
 					log.String("key", common.RuntimeKeyUserAttributesCacheTTLSeconds),
 					log.String("ttlValue", ttlSecondsStr),
 					log.String("error", err.Error()))
@@ -203,7 +203,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 			}
 			result, creationErr := a.attributeCacheSvc.CreateAttributeCache(ctx.Context, attributeCache)
 			if creationErr != nil {
-				logger.ErrorWithContext(ctx.Context, "Failed to create attribute cache",
+				logger.Error(ctx.Context, "Failed to create attribute cache",
 					log.String("error", creationErr.ErrorDescription.DefaultValue))
 				return "", errors.New("failed to create attribute cache")
 			}
@@ -220,7 +220,7 @@ func (a *authAssertExecutor) generateAuthAssertion(ctx *core.NodeContext, logger
 	token, _, err := a.jwtService.GenerateJWT(
 		ctx.Context, tokenSub, iss, validityPeriod, jwtClaims, jwt.TokenTypeJWT, "")
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to generate JWT token",
+		logger.Error(ctx.Context, "Failed to generate JWT token",
 			log.String("error", err.Error.DefaultValue))
 		return "", errors.New("failed to generate JWT token: " + err.Error.DefaultValue)
 	}
@@ -284,12 +284,12 @@ func (a *authAssertExecutor) getRequiredUserAttributes(ctx *core.NodeContext) (u
 	if _, consentRecorded := ctx.RuntimeData[common.RuntimeKeyConsentID]; consentRecorded {
 		// Get user attributes from consented attributes if consent was collected in this flow
 		if consentedAttrsStr, exists := ctx.RuntimeData[common.RuntimeKeyConsentedAttributes]; exists {
-			logger.DebugWithContext(ctx.Context, "Consent recorded with approved attributes")
+			logger.Debug(ctx.Context, "Consent recorded with approved attributes")
 			return strings.Fields(consentedAttrsStr)
 		}
 
 		// If consent was recorded but no attributes were approved, attributes are empty
-		logger.DebugWithContext(ctx.Context, "Consent recorded but no attributes approved")
+		logger.Debug(ctx.Context, "Consent recorded but no attributes approved")
 		return []string{}
 	}
 
@@ -300,16 +300,16 @@ func (a *authAssertExecutor) getRequiredUserAttributes(ctx *core.NodeContext) (u
 
 	if essentialExists || optionalExists {
 		userAttributes = []string{}
-		logger.DebugWithContext(ctx.Context,
+		logger.Debug(ctx.Context,
 			"Essential/ optional attributes exists in runtime data. Applying attribute filtering")
 
 		if essentialExists {
-			logger.DebugWithContext(ctx.Context, "Adding required essential attributes to user attributes list")
+			logger.Debug(ctx.Context, "Adding required essential attributes to user attributes list")
 			userAttributes = append(userAttributes,
 				strings.Fields(ctx.RuntimeData[common.RuntimeKeyRequiredEssentialAttributes])...)
 		}
 		if optionalExists {
-			logger.DebugWithContext(ctx.Context, "Adding required optional attributes to user attributes list")
+			logger.Debug(ctx.Context, "Adding required optional attributes to user attributes list")
 			userAttributes = append(userAttributes,
 				strings.Fields(ctx.RuntimeData[common.RuntimeKeyRequiredOptionalAttributes])...)
 		}
@@ -320,11 +320,11 @@ func (a *authAssertExecutor) getRequiredUserAttributes(ctx *core.NodeContext) (u
 	// If consent was not recorded and no essential/ optional attributes specified, fallback to
 	// application token config
 	if ctx.Application.Assertion != nil {
-		logger.DebugWithContext(ctx.Context, "Adding application token attributes to user attributes list")
+		logger.Debug(ctx.Context, "Adding application token attributes to user attributes list")
 		return ctx.Application.Assertion.UserAttributes
 	}
 
-	logger.DebugWithContext(ctx.Context, "No user attributes configured for inclusion in assertion")
+	logger.Debug(ctx.Context, "No user attributes configured for inclusion in assertion")
 	return []string{}
 }
 
@@ -484,20 +484,20 @@ func (a *authAssertExecutor) getUserAttributesFromUserProvider(ctx context.Conte
 	var jsonAttrs json.RawMessage
 	res, err := a.entityProvider.GetEntity(userID)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to fetch user attributes",
+		logger.Error(ctx, "Failed to fetch user attributes",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Any("error", err))
 		return nil, errors.New("something went wrong while fetching user attributes: " + err.Error())
 	}
 	jsonAttrs = res.Attributes
 
 	if len(jsonAttrs) == 0 {
-		logger.ErrorWithContext(ctx, "No user attributes returned")
+		logger.Error(ctx, "No user attributes returned")
 		return nil, errors.New("no user attributes returned")
 	}
 
 	var attrs map[string]interface{}
 	if err := json.Unmarshal(jsonAttrs, &attrs); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to unmarshal user attributes",
+		logger.Error(ctx, "Failed to unmarshal user attributes",
 			log.MaskedString(log.LoggerKeyUserID, userID),
 			log.Error(err))
 		return nil, errors.New("something went wrong while unmarshalling user attributes: " + err.Error())
@@ -514,7 +514,7 @@ func (a *authAssertExecutor) appendOUDetailsToClaims(
 
 	organizationUnit, svcErr := a.ouService.GetOrganizationUnit(ctx, ouID)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to fetch organization unit details",
+		logger.Error(ctx, "Failed to fetch organization unit details",
 			log.String(ouIDKey, ouID), log.Any("error", svcErr))
 		return errors.New("something went wrong while fetching organization unit: " +
 			svcErr.ErrorDescription.DefaultValue)
@@ -548,7 +548,7 @@ func (a *authAssertExecutor) fetchAllUserGroups(
 
 	groups, err := a.entityProvider.GetTransitiveEntityGroups(userID)
 	if err != nil {
-		a.logger.ErrorWithContext(ctx, "Failed to fetch transitive user groups",
+		a.logger.Error(ctx, "Failed to fetch transitive user groups",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Any("error", err))
 		return nil, errors.New("something went wrong while fetching user groups: " + err.Error())
 	}
@@ -581,7 +581,7 @@ func (a *authAssertExecutor) appendRolesToClaims(
 
 	roles, svcErr := a.roleService.GetUserRoles(ctx.Context, ctx.AuthenticatedUser.UserID, groupIDs)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to fetch user roles",
+		logger.Error(ctx.Context, "Failed to fetch user roles",
 			log.MaskedString(log.LoggerKeyUserID, ctx.AuthenticatedUser.UserID),
 			log.Any("error", svcErr))
 		return errors.New("something went wrong while fetching user roles: " + svcErr.ErrorDescription.DefaultValue)

--- a/backend/internal/flow/executor/authz_executor.go
+++ b/backend/internal/flow/executor/authz_executor.go
@@ -71,14 +71,14 @@ func newAuthorizationExecutor(
 // calling the authorization service, and storing authorized permissions in runtime data.
 func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := a.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing authorization executor")
+	logger.Debug(ctx.Context, "Executing authorization executor")
 
 	execResp := &common.ExecutorResponse{
 		RuntimeData: make(map[string]string),
 	}
 
 	if !ctx.AuthenticatedUser.IsAuthenticated && ctx.FlowType == common.FlowTypeRegistration {
-		logger.DebugWithContext(ctx.Context,
+		logger.Debug(ctx.Context,
 			"Sending executor complete response for unauthenticated user in registration flow")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
@@ -94,12 +94,12 @@ func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.Executor
 	requestedPerms := extractRequestedPermissions(ctx)
 
 	if len(requestedPerms) == 0 {
-		logger.DebugWithContext(ctx.Context, "No permissions to check, returning empty permissions")
+		logger.Debug(ctx.Context, "No permissions to check, returning empty permissions")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "Determined required permissions", log.Int("count", len(requestedPerms)))
+	logger.Debug(ctx.Context, "Determined required permissions", log.Int("count", len(requestedPerms)))
 
 	// Extract user ID and group IDs
 	userID := ctx.AuthenticatedUser.UserID
@@ -108,7 +108,7 @@ func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.Executor
 		return nil, errors.Join(errors.New("Failed to extract group IDs"), err)
 	}
 
-	logger.DebugWithContext(ctx.Context, "Calling authorization service",
+	logger.Debug(ctx.Context, "Calling authorization service",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.Int("groupCount", len(groupIDs)),
 		log.Int("permissionCount", len(requestedPerms)))
@@ -122,7 +122,7 @@ func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.Executor
 
 	authzResp, svcErr := a.authzService.GetAuthorizedPermissions(ctx.Context, authzReq)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx.Context, "Authorization service call failed",
+		logger.Error(ctx.Context, "Authorization service call failed",
 			log.String("error", svcErr.Error.DefaultValue))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrAuthorizationFailed
@@ -130,7 +130,7 @@ func (a *authorizationExecutor) Execute(ctx *core.NodeContext) (*common.Executor
 	}
 
 	setAuthorizedPermissions(execResp, authzResp.AuthorizedPermissions)
-	logger.DebugWithContext(ctx.Context, "Authorization completed successfully",
+	logger.Debug(ctx.Context, "Authorization completed successfully",
 		log.Int("authorizedCount", len(authzResp.AuthorizedPermissions)))
 
 	execResp.Status = common.ExecComplete
@@ -185,7 +185,7 @@ func (a *authorizationExecutor) extractGroupIDs(ctx *core.NodeContext) ([]string
 
 	// If no groups found in context, fetch transitive groups from entity provider
 	if a.entityProvider != nil && ctx.AuthenticatedUser.UserID != "" {
-		a.logger.DebugWithContext(ctx.Context,
+		a.logger.Debug(ctx.Context,
 			"Groups not found in context, fetching transitive groups from entity provider",
 			log.MaskedString(log.LoggerKeyUserID, ctx.AuthenticatedUser.UserID))
 

--- a/backend/internal/flow/executor/basic_auth_executor.go
+++ b/backend/internal/flow/executor/basic_auth_executor.go
@@ -85,7 +85,7 @@ func newBasicAuthExecutor(
 // Execute executes the basic authentication logic.
 func (b *basicAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := b.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing basic authentication executor")
+	logger.Debug(ctx.Context, "Executing basic authentication executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -110,7 +110,7 @@ func (b *basicAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResp
 			return execResp, nil
 		}
 	} else if !b.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required inputs for basic authentication executor is not provided")
+		logger.Debug(ctx.Context, "Required inputs for basic authentication executor is not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -146,7 +146,7 @@ func (b *basicAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResp
 	execResp.AuthenticatedUser = *authenticatedUser
 	execResp.Status = common.ExecComplete
 
-	logger.DebugWithContext(ctx.Context, "Basic authentication executor execution completed",
+	logger.Debug(ctx.Context, "Basic authentication executor execution completed",
 		log.String("status", string(execResp.Status)),
 		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
@@ -196,7 +196,7 @@ func (b *basicAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 		}
 		if execResp.Status == common.ExecFailure {
 			if execResp.Error != nil && execResp.Error.Code == ErrUserNotFound.Code {
-				logger.DebugWithContext(ctx.Context,
+				logger.Debug(ctx.Context,
 					"User not found for the provided attributes. Proceeding with registration flow.")
 				execResp.Status = common.ExecComplete
 				return &authncm.AuthenticatedUser{
@@ -233,7 +233,7 @@ func (b *basicAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 			return nil, nil
 		}
 
-		logger.ErrorWithContext(ctx.Context, "Failed to authenticate user",
+		logger.Error(ctx.Context, "Failed to authenticate user",
 			log.String("errorCode", svcErr.Code), log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return nil, errors.New("failed to authenticate user")
 	}
@@ -245,15 +245,15 @@ func (b *basicAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 
 	if err != nil {
 		if err.Code != entityprovider.ErrorCodeNotImplemented {
-			logger.ErrorWithContext(ctx.Context, "Failed to get user attributes", log.Error(err))
+			logger.Error(ctx.Context, "Failed to get user attributes", log.Error(err))
 			return nil, errors.New("failed to get user attributes")
 		}
-		logger.DebugWithContext(ctx.Context, "User provider is not implemented. User attributes will be empty.")
+		logger.Debug(ctx.Context, "User provider is not implemented. User attributes will be empty.")
 	}
 
 	if err == nil && user != nil && len(user.Attributes) > 0 {
 		if err := json.Unmarshal(user.Attributes, &userAttributes); err != nil {
-			logger.ErrorWithContext(ctx.Context, "Failed to unmarshal user attributes", log.Error(err))
+			logger.Error(ctx.Context, "Failed to unmarshal user attributes", log.Error(err))
 			return nil, errors.New("failed to unmarshal user attributes")
 		}
 	}

--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -89,7 +89,7 @@ func newConsentExecutor(
 // Execute runs the consent enforcement logic.
 func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing consent executor")
+	logger.Debug(ctx.Context, "Executing consent executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -98,7 +98,7 @@ func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespon
 	}
 
 	if !e.ValidatePrerequisites(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Prerequisites validation failed for consent executor")
+		logger.Debug(ctx.Context, "Prerequisites validation failed for consent executor")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrConsentPrereqFailed
 		return execResp, nil
@@ -110,11 +110,11 @@ func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespon
 	userID := ctx.AuthenticatedUser.UserID
 
 	if !e.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required consent decisions not provided; checking if consent is needed")
+		logger.Debug(ctx.Context, "Required consent decisions not provided; checking if consent is needed")
 		return e.checkConsent(ctx, execResp, ouID, appID, userID)
 	}
 
-	logger.DebugWithContext(ctx.Context, "Consent decisions provided; processing consent decisions")
+	logger.Debug(ctx.Context, "Consent decisions provided; processing consent decisions")
 	return e.handleConsentDecisions(ctx, execResp, ouID, appID, userID)
 }
 
@@ -122,7 +122,7 @@ func (e *consentExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespon
 func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.ExecutorResponse,
 	ouID, appID, userID string) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Checking if user consent is required")
+	logger.Debug(ctx.Context, "Checking if user consent is required")
 
 	essentialAttributes, optionalAttributes := e.getRequiredAttributes(ctx)
 	authorizedPermissions := strings.Fields(ctx.RuntimeData["authorized_permissions"])
@@ -136,19 +136,19 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 		availableAttributes)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx.Context, "Client error while resolving user consent", log.Any("error", svcErr))
+			logger.Debug(ctx.Context, "Client error while resolving user consent", log.Any("error", svcErr))
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrConsentResolutionFailed
 			return execResp, nil
 		}
 
-		logger.ErrorWithContext(ctx.Context, "Failed to resolve consent", log.Any("error", svcErr))
+		logger.Error(ctx.Context, "Failed to resolve consent", log.Any("error", svcErr))
 		return nil, errors.New("failed to resolve consent")
 	}
 
 	// All consents are active — nothing to prompt
 	if promptData == nil {
-		logger.DebugWithContext(ctx.Context, "All required consents are active; completing consent executor")
+		logger.Debug(ctx.Context, "All required consents are active; completing consent executor")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
@@ -156,7 +156,7 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 	// Consent is needed — forward prompt data to the prompt node via ForwardedData
 	promptJSON, err := json.Marshal(promptData.Purposes)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to marshal consent prompt data", log.Error(err))
+		logger.Error(ctx.Context, "Failed to marshal consent prompt data", log.Error(err))
 		return nil, errors.New("failed to prepare consent prompt data")
 	}
 
@@ -173,14 +173,14 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 		if timeoutSec, err := strconv.ParseInt(timeoutStr, 10, 64); err == nil && timeoutSec > 0 {
 			expiresAt := time.Now().Add(time.Duration(timeoutSec) * time.Second).UnixMilli()
 			expiresAtStr := strconv.FormatInt(expiresAt, 10)
-			logger.DebugWithContext(ctx.Context, "Consent timeout configured", log.String("expiresAt", expiresAtStr))
+			logger.Debug(ctx.Context, "Consent timeout configured", log.String("expiresAt", expiresAtStr))
 
 			execResp.AdditionalData[common.DataStepTimeout] = expiresAtStr
 			execResp.RuntimeData[common.RuntimeKeyStepTimeout] = expiresAtStr
 		}
 	}
 
-	logger.DebugWithContext(ctx.Context, "Prompting for user consent",
+	logger.Debug(ctx.Context, "Prompting for user consent",
 		log.Int("purposeCount", len(promptData.Purposes)))
 	execResp.Status = common.ExecUserInputRequired
 	return execResp, nil
@@ -190,11 +190,11 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp *common.ExecutorResponse,
 	ouID, appID, userID string) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Processing consent decisions from user")
+	logger.Debug(ctx.Context, "Processing consent decisions from user")
 
 	decisionsJSON, ok := ctx.UserInputs[userInputConsentDecisions]
 	if !ok || decisionsJSON == "" {
-		logger.DebugWithContext(ctx.Context, "Consent decisions input is missing or empty")
+		logger.Debug(ctx.Context, "Consent decisions input is missing or empty")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrConsentDecisionsMissing
 		return execResp, nil
@@ -207,7 +207,7 @@ func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp
 
 	var decisions consentauthn.ConsentDecisions
 	if err := json.Unmarshal([]byte(decisionsJSON), &decisions); err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to parse consent decisions", log.Error(err))
+		logger.Error(ctx.Context, "Failed to parse consent decisions", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrConsentDecisionsParseFail
 		return execResp, nil
@@ -217,7 +217,7 @@ func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp
 	if expiresAtStr, ok := ctx.RuntimeData[common.RuntimeKeyStepTimeout]; ok && expiresAtStr != "" {
 		if expiresAt, err := strconv.ParseInt(expiresAtStr, 10, 64); err == nil {
 			if time.Now().UnixMilli() > expiresAt {
-				logger.DebugWithContext(ctx.Context, "Consent prompt has timed out", log.Any("expiresAt", expiresAt))
+				logger.Debug(ctx.Context, "Consent prompt has timed out", log.Any("expiresAt", expiresAt))
 				execResp.Status = common.ExecFailure
 				execResp.Error = &ErrConsentPromptTimedOut
 				return execResp, nil
@@ -242,20 +242,20 @@ func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp
 		// Essential consent denied: the consent record was persisted but the user denied
 		// a required attribute, so the flow cannot proceed
 		if svcErr.Code == consentauthn.ErrorEssentialConsentDenied.Code {
-			logger.DebugWithContext(ctx.Context, "User denied essential consent attributes")
+			logger.Debug(ctx.Context, "User denied essential consent attributes")
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrConsentDenied
 			return execResp, nil
 		}
 
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx.Context, "Client error while recording user consent", log.Any("error", svcErr))
+			logger.Debug(ctx.Context, "Client error while recording user consent", log.Any("error", svcErr))
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrConsentRecordFailed
 			return execResp, nil
 		}
 
-		logger.ErrorWithContext(ctx.Context, "Failed to record consent", log.Any("error", svcErr))
+		logger.Error(ctx.Context, "Failed to record consent", log.Any("error", svcErr))
 		return nil, errors.New("failed to record consent")
 	}
 
@@ -271,7 +271,7 @@ func (e *consentExecutor) handleConsentDecisions(ctx *core.NodeContext, execResp
 	consentedPerms := collectConsentedPermissions(consentRecord)
 	execResp.RuntimeData[common.RuntimeKeyConsentedPermissions] = strings.Join(consentedPerms, " ")
 
-	logger.DebugWithContext(ctx.Context, "Consent recorded successfully", log.String("consentID", consentRecord.ID))
+	logger.Debug(ctx.Context, "Consent recorded successfully", log.String("consentID", consentRecord.ID))
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }
@@ -331,7 +331,7 @@ func (e *consentExecutor) buildAugmentedAvailableAttributes(ctx *core.NodeContex
 	if ctx.AuthUser.IsAuthenticated() {
 		attrs, svcErr := e.authnProvider.GetUserAvailableAttributes(ctx.Context, ctx.AuthUser)
 		if svcErr != nil {
-			e.logger.DebugWithContext(ctx.Context,
+			e.logger.Debug(ctx.Context,
 				"Failed to get available attributes from AuthUser; using AuthenticatedUser only",
 				log.Any("error", svcErr))
 		} else if attrs != nil {

--- a/backend/internal/flow/executor/credential_setter.go
+++ b/backend/internal/flow/executor/credential_setter.go
@@ -68,7 +68,7 @@ func newCredentialSetter(
 // Execute sets the password for the user identified by userID in RuntimeData.
 func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing credential set")
+	logger.Debug(ctx.Context, "Executing credential set")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -77,21 +77,21 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 
 	// Check if password is provided
 	if !e.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Requested credentials not provided, requesting input")
+		logger.Debug(ctx.Context, "Requested credentials not provided, requesting input")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
 
 	// Validate prerequisites
 	if !e.ValidatePrerequisites(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Prerequisites not met for credential setter")
+		logger.Debug(ctx.Context, "Prerequisites not met for credential setter")
 		return execResp, nil
 	}
 
 	// Get userID from context
 	userID := e.GetUserIDFromContext(ctx)
 	if userID == "" {
-		logger.DebugWithContext(ctx.Context, "User ID not found in flow context")
+		logger.Debug(ctx.Context, "User ID not found in flow context")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserIDMissingInContext
 		return execResp, nil
@@ -100,7 +100,7 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	var credentialKey, credentialValue string
 	requiredInputs := e.GetRequiredInputs(ctx)
 	if len(requiredInputs) == 0 {
-		logger.DebugWithContext(ctx.Context, "No required inputs configured for credential setter")
+		logger.Debug(ctx.Context, "No required inputs configured for credential setter")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCredentialInputMissing
 		return execResp, nil
@@ -109,7 +109,7 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	input := requiredInputs[0]
 	credentialKey = input.Identifier
 	if credentialKey == "" {
-		logger.DebugWithContext(ctx.Context, "Required input has empty identifier in credential setter")
+		logger.Debug(ctx.Context, "Required input has empty identifier in credential setter")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCredentialInputInvalid
 		return execResp, nil
@@ -117,7 +117,7 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	credentialValue = ctx.UserInputs[credentialKey]
 
 	if credentialValue == "" {
-		logger.DebugWithContext(ctx.Context, "Credential value is empty", log.String("credentialKey", credentialKey))
+		logger.Debug(ctx.Context, "Credential value is empty", log.String("credentialKey", credentialKey))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCredentialValueEmpty
 		return execResp, nil
@@ -128,7 +128,7 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 		credentialKey: credentialValue,
 	})
 	if err != nil {
-		logger.DebugWithContext(ctx.Context, "Failed to marshal credentials", log.Error(err))
+		logger.Debug(ctx.Context, "Failed to marshal credentials", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCredentialProcessingFailed
 		return execResp, nil
@@ -137,14 +137,14 @@ func (e *credentialSetter) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	// Update user credentials
 	svcErr := e.entityProvider.UpdateCredentials(userID, credentials)
 	if svcErr != nil {
-		logger.DebugWithContext(ctx.Context, "Failed to update user credentials",
+		logger.Debug(ctx.Context, "Failed to update user credentials",
 			log.MaskedString(log.LoggerKeyUserID, userID))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCredentialSetFailed
 		return execResp, nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "Successfully set credentials for user",
+	logger.Debug(ctx.Context, "Successfully set credentials for user",
 		log.MaskedString(log.LoggerKeyUserID, userID))
 	execResp.Status = common.ExecComplete
 	return execResp, nil

--- a/backend/internal/flow/executor/email_executor.go
+++ b/backend/internal/flow/executor/email_executor.go
@@ -74,7 +74,7 @@ func (e *emailExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 // executeSend resolves the email template, constructs the email, and sends it.
 func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing email executor in send mode")
+	logger.Debug(ctx.Context, "Executing email executor in send mode")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -83,7 +83,7 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 
 	// 1. Check for SkipDelivery FIRST
 	if skip, ok := ctx.RuntimeData[common.RuntimeKeySkipDelivery]; ok && skip == dataValueTrue {
-		logger.DebugWithContext(ctx.Context, "Delivery marked as skipped, completing without sending email")
+		logger.Debug(ctx.Context, "Delivery marked as skipped, completing without sending email")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
@@ -92,7 +92,7 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 		execResp.AdditionalData[common.DataEmailSent] = dataValueFalse
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrEmailServiceNotConfigured
-		logger.DebugWithContext(ctx.Context, "Email client not configured")
+		logger.Debug(ctx.Context, "Email client not configured")
 		return execResp, nil
 	}
 
@@ -105,7 +105,7 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 		return nil, err
 	}
 	if recipient == "" {
-		logger.DebugWithContext(ctx.Context, "Email recipient not found")
+		logger.Debug(ctx.Context, "Email recipient not found")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrEmailRecipientMissing
 		return execResp, nil
@@ -148,7 +148,7 @@ func (e *emailExecutor) executeSend(ctx *core.NodeContext) (*common.ExecutorResp
 		return execResp, nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "Email sent successfully", log.MaskedString("recipient", recipient))
+	logger.Debug(ctx.Context, "Email sent successfully", log.MaskedString("recipient", recipient))
 
 	execResp.AdditionalData[common.DataEmailSent] = dataValueTrue
 	execResp.Status = common.ExecComplete
@@ -185,7 +185,7 @@ func (e *emailExecutor) resolveRecipientEmail(ctx *core.NodeContext, logger *log
 		if recipientEmail, err := GetUserAttribute(user, emailAttr); err == nil {
 			return recipientEmail, nil
 		}
-		logger.DebugWithContext(ctx.Context, "Email attribute not found on user entity",
+		logger.Debug(ctx.Context, "Email attribute not found on user entity",
 			log.String("attribute", emailAttr))
 	}
 
@@ -221,7 +221,7 @@ func (e *emailExecutor) resolveTemplateData(ctx *core.NodeContext) template.Temp
 					templateData[k] = v
 				}
 			default:
-				e.logger.DebugWithContext(ctx.Context, "Forwarded template data is of unknown type",
+				e.logger.Debug(ctx.Context, "Forwarded template data is of unknown type",
 					log.String("type", fmt.Sprintf("%T", forwardedTemplateData)))
 			}
 		}

--- a/backend/internal/flow/executor/federated_auth_resolver_executor.go
+++ b/backend/internal/flow/executor/federated_auth_resolver_executor.go
@@ -70,7 +70,7 @@ func newFederatedAuthResolverExecutor(
 // attribute), matching the same pattern used by the IdentifyingExecutor's filterUsersByAttributes.
 func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := f.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing federated auth resolver")
+	logger.Debug(ctx.Context, "Executing federated auth resolver")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -78,7 +78,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 	}
 
 	if !f.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required inputs not provided")
+		logger.Debug(ctx.Context, "Required inputs not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -112,7 +112,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 	matched := filterUsersByAttributes(candidates, filters)
 
 	if len(matched) == 0 {
-		logger.DebugWithContext(ctx.Context, "No user matched the provided selection")
+		logger.Debug(ctx.Context, "No user matched the provided selection")
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = f.GetRequiredInputs(ctx)
 		execResp.Error = &ErrUserNotFound
@@ -123,7 +123,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 		// Still ambiguous — extract remaining disambiguation options and request more input
 		options := extractDisambiguationOptions(matched)
 		if len(options) == 0 {
-			logger.DebugWithContext(ctx.Context, "Candidates are indistinguishable, no further disambiguation possible")
+			logger.Debug(ctx.Context, "Candidates are indistinguishable, no further disambiguation possible")
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrFailedToIdentifyUser
 			return execResp, nil
@@ -139,7 +139,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 			common.ForwardedDataKeyInputs: options,
 		}
 
-		logger.DebugWithContext(ctx.Context, "Multiple users still match, requesting additional attributes",
+		logger.Debug(ctx.Context, "Multiple users still match, requesting additional attributes",
 			log.Int("candidateCount", len(matched)))
 		return execResp, nil
 	}
@@ -151,7 +151,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 	// proof of federated authentication, so we must fail closed.
 	sub, hasSub := ctx.RuntimeData[userAttributeSub]
 	if !hasSub || sub == "" {
-		logger.DebugWithContext(ctx.Context, "No federated sub claim found, cannot authenticate")
+		logger.Debug(ctx.Context, "No federated sub claim found, cannot authenticate")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserNotAuthenticated
 		return execResp, nil
@@ -166,7 +166,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *core.NodeContext) (*common.
 		UserType:        resolvedUser.Type,
 	}
 
-	logger.DebugWithContext(ctx.Context, "Federated auth resolver completed successfully",
+	logger.Debug(ctx.Context, "Federated auth resolver completed successfully",
 		log.MaskedString("userID", resolvedUser.ID))
 
 	return execResp, nil

--- a/backend/internal/flow/executor/http_request_executor.go
+++ b/backend/internal/flow/executor/http_request_executor.go
@@ -107,7 +107,7 @@ func newHTTPRequestExecutor(
 // Execute executes the HTTP request logic.
 func (h *httpRequestExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing HTTP request executor")
+	logger.Debug(ctx.Context, "Executing HTTP request executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -116,7 +116,7 @@ func (h *httpRequestExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 
 	config, err := h.parseAndValidateConfig(ctx.Context, ctx.NodeProperties)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to parse/validate HTTP request configuration", log.Error(err))
+		logger.Error(ctx.Context, "Failed to parse/validate HTTP request configuration", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrHTTPRequestConfigInvalid
 		return execResp, nil
@@ -127,17 +127,17 @@ func (h *httpRequestExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 
 	response, err := h.executeRequestWithRetry(ctx, config)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to execute HTTP request", log.Error(err))
+		logger.Error(ctx.Context, "Failed to execute HTTP request", log.Error(err))
 		return h.handleRequestError(ctx.Context, execResp, config, err.Error(), logger), nil
 	}
 
 	if err := h.processResponse(ctx, config, response, execResp); err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to process response", log.Error(err))
+		logger.Error(ctx.Context, "Failed to process response", log.Error(err))
 		return h.handleRequestError(ctx.Context, execResp, config, err.Error(), logger), nil
 	}
 
 	execResp.Status = common.ExecComplete
-	logger.DebugWithContext(ctx.Context, "HTTP request executor execution completed",
+	logger.Debug(ctx.Context, "HTTP request executor execution completed",
 		log.String("status", string(execResp.Status)))
 
 	return execResp, nil
@@ -221,7 +221,7 @@ func (h *httpRequestExecutor) parseHeaderAndBody(
 	ctx context.Context, config *httpRequestConfig, propsMap map[string]interface{}) {
 	if headersStr, ok := propsMap["headers"].(string); ok {
 		if err := json.Unmarshal([]byte(headersStr), &config.Headers); err != nil {
-			h.logger.WarnWithContext(ctx, "Failed to parse headers JSON string, ignoring headers", log.Error(err))
+			h.logger.Warn(ctx, "Failed to parse headers JSON string, ignoring headers", log.Error(err))
 		}
 	} else if headersMap, ok := propsMap["headers"].(map[string]interface{}); ok {
 		for k, v := range headersMap {
@@ -233,7 +233,7 @@ func (h *httpRequestExecutor) parseHeaderAndBody(
 
 	if bodyStr, ok := propsMap["body"].(string); ok {
 		if err := json.Unmarshal([]byte(bodyStr), &config.Body); err != nil {
-			h.logger.WarnWithContext(ctx, "Failed to parse body JSON string, ignoring body", log.Error(err))
+			h.logger.Warn(ctx, "Failed to parse body JSON string, ignoring body", log.Error(err))
 		}
 	} else if bodyMap, ok := propsMap["body"].(map[string]interface{}); ok {
 		config.Body = bodyMap
@@ -245,7 +245,7 @@ func (h *httpRequestExecutor) parseResponseMapping(
 	ctx context.Context, config *httpRequestConfig, propsMap map[string]interface{}) {
 	if mappingStr, ok := propsMap["responseMapping"].(string); ok {
 		if err := json.Unmarshal([]byte(mappingStr), &config.ResponseMapping); err != nil {
-			h.logger.WarnWithContext(ctx, "Failed to parse response mapping JSON string, ignoring response mapping",
+			h.logger.Warn(ctx, "Failed to parse response mapping JSON string, ignoring response mapping",
 				log.Error(err))
 		}
 	} else if mappingMap, ok := propsMap["responseMapping"].(map[string]interface{}); ok {
@@ -265,7 +265,7 @@ func (h *httpRequestExecutor) parseErrorHandling(
 		if err := json.Unmarshal([]byte(errorHandlingStr), &eh); err == nil {
 			config.ErrorHandling = &eh
 		} else {
-			h.logger.WarnWithContext(ctx, "Failed to parse error handling JSON string, ignoring error handling",
+			h.logger.Warn(ctx, "Failed to parse error handling JSON string, ignoring error handling",
 				log.Error(err))
 		}
 	} else if ehMap, ok := propsMap["errorHandling"].(map[string]interface{}); ok {
@@ -327,7 +327,7 @@ func (h *httpRequestExecutor) enrichOURuntimeData(ctx *core.NodeContext, config 
 	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	organizationUnit, svcErr := h.ouService.GetOrganizationUnit(ctx.Context, ouID)
 	if svcErr != nil {
-		logger.WarnWithContext(ctx.Context, "Failed to fetch OU details for placeholder enrichment",
+		logger.Warn(ctx.Context, "Failed to fetch OU details for placeholder enrichment",
 			log.String(ouIDKey, ouID), log.String("error", svcErr.Error.DefaultValue))
 		return
 	}
@@ -392,7 +392,7 @@ func (h *httpRequestExecutor) executeRequestWithRetry(ctx *core.NodeContext,
 	attempts := retryCount + 1
 	for attempt := 0; attempt < attempts; attempt++ {
 		if attempt > 0 {
-			logger.DebugWithContext(ctx.Context, "Retrying HTTP request",
+			logger.Debug(ctx.Context, "Retrying HTTP request",
 				log.Int("attempt", attempt), log.Int("maxRetries", retryCount))
 			time.Sleep(time.Duration(retryDelay) * time.Millisecond)
 		}
@@ -439,7 +439,7 @@ func (h *httpRequestExecutor) executeRequest(ctx *core.NodeContext, config *http
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	logger.DebugWithContext(ctx.Context, "Sending HTTP request", log.String("method", config.Method),
+	logger.Debug(ctx.Context, "Sending HTTP request", log.String("method", config.Method),
 		log.MaskedString("url", config.URL))
 
 	response, err := httpClient.Do(req)
@@ -456,7 +456,7 @@ func (h *httpRequestExecutor) processResponse(ctx *core.NodeContext, config *htt
 	logger := h.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	defer func() {
 		if err := response.Body.Close(); err != nil {
-			logger.ErrorWithContext(ctx.Context, "Failed to close response body", log.Error(err))
+			logger.Error(ctx.Context, "Failed to close response body", log.Error(err))
 		}
 	}()
 
@@ -465,7 +465,7 @@ func (h *httpRequestExecutor) processResponse(ctx *core.NodeContext, config *htt
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	logger.DebugWithContext(ctx.Context, "Received HTTP response", log.Int("statusCode", response.StatusCode),
+	logger.Debug(ctx.Context, "Received HTTP response", log.Int("statusCode", response.StatusCode),
 		log.String("status", response.Status))
 
 	// Check for error status codes
@@ -539,14 +539,14 @@ func (h *httpRequestExecutor) handleRequestError(
 	}
 
 	if failOnError {
-		logger.DebugWithContext(ctx, "Failing execution due to HTTP request error", log.String("error", errorMessage))
+		logger.Debug(ctx, "Failing execution due to HTTP request error", log.String("error", errorMessage))
 		execResp.Status = common.ExecFailure
 		execResp.Error = serviceerror.CustomServiceError(ErrHTTPRequestFailed, i18ncore.I18nMessage{
 			Key:          ErrHTTPRequestFailed.ErrorDescription.Key,
 			DefaultValue: errorMessage,
 		})
 	} else {
-		logger.DebugWithContext(ctx, "Continuing execution despite HTTP request error",
+		logger.Debug(ctx, "Continuing execution despite HTTP request error",
 			log.String("error", errorMessage))
 		execResp.Status = common.ExecComplete
 	}

--- a/backend/internal/flow/executor/identifying_executor.go
+++ b/backend/internal/flow/executor/identifying_executor.go
@@ -79,7 +79,7 @@ func newIdentifyingExecutor(
 func (i *identifyingExecutor) IdentifyUser(ctx context.Context, filters map[string]interface{},
 	execResp *common.ExecutorResponse) (*string, error) {
 	logger := i.logger
-	logger.DebugWithContext(ctx, "Identifying user with filters")
+	logger.Debug(ctx, "Identifying user with filters")
 
 	// filter out non-searchable attributes
 	var searchableFilter = make(map[string]interface{})
@@ -93,13 +93,13 @@ func (i *identifyingExecutor) IdentifyUser(ctx context.Context, filters map[stri
 	if err != nil {
 		switch err.Code {
 		case entityprovider.ErrorCodeEntityNotFound:
-			logger.DebugWithContext(ctx, "User not found for the provided filters")
+			logger.Debug(ctx, "User not found for the provided filters")
 			execResp.Error = &ErrUserNotFound
 		case entityprovider.ErrorCodeAmbiguousEntity:
-			logger.DebugWithContext(ctx, "Multiple users found for the provided filters")
+			logger.Debug(ctx, "Multiple users found for the provided filters")
 			execResp.Error = &ErrAmbiguousUserIdentity
 		default:
-			logger.DebugWithContext(ctx, "Failed to identify user due to error: "+err.Error())
+			logger.Debug(ctx, "Failed to identify user due to error: "+err.Error())
 			execResp.Error = &ErrFailedToIdentifyUser
 		}
 		execResp.Status = common.ExecFailure
@@ -107,7 +107,7 @@ func (i *identifyingExecutor) IdentifyUser(ctx context.Context, filters map[stri
 	}
 
 	if userID == nil || *userID == "" {
-		logger.DebugWithContext(ctx, "User not found for the provided filter")
+		logger.Debug(ctx, "User not found for the provided filter")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserNotFound
 		return nil, nil
@@ -119,7 +119,7 @@ func (i *identifyingExecutor) IdentifyUser(ctx context.Context, filters map[stri
 // Execute executes the identifying executor logic.
 func (i *identifyingExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := i.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing identifying executor")
+	logger.Debug(ctx.Context, "Executing identifying executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -127,7 +127,7 @@ func (i *identifyingExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 	}
 
 	if !i.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required inputs for identifying executor are not provided")
+		logger.Debug(ctx.Context, "Required inputs for identifying executor are not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -151,7 +151,7 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 
 	userID, err := i.IdentifyUser(ctx.Context, userSearchAttributes, execResp)
 	if err != nil {
-		logger.DebugWithContext(ctx.Context, "Failed to identify user due to error: "+err.Error())
+		logger.Debug(ctx.Context, "Failed to identify user due to error: "+err.Error())
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrFailedToIdentifyUser
 		return execResp, nil
@@ -166,7 +166,7 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 	_, loginHintAttrSet := ctx.NodeProperties[propertyKeyLoginHintAttribute]
 	if execResp.Status == common.ExecFailure &&
 		execResp.Error != nil && execResp.Error.Code == ErrUserNotFound.Code && !loginHintAttrSet {
-		logger.DebugWithContext(ctx.Context, "User not found — promoting to user input required",
+		logger.Debug(ctx.Context, "User not found — promoting to user input required",
 			log.Int("searchAttributeCount", len(userSearchAttributes)))
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = i.GetRequiredInputs(ctx)
@@ -177,7 +177,7 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 	}
 
 	if userID == nil || *userID == "" {
-		logger.DebugWithContext(ctx.Context, "User not found for the provided attributes")
+		logger.Debug(ctx.Context, "User not found for the provided attributes")
 		if !loginHintAttrSet {
 			execResp.Status = common.ExecUserInputRequired
 			execResp.Inputs = i.GetRequiredInputs(ctx)
@@ -191,7 +191,7 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 	execResp.RuntimeData[userAttributeUserID] = *userID
 	execResp.Status = common.ExecComplete
 
-	logger.DebugWithContext(ctx.Context, "Identifying executor completed successfully",
+	logger.Debug(ctx.Context, "Identifying executor completed successfully",
 		log.MaskedString(log.LoggerKeyUserID, *userID))
 
 	return execResp, nil
@@ -201,7 +201,7 @@ func (i *identifyingExecutor) executeIdentify(ctx *core.NodeContext,
 func (i *identifyingExecutor) executeResolve(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
 	logger := i.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing identifying executor in resolve mode")
+	logger.Debug(ctx.Context, "Executing identifying executor in resolve mode")
 
 	userSearchAttributes := i.buildSearchAttributes(ctx)
 
@@ -228,7 +228,7 @@ func (i *identifyingExecutor) executeResolve(ctx *core.NodeContext,
 
 	switch len(candidates) {
 	case 0:
-		logger.DebugWithContext(ctx.Context, "No matching users after filtering")
+		logger.Debug(ctx.Context, "No matching users after filtering")
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = i.GetRequiredInputs(ctx)
 		execResp.Error = &ErrUserNotFound
@@ -236,7 +236,7 @@ func (i *identifyingExecutor) executeResolve(ctx *core.NodeContext,
 	case 1:
 		execResp.RuntimeData[userAttributeUserID] = candidates[0].ID
 		execResp.Status = common.ExecComplete
-		logger.DebugWithContext(ctx.Context, "User resolved successfully",
+		logger.Debug(ctx.Context, "User resolved successfully",
 			log.MaskedString("userID", candidates[0].ID))
 		return execResp, nil
 	default:
@@ -291,10 +291,10 @@ func (i *identifyingExecutor) searchCandidates(ctx context.Context,
 	users, err := i.entityProvider.SearchEntities(searchableFilters)
 	if err != nil {
 		if err.Code == entityprovider.ErrorCodeEntityNotFound {
-			logger.DebugWithContext(ctx, "No users found for the provided filters")
+			logger.Debug(ctx, "No users found for the provided filters")
 			return []*entityprovider.Entity{}, nil
 		}
-		logger.DebugWithContext(ctx, "Failed to search users: "+err.Error())
+		logger.Debug(ctx, "Failed to search users: "+err.Error())
 		return nil, errors.New(ErrFailedToIdentifyUser.Error.DefaultValue)
 	}
 
@@ -307,7 +307,7 @@ func (i *identifyingExecutor) getFilteredCandidates(ctx context.Context,
 	logger *log.Logger) ([]*entityprovider.Entity, error) {
 	var candidates []*entityprovider.Entity
 	if err := json.Unmarshal([]byte(storedCandidates), &candidates); err != nil {
-		logger.DebugWithContext(ctx, "Failed to deserialize candidate users")
+		logger.Debug(ctx, "Failed to deserialize candidate users")
 		return nil, errors.New(ErrFailedToIdentifyUser.Error.DefaultValue)
 	}
 
@@ -322,7 +322,7 @@ func (i *identifyingExecutor) handleAmbiguousCandidates(ctx context.Context,
 	logger *log.Logger) (*common.ExecutorResponse, error) {
 	options := extractDisambiguationOptions(candidates)
 	if len(options) == 0 {
-		logger.DebugWithContext(ctx, "Candidates are indistinguishable, no disambiguation options available",
+		logger.Debug(ctx, "Candidates are indistinguishable, no disambiguation options available",
 			log.Int("candidateCount", len(candidates)))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrFailedToIdentifyUser
@@ -331,7 +331,7 @@ func (i *identifyingExecutor) handleAmbiguousCandidates(ctx context.Context,
 
 	candidatesJSON, err := json.Marshal(candidates)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Failed to serialize candidate users")
+		logger.Debug(ctx, "Failed to serialize candidate users")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrFailedToIdentifyUser
 		return execResp, nil
@@ -343,7 +343,7 @@ func (i *identifyingExecutor) handleAmbiguousCandidates(ctx context.Context,
 		common.ForwardedDataKeyInputs: options,
 	}
 
-	logger.DebugWithContext(ctx, "Multiple users still match, requesting additional attributes",
+	logger.Debug(ctx, "Multiple users still match, requesting additional attributes",
 		log.Int("candidateCount", len(candidates)))
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -85,7 +85,7 @@ func (e *inviteExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespons
 // executeGenerate generates the invite token and link.
 func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing invite executor in generate mode")
+	logger.Debug(ctx.Context, "Executing invite executor in generate mode")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -95,7 +95,7 @@ func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.Executo
 
 	inviteToken, err := e.getOrGenerateToken(ctx)
 	if err != nil {
-		logger.DebugWithContext(ctx.Context, "Failed to get or generate invite token", log.Error(err))
+		logger.Debug(ctx.Context, "Failed to get or generate invite token", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrInviteTokenGenerationFailed
 		return execResp, nil
@@ -122,7 +122,7 @@ func (e *inviteExecutor) executeGenerate(ctx *core.NodeContext) (*common.Executo
 // executeVerify validates the user-provided invite token against the stored token.
 func (e *inviteExecutor) executeVerify(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing invite executor in verify mode")
+	logger.Debug(ctx.Context, "Executing invite executor in verify mode")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -140,21 +140,21 @@ func (e *inviteExecutor) executeVerify(ctx *core.NodeContext) (*common.ExecutorR
 	storedToken, hasStoredToken := ctx.RuntimeData[common.RuntimeKeyStoredInviteToken]
 
 	if !hasStoredToken {
-		logger.DebugWithContext(ctx.Context, "No invite token found in runtime data")
+		logger.Debug(ctx.Context, "No invite token found in runtime data")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrInvalidInviteToken
 		return execResp, nil
 	}
 
 	if inviteTokenInput != storedToken {
-		logger.DebugWithContext(ctx.Context, "Invite token mismatch",
+		logger.Debug(ctx.Context, "Invite token mismatch",
 			log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrInvalidInviteToken
 		return execResp, nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "Invite token validated successfully")
+	logger.Debug(ctx.Context, "Invite token validated successfully")
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/magic_link_executor.go
+++ b/backend/internal/flow/executor/magic_link_executor.go
@@ -93,12 +93,12 @@ func newMagicLinkExecutor(
 // Execute executes the Magic Link authentication logic.
 func (m *magicLinkExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := m.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing Magic Link authentication executor")
+	logger.Debug(ctx.Context, "Executing Magic Link authentication executor")
 
 	execResp := newMagicLinkExecutorResponse()
 
 	if !m.ValidatePrerequisites(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Prerequisites not met for Magic Link authentication executor")
+		logger.Debug(ctx.Context, "Prerequisites not met for Magic Link authentication executor")
 		return execResp, nil
 	}
 
@@ -131,7 +131,7 @@ func (m *magicLinkExecutor) executeGenerate(ctx *core.NodeContext) (*common.Exec
 	if err != nil {
 		return execResp, err
 	}
-	logger.DebugWithContext(ctx.Context, "Magic link generation completed",
+	logger.Debug(ctx.Context, "Magic link generation completed",
 		log.String("status", string(execResp.Status)))
 	return execResp, nil
 }
@@ -161,7 +161,7 @@ func (m *magicLinkExecutor) InitiateMagicLink(ctx *core.NodeContext,
 		}
 		if userID != nil && *userID != "" {
 			// ANTI-ENUMERATION: Pretend it succeeded but skip sending the magic link.
-			logger.DebugWithContext(ctx.Context,
+			logger.Debug(ctx.Context,
 				"Registration attempted for existing user. Skipping delivery to prevent enumeration.")
 			execResp.RuntimeData[common.RuntimeKeySkipDelivery] = dataValueTrue
 			execResp.Status = common.ExecComplete
@@ -178,7 +178,7 @@ func (m *magicLinkExecutor) InitiateMagicLink(ctx *core.NodeContext,
 		} else {
 			identifiedUserID, providerErr := m.entityProvider.IdentifyEntity(searchAttrs)
 			if providerErr != nil || identifiedUserID == nil || *identifiedUserID == "" {
-				logger.DebugWithContext(ctx.Context, "User not found, completing without delivery for anti-enumeration")
+				logger.Debug(ctx.Context, "User not found, completing without delivery for anti-enumeration")
 				execResp.RuntimeData[common.RuntimeKeySkipDelivery] = dataValueTrue
 				execResp.Status = common.ExecComplete
 				return execResp, nil
@@ -323,7 +323,7 @@ func (m *magicLinkExecutor) executeVerify(ctx *core.NodeContext) (*common.Execut
 	execResp := newMagicLinkExecutorResponse()
 
 	if !m.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required inputs for Magic Link verification are not provided")
+		logger.Debug(ctx.Context, "Required inputs for Magic Link verification are not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -367,7 +367,7 @@ func (m *magicLinkExecutor) executeVerify(ctx *core.NodeContext) (*common.Execut
 
 	if ctx.FlowType == common.FlowTypeRegistration {
 		if authnResult.IsExistingUser {
-			logger.DebugWithContext(ctx.Context, "User already exists during magic link registration verification.")
+			logger.Debug(ctx.Context, "User already exists during magic link registration verification.")
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrUserAlreadyExists
 			return execResp, nil
@@ -384,7 +384,7 @@ func (m *magicLinkExecutor) executeVerify(ctx *core.NodeContext) (*common.Execut
 	execResp.AuthenticatedUser = *authenticatedUser
 
 	execResp.Status = common.ExecComplete
-	logger.DebugWithContext(ctx.Context, "Magic link verify completed successfully")
+	logger.Debug(ctx.Context, "Magic link verify completed successfully")
 	return execResp, nil
 }
 
@@ -394,13 +394,13 @@ func (m *magicLinkExecutor) validateFlowClaims(ctx *core.NodeContext,
 	token string, logger *log.Logger) (string, *serviceerror.ServiceError) {
 	payload, decodeErr := jwt.DecodeJWTPayload(token)
 	if decodeErr != nil {
-		logger.DebugWithContext(ctx.Context, "Failed to decode magic link token", log.Error(decodeErr))
+		logger.Debug(ctx.Context, "Failed to decode magic link token", log.Error(decodeErr))
 		return "", &ErrInvalidMagicLinkToken
 	}
 
 	executionIDClaim := utils.ConvertInterfaceValueToString(payload["executionId"])
 	if executionIDClaim == "" || executionIDClaim != ctx.ExecutionID {
-		logger.DebugWithContext(ctx.Context, "Magic link token executionId mismatch")
+		logger.Debug(ctx.Context, "Magic link token executionId mismatch")
 		return "", &ErrInvalidMagicLinkToken
 	}
 
@@ -409,11 +409,11 @@ func (m *magicLinkExecutor) validateFlowClaims(ctx *core.NodeContext,
 		return "", &ErrInvalidMagicLinkToken
 	}
 	if usedJti, exists := ctx.RuntimeData[common.RuntimeKeyMagicLinkUsedJti]; exists && usedJti == jtiClaim {
-		logger.DebugWithContext(ctx.Context, "Magic link token has already been used", log.String("jti", jtiClaim))
+		logger.Debug(ctx.Context, "Magic link token has already been used", log.String("jti", jtiClaim))
 		return "", &ErrInvalidMagicLinkToken
 	}
 
-	logger.DebugWithContext(ctx.Context, "Magic link token validated successfully")
+	logger.Debug(ctx.Context, "Magic link token validated successfully")
 	return jtiClaim, nil
 }
 

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -122,7 +122,7 @@ func newOAuthExecutor(
 //nolint:dupl // OAuth and OIDC executors share the same execute skeleton with type-specific behavior.
 func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing OAuth authentication executor")
+	logger.Debug(ctx.Context, "Executing OAuth authentication executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -130,7 +130,7 @@ func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 	}
 
 	if !o.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required inputs for OAuth authentication executor is not provided")
+		logger.Debug(ctx.Context, "Required inputs for OAuth authentication executor is not provided")
 		err := o.BuildAuthorizeFlow(ctx, execResp)
 		if err != nil {
 			return nil, err
@@ -142,7 +142,7 @@ func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 		}
 	}
 
-	logger.DebugWithContext(ctx.Context, "OAuth authentication executor execution completed",
+	logger.Debug(ctx.Context, "OAuth authentication executor execution completed",
 		log.String("status", string(execResp.Status)),
 		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
@@ -152,7 +152,7 @@ func (o *oAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse
 // BuildAuthorizeFlow constructs the redirection to the external OAuth provider for user authentication.
 func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *common.ExecutorResponse) error {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Initiating OAuth authentication flow")
+	logger.Debug(ctx.Context, "Initiating OAuth authentication flow")
 
 	idpID, err := o.GetIdpID(ctx)
 	if err != nil {
@@ -167,7 +167,7 @@ func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *comm
 			return nil
 		}
 
-		logger.ErrorWithContext(ctx.Context, "Failed to build authorize URL", log.String("errorCode", svcErr.Code),
+		logger.Error(ctx.Context, "Failed to build authorize URL", log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return errors.New("failed to build authorize URL")
 	}
@@ -200,7 +200,7 @@ func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *core.NodeContext, execResp *comm
 func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Processing OAuth authentication response")
+	logger.Debug(ctx.Context, "Processing OAuth authentication response")
 
 	code, ok := ctx.UserInputs[userInputCode]
 	if !ok || code == "" {
@@ -216,7 +216,7 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	if returnedState, ok := ctx.UserInputs[userInputState]; ok && returnedState != "" {
 		expectedState := ctx.RuntimeData[common.RuntimeKeyOAuthState]
 		if returnedState != expectedState {
-			logger.DebugWithContext(ctx.Context, "OAuth state mismatch")
+			logger.Debug(ctx.Context, "OAuth state mismatch")
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrInvalidOAuthState
 			return nil
@@ -245,13 +245,13 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 			return nil
 		}
 
-		logger.ErrorWithContext(ctx.Context, "Federated authentication failed", log.String("errorCode", svcErr.Code),
+		logger.Error(ctx.Context, "Federated authentication failed", log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return errors.New("federated authentication failed")
 	}
 
 	if basicResult == nil {
-		logger.ErrorWithContext(ctx.Context, "authnProvider.AuthenticateUser returned nil result")
+		logger.Error(ctx.Context, "authnProvider.AuthenticateUser returned nil result")
 		return errors.New("OAuth authentication failed")
 	}
 
@@ -287,7 +287,7 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		return nil
 	}
 	if contextUser == nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to resolve context user after OAuth authentication")
+		logger.Error(ctx.Context, "Failed to resolve context user after OAuth authentication")
 		return errors.New("unexpected error occurred while resolving user")
 	}
 
@@ -324,7 +324,7 @@ func (o *oAuthExecutor) GetIdpID(ctx *core.NodeContext) (string, error) {
 // getIDPName retrieves the name of the identity provider using its ID.
 func (o *oAuthExecutor) getIDPName(ctx context.Context, idpID string) (string, error) {
 	logger := o.logger
-	logger.DebugWithContext(ctx, "Retrieving IDP name for the given IDP ID")
+	logger.Debug(ctx, "Retrieving IDP name for the given IDP ID")
 
 	idp, svcErr := o.idpService.GetIdentityProvider(ctx, idpID)
 	if svcErr != nil {
@@ -332,7 +332,7 @@ func (o *oAuthExecutor) getIDPName(ctx context.Context, idpID string) (string, e
 			return "", fmt.Errorf("failed to get identity provider: %s", svcErr.ErrorDescription.DefaultValue)
 		}
 
-		logger.ErrorWithContext(ctx, "Error while retrieving identity provider", log.String("errorCode", svcErr.Code),
+		logger.Error(ctx, "Error while retrieving identity provider", log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return "", errors.New("error while retrieving identity provider")
 	}
@@ -367,7 +367,7 @@ func (o *oAuthExecutor) getContextUserForAuthentication(ctx *core.NodeContext,
 				// Ambiguous user: exists in multiple OUs. Set sub for downstream
 				// disambiguation but do NOT mark as eligible for provisioning since
 				// the user already exists.
-				logger.DebugWithContext(ctx.Context, "Ambiguous user detected, deferring to flow for disambiguation")
+				logger.Debug(ctx.Context, "Ambiguous user detected, deferring to flow for disambiguation")
 				execResp.Status = common.ExecComplete
 				execResp.Error = nil
 				execResp.RuntimeData[userAttributeSub] = sub
@@ -378,7 +378,7 @@ func (o *oAuthExecutor) getContextUserForAuthentication(ctx *core.NodeContext,
 			}
 
 			// Genuinely new user: no local account exists
-			logger.DebugWithContext(ctx.Context, "User not found, but authentication is allowed without a local user")
+			logger.Debug(ctx.Context, "User not found, but authentication is allowed without a local user")
 
 			err := o.resolveUserTypeForAutoProvisioning(ctx, execResp)
 			if err != nil {
@@ -430,7 +430,7 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 		// OU when cross-OU provisioning is explicitly allowed. The ProvisioningExecutor enforces
 		// the same-OU duplicate guard, so we don't need to fail here.
 		if isRegistrationWithExistingUserAllowed(ctx) && isCrossOUProvisioningAllowed(ctx) {
-			logger.DebugWithContext(ctx.Context,
+			logger.Debug(ctx.Context,
 				"Ambiguous user detected, proceeding with cross-OU provisioning eligibility")
 			execResp.Status = common.ExecComplete
 			execResp.Error = nil
@@ -441,7 +441,7 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 			}, nil
 		}
 
-		logger.DebugWithContext(ctx.Context,
+		logger.Debug(ctx.Context,
 			"Ambiguous user detected in registration flow, cannot proceed with registration")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrAmbiguousUserIdentity
@@ -450,7 +450,7 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 
 	// If no local user is found, proceed with registration
 	if internalUser == nil {
-		logger.DebugWithContext(ctx.Context,
+		logger.Debug(ctx.Context,
 			"User not found for the provided sub claim. Proceeding with registration flow.")
 		execResp.Status = common.ExecComplete
 		execResp.Error = nil
@@ -468,7 +468,7 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 			// the target OU. The same-OU duplicate guard is enforced by the ProvisioningExecutor
 			// itself, which has access to the target OU context. We intentionally do not set
 			// RuntimeKeySkipProvisioning here because we want provisioning to run.
-			logger.DebugWithContext(ctx.Context,
+			logger.Debug(ctx.Context,
 				"User already exists, proceeding with cross-OU provisioning to target OU")
 			execResp.Status = common.ExecComplete
 			execResp.Error = nil
@@ -479,7 +479,7 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 			}, nil
 		}
 
-		logger.DebugWithContext(ctx.Context, "User already exists, but registration flow is allowed to continue")
+		logger.Debug(ctx.Context, "User already exists, but registration flow is allowed to continue")
 		execResp.Status = common.ExecComplete
 		execResp.Error = nil
 		execResp.RuntimeData[common.RuntimeKeySkipProvisioning] = dataValueTrue
@@ -502,10 +502,10 @@ func (o *oAuthExecutor) getContextUserForRegistration(ctx *core.NodeContext,
 func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Resolving user type for automatic provisioning")
+	logger.Debug(ctx.Context, "Resolving user type for automatic provisioning")
 
 	if len(ctx.Application.AllowedUserTypes) == 0 {
-		logger.DebugWithContext(ctx.Context, "No allowed user types configured for the application")
+		logger.Debug(ctx.Context, "No allowed user types configured for the application")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCannotProvisionAutomatically
 		return nil
@@ -523,7 +523,7 @@ func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext
 				return nil
 			}
 
-			logger.ErrorWithContext(ctx.Context, "Error while retrieving user type",
+			logger.Error(ctx.Context, "Error while retrieving user type",
 				log.String("errorCode", svcErr.Code),
 				log.String("description", svcErr.ErrorDescription.DefaultValue))
 			return errors.New("error while retrieving user type")
@@ -535,7 +535,7 @@ func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext
 
 	// Fail if no user types have self-registration enabled
 	if len(selfRegEnabledSchemas) == 0 {
-		logger.DebugWithContext(ctx.Context,
+		logger.Debug(ctx.Context,
 			"No user types with self-registration enabled, cannot provision automatically")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSelfRegistrationDisabled
@@ -544,7 +544,7 @@ func (o *oAuthExecutor) resolveUserTypeForAutoProvisioning(ctx *core.NodeContext
 
 	// Fail if multiple user types have self-registration enabled
 	if len(selfRegEnabledSchemas) > 1 {
-		logger.DebugWithContext(ctx.Context,
+		logger.Debug(ctx.Context,
 			"Multiple user types with self-registration enabled, cannot resolve user type automatically")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrCannotProvisionAutomatically

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -98,7 +98,7 @@ func newOIDCAuthExecutor(
 //nolint:dupl // OAuth and OIDC executors share the same execute skeleton with type-specific behavior.
 func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing OIDC authentication executor")
+	logger.Debug(ctx.Context, "Executing OIDC authentication executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -106,7 +106,7 @@ func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	}
 
 	if !o.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required inputs for OIDC authentication executor is not provided")
+		logger.Debug(ctx.Context, "Required inputs for OIDC authentication executor is not provided")
 		err := o.BuildAuthorizeFlow(ctx, execResp)
 		if err != nil {
 			return nil, err
@@ -118,7 +118,7 @@ func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 		}
 	}
 
-	logger.DebugWithContext(ctx.Context, "OIDC authentication executor execution completed",
+	logger.Debug(ctx.Context, "OIDC authentication executor execution completed",
 		log.String("status", string(execResp.Status)),
 		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
@@ -129,7 +129,7 @@ func (o *oidcAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Processing OIDC authentication response")
+	logger.Debug(ctx.Context, "Processing OIDC authentication response")
 
 	code, ok := ctx.UserInputs[userInputCode]
 	if !ok || code == "" {
@@ -145,7 +145,7 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	if returnedState, ok := ctx.UserInputs[userInputState]; ok && returnedState != "" {
 		expectedState := ctx.RuntimeData[common.RuntimeKeyOAuthState]
 		if returnedState != expectedState {
-			logger.DebugWithContext(ctx.Context, "OAuth state mismatch")
+			logger.Debug(ctx.Context, "OAuth state mismatch")
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrInvalidOAuthState
 			return nil
@@ -174,13 +174,13 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 			return nil
 		}
 
-		logger.ErrorWithContext(ctx.Context, "OIDC authentication failed", log.String("errorCode", svcErr.Code),
+		logger.Error(ctx.Context, "OIDC authentication failed", log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return errors.New("OIDC authentication failed")
 	}
 
 	if basicResult == nil {
-		logger.ErrorWithContext(ctx.Context, "authnProvider.AuthenticateUser returned nil result")
+		logger.Error(ctx.Context, "authnProvider.AuthenticateUser returned nil result")
 		return errors.New("OIDC authentication failed")
 	}
 
@@ -226,7 +226,7 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 		return nil
 	}
 	if contextUser == nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to resolve context user after OIDC authentication")
+		logger.Error(ctx.Context, "Failed to resolve context user after OIDC authentication")
 		return errors.New("unexpected error occurred while resolving user")
 	}
 

--- a/backend/internal/flow/executor/openid4vp_verifier.go
+++ b/backend/internal/flow/executor/openid4vp_verifier.go
@@ -82,7 +82,7 @@ func (e *openid4vpVerifier) Execute(ctx *core.NodeContext) (*common.ExecutorResp
 	}
 
 	if e.service == nil {
-		logger.ErrorWithContext(ctx.Context, "OpenID4VP verifier service is not configured")
+		logger.Error(ctx.Context, "OpenID4VP verifier service is not configured")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrOpenID4VPNotConfigured
 		return execResp, nil
@@ -102,7 +102,7 @@ func (e *openid4vpVerifier) initiate(
 	definitionID := presentationDefinitionID(ctx)
 	init, err := e.service.Initiate(ctx.Context, definitionID)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to initiate OpenID4VP request",
+		logger.Error(ctx.Context, "Failed to initiate OpenID4VP request",
 			log.String("definitionID", definitionID), log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrOpenID4VPInitiateFailed
@@ -139,7 +139,7 @@ func (e *openid4vpVerifier) poll(
 ) (*common.ExecutorResponse, error) {
 	rs, err := e.service.Result(ctx.Context, state)
 	if err != nil {
-		logger.DebugWithContext(ctx.Context, "OpenID4VP request state not found or expired", log.Error(err))
+		logger.Debug(ctx.Context, "OpenID4VP request state not found or expired", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrOpenID4VPExpired
 		return execResp, nil
@@ -157,7 +157,7 @@ func (e *openid4vpVerifier) poll(
 		}
 		execResp.Status = common.ExecComplete
 	case openid4vp.StatusFailed:
-		logger.DebugWithContext(ctx.Context, "OpenID4VP presentation verification failed",
+		logger.Debug(ctx.Context, "OpenID4VP presentation verification failed",
 			log.String("reason", rs.FailureReason))
 		execResp.Status = common.ExecFailure
 		execResp.Error = serviceerror.CustomServiceError(ErrOpenID4VPVerificationFailed,
@@ -191,7 +191,7 @@ func (e *openid4vpVerifier) resolveUserType(
 			if svcErr.Type == serviceerror.ClientErrorType {
 				continue
 			}
-			logger.ErrorWithContext(ctx.Context, "Failed to retrieve user type", log.String("userType", name))
+			logger.Error(ctx.Context, "Failed to retrieve user type", log.String("userType", name))
 			return
 		}
 		if et.AllowSelfRegistration {
@@ -232,7 +232,7 @@ func (e *openid4vpVerifier) resolveLocalUser(ctx context.Context,
 	if err != nil || userID == nil || *userID == "" {
 		return false
 	}
-	logger.DebugWithContext(ctx, "Found existing local account for EUDI credential",
+	logger.Debug(ctx, "Found existing local account for EUDI credential",
 		log.MaskedString(log.LoggerKeyUserID, *userID))
 	execResp.AuthenticatedUser.UserID = *userID
 	return true

--- a/backend/internal/flow/executor/ou_executor.go
+++ b/backend/internal/flow/executor/ou_executor.go
@@ -77,7 +77,7 @@ func newOUExecutor(
 // Execute executes the ou creation logic.
 func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing OU creation executor")
+	logger.Debug(ctx.Context, "Executing OU creation executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -85,14 +85,14 @@ func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, e
 	}
 
 	if !o.ValidatePrerequisites(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Prerequisites validation failed for OU creation")
+		logger.Debug(ctx.Context, "Prerequisites validation failed for OU creation")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrOUCreationPrereqFailed
 		return execResp, nil
 	}
 
 	if !o.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required inputs for OU creation is not provided")
+		logger.Debug(ctx.Context, "Required inputs for OU creation is not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -100,7 +100,7 @@ func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, e
 	// Create the OU using the OU service.
 	ouRequest, err := o.getOrganizationUnitRequest(ctx)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to build organization unit request",
+		logger.Error(ctx.Context, "Failed to build organization unit request",
 			log.String("error", err.Error()))
 		return nil, err
 	}
@@ -125,21 +125,21 @@ func (o *ouExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, e
 			return execResp, nil
 		}
 
-		logger.ErrorWithContext(ctx.Context, "Error occurred while creating organization unit: ",
+		logger.Error(ctx.Context, "Error occurred while creating organization unit: ",
 			log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		return nil, errors.New("failed to create organization unit")
 	}
 
 	if createdOU.ID == "" {
-		logger.ErrorWithContext(ctx.Context, "Organization unit creation failed: received empty OU ID")
+		logger.Error(ctx.Context, "Organization unit creation failed: received empty OU ID")
 		return nil, errors.New("failed to create organization unit")
 	}
 
 	// Set the created OU ID in the runtime data for further use in the flow.
 	execResp.RuntimeData[ouIDKey] = createdOU.ID
 
-	logger.DebugWithContext(ctx.Context, "Organization unit created successfully", log.String(ouIDKey, createdOU.ID))
+	logger.Debug(ctx.Context, "Organization unit created successfully", log.String(ouIDKey, createdOU.ID))
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/ou_resolver_executor.go
+++ b/backend/internal/flow/executor/ou_resolver_executor.go
@@ -92,7 +92,7 @@ func (e *ouResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 
 	resolveFrom := e.getResolveFrom(ctx)
 	if resolveFrom == "" {
-		logger.DebugWithContext(ctx.Context, "resolveFrom not configured, skipping OU override")
+		logger.Debug(ctx.Context, "resolveFrom not configured, skipping OU override")
 		return execResp, nil
 	}
 
@@ -104,7 +104,7 @@ func (e *ouResolverExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 	case ouResolveFromPromptAll:
 		return e.resolveFromPromptAll(ctx, logger)
 	default:
-		logger.ErrorWithContext(ctx.Context, "Unsupported resolveFrom value", log.String("resolveFrom", resolveFrom))
+		logger.Error(ctx.Context, "Unsupported resolveFrom value", log.String("resolveFrom", resolveFrom))
 		execResp.Status = common.ExecFailure
 		execResp.Error = serviceerror.CustomServiceError(ErrOUResolutionFailed, i18ncore.I18nMessage{
 			Key:          ErrOUResolutionFailed.ErrorDescription.Key,
@@ -119,7 +119,7 @@ func (e *ouResolverExecutor) resolveFromCaller(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse, logger *log.Logger) (*common.ExecutorResponse, error) {
 	callerOUID := security.GetOUID(ctx.Context)
 	if callerOUID == "" {
-		logger.ErrorWithContext(ctx.Context, "Caller OU not found in security context")
+		logger.Error(ctx.Context, "Caller OU not found in security context")
 		execResp.Status = common.ExecFailure
 		execResp.Error = serviceerror.CustomServiceError(ErrOUResolutionFailed, i18ncore.I18nMessage{
 			Key:          ErrOUResolutionFailed.ErrorDescription.Key,
@@ -128,7 +128,7 @@ func (e *ouResolverExecutor) resolveFromCaller(ctx *core.NodeContext,
 		return execResp, nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "Overriding user OU with caller's OU", log.String("callerOUID", callerOUID))
+	logger.Debug(ctx.Context, "Overriding user OU with caller's OU", log.String("callerOUID", callerOUID))
 	execResp.RuntimeData[ouIDKey] = callerOUID
 
 	return execResp, nil
@@ -168,7 +168,7 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
 			return nil, errors.New("failed to validate selected organization unit: " + svcErr.Error.DefaultValue)
 		}
 		if !isDescendant {
-			logger.DebugWithContext(ctx.Context, "Selected OU is not a descendant of the parent OU",
+			logger.Debug(ctx.Context, "Selected OU is not a descendant of the parent OU",
 				log.String(ouIDKey, selectedOUID),
 				log.String("parentOUID", parentOUID))
 			execResp.Status = common.ExecUserInputRequired
@@ -177,7 +177,7 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
 			return execResp, nil
 		}
 
-		logger.DebugWithContext(ctx.Context, "OU selected by user", log.String(ouIDKey, selectedOUID))
+		logger.Debug(ctx.Context, "OU selected by user", log.String(ouIDKey, selectedOUID))
 		execResp.RuntimeData[ouIDKey] = selectedOUID
 		execResp.Status = common.ExecComplete
 		return execResp, nil
@@ -190,13 +190,13 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *core.NodeContext,
 	}
 
 	if children.TotalResults == 0 {
-		logger.DebugWithContext(ctx.Context, "No child OUs found, skipping OU selection")
+		logger.Debug(ctx.Context, "No child OUs found, skipping OU selection")
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
 
 	// Child OUs exist — prompt the user to select one.
-	logger.DebugWithContext(ctx.Context, "Child OUs found, requesting OU selection",
+	logger.Debug(ctx.Context, "Child OUs found, requesting OU selection",
 		log.String("parentOUID", parentOUID),
 		log.Int("totalChildren", children.TotalResults))
 
@@ -237,14 +237,14 @@ func (e *ouResolverExecutor) resolveFromPromptAll(ctx *core.NodeContext,
 			return execResp, nil
 		}
 
-		logger.DebugWithContext(ctx.Context, "OU selected by user", log.String(ouIDKey, selectedOUID))
+		logger.Debug(ctx.Context, "OU selected by user", log.String(ouIDKey, selectedOUID))
 		execResp.RuntimeData[ouIDKey] = selectedOUID
 		execResp.Status = common.ExecComplete
 		return execResp, nil
 	}
 
 	// No selection yet — prompt the user with the full OU tree.
-	logger.DebugWithContext(ctx.Context, "Requesting OU selection from full tree")
+	logger.Debug(ctx.Context, "Requesting OU selection from full tree")
 	execResp.Status = common.ExecUserInputRequired
 
 	inputs := e.GetDefaultInputs()

--- a/backend/internal/flow/executor/passkey_executor.go
+++ b/backend/internal/flow/executor/passkey_executor.go
@@ -144,7 +144,7 @@ func newPasskeyAuthExecutor(
 // Execute executes the passkey authentication logic.
 func (p *passkeyAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing passkey authentication executor")
+	logger.Debug(ctx.Context, "Executing passkey authentication executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -152,7 +152,7 @@ func (p *passkeyAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 	}
 
 	if !p.ValidatePrerequisites(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Prerequisites not met for passkey authentication executor")
+		logger.Debug(ctx.Context, "Prerequisites not met for passkey authentication executor")
 		return execResp, nil
 	}
 
@@ -180,16 +180,16 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 	userID := p.GetUserIDFromContext(ctx)
 
 	if userID == "" {
-		logger.DebugWithContext(ctx.Context, "Generating usernameless passkey authentication challenge")
+		logger.Debug(ctx.Context, "Generating usernameless passkey authentication challenge")
 	} else {
-		logger.DebugWithContext(ctx.Context, "Generating passkey authentication challenge",
+		logger.Debug(ctx.Context, "Generating passkey authentication challenge",
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
 	// Get relying party ID from node properties or use a default
 	relyingPartyID := p.getRelyingPartyID(ctx)
 	if relyingPartyID == "" {
-		logger.ErrorWithContext(ctx.Context, "Relying party ID not configured")
+		logger.Error(ctx.Context, "Relying party ID not configured")
 		return execResp, errors.New("relying party ID is not configured in node properties")
 	}
 
@@ -201,7 +201,7 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 	startData, svcErr := p.passkeyService.StartAuthentication(ctx.Context, startReq)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx.Context, "Failed to start passkey authentication",
+			logger.Debug(ctx.Context, "Failed to start passkey authentication",
 				log.MaskedString(log.LoggerKeyUserID, userID),
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			execResp.Status = common.ExecFailure
@@ -211,7 +211,7 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 			})
 			return execResp, nil
 		}
-		logger.ErrorWithContext(ctx.Context, "Failed to start passkey authentication",
+		logger.Error(ctx.Context, "Failed to start passkey authentication",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(errors.New(svcErr.ErrorDescription.DefaultValue)))
 		return execResp, fmt.Errorf("failed to start passkey authentication: %s", svcErr.ErrorDescription.DefaultValue)
 	}
@@ -222,7 +222,7 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 	// Marshal the challenge options to JSON
 	challengeJSON, err := json.Marshal(startData.PublicKeyCredentialRequestOptions)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to marshal challenge options", log.Error(err))
+		logger.Error(ctx.Context, "Failed to marshal challenge options", log.Error(err))
 		return execResp, fmt.Errorf("failed to marshal challenge options: %w", err)
 	}
 
@@ -231,9 +231,9 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 	execResp.Status = common.ExecComplete
 
 	if userID == "" {
-		logger.DebugWithContext(ctx.Context, "Usernameless passkey challenge generated successfully")
+		logger.Debug(ctx.Context, "Usernameless passkey challenge generated successfully")
 	} else {
-		logger.DebugWithContext(ctx.Context, "Passkey challenge generated successfully",
+		logger.Debug(ctx.Context, "Passkey challenge generated successfully",
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 	return execResp, nil
@@ -243,11 +243,11 @@ func (p *passkeyAuthExecutor) executeChallenge(ctx *core.NodeContext,
 func (p *passkeyAuthExecutor) executeVerify(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Verifying passkey authentication response")
+	logger.Debug(ctx.Context, "Verifying passkey authentication response")
 
 	// Check for required inputs
 	if !p.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required inputs for passkey verification are not provided")
+		logger.Debug(ctx.Context, "Required inputs for passkey verification are not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -255,7 +255,7 @@ func (p *passkeyAuthExecutor) executeVerify(ctx *core.NodeContext,
 	// Validate the passkey
 	err := p.validatePasskey(ctx, execResp, logger)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Error validating passkey", log.Error(err))
+		logger.Error(ctx.Context, "Error validating passkey", log.Error(err))
 		return execResp, fmt.Errorf("error validating passkey: %w", err)
 	}
 	if execResp.Status == common.ExecFailure || execResp.Status == common.ExecUserInputRequired {
@@ -265,14 +265,14 @@ func (p *passkeyAuthExecutor) executeVerify(ctx *core.NodeContext,
 	// Get authenticated user details
 	authenticatedUser, err := p.getAuthenticatedUser(ctx, execResp)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to get authenticated user details", log.Error(err))
+		logger.Error(ctx.Context, "Failed to get authenticated user details", log.Error(err))
 		return execResp, fmt.Errorf("failed to get authenticated user details: %w", err)
 	}
 
 	execResp.AuthenticatedUser = *authenticatedUser
 	execResp.Status = common.ExecComplete
 
-	logger.DebugWithContext(ctx.Context, "Passkey verification completed successfully",
+	logger.Debug(ctx.Context, "Passkey verification completed successfully",
 		log.String("status", string(execResp.Status)),
 		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
@@ -291,12 +291,12 @@ func (p *passkeyAuthExecutor) validatePasskey(ctx *core.NodeContext, execResp *c
 	signature := ctx.UserInputs[inputSignature]
 	userHandle := ctx.UserInputs[inputUserHandle]
 
-	logger.DebugWithContext(ctx.Context, "Validating passkey", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx.Context, "Validating passkey", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	// Get session token from runtime data
 	sessionToken := ctx.RuntimeData[runtimePasskeySessionToken]
 	if sessionToken == "" {
-		logger.ErrorWithContext(ctx.Context, "No session token found for passkey authentication",
+		logger.Error(ctx.Context, "No session token found for passkey authentication",
 			log.MaskedString(log.LoggerKeyUserID, userID))
 		return fmt.Errorf("no session token found for passkey authentication")
 	}
@@ -315,7 +315,7 @@ func (p *passkeyAuthExecutor) validatePasskey(ctx *core.NodeContext, execResp *c
 		ctx.Context, nil, credentials, nil, nil, ctx.AuthUser)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx.Context, "Passkey verification failed",
+			logger.Debug(ctx.Context, "Passkey verification failed",
 				log.MaskedString(log.LoggerKeyUserID, userID),
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			// Return USER_INPUT_REQUIRED to allow retry on invalid passkey
@@ -324,7 +324,7 @@ func (p *passkeyAuthExecutor) validatePasskey(ctx *core.NodeContext, execResp *c
 			execResp.Error = &ErrInvalidPasskey
 			return nil
 		}
-		logger.ErrorWithContext(ctx.Context, "Failed to verify passkey", log.MaskedString(log.LoggerKeyUserID, userID),
+		logger.Error(ctx.Context, "Failed to verify passkey", log.MaskedString(log.LoggerKeyUserID, userID),
 			log.String("error", svcErr.ErrorDescription.DefaultValue))
 		return fmt.Errorf("failed to verify passkey: %s", svcErr.ErrorDescription.DefaultValue)
 	}
@@ -338,7 +338,7 @@ func (p *passkeyAuthExecutor) validatePasskey(ctx *core.NodeContext, execResp *c
 	// Clear session token after successful verification
 	execResp.RuntimeData[runtimePasskeySessionToken] = ""
 
-	logger.DebugWithContext(ctx.Context, "Passkey validated successfully",
+	logger.Debug(ctx.Context, "Passkey validated successfully",
 		log.MaskedString(log.LoggerKeyUserID, userID))
 	return nil
 }
@@ -383,7 +383,7 @@ func (p *passkeyAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Starting passkey registration")
+	logger.Debug(ctx.Context, "Starting passkey registration")
 
 	userID := p.GetUserIDFromContext(ctx)
 	if userID == "" {
@@ -394,7 +394,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 
 	relyingPartyID := p.getRelyingPartyID(ctx)
 	if relyingPartyID == "" {
-		logger.ErrorWithContext(ctx.Context, "Relying party ID not configured")
+		logger.Error(ctx.Context, "Relying party ID not configured")
 		return execResp, errors.New("relying party ID is not configured in node properties")
 	}
 
@@ -417,7 +417,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 	startData, svcErr := p.passkeyService.StartRegistration(ctx.Context, regReq)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx.Context, "Failed to start passkey registration",
+			logger.Debug(ctx.Context, "Failed to start passkey registration",
 				log.MaskedString(log.LoggerKeyUserID, userID),
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			execResp.Status = common.ExecFailure
@@ -427,7 +427,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 			})
 			return execResp, nil
 		}
-		logger.ErrorWithContext(ctx.Context, "Failed to start passkey registration",
+		logger.Error(ctx.Context, "Failed to start passkey registration",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(errors.New(svcErr.ErrorDescription.DefaultValue)))
 		return execResp, fmt.Errorf("failed to start passkey registration: %s", svcErr.ErrorDescription.DefaultValue)
 	}
@@ -438,7 +438,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 	// Marshal the creation options to JSON
 	creationJSON, err := json.Marshal(startData.PublicKeyCredentialCreationOptions)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to marshal creation options", log.Error(err))
+		logger.Error(ctx.Context, "Failed to marshal creation options", log.Error(err))
 		return execResp, fmt.Errorf("failed to marshal creation options: %w", err)
 	}
 
@@ -446,7 +446,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 	execResp.AdditionalData[runtimePasskeyCreationOptions] = string(creationJSON)
 	execResp.Status = common.ExecComplete
 
-	logger.DebugWithContext(ctx.Context, "Passkey registration options generated successfully",
+	logger.Debug(ctx.Context, "Passkey registration options generated successfully",
 		log.MaskedString(log.LoggerKeyUserID, userID))
 	return execResp, nil
 }
@@ -455,7 +455,7 @@ func (p *passkeyAuthExecutor) executeRegisterStart(ctx *core.NodeContext,
 func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) (*common.ExecutorResponse, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Finishing passkey registration")
+	logger.Debug(ctx.Context, "Finishing passkey registration")
 
 	// Check for required inputs
 	allInputs := []common.Input{
@@ -477,7 +477,7 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 	}
 
 	if missingRequiredInputs {
-		logger.DebugWithContext(ctx.Context, "Required inputs for passkey registration are not provided")
+		logger.Debug(ctx.Context, "Required inputs for passkey registration are not provided")
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = allInputs
 		return execResp, nil
@@ -495,7 +495,7 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 	// Get session token from runtime data
 	sessionToken := ctx.RuntimeData[runtimePasskeySessionToken]
 	if sessionToken == "" {
-		logger.ErrorWithContext(ctx.Context, "No session token found for passkey registration")
+		logger.Error(ctx.Context, "No session token found for passkey registration")
 		return execResp, fmt.Errorf("no session token found for passkey registration")
 	}
 
@@ -513,7 +513,7 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 	finishData, svcErr := p.passkeyService.FinishRegistration(ctx.Context, finishReq)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx.Context, "Passkey registration failed",
+			logger.Debug(ctx.Context, "Passkey registration failed",
 				log.String("error", svcErr.ErrorDescription.DefaultValue))
 			// Return USER_INPUT_REQUIRED to allow retry on invalid registration
 			execResp.Status = common.ExecUserInputRequired
@@ -524,7 +524,7 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 			})
 			return execResp, nil
 		}
-		logger.ErrorWithContext(ctx.Context, "Failed to finish passkey registration",
+		logger.Error(ctx.Context, "Failed to finish passkey registration",
 			log.String("error", svcErr.ErrorDescription.DefaultValue))
 		return execResp, fmt.Errorf("failed to finish passkey registration: %s", svcErr.ErrorDescription.DefaultValue)
 	}
@@ -546,21 +546,21 @@ func (p *passkeyAuthExecutor) executeRegisterFinish(ctx *core.NodeContext,
 		// For registration flows, user may not be fully authenticated yet
 		// Return credential info but don't set authenticated user
 		execResp.Status = common.ExecComplete
-		logger.DebugWithContext(ctx.Context, "Passkey registration completed for registration flow")
+		logger.Debug(ctx.Context, "Passkey registration completed for registration flow")
 	} else {
 		// For authentication flows (adding passkey to existing account)
 		// Get and return authenticated user details
 		authenticatedUser, err := p.getAuthenticatedUser(ctx, execResp)
 		if err != nil {
-			logger.ErrorWithContext(ctx.Context, "Failed to get authenticated user details", log.Error(err))
+			logger.Error(ctx.Context, "Failed to get authenticated user details", log.Error(err))
 			return execResp, fmt.Errorf("failed to get authenticated user details: %w", err)
 		}
 		execResp.AuthenticatedUser = *authenticatedUser
 		execResp.Status = common.ExecComplete
-		logger.DebugWithContext(ctx.Context, "Passkey registration completed for existing user")
+		logger.Debug(ctx.Context, "Passkey registration completed for existing user")
 	}
 
-	logger.DebugWithContext(ctx.Context, "Passkey registration finished successfully",
+	logger.Debug(ctx.Context, "Passkey registration finished successfully",
 		log.String("credentialID", finishData.CredentialID))
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/permission_validator.go
+++ b/backend/internal/flow/executor/permission_validator.go
@@ -65,11 +65,11 @@ func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 	// Get required scopes from node properties.
 	requiredScopes := e.getRequiredScopes(ctx)
 
-	logger.DebugWithContext(ctx.Context, "Checking scope protection", log.Any("requiredScopes", requiredScopes))
+	logger.Debug(ctx.Context, "Checking scope protection", log.Any("requiredScopes", requiredScopes))
 
 	// Check if context exists
 	if ctx.Context == nil {
-		logger.DebugWithContext(ctx.Context, "No context available - blocking access")
+		logger.Debug(ctx.Context, "No context available - blocking access")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrInsufficientPermissions
 		return execResp, nil
@@ -77,7 +77,7 @@ func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 
 	// Extract permissions from request context
 	userPermissions := security.GetPermissions(ctx.Context)
-	logger.DebugWithContext(ctx.Context, "Extracted permissions from context",
+	logger.Debug(ctx.Context, "Extracted permissions from context",
 		log.Int("permissionCount", len(userPermissions)),
 		log.String("permissions", strings.Join(userPermissions, ", ")))
 
@@ -85,14 +85,14 @@ func (e *permissionValidator) Execute(ctx *core.NodeContext) (*common.ExecutorRe
 	if !slices.ContainsFunc(requiredScopes, func(reqScope string) bool {
 		return slices.Contains(userPermissions, reqScope)
 	}) {
-		logger.DebugWithContext(ctx.Context, "Request lacks required scope",
+		logger.Debug(ctx.Context, "Request lacks required scope",
 			log.Any("requiredScopes", requiredScopes))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrInsufficientPermissions
 		return execResp, nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "Scope protection passed", log.Any("requiredScopes", requiredScopes))
+	logger.Debug(ctx.Context, "Scope protection passed", log.Any("requiredScopes", requiredScopes))
 	execResp.Status = common.ExecComplete
 	return execResp, nil
 }

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -82,7 +82,7 @@ func newProvisioningExecutor(
 // Execute executes the user provisioning logic based on the inputs provided.
 func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing user provisioning executor")
+	logger.Debug(ctx.Context, "Executing user provisioning executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -93,7 +93,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 	if ctx.FlowType == common.FlowTypeAuthentication {
 		eligible, ok := ctx.RuntimeData[common.RuntimeKeyUserEligibleForProvisioning]
 		if !ok || eligible != dataValueTrue {
-			logger.DebugWithContext(ctx.Context, "User is not eligible for provisioning, skipping execution")
+			logger.Debug(ctx.Context, "User is not eligible for provisioning, skipping execution")
 			execResp.Status = common.ExecComplete
 			return execResp, nil
 		}
@@ -104,7 +104,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 			return execResp, nil
 		}
 
-		logger.DebugWithContext(ctx.Context, "Required inputs for provisioning executor is not provided")
+		logger.Debug(ctx.Context, "Required inputs for provisioning executor is not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -114,7 +114,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 		return nil, err
 	}
 	if len(identifyingAttrs) == 0 && len(credentialAttrs) == 0 {
-		logger.DebugWithContext(ctx.Context, "No user attributes provided for provisioning")
+		logger.Debug(ctx.Context, "No user attributes provided for provisioning")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrProvisioningUserAttrsMissing
 		return execResp, nil
@@ -122,7 +122,7 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 
 	userID, err := p.IdentifyUser(ctx.Context, identifyingAttrs, execResp)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to identify user", log.Error(err))
+		logger.Error(ctx.Context, "Failed to identify user", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrFailedToIdentifyUser
 		return execResp, nil
@@ -161,24 +161,24 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 	}
 	createdEntity, err := p.createUserInStore(ctx, userAttributes)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to create user in the store", log.Error(err))
+		logger.Error(ctx.Context, "Failed to create user in the store", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrProvisioningFailed
 		return execResp, nil
 	}
 	if createdEntity == nil || createdEntity.ID == "" {
-		logger.ErrorWithContext(ctx.Context, "Created user is nil or has no ID")
+		logger.Error(ctx.Context, "Created user is nil or has no ID")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrProvisioningFailed
 		return execResp, nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "User created successfully",
+	logger.Debug(ctx.Context, "User created successfully",
 		log.MaskedString(log.LoggerKeyUserID, createdEntity.ID))
 
 	// Assign user to groups and roles
 	if err := p.assignGroupsAndRoles(ctx, createdEntity.ID); err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to assign groups and roles to provisioned user",
+		logger.Error(ctx.Context, "Failed to assign groups and roles to provisioned user",
 			log.MaskedString(log.LoggerKeyUserID, createdEntity.ID),
 			log.Error(err))
 		execResp.Status = common.ExecFailure
@@ -197,13 +197,13 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 // Returns true if provisioning should proceed (cross-OU case), false if execution should stop.
 func (p *provisioningExecutor) handleExistingUser(ctx *core.NodeContext, userID string,
 	execResp *common.ExecutorResponse, logger *log.Logger) (bool, error) {
-	logger.DebugWithContext(ctx.Context, "User already exists", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx.Context, "User already exists", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	// If it's a registration flow, check if proceeding with an existing user
 	if ctx.FlowType == common.FlowTypeRegistration {
 		existing, ok := ctx.RuntimeData[common.RuntimeKeySkipProvisioning]
 		if ok && existing == dataValueTrue {
-			logger.DebugWithContext(ctx.Context,
+			logger.Debug(ctx.Context,
 				"Proceeding with an existing user in registration flow, skipping execution")
 			execResp.RuntimeData[userAttributeUserID] = userID
 			execResp.Status = common.ExecComplete
@@ -247,7 +247,7 @@ func (p *provisioningExecutor) handleExistingUser(ctx *core.NodeContext, userID 
 		return false, nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "Existing user is in a different OU, proceeding with cross-OU provisioning",
+	logger.Debug(ctx.Context, "Existing user is in a different OU, proceeding with cross-OU provisioning",
 		log.String("existingOUID", existingUser.OUID),
 		log.String("targetOUID", targetOUID))
 	return true, nil
@@ -259,7 +259,7 @@ func (p *provisioningExecutor) buildProvisioningResponse(ctx *core.NodeContext, 
 	retAttributes := make(map[string]interface{})
 	if len(createdEntity.Attributes) > 0 {
 		if err := json.Unmarshal(createdEntity.Attributes, &retAttributes); err != nil {
-			logger.ErrorWithContext(ctx.Context, "Failed to unmarshal user attributes", log.Error(err))
+			logger.Error(ctx.Context, "Failed to unmarshal user attributes", log.Error(err))
 			return err
 		}
 	}
@@ -299,13 +299,13 @@ func (p *provisioningExecutor) resolveAmbiguousUserForProvisioning(ctx *core.Nod
 			return nil, fmt.Errorf("ambiguous user search returned an entity with missing OUID")
 		}
 		if m.OUID == targetOUID {
-			logger.DebugWithContext(ctx.Context, "Ambiguous user has a match in the target OU",
+			logger.Debug(ctx.Context, "Ambiguous user has a match in the target OU",
 				log.MaskedString(log.LoggerKeyUserID, m.ID))
 			return &m.ID, nil
 		}
 	}
 
-	logger.DebugWithContext(ctx.Context, "Ambiguous user has no match in target OU",
+	logger.Debug(ctx.Context, "Ambiguous user has no match in target OU",
 		log.Int("matchCount", len(matches)))
 	return nil, nil
 }
@@ -321,7 +321,7 @@ func (p *provisioningExecutor) resolveAmbiguousUserForProvisioning(ctx *core.Nod
 func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) bool {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Checking inputs for the provisioning executor")
+	logger.Debug(ctx.Context, "Checking inputs for the provisioning executor")
 
 	if execResp.RuntimeData == nil {
 		execResp.RuntimeData = make(map[string]string)
@@ -337,7 +337,7 @@ func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 	// Fetch all schema attributes (credential and non-credential) in a single call.
 	allSchemaAttrs, err := p.fetchSchemaAttributes(ctx, true, true)
 	if err != nil {
-		logger.WarnWithContext(ctx.Context, "Failed to fetch schema attributes for provisioning", log.Any("error", err))
+		logger.Warn(ctx.Context, "Failed to fetch schema attributes for provisioning", log.Any("error", err))
 		execResp.Status = common.ExecFailure
 		return false
 	}
@@ -374,7 +374,7 @@ func (p *provisioningExecutor) HasRequiredInputs(ctx *core.NodeContext,
 		execResp.ForwardedData = make(map[string]interface{})
 	}
 	execResp.ForwardedData[common.ForwardedDataKeyInputs] = toForward
-	logger.DebugWithContext(ctx.Context, "Schema attributes are missing, requesting via prompt",
+	logger.Debug(ctx.Context, "Schema attributes are missing, requesting via prompt",
 		log.Int("missingCount", len(allSchemaMissing)))
 	return false
 }
@@ -576,7 +576,7 @@ func (p *provisioningExecutor) getAttributesForProvisioning(
 func (p *provisioningExecutor) createUserInStore(nodeCtx *core.NodeContext,
 	userAttributes map[string]interface{}) (*entityprovider.Entity, error) {
 	logger := p.logger.With(log.String(log.LoggerKeyExecutionID, nodeCtx.ExecutionID))
-	logger.DebugWithContext(nodeCtx.Context, "Creating the user account")
+	logger.Debug(nodeCtx.Context, "Creating the user account")
 
 	ouID := p.getOUID(nodeCtx)
 	if ouID == "" {
@@ -606,7 +606,7 @@ func (p *provisioningExecutor) createUserInStore(nodeCtx *core.NodeContext,
 		return nil, fmt.Errorf("failed to create user in the store: %s", svcErr.Message)
 	}
 	if retEntity != nil && retEntity.ID != "" {
-		logger.DebugWithContext(nodeCtx.Context, "User account created successfully",
+		logger.Debug(nodeCtx.Context, "User account created successfully",
 			log.MaskedString(log.LoggerKeyUserID, retEntity.ID))
 	}
 
@@ -652,11 +652,11 @@ func (p *provisioningExecutor) assignGroupsAndRoles(
 
 	// Skip if no group or role configured
 	if groupID == "" && roleID == "" {
-		logger.DebugWithContext(ctx.Context, "No group or role configured for assignment, skipping")
+		logger.Debug(ctx.Context, "No group or role configured for assignment, skipping")
 		return nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "Assigning group and role to provisioned user",
+	logger.Debug(ctx.Context, "Assigning group and role to provisioned user",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.String("groupID", groupID),
 		log.String("roleID", roleID))
@@ -684,7 +684,7 @@ func (p *provisioningExecutor) assignGroupsAndRoles(
 		return roleErr
 	}
 
-	logger.DebugWithContext(ctx.Context, "Successfully assigned group and role",
+	logger.Debug(ctx.Context, "Successfully assigned group and role",
 		log.MaskedString(log.LoggerKeyUserID, userID))
 	return nil
 }
@@ -734,7 +734,7 @@ func (p *provisioningExecutor) assignToGroup(
 	groupID string,
 	logger *log.Logger,
 ) error {
-	logger.DebugWithContext(ctx, "Adding user to group",
+	logger.Debug(ctx, "Adding user to group",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.String("groupID", groupID))
 
@@ -747,14 +747,14 @@ func (p *provisioningExecutor) assignToGroup(
 
 	_, svcErr := p.groupService.AddGroupMembers(ctx, groupID, members)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to add user to group",
+		logger.Error(ctx, "Failed to add user to group",
 			log.String("groupID", groupID),
 			log.MaskedString(log.LoggerKeyUserID, userID),
 			log.String("error", svcErr.Error.DefaultValue))
 		return fmt.Errorf("failed to add user to group: %s", svcErr.Error.DefaultValue)
 	}
 
-	logger.DebugWithContext(ctx, "Successfully added user to group",
+	logger.Debug(ctx, "Successfully added user to group",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.String("groupID", groupID))
 	return nil
@@ -764,13 +764,13 @@ func (p *provisioningExecutor) assignToGroup(
 func (p *provisioningExecutor) assignToRole(
 	ctx context.Context, userID string, roleID string, logger *log.Logger) error {
 	if p.roleAssignmentService == nil {
-		logger.ErrorWithContext(ctx, "Role assignment service is not configured",
+		logger.Error(ctx, "Role assignment service is not configured",
 			log.String("roleID", roleID),
 			log.MaskedString(log.LoggerKeyUserID, userID))
 		return fmt.Errorf("role assignment service not configured")
 	}
 
-	logger.DebugWithContext(ctx, "Adding user to role",
+	logger.Debug(ctx, "Adding user to role",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.String("roleID", roleID))
 
@@ -784,14 +784,14 @@ func (p *provisioningExecutor) assignToRole(
 
 	svcErr := p.roleAssignmentService.AddAssignments(ctx, roleID, assignments)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to add role assignment",
+		logger.Error(ctx, "Failed to add role assignment",
 			log.String("roleID", roleID),
 			log.MaskedString(log.LoggerKeyUserID, userID),
 			log.String("error", svcErr.Error.DefaultValue))
 		return fmt.Errorf("failed to assign role: %s", svcErr.Error.DefaultValue)
 	}
 
-	logger.DebugWithContext(ctx, "Successfully assigned role",
+	logger.Debug(ctx, "Successfully assigned role",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.String("roleID", roleID))
 	return nil

--- a/backend/internal/flow/executor/registry.go
+++ b/backend/internal/flow/executor/registry.go
@@ -53,21 +53,21 @@ func (r *executorRegistry) RegisterExecutor(name string, exec core.ExecutorInter
 	// so there is no request context (or trace ID) to propagate.
 	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ExecutorRegistry"))
-	logger.DebugWithContext(ctx, "Registering executor", log.String("executorName", exec.GetName()))
+	logger.Debug(ctx, "Registering executor", log.String("executorName", exec.GetName()))
 
 	if exec == nil {
-		logger.WarnWithContext(ctx, "Skipping registration of nil executor")
+		logger.Warn(ctx, "Skipping registration of nil executor")
 		return
 	}
 	if name == "" {
-		logger.WarnWithContext(ctx, "Skipping registration of executor with empty name")
+		logger.Warn(ctx, "Skipping registration of executor with empty name")
 		return
 	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, ok := r.executors[name]; ok {
-		logger.WarnWithContext(ctx, "Executor already registered", log.String("executorName", name))
+		logger.Warn(ctx, "Executor already registered", log.String("executorName", name))
 		return
 	}
 	r.executors[name] = exec

--- a/backend/internal/flow/executor/sms_auth_executor.go
+++ b/backend/internal/flow/executor/sms_auth_executor.go
@@ -95,7 +95,7 @@ func newSMSOTPAuthExecutor(
 // Execute executes the SMS OTP authentication logic.
 func (s *smsOTPAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing SMS OTP authentication executor")
+	logger.Debug(ctx.Context, "Executing SMS OTP authentication executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -106,7 +106,7 @@ func (s *smsOTPAuthExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorRes
 	switch ctx.ExecutorMode {
 	case ExecutorModeSend:
 		if !s.ValidatePrerequisites(ctx, execResp) {
-			logger.DebugWithContext(ctx.Context, "Prerequisites not met for SMS OTP authentication executor")
+			logger.Debug(ctx.Context, "Prerequisites not met for SMS OTP authentication executor")
 			return execResp, nil
 		}
 		return s.executeSend(ctx, execResp)
@@ -127,7 +127,7 @@ func (s *smsOTPAuthExecutor) executeSend(ctx *core.NodeContext,
 		return execResp, err
 	}
 
-	logger.DebugWithContext(ctx.Context, "SMS OTP send completed", log.String("status", string(execResp.Status)))
+	logger.Debug(ctx.Context, "SMS OTP send completed", log.String("status", string(execResp.Status)))
 
 	return execResp, nil
 }
@@ -138,7 +138,7 @@ func (s *smsOTPAuthExecutor) executeVerify(ctx *core.NodeContext,
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	if !s.HasRequiredInputs(ctx, execResp) {
-		logger.DebugWithContext(ctx.Context, "Required inputs for SMS OTP verification are not provided")
+		logger.Debug(ctx.Context, "Required inputs for SMS OTP verification are not provided")
 		execResp.Status = common.ExecUserInputRequired
 		return execResp, nil
 	}
@@ -148,7 +148,7 @@ func (s *smsOTPAuthExecutor) executeVerify(ctx *core.NodeContext,
 		return execResp, err
 	}
 
-	logger.DebugWithContext(ctx.Context, "SMS OTP verify completed",
+	logger.Debug(ctx.Context, "SMS OTP verify completed",
 		log.String("status", string(execResp.Status)),
 		log.Bool("isAuthenticated", execResp.AuthenticatedUser.IsAuthenticated))
 
@@ -159,7 +159,7 @@ func (s *smsOTPAuthExecutor) executeVerify(ctx *core.NodeContext,
 func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Sending SMS OTP to user")
+	logger.Debug(ctx.Context, "Sending SMS OTP to user")
 
 	phoneAttr := s.resolvePhoneInput(ctx, mobileNumberInput).Identifier
 	mobileNumber, err := s.getUserMobileFromContext(ctx, phoneAttr)
@@ -177,13 +177,13 @@ func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 	} else {
 		// Identify user by mobile number if not authenticated
 		if mobileNumber == "" {
-			logger.ErrorWithContext(ctx.Context, "Mobile number is empty in the context")
+			logger.Error(ctx.Context, "Mobile number is empty in the context")
 		}
 
 		filter := map[string]interface{}{phoneAttr: mobileNumber}
 		userID, err = s.IdentifyUser(ctx.Context, filter, execResp)
 		if err != nil {
-			logger.ErrorWithContext(ctx.Context, "Failed to identify user", log.Error(err))
+			logger.Error(ctx.Context, "Failed to identify user", log.Error(err))
 			return fmt.Errorf("failed to identify user: %w", err)
 		}
 	}
@@ -222,14 +222,14 @@ func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 
 	// Send the OTP to the user's mobile number.
 	if err := s.generateAndSendOTP(mobileNumber, ctx, execResp, logger); err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to send OTP", log.Error(err))
+		logger.Error(ctx.Context, "Failed to send OTP", log.Error(err))
 		return fmt.Errorf("failed to send OTP: %w", err)
 	}
 	if execResp.Status == common.ExecFailure {
 		return nil
 	}
 
-	logger.DebugWithContext(ctx.Context, "SMS OTP sent successfully")
+	logger.Debug(ctx.Context, "SMS OTP sent successfully")
 	execResp.RuntimeData[common.RuntimeKeySMSOTPMobileNumber] = mobileNumber
 	execResp.RuntimeData[common.RuntimeKeySMSOTPPhoneAttr] = phoneAttr
 	execResp.Status = common.ExecComplete
@@ -241,11 +241,11 @@ func (s *smsOTPAuthExecutor) InitiateOTP(ctx *core.NodeContext,
 func (s *smsOTPAuthExecutor) ProcessAuthFlowResponse(ctx *core.NodeContext,
 	execResp *common.ExecutorResponse) error {
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Processing authentication flow response for SMS OTP")
+	logger.Debug(ctx.Context, "Processing authentication flow response for SMS OTP")
 
 	authenticatedUser, err := s.getAuthenticatedUser(ctx, execResp)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to get authenticated user details", log.Error(err))
+		logger.Error(ctx.Context, "Failed to get authenticated user details", log.Error(err))
 		return fmt.Errorf("failed to get authenticated user details: %w", err)
 	}
 	if execResp.Status == common.ExecFailure || execResp.Status == common.ExecUserInputRequired {
@@ -268,13 +268,13 @@ func (s *smsOTPAuthExecutor) ValidatePrerequisites(ctx *core.NodeContext,
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	if ctx.FlowType == common.FlowTypeRegistration {
-		logger.DebugWithContext(ctx.Context, "Prerequisites not met for registration flow, prompting for mobile number")
+		logger.Debug(ctx.Context, "Prerequisites not met for registration flow, prompting for mobile number")
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = []common.Input{s.resolvePhoneInput(ctx, mobileNumberInput)}
 		return false
 	}
 
-	logger.DebugWithContext(ctx.Context, "Trying to satisfy prerequisites for SMS OTP authentication executor")
+	logger.Debug(ctx.Context, "Trying to satisfy prerequisites for SMS OTP authentication executor")
 
 	s.satisfyPrerequisites(ctx, execResp)
 	if execResp.Status == common.ExecFailure {
@@ -342,16 +342,16 @@ func (s *smsOTPAuthExecutor) satisfyPrerequisites(ctx *core.NodeContext,
 	execResp.Status = ""
 	execResp.Error = nil
 
-	logger.DebugWithContext(ctx.Context, "Trying to resolve user ID from context data")
+	logger.Debug(ctx.Context, "Trying to resolve user ID from context data")
 	userIDResolved, err := s.resolveUserID(ctx)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to resolve user ID from context data", log.Error(err))
+		logger.Error(ctx.Context, "Failed to resolve user ID from context data", log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserIDMissingInContext
 		return
 	}
 	if !userIDResolved {
-		logger.DebugWithContext(ctx.Context, "User ID could not be resolved from context data")
+		logger.Debug(ctx.Context, "User ID could not be resolved from context data")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserIDMissingInContext
 		return
@@ -362,11 +362,11 @@ func (s *smsOTPAuthExecutor) satisfyPrerequisites(ctx *core.NodeContext,
 	//  prompt the user to enter their mobile number.
 	//  We should verify whether this is the expected behavior.
 
-	logger.DebugWithContext(ctx.Context, "Retrieving mobile number from user ID",
+	logger.Debug(ctx.Context, "Retrieving mobile number from user ID",
 		log.MaskedString(log.LoggerKeyUserID, userID))
 	mobileNumber, err := s.getUserMobileNumber(userID, ctx, execResp)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to retrieve mobile number",
+		logger.Error(ctx.Context, "Failed to retrieve mobile number",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
 		execResp.Status = common.ExecFailure
 		execResp.Error = errFailedToRetrieveAttribute("mobile number")
@@ -376,7 +376,7 @@ func (s *smsOTPAuthExecutor) satisfyPrerequisites(ctx *core.NodeContext,
 		return
 	}
 
-	logger.DebugWithContext(ctx.Context, "Mobile number retrieved successfully",
+	logger.Debug(ctx.Context, "Mobile number retrieved successfully",
 		log.MaskedString(log.LoggerKeyUserID, userID))
 	ctx.RuntimeData[s.resolvePhoneInput(ctx, mobileNumberInput).Identifier] = mobileNumber
 
@@ -393,7 +393,7 @@ func (s *smsOTPAuthExecutor) resolveUserID(ctx *core.NodeContext) (bool, error) 
 	// First, check if the user ID is already available in the context.
 	userID := s.GetUserIDFromContext(ctx)
 	if userID != "" {
-		logger.DebugWithContext(ctx.Context, "User ID found in context data",
+		logger.Debug(ctx.Context, "User ID found in context data",
 			log.MaskedString(log.LoggerKeyUserID, userID))
 		if ctx.RuntimeData == nil {
 			ctx.RuntimeData = make(map[string]string)
@@ -439,7 +439,7 @@ func (s *smsOTPAuthExecutor) resolveUserID(ctx *core.NodeContext) (bool, error) 
 // resolveUserIDFromAttribute attempts to resolve the user ID from a specific attribute in the context.
 func (s *smsOTPAuthExecutor) resolveUserIDFromAttribute(ctx *core.NodeContext,
 	attributeName string, logger *log.Logger) (bool, error) {
-	logger.DebugWithContext(ctx.Context, "Resolving user ID from attribute", log.String("attributeName", attributeName))
+	logger.Debug(ctx.Context, "Resolving user ID from attribute", log.String("attributeName", attributeName))
 
 	attributeValue := ctx.UserInputs[attributeName]
 	if attributeValue == "" {
@@ -452,7 +452,7 @@ func (s *smsOTPAuthExecutor) resolveUserIDFromAttribute(ctx *core.NodeContext,
 			return false, fmt.Errorf("failed to identify user by %s: %s", attributeName, providerErr.Error())
 		}
 		if userID != nil && *userID != "" {
-			logger.DebugWithContext(ctx.Context, "User ID resolved from attribute",
+			logger.Debug(ctx.Context, "User ID resolved from attribute",
 				log.String("attributeName", attributeName),
 				log.MaskedString(log.LoggerKeyUserID, *userID))
 			if ctx.RuntimeData == nil {
@@ -471,18 +471,18 @@ func (s *smsOTPAuthExecutor) getUserMobileNumber(userID string, ctx *core.NodeCo
 	execResp *common.ExecutorResponse) (string, error) {
 	logger := s.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID),
 		log.MaskedString(log.LoggerKeyUserID, userID))
-	logger.DebugWithContext(ctx.Context, "Retrieving user mobile number")
+	logger.Debug(ctx.Context, "Retrieving user mobile number")
 
 	// Try to get mobile number from context
 	phoneAttr := s.resolvePhoneInput(ctx, mobileNumberInput).Identifier
 	mobileNumber, err := s.getUserMobileFromContext(ctx, phoneAttr)
 	if err == nil && mobileNumber != "" {
-		logger.DebugWithContext(ctx.Context, "Mobile number found in context, skipping user store call")
+		logger.Debug(ctx.Context, "Mobile number found in context, skipping user store call")
 		return mobileNumber, nil
 	}
 
 	// Mobile number not in context, fetch from user store
-	logger.DebugWithContext(ctx.Context, "Mobile number not in context, fetching from user store")
+	logger.Debug(ctx.Context, "Mobile number not in context, fetching from user store")
 	user, providerErr := s.entityProvider.GetEntity(userID)
 	if providerErr != nil {
 		return "", fmt.Errorf("failed to retrieve user details: %s", providerErr.Error())
@@ -503,7 +503,7 @@ func (s *smsOTPAuthExecutor) getUserMobileNumber(userID string, ctx *core.NodeCo
 	}
 
 	if mobileNumber == "" {
-		logger.DebugWithContext(ctx.Context, "Mobile number not found in user attributes or context")
+		logger.Debug(ctx.Context, "Mobile number not found in user attributes or context")
 		execResp.Status = common.ExecFailure
 		execResp.Error = errAttributeNotFoundFor("mobile")
 		return "", nil
@@ -564,14 +564,14 @@ func (s *smsOTPAuthExecutor) validateAttempts(ctx *core.NodeContext, execResp *c
 	if attemptCountStr != "" {
 		count, err := strconv.Atoi(attemptCountStr)
 		if err != nil {
-			logger.ErrorWithContext(ctx.Context, "Failed to parse attempt count", log.Error(err))
+			logger.Error(ctx.Context, "Failed to parse attempt count", log.Error(err))
 			return 0, fmt.Errorf("failed to parse attempt count: %w", err)
 		}
 		attemptCount = count
 	}
 
 	if attemptCount >= s.getOTPMaxAttempts() {
-		logger.DebugWithContext(ctx.Context, "Maximum OTP attempts reached",
+		logger.Debug(ctx.Context, "Maximum OTP attempts reached",
 			log.MaskedString(log.LoggerKeyUserID, userID),
 			log.Int("attemptCount", attemptCount))
 		execResp.Status = common.ExecFailure
@@ -604,11 +604,11 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 
 	userID := ctx.RuntimeData[userAttributeUserID]
 
-	logger.DebugWithContext(ctx.Context, "Validating OTP", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx.Context, "Validating OTP", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	providedOTP := ctx.UserInputs[userInputOTP]
 	if providedOTP == "" {
-		logger.DebugWithContext(ctx.Context, "Provided OTP is empty", log.MaskedString(log.LoggerKeyUserID, userID))
+		logger.Debug(ctx.Context, "Provided OTP is empty", log.MaskedString(log.LoggerKeyUserID, userID))
 		execResp.Status = common.ExecUserInputRequired
 		execResp.Inputs = s.GetRequiredInputs(ctx)
 		execResp.Error = &ErrInvalidOTP
@@ -617,7 +617,7 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 
 	sessionToken := ctx.RuntimeData["otpSessionToken"]
 	if sessionToken == "" {
-		logger.ErrorWithContext(ctx.Context, "No session token found for OTP validation",
+		logger.Error(ctx.Context, "No session token found for OTP validation",
 			log.MaskedString(log.LoggerKeyUserID, userID))
 		return nil, fmt.Errorf("no session token found for OTP validation")
 	}
@@ -635,14 +635,14 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 			ctx.Context, nil, creds, nil, nil, ctx.AuthUser)
 		if svcErr != nil {
 			if svcErr.Code == authnprovidermgr.ErrorAuthenticationFailed.Code {
-				logger.DebugWithContext(ctx.Context, "OTP verification failed",
+				logger.Debug(ctx.Context, "OTP verification failed",
 					log.MaskedString(log.LoggerKeyUserID, userID))
 				execResp.Status = common.ExecUserInputRequired
 				execResp.Inputs = s.GetRequiredInputs(ctx)
 				execResp.Error = &ErrInvalidOTP
 				return nil, nil
 			}
-			logger.ErrorWithContext(ctx.Context, "Failed to verify OTP",
+			logger.Error(ctx.Context, "Failed to verify OTP",
 				log.MaskedString(log.LoggerKeyUserID, userID), log.Any("serviceError", svcErr))
 			return nil, fmt.Errorf("failed to verify OTP: %s", svcErr.ErrorDescription.DefaultValue)
 		}
@@ -669,21 +669,21 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 		ctx.Context, nil, creds, nil, nil, ctx.AuthUser)
 	if svcErr != nil {
 		if svcErr.Code == authnprovidermgr.ErrorAuthenticationFailed.Code {
-			logger.DebugWithContext(ctx.Context, "OTP verification failed",
+			logger.Debug(ctx.Context, "OTP verification failed",
 				log.MaskedString(log.LoggerKeyUserID, userID))
 			execResp.Status = common.ExecUserInputRequired
 			execResp.Inputs = s.GetRequiredInputs(ctx)
 			execResp.Error = &ErrInvalidOTP
 			return nil, nil
 		}
-		logger.ErrorWithContext(ctx.Context, "Failed to verify OTP",
+		logger.Error(ctx.Context, "Failed to verify OTP",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Any("serviceError", svcErr))
 		return nil, fmt.Errorf("failed to verify OTP: %s", svcErr.ErrorDescription.DefaultValue)
 	}
 	execResp.AuthUser = newAuthUser
 
 	execResp.RuntimeData["otpSessionToken"] = ""
-	logger.DebugWithContext(ctx.Context, "OTP validated successfully", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx.Context, "OTP validated successfully", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	// Check if user is already authenticated
 	if ctx.AuthenticatedUser.IsAuthenticated && ctx.AuthenticatedUser.UserID != "" {
@@ -697,22 +697,22 @@ func (s *smsOTPAuthExecutor) getAuthenticatedUser(ctx *core.NodeContext,
 	// User not available in context, try to retrieve the user and get the attributes
 	userID = authnResult.UserID
 
-	logger.DebugWithContext(ctx.Context, "Fetching user details from user store",
+	logger.Debug(ctx.Context, "Fetching user details from user store",
 		log.MaskedString(log.LoggerKeyUserID, userID))
 
 	attrs := map[string]interface{}{}
 	user, err := s.entityProvider.GetEntity(userID)
 	if err != nil {
 		if err.Code != entityprovider.ErrorCodeNotImplemented {
-			logger.ErrorWithContext(ctx.Context, "Failed to get user attributes", log.Error(err))
+			logger.Error(ctx.Context, "Failed to get user attributes", log.Error(err))
 			return nil, errors.New("failed to get user attributes")
 		}
-		logger.DebugWithContext(ctx.Context, "User provider is not implemented. User attributes will be empty.")
+		logger.Debug(ctx.Context, "User provider is not implemented. User attributes will be empty.")
 	}
 
 	if err == nil && user != nil {
 		if err := json.Unmarshal(user.Attributes, &attrs); err != nil {
-			logger.ErrorWithContext(ctx.Context, "Failed to unmarshal user attributes", log.Error(err))
+			logger.Error(ctx.Context, "Failed to unmarshal user attributes", log.Error(err))
 			return nil, errors.New("failed to unmarshal user attributes")
 		}
 	}

--- a/backend/internal/flow/executor/sms_executor.go
+++ b/backend/internal/flow/executor/sms_executor.go
@@ -73,7 +73,7 @@ func newSMSExecutor(flowFactory core.FlowFactoryInterface,
 // then renders the SMS body from a template and sends it.
 func (e *smsExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := e.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing SMS executor")
+	logger.Debug(ctx.Context, "Executing SMS executor")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -88,14 +88,14 @@ func (e *smsExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, 
 
 	recipient := resolveRecipientMobile(ctx, phoneAttr, e.entityProvider)
 	if recipient == "" {
-		logger.DebugWithContext(ctx.Context, "SMS recipient not found in user inputs or runtime data")
+		logger.Debug(ctx.Context, "SMS recipient not found in user inputs or runtime data")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSMSRecipientMissing
 		return execResp, nil
 	}
 
 	if !isValidPhoneNumber(recipient) {
-		logger.DebugWithContext(ctx.Context, "SMS recipient is not a valid phone number",
+		logger.Debug(ctx.Context, "SMS recipient is not a valid phone number",
 			log.String("phoneAttr", phoneAttr))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSMSInvalidPhone
@@ -147,7 +147,7 @@ func (e *smsExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, 
 		return nil, fmt.Errorf("SMS send failed: %s", notifSvcErr.ErrorDescription)
 	}
 
-	logger.DebugWithContext(ctx.Context, "SMS sent successfully", log.MaskedString("recipient", recipient))
+	logger.Debug(ctx.Context, "SMS sent successfully", log.MaskedString("recipient", recipient))
 
 	execResp.AdditionalData[common.DataSMSSent] = dataValueTrue
 	execResp.Status = common.ExecComplete

--- a/backend/internal/flow/executor/user_type_resolver.go
+++ b/backend/internal/flow/executor/user_type_resolver.go
@@ -83,7 +83,7 @@ func newUserTypeResolver(
 // Execute resolves the user type from inputs or prompts the user to select one.
 func (u *userTypeResolver) Execute(ctx *core.NodeContext) (*common.ExecutorResponse, error) {
 	logger := u.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
-	logger.DebugWithContext(ctx.Context, "Executing user type resolver")
+	logger.Debug(ctx.Context, "Executing user type resolver")
 
 	execResp := &common.ExecutorResponse{
 		AdditionalData: make(map[string]string),
@@ -99,7 +99,7 @@ func (u *userTypeResolver) Execute(ctx *core.NodeContext) (*common.ExecutorRespo
 	case common.FlowTypeUserOnboarding:
 		return u.handleUserOnboardingFlows(ctx, execResp)
 	default:
-		logger.DebugWithContext(ctx.Context, "User type resolver is not applicable for the flow type",
+		logger.Debug(ctx.Context, "User type resolver is not applicable for the flow type",
 			log.String("flowType", string(ctx.FlowType)))
 		execResp.Status = common.ExecComplete
 		return execResp, nil
@@ -113,7 +113,7 @@ func (u *userTypeResolver) handleAuthenticationFlows(ctx *core.NodeContext, exec
 
 	// Validate that allowed user types are defined
 	if len(ctx.Application.AllowedUserTypes) == 0 {
-		logger.DebugWithContext(ctx.Context, "No allowed user types configured for authentication")
+		logger.Debug(ctx.Context, "No allowed user types configured for authentication")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrAuthNotAvailableForApp
 		return execResp, nil
@@ -136,7 +136,7 @@ func (u *userTypeResolver) handleRegistrationFlows(ctx *core.NodeContext, execRe
 		//  userType has an attached ou. Need to find userType from the application's ou.
 		//  Also should check if self registration is enabled for the user type when the support is available.
 
-		logger.DebugWithContext(ctx.Context, "No allowed user types found for the application")
+		logger.Debug(ctx.Context, "No allowed user types found for the application")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSelfRegNotAvailableForApp
 		return execResp, nil
@@ -153,7 +153,7 @@ func (u *userTypeResolver) handleRegistrationFlows(ctx *core.NodeContext, execRe
 		}
 
 		if len(filtered) == 0 {
-			logger.DebugWithContext(ctx.Context, "No valid user types after filtering with node allowedUserTypes",
+			logger.Debug(ctx.Context, "No valid user types after filtering with node allowedUserTypes",
 				log.Any("applicationAllowed", allowed), log.Any("nodeAllowed", nodeAllowedUserTypes))
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrNoValidUserTypes
@@ -193,7 +193,7 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	if userType, ok := ctx.UserInputs[userTypeKey]; ok && userType != "" {
 		// If allowedUserTypes is configured, validate the input against it
 		if len(allowedUserTypes) > 0 && !slices.Contains(allowedUserTypes, userType) {
-			logger.DebugWithContext(ctx.Context, "User type not in allowed list", log.String(userTypeKey, userType),
+			logger.Debug(ctx.Context, "User type not in allowed list", log.String(userTypeKey, userType),
 				log.Any("allowedUserTypes", allowedUserTypes))
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrUserTypeNotAllowed
@@ -211,14 +211,14 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 		if selectedOUID, exists := ctx.RuntimeData[ouIDKey]; exists && selectedOUID != "" {
 			isValid, svcErr := u.ouService.IsParent(ctx.Context, ouID, selectedOUID)
 			if svcErr != nil {
-				logger.ErrorWithContext(ctx.Context, "Failed to validate user type against selected OU",
+				logger.Error(ctx.Context, "Failed to validate user type against selected OU",
 					log.String(userTypeKey, userType), log.String(ouIDKey, selectedOUID),
 					log.String("error", svcErr.Error.DefaultValue))
 				return nil, fmt.Errorf("failed to validate user type against selected OU: %s",
 					svcErr.Error.DefaultValue)
 			}
 			if !isValid {
-				logger.DebugWithContext(ctx.Context, "User type not valid for selected OU",
+				logger.Debug(ctx.Context, "User type not valid for selected OU",
 					log.String(userTypeKey, userType), log.String(ouIDKey, selectedOUID))
 				execResp.Status = common.ExecFailure
 				execResp.Error = &ErrUserTypeNotValidForOU
@@ -228,7 +228,7 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 
 		execResp.RuntimeData[userTypeKey] = userType
 		execResp.RuntimeData[defaultOUIDKey] = ouID
-		logger.DebugWithContext(ctx.Context, "User type resolved for user onboarding",
+		logger.Debug(ctx.Context, "User type resolved for user onboarding",
 			log.String(userTypeKey, userType),
 			log.String(ouIDKey, entityType.OUID))
 		execResp.Status = common.ExecComplete
@@ -239,7 +239,7 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	schemas, svcErr := u.entityTypeService.GetEntityTypeList(ctx.Context,
 		entitytype.TypeCategoryUser, 100, 0, false)
 	if svcErr != nil {
-		logger.DebugWithContext(ctx.Context, "Failed to list user types",
+		logger.Debug(ctx.Context, "Failed to list user types",
 			log.String("error", svcErr.Error.DefaultValue))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrUserTypeRetrievalFailed
@@ -247,7 +247,7 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	}
 
 	if len(schemas.Types) == 0 {
-		logger.DebugWithContext(ctx.Context, "No user types available")
+		logger.Debug(ctx.Context, "No user types available")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrNoUserTypesAvailable
 		return execResp, nil
@@ -268,7 +268,7 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	}
 
 	if len(availableSchemas) == 0 {
-		logger.DebugWithContext(ctx.Context, "No valid user types found after filtering",
+		logger.Debug(ctx.Context, "No valid user types found after filtering",
 			log.Any("allowedUserTypes", allowedUserTypes))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrNoValidUserTypes
@@ -278,7 +278,7 @@ func (u *userTypeResolver) handleUserOnboardingFlows(ctx *core.NodeContext,
 	// If only one user type is available, select it automatically
 	if len(availableSchemas) == 1 {
 		schema := availableSchemas[0]
-		logger.DebugWithContext(ctx.Context, "User type auto-selected for user onboarding",
+		logger.Debug(ctx.Context, "User type auto-selected for user onboarding",
 			log.String(userTypeKey, schema.Name),
 			log.String(ouIDKey, schema.OUID))
 
@@ -310,7 +310,7 @@ func (u *userTypeResolver) getAllowedUserTypesFromProperties(ctx *core.NodeConte
 
 	items, ok := val.([]interface{})
 	if !ok {
-		u.logger.DebugWithContext(ctx.Context, "allowedUserTypes property is not a valid array")
+		u.logger.Debug(ctx.Context, "allowedUserTypes property is not a valid array")
 		return nil
 	}
 
@@ -322,7 +322,7 @@ func (u *userTypeResolver) getAllowedUserTypesFromProperties(ctx *core.NodeConte
 	}
 
 	if len(userTypes) > 0 {
-		u.logger.DebugWithContext(ctx.Context, "Allowed user types configured from node properties",
+		u.logger.Debug(ctx.Context, "Allowed user types configured from node properties",
 			log.Any("allowedUserTypes", userTypes))
 	}
 
@@ -357,7 +357,7 @@ func (u *userTypeResolver) filterSchemasByOU(ctx *core.NodeContext,
 	for _, schema := range schemas {
 		isValid, svcErr := u.ouService.IsParent(ctx.Context, schema.OUID, selectedOUID)
 		if svcErr != nil {
-			logger.ErrorWithContext(ctx.Context, "Failed to check OU ancestry for schema",
+			logger.Error(ctx.Context, "Failed to check OU ancestry for schema",
 				log.String("schema", schema.Name), log.String("error", svcErr.Error.DefaultValue))
 			return nil, fmt.Errorf("failed to check OU ancestry for schema %s: %s",
 				schema.Name, svcErr.Error.DefaultValue)
@@ -367,7 +367,7 @@ func (u *userTypeResolver) filterSchemasByOU(ctx *core.NodeContext,
 		}
 	}
 
-	logger.DebugWithContext(ctx.Context, "Filtered schemas by selected OU",
+	logger.Debug(ctx.Context, "Filtered schemas by selected OU",
 		log.String(ouIDKey, selectedOUID),
 		log.Int("before", len(schemas)),
 		log.Int("after", len(filtered)))
@@ -380,14 +380,14 @@ func (u *userTypeResolver) resolveUserTypeFromInput(ctx context.Context, execRes
 	userType string, allowed []string) error {
 	logger := u.logger
 	if slices.Contains(allowed, userType) {
-		logger.DebugWithContext(ctx, "User type resolved from input", log.String(userTypeKey, userType))
+		logger.Debug(ctx, "User type resolved from input", log.String(userTypeKey, userType))
 
 		entityType, ouID, err := u.getEntityTypeAndOU(ctx, userType)
 		if err != nil {
 			return err
 		}
 		if !entityType.AllowSelfRegistration {
-			logger.DebugWithContext(ctx, "Self registration not enabled for user type",
+			logger.Debug(ctx, "Self registration not enabled for user type",
 				log.String(userTypeKey, userType))
 			execResp.Status = common.ExecFailure
 			execResp.Error = &ErrSelfRegDisabledForUserType
@@ -417,14 +417,14 @@ func (u *userTypeResolver) resolveUserTypeFromSingleAllowed(ctx context.Context,
 	}
 
 	if !entityType.AllowSelfRegistration {
-		logger.DebugWithContext(ctx, "Self registration not enabled for user type",
+		logger.Debug(ctx, "Self registration not enabled for user type",
 			log.String(userTypeKey, allowedUserType))
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSelfRegDisabledForUserType
 		return nil
 	}
 
-	logger.DebugWithContext(ctx, "User type resolved from allowed list", log.String(userTypeKey, allowedUserType))
+	logger.Debug(ctx, "User type resolved from allowed list", log.String(userTypeKey, allowedUserType))
 
 	// Add userType and ouID to runtime data
 	execResp.RuntimeData[userTypeKey] = allowedUserType
@@ -456,7 +456,7 @@ func (u *userTypeResolver) resolveUserTypeFromMultipleAllowed(ctx context.Contex
 
 	// Fail if no user types have self registration enabled
 	if len(selfRegEnabledUserTypes) == 0 {
-		logger.DebugWithContext(ctx, "No user types with self registration enabled")
+		logger.Debug(ctx, "No user types with self registration enabled")
 		execResp.Status = common.ExecFailure
 		execResp.Error = &ErrSelfRegNotAvailableForApp
 		return nil
@@ -465,7 +465,7 @@ func (u *userTypeResolver) resolveUserTypeFromMultipleAllowed(ctx context.Contex
 	// If only one user type has self registration enabled, select it automatically
 	if len(selfRegEnabledUserTypes) == 1 {
 		record := selfRegEnabledUserTypes[0]
-		logger.DebugWithContext(ctx, "User type auto-selected", log.String(userTypeKey, record.entityType.Name))
+		logger.Debug(ctx, "User type auto-selected", log.String(userTypeKey, record.entityType.Name))
 
 		// Add userType and ouID to runtime data
 		execResp.RuntimeData[userTypeKey] = record.entityType.Name
@@ -481,7 +481,7 @@ func (u *userTypeResolver) resolveUserTypeFromMultipleAllowed(ctx context.Contex
 		selfRegUserTypes = append(selfRegUserTypes, record.entityType.Name)
 	}
 
-	logger.DebugWithContext(ctx,
+	logger.Debug(ctx,
 		"Prompting for user type selection as multiple user types are available for self registration",
 		log.Any("userTypes", selfRegUserTypes))
 
@@ -497,17 +497,17 @@ func (u *userTypeResolver) getEntityTypeAndOU(
 
 	entityType, svcErr := u.entityTypeService.GetEntityTypeByName(ctx, entitytype.TypeCategoryUser, userType)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to resolve user type",
+		logger.Error(ctx, "Failed to resolve user type",
 			log.String(userTypeKey, userType), log.String("error", svcErr.Error.DefaultValue))
 		return nil, "", fmt.Errorf("failed to resolve user type: %s", userType)
 	}
 
 	if entityType.OUID == "" {
-		logger.ErrorWithContext(ctx, "No organization unit found for user type", log.String(userTypeKey, userType))
+		logger.Error(ctx, "No organization unit found for user type", log.String(userTypeKey, userType))
 		return nil, "", fmt.Errorf("no organization unit found for user type: %s", userType)
 	}
 
-	logger.DebugWithContext(ctx, "Entity type resolved for user type", log.String(userTypeKey, userType),
+	logger.Debug(ctx, "Entity type resolved for user type", log.String(userTypeKey, userType),
 		log.String(ouIDKey, entityType.OUID))
 	return entityType, entityType.OUID, nil
 }
@@ -515,7 +515,7 @@ func (u *userTypeResolver) getEntityTypeAndOU(
 // promptUserSelection prompts the user to select a user type from the provided options.
 func (u *userTypeResolver) promptUserSelection(
 	ctx context.Context, execResp *common.ExecutorResponse, options []string) {
-	u.logger.DebugWithContext(ctx, "Prompting user for user type selection", log.Any("userTypes", options))
+	u.logger.Debug(ctx, "Prompting user for user type selection", log.Any("userTypes", options))
 
 	execResp.Status = common.ExecUserInputRequired
 

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -88,7 +88,7 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 	// Execute the graph nodes until a terminal condition is met or currentNode is nil
 	challengeTokenValidated := false
 	for currentNode != nil {
-		logger.DebugWithContext(ctx.Context, "Executing node", log.String("nodeID", currentNode.GetID()),
+		logger.Debug(ctx.Context, "Executing node", log.String("nodeID", currentNode.GetID()),
 			log.String("nodeType", string(currentNode.GetType())))
 
 		nodeCtx := &core.NodeContext{
@@ -127,7 +127,7 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *serviceerror.Servi
 
 		// Check if the node should be executed based on its condition
 		if !currentNode.ShouldExecute(nodeCtx) {
-			logger.DebugWithContext(ctx.Context, "Skipping node due to unmet condition",
+			logger.Debug(ctx.Context, "Skipping node due to unmet condition",
 				log.String("nodeID", currentNode.GetID()))
 			nextNode, svcErr := fe.skipToNextNode(ctx, currentNode, logger)
 			if svcErr != nil {
@@ -262,17 +262,17 @@ func (fe *flowEngine) setCurrentExecutionNode(ctx *EngineContext,
 	logger *log.Logger) *serviceerror.ServiceError {
 	graph := ctx.Graph
 	if graph == nil {
-		logger.ErrorWithContext(ctx.Context, "Flow graph is not initialized in the context")
+		logger.Error(ctx.Context, "Flow graph is not initialized in the context")
 		return &serviceerror.InternalServerError
 	}
 
 	currentNode := ctx.CurrentNode
 	if currentNode == nil {
-		logger.DebugWithContext(ctx.Context, "Current node is nil. Setting start node as the current node.")
+		logger.Debug(ctx.Context, "Current node is nil. Setting start node as the current node.")
 		var err error
 		currentNode, err = graph.GetStartNode()
 		if err != nil {
-			logger.ErrorWithContext(ctx.Context, "Start node not found in the flow graph", log.Error(err))
+			logger.Error(ctx.Context, "Start node not found in the flow graph", log.Error(err))
 			return &serviceerror.InternalServerError
 		}
 		ctx.CurrentNode = currentNode
@@ -309,7 +309,7 @@ func (fe *flowEngine) setNodeExecutor(
 	}
 	executableNode, ok := node.(core.ExecutorBackedNodeInterface)
 	if !ok {
-		logger.ErrorWithContext(ctx, "Task execution node does not implement ExecutorBackedNodeInterface",
+		logger.Error(ctx, "Task execution node does not implement ExecutorBackedNodeInterface",
 			log.String("nodeID", node.GetID()))
 		return &serviceerror.InternalServerError
 	}
@@ -319,19 +319,19 @@ func (fe *flowEngine) setNodeExecutor(
 		return nil
 	}
 
-	logger.DebugWithContext(ctx, "Executor not set for the node. Constructing executor.",
+	logger.Debug(ctx, "Executor not set for the node. Constructing executor.",
 		log.String("nodeID", node.GetID()))
 
 	executorName := executableNode.GetExecutorName()
 	if executorName == "" {
-		logger.ErrorWithContext(ctx, "Executor name not configured for executable node",
+		logger.Error(ctx, "Executor name not configured for executable node",
 			log.String("nodeID", node.GetID()))
 		return &serviceerror.InternalServerError
 	}
 
 	executor, err := fe.getExecutorByName(executorName)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Error constructing executor for node", log.String("nodeID", node.GetID()),
+		logger.Error(ctx, "Error constructing executor for node", log.String("nodeID", node.GetID()),
 			log.String("executorName", executorName), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
@@ -521,7 +521,7 @@ func (fe *flowEngine) processNodeResponse(ctx *EngineContext, nodeResp *common.N
 	flowStep *FlowStep, logger *log.Logger) (
 	core.NodeInterface, bool, *serviceerror.ServiceError) {
 	if nodeResp.Status == "" {
-		logger.ErrorWithContext(ctx.Context, "Node response status not found in the flow graph")
+		logger.Error(ctx.Context, "Node response status not found in the flow graph")
 		return nil, false, &serviceerror.InternalServerError
 	}
 
@@ -553,7 +553,7 @@ func (fe *flowEngine) processNodeResponse(ctx *EngineContext, nodeResp *common.N
 		flowStep.Error = nodeResp.Error
 		return nil, false, nil
 	default:
-		logger.ErrorWithContext(ctx.Context, "Unsupported response status returned from the node",
+		logger.Error(ctx.Context, "Unsupported response status returned from the node",
 			log.String("status", string(nodeResp.Status)))
 		return nil, false, &serviceerror.InternalServerError
 	}
@@ -576,7 +576,7 @@ func (fe *flowEngine) handleDisplayOnlyPromptResponse(ctx *EngineContext,
 
 	nextNode, exists := ctx.Graph.GetNode(nextNodeID)
 	if !exists || nextNode == nil {
-		logger.ErrorWithContext(ctx.Context, "Display-only prompt references unknown next node",
+		logger.Error(ctx.Context, "Display-only prompt references unknown next node",
 			log.String("nextNodeID", nextNodeID))
 		return nil, continueExecution, &serviceerror.InternalServerError
 	}
@@ -626,7 +626,7 @@ func (fe *flowEngine) handleCompletedResponse(ctx *EngineContext,
 	core.NodeInterface, *serviceerror.ServiceError) {
 	nextNode, err := fe.resolveToNextNode(ctx, nodeResp)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Error moving to the next node", log.Error(err))
+		logger.Error(ctx.Context, "Error moving to the next node", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	ctx.CurrentNode = nextNode
@@ -642,19 +642,19 @@ func (fe *flowEngine) handleIncompleteResponse(ctx *EngineContext, nodeResp *com
 	case common.NodeResponseTypeRedirection:
 		err := fe.resolveStepForRedirection(ctx, nodeResp, flowStep)
 		if err != nil {
-			logger.ErrorWithContext(ctx.Context, "Error while resolving step for redirection", log.Error(err))
+			logger.Error(ctx.Context, "Error while resolving step for redirection", log.Error(err))
 			return &serviceerror.InternalServerError
 		}
 		return nil
 	case common.NodeResponseTypeView:
 		err := fe.resolveStepDetailsForPrompt(ctx, nodeResp, flowStep)
 		if err != nil {
-			logger.ErrorWithContext(ctx.Context, "Error while resolving step details for prompt", log.Error(err))
+			logger.Error(ctx.Context, "Error while resolving step details for prompt", log.Error(err))
 			return &serviceerror.InternalServerError
 		}
 		return nil
 	default:
-		logger.ErrorWithContext(ctx.Context, "Unsupported response type returned from the node",
+		logger.Error(ctx.Context, "Unsupported response type returned from the node",
 			log.String("responseType", string(nodeResp.Type)))
 		return &serviceerror.InternalServerError
 	}
@@ -669,13 +669,13 @@ func (fe *flowEngine) handleForwardResponse(ctx *EngineContext,
 	if nodeResp.Error != nil {
 		errorMsg = nodeResp.Error.Error.DefaultValue
 	}
-	logger.DebugWithContext(ctx.Context, "Forwarding to next node",
+	logger.Debug(ctx.Context, "Forwarding to next node",
 		log.String("nextNodeID", nodeResp.NextNodeID),
 		log.String("error", errorMsg))
 
 	nextNode, err := fe.resolveToNextNode(ctx, nodeResp)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Error resolving to next node", log.Error(err))
+		logger.Error(ctx.Context, "Error resolving to next node", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	ctx.CurrentNode = nextNode
@@ -690,12 +690,12 @@ func (fe *flowEngine) skipToNextNode(ctx *EngineContext, currentNode core.NodeIn
 
 	// Condition must specify where to skip to
 	if condition == nil || condition.OnSkip == "" {
-		logger.ErrorWithContext(ctx.Context, "Node has condition but onSkip is not specified",
+		logger.Error(ctx.Context, "Node has condition but onSkip is not specified",
 			log.String("nodeID", currentNode.GetID()))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx.Context, "Using condition's onSkip for skipped node",
+	logger.Debug(ctx.Context, "Using condition's onSkip for skipped node",
 		log.String("nodeID", currentNode.GetID()), log.String("onSkip", condition.OnSkip))
 
 	nodeResp := &common.NodeResponse{NextNodeID: condition.OnSkip}
@@ -703,7 +703,7 @@ func (fe *flowEngine) skipToNextNode(ctx *EngineContext, currentNode core.NodeIn
 	// Resolve to the next node
 	nextNode, err := fe.resolveToNextNode(ctx, nodeResp)
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Error moving to the next node after skipping", log.Error(err))
+		logger.Error(ctx.Context, "Error moving to the next node after skipping", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	ctx.CurrentNode = nextNode
@@ -716,7 +716,7 @@ func (fe *flowEngine) resolveToNextNode(engineCtx *EngineContext, nodeResp *comm
 	logger := fe.logger.With(log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 	graph := engineCtx.Graph
 	if nodeResp == nil || nodeResp.NextNodeID == "" {
-		logger.DebugWithContext(engineCtx.Context, "No next node ID in response. Returning nil.")
+		logger.Debug(engineCtx.Context, "No next node ID in response. Returning nil.")
 		return nil, nil
 	}
 
@@ -725,7 +725,7 @@ func (fe *flowEngine) resolveToNextNode(engineCtx *EngineContext, nodeResp *comm
 		return nil, errors.New("next node not found in the graph")
 	}
 
-	logger.DebugWithContext(engineCtx.Context, "Moving to next node", log.String("nextNodeID", nextNode.GetID()))
+	logger.Debug(engineCtx.Context, "Moving to next node", log.String("nextNodeID", nextNode.GetID()))
 	return nextNode, nil
 }
 
@@ -846,7 +846,7 @@ func (fe *flowEngine) validateSegmentResumePolicy(ctx *EngineContext, logger *lo
 		return false
 	}
 
-	logger.DebugWithContext(ctx.Context,
+	logger.Debug(ctx.Context,
 		"Segment restart allowed; skipping challenge token validation for segment resume",
 		log.String("segmentID", seg.ID), log.String("segmentStartNodeID", seg.StartNodeID))
 
@@ -862,27 +862,27 @@ func (fe *flowEngine) validateChallengeToken(
 	logger := fe.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 
 	if ctx.ChallengeTokenHash == "" {
-		logger.DebugWithContext(ctx.Context, "Challenge token hash is empty in the context; skipping validation")
+		logger.Debug(ctx.Context, "Challenge token hash is empty in the context; skipping validation")
 		return nil
 	}
 	if currentNode != nil {
 		policy := currentNode.GetExecutionPolicy()
 		if policy != nil && policy.SkipChallengeValidation {
-			logger.DebugWithContext(ctx.Context,
+			logger.Debug(ctx.Context,
 				"Current node's execution policy set to skip challenge token validation; skipping")
 			return nil
 		}
 	} else {
-		logger.DebugWithContext(ctx.Context,
+		logger.Debug(ctx.Context,
 			"Current node is nil while validating challenge token; enforcing validation")
 	}
 
 	if ctx.ChallengeTokenIn == "" {
-		logger.DebugWithContext(ctx.Context, "Challenge token is empty in the request")
+		logger.Debug(ctx.Context, "Challenge token is empty in the request")
 		return &ErrorInvalidChallengeToken
 	}
 	if !cryptolib.ValidateTokenHash(ctx.ChallengeTokenIn, ctx.ChallengeTokenHash) {
-		logger.DebugWithContext(ctx.Context, "Invalid challenge token provided in the request")
+		logger.Debug(ctx.Context, "Invalid challenge token provided in the request")
 		return &ErrorInvalidChallengeToken
 	}
 
@@ -897,7 +897,7 @@ func (fe *flowEngine) rotateChallengeToken(ctx *EngineContext, flowStep *FlowSte
 
 	newToken, err := cryptolib.GenerateSecureToken()
 	if err != nil {
-		logger.ErrorWithContext(ctx.Context, "Failed to generate new challenge token", log.Error(err))
+		logger.Error(ctx.Context, "Failed to generate new challenge token", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/flow/flowexec/handler.go
+++ b/backend/internal/flow/flowexec/handler.go
@@ -86,7 +86,7 @@ func (h *flowExecutionHandler) HandleFlowExecutionRequest(w http.ResponseWriter,
 
 	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, flowResp)
 
-	logger.DebugWithContext(r.Context(), "Flow execution request handled successfully",
+	logger.Debug(r.Context(), "Flow execution request handled successfully",
 		log.String(log.LoggerKeyExecutionID, flowResp.ExecutionID))
 }
 

--- a/backend/internal/flow/flowexec/redis_store.go
+++ b/backend/internal/flow/flowexec/redis_store.go
@@ -83,7 +83,7 @@ func (s *redisFlowStore) StoreFlowContext(ctx context.Context, dbModel FlowConte
 		return fmt.Errorf("failed to store flow context in Redis: %w", err)
 	}
 
-	logger.DebugWithContext(ctx, "Stored flow context in Redis", log.String("executionID", dbModel.ExecutionID))
+	logger.Debug(ctx, "Stored flow context in Redis", log.String("executionID", dbModel.ExecutionID))
 	return nil
 }
 

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -106,7 +106,7 @@ func (s *flowExecService) Execute(ctx context.Context,
 	if isNewFlow(executionID) {
 		engineCtx, loadErr = s.loadNewContext(ctx, appID, flowType, verbose, action, inputs, logger)
 		if loadErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to load new flow context",
+			logger.Error(ctx, "Failed to load new flow context",
 				log.String("appID", appID),
 				log.String("flowType", flowType),
 				log.String("error", loadErr.Error.DefaultValue))
@@ -129,7 +129,7 @@ func (s *flowExecService) Execute(ctx context.Context,
 	} else {
 		engineCtx, loadErr = s.loadPrevContext(ctx, executionID, action, inputs, logger)
 		if loadErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to load previous flow context",
+			logger.Error(ctx, "Failed to load previous flow context",
 				log.String(log.LoggerKeyExecutionID, executionID),
 				log.String("error", loadErr.Error.DefaultValue))
 			return nil, loadErr
@@ -146,7 +146,7 @@ func (s *flowExecService) Execute(ctx context.Context,
 	if flowErr != nil {
 		if !isNewFlow(executionID) && flowErr.Code != ErrorInvalidChallengeToken.Code {
 			if removeErr := s.removeContext(ctx, engineCtx.ExecutionID, logger); removeErr != nil {
-				logger.ErrorWithContext(ctx, "Failed to remove flow context after engine failure",
+				logger.Error(ctx, "Failed to remove flow context after engine failure",
 					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(removeErr))
 				return nil, &serviceerror.InternalServerError
 			}
@@ -157,7 +157,7 @@ func (s *flowExecService) Execute(ctx context.Context,
 	if isComplete(flowStep) {
 		if !isNewFlow(executionID) {
 			if removeErr := s.removeContext(ctx, engineCtx.ExecutionID, logger); removeErr != nil {
-				logger.ErrorWithContext(ctx, "Failed to remove flow context after completion",
+				logger.Error(ctx, "Failed to remove flow context after completion",
 					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(removeErr))
 				return nil, &serviceerror.InternalServerError
 			}
@@ -165,13 +165,13 @@ func (s *flowExecService) Execute(ctx context.Context,
 	} else {
 		if isNewFlow(executionID) {
 			if storeErr := s.storeContext(ctx, engineCtx, 0, logger); storeErr != nil {
-				logger.ErrorWithContext(ctx, "Failed to store initial flow context",
+				logger.Error(ctx, "Failed to store initial flow context",
 					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(storeErr))
 				return nil, &serviceerror.InternalServerError
 			}
 		} else {
 			if updateErr := s.updateContext(ctx, engineCtx, &flowStep, logger); updateErr != nil {
-				logger.ErrorWithContext(ctx, "Failed to update flow context",
+				logger.Error(ctx, "Failed to update flow context",
 					log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID), log.Error(updateErr))
 				return nil, &serviceerror.InternalServerError
 			}
@@ -210,14 +210,14 @@ func (s *flowExecService) initContext(ctx context.Context, appID string, flowTyp
 	engineCtx := EngineContext{}
 	executionID, err := sysutils.GenerateUUIDv7()
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+		logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	engineCtx.ExecutionID = executionID
 
 	graph, svcErr := s.flowMgtService.GetGraph(ctx, graphID)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Error retrieving flow graph from flow management service",
+		logger.Error(ctx, "Error retrieving flow graph from flow management service",
 			log.String("graphID", graphID), log.String("error", svcErr.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -279,21 +279,21 @@ func (s *flowExecService) loadContextFromStore(ctx context.Context, executionID 
 
 	graphID, err := dbModel.GetGraphID(ctx)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to extract graph ID from flow context",
+		logger.Error(ctx, "Failed to extract graph ID from flow context",
 			log.String(log.LoggerKeyExecutionID, executionID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	graph, svcErr := s.flowMgtService.GetGraph(ctx, graphID)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Error retrieving flow graph from flow management service",
+		logger.Error(ctx, "Error retrieving flow graph from flow management service",
 			log.String("graphID", graphID), log.String("error", svcErr.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	engineContext, err := dbModel.ToEngineContext(ctx, graph)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to convert flow context from database format",
+		logger.Error(ctx, "Failed to convert flow context from database format",
 			log.String(log.LoggerKeyExecutionID, executionID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -335,7 +335,7 @@ func (s *flowExecService) buildFlowApplication(
 		if errors.Is(err, inboundclient.ErrInboundClientNotFound) {
 			return nil, &ErrorInvalidAppID
 		}
-		logger.ErrorWithContext(ctx, "Server error while retrieving inbound client",
+		logger.Error(ctx, "Server error while retrieving inbound client",
 			log.String("appID", appID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -345,7 +345,7 @@ func (s *flowExecService) buildFlowApplication(
 
 	entity, epErr := s.entityProvider.GetEntity(appID)
 	if epErr != nil && epErr.Code != entityprovider.ErrorCodeEntityNotFound {
-		logger.ErrorWithContext(ctx, "Failed to retrieve entity for flow context",
+		logger.Error(ctx, "Failed to retrieve entity for flow context",
 			log.String("appID", appID), log.Error(epErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -407,7 +407,7 @@ func (s *flowExecService) removeContext(ctx context.Context, executionID string,
 		return fmt.Errorf("failed to remove flow context from database: %w", txErr)
 	}
 
-	logger.DebugWithContext(ctx, "Flow context removed successfully from database",
+	logger.Debug(ctx, "Flow context removed successfully from database",
 		log.String(log.LoggerKeyExecutionID, executionID))
 	return nil
 }
@@ -418,7 +418,7 @@ func (s *flowExecService) updateContext(ctx context.Context, engineCtx *EngineCo
 	if flowStep.Status == common.FlowStatusComplete {
 		return s.removeContext(ctx, engineCtx.ExecutionID, logger)
 	} else {
-		logger.DebugWithContext(ctx, "Flow execution is incomplete, updating the flow context",
+		logger.Debug(ctx, "Flow execution is incomplete, updating the flow context",
 			log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 
 		if engineCtx.ExecutionID == "" {
@@ -437,7 +437,7 @@ func (s *flowExecService) updateContext(ctx context.Context, engineCtx *EngineCo
 			return fmt.Errorf("failed to update flow context in database: %w", txErr)
 		}
 
-		logger.DebugWithContext(ctx, "Flow context updated successfully in database",
+		logger.Debug(ctx, "Flow context updated successfully in database",
 			log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 		return nil
 	}
@@ -466,7 +466,7 @@ func (s *flowExecService) storeContext(ctx context.Context, engineCtx *EngineCon
 		return fmt.Errorf("failed to store flow context in database: %w", txErr)
 	}
 
-	logger.DebugWithContext(ctx, "Flow context stored successfully in database",
+	logger.Debug(ctx, "Flow context stored successfully in database",
 		log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 	return nil
 }
@@ -505,7 +505,7 @@ func (s *flowExecService) getFlowGraph(ctx context.Context, appID string, flowTy
 		if errors.Is(err, inboundclient.ErrInboundClientNotFound) {
 			return "", &ErrorInvalidAppID
 		}
-		logger.ErrorWithContext(ctx, "Server error while retrieving inbound client",
+		logger.Error(ctx, "Server error while retrieving inbound client",
 			log.String("appID", appID), log.Error(err))
 		return "", &serviceerror.InternalServerError
 	}
@@ -517,7 +517,7 @@ func (s *flowExecService) getFlowGraph(ctx context.Context, appID string, flowTy
 		if !client.IsRegistrationFlowEnabled {
 			return "", &ErrorRegistrationFlowDisabled
 		} else if client.RegistrationFlowID == "" {
-			logger.ErrorWithContext(ctx, "Registration flow is not configured for the entity",
+			logger.Error(ctx, "Registration flow is not configured for the entity",
 				log.String("appID", appID))
 			return "", &serviceerror.InternalServerError
 		}
@@ -528,7 +528,7 @@ func (s *flowExecService) getFlowGraph(ctx context.Context, appID string, flowTy
 		if !client.IsRecoveryFlowEnabled {
 			return "", &ErrorRecoveryFlowDisabled
 		} else if client.RecoveryFlowID == "" {
-			logger.ErrorWithContext(ctx, "Recovery flow is not configured for the application",
+			logger.Error(ctx, "Recovery flow is not configured for the application",
 				log.String("appID", appID))
 			return "", &serviceerror.InternalServerError
 		}
@@ -537,7 +537,7 @@ func (s *flowExecService) getFlowGraph(ctx context.Context, appID string, flowTy
 
 	// Default to authentication flow ID
 	if client.AuthFlowID == "" {
-		logger.ErrorWithContext(ctx, "Authentication flow is not configured for the entity",
+		logger.Error(ctx, "Authentication flow is not configured for the entity",
 			log.String("appID", appID))
 		return "", &serviceerror.InternalServerError
 	}
@@ -574,7 +574,7 @@ func (s *flowExecService) getSystemFlowGraph(ctx context.Context, flowType commo
 
 	flow, err := s.flowMgtService.GetFlowByHandle(ctx, handle, flowType)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get system flow by handle",
+		logger.Error(ctx, "Failed to get system flow by handle",
 			log.String("handle", handle), log.String("flowType", string(flowType)))
 		return "", err
 	}
@@ -631,7 +631,7 @@ func (s *flowExecService) InitiateFlow(ctx context.Context,
 	// This uses verbose true to ensure step layouts are returned during execution
 	engineCtx, err := s.initContext(ctx, initContext.ApplicationID, flowType, true, logger)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to initialize flow context",
+		logger.Error(ctx, "Failed to initialize flow context",
 			log.String("appID", initContext.ApplicationID),
 			log.String("flowType", initContext.FlowType),
 			log.String("error", err.Error.DefaultValue))
@@ -643,13 +643,13 @@ func (s *flowExecService) InitiateFlow(ctx context.Context,
 
 	// Store the context without executing the flow
 	if storeErr := s.storeContext(ctx, engineCtx, 0, logger); storeErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to store initial flow context",
+		logger.Error(ctx, "Failed to store initial flow context",
 			log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID),
 			log.Error(storeErr))
 		return "", &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Flow initiated successfully",
+	logger.Debug(ctx, "Flow initiated successfully",
 		log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID))
 	return engineCtx.ExecutionID, nil
 }
@@ -680,7 +680,7 @@ func (s *flowExecService) InitiateAndExecute(ctx context.Context,
 
 	engineCtx, err := s.initContext(ctx, initContext.ApplicationID, flowType, true, logger)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to initialize flow context",
+		logger.Error(ctx, "Failed to initialize flow context",
 			log.String("appID", initContext.ApplicationID),
 			log.String("flowType", initContext.FlowType),
 			log.String("error", err.Error.DefaultValue))
@@ -692,7 +692,7 @@ func (s *flowExecService) InitiateAndExecute(ctx context.Context,
 
 	flowStep, flowErr := s.flowEngine.Execute(engineCtx)
 	if flowErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to execute flow",
+		logger.Error(ctx, "Failed to execute flow",
 			log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID),
 			log.String("error", flowErr.Error.DefaultValue))
 		return nil, flowErr
@@ -700,7 +700,7 @@ func (s *flowExecService) InitiateAndExecute(ctx context.Context,
 
 	if flowStep.Status == common.FlowStatusIncomplete {
 		if storeErr := s.storeContext(ctx, engineCtx, initContext.ExpirySeconds, logger); storeErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to store flow context after execution",
+			logger.Error(ctx, "Failed to store flow context after execution",
 				log.String(log.LoggerKeyExecutionID, engineCtx.ExecutionID),
 				log.Error(storeErr))
 			return nil, &serviceerror.InternalServerError
@@ -719,7 +719,7 @@ func (s *flowExecService) getFlowContext(ctx context.Context, executionID string
 
 	dbModel, err := s.flowStore.GetFlowContext(ctx, executionID)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Error retrieving flow context from store",
+		logger.Error(ctx, "Error retrieving flow context from store",
 			log.String(log.LoggerKeyExecutionID, executionID),
 			log.String("error", err.Error()))
 		return nil, &serviceerror.InternalServerError
@@ -733,7 +733,7 @@ func (s *flowExecService) getFlowContext(ctx context.Context, executionID string
 		decryptParams := cryptolib.AlgorithmParams{Algorithm: cryptolib.AlgorithmAESGCM}
 		decrypted, decryptErr := s.cryptoSvc.Decrypt(ctx, nil, decryptParams, []byte(dbModel.Context))
 		if decryptErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to decrypt flow context",
+			logger.Error(ctx, "Failed to decrypt flow context",
 				log.String(log.LoggerKeyExecutionID, executionID), log.Error(decryptErr))
 			return nil, &serviceerror.InternalServerError
 		}

--- a/backend/internal/flow/flowmeta/handler.go
+++ b/backend/internal/flow/flowmeta/handler.go
@@ -87,7 +87,7 @@ func (h *flowMetaHandler) HandleGetFlowMetadata(w http.ResponseWriter, r *http.R
 
 	// Return success response
 	sysutils.WriteSuccessResponse(r.Context(), w, http.StatusOK, metadata)
-	h.logger.DebugWithContext(r.Context(), "Flow metadata retrieved successfully",
+	h.logger.Debug(r.Context(), "Flow metadata retrieved successfully",
 		log.String("type", metaType),
 		log.String("id", id))
 }

--- a/backend/internal/flow/flowmeta/service.go
+++ b/backend/internal/flow/flowmeta/service.go
@@ -122,7 +122,7 @@ func (fms *flowMetaService) GetFlowMetadata(
 	fms.populateDesignMetadata(ctx, metaType, id, ouID, response)
 	fms.populateI18nMetadata(ctx, response, lang, ns)
 
-	fms.logger.DebugWithContext(ctx, "Successfully retrieved flow metadata",
+	fms.logger.Debug(ctx, "Successfully retrieved flow metadata",
 		log.String("type", string(metaType)),
 		log.String("id", id))
 
@@ -173,7 +173,7 @@ func (fms *flowMetaService) populateTypeMetadata(
 		if errors.Is(err, inboundclient.ErrInboundClientNotFound) {
 			return "", &ErrorApplicationNotFound
 		}
-		fms.logger.ErrorWithContext(ctx, "Failed to get inbound client", log.String("appID", id), log.Error(err))
+		fms.logger.Error(ctx, "Failed to get inbound client", log.String("appID", id), log.Error(err))
 		return "", &ErrorApplicationFetchFailed
 	}
 	if client == nil {
@@ -182,7 +182,7 @@ func (fms *flowMetaService) populateTypeMetadata(
 
 	entity, epErr := fms.entityProvider.GetEntity(id)
 	if epErr != nil && epErr.Code != entityprovider.ErrorCodeEntityNotFound {
-		fms.logger.ErrorWithContext(ctx, "Failed to get entity", log.String("appID", id), log.Error(epErr))
+		fms.logger.Error(ctx, "Failed to get entity", log.String("appID", id), log.Error(epErr))
 		return "", &ErrorApplicationFetchFailed
 	}
 
@@ -196,7 +196,7 @@ func (fms *flowMetaService) populateTypeMetadata(
 			return "", &ErrorOUNotFound
 		}
 
-		fms.logger.ErrorWithContext(ctx, "Failed to get root organization unit",
+		fms.logger.Error(ctx, "Failed to get root organization unit",
 			log.String("error", ouErr.Error.DefaultValue),
 			log.String("code", ouErr.Code))
 		return "", &ErrorOUFetchFailed
@@ -224,7 +224,7 @@ func (fms *flowMetaService) populateOUMetadata(
 			return &ErrorOUNotFound
 		}
 
-		fms.logger.ErrorWithContext(ctx, "Failed to get organization unit",
+		fms.logger.Error(ctx, "Failed to get organization unit",
 			log.String("ouID", ouID),
 			log.String("error", svcErr.Error.DefaultValue),
 			log.String("code", svcErr.Code))
@@ -261,7 +261,7 @@ func (fms *flowMetaService) populateDesignMetadata(
 
 	designResp, svcErr := fms.designResolve.ResolveDesign(ctx, designType, designID)
 	if svcErr != nil {
-		fms.logger.DebugWithContext(ctx, "Failed to get design configuration",
+		fms.logger.Debug(ctx, "Failed to get design configuration",
 			log.String("type", string(designType)),
 			log.String("id", designID),
 			log.String("error", svcErr.Error.DefaultValue))
@@ -284,7 +284,7 @@ func (fms *flowMetaService) populateI18nMetadata(
 	ctx context.Context, response *FlowMetadataResponse, lang string, ns string) {
 	i18nResp, i18nErr := fms.i18nService.ResolveTranslations(ctx, lang, ns)
 	if i18nErr != nil {
-		fms.logger.DebugWithContext(ctx, "Failed to get i18n translations",
+		fms.logger.Debug(ctx, "Failed to get i18n translations",
 			log.String("language", lang),
 			log.String("namespace", ns),
 			log.String("error", i18nErr.Error.DefaultValue))
@@ -296,7 +296,7 @@ func (fms *flowMetaService) populateI18nMetadata(
 
 	languages, i18nErr := fms.i18nService.ListLanguages(ctx)
 	if i18nErr != nil {
-		fms.logger.DebugWithContext(ctx, "Failed to list languages",
+		fms.logger.Debug(ctx, "Failed to list languages",
 			log.String("error", i18nErr.Error.DefaultValue))
 		response.I18n.Languages = []string{i18nmgt.SystemLanguage}
 		return

--- a/backend/internal/flow/mgt/cache_backed_store.go
+++ b/backend/internal/flow/mgt/cache_backed_store.go
@@ -205,9 +205,9 @@ func (s *cacheBackedFlowStore) cacheFlow(ctx context.Context, flow *CompleteFlow
 			Key: flow.ID,
 		}
 		if err := s.flowByIDCache.Set(ctx, cacheKey, flow); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to cache flow by ID", log.Error(err))
+			logger.Error(ctx, "Failed to cache flow by ID", log.Error(err))
 		} else {
-			logger.DebugWithContext(ctx, "Flow cached by ID")
+			logger.Debug(ctx, "Flow cached by ID")
 		}
 	}
 
@@ -215,10 +215,10 @@ func (s *cacheBackedFlowStore) cacheFlow(ctx context.Context, flow *CompleteFlow
 	if flow.Handle != "" && flow.FlowType != "" {
 		handleCacheKey := getFlowByHandleCacheKey(flow.Handle, flow.FlowType)
 		if err := s.flowByHandleCache.Set(ctx, handleCacheKey, flow); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to cache flow by handle", log.String("handle", flow.Handle),
+			logger.Error(ctx, "Failed to cache flow by handle", log.String("handle", flow.Handle),
 				log.String("flowType", string(flow.FlowType)), log.Error(err))
 		} else {
-			logger.DebugWithContext(ctx, "Flow cached by handle",
+			logger.Debug(ctx, "Flow cached by handle",
 				log.String("handle", flow.Handle), log.String("flowType", string(flow.FlowType)))
 		}
 	}
@@ -233,9 +233,9 @@ func (s *cacheBackedFlowStore) invalidateFlowCache(ctx context.Context, flowID s
 			Key: flowID,
 		}
 		if err := s.flowByIDCache.Delete(ctx, cacheKey); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to invalidate flow cache by ID", log.Error(err))
+			logger.Error(ctx, "Failed to invalidate flow cache by ID", log.Error(err))
 		} else {
-			logger.DebugWithContext(ctx, "Flow cache invalidated by ID")
+			logger.Debug(ctx, "Flow cache invalidated by ID")
 		}
 	}
 }
@@ -249,7 +249,7 @@ func (s *cacheBackedFlowStore) invalidateFlowCacheByHandle(
 
 	cacheKey := getFlowByHandleCacheKey(handle, flowType)
 	if err := s.flowByHandleCache.Delete(ctx, cacheKey); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to invalidate flow cache by handle",
+		s.logger.Error(ctx, "Failed to invalidate flow cache by handle",
 			log.String("handle", handle), log.String("flowType", string(flowType)), log.Error(err))
 	}
 }

--- a/backend/internal/flow/mgt/graph_builder.go
+++ b/backend/internal/flow/mgt/graph_builder.go
@@ -72,13 +72,13 @@ func (b *graphBuilder) GetGraph(ctx context.Context, flow *CompleteFlowDefinitio
 	logger := b.logger.With(log.String("flowID", flow.ID))
 	// Check cache first
 	if cachedGraph, ok := b.graphCache.Get(ctx, flow.ID); ok {
-		logger.DebugWithContext(ctx, "Graph retrieved from cache")
+		logger.Debug(ctx, "Graph retrieved from cache")
 		return cachedGraph, nil
 	}
 
 	graph, err := b.buildGraph(ctx, flow)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to build graph", log.Error(err))
+		logger.Error(ctx, "Failed to build graph", log.Error(err))
 		return nil, serviceerror.CustomServiceError(ErrorGraphBuildFailure, i18ncore.I18nMessage{
 			Key:          "error.flowmgtservice.graph_build_failure_description",
 			DefaultValue: err.Error(),
@@ -87,9 +87,9 @@ func (b *graphBuilder) GetGraph(ctx context.Context, flow *CompleteFlowDefinitio
 
 	// Cache the built graph
 	if cacheErr := b.graphCache.Set(ctx, flow.ID, graph); cacheErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to cache graph", log.Error(cacheErr))
+		logger.Error(ctx, "Failed to cache graph", log.Error(cacheErr))
 	}
-	logger.DebugWithContext(ctx, "Graph built and cached successfully")
+	logger.Debug(ctx, "Graph built and cached successfully")
 
 	return graph, nil
 }
@@ -101,10 +101,10 @@ func (b *graphBuilder) InvalidateCache(ctx context.Context, flowID string) {
 	}
 
 	if err := b.graphCache.Invalidate(ctx, flowID); err != nil {
-		b.logger.ErrorWithContext(ctx, "Failed to delete graph from cache",
+		b.logger.Error(ctx, "Failed to delete graph from cache",
 			log.String("flowID", flowID), log.Error(err))
 	}
-	b.logger.DebugWithContext(ctx, "Graph cache invalidated", log.String("flowID", flowID))
+	b.logger.Debug(ctx, "Graph cache invalidated", log.String("flowID", flowID))
 }
 
 // buildGraph converts a CompleteFlowDefinition to a core.GraphInterface for execution.
@@ -266,12 +266,12 @@ func (b *graphBuilder) configureNodeInputs(ctx context.Context, nodeDef *NodeDef
 
 	executorNode, ok := node.(core.ExecutorBackedNodeInterface)
 	if !ok {
-		logger.DebugWithContext(ctx, "Node is not executor-backed; skipping input configuration")
+		logger.Debug(ctx, "Node is not executor-backed; skipping input configuration")
 		return
 	}
 
 	if nodeDef.Executor == nil || len(nodeDef.Executor.Inputs) == 0 {
-		logger.DebugWithContext(ctx, "No inputs defined for executor; setting empty input list")
+		logger.Debug(ctx, "No inputs defined for executor; setting empty input list")
 		executorNode.SetInputs([]common.Input{})
 		return
 	}
@@ -347,13 +347,13 @@ func (b *graphBuilder) configureNodePrompts(ctx context.Context, nodeDef *NodeDe
 	logger := b.logger.With(log.String("nodeID", nodeDef.ID))
 
 	if len(nodeDef.Prompts) == 0 {
-		logger.DebugWithContext(ctx, "No prompts to configure for this node")
+		logger.Debug(ctx, "No prompts to configure for this node")
 		return nil
 	}
 
 	promptNode, ok := node.(core.PromptNodeInterface)
 	if !ok {
-		logger.DebugWithContext(ctx, "Node is not a prompt node; skipping prompt configuration")
+		logger.Debug(ctx, "Node is not a prompt node; skipping prompt configuration")
 		return nil
 	}
 
@@ -420,7 +420,7 @@ func (b *graphBuilder) configureDisplayOnlyProperties(
 			nodeDef.ID)
 	}
 
-	logger.DebugWithContext(ctx, "Configuring display-only next for prompt node", log.String("next", nodeDef.Next))
+	logger.Debug(ctx, "Configuring display-only next for prompt node", log.String("next", nodeDef.Next))
 	promptNode.SetNextNode(nodeDef.Next)
 
 	if nodeDef.Message != "" {
@@ -475,13 +475,13 @@ func (b *graphBuilder) configureNodeExecutor(
 	logger := b.logger.With(log.String("nodeID", nodeDef.ID))
 
 	if nodeDef.Executor == nil {
-		logger.DebugWithContext(ctx, "No executor to configure for this node")
+		logger.Debug(ctx, "No executor to configure for this node")
 		return nil
 	}
 
 	executableNode, ok := node.(core.ExecutorBackedNodeInterface)
 	if !ok {
-		logger.DebugWithContext(ctx, "Node does not support executors; skipping executor configuration")
+		logger.Debug(ctx, "Node does not support executors; skipping executor configuration")
 		return nil
 	}
 

--- a/backend/internal/flow/mgt/handler.go
+++ b/backend/internal/flow/mgt/handler.go
@@ -83,7 +83,7 @@ func (h *flowMgtHandler) listFlows(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteSuccessResponse(ctx, w, http.StatusOK, flowList)
-	h.logger.DebugWithContext(ctx, "Flows listed successfully", log.Int(logKeyCount, flowList.Count))
+	h.logger.Debug(ctx, "Flows listed successfully", log.Int(logKeyCount, flowList.Count))
 }
 
 // createFlow handles POST requests to create a new flow definition.
@@ -103,7 +103,7 @@ func (h *flowMgtHandler) createFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdFlow)
-	h.logger.DebugWithContext(ctx, "Flow created successfully", log.String(logKeyFlowID, createdFlow.ID))
+	h.logger.Debug(ctx, "Flow created successfully", log.String(logKeyFlowID, createdFlow.ID))
 }
 
 // getFlow handles GET requests to retrieve a flow definition by its ID.
@@ -122,7 +122,7 @@ func (h *flowMgtHandler) getFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteSuccessResponse(ctx, w, http.StatusOK, flow)
-	h.logger.DebugWithContext(ctx, "Flow retrieved successfully", log.String(logKeyFlowID, flowID))
+	h.logger.Debug(ctx, "Flow retrieved successfully", log.String(logKeyFlowID, flowID))
 }
 
 // updateFlow handles PUT requests to update an existing flow definition.
@@ -148,7 +148,7 @@ func (h *flowMgtHandler) updateFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteSuccessResponse(ctx, w, http.StatusOK, updatedFlow)
-	h.logger.DebugWithContext(ctx, "Flow updated successfully", log.String(logKeyFlowID, flowID))
+	h.logger.Debug(ctx, "Flow updated successfully", log.String(logKeyFlowID, flowID))
 }
 
 // deleteFlow handles DELETE requests to remove a flow definition by its ID.
@@ -167,7 +167,7 @@ func (h *flowMgtHandler) deleteFlow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	h.logger.DebugWithContext(ctx, "Flow deleted successfully", log.String(logKeyFlowID, flowID))
+	h.logger.Debug(ctx, "Flow deleted successfully", log.String(logKeyFlowID, flowID))
 }
 
 // Flow version management HTTP handler methods
@@ -188,7 +188,7 @@ func (h *flowMgtHandler) listFlowVersions(w http.ResponseWriter, r *http.Request
 	}
 
 	utils.WriteSuccessResponse(ctx, w, http.StatusOK, versionList)
-	h.logger.DebugWithContext(ctx, "Flow versions listed successfully", log.String(logKeyFlowID, flowID))
+	h.logger.Debug(ctx, "Flow versions listed successfully", log.String(logKeyFlowID, flowID))
 }
 
 // getFlowVersion handles GET requests to retrieve a specific version of a flow definition.
@@ -215,7 +215,7 @@ func (h *flowMgtHandler) getFlowVersion(w http.ResponseWriter, r *http.Request) 
 	}
 
 	utils.WriteSuccessResponse(ctx, w, http.StatusOK, flowVersion)
-	h.logger.DebugWithContext(ctx, "Flow version retrieved successfully",
+	h.logger.Debug(ctx, "Flow version retrieved successfully",
 		log.String(logKeyFlowID, flowID), log.Int(logKeyVersion, version))
 }
 
@@ -241,7 +241,7 @@ func (h *flowMgtHandler) restoreFlowVersion(w http.ResponseWriter, r *http.Reque
 	}
 
 	utils.WriteSuccessResponse(ctx, w, http.StatusOK, flow)
-	h.logger.DebugWithContext(ctx, "Flow version restored successfully",
+	h.logger.Debug(ctx, "Flow version restored successfully",
 		log.String(logKeyFlowID, flowID), log.Int(logKeyVersion, request.Version))
 }
 
@@ -311,7 +311,7 @@ func handleError(ctx context.Context, w http.ResponseWriter, svcErr *serviceerro
 		statusCode = http.StatusConflict
 	case serviceerror.InternalServerError.Code:
 		statusCode = http.StatusInternalServerError
-		log.GetLogger().ErrorWithContext(ctx, "Internal server error in flow handler",
+		log.GetLogger().Error(ctx, "Internal server error in flow handler",
 			log.String("code", svcErr.Code),
 			log.String("error", svcErr.Error.DefaultValue),
 			log.String("description", svcErr.ErrorDescription.DefaultValue))

--- a/backend/internal/flow/mgt/inference.go
+++ b/backend/internal/flow/mgt/inference.go
@@ -49,7 +49,7 @@ func newFlowInferenceService() flowInferenceServiceInterface {
 // InferRegistrationFlow creates a registration flow definition from an authentication flow
 func (s *flowInferenceService) InferRegistrationFlow(
 	ctx context.Context, authFlow *FlowDefinition) (*FlowDefinition, error) {
-	s.logger.DebugWithContext(ctx, "Inferring registration flow from authentication flow",
+	s.logger.Debug(ctx, "Inferring registration flow from authentication flow",
 		log.String("authFlowName", authFlow.Name))
 
 	regFlowName := s.generateRegistrationFlowName(authFlow.Name)
@@ -67,9 +67,9 @@ func (s *flowInferenceService) InferRegistrationFlow(
 		if err := s.insertProvisioningNode(ctx, &regNodes, hasLayout); err != nil {
 			return nil, err
 		}
-		s.logger.DebugWithContext(ctx, "Inserted provisioning node into registration flow")
+		s.logger.Debug(ctx, "Inserted provisioning node into registration flow")
 	} else {
-		s.logger.DebugWithContext(ctx, "Provisioning node already exists, skipping insertion")
+		s.logger.Debug(ctx, "Provisioning node already exists, skipping insertion")
 	}
 
 	startNodeID, err := s.findStartNode(regNodes)
@@ -89,9 +89,9 @@ func (s *flowInferenceService) InferRegistrationFlow(
 		// Append the prompt node to the flow
 		regNodes = append(regNodes, userTypePromptNode)
 
-		s.logger.DebugWithContext(ctx, "Inserted user type resolver node with prompt into registration flow")
+		s.logger.Debug(ctx, "Inserted user type resolver node with prompt into registration flow")
 	} else {
-		s.logger.DebugWithContext(ctx, "User type resolver node already exists, skipping insertion")
+		s.logger.Debug(ctx, "User type resolver node already exists, skipping insertion")
 	}
 
 	// Insert phone input prompt if SMS OTP send nodes are present
@@ -312,14 +312,14 @@ func (s *flowInferenceService) insertProvisioningNode(
 	var targetNodeID string
 	if hasAuthAssert {
 		targetNodeID = authAssertNodeID
-		s.logger.DebugWithContext(ctx, "Found AuthAssertExecutor, inserting provisioning node before it")
+		s.logger.Debug(ctx, "Found AuthAssertExecutor, inserting provisioning node before it")
 	} else {
 		endNodeID, err := s.findEndNode(*nodes)
 		if err != nil {
 			return err
 		}
 		targetNodeID = endNodeID
-		s.logger.DebugWithContext(ctx, "No AuthAssertExecutor found, inserting provisioning node before END")
+		s.logger.Debug(ctx, "No AuthAssertExecutor found, inserting provisioning node before END")
 	}
 
 	provisioningNode := s.createProvisioningNode(targetNodeID, includeLayout)
@@ -565,7 +565,7 @@ func (s *flowInferenceService) insertPhoneInputPromptIfNeeded(
 
 	// If phone input already collected by an existing prompt, no need to insert another prompt
 	if hasPhoneInputPrompt {
-		s.logger.DebugWithContext(ctx, "Phone input already collected in the flow, skipping insertion")
+		s.logger.Debug(ctx, "Phone input already collected in the flow, skipping insertion")
 		return
 	}
 
@@ -586,12 +586,12 @@ func (s *flowInferenceService) insertPhoneInputPromptIfNeeded(
 
 	err := s.insertNodeBefore(nodes, phonePromptNode, smsSendNodeID)
 	if err != nil {
-		s.logger.WarnWithContext(ctx, "Failed to insert phone input prompt before SMS send node",
+		s.logger.Warn(ctx, "Failed to insert phone input prompt before SMS send node",
 			log.String("nodeID", smsSendNodeID), log.Error(err))
 		return
 	}
 
-	s.logger.DebugWithContext(ctx, "Inserted phone input prompt before SMS send node",
+	s.logger.Debug(ctx, "Inserted phone input prompt before SMS send node",
 		log.String("smsNodeID", smsSendNodeID))
 }
 

--- a/backend/internal/flow/mgt/service.go
+++ b/backend/internal/flow/mgt/service.go
@@ -121,7 +121,7 @@ func (s *flowMgtService) ListFlows(ctx context.Context, limit, offset int, flowT
 
 	flows, totalCount, err := s.store.ListFlows(ctx, limit, offset, string(flowType))
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to list flows", log.Error(err))
+		s.logger.Error(ctx, "Failed to list flows", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -147,7 +147,7 @@ func (s *flowMgtService) CreateFlow(ctx context.Context, flowDef *FlowDefinition
 	if flowID == "" {
 		generated, genErr := utils.GenerateUUIDv7()
 		if genErr != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to generate UUID v7", log.Error(genErr))
+			s.logger.Error(ctx, "Failed to generate UUID v7", log.Error(genErr))
 			return nil, &serviceerror.InternalServerError
 		}
 		flowID = generated
@@ -184,11 +184,11 @@ func (s *flowMgtService) CreateFlow(ctx context.Context, flowDef *FlowDefinition
 		if errors.Is(txErr, errFlowHandleExists) {
 			return nil, &ErrorDuplicateFlowHandle
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to create flow", log.Error(txErr))
+		s.logger.Error(ctx, "Failed to create flow", log.Error(txErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	s.logger.DebugWithContext(ctx, "Flow created successfully", log.String(logKeyFlowID, flowID))
+	s.logger.Debug(ctx, "Flow created successfully", log.String(logKeyFlowID, flowID))
 
 	s.tryInferRegistrationFlow(ctx, flowID, flowDef)
 
@@ -207,7 +207,7 @@ func (s *flowMgtService) GetFlow(ctx context.Context, flowID string) (
 		if errors.Is(err, errFlowNotFound) {
 			return nil, &ErrorFlowNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to get flow", log.String(logKeyFlowID, flowID), log.Error(err))
+		s.logger.Error(ctx, "Failed to get flow", log.String(logKeyFlowID, flowID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -229,7 +229,7 @@ func (s *flowMgtService) GetFlowByHandle(ctx context.Context, handle string, flo
 		if errors.Is(err, errFlowNotFound) {
 			return nil, &ErrorFlowNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to get flow by handle", log.String("handle", handle),
+		s.logger.Error(ctx, "Failed to get flow by handle", log.String("handle", handle),
 			log.String("flowType", string(flowType)), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -286,11 +286,11 @@ func (s *flowMgtService) UpdateFlow(ctx context.Context, flowID string, flowDef 
 		if errors.Is(txErr, errFlowNotFound) {
 			return nil, &ErrorFlowNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to update flow", log.Error(txErr))
+		logger.Error(ctx, "Failed to update flow", log.Error(txErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Flow updated successfully")
+	logger.Debug(ctx, "Flow updated successfully")
 
 	// Invalidate the cached graph since the flow has been updated
 	s.graphBuilder.InvalidateCache(ctx, flowID)
@@ -312,7 +312,7 @@ func (s *flowMgtService) DeleteFlow(ctx context.Context, flowID string) *service
 			// Silently return if the flow does not exist
 			return nil
 		}
-		logger.ErrorWithContext(ctx, "Failed to get existing flow", log.Error(err))
+		logger.Error(ctx, "Failed to get existing flow", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -322,11 +322,11 @@ func (s *flowMgtService) DeleteFlow(ctx context.Context, flowID string) *service
 
 	err = s.store.DeleteFlow(ctx, flowID)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to delete flow", log.Error(err))
+		logger.Error(ctx, "Failed to delete flow", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Flow deleted successfully")
+	logger.Debug(ctx, "Flow deleted successfully")
 
 	// Invalidate the cached graph since the flow has been deleted
 	s.graphBuilder.InvalidateCache(ctx, flowID)
@@ -350,13 +350,13 @@ func (s *flowMgtService) ListFlowVersions(ctx context.Context, flowID string) (
 		if errors.Is(err, errFlowNotFound) {
 			return nil, &ErrorFlowNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get existing flow", log.Error(err))
+		logger.Error(ctx, "Failed to get existing flow", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	versions, err := s.store.ListFlowVersions(ctx, flowID)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to list flow versions", log.Error(err))
+		logger.Error(ctx, "Failed to list flow versions", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -386,7 +386,7 @@ func (s *flowMgtService) GetFlowVersion(ctx context.Context, flowID string, vers
 		if errors.Is(err, errVersionNotFound) {
 			return nil, &ErrorVersionNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to get flow version", log.String(logKeyFlowID, flowID),
+		s.logger.Error(ctx, "Failed to get flow version", log.String(logKeyFlowID, flowID),
 			log.Int(logKeyVersion, version), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -424,11 +424,11 @@ func (s *flowMgtService) RestoreFlowVersion(ctx context.Context, flowID string, 
 		if errors.Is(txErr, errVersionNotFound) {
 			return nil, &ErrorVersionNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to restore flow version", log.Error(txErr))
+		logger.Error(ctx, "Failed to restore flow version", log.Error(txErr))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Flow version restored successfully")
+	logger.Debug(ctx, "Flow version restored successfully")
 
 	// Invalidate the cached graph since a version has been restored
 	s.graphBuilder.InvalidateCache(ctx, flowID)
@@ -451,7 +451,7 @@ func (s *flowMgtService) GetGraph(ctx context.Context, flowID string) (
 		if errors.Is(err, errFlowNotFound) {
 			return nil, &ErrorFlowNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to get flow for graph building", log.String(logKeyFlowID, flowID),
+		s.logger.Error(ctx, "Failed to get flow for graph building", log.String(logKeyFlowID, flowID),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -581,12 +581,12 @@ func (s *flowMgtService) tryInferRegistrationFlow(ctx context.Context, authFlowI
 	logger := s.logger.With(log.String("authFlowID", authFlowID))
 
 	if !config.GetServerRuntime().Config.Flow.AutoInferRegistration {
-		logger.DebugWithContext(ctx, "Automatic registration flow inference is disabled")
+		logger.Debug(ctx, "Automatic registration flow inference is disabled")
 		return
 	}
 
 	if authFlowDef.FlowType != common.FlowTypeAuthentication {
-		logger.DebugWithContext(ctx, "Flow is not an authentication flow, skipping registration inference",
+		logger.Debug(ctx, "Flow is not an authentication flow, skipping registration inference",
 			log.String("flowType", string(authFlowDef.FlowType)))
 		return
 	}
@@ -594,33 +594,33 @@ func (s *flowMgtService) tryInferRegistrationFlow(ctx context.Context, authFlowI
 	// Check if auth flow already contains PasskeyAuthExecutor with registration modes
 	// If so, skip registration flow inference as the auth flow handles registration internally
 	if s.hasPasskeyRegistrationModes(authFlowDef) {
-		logger.DebugWithContext(ctx, "Authentication flow contains PasskeyAuthExecutor with "+
+		logger.Debug(ctx, "Authentication flow contains PasskeyAuthExecutor with "+
 			"register_start and register_finish modes, skipping registration inference")
 		return
 	}
 
-	logger.DebugWithContext(ctx, "Inferring registration flow from authentication flow",
+	logger.Debug(ctx, "Inferring registration flow from authentication flow",
 		log.String("flowName", authFlowDef.Name))
 
 	regFlowDef, inferErr := s.inferenceService.InferRegistrationFlow(ctx, authFlowDef)
 	if inferErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to infer registration flow", log.Error(inferErr))
+		logger.Error(ctx, "Failed to infer registration flow", log.Error(inferErr))
 		return
 	}
 
 	regFlowID, uuidErr := utils.GenerateUUIDv7()
 	if uuidErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to generate UUID for inferred registration flow", log.Error(uuidErr))
+		logger.Error(ctx, "Failed to generate UUID for inferred registration flow", log.Error(uuidErr))
 		return
 	}
 
 	_, storeErr := s.store.CreateFlow(ctx, regFlowID, regFlowDef)
 	if storeErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to create inferred registration flow", log.Error(storeErr))
+		logger.Error(ctx, "Failed to create inferred registration flow", log.Error(storeErr))
 		return
 	}
 
-	logger.DebugWithContext(ctx, "Successfully inferred and created registration flow",
+	logger.Debug(ctx, "Successfully inferred and created registration flow",
 		log.String("authFlowName", authFlowDef.Name), log.String("regFlowID", regFlowID),
 		log.String("regFlowName", regFlowDef.Name))
 }

--- a/backend/internal/group/declarative_resource.go
+++ b/backend/internal/group/declarative_resource.go
@@ -194,7 +194,7 @@ func loadDeclarativeResources(
 				return v.ID
 			}
 			// Declarative resource loading runs during startup, outside any request.
-			log.GetLogger().ErrorWithContext(context.Background(),
+			log.GetLogger().Error(context.Background(),
 				"IDExtractor: type assertion failed for groupDeclarativeResource")
 			return ""
 		},

--- a/backend/internal/group/file_based_store.go
+++ b/backend/internal/group/file_based_store.go
@@ -75,7 +75,7 @@ func (f *fileBasedGroupStore) GetGroupList(ctx context.Context, limit, offset in
 	for _, item := range list {
 		grpData, err := groupFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
-			log.GetLogger().WarnWithContext(ctx, "Skipping malformed group in GetGroupList",
+			log.GetLogger().Warn(ctx, "Skipping malformed group in GetGroupList",
 				log.String("groupID", item.ID.ID),
 				log.Error(err))
 			continue
@@ -447,7 +447,7 @@ func (f *fileBasedGroupStore) GetGroupsByIDs(ctx context.Context, groupIDs []str
 		}
 		grpData, err := groupFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
-			log.GetLogger().WarnWithContext(ctx, "Skipping malformed group in GetGroupsByIDs",
+			log.GetLogger().Warn(ctx, "Skipping malformed group in GetGroupsByIDs",
 				log.String("groupID", item.ID.ID),
 				log.Error(err))
 			continue

--- a/backend/internal/group/handler.go
+++ b/backend/internal/group/handler.go
@@ -68,7 +68,7 @@ func (gh *groupHandler) HandleGroupListRequest(w http.ResponseWriter, r *http.Re
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, groupListResponse)
 
-	logger.DebugWithContext(ctx, "Successfully listed groups with pagination",
+	logger.Debug(ctx, "Successfully listed groups with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", groupListResponse.TotalResults),
 		log.Int("count", groupListResponse.Count))
@@ -101,7 +101,7 @@ func (gh *groupHandler) HandleGroupListByPathRequest(w http.ResponseWriter, r *h
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, groupListResponse)
 
-	logger.DebugWithContext(ctx, "Successfully listed groups by path", log.String("path", path),
+	logger.Debug(ctx, "Successfully listed groups by path", log.String("path", path),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", groupListResponse.TotalResults),
 		log.Int("count", groupListResponse.Count))
@@ -135,7 +135,7 @@ func (gh *groupHandler) HandleGroupPostRequest(w http.ResponseWriter, r *http.Re
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdGroup)
 
-	logger.DebugWithContext(ctx, "Successfully created group", log.String("group id", createdGroup.ID))
+	logger.Debug(ctx, "Successfully created group", log.String("group id", createdGroup.ID))
 }
 
 // HandleGroupPostByPathRequest handles the create group by OU path request.
@@ -170,7 +170,7 @@ func (gh *groupHandler) HandleGroupPostByPathRequest(w http.ResponseWriter, r *h
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, group)
 
-	logger.DebugWithContext(ctx, "Successfully created group by path",
+	logger.Debug(ctx, "Successfully created group by path",
 		log.String("path", path), log.String("groupName", group.Name))
 }
 
@@ -201,7 +201,7 @@ func (gh *groupHandler) HandleGroupGetRequest(w http.ResponseWriter, r *http.Req
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, group)
 
-	logger.DebugWithContext(ctx, "Successfully retrieved group", log.String("group id", id))
+	logger.Debug(ctx, "Successfully retrieved group", log.String("group id", id))
 }
 
 // HandleGroupPutRequest handles the update group request.
@@ -244,7 +244,7 @@ func (gh *groupHandler) HandleGroupPutRequest(w http.ResponseWriter, r *http.Req
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, group)
 
-	logger.DebugWithContext(ctx, "Successfully updated group", log.String("group id", id))
+	logger.Debug(ctx, "Successfully updated group", log.String("group id", id))
 }
 
 // HandleGroupDeleteRequest handles the delete group request.
@@ -271,7 +271,7 @@ func (gh *groupHandler) HandleGroupDeleteRequest(w http.ResponseWriter, r *http.
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
-	logger.DebugWithContext(ctx, "Successfully deleted group", log.String("group id", id))
+	logger.Debug(ctx, "Successfully deleted group", log.String("group id", id))
 }
 
 // HandleGroupMembersGetRequest handles the get group members request.
@@ -307,7 +307,7 @@ func (gh *groupHandler) HandleGroupMembersGetRequest(w http.ResponseWriter, r *h
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, memberListResponse)
 
-	logger.DebugWithContext(ctx, "Successfully retrieved group members", log.String("group id", id),
+	logger.Debug(ctx, "Successfully retrieved group members", log.String("group id", id),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", memberListResponse.TotalResults),
 		log.Int("count", memberListResponse.Count))
@@ -341,7 +341,7 @@ func (gh *groupHandler) HandleGroupMembersAddRequest(w http.ResponseWriter, r *h
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, group)
-	logger.DebugWithContext(ctx, "Successfully added members to group", log.String("group id", id))
+	logger.Debug(ctx, "Successfully added members to group", log.String("group id", id))
 }
 
 // HandleGroupMembersRemoveRequest handles the remove members from group request.
@@ -372,7 +372,7 @@ func (gh *groupHandler) HandleGroupMembersRemoveRequest(w http.ResponseWriter, r
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, group)
-	logger.DebugWithContext(ctx, "Successfully removed members from group", log.String("group id", id))
+	logger.Debug(ctx, "Successfully removed members from group", log.String("group id", id))
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.

--- a/backend/internal/group/service.go
+++ b/backend/internal/group/service.go
@@ -115,13 +115,13 @@ func (gs *groupService) listAllGroups(ctx context.Context, limit, offset int, in
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	totalCount, err := gs.groupStore.GetGroupListCount(ctx)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get group count", log.Error(err))
+		logger.Error(ctx, "Failed to get group count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	groups, err := gs.groupStore.GetGroupList(ctx, limit, offset)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to list groups", log.Error(err))
+		logger.Error(ctx, "Failed to list groups", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -164,7 +164,7 @@ func (gs *groupService) listGroupsByOUIDs(ctx context.Context, ouIDs []string, l
 
 	totalCount, err := gs.groupStore.GetGroupListCountByOUIDs(ctx, ouIDs)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get group count by OU IDs", log.Error(err))
+		logger.Error(ctx, "Failed to get group count by OU IDs", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -180,7 +180,7 @@ func (gs *groupService) listGroupsByOUIDs(ctx context.Context, ouIDs []string, l
 
 	groups, err := gs.groupStore.GetGroupListByOUIDs(ctx, ouIDs, limit, offset)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to list groups by OU IDs", log.Error(err))
+		logger.Error(ctx, "Failed to list groups by OU IDs", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -209,7 +209,7 @@ func (gs *groupService) GetGroupsByPath(
 	ctx context.Context, handlePath string, limit, offset int, includeDisplay bool,
 ) (*GroupListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Getting groups by path", log.String("path", handlePath))
+	logger.Debug(ctx, "Getting groups by path", log.String("path", handlePath))
 
 	serviceError := gs.validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -235,13 +235,13 @@ func (gs *groupService) GetGroupsByPath(
 
 	totalCount, err := gs.groupStore.GetGroupsByOrganizationUnitCount(ctx, oUID)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get group count by organization unit", log.Error(err))
+		logger.Error(ctx, "Failed to get group count by organization unit", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	groups, err := gs.groupStore.GetGroupsByOrganizationUnit(ctx, oUID, limit, offset)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to list groups by organization unit", log.Error(err))
+		logger.Error(ctx, "Failed to list groups by organization unit", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -270,10 +270,10 @@ func (gs *groupService) GetGroupsByPath(
 func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequest) (
 	*Group, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Creating group", log.String("name", request.Name))
+	logger.Debug(ctx, "Creating group", log.String("name", request.Name))
 
 	if isGroupDeclarativeModeEnabled() {
-		logger.DebugWithContext(ctx, "Cannot create group in declarative-only mode")
+		logger.Debug(ctx, "Cannot create group in declarative-only mode")
 		return nil, &ErrorDeclarativeModeGroupCreateNotAllowed
 	}
 
@@ -315,7 +315,7 @@ func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequ
 		if err := gs.groupStore.CheckGroupNameConflictForCreate(
 			txCtx, request.Name, request.OUID); err != nil {
 			if errors.Is(err, ErrGroupNameConflict) {
-				logger.DebugWithContext(ctx, "Group name conflict detected", log.String("name", request.Name))
+				logger.Debug(ctx, "Group name conflict detected", log.String("name", request.Name))
 				capturedSvcErr = &ErrorGroupNameConflict
 				return errors.New("rollback for group name conflict")
 			}
@@ -353,7 +353,7 @@ func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequ
 	}
 
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create group", log.Error(err), log.String("name", request.Name))
+		logger.Error(ctx, "Failed to create group", log.Error(err), log.String("name", request.Name))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -364,7 +364,7 @@ func (gs *groupService) CreateGroup(ctx context.Context, request CreateGroupRequ
 	}
 	createdGroup.Members = resolvedMembers
 
-	logger.DebugWithContext(ctx, "Successfully created group",
+	logger.Debug(ctx, "Successfully created group",
 		log.String("id", createdGroup.ID), log.String("name", createdGroup.Name))
 	return createdGroup, nil
 }
@@ -374,7 +374,7 @@ func (gs *groupService) CreateGroupByPath(
 	ctx context.Context, handlePath string, request CreateGroupByPathRequest,
 ) (*Group, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Creating group by path",
+	logger.Debug(ctx, "Creating group by path",
 		log.String("path", handlePath), log.String("name", request.Name))
 
 	serviceError := gs.validateAndProcessHandlePath(handlePath)
@@ -406,7 +406,7 @@ func (gs *groupService) GetGroup(
 	ctx context.Context, groupID string, includeDisplay bool,
 ) (*Group, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Retrieving group", log.String("id", groupID))
+	logger.Debug(ctx, "Retrieving group", log.String("id", groupID))
 
 	if groupID == "" {
 		return nil, &ErrorMissingGroupID
@@ -415,10 +415,10 @@ func (gs *groupService) GetGroup(
 	groupDAO, err := gs.groupStore.GetGroup(ctx, groupID)
 	if err != nil {
 		if errors.Is(err, ErrGroupNotFound) {
-			logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
+			logger.Debug(ctx, "Group not found", log.String("id", groupID))
 			return nil, &ErrorGroupNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to retrieve group", log.String("id", groupID), log.Error(err))
+		logger.Error(ctx, "Failed to retrieve group", log.String("id", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -438,14 +438,14 @@ func (gs *groupService) GetGroup(
 		handleMap, svcErr := gs.ouService.GetOrganizationUnitHandlesByIDs(
 			ctx, []string{group.OUID})
 		if svcErr != nil {
-			logger.WarnWithContext(ctx, "Failed to resolve OU handle for group, skipping",
+			logger.Warn(ctx, "Failed to resolve OU handle for group, skipping",
 				log.String("id", groupID), log.Any("error", svcErr))
 		} else if handle, ok := handleMap[group.OUID]; ok {
 			group.OUHandle = handle
 		}
 	}
 
-	logger.DebugWithContext(ctx, "Successfully retrieved group",
+	logger.Debug(ctx, "Successfully retrieved group",
 		log.String("id", group.ID), log.String("name", group.Name))
 	return &group, nil
 }
@@ -454,7 +454,7 @@ func (gs *groupService) GetGroup(
 func (gs *groupService) UpdateGroup(
 	ctx context.Context, groupID string, request UpdateGroupRequest) (*Group, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Updating group", log.String("id", groupID), log.String("name", request.Name))
+	logger.Debug(ctx, "Updating group", log.String("id", groupID), log.String("name", request.Name))
 
 	if groupID == "" {
 		return nil, &ErrorMissingGroupID
@@ -465,11 +465,11 @@ func (gs *groupService) UpdateGroup(
 	}
 
 	if isDeclarative, err := gs.groupStore.IsGroupDeclarative(ctx, groupID); err != nil {
-		logger.WarnWithContext(ctx, "Failed to check if group is declarative",
+		logger.Warn(ctx, "Failed to check if group is declarative",
 			log.String("groupID", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	} else if isDeclarative {
-		logger.DebugWithContext(ctx, "Cannot update declarative group", log.String("id", groupID))
+		logger.Debug(ctx, "Cannot update declarative group", log.String("id", groupID))
 		return nil, &ErrorImmutableGroup
 	}
 
@@ -480,7 +480,7 @@ func (gs *groupService) UpdateGroup(
 		existingGroupDAO, err := gs.groupStore.GetGroup(txCtx, groupID)
 		if err != nil {
 			if errors.Is(err, ErrGroupNotFound) {
-				logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
+				logger.Debug(ctx, "Group not found", log.String("id", groupID))
 				capturedSvcErr = &ErrorGroupNotFound
 				return errors.New("rollback for group not found")
 			}
@@ -525,7 +525,7 @@ func (gs *groupService) UpdateGroup(
 				txCtx, request.Name, request.OUID, groupID)
 			if err != nil {
 				if errors.Is(err, ErrGroupNameConflict) {
-					logger.DebugWithContext(ctx, "Group name conflict detected during update",
+					logger.Debug(ctx, "Group name conflict detected during update",
 						log.String("name", request.Name))
 					capturedSvcErr = &ErrorGroupNameConflict
 					return errors.New("rollback for group name conflict")
@@ -555,11 +555,11 @@ func (gs *groupService) UpdateGroup(
 	}
 
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to update group", log.Error(err), log.String("groupID", groupID))
+		logger.Error(ctx, "Failed to update group", log.Error(err), log.String("groupID", groupID))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully updated group",
+	logger.Debug(ctx, "Successfully updated group",
 		log.String("id", groupID), log.String("name", request.Name))
 	return updatedGroup, nil
 }
@@ -567,18 +567,18 @@ func (gs *groupService) UpdateGroup(
 // DeleteGroup delete the specified group by its id.
 func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Deleting group", log.String("id", groupID))
+	logger.Debug(ctx, "Deleting group", log.String("id", groupID))
 
 	if groupID == "" {
 		return &ErrorMissingGroupID
 	}
 
 	if isDeclarative, err := gs.groupStore.IsGroupDeclarative(ctx, groupID); err != nil {
-		logger.WarnWithContext(ctx, "Failed to check if group is declarative",
+		logger.Warn(ctx, "Failed to check if group is declarative",
 			log.String("groupID", groupID), log.Error(err))
 		return &serviceerror.InternalServerError
 	} else if isDeclarative {
-		logger.DebugWithContext(ctx, "Cannot delete declarative group", log.String("id", groupID))
+		logger.Debug(ctx, "Cannot delete declarative group", log.String("id", groupID))
 		return &ErrorImmutableGroup
 	}
 
@@ -588,7 +588,7 @@ func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *servic
 		existingGroupDAO, err := gs.groupStore.GetGroup(txCtx, groupID)
 		if err != nil {
 			if errors.Is(err, ErrGroupNotFound) {
-				logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
+				logger.Debug(ctx, "Group not found", log.String("id", groupID))
 				capturedSvcErr = &ErrorGroupNotFound
 				return errors.New("rollback for group not found")
 			}
@@ -616,11 +616,11 @@ func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *servic
 	}
 
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to delete group", log.Error(err), log.String("groupID", groupID))
+		logger.Error(ctx, "Failed to delete group", log.Error(err), log.String("groupID", groupID))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully deleted group", log.String("id", groupID))
+	logger.Debug(ctx, "Successfully deleted group", log.String("id", groupID))
 	return nil
 }
 
@@ -640,10 +640,10 @@ func (gs *groupService) GetGroupMembers(ctx context.Context, groupID string, lim
 	existingGroupDAO, err := gs.groupStore.GetGroup(ctx, groupID)
 	if err != nil {
 		if errors.Is(err, ErrGroupNotFound) {
-			logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
+			logger.Debug(ctx, "Group not found", log.String("id", groupID))
 			return nil, &ErrorGroupNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to retrieve group", log.String("id", groupID), log.Error(err))
+		logger.Error(ctx, "Failed to retrieve group", log.String("id", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -658,13 +658,13 @@ func (gs *groupService) GetGroupMembers(ctx context.Context, groupID string, lim
 
 	totalCount, err := gs.groupStore.GetGroupMemberCount(ctx, groupID)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get group member count", log.String("groupID", groupID), log.Error(err))
+		logger.Error(ctx, "Failed to get group member count", log.String("groupID", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	members, err := gs.groupStore.GetGroupMembers(ctx, groupID, limit, offset)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get group members", log.String("groupID", groupID), log.Error(err))
+		logger.Error(ctx, "Failed to get group members", log.String("groupID", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -714,7 +714,7 @@ func (gs *groupService) resolveMembers(
 	if len(entityIDs) > 0 {
 		entities, err := gs.entityService.GetEntitiesByIDs(ctx, entityIDs)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to batch-fetch entities for member resolution", log.Error(err))
+			logger.Error(ctx, "Failed to batch-fetch entities for member resolution", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		entityMap = make(map[string]*entity.Entity, len(entities))
@@ -738,7 +738,7 @@ func (gs *groupService) resolveMembers(
 		var svcErr *serviceerror.ServiceError
 		groupsMap, svcErr = gs.GetGroupsByIDs(ctx, groupIDs)
 		if svcErr != nil {
-			logger.WarnWithContext(ctx, "Failed to batch-fetch groups for display resolution", log.Any("error", svcErr))
+			logger.Warn(ctx, "Failed to batch-fetch groups for display resolution", log.Any("error", svcErr))
 		}
 	}
 
@@ -750,7 +750,7 @@ func (gs *groupService) resolveMembers(
 		case memberTypeEntity:
 			e, ok := entityMap[members[i].ID]
 			if !ok {
-				logger.WarnWithContext(ctx, "Skipping orphaned entity member", log.String("id", members[i].ID))
+				logger.Warn(ctx, "Skipping orphaned entity member", log.String("id", members[i].ID))
 				continue
 			}
 			// Set the public type from the entity category ("user", "app", or "agent").
@@ -785,7 +785,7 @@ func (gs *groupService) resolveMembers(
 func (gs *groupService) AddGroupMembers(
 	ctx context.Context, groupID string, members []Member) (*Group, *serviceerror.ServiceError) {
 	log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)).
-		DebugWithContext(ctx, "Adding members to group", log.String("id", groupID))
+		Debug(ctx, "Adding members to group", log.String("id", groupID))
 	return gs.modifyGroupMembers(ctx, groupID, members,
 		gs.groupStore.AddGroupMembers,
 		"Failed to add members to group",
@@ -797,7 +797,7 @@ func (gs *groupService) AddGroupMembers(
 func (gs *groupService) RemoveGroupMembers(
 	ctx context.Context, groupID string, members []Member) (*Group, *serviceerror.ServiceError) {
 	log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)).
-		DebugWithContext(ctx, "Removing members from group", log.String("id", groupID))
+		Debug(ctx, "Removing members from group", log.String("id", groupID))
 	return gs.modifyGroupMembers(ctx, groupID, members,
 		gs.groupStore.RemoveGroupMembers,
 		"Failed to remove members from group",
@@ -831,10 +831,10 @@ func (gs *groupService) modifyGroupMembers(
 	existingGroup, err := gs.groupStore.GetGroup(ctx, groupID)
 	if err != nil {
 		if errors.Is(err, ErrGroupNotFound) {
-			logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
+			logger.Debug(ctx, "Group not found", log.String("id", groupID))
 			return nil, &ErrorGroupNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to fetch group", log.String("id", groupID), log.Error(err))
+		logger.Error(ctx, "Failed to fetch group", log.String("id", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -867,7 +867,7 @@ func (gs *groupService) modifyGroupMembers(
 		existingGroupDAO, err := gs.groupStore.GetGroup(txCtx, groupID)
 		if err != nil {
 			if errors.Is(err, ErrGroupNotFound) {
-				logger.DebugWithContext(ctx, "Group not found", log.String("id", groupID))
+				logger.Debug(ctx, "Group not found", log.String("id", groupID))
 				capturedSvcErr = &ErrorGroupNotFound
 				return errors.New("rollback for group not found")
 			}
@@ -902,7 +902,7 @@ func (gs *groupService) modifyGroupMembers(
 	}
 
 	if err != nil {
-		logger.ErrorWithContext(ctx, errMsg, log.String("id", groupID), log.Error(err))
+		logger.Error(ctx, errMsg, log.String("id", groupID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -912,7 +912,7 @@ func (gs *groupService) modifyGroupMembers(
 		return nil, svcErr
 	}
 	updatedGroup.Members = resolvedMembers
-	logger.DebugWithContext(ctx, successMsg, log.String("id", groupID))
+	logger.Debug(ctx, successMsg, log.String("id", groupID))
 	return &updatedGroup, nil
 }
 
@@ -984,7 +984,7 @@ func (gs *groupService) validateEntityMembers(
 
 	entities, err := gs.entityService.GetEntitiesByIDs(ctx, entityIDs)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to fetch entities for member validation", log.Error(err))
+		logger.Error(ctx, "Failed to fetch entities for member validation", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -997,7 +997,7 @@ func (gs *groupService) validateEntityMembers(
 		claimed := typeByID[e.ID]
 		actual := MemberType(e.Category)
 		if claimed != actual {
-			logger.DebugWithContext(ctx, "Member type mismatch", log.String("id", e.ID),
+			logger.Debug(ctx, "Member type mismatch", log.String("id", e.ID),
 				log.String("claimed", string(claimed)), log.String("actual", string(actual)))
 			return &ErrorInvalidMemberID
 		}
@@ -1021,12 +1021,12 @@ func (gs *groupService) validateEntityMembers(
 
 	outOfScopeIDs, err := gs.entityService.ValidateEntityIDsInOUs(ctx, userIDs, accessibleOUs.IDs)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to validate user IDs in OUs", log.Error(err))
+		logger.Error(ctx, "Failed to validate user IDs in OUs", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
 	if len(outOfScopeIDs) > 0 {
-		logger.DebugWithContext(ctx, "User IDs outside accessible OUs",
+		logger.Debug(ctx, "User IDs outside accessible OUs",
 			log.MaskedStrings("outOfScopeIDs", outOfScopeIDs))
 		return &serviceerror.ErrorUnauthorized
 	}
@@ -1058,7 +1058,7 @@ func (gs *groupService) validateOU(ctx context.Context, ouID string) *serviceerr
 
 	isExists, err := gs.ouService.IsOrganizationUnitExists(ctx, ouID)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check organization unit existence", log.Any("error: ", err))
+		logger.Error(ctx, "Failed to check organization unit existence", log.Any("error: ", err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -1087,7 +1087,7 @@ func resolveDisplayAttributePaths(
 	displayPaths, svcErr := schemaService.GetDisplayAttributesByNames(ctx, entitytype.TypeCategoryUser, uniqueTypes)
 	if svcErr != nil {
 		if logger != nil {
-			logger.WarnWithContext(ctx, "Failed to resolve display attribute paths, skipping display resolution",
+			logger.Warn(ctx, "Failed to resolve display attribute paths, skipping display resolution",
 				log.Any("error", svcErr))
 		}
 		return nil
@@ -1116,12 +1116,12 @@ func (gs *groupService) ValidateGroupIDs(ctx context.Context, groupIDs []string)
 
 	invalidGroupIDs, err := gs.groupStore.ValidateGroupIDs(ctx, groupIDs)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to validate group IDs", log.Error(err))
+		logger.Error(ctx, "Failed to validate group IDs", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
 	if len(invalidGroupIDs) > 0 {
-		logger.DebugWithContext(ctx, "Invalid group IDs found", log.Any("invalidGroupIDs", invalidGroupIDs))
+		logger.Debug(ctx, "Invalid group IDs found", log.Any("invalidGroupIDs", invalidGroupIDs))
 		return &ErrorInvalidGroupMemberID
 	}
 
@@ -1150,7 +1150,7 @@ func (gs *groupService) GetGroupsByIDs(
 
 	groupDAOs, err := gs.groupStore.GetGroupsByIDs(ctx, uniqueIDs)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get groups by IDs", log.Error(err))
+		logger.Error(ctx, "Failed to get groups by IDs", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1204,7 +1204,7 @@ func (gs *groupService) populateGroupOUHandles(ctx context.Context, groups []Gro
 
 	handleMap, svcErr := gs.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
 	if svcErr != nil {
-		logger.WarnWithContext(ctx, "Failed to resolve OU handles for groups, skipping", log.Any("error", svcErr))
+		logger.Warn(ctx, "Failed to resolve OU handles for groups, skipping", log.Any("error", svcErr))
 		return
 	}
 
@@ -1260,7 +1260,7 @@ func (gs *groupService) checkGroupAccess(
 
 	hasAccess, err := gs.authzService.IsActionAllowed(ctx, action, &actionCtx)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check authorization", log.String("err", err.Error.DefaultValue))
+		logger.Error(ctx, "Failed to check authorization", log.String("err", err.Error.DefaultValue))
 		return &serviceerror.InternalServerError
 	}
 	if !hasAccess {

--- a/backend/internal/group/service_test.go
+++ b/backend/internal/group/service_test.go
@@ -2530,3 +2530,227 @@ func TestUpdateGroupMembers_OUValidationFailure(t *testing.T) {
 	require.NotNil(t, svcErr)
 	require.Equal(t, serviceerror.InternalServerError.Code, svcErr.Code)
 }
+
+func newScopedListAuthz(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+	authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+	authzMock.On("GetAccessibleResources", mock.Anything, security.ActionListGroups, security.ResourceTypeOU).
+		Return(&sysauthz.AccessibleResources{AllAllowed: false, IDs: []string{testOUID1}},
+			(*serviceerror.ServiceError)(nil))
+	return authzMock
+}
+
+func TestListGroupsByOUIDs_CountError(t *testing.T) {
+	storeMock := newGroupStoreInterfaceMock(t)
+	storeMock.On("GetGroupListCountByOUIDs", mock.Anything, []string{testOUID1}).
+		Return(0, errors.New("count fail")).Once()
+
+	service := &groupService{
+		authzService: newScopedListAuthz(t),
+		groupStore:   storeMock,
+	}
+
+	response, err := service.GetGroupList(context.Background(), 5, 0, false)
+	require.Nil(t, response)
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+func TestListGroupsByOUIDs_ListError(t *testing.T) {
+	storeMock := newGroupStoreInterfaceMock(t)
+	storeMock.On("GetGroupListCountByOUIDs", mock.Anything, []string{testOUID1}).
+		Return(2, nil).Once()
+	storeMock.On("GetGroupListByOUIDs", mock.Anything, []string{testOUID1}, 5, 0).
+		Return(nil, errors.New("list fail")).Once()
+
+	service := &groupService{
+		authzService: newScopedListAuthz(t),
+		groupStore:   storeMock,
+	}
+
+	response, err := service.GetGroupList(context.Background(), 5, 0, false)
+	require.Nil(t, response)
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+func TestUpdateGroup_IsDeclarativeError(t *testing.T) {
+	storeMock := newGroupStoreInterfaceMock(t)
+	storeMock.On("IsGroupDeclarative", mock.Anything, "grp-001").
+		Return(false, errors.New("declarative check fail")).Once()
+
+	service := &groupService{
+		authzService:  newAllowAllAuthz(t),
+		groupStore:    storeMock,
+		transactioner: &stubTransactioner{},
+	}
+
+	group, err := service.UpdateGroup(context.Background(), "grp-001",
+		UpdateGroupRequest{Name: "name", OUID: "ou"})
+	require.Nil(t, group)
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+func TestDeleteGroup_IsDeclarativeError(t *testing.T) {
+	storeMock := newGroupStoreInterfaceMock(t)
+	storeMock.On("IsGroupDeclarative", mock.Anything, "grp-001").
+		Return(false, errors.New("declarative check fail")).Once()
+
+	service := &groupService{
+		authzService:  newAllowAllAuthz(t),
+		groupStore:    storeMock,
+		transactioner: &stubTransactioner{},
+	}
+
+	err := service.DeleteGroup(context.Background(), "grp-001")
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+func TestResolveMembers_GetGroupsByIDsError(t *testing.T) {
+	storeMock := newGroupStoreInterfaceMock(t)
+	storeMock.On("GetGroupsByIDs", mock.Anything, []string{"group-1"}).
+		Return(nil, errors.New("groups fetch fail")).Once()
+
+	service := &groupService{
+		groupStore: storeMock,
+	}
+	logger := log.GetLogger()
+
+	members := []Member{{ID: "group-1", Type: MemberTypeGroup}}
+	resolved, svcErr := service.resolveMembers(context.Background(), members, true, logger)
+	require.Nil(t, svcErr)
+	require.Len(t, resolved, 1)
+	require.Equal(t, "group-1", resolved[0].Display)
+}
+
+func TestResolveMembers_OrphanedEntityMember(t *testing.T) {
+	entitySvcMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entitySvcMock.On("GetEntitiesByIDs", mock.Anything, []string{"user-1"}).
+		Return([]entity.Entity{}, nil).Once()
+
+	service := &groupService{
+		entityService: entitySvcMock,
+	}
+	logger := log.GetLogger()
+
+	members := []Member{{ID: "user-1", Type: memberTypeEntity}}
+	resolved, svcErr := service.resolveMembers(context.Background(), members, false, logger)
+	require.Nil(t, svcErr)
+	require.Empty(t, resolved)
+}
+
+func TestModifyGroupMembers_GetGroupError(t *testing.T) {
+	storeMock := newGroupStoreInterfaceMock(t)
+	storeMock.On("GetGroup", mock.Anything, "grp-001").
+		Return(GroupDAO{}, errors.New("db error")).Once()
+
+	service := &groupService{
+		authzService:  newAllowAllAuthz(t),
+		groupStore:    storeMock,
+		transactioner: &stubTransactioner{},
+	}
+
+	group, err := service.AddGroupMembers(context.Background(), "grp-001",
+		[]Member{{ID: "usr-001", Type: MemberTypeUser}})
+	require.Nil(t, group)
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+func TestModifyGroupMembers_InnerGroupNotFound(t *testing.T) {
+	storeMock := newGroupStoreInterfaceMock(t)
+	entitySvcMock := entitymock.NewEntityServiceInterfaceMock(t)
+
+	storeMock.On("GetGroup", mock.Anything, "grp-001").
+		Return(GroupDAO{ID: "grp-001"}, nil).Once()
+	entitySvcMock.On("GetEntitiesByIDs", mock.Anything, []string{"usr-001"}).
+		Return([]entity.Entity{{ID: "usr-001", Category: entity.EntityCategoryUser}}, nil).Once()
+	storeMock.On("GetGroup", mock.Anything, "grp-001").
+		Return(GroupDAO{}, ErrGroupNotFound).Once()
+
+	service := &groupService{
+		authzService:  newAllowAllAuthz(t),
+		groupStore:    storeMock,
+		entityService: entitySvcMock,
+		transactioner: &stubTransactioner{},
+	}
+
+	group, err := service.AddGroupMembers(context.Background(), "grp-001",
+		[]Member{{ID: "usr-001", Type: MemberTypeUser}})
+	require.Nil(t, group)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorGroupNotFound.Code, err.Code)
+}
+
+func TestValidateEntityMembers_GetEntitiesError(t *testing.T) {
+	entitySvcMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entitySvcMock.On("GetEntitiesByIDs", mock.Anything, []string{"usr-001"}).
+		Return(nil, errors.New("entity fetch fail")).Once()
+
+	service := &groupService{
+		authzService:  newAllowAllAuthz(t),
+		entityService: entitySvcMock,
+	}
+
+	err := service.validateEntityMembers(context.Background(),
+		[]Member{{ID: "usr-001", Type: MemberTypeUser}}, security.ActionCreateGroup)
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+func TestValidateEntityMembers_TypeMismatch(t *testing.T) {
+	entitySvcMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entitySvcMock.On("GetEntitiesByIDs", mock.Anything, []string{"usr-001"}).
+		Return([]entity.Entity{{ID: "usr-001", Category: entity.EntityCategoryApp}}, nil).Once()
+
+	service := &groupService{
+		authzService:  newAllowAllAuthz(t),
+		entityService: entitySvcMock,
+	}
+
+	err := service.validateEntityMembers(context.Background(),
+		[]Member{{ID: "usr-001", Type: MemberTypeUser}}, security.ActionCreateGroup)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorInvalidMemberID.Code, err.Code)
+}
+
+func TestGetGroupsByIDs_StoreError(t *testing.T) {
+	storeMock := newGroupStoreInterfaceMock(t)
+	storeMock.On("GetGroupsByIDs", mock.Anything, []string{"grp-001"}).
+		Return(nil, errors.New("store fail")).Once()
+
+	service := &groupService{
+		groupStore: storeMock,
+	}
+
+	result, err := service.GetGroupsByIDs(context.Background(), []string{"grp-001"})
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+func TestPopulateGroupOUHandles_ServiceError(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("GetOrganizationUnitHandlesByIDs", mock.Anything, []string{testOUID1}).
+		Return((map[string]string)(nil), &serviceerror.ServiceError{Code: "OU-5000"}).Once()
+
+	service := &groupService{
+		ouService: ouServiceMock,
+	}
+	logger := log.GetLogger()
+
+	groups := []GroupBasic{{ID: "g1", OUID: testOUID1}}
+	service.populateGroupOUHandles(context.Background(), groups, logger)
+	require.Empty(t, groups[0].OUHandle)
+}
+
+func TestCheckGroupAccess_AuthzError(t *testing.T) {
+	service := &groupService{
+		authzService: newAuthzError(t),
+	}
+
+	err := service.checkGroupAccess(context.Background(), security.ActionReadGroup, testOUID1, "grp-001")
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}

--- a/backend/internal/group/store.go
+++ b/backend/internal/group/store.go
@@ -349,7 +349,7 @@ func (s *groupStore) DeleteGroup(ctx context.Context, id string) error {
 	}
 
 	if result == 0 {
-		logger.DebugWithContext(ctx, "Group not found with id: "+id)
+		logger.Debug(ctx, "Group not found with id: "+id)
 	}
 
 	return nil

--- a/backend/internal/idp/cache_backed_store.go
+++ b/backend/internal/idp/cache_backed_store.go
@@ -169,7 +169,7 @@ func (s *cacheBackedIDPStore) cacheIDP(ctx context.Context, idp *IDPDTO) {
 
 	idKey := cache.CacheKey{Key: idp.ID}
 	if err := s.idpByIDCache.Set(ctx, idKey, idp); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to cache IDP by ID", log.Error(err), log.String("idpID", idp.ID))
+		logger.Error(ctx, "Failed to cache IDP by ID", log.Error(err), log.String("idpID", idp.ID))
 	}
 }
 
@@ -182,7 +182,7 @@ func (s *cacheBackedIDPStore) invalidateIDP(ctx context.Context, idp *IDPDTO) {
 	if idp.ID != "" {
 		idKey := cache.CacheKey{Key: idp.ID}
 		if err := s.idpByIDCache.Delete(ctx, idKey); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to invalidate IDP cache by ID",
+			logger.Error(ctx, "Failed to invalidate IDP cache by ID",
 				log.Error(err), log.String("idpID", idp.ID))
 		}
 	}
@@ -196,7 +196,7 @@ func (s *cacheBackedIDPStore) invalidateIDP(ctx context.Context, idp *IDPDTO) {
 		}
 		propKey := cache.CacheKey{Key: prop.GetName() + ":" + val}
 		if err := s.idpByPropertyCache.Delete(ctx, propKey); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to invalidate IDP property cache", log.Error(err))
+			logger.Error(ctx, "Failed to invalidate IDP property cache", log.Error(err))
 		}
 	}
 }

--- a/backend/internal/idp/declarative_resource.go
+++ b/backend/internal/idp/declarative_resource.go
@@ -105,7 +105,7 @@ func (e *idpExporter) ValidateResource(ctx context.Context,
 	}
 
 	if len(idpDTO.Properties) == 0 {
-		logger.WarnWithContext(ctx, "Identity provider has no properties",
+		logger.Warn(ctx, "Identity provider has no properties",
 			log.String("idpID", id), log.String("name", idpDTO.Name))
 	}
 

--- a/backend/internal/idp/handler.go
+++ b/backend/internal/idp/handler.go
@@ -61,7 +61,7 @@ func (ih *idpHandler) HandleIDPPostRequest(w http.ResponseWriter, r *http.Reques
 
 	properties, err := getSanitizedProperties(createRequest.Properties)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to sanitize properties", log.Error(err))
+		logger.Error(ctx, "Failed to sanitize properties", log.Error(err))
 		writeServiceErrorResponse(ctx, w, &serviceerror.InternalServerError)
 		return
 	}
@@ -80,7 +80,7 @@ func (ih *idpHandler) HandleIDPPostRequest(w http.ResponseWriter, r *http.Reques
 
 	idpResponse, err := getIDPResponse(*createdIDP)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to convert IDP to response",
+		logger.Error(ctx, "Failed to convert IDP to response",
 			log.String("idp", createdIDP.Name), log.Error(err))
 		writeServiceErrorResponse(ctx, w, &serviceerror.InternalServerError)
 		return
@@ -136,7 +136,7 @@ func (ih *idpHandler) HandleIDPGetRequest(w http.ResponseWriter, r *http.Request
 
 	idpResponse, err := getIDPResponse(*idp)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
+		logger.Error(ctx, "Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
 		writeServiceErrorResponse(ctx, w, &serviceerror.InternalServerError)
 		return
 	}
@@ -172,7 +172,7 @@ func (ih *idpHandler) HandleIDPPutRequest(w http.ResponseWriter, r *http.Request
 
 	properties, err := getSanitizedProperties(updateRequest.Properties)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to sanitize properties", log.Error(err))
+		logger.Error(ctx, "Failed to sanitize properties", log.Error(err))
 		writeServiceErrorResponse(ctx, w, &serviceerror.InternalServerError)
 		return
 	}
@@ -193,7 +193,7 @@ func (ih *idpHandler) HandleIDPPutRequest(w http.ResponseWriter, r *http.Request
 
 	idpResponse, err := getIDPResponse(*idp)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
+		logger.Error(ctx, "Failed to convert IDP to response", log.String("idp", idp.Name), log.Error(err))
 		writeServiceErrorResponse(ctx, w, &serviceerror.InternalServerError)
 		return
 	}

--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -76,7 +76,7 @@ func (is *idpService) CreateIdentityProvider(
 	if idp.ID == "" {
 		id, genErr := is.uuidGenerator()
 		if genErr != nil {
-			logger.ErrorWithContext(ctx, "failed to generate ID for identity provider", log.Error(genErr))
+			logger.Error(ctx, "failed to generate ID for identity provider", log.Error(genErr))
 			return nil, &serviceerror.InternalServerError
 		}
 		idp.ID = id
@@ -109,7 +109,7 @@ func (is *idpService) CreateIdentityProvider(
 		return nil, svcErr
 	}
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create identity provider",
+		logger.Error(ctx, "Failed to create identity provider",
 			log.Error(err), log.String("idpName", idp.Name))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -125,7 +125,7 @@ func (is *idpService) GetIdentityProviderList(ctx context.Context) ([]BasicIDPDT
 		if errors.Is(err, ErrResultLimitExceededInCompositeMode) {
 			return nil, &ErrorResultLimitExceededInCompositeMode
 		}
-		logger.ErrorWithContext(ctx, "Failed to get identity provider list", log.Error(err))
+		logger.Error(ctx, "Failed to get identity provider list", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -144,7 +144,7 @@ func (is *idpService) GetIdentityProvider(ctx context.Context, idpID string) (*I
 		if errors.Is(err, ErrIDPNotFound) {
 			return nil, &ErrorIDPNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get identity provider", log.String("idpID", idpID), log.Error(err))
+		logger.Error(ctx, "Failed to get identity provider", log.String("idpID", idpID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -164,7 +164,7 @@ func (is *idpService) GetIdentityProviderByName(ctx context.Context,
 		if errors.Is(err, ErrIDPNotFound) {
 			return nil, &ErrorIDPNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get identity provider by name",
+		logger.Error(ctx, "Failed to get identity provider by name",
 			log.String("idpName", idpName), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -185,7 +185,7 @@ func (is *idpService) GetIdentityProvidersByProperty(ctx context.Context,
 		if errors.Is(err, ErrIDPNotFound) {
 			return nil, &ErrorIDPNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get identity providers by property",
+		logger.Error(ctx, "Failed to get identity providers by property",
 			log.String("propertyKey", propertyKey),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -252,7 +252,7 @@ func (is *idpService) UpdateIdentityProvider(ctx context.Context, idpID string, 
 		return nil, svcErr
 	}
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to update identity provider", log.Error(err), log.String("idpID", idpID))
+		logger.Error(ctx, "Failed to update identity provider", log.Error(err), log.String("idpID", idpID))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -299,7 +299,7 @@ func (is *idpService) DeleteIdentityProvider(ctx context.Context, idpID string) 
 		return svcErr
 	}
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to delete identity provider", log.Error(err), log.String("idpID", idpID))
+		logger.Error(ctx, "Failed to delete identity provider", log.Error(err), log.String("idpID", idpID))
 		return &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/idp/store.go
+++ b/backend/internal/idp/store.go
@@ -303,7 +303,7 @@ func (s *idpStore) DeleteIdentityProvider(ctx context.Context, id string) error 
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
 	if rowsAffected == 0 {
-		logger.DebugWithContext(ctx, "idp not found with id: "+id)
+		logger.Debug(ctx, "idp not found with id: "+id)
 	}
 
 	return nil

--- a/backend/internal/idp/utils.go
+++ b/backend/internal/idp/utils.go
@@ -79,7 +79,7 @@ func validateIDPProperties(ctx context.Context, idpType IDPType, properties []cm
 	logger *log.Logger) ([]cmodels.Property, *serviceerror.ServiceError) {
 	config, exists := idpPropertyConfigs[idpType]
 	if !exists {
-		logger.ErrorWithContext(ctx, "No property configuration found for IDP type",
+		logger.Error(ctx, "No property configuration found for IDP type",
 			log.String("idpType", string(idpType)))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -216,7 +216,7 @@ func createAndAppendProperty(ctx context.Context, propertyMap map[string]cmodels
 ) *serviceerror.ServiceError {
 	prop, err := cmodels.NewProperty(name, value, isSecret)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create property", log.String("propertyName", name), log.Error(err))
+		logger.Error(ctx, "Failed to create property", log.String("propertyName", name), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	propertyMap[name] = *prop

--- a/backend/internal/inboundclient/cache_backed_store.go
+++ b/backend/internal/inboundclient/cache_backed_store.go
@@ -154,7 +154,7 @@ func (c *cachedBackStore) cacheInboundClient(ctx context.Context, client *inboun
 	}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InboundClientCachedBackStore"))
 	if err := c.inboundClientCache.Set(ctx, cache.CacheKey{Key: client.ID}, client); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to cache inbound client",
+		logger.Error(ctx, "Failed to cache inbound client",
 			log.String("entityID", client.ID), log.Error(err))
 	}
 }
@@ -165,7 +165,7 @@ func (c *cachedBackStore) cacheOAuthProfile(ctx context.Context, entityID string
 	}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InboundClientCachedBackStore"))
 	if err := c.oauthProfileCache.Set(ctx, cache.CacheKey{Key: entityID}, profile); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to cache OAuth profile", log.String("entityID", entityID), log.Error(err))
+		logger.Error(ctx, "Failed to cache OAuth profile", log.String("entityID", entityID), log.Error(err))
 	}
 }
 
@@ -175,7 +175,7 @@ func (c *cachedBackStore) invalidateInboundClient(ctx context.Context, entityID 
 	}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InboundClientCachedBackStore"))
 	if err := c.inboundClientCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to invalidate inbound client cache",
+		logger.Error(ctx, "Failed to invalidate inbound client cache",
 			log.String("entityID", entityID), log.Error(err))
 	}
 }
@@ -186,7 +186,7 @@ func (c *cachedBackStore) invalidateOAuthProfile(ctx context.Context, entityID s
 	}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InboundClientCachedBackStore"))
 	if err := c.oauthProfileCache.Delete(ctx, cache.CacheKey{Key: entityID}); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to invalidate OAuth profile cache",
+		logger.Error(ctx, "Failed to invalidate OAuth profile cache",
 			log.String("entityID", entityID), log.Error(err))
 	}
 }

--- a/backend/internal/inboundclient/model/oauth.go
+++ b/backend/internal/inboundclient/model/oauth.go
@@ -303,7 +303,7 @@ func ValidateRedirectURI(ctx context.Context, redirectURIs []string, redirectURI
 
 	parsedRedirectURI, err := utils.ParseURL(redirectURI)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to parse redirect URI", log.Error(err))
+		logger.Error(ctx, "Failed to parse redirect URI", log.Error(err))
 		return fmt.Errorf("invalid redirect URI: %s", err.Error())
 	}
 	if parsedRedirectURI.Fragment != "" {

--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -328,7 +328,7 @@ func (s *inboundClientService) resolveClientID(ctx context.Context, entityID str
 	}
 	e, epErr := s.entityProvider.GetEntity(entityID)
 	if epErr != nil {
-		s.logger.WarnWithContext(ctx, "Failed to resolve OAuth client_id from entity provider",
+		s.logger.Warn(ctx, "Failed to resolve OAuth client_id from entity provider",
 			log.String("entityID", entityID), log.Error(epErr))
 		return ""
 	}
@@ -1053,7 +1053,7 @@ func (s *inboundClientService) validateAllowedUserTypes(
 		entityTypeList, svcErr := s.entityType.GetEntityTypeList(
 			security.WithRuntimeContext(ctx), entitytype.TypeCategoryUser, limit, offset, false)
 		if svcErr != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to retrieve user type list for validation",
+			s.logger.Error(ctx, "Failed to retrieve user type list for validation",
 				log.String("error", svcErr.Error.DefaultValue), log.String("code", svcErr.Code))
 			return ErrUserSchemaLookupFailed
 		}
@@ -1400,7 +1400,7 @@ func (s *inboundClientService) syncConsentOnUpdate(ctx context.Context,
 		// is left alone — it has an independent lifecycle bound to the resource service.
 		if delErr := s.consentService.DeleteConsentPurpose(ctx, ouID, existing[0].ID); delErr != nil {
 			if delErr.Code == consent.ErrorDeletingConsentPurposeWithAssociatedRecords.Code {
-				s.logger.WarnWithContext(ctx, "Cannot delete attribute consent purpose due to existing consents",
+				s.logger.Warn(ctx, "Cannot delete attribute consent purpose due to existing consents",
 					log.String("entityID", entityID))
 				return nil
 			}
@@ -1454,7 +1454,7 @@ func (s *inboundClientService) syncConsentOnDelete(ctx context.Context, entityID
 	for _, p := range purposes {
 		if delErr := s.consentService.DeleteConsentPurpose(ctx, ouID, p.ID); delErr != nil {
 			if delErr.Code == consent.ErrorDeletingConsentPurposeWithAssociatedRecords.Code {
-				s.logger.WarnWithContext(ctx, "Cannot delete consent purpose due to existing consents",
+				s.logger.Warn(ctx, "Cannot delete consent purpose due to existing consents",
 					log.String("entityID", entityID), log.String("purposeID", p.ID),
 					log.String("purposeNamespace", string(p.Namespace)))
 				continue

--- a/backend/internal/inboundclient/store.go
+++ b/backend/internal/inboundclient/store.go
@@ -407,7 +407,7 @@ func buildInboundClientFromRow(ctx context.Context, row map[string]interface{}) 
 	if blobStr := parseJSONColumnString(row, "properties"); blobStr != "" {
 		var blob inboundClientJSONBlob
 		if err := json.Unmarshal([]byte(blobStr), &blob); err != nil {
-			log.GetLogger().DebugWithContext(ctx, "Failed to unmarshal properties", log.Error(err))
+			log.GetLogger().Debug(ctx, "Failed to unmarshal properties", log.Error(err))
 		} else {
 			client.Assertion = blob.Assertion
 			client.LoginConsent = blob.LoginConsent

--- a/backend/internal/notification/declarative_resource.go
+++ b/backend/internal/notification/declarative_resource.go
@@ -107,7 +107,7 @@ func (e *notificationSenderExporter) ValidateResource(ctx context.Context,
 	}
 
 	if len(sender.Properties) == 0 {
-		logger.WarnWithContext(ctx, "Notification sender has no properties",
+		logger.Warn(ctx, "Notification sender has no properties",
 			log.String("senderID", id), log.String("name", sender.Name))
 	}
 

--- a/backend/internal/notification/init.go
+++ b/backend/internal/notification/init.go
@@ -46,7 +46,7 @@ func Initialize(mux *http.ServeMux, jwtService jwt.JWTServiceInterface,
 		notificationStore, tx, err = newNotificationStore()
 		if err != nil {
 			// Service initialization runs during application startup, outside any request.
-			log.GetLogger().ErrorWithContext(context.Background(),
+			log.GetLogger().Error(context.Background(),
 				"Failed to initialize notification store", log.Error(err))
 			return nil, nil, nil, nil, err
 		}

--- a/backend/internal/notification/message/custom_client.go
+++ b/backend/internal/notification/message/custom_client.go
@@ -74,7 +74,7 @@ func NewCustomClient(ctx context.Context, sender common.NotificationSenderDTO) (
 		case common.CustomPropKeyContentType:
 			client.contentType = strings.ToUpper(value)
 		default:
-			logger.WarnWithContext(ctx, "Unknown property for Custom client", log.String("property", prop.GetName()))
+			logger.Warn(ctx, "Unknown property for Custom client", log.String("property", prop.GetName()))
 		}
 	}
 	client.httpClient = syshttp.NewHTTPClientWithTimeout(httpClientTimeout)
@@ -105,7 +105,7 @@ func (c *CustomClient) Send(ctx context.Context, channel common.ChannelType, dat
 // sendSMS sends an SMS via the custom webhook.
 func (c *CustomClient) sendSMS(ctx context.Context, data common.NotificationData) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, customClientLoggerComponentName))
-	logger.DebugWithContext(ctx, "Sending SMS via custom client", log.MaskedString("to", data.Recipient))
+	logger.Debug(ctx, "Sending SMS via custom client", log.MaskedString("to", data.Recipient))
 
 	var req *http.Request
 	var err error
@@ -144,15 +144,15 @@ func (c *CustomClient) sendSMS(ctx context.Context, data common.NotificationData
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to close response body", log.Error(closeErr))
+			logger.Error(ctx, "Failed to close response body", log.Error(closeErr))
 		}
 	}()
 
-	logger.DebugWithContext(ctx, "Received response from custom provider", log.Int("statusCode", resp.StatusCode))
+	logger.Debug(ctx, "Received response from custom provider", log.Int("statusCode", resp.StatusCode))
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		logger.ErrorWithContext(ctx, "Failed to send SMS via custom client", log.Int("statusCode", resp.StatusCode),
+		logger.Error(ctx, "Failed to send SMS via custom client", log.Int("statusCode", resp.StatusCode),
 			log.String("response", string(bodyBytes)))
 		return fmt.Errorf("custom SMS send failed, status: %d, response: %s", resp.StatusCode, string(bodyBytes))
 	}

--- a/backend/internal/notification/message/twilio_client.go
+++ b/backend/internal/notification/message/twilio_client.go
@@ -68,7 +68,7 @@ func NewTwilioClient(ctx context.Context, sender common.NotificationSenderDTO) (
 		case common.TwilioPropKeySenderID:
 			client.senderID = value
 		default:
-			logger.WarnWithContext(ctx, "Unknown property for Twilio client", log.String("property", prop.GetName()))
+			logger.Warn(ctx, "Unknown property for Twilio client", log.String("property", prop.GetName()))
 		}
 	}
 	client.url = fmt.Sprintf(twilioURL, client.accountSID)
@@ -100,7 +100,7 @@ func (c *TwilioClient) Send(ctx context.Context, channel common.ChannelType, dat
 // sendSMS sends an SMS via the Twilio API.
 func (c *TwilioClient) sendSMS(ctx context.Context, data common.NotificationData) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, twilioLoggerComponentName))
-	logger.DebugWithContext(ctx, "Sending SMS via Twilio", log.MaskedString("to", data.Recipient))
+	logger.Debug(ctx, "Sending SMS via Twilio", log.MaskedString("to", data.Recipient))
 
 	formData := url.Values{}
 	formData.Set("To", data.Recipient)
@@ -121,15 +121,15 @@ func (c *TwilioClient) sendSMS(ctx context.Context, data common.NotificationData
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to close response body", log.Error(closeErr))
+			logger.Error(ctx, "Failed to close response body", log.Error(closeErr))
 		}
 	}()
 
-	logger.DebugWithContext(ctx, "Received response from Twilio", log.Int("statusCode", resp.StatusCode))
+	logger.Debug(ctx, "Received response from Twilio", log.Int("statusCode", resp.StatusCode))
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		logger.ErrorWithContext(ctx, "Failed to send SMS via Twilio", log.Int("statusCode", resp.StatusCode),
+		logger.Error(ctx, "Failed to send SMS via Twilio", log.Int("statusCode", resp.StatusCode),
 			log.String("response", string(bodyBytes)))
 		return fmt.Errorf("twilio SMS send failed, status: %d, response: %s", resp.StatusCode, string(bodyBytes))
 	}

--- a/backend/internal/notification/message/vonage_client.go
+++ b/backend/internal/notification/message/vonage_client.go
@@ -68,7 +68,7 @@ func NewVonageClient(ctx context.Context, sender common.NotificationSenderDTO) (
 		case common.VonagePropKeySenderID:
 			client.senderID = value
 		default:
-			logger.WarnWithContext(ctx, "Unknown property for Vonage client", log.String("property", prop.GetName()))
+			logger.Warn(ctx, "Unknown property for Vonage client", log.String("property", prop.GetName()))
 		}
 	}
 	client.httpClient = syshttp.NewHTTPClientWithTimeout(httpClientTimeout)
@@ -99,7 +99,7 @@ func (v *VonageClient) Send(ctx context.Context, channel common.ChannelType, dat
 // sendSMS sends an SMS via the Vonage API.
 func (v *VonageClient) sendSMS(ctx context.Context, data common.NotificationData) error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, vonageLoggerComponentName))
-	logger.DebugWithContext(ctx, "Sending SMS via Vonage", log.MaskedString("to", data.Recipient))
+	logger.Debug(ctx, "Sending SMS via Vonage", log.MaskedString("to", data.Recipient))
 
 	formattedPhoneNumber := v.formatPhoneNumber(data.Recipient)
 
@@ -134,15 +134,15 @@ func (v *VonageClient) sendSMS(ctx context.Context, data common.NotificationData
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to close response body", log.Error(closeErr))
+			logger.Error(ctx, "Failed to close response body", log.Error(closeErr))
 		}
 	}()
 
-	logger.DebugWithContext(ctx, "Received response from Vonage", log.Int("statusCode", resp.StatusCode))
+	logger.Debug(ctx, "Received response from Vonage", log.Int("statusCode", resp.StatusCode))
 
 	if resp.StatusCode != http.StatusAccepted {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		logger.ErrorWithContext(ctx, "Failed to send SMS via Vonage", log.Int("statusCode", resp.StatusCode),
+		logger.Error(ctx, "Failed to send SMS via Vonage", log.Int("statusCode", resp.StatusCode),
 			log.String("response", string(bodyBytes)))
 		return fmt.Errorf("vonage SMS send failed, status: %d, response: %s", resp.StatusCode, string(bodyBytes))
 	}

--- a/backend/internal/notification/message_handler.go
+++ b/backend/internal/notification/message_handler.go
@@ -63,7 +63,7 @@ func (h *messageNotificationSenderHandler) HandleSenderListRequest(w http.Respon
 	for _, sender := range senders {
 		senderResponse, err := getSenderResponseFromDTO(&sender)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to convert sender to response",
+			logger.Error(ctx, "Failed to convert sender to response",
 				log.String("sender", sender.Name), log.Error(err))
 			h.handleError(
 				ctx,
@@ -90,7 +90,7 @@ func (h *messageNotificationSenderHandler) HandleSenderCreateRequest(w http.Resp
 
 	senderDTO, err := getDTOFromSenderRequest(sender)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to process sender request", log.Error(err))
+		logger.Error(ctx, "Failed to process sender request", log.Error(err))
 		h.handleError(ctx, w, &serviceerror.InternalServerError, "Failed to process sender request: "+err.Error())
 		return
 	}
@@ -114,7 +114,7 @@ func (h *messageNotificationSenderHandler) HandleSenderCreateRequest(w http.Resp
 
 	senderResponse, err := getSenderResponseFromDTO(createdSender)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to convert sender to response",
+		logger.Error(ctx, "Failed to convert sender to response",
 			log.String("sender", createdSender.Name), log.Error(err))
 		h.handleError(ctx, w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
 		return
@@ -149,7 +149,7 @@ func (h *messageNotificationSenderHandler) HandleSenderGetRequest(w http.Respons
 
 	senderResponse, err := getSenderResponseFromDTO(sender)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to convert sender to response",
+		logger.Error(ctx, "Failed to convert sender to response",
 			log.String("sender", sender.Name), log.Error(err))
 		h.handleError(ctx, w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
 		return
@@ -175,7 +175,7 @@ func (h *messageNotificationSenderHandler) HandleSenderUpdateRequest(w http.Resp
 
 	senderDTO, err := getDTOFromSenderRequest(sender)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to process sender request", log.Error(err))
+		logger.Error(ctx, "Failed to process sender request", log.Error(err))
 		h.handleError(ctx, w, &serviceerror.InternalServerError, "Failed to process sender request: "+err.Error())
 		return
 	}
@@ -188,7 +188,7 @@ func (h *messageNotificationSenderHandler) HandleSenderUpdateRequest(w http.Resp
 
 	senderResponse, err := getSenderResponseFromDTO(updatedSender)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to convert sender to response",
+		logger.Error(ctx, "Failed to convert sender to response",
 			log.String("sender", updatedSender.Name), log.Error(err))
 		h.handleError(ctx, w, &serviceerror.InternalServerError, "Failed to convert sender to response: "+err.Error())
 		return

--- a/backend/internal/notification/mgt_service.go
+++ b/backend/internal/notification/mgt_service.go
@@ -65,7 +65,7 @@ func (s *notificationSenderMgtService) CreateSender(
 	ctx context.Context, sender common.NotificationSenderDTO) (
 	*common.NotificationSenderDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.DebugWithContext(ctx, "Creating notification sender", log.String("name", sender.Name))
+	logger.Debug(ctx, "Creating notification sender", log.String("name", sender.Name))
 
 	if err := declarativeresource.CheckDeclarativeCreate(); err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s *notificationSenderMgtService) CreateSender(
 	if sender.ID == "" {
 		id, err := s.uuidGenerator()
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+			logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		sender.ID = id
@@ -92,7 +92,7 @@ func (s *notificationSenderMgtService) CreateSender(
 			return err
 		}
 		if senderRetv != nil {
-			logger.DebugWithContext(ctx, "Notification sender already exists", log.String("name", sender.Name),
+			logger.Debug(ctx, "Notification sender already exists", log.String("name", sender.Name),
 				log.String("id", senderRetv.ID))
 			svcErr = &ErrorDuplicateSenderName
 			return errors.New("sender already exists")
@@ -110,7 +110,7 @@ func (s *notificationSenderMgtService) CreateSender(
 		return nil, svcErr
 	}
 	if transactErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to create notification sender",
+		logger.Error(ctx, "Failed to create notification sender",
 			log.Error(transactErr), log.String("name", sender.Name))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -129,11 +129,11 @@ func (s *notificationSenderMgtService) CreateSender(
 func (s *notificationSenderMgtService) ListSenders(ctx context.Context) ([]common.NotificationSenderDTO,
 	*serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.DebugWithContext(ctx, "Listing all notification senders")
+	logger.Debug(ctx, "Listing all notification senders")
 
 	senders, err := s.notificationStore.listSenders(ctx)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to list notification senders", log.Error(err))
+		logger.Error(ctx, "Failed to list notification senders", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -144,7 +144,7 @@ func (s *notificationSenderMgtService) ListSenders(ctx context.Context) ([]commo
 func (s *notificationSenderMgtService) GetSender(ctx context.Context, id string) (*common.NotificationSenderDTO,
 	*serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.DebugWithContext(ctx, "Retrieving notification sender", log.String("id", id))
+	logger.Debug(ctx, "Retrieving notification sender", log.String("id", id))
 
 	if id == "" {
 		return nil, &ErrorInvalidSenderID
@@ -152,7 +152,7 @@ func (s *notificationSenderMgtService) GetSender(ctx context.Context, id string)
 
 	sender, err := s.notificationStore.getSenderByID(ctx, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to retrieve notification sender", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to retrieve notification sender", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -167,7 +167,7 @@ func (s *notificationSenderMgtService) GetSender(ctx context.Context, id string)
 func (s *notificationSenderMgtService) GetSenderByName(ctx context.Context, name string) (*common.NotificationSenderDTO,
 	*serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.DebugWithContext(ctx, "Retrieving notification sender by name", log.String("name", name))
+	logger.Debug(ctx, "Retrieving notification sender by name", log.String("name", name))
 
 	if name == "" {
 		return nil, &ErrorInvalidSenderName
@@ -175,7 +175,7 @@ func (s *notificationSenderMgtService) GetSenderByName(ctx context.Context, name
 
 	sender, err := s.notificationStore.getSenderByName(ctx, name)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to retrieve notification sender", log.String("name", name), log.Error(err))
+		logger.Error(ctx, "Failed to retrieve notification sender", log.String("name", name), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -190,7 +190,7 @@ func (s *notificationSenderMgtService) GetSenderByName(ctx context.Context, name
 func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id string,
 	sender common.NotificationSenderDTO) (*common.NotificationSenderDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.DebugWithContext(ctx, "Updating notification sender", log.String("id", id), log.String("name", sender.Name))
+	logger.Debug(ctx, "Updating notification sender", log.String("id", id), log.String("name", sender.Name))
 
 	if err := declarativeresource.CheckDeclarativeUpdate(); err != nil {
 		return nil, err
@@ -211,7 +211,7 @@ func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id stri
 			return err
 		}
 		if senderRetv == nil {
-			logger.DebugWithContext(ctx, "Notification sender not found", log.String("id", id))
+			logger.Debug(ctx, "Notification sender not found", log.String("id", id))
 			svcErr = &ErrorSenderNotFound
 			return errors.New("sender not found")
 		}
@@ -223,7 +223,7 @@ func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id stri
 				return err
 			}
 			if senderWithUpdatedName != nil && senderWithUpdatedName.ID != id {
-				logger.DebugWithContext(ctx, "Another sender with the same name already exists",
+				logger.Debug(ctx, "Another sender with the same name already exists",
 					log.String("name", sender.Name), log.String("existingID", senderWithUpdatedName.ID))
 				svcErr = &ErrorDuplicateSenderName
 				return errors.New("duplicate name")
@@ -232,7 +232,7 @@ func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id stri
 
 		// Ensure the type is not changed
 		if sender.Type != senderRetv.Type {
-			logger.DebugWithContext(ctx, "Attempting to change sender type", log.String("id", id),
+			logger.Debug(ctx, "Attempting to change sender type", log.String("id", id),
 				log.String("originalType", string(senderRetv.Type)), log.String("newType", string(sender.Type)))
 			svcErr = &ErrorSenderTypeUpdateNotAllowed
 			return errors.New("cannot change type")
@@ -250,7 +250,7 @@ func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id stri
 		return nil, svcErr
 	}
 	if transactErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to update notification sender",
+		logger.Error(ctx, "Failed to update notification sender",
 			log.Error(transactErr), log.String("id", id))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -268,7 +268,7 @@ func (s *notificationSenderMgtService) UpdateSender(ctx context.Context, id stri
 // DeleteSender deletes a notification sender
 func (s *notificationSenderMgtService) DeleteSender(ctx context.Context, id string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "NotificationSenderMgtService"))
-	logger.DebugWithContext(ctx, "Deleting notification sender", log.String("id", id))
+	logger.Debug(ctx, "Deleting notification sender", log.String("id", id))
 
 	if err := declarativeresource.CheckDeclarativeDelete(); err != nil {
 		return err
@@ -286,7 +286,7 @@ func (s *notificationSenderMgtService) DeleteSender(ctx context.Context, id stri
 	})
 
 	if transactErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to delete notification sender",
+		logger.Error(ctx, "Failed to delete notification sender",
 			log.Error(transactErr), log.String("id", id))
 		return &serviceerror.InternalServerError
 	}

--- a/backend/internal/notification/notification_sender_service.go
+++ b/backend/internal/notification/notification_sender_service.go
@@ -71,7 +71,7 @@ func (s *notificationSenderService) Send(ctx context.Context, channel common.Cha
 	}
 
 	if err := _client.Send(ctx, channel, data); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to send notification",
+		s.logger.Error(ctx, "Failed to send notification",
 			log.String("channel", string(channel)), log.Error(err))
 		return &serviceerror.InternalServerError
 	}

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -69,7 +69,7 @@ func newOTPService(notifSenderSvc NotificationSenderMgtSvcInterface,
 func (s *otpService) SendOTP(
 	ctx context.Context, otpDTO common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "OTPService"))
-	logger.DebugWithContext(ctx, "Sending OTP", log.MaskedString("recipient", otpDTO.Recipient),
+	logger.Debug(ctx, "Sending OTP", log.MaskedString("recipient", otpDTO.Recipient),
 		log.String("channel", otpDTO.Channel), log.String("senderId", otpDTO.SenderID))
 
 	if err := s.validateOTPSendRequest(otpDTO); err != nil {
@@ -92,7 +92,7 @@ func (s *otpService) SendOTP(
 
 	otp, err := s.generateOTP()
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to generate OTP", log.Error(err))
+		logger.Error(ctx, "Failed to generate OTP", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -117,11 +117,11 @@ func (s *otpService) SendOTP(
 
 	sessionToken, err := s.createSessionToken(ctx, sessionData)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create session token", log.Error(err))
+		logger.Error(ctx, "Failed to create session token", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "OTP sent successfully", log.MaskedString("recipient", otpDTO.Recipient))
+	logger.Debug(ctx, "OTP sent successfully", log.MaskedString("recipient", otpDTO.Recipient))
 
 	return &common.SendOTPResultDTO{
 		SessionToken: sessionToken,
@@ -132,7 +132,7 @@ func (s *otpService) SendOTP(
 func (s *otpService) VerifyOTP(
 	ctx context.Context, otpDTO common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "OTPService"))
-	logger.DebugWithContext(ctx, "Verifying OTP")
+	logger.Debug(ctx, "Verifying OTP")
 
 	if err := s.validateOTPVerifyRequest(otpDTO); err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func (s *otpService) VerifyOTP(
 	// Check if OTP has expired
 	currentTime := time.Now().UnixMilli()
 	if currentTime > sessionData.ExpiryTime {
-		logger.DebugWithContext(ctx, "OTP has expired")
+		logger.Debug(ctx, "OTP has expired")
 		return &common.VerifyOTPResultDTO{
 			Status:    common.OTPVerifyStatusInvalid,
 			Recipient: sessionData.Recipient,
@@ -156,7 +156,7 @@ func (s *otpService) VerifyOTP(
 	// Verify OTP value by comparing hashes
 	providedOTPHash := cryptolib.GenerateThumbprintFromString(otpDTO.OTPCode)
 	if providedOTPHash != sessionData.OTPValue {
-		logger.DebugWithContext(ctx, "Invalid OTP provided")
+		logger.Debug(ctx, "Invalid OTP provided")
 		return &common.VerifyOTPResultDTO{
 			Status:    common.OTPVerifyStatusInvalid,
 			Recipient: sessionData.Recipient,
@@ -259,7 +259,7 @@ func (s *otpService) sendSMSOTP(ctx context.Context, recipient, otp string,
 	templateData := template.TemplateData{"otp": otp, "expiryMinutes": expiryMinutes}
 	rendered, svcErr := s.templateService.Render(ctx, template.ScenarioOTP, template.TemplateTypeSMS, templateData)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to render SMS OTP template", log.String("error", svcErr.Code))
+		logger.Error(ctx, "Failed to render SMS OTP template", log.String("error", svcErr.Code))
 		return &serviceerror.InternalServerError
 	}
 
@@ -274,7 +274,7 @@ func (s *otpService) sendSMSOTP(ctx context.Context, recipient, otp string,
 
 	notifData := common.NotificationData{Recipient: recipient, Body: rendered.Body}
 	if err := _client.Send(ctx, common.ChannelTypeSMS, notifData); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to send SMS OTP", log.Error(err))
+		logger.Error(ctx, "Failed to send SMS OTP", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -308,7 +308,7 @@ func (s *otpService) verifyAndDecodeSessionToken(ctx context.Context, token stri
 	jwtConfig := config.GetServerRuntime().Config.JWT
 	svcErr := s.jwtService.VerifyJWT(ctx, token, "otp-svc", jwtConfig.Issuer)
 	if svcErr != nil {
-		logger.DebugWithContext(ctx, "Invalid session token", log.String("error", svcErr.Error.DefaultValue))
+		logger.Debug(ctx, "Invalid session token", log.String("error", svcErr.Error.DefaultValue))
 		return nil, &ErrorInvalidSessionToken
 	}
 

--- a/backend/internal/notification/store.go
+++ b/backend/internal/notification/store.go
@@ -163,7 +163,7 @@ func (s *notificationStore) getSender(ctx context.Context, query dbmodel.DBQuery
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
 	if len(results) == 0 {
-		logger.DebugWithContext(ctx, "Notification sender not found", log.String("identifier", identifier))
+		logger.Debug(ctx, "Notification sender not found", log.String("identifier", identifier))
 		return nil, nil
 	}
 	if len(results) > 1 {
@@ -234,7 +234,7 @@ func (s *notificationStore) deleteSender(ctx context.Context, id string) error {
 		return fmt.Errorf("failed to execute delete query: %w", err)
 	}
 	if rowsAffected == 0 {
-		logger.DebugWithContext(ctx, "No sender found to delete", log.String("id", id))
+		logger.Debug(ctx, "No sender found to delete", log.String("id", id))
 	}
 
 	return nil

--- a/backend/internal/oauth/jwks/handler.go
+++ b/backend/internal/oauth/jwks/handler.go
@@ -52,7 +52,7 @@ func (h *jwksHandler) HandleJWKSRequest(w http.ResponseWriter, r *http.Request) 
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, jwksResponse)
-	logger.DebugWithContext(ctx, "JWKS response successfully sent")
+	logger.Debug(ctx, "JWKS response successfully sent")
 }
 
 // logAndWriteError logs server errors and writes an appropriate error response to the HTTP response writer.
@@ -61,7 +61,7 @@ func (h *jwksHandler) logAndWriteError(ctx context.Context, w http.ResponseWrite
 	statusCode := http.StatusBadRequest
 	if svcErr.Type == serviceerror.ServerErrorType {
 		statusCode = http.StatusInternalServerError
-		logger.ErrorWithContext(ctx, "Failed to retrieve JWKS", log.String("error_code", svcErr.Code))
+		logger.Error(ctx, "Failed to retrieve JWKS", log.String("error_code", svcErr.Code))
 	}
 
 	errResp := apierror.ErrorResponse{

--- a/backend/internal/oauth/jwks/service.go
+++ b/backend/internal/oauth/jwks/service.go
@@ -59,7 +59,7 @@ func newJWKSService(cryptoProvider kmprovider.RuntimeCryptoProvider) JWKSService
 func (s *jwksService) GetJWKS(ctx context.Context) (*JWKSResponse, *serviceerror.ServiceError) {
 	publicKeys, err := s.cryptoProvider.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to retrieve public keys", log.Error(err))
+		s.logger.Error(ctx, "Failed to retrieve public keys", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -89,7 +89,7 @@ func (s *jwksService) GetJWKS(ctx context.Context) (*JWKSResponse, *serviceerror
 		case ed25519.PublicKey:
 			jwksKeys = append(jwksKeys, getEdDSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256))
 		default:
-			s.logger.DebugWithContext(ctx, "Unsupported public key type for JWKS", log.String("keyID", keyInfo.KeyID))
+			s.logger.Debug(ctx, "Unsupported public key type for JWKS", log.String("keyID", keyInfo.KeyID))
 			continue
 		}
 	}

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -73,7 +73,7 @@ func (ah *authorizeHandler) HandleAuthorizeGetRequest(w http.ResponseWriter, r *
 			}
 			redirectURI, err := oauth2utils.GetURIWithQueryParams(authErr.ClientRedirectURI, queryParams)
 			if err != nil {
-				ah.logger.ErrorWithContext(ctx, "Failed to construct client redirect URI", log.Error(err))
+				ah.logger.Error(ctx, "Failed to construct client redirect URI", log.Error(err))
 				ah.redirectToErrorPage(w, r, oauth2const.ErrorServerError, "Failed to process authorization request")
 				return
 			}
@@ -128,7 +128,7 @@ func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWrit
 
 	if r == nil || w == nil {
 		// The request may be nil here, so there is no request context to propagate.
-		logger.ErrorWithContext(context.Background(), "Request or response writer is nil")
+		logger.Error(context.Background(), "Request or response writer is nil")
 		return nil
 	}
 
@@ -145,7 +145,7 @@ func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWrit
 	}
 
 	if err != nil {
-		ah.logger.DebugWithContext(r.Context(), "Invalid authorize request", log.Error(err))
+		ah.logger.Debug(r.Context(), "Invalid authorize request", log.Error(err))
 		utils.WriteJSONError(r.Context(), w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
 			http.StatusBadRequest, nil)
 	}
@@ -227,7 +227,7 @@ func (ah *authorizeHandler) redirectToLoginPage(w http.ResponseWriter, r *http.R
 
 	if w == nil || r == nil {
 		// The request may be nil here, so there is no request context to propagate.
-		logger.ErrorWithContext(context.Background(),
+		logger.Error(context.Background(),
 			"Response writer or request is nil. Cannot redirect to login page.")
 		return
 	}
@@ -235,11 +235,11 @@ func (ah *authorizeHandler) redirectToLoginPage(w http.ResponseWriter, r *http.R
 
 	redirectURI, err := getLoginPageRedirectURI(queryParams)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to construct login page URL", log.Error(err))
+		logger.Error(ctx, "Failed to construct login page URL", log.Error(err))
 		ah.redirectToErrorPage(w, r, oauth2const.ErrorServerError, "Failed to process authorization request")
 		return
 	}
-	logger.DebugWithContext(ctx, "Redirecting to login page")
+	logger.Debug(ctx, "Redirecting to login page")
 
 	http.Redirect(w, r, redirectURI, http.StatusFound)
 }
@@ -267,7 +267,7 @@ func (ah *authorizeHandler) redirectToErrorPage(w http.ResponseWriter, r *http.R
 
 	if w == nil || r == nil {
 		// The request may be nil here, so there is no request context to propagate.
-		logger.ErrorWithContext(context.Background(),
+		logger.Error(context.Background(),
 			"Response writer or request is nil. Cannot redirect to error page.")
 		return
 	}
@@ -275,11 +275,11 @@ func (ah *authorizeHandler) redirectToErrorPage(w http.ResponseWriter, r *http.R
 
 	redirectURL, err := getErrorPageRedirectURL(code, msg)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to construct error page URL", log.Error(err))
+		logger.Error(ctx, "Failed to construct error page URL", log.Error(err))
 		http.Error(w, "Failed to redirect to error page", http.StatusInternalServerError)
 		return
 	}
-	logger.DebugWithContext(ctx, "Redirecting to error page")
+	logger.Debug(ctx, "Redirecting to error page")
 
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
@@ -335,7 +335,7 @@ func (ah *authorizeHandler) writeAuthZResponseToClientRedirect(
 
 	redirectURI, err := oauth2utils.GetURIWithQueryParams(authErr.ClientRedirectURI, queryParams)
 	if err != nil {
-		ah.logger.ErrorWithContext(ctx, "Failed to construct client redirect URI", log.Error(err))
+		ah.logger.Error(ctx, "Failed to construct client redirect URI", log.Error(err))
 		ah.writeAuthZResponseToErrorPage(ctx, w, oauth2const.ErrorServerError,
 			"Failed to process authorization request", authErr.State)
 		return

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -123,7 +123,7 @@ func (as *authorizeService) GetAuthorizationCodeDetails(
 		return nil
 	})
 	if err != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to get authorization code details", log.Error(err))
+		as.logger.Error(ctx, "Failed to get authorization code details", log.Error(err))
 		return nil, err
 	}
 	return record, nil
@@ -146,7 +146,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 	// Retrieve the OAuth client based on the client ID.
 	app, lookupErr := as.inboundClient.GetOAuthClientByClientID(ctx, clientID)
 	if lookupErr != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to retrieve OAuth client", log.Error(lookupErr))
+		as.logger.Error(ctx, "Failed to retrieve OAuth client", log.Error(lookupErr))
 		return nil, &AuthorizationError{
 			Code:    oauth2const.ErrorServerError,
 			Message: "Failed to process authorization request",
@@ -181,7 +181,7 @@ func (as *authorizeService) handlePARAuthorizationRequest(
 ) (*AuthorizationInitResult, *AuthorizationError) {
 	oauthParams, err := as.parService.ResolvePushedAuthorizationRequest(ctx, requestURI, clientID)
 	if err != nil {
-		as.logger.DebugWithContext(ctx, "Failed to resolve PAR request", log.Error(err))
+		as.logger.Debug(ctx, "Failed to resolve PAR request", log.Error(err))
 		if errors.Is(err, par.ErrPARResolutionFailed) {
 			return nil, &AuthorizationError{
 				Code:    oauth2const.ErrorServerError,
@@ -229,7 +229,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 		var err error
 		claimsRequest, err = oauth2utils.ParseClaimsRequest(claimsParam)
 		if err != nil {
-			as.logger.DebugWithContext(ctx, "Failed to parse claims parameter", log.Error(err))
+			as.logger.Debug(ctx, "Failed to parse claims parameter", log.Error(err))
 			return nil, &AuthorizationError{
 				Code:    oauth2const.ErrorInvalidRequest,
 				Message: "The claims request parameter is malformed or contains invalid values",
@@ -292,7 +292,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 	// TODO: This should be removed when supporting other means of authorization.
 	if redirectURI == "" {
 		if len(app.RedirectURIs) == 0 {
-			as.logger.ErrorWithContext(ctx, "OAuth application has no registered redirect URIs",
+			as.logger.Error(ctx, "OAuth application has no registered redirect URIs",
 				log.String("client_id", app.ClientID))
 			return nil, &AuthorizationError{
 				Code:    oauth2const.ErrorServerError,
@@ -334,7 +334,7 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 
 	executionID, flowErr := as.flowExecService.InitiateFlow(ctx, flowInitCtx)
 	if flowErr != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to initiate authentication flow",
+		as.logger.Error(ctx, "Failed to initiate authentication flow",
 			log.String("error_code", flowErr.Code))
 		return nil, &AuthorizationError{
 			Code:              oauth2const.ErrorServerError,
@@ -352,7 +352,7 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 	// Store authorization request context in the store.
 	identifier, storeErr := as.authReqStore.AddRequest(ctx, authRequestCtx)
 	if storeErr != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to store authorization request context", log.Error(storeErr))
+		as.logger.Error(ctx, "Failed to store authorization request context", log.Error(storeErr))
 		return nil, &AuthorizationError{
 			Code:              oauth2const.ErrorServerError,
 			Message:           "Failed to process authorization request",
@@ -372,7 +372,7 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 	// TODO: May require another redirection to a warn consent page when it directly goes to a federated IDP.
 	parsedRedirectURI, err := utils.ParseURL(oauthParams.RedirectURI)
 	if err != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to parse redirect URI", log.Error(err))
+		as.logger.Error(ctx, "Failed to parse redirect URI", log.Error(err))
 		return nil, &AuthorizationError{
 			Code:              oauth2const.ErrorServerError,
 			Message:           "Failed to process authorization request",
@@ -427,7 +427,7 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 
 		// Verify the assertion.
 		if err := as.verifyAssertion(ctx, assertion); err != nil {
-			as.logger.DebugWithContext(ctx, "Assertion verification failed", log.Error(err))
+			as.logger.Debug(ctx, "Assertion verification failed", log.Error(err))
 			authErr = &AuthorizationError{
 				Code:              oauth2const.ErrorInvalidRequest,
 				Message:           "Authorization request failed",
@@ -469,7 +469,7 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 			if err := validateSubClaimConstraint(
 				authRequestCtx.OAuthParameters.ClaimsRequest, claims.userID,
 			); err != nil {
-				as.logger.DebugWithContext(ctx, "Sub claim validation failed", log.Error(err))
+				as.logger.Debug(ctx, "Sub claim validation failed", log.Error(err))
 				authErr = &AuthorizationError{
 					Code:              oauth2const.ErrorAccessDenied,
 					Message:           "Authorization request failed",
@@ -541,12 +541,12 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 
 	if authErr != nil {
 		if authErr.Code == oauth2const.ErrorServerError {
-			as.logger.ErrorWithContext(ctx, "Failed to process authorization callback", log.Error(err))
+			as.logger.Error(ctx, "Failed to process authorization callback", log.Error(err))
 		}
 		return "", authErr
 	}
 	if err != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to process authorization callback", log.Error(err))
+		as.logger.Error(ctx, "Failed to process authorization callback", log.Error(err))
 		return "", &AuthorizationError{
 			Code:    oauth2const.ErrorServerError,
 			Message: "Failed to process authorization request",
@@ -560,17 +560,17 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 func (as *authorizeService) loadAuthRequestContext(ctx context.Context, authID string) (*authRequestContext, error) {
 	ok, authRequestCtx, err := as.authReqStore.GetRequest(ctx, authID)
 	if err != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to retrieve authorization request context", log.Error(err))
+		as.logger.Error(ctx, "Failed to retrieve authorization request context", log.Error(err))
 		return nil, errors.New("failed to retrieve authorization request context")
 	}
 	if !ok {
-		as.logger.DebugWithContext(ctx, "Authorization request context not found", log.String("auth_id", authID))
+		as.logger.Debug(ctx, "Authorization request context not found", log.String("auth_id", authID))
 		return nil, errAuthRequestNotFound
 	}
 
 	// Remove the authorization request context after retrieval.
 	if clearErr := as.authReqStore.ClearRequest(ctx, authID); clearErr != nil {
-		as.logger.ErrorWithContext(ctx, "Failed to clear authorization request context", log.Error(clearErr))
+		as.logger.Error(ctx, "Failed to clear authorization request context", log.Error(clearErr))
 	}
 	return &authRequestCtx, nil
 }
@@ -578,7 +578,7 @@ func (as *authorizeService) loadAuthRequestContext(ctx context.Context, authID s
 // verifyAssertion verifies the JWT assertion.
 func (as *authorizeService) verifyAssertion(ctx context.Context, assertion string) error {
 	if err := as.jwtService.VerifyJWT(ctx, assertion, "", ""); err != nil {
-		as.logger.DebugWithContext(ctx, "Invalid assertion signature", log.String("error", err.Error.DefaultValue))
+		as.logger.Debug(ctx, "Invalid assertion signature", log.String("error", err.Error.DefaultValue))
 		return errors.New("invalid assertion signature")
 	}
 	return nil

--- a/backend/internal/oauth/oauth2/authz/validator.go
+++ b/backend/internal/oauth/oauth2/authz/validator.go
@@ -55,7 +55,7 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(ctx contex
 	}
 
 	if err := oauthApp.ValidateRedirectURI(ctx, redirectURI); err != nil {
-		logger.DebugWithContext(ctx, "Validation failed for redirect URI", log.Error(err))
+		logger.Debug(ctx, "Validation failed for redirect URI", log.Error(err))
 		return false, constants.ErrorInvalidRequest, "Invalid redirect URI"
 	}
 

--- a/backend/internal/oauth/oauth2/callback/callback.go
+++ b/backend/internal/oauth/oauth2/callback/callback.go
@@ -149,7 +149,7 @@ func (
 	}
 	redirectURI, err := oauth2utils.GetURIWithQueryParams(authErr.ClientRedirectURI, queryParams)
 	if err != nil {
-		d.logger.ErrorWithContext(ctx, "Failed to construct client redirect URI", log.Error(err))
+		d.logger.Error(ctx, "Failed to construct client redirect URI", log.Error(err))
 		d.writeErrorPageRedirect(ctx, w, oauth2const.ErrorServerError,
 			"Failed to process authorization request", authErr.State)
 		return

--- a/backend/internal/oauth/oauth2/ciba/handler.go
+++ b/backend/internal/oauth/oauth2/ciba/handler.go
@@ -59,7 +59,7 @@ func (h *cibaHandler) HandleBackchannelAuthRequest(w http.ResponseWriter, r *htt
 	// Get authenticated client from context (set by ClientAuthMiddleware).
 	clientInfo := clientauth.GetOAuthClient(r.Context())
 	if clientInfo == nil {
-		h.logger.ErrorWithContext(r.Context(),
+		h.logger.Error(r.Context(),
 			"OAuth client not found in context - ClientAuthMiddleware must be applied")
 		utils.WriteJSONError(r.Context(), w, oauth2const.ErrorServerError, "Something went wrong",
 			http.StatusInternalServerError, nil)

--- a/backend/internal/oauth/oauth2/ciba/service.go
+++ b/backend/internal/oauth/oauth2/ciba/service.go
@@ -109,7 +109,7 @@ func (s *cibaService) InitiateBackchannelAuth(
 
 	authReqID, err := utils.GenerateUUIDv7()
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to generate auth_req_id", log.Error(err))
+		s.logger.Error(ctx, "Failed to generate auth_req_id", log.Error(err))
 		return nil, &CIBAError{
 			Code:    oauth2const.ErrorServerError,
 			Message: "Failed to process backchannel authentication request",
@@ -171,7 +171,7 @@ func (s *cibaService) InitiateBackchannelAuth(
 		},
 	})
 	if flowErr != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to initiate and execute CIBA authentication flow",
+		s.logger.Error(ctx, "Failed to initiate and execute CIBA authentication flow",
 			log.String("error_code", flowErr.Code))
 		return nil, &CIBAError{
 			Code:    oauth2const.ErrorServerError,
@@ -192,7 +192,7 @@ func (s *cibaService) InitiateBackchannelAuth(
 		ExpiryTime:     now.Add(time.Duration(expiresIn) * time.Second),
 	}
 	if storeErr := s.store.Add(ctx, cibaRequest); storeErr != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to store CIBA authentication request", log.Error(storeErr))
+		s.logger.Error(ctx, "Failed to store CIBA authentication request", log.Error(storeErr))
 		return nil, &CIBAError{
 			Code:    oauth2const.ErrorServerError,
 			Message: "Failed to process backchannel authentication request",
@@ -223,7 +223,7 @@ func (s *cibaService) HandleCallback(ctx context.Context, authReqID, assertion s
 				Message: "Invalid auth_req_id",
 			}
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to retrieve CIBA authentication request", log.Error(err))
+		s.logger.Error(ctx, "Failed to retrieve CIBA authentication request", log.Error(err))
 		return &CIBAError{
 			Code:    oauth2const.ErrorServerError,
 			Message: "Failed to process backchannel authentication callback",
@@ -248,7 +248,7 @@ func (s *cibaService) HandleCallback(ctx context.Context, authReqID, assertion s
 	expectedAud := s.resolveExpectedAudience(ctx, record.ClientID)
 
 	if verifyErr := s.jwtService.VerifyJWT(ctx, assertion, expectedAud, ""); verifyErr != nil {
-		s.logger.DebugWithContext(ctx, "Assertion verification failed",
+		s.logger.Debug(ctx, "Assertion verification failed",
 			log.String("error", verifyErr.Error.DefaultValue))
 		return &CIBAError{
 			Code:    oauth2const.ErrorInvalidRequest,
@@ -258,7 +258,7 @@ func (s *cibaService) HandleCallback(ctx context.Context, authReqID, assertion s
 
 	claims, authTime, decodeErr := decodeAttributesFromAssertion(assertion)
 	if decodeErr != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to decode assertion claims", log.Error(decodeErr))
+		s.logger.Error(ctx, "Failed to decode assertion claims", log.Error(decodeErr))
 		return &CIBAError{
 			Code:    oauth2const.ErrorServerError,
 			Message: "Failed to process backchannel authentication callback",
@@ -270,7 +270,7 @@ func (s *cibaService) HandleCallback(ctx context.Context, authReqID, assertion s
 	// record prevents an assertion minted for one CIBA request from authorizing another (e.g. a
 	// narrow-scope authentication being replayed against a broader-scope request for the same user).
 	if claims.cibaAuthReqID == "" || claims.cibaAuthReqID != record.AuthReqID {
-		s.logger.DebugWithContext(ctx, "Assertion is not bound to the backchannel authentication request",
+		s.logger.Debug(ctx, "Assertion is not bound to the backchannel authentication request",
 			log.MaskedString("auth_req_id", authReqID))
 		return &CIBAError{
 			Code:    oauth2const.ErrorAccessDenied,
@@ -282,7 +282,7 @@ func (s *cibaService) HandleCallback(ctx context.Context, authReqID, assertion s
 	// It was not pre-resolved at request initiation; the flow's identifying executor
 	// resolves it from the login_hint during server-side execution.
 	if claims.userID == "" {
-		s.logger.DebugWithContext(ctx, "Assertion subject is missing",
+		s.logger.Debug(ctx, "Assertion subject is missing",
 			log.MaskedString("auth_req_id", authReqID))
 		return &CIBAError{
 			Code:    oauth2const.ErrorAccessDenied,
@@ -304,7 +304,7 @@ func (s *cibaService) HandleCallback(ctx context.Context, authReqID, assertion s
 
 	if markErr := s.store.MarkAuthenticated(ctx, authReqID, claims.userID, authorizedScopes,
 		claims.attributeCacheID, claims.completedACR, authTime); markErr != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to mark CIBA authentication request as authenticated",
+		s.logger.Error(ctx, "Failed to mark CIBA authentication request as authenticated",
 			log.Error(markErr))
 		return &CIBAError{
 			Code:    oauth2const.ErrorServerError,
@@ -321,7 +321,7 @@ func (s *cibaService) HandleCallback(ctx context.Context, authReqID, assertion s
 func (s *cibaService) resolveExpectedAudience(ctx context.Context, clientID string) string {
 	app, err := s.inboundClient.GetOAuthClientByClientID(ctx, clientID)
 	if err != nil {
-		s.logger.WarnWithContext(ctx, "Failed to resolve client for audience validation; skipping audience check",
+		s.logger.Warn(ctx, "Failed to resolve client for audience validation; skipping audience check",
 			log.Error(err))
 		return ""
 	}

--- a/backend/internal/oauth/oauth2/clientauth/clientauth.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth.go
@@ -110,7 +110,7 @@ func authenticate(
 
 	case constants.TokenEndpointAuthMethodPrivateKeyJWT:
 		if clientAssertionType != constants.SupportedClientAssertionType {
-			logger.DebugWithContext(ctx, "Invalid client assertion: unsupported client assertion type")
+			logger.Debug(ctx, "Invalid client assertion: unsupported client assertion type")
 			return nil, errInvalidClientAssertion
 		}
 		extracted, err := extractClientIDFromAssertion(ctx, clientAssertion)
@@ -132,7 +132,7 @@ func authenticate(
 
 	oauthApp, err := inboundClient.GetOAuthClientByClientID(ctx, clientID)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to retrieve OAuth client",
+		logger.Error(ctx, "Failed to retrieve OAuth client",
 			log.Error(err), log.MaskedString("clientID", clientID))
 		return nil, errInvalidClientCredentials
 	}
@@ -150,7 +150,7 @@ func authenticate(
 	case constants.TokenEndpointAuthMethodPrivateKeyJWT:
 		if err := validateClientAssertion(ctx, oauthApp, jwtService, endpointURL, clientID,
 			clientAssertion); err != nil {
-			logger.DebugWithContext(ctx, "Invalid client assertion: "+err.Error())
+			logger.Debug(ctx, "Invalid client assertion: "+err.Error())
 			return nil, errInvalidClientAssertion
 		}
 	case constants.TokenEndpointAuthMethodClientSecretBasic,
@@ -160,7 +160,7 @@ func authenticate(
 			map[string]interface{}{"clientSecret": clientSecret},
 			nil, nil, authnprovidermgr.AuthUser{})
 		if authnErr != nil {
-			logger.DebugWithContext(ctx, "Client secret authentication failed",
+			logger.Debug(ctx, "Client secret authentication failed",
 				log.MaskedString("clientID", clientID))
 			return nil, errInvalidClientCredentials
 		}
@@ -217,14 +217,14 @@ func extractClientIDFromAssertion(ctx context.Context, assertion string) (string
 
 	payload, err := jwt.DecodeJWTPayload(assertion)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Invalid client assertion: failed to decode jwt")
+		logger.Debug(ctx, "Invalid client assertion: failed to decode jwt")
 		return "", errInvalidClientAssertion
 	}
 
 	subject, ok := payload["sub"].(string)
 
 	if !ok || subject == "" {
-		logger.DebugWithContext(ctx, "Invalid client assertion: missing 'sub' claim or 'sub' claim is not a string")
+		logger.Debug(ctx, "Invalid client assertion: missing 'sub' claim or 'sub' claim is not a string")
 		return "", errInvalidClientAssertion
 	}
 

--- a/backend/internal/oauth/oauth2/dcr/handler.go
+++ b/backend/internal/oauth/oauth2/dcr/handler.go
@@ -60,7 +60,7 @@ func (dh *dcrHandler) HandleDCRRegistration(w http.ResponseWriter, r *http.Reque
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
 			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DCRHandler"))
-			logger.ErrorWithContext(ctx, "Internal server error processing DCR registration request",
+			logger.Error(ctx, "Internal server error processing DCR registration request",
 				log.MaskedString("client_name", dcrRequest.ClientName),
 				log.String("error_code", svcErr.Code),
 				log.String("error", svcErr.Error.DefaultValue),

--- a/backend/internal/oauth/oauth2/dcr/init.go
+++ b/backend/internal/oauth/oauth2/dcr/init.go
@@ -44,7 +44,7 @@ func Initialize(
 	if err != nil {
 		wrappedErr := fmt.Errorf("failed to get runtime DB transactioner for DCR: %w", err)
 		// Service initialization runs during application startup, outside any request.
-		log.GetLogger().ErrorWithContext(context.Background(),
+		log.GetLogger().Error(context.Background(),
 			"Failed to initialize DCR service", log.Error(wrappedErr))
 		return wrappedErr
 	}

--- a/backend/internal/oauth/oauth2/dcr/service.go
+++ b/backend/internal/oauth/oauth2/dcr/service.go
@@ -86,12 +86,12 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 	if request.OUID == "" {
 		rootOUs, svcErr := ds.ouService.GetOrganizationUnitList(ctx, 1, 0, nil)
 		if svcErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to retrieve root organization units for DCR",
+			logger.Error(ctx, "Failed to retrieve root organization units for DCR",
 				log.String("error", svcErr.Error.DefaultValue))
 			return nil, &ErrorServerError
 		}
 		if rootOUs == nil || rootOUs.TotalResults == 0 || len(rootOUs.OrganizationUnits) == 0 {
-			logger.ErrorWithContext(ctx, "No root organization unit available for DCR registration")
+			logger.Error(ctx, "No root organization unit available for DCR registration")
 			return nil, &ErrorServerError
 		}
 		request.OUID = rootOUs.OrganizationUnits[0].ID
@@ -99,7 +99,7 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 
 	appDTO, svcErr := ds.convertDCRToApplication(request)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to convert DCR request to application DTO",
+		logger.Error(ctx, "Failed to convert DCR request to application DTO",
 			log.String("error", svcErr.Error.DefaultValue))
 		return nil, &ErrorServerError
 	}
@@ -112,12 +112,12 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 		createdApp, svcErr := ds.appService.CreateApplication(txCtx, appDTO)
 		if svcErr != nil {
 			if svcErr.Type == serviceerror.ServerErrorType {
-				logger.ErrorWithContext(ctx, "Failed to create application via Application service",
+				logger.Error(ctx, "Failed to create application via Application service",
 					log.String("error_code", svcErr.Code))
 				capturedErr = &ErrorServerError
 				return errors.New("failed to create application")
 			}
-			logger.DebugWithContext(ctx, "Failed to create application via Application service",
+			logger.Debug(ctx, "Failed to create application via Application service",
 				log.String("error_code", svcErr.Code))
 			capturedErr = ds.mapApplicationErrorToDCRError(svcErr)
 			return errors.New("failed to create application")
@@ -128,7 +128,7 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 		var convErr *serviceerror.ServiceError
 		response, convErr = ds.convertApplicationToDCRResponse(createdApp, request.ClientName)
 		if convErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to convert application to DCR response",
+			logger.Error(ctx, "Failed to convert application to DCR response",
 				log.String("error", convErr.Error.DefaultValue))
 			capturedErr = convErr
 			return errors.New("conversion failed")
@@ -152,7 +152,7 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 	// If the compensation DeleteApplication also fails, the app record is left without localized
 	// metadata — an accepted gap that can be cleaned up manually or via a future sweep.
 	if writeErr := ds.writeLocalizedVariants(ctx, createdAppID, request); writeErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to write localized variants for DCR client; compensating by deleting app",
+		logger.Error(ctx, "Failed to write localized variants for DCR client; compensating by deleting app",
 			log.String("appID", createdAppID), log.String("error", writeErr.Error.DefaultValue))
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer cleanupCancel()
@@ -160,12 +160,12 @@ func (ds *dcrService) RegisterClient(ctx context.Context, request *DCRRegistrati
 			if cleanErr := ds.i18nService.DeleteTranslationsByKey(
 				cleanupCtx, application.AppI18nNamespace(), application.AppI18nKey(createdAppID, field),
 			); cleanErr != nil {
-				logger.ErrorWithContext(ctx, "Failed to clean up partial i18n row after write failure",
+				logger.Error(ctx, "Failed to clean up partial i18n row after write failure",
 					log.String("appID", createdAppID), log.String("field", field))
 			}
 		}
 		if delSvcErr := ds.appService.DeleteApplication(cleanupCtx, createdAppID); delSvcErr != nil {
-			logger.ErrorWithContext(ctx,
+			logger.Error(ctx,
 				"Compensation delete failed after i18n write failure; app record may be orphaned",
 				log.String("appID", createdAppID))
 		}
@@ -403,7 +403,7 @@ func (ds *dcrService) writeLocalizedVariants(
 	ctx context.Context, appID string, request *DCRRegistrationRequest) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DCRService"))
 	if ds.i18nService == nil {
-		logger.DebugWithContext(ctx, "i18n service not configured, skipping localized variant writes")
+		logger.Debug(ctx, "i18n service not configured, skipping localized variant writes")
 		return nil
 	}
 	ns := application.AppI18nNamespace()
@@ -448,13 +448,13 @@ func (ds *dcrService) writeLocalizedVariants(
 	}
 	if svcErr := ds.i18nService.SetTranslationOverridesForNamespace(ctx, ns, entries); svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.DebugWithContext(ctx, "Invalid client metadata in localized variants",
+			logger.Debug(ctx, "Invalid client metadata in localized variants",
 				log.String("appID", appID),
 				log.String("errorCode", svcErr.Code),
 				log.String("error", svcErr.Error.DefaultValue))
 			return &ErrorServerError
 		}
-		logger.ErrorWithContext(ctx, "Failed to write localized variants",
+		logger.Error(ctx, "Failed to write localized variants",
 			log.String("appID", appID),
 			log.String("errorCode", svcErr.Code),
 			log.String("error", svcErr.Error.DefaultValue))

--- a/backend/internal/oauth/oauth2/discovery/handler.go
+++ b/backend/internal/oauth/oauth2/discovery/handler.go
@@ -52,7 +52,7 @@ func (dh *discoveryHandler) HandleOAuth2AuthorizationServerMetadata(w http.Respo
 	metadata := dh.discoveryService.GetOAuth2AuthorizationServerMetadata(ctx)
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, metadata)
-	logger.DebugWithContext(ctx, "OAuth 2.0 Authorization Server Metadata response sent successfully")
+	logger.Debug(ctx, "OAuth 2.0 Authorization Server Metadata response sent successfully")
 }
 
 // HandleOIDCDiscovery handles OpenID Connect Discovery requests
@@ -67,5 +67,5 @@ func (dh *discoveryHandler) HandleOIDCDiscovery(w http.ResponseWriter, r *http.R
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, metadata)
-	logger.DebugWithContext(ctx, "OIDC discovery response sent successfully")
+	logger.Debug(ctx, "OIDC discovery response sent successfully")
 }

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -185,7 +185,7 @@ func (ds *discoveryService) getSupportedSubjectTypes() []string {
 func (ds *discoveryService) getSupportedSigningAlgorithms(ctx context.Context) ([]string, error) {
 	keys, err := ds.cryptoProvider.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
 	if err != nil {
-		log.GetLogger().ErrorWithContext(ctx,
+		log.GetLogger().Error(ctx,
 			"Failed to retrieve public keys for signing algorithm discovery", log.Error(err))
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (ds *discoveryService) getSupportedSigningAlgorithms(ctx context.Context) (
 	}
 	if len(result) == 0 {
 		err = errors.New("no valid signing algorithms found")
-		log.GetLogger().ErrorWithContext(ctx,
+		log.GetLogger().Error(ctx,
 			"No valid signing algorithms found in registered public keys", log.Error(err))
 		return nil, err
 	}

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -120,7 +120,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 	if authCode.AttributeCacheID != "" {
 		userAttributes, err := h.attributeCache.GetAttributeCache(ctx, authCode.AttributeCacheID)
 		if err != nil {
-			logger.ErrorWithContext(ctx,
+			logger.Error(ctx,
 				"Failed to get user attributes from attribute cache. "+err.ErrorDescription.DefaultValue)
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
@@ -228,7 +228,7 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 			CompletedACR:   authCode.CompletedACR,
 		})
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to generate ID token", log.Error(err))
+			logger.Error(ctx, "Failed to generate ID token", log.Error(err))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
 				ErrorDescription: "Failed to generate token",
@@ -272,7 +272,7 @@ func (h *authorizationCodeGrantHandler) retrieveAndValidateAuthCode(
 		// Validate PKCE
 		if err := pkce.ValidatePKCE(authCode.CodeChallenge, authCode.CodeChallengeMethod,
 			tokenRequest.CodeVerifier); err != nil {
-			logger.DebugWithContext(ctx, "PKCE validation failed", log.Error(err))
+			logger.Debug(ctx, "PKCE validation failed", log.Error(err))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorInvalidGrant,
 				ErrorDescription: "Invalid code verifier",

--- a/backend/internal/oauth/oauth2/granthandlers/ciba.go
+++ b/backend/internal/oauth/oauth2/granthandlers/ciba.go
@@ -117,7 +117,7 @@ func (h *cibaGrantHandler) HandleGrant(ctx context.Context, tokenRequest *model.
 	if now.After(record.ExpiryTime) {
 		if record.State != ciba.CIBAStateExpired && record.State != ciba.CIBAStateConsumed {
 			if updateErr := h.cibaService.UpdateState(ctx, record.AuthReqID, ciba.CIBAStateExpired); updateErr != nil {
-				logger.ErrorWithContext(ctx, "Failed to mark CIBA request as expired", log.Error(updateErr))
+				logger.Error(ctx, "Failed to mark CIBA request as expired", log.Error(updateErr))
 			}
 		}
 		return nil, &model.ErrorResponse{
@@ -156,7 +156,7 @@ func (h *cibaGrantHandler) handlePending(ctx context.Context, record *ciba.CIBAA
 		now.Sub(record.LastPolledAt) < time.Duration(constants.CIBADefaultIntervalSeconds)*time.Second
 
 	if updateErr := h.cibaService.UpdateLastPolled(ctx, record.AuthReqID, now); updateErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to update CIBA last polled time", log.Error(updateErr))
+		logger.Error(ctx, "Failed to update CIBA last polled time", log.Error(updateErr))
 	}
 
 	if tooFast {
@@ -186,7 +186,7 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 	if record.AttributeCacheID != "" {
 		cacheEntry, cacheErr := h.attributeCache.GetAttributeCache(ctx, record.AttributeCacheID)
 		if cacheErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to get user attributes from attribute cache",
+			logger.Error(ctx, "Failed to get user attributes from attribute cache",
 				log.String("error", cacheErr.ErrorDescription.DefaultValue))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
@@ -207,7 +207,7 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 		OAuthApp:         oauthApp,
 	})
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to generate access token", log.Error(err))
+		logger.Error(ctx, "Failed to generate access token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorServerError,
 			ErrorDescription: "Failed to generate token",
@@ -229,7 +229,7 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 			CompletedACR:   record.CompletedACR,
 		})
 		if idErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to generate ID token", log.Error(idErr))
+			logger.Error(ctx, "Failed to generate ID token", log.Error(idErr))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
 				ErrorDescription: "Failed to generate token",
@@ -242,7 +242,7 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 	// consumed it, reject this one with invalid_grant.
 	consumed, consumeErr := h.cibaService.MarkConsumed(ctx, record.AuthReqID)
 	if consumeErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to consume CIBA authentication request", log.Error(consumeErr))
+		logger.Error(ctx, "Failed to consume CIBA authentication request", log.Error(consumeErr))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorServerError,
 			ErrorDescription: "Failed to process token request",

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
@@ -112,7 +112,7 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 			if groupErr != nil {
 				// Ignore unimplemented providers to preserve existing behavior.
 				if groupErr.Code != entityprovider.ErrorCodeNotImplemented {
-					logger.ErrorWithContext(ctx, "Failed to resolve app group memberships",
+					logger.Error(ctx, "Failed to resolve app group memberships",
 						log.String("appID", oauthApp.ID), log.String("error", groupErr.Error()))
 					return nil, &model.ErrorResponse{
 						Error:            constants.ErrorServerError,
@@ -134,7 +134,7 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 			RequestedPermissions: scopes,
 		})
 		if svcErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to get authorized permissions for app",
+			logger.Error(ctx, "Failed to get authorized permissions for app",
 				log.String("appID", oauthApp.ID), log.String("error", svcErr.Error.DefaultValue))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -104,7 +104,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	refreshTokenClaims, err := h.tokenValidator.ValidateRefreshToken(
 		ctx, tokenRequest.RefreshToken, tokenRequest.ClientID)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Failed to validate refresh token", log.Error(err))
+		logger.Debug(ctx, "Failed to validate refresh token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorInvalidGrant,
 			ErrorDescription: "Invalid refresh token",
@@ -168,7 +168,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	if refreshTokenClaims.AttributeCacheID != "" {
 		cacheEntry, fetchErr = h.attrCacheService.GetAttributeCache(ctx, refreshTokenClaims.AttributeCacheID)
 		if fetchErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to get user attributes from attribute cache",
+			logger.Error(ctx, "Failed to get user attributes from attribute cache",
 				log.String("error", fetchErr.ErrorDescription.DefaultValue))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
@@ -176,7 +176,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 			}
 		}
 		if cacheEntry == nil {
-			logger.ErrorWithContext(ctx, "Attribute cache entry not found for cache ID",
+			logger.Error(ctx, "Attribute cache entry not found for cache ID",
 				log.String("cache_id", refreshTokenClaims.AttributeCacheID))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
@@ -206,7 +206,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	}
 	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, accessTokenCtx)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to generate access token", log.Error(err))
+		logger.Error(ctx, "Failed to generate access token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorServerError,
 			ErrorDescription: "Failed to generate access token",
@@ -229,7 +229,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 			ClaimsRequest:  refreshTokenClaims.ClaimsRequest,
 		})
 		if idErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to generate ID token", log.Error(idErr))
+			logger.Error(ctx, "Failed to generate ID token", log.Error(idErr))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorServerError,
 				ErrorDescription: "Failed to generate token",
@@ -245,14 +245,14 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 	// Issue a new refresh token if renew_on_grant is enabled; otherwise reuse the existing one.
 	// RFC 8707 §5: the refresh token preserves the full original audience, not the narrowed one.
 	if renewRefreshToken {
-		logger.DebugWithContext(ctx, "Renewing refresh token", log.String("client_id", tokenRequest.ClientID))
+		logger.Debug(ctx, "Renewing refresh token", log.String("client_id", tokenRequest.ClientID))
 		errResp := h.IssueRefreshToken(ctx, tokenResponse, oauthApp,
 			refreshTokenClaims.Sub, refreshTokenClaims.Audiences,
 			refreshTokenClaims.GrantType, newTokenScopes,
 			refreshTokenClaims.ClaimsRequest, refreshTokenClaims.ClaimsLocales,
 			refreshTokenClaims.AttributeCacheID)
 		if errResp != nil && errResp.Error != "" {
-			logger.ErrorWithContext(ctx, "Failed to issue refresh token", log.String("error", errResp.Error))
+			logger.Error(ctx, "Failed to issue refresh token", log.String("error", errResp.Error))
 			return nil, errResp
 		}
 	} else {
@@ -357,7 +357,7 @@ func (h *refreshTokenGrantHandler) extendCacheTTL(
 	desiredTTL := int(maxExpiry-now) + constants.AttributeCacheTTLBufferSeconds
 	if desiredTTL > cacheEntry.TTLSeconds {
 		if extErr := h.attrCacheService.ExtendAttributeCacheTTL(ctx, cacheID, desiredTTL); extErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to extend attribute cache TTL",
+			logger.Error(ctx, "Failed to extend attribute cache TTL",
 				log.String("cache_id", cacheID),
 				log.String("error", extErr.Error.String()))
 			return &model.ErrorResponse{
@@ -377,7 +377,7 @@ func (h *refreshTokenGrantHandler) validateAndApplyScopes(ctx context.Context, r
 	trimmedRequestedScopes := tokenservice.ParseScopes(requestedScopes)
 
 	if len(trimmedRequestedScopes) == 0 {
-		logger.DebugWithContext(ctx, "No scopes requested. Granting all scopes from refresh token",
+		logger.Debug(ctx, "No scopes requested. Granting all scopes from refresh token",
 			log.Any("scopes", refreshTokenScopes))
 		return refreshTokenScopes, nil
 	}
@@ -391,6 +391,6 @@ func (h *refreshTokenGrantHandler) validateAndApplyScopes(ctx context.Context, r
 		}
 	}
 
-	logger.DebugWithContext(ctx, "Applied scope downscoping", log.Any("grantedScopes", trimmedRequestedScopes))
+	logger.Debug(ctx, "Applied scope downscoping", log.Any("grantedScopes", trimmedRequestedScopes))
 	return trimmedRequestedScopes, nil
 }

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -139,7 +139,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	// Validate and extract subject token claims
 	subjectClaims, err := h.tokenValidator.ValidateSubjectToken(ctx, tokenRequest.SubjectToken, oauthApp)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Failed to validate subject token", log.Error(err))
+		logger.Debug(ctx, "Failed to validate subject token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorInvalidRequest,
 			ErrorDescription: "Invalid subject_token",
@@ -157,7 +157,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	if tokenRequest.ActorToken != "" {
 		actorClaims, err = h.tokenValidator.ValidateSubjectToken(ctx, tokenRequest.ActorToken, oauthApp)
 		if err != nil {
-			logger.DebugWithContext(ctx, "Failed to validate actor token", log.Error(err))
+			logger.Debug(ctx, "Failed to validate actor token", log.Error(err))
 			return nil, &model.ErrorResponse{
 				Error:            constants.ErrorInvalidRequest,
 				ErrorDescription: "Invalid actor_token",
@@ -208,7 +208,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 		DPoPJkt:        dpop.GetJkt(ctx),
 	})
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to generate token", log.Error(err))
+		logger.Error(ctx, "Failed to generate token", log.Error(err))
 		return nil, &model.ErrorResponse{
 			Error:            constants.ErrorServerError,
 			ErrorDescription: "Failed to generate token",

--- a/backend/internal/oauth/oauth2/introspect/handler.go
+++ b/backend/internal/oauth/oauth2/introspect/handler.go
@@ -61,7 +61,7 @@ func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *h
 
 	response, err := h.service.IntrospectToken(ctx, token, tokenTypeHint)
 	if err != nil {
-		h.logger.ErrorWithContext(ctx, "Failed to introspect token", log.Error(err))
+		h.logger.Error(ctx, "Failed to introspect token", log.Error(err))
 		sysutils.WriteJSONError(ctx, w, constants.ErrorServerError,
 			"An unexpected error occurred while processing the request",
 			http.StatusInternalServerError, nil)

--- a/backend/internal/oauth/oauth2/introspect/service.go
+++ b/backend/internal/oauth/oauth2/introspect/service.go
@@ -65,7 +65,7 @@ func (s *tokenIntrospectionService) IntrospectToken(
 
 	_, payload, err := jwt.DecodeJWT(token)
 	if err != nil {
-		logger.DebugWithContext(ctx, "Failed to decode JWT", log.Error(err))
+		logger.Debug(ctx, "Failed to decode JWT", log.Error(err))
 		return &IntrospectResponse{
 			Active: false,
 		}, nil
@@ -80,7 +80,7 @@ func (s *tokenIntrospectionService) IntrospectToken(
 // validateToken verifies the signature and validity of the token.
 func (s *tokenIntrospectionService) validateToken(ctx context.Context, logger *log.Logger, token string) bool {
 	if err := s.jwtService.VerifyJWT(ctx, token, "", ""); err != nil {
-		logger.DebugWithContext(ctx, "Failed to verify refresh token", log.String("error", err.Error.DefaultValue))
+		logger.Debug(ctx, "Failed to verify refresh token", log.String("error", err.Error.DefaultValue))
 		return false
 	}
 	return true

--- a/backend/internal/oauth/oauth2/jwksresolver/resolver.go
+++ b/backend/internal/oauth/oauth2/jwksresolver/resolver.go
@@ -75,7 +75,7 @@ func (r *Resolver) ResolveEncryptionKey(
 	policy KeyUsePolicy,
 ) (crypto.PublicKey, string, *serviceerror.ServiceError) {
 	if certificate == nil || certificate.Type == "" {
-		r.logger.ErrorWithContext(ctx, "No certificate configured for encryption key resolution")
+		r.logger.Error(ctx, "No certificate configured for encryption key resolution")
 		return nil, "", &serviceerror.InternalServerError
 	}
 
@@ -90,7 +90,7 @@ func (r *Resolver) ResolveEncryptionKey(
 		}
 		jwksData = body
 	default:
-		r.logger.ErrorWithContext(ctx, "Unsupported certificate type for encryption key resolution",
+		r.logger.Error(ctx, "Unsupported certificate type for encryption key resolution",
 			log.String("type", string(certificate.Type)))
 		return nil, "", &serviceerror.InternalServerError
 	}
@@ -102,28 +102,28 @@ func (r *Resolver) ResolveEncryptionKey(
 // It does not log JWKS body, key material, or HTTP response headers.
 func (r *Resolver) fetchJWKS(ctx context.Context, jwksURI string) ([]byte, *serviceerror.ServiceError) {
 	if r.httpClient == nil {
-		r.logger.ErrorWithContext(ctx, "HTTP client is not configured for JWKS resolver")
+		r.logger.Error(ctx, "HTTP client is not configured for JWKS resolver")
 		return nil, &serviceerror.InternalServerError
 	}
 	if err := syshttp.IsSSRFSafeURL(jwksURI); err != nil {
-		r.logger.ErrorWithContext(ctx, "JWKS URI is not SSRF-safe",
+		r.logger.Error(ctx, "JWKS URI is not SSRF-safe",
 			log.String("endpoint", jwksEndpoint(jwksURI)), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURI, nil)
 	if err != nil {
-		r.logger.ErrorWithContext(ctx, "Failed to build JWKS request", log.Error(err))
+		r.logger.Error(ctx, "Failed to build JWKS request", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	resp, err := r.httpClient.Do(req)
 	if err != nil {
-		r.logger.ErrorWithContext(ctx, "Failed to fetch JWKS from URI",
+		r.logger.Error(ctx, "Failed to fetch JWKS from URI",
 			log.String("endpoint", jwksEndpoint(jwksURI)), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		r.logger.ErrorWithContext(ctx, "JWKS URI returned non-200 status",
+		r.logger.Error(ctx, "JWKS URI returned non-200 status",
 			log.String("endpoint", jwksEndpoint(jwksURI)), log.Int("statusCode", resp.StatusCode))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -131,11 +131,11 @@ func (r *Resolver) fetchJWKS(ctx context.Context, jwksURI string) ([]byte, *serv
 	limitedReader := io.LimitReader(resp.Body, maxJWKSBytes+1)
 	body, err := io.ReadAll(limitedReader)
 	if err != nil {
-		r.logger.ErrorWithContext(ctx, "Failed to read JWKS response body", log.Error(err))
+		r.logger.Error(ctx, "Failed to read JWKS response body", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if len(body) > maxJWKSBytes {
-		r.logger.ErrorWithContext(ctx, "JWKS URI response exceeds 1 MB size limit",
+		r.logger.Error(ctx, "JWKS URI response exceeds 1 MB size limit",
 			log.String("endpoint", jwksEndpoint(jwksURI)))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -153,7 +153,7 @@ func (r *Resolver) parseEncryptionKeyFromJWKS(ctx context.Context,
 		Keys []map[string]interface{} `json:"keys"`
 	}
 	if err := json.Unmarshal(jwksData, &jwksObj); err != nil {
-		r.logger.ErrorWithContext(ctx, "Failed to parse JWKS for encryption key resolution", log.Error(err))
+		r.logger.Error(ctx, "Failed to parse JWKS for encryption key resolution", log.Error(err))
 		return nil, "", &serviceerror.InternalServerError
 	}
 
@@ -185,7 +185,7 @@ func (r *Resolver) parseEncryptionKeyFromJWKS(ctx context.Context,
 		}
 	}
 
-	r.logger.ErrorWithContext(ctx, "No suitable RSA encryption key found in JWKS", log.String("alg", encryptionAlg))
+	r.logger.Error(ctx, "No suitable RSA encryption key found in JWKS", log.String("alg", encryptionAlg))
 	return nil, "", &serviceerror.InternalServerError
 }
 

--- a/backend/internal/oauth/oauth2/par/handler.go
+++ b/backend/internal/oauth/oauth2/par/handler.go
@@ -62,7 +62,7 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 	// Client authentication is handled by the ClientAuthMiddleware.
 	clientInfo := clientauth.GetOAuthClient(ctx)
 	if clientInfo == nil {
-		h.logger.ErrorWithContext(ctx, "OAuth client not found in context - ClientAuthMiddleware must be applied")
+		h.logger.Error(ctx, "OAuth client not found in context - ClientAuthMiddleware must be applied")
 		utils.WriteJSONError(ctx, w, oauth2const.ErrorServerError,
 			"Something went wrong", http.StatusInternalServerError, nil)
 		return
@@ -80,7 +80,7 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 	if errCode != "" {
 		statusCode := http.StatusBadRequest
 		if errCode == oauth2const.ErrorServerError {
-			h.logger.ErrorWithContext(ctx, "Internal server error verifying DPoP header",
+			h.logger.Error(ctx, "Internal server error verifying DPoP header",
 				log.MaskedString("clientID", clientInfo.ClientID),
 				log.String("errorCode", errCode),
 				log.String("errorDescription", errDesc),
@@ -88,7 +88,7 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 			statusCode = http.StatusInternalServerError
 		}
 		if errCode == oauth2const.ErrorInvalidDPoPProof {
-			h.logger.DebugWithContext(ctx, "DPoP proof rejected at PAR",
+			h.logger.Debug(ctx, "DPoP proof rejected at PAR",
 				log.MaskedString("clientID", clientInfo.ClientID),
 				log.String("error", errDesc))
 			errDesc = "Invalid DPoP proof"
@@ -110,7 +110,7 @@ func (h *parHandler) HandlePARRequest(w http.ResponseWriter, r *http.Request) {
 	if errCode != "" {
 		statusCode := http.StatusBadRequest
 		if errCode == oauth2const.ErrorServerError {
-			h.logger.ErrorWithContext(ctx, "Internal server error processing pushed authorization request",
+			h.logger.Error(ctx, "Internal server error processing pushed authorization request",
 				log.MaskedString("clientID", clientInfo.ClientID),
 				log.String("errorCode", errCode),
 				log.String("errorDescription", errDesc),
@@ -134,7 +134,7 @@ func (h *parHandler) verifyDPoPHeader(ctx context.Context, r *http.Request) (str
 		return "", oauth2const.ErrorInvalidDPoPProof, "Multiple DPoP headers"
 	}
 	if h.dpopVerifier == nil {
-		h.logger.ErrorWithContext(ctx, "DPoP verifier is not configured")
+		h.logger.Error(ctx, "DPoP verifier is not configured")
 		return "", oauth2const.ErrorServerError, "Something went wrong"
 	}
 	result, err := h.dpopVerifier.Verify(ctx, dpop.VerifyParams{

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -149,7 +149,7 @@ func (s *parService) HandlePushedAuthorizationRequest(
 
 	randomKey, err := s.store.Store(ctx, parRequest, expiresIn)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to store pushed authorization request", log.Error(err))
+		s.logger.Error(ctx, "Failed to store pushed authorization request", log.Error(err))
 		return nil, oauth2const.ErrorServerError, "Failed to process pushed authorization request"
 	}
 
@@ -180,7 +180,7 @@ func (s *parService) ResolvePushedAuthorizationRequest(
 
 	parRequest, found, err := s.store.Consume(ctx, randomKey)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to consume PAR request", log.Error(err))
+		s.logger.Error(ctx, "Failed to consume PAR request", log.Error(err))
 		return nil, ErrPARResolutionFailed
 	}
 	if !found {
@@ -190,7 +190,7 @@ func (s *parService) ResolvePushedAuthorizationRequest(
 	// Verify client_id binding: the client making the authorization request must match
 	// the client that pushed the authorization request.
 	if parRequest.ClientID != clientID {
-		s.logger.DebugWithContext(ctx, "Client ID mismatch for PAR request",
+		s.logger.Debug(ctx, "Client ID mismatch for PAR request",
 			log.String("expected", parRequest.ClientID),
 			log.String("actual", clientID))
 		return nil, errClientIDMismatch

--- a/backend/internal/oauth/oauth2/token/handler.go
+++ b/backend/internal/oauth/oauth2/token/handler.go
@@ -87,7 +87,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 	// Get authenticated client from context (set by ClientAuthMiddleware).
 	clientInfo := clientauth.GetOAuthClient(r.Context())
 	if clientInfo == nil {
-		logger.ErrorWithContext(ctx, "OAuth client not found in context - ClientAuthMiddleware must be applied")
+		logger.Error(ctx, "OAuth client not found in context - ClientAuthMiddleware must be applied")
 		utils.WriteJSONError(r.Context(), w, constants.ErrorServerError,
 			"Something went wrong", http.StatusInternalServerError, nil)
 		return
@@ -128,7 +128,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 			}
 			description := tokenError.ErrorDescription
 			if tokenError.Error == constants.ErrorInvalidDPoPProof {
-				logger.DebugWithContext(ctx, "DPoP proof rejected", log.String("error", description))
+				logger.Debug(ctx, "DPoP proof rejected", log.String("error", description))
 				description = "Invalid DPoP proof"
 			}
 			utils.WriteJSONError(r.Context(), w, tokenError.Error, description, statusCode, nil)
@@ -139,7 +139,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	logger.DebugWithContext(ctx, "Token response sending", log.String("client_id", clientInfo.ClientID))
+	logger.Debug(ctx, "Token response sending", log.String("client_id", clientInfo.ClientID))
 
 	// Must include the following headers when sensitive data is returned.
 	w.Header().Set(sysconst.CacheControlHeaderName, sysconst.CacheControlNoStore)

--- a/backend/internal/oauth/oauth2/token/service.go
+++ b/backend/internal/oauth/oauth2/token/service.go
@@ -123,7 +123,7 @@ func (ts *tokenService) ProcessTokenRequest(
 				ErrorDescription: "Unsupported grant type",
 			}
 		}
-		logger.ErrorWithContext(ctx, "Failed to get grant handler", log.Error(handlerErr))
+		logger.Error(ctx, "Failed to get grant handler", log.Error(handlerErr))
 		publishTokenIssuanceFailedEvent(ts.observabilitySvc, ctx, clientID, grantTypeStr, scopeStr,
 			500, "Failed to get grant handler", startTime)
 		return nil, &model.ErrorResponse{
@@ -197,12 +197,12 @@ func (ts *tokenService) ProcessTokenRequest(
 	// Issue refresh token if applicable.
 	if (grantType == constants.GrantTypeAuthorizationCode || grantType == constants.GrantTypeCIBA) &&
 		oauthApp.IsAllowedGrantType(constants.GrantTypeRefreshToken) {
-		logger.DebugWithContext(ctx, "Issuing refresh token for the token request",
+		logger.Debug(ctx, "Issuing refresh token for the token request",
 			log.String("client_id", clientID), log.String("grant_type", grantTypeStr))
 
 		refreshGrantHandler, handlerErr := ts.grantHandlerProvider.GetGrantHandler(constants.GrantTypeRefreshToken)
 		if handlerErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to get refresh grant handler", log.Error(handlerErr))
+			logger.Error(ctx, "Failed to get refresh grant handler", log.Error(handlerErr))
 			publishTokenIssuanceFailedEvent(ts.observabilitySvc, ctx, clientID, grantTypeStr, scopeStr,
 				500, "Failed to get refresh grant handler", startTime)
 			return nil, &model.ErrorResponse{
@@ -212,7 +212,7 @@ func (ts *tokenService) ProcessTokenRequest(
 		}
 		refreshGrantHandlerTyped, ok := refreshGrantHandler.(granthandlers.RefreshTokenGrantHandlerInterface)
 		if !ok {
-			logger.ErrorWithContext(ctx, "Failed to cast refresh grant handler",
+			logger.Error(ctx, "Failed to cast refresh grant handler",
 				log.String("client_id", clientID), log.String("grant_type", grantTypeStr))
 			publishTokenIssuanceFailedEvent(ts.observabilitySvc, ctx, clientID, grantTypeStr, scopeStr,
 				500, "Internal Server Error", startTime)
@@ -264,7 +264,7 @@ func (ts *tokenService) ProcessTokenRequest(
 		}
 	}
 
-	logger.DebugWithContext(ctx, "Token generated successfully",
+	logger.Debug(ctx, "Token generated successfully",
 		log.String("client_id", clientID), log.String("grant_type", grantTypeStr))
 
 	ts.publishTokenIssuedEvent(ctx, clientID, grantTypeStr, scopes, startTime)

--- a/backend/internal/oauth/oauth2/userinfo/handler.go
+++ b/backend/internal/oauth/oauth2/userinfo/handler.go
@@ -141,7 +141,7 @@ func (h *userInfoHandler) writeUserInfoResponse(ctx context.Context, w http.Resp
 		utils.WriteSuccessResponse(ctx, w, http.StatusOK, result.JSONBody)
 	}
 
-	h.logger.DebugWithContext(ctx, "UserInfo response sent successfully")
+	h.logger.Debug(ctx, "UserInfo response sent successfully")
 }
 
 // writeServiceErrorResponse writes a service error response. The dpop flag selects
@@ -165,7 +165,7 @@ func (h *userInfoHandler) writeServiceErrorResponse(ctx context.Context,
 	}
 
 	if statusCode == http.StatusInternalServerError {
-		h.logger.ErrorWithContext(ctx, "Internal server error processing userinfo request",
+		h.logger.Error(ctx, "Internal server error processing userinfo request",
 			log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
 		utils.WriteJSONError(ctx, w, constants.ErrorServerError,

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -95,13 +95,13 @@ func (s *userInfoService) GetUserInfo(
 
 	accessTokenClaims, err := s.tokenValidator.ValidateAccessToken(ctx, accessToken)
 	if err != nil {
-		s.logger.DebugWithContext(ctx, "Failed to verify access token", log.Error(err))
+		s.logger.Debug(ctx, "Failed to verify access token", log.Error(err))
 		return nil, &errorInvalidAccessToken
 	}
 
 	boundJkt, _ := dpop.ExtractCnfJkt(accessTokenClaims.Claims)
 	if boundJkt != "" {
-		s.logger.DebugWithContext(ctx, "DPoP-bound access token presented under Bearer scheme")
+		s.logger.Debug(ctx, "DPoP-bound access token presented under Bearer scheme")
 		return nil, &errorBearerDowngrade
 	}
 
@@ -120,18 +120,18 @@ func (s *userInfoService) GetUserInfoForDPoP(
 
 	accessTokenClaims, err := s.tokenValidator.ValidateAccessToken(ctx, accessToken)
 	if err != nil {
-		s.logger.DebugWithContext(ctx, "Failed to verify access token", log.Error(err))
+		s.logger.Debug(ctx, "Failed to verify access token", log.Error(err))
 		return nil, &errorInvalidAccessToken
 	}
 
 	expectedJkt, _ := dpop.ExtractCnfJkt(accessTokenClaims.Claims)
 	if expectedJkt == "" {
-		s.logger.DebugWithContext(ctx, "DPoP scheme used with non-bound access token")
+		s.logger.Debug(ctx, "DPoP scheme used with non-bound access token")
 		return nil, &errorDPoPProofInvalid
 	}
 
 	if s.dpopVerifier == nil {
-		s.logger.ErrorWithContext(ctx, "DPoP verifier not configured")
+		s.logger.Error(ctx, "DPoP verifier not configured")
 		return nil, &serviceerror.InternalServerError
 	}
 	if _, dpopErr := s.dpopVerifier.Verify(ctx, dpop.VerifyParams{
@@ -141,7 +141,7 @@ func (s *userInfoService) GetUserInfoForDPoP(
 		AccessToken: accessToken,
 		ExpectedJkt: expectedJkt,
 	}); dpopErr != nil {
-		s.logger.DebugWithContext(ctx, "DPoP proof verification failed", log.Error(dpopErr))
+		s.logger.Debug(ctx, "DPoP proof verification failed", log.Error(dpopErr))
 		return nil, &errorDPoPProofInvalid
 	}
 
@@ -182,7 +182,7 @@ func (s *userInfoService) buildResponseFromClaims(
 	userAttributes, err := tokenservice.FetchUserAttributes(ctx, s.attributeCacheSvc,
 		allowedUserAttributes, attributeCacheID)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to fetch user attributes",
+		s.logger.Error(ctx, "Failed to fetch user attributes",
 			log.MaskedString(log.LoggerKeyUserID, sub), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -230,7 +230,7 @@ func (s *userInfoService) generateJWEUserInfo(
 
 	payload, err := json.Marshal(response)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to marshal userinfo claims for JWE")
+		s.logger.Error(ctx, "Failed to marshal userinfo claims for JWE")
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -242,7 +242,7 @@ func (s *userInfoService) generateJWEUserInfo(
 		rpKID,
 	)
 	if svcErr != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to encrypt userinfo JWE")
+		s.logger.Error(ctx, "Failed to encrypt userinfo JWE")
 		return nil, svcErr
 	}
 
@@ -277,7 +277,7 @@ func (s *userInfoService) generateNestedJWTUserInfo(
 		rpKID,
 	)
 	if svcErr != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to encrypt nested JWT userinfo JWE")
+		s.logger.Error(ctx, "Failed to encrypt nested JWT userinfo JWE")
 		return nil, svcErr
 	}
 
@@ -320,10 +320,10 @@ func (s *userInfoService) generateJWSUserInfo(
 	)
 	if err != nil {
 		if err.Code == jwt.ErrorUnsupportedJWSAlgorithm.Code {
-			s.logger.ErrorWithContext(ctx, "UserInfo signing algorithm is not supported by the server key",
+			s.logger.Error(ctx, "UserInfo signing algorithm is not supported by the server key",
 				log.String("alg", signingAlg), log.String("error", err.Error.DefaultValue))
 		} else {
-			s.logger.ErrorWithContext(ctx, "Failed to generate signed UserInfo JWT",
+			s.logger.Error(ctx, "Failed to generate signed UserInfo JWT",
 				log.String("error", err.Error.DefaultValue))
 		}
 		return nil, &serviceerror.InternalServerError
@@ -349,7 +349,7 @@ func (s *userInfoService) validateGrantType(
 	}
 
 	if constants.GrantType(grantTypeString) == constants.GrantTypeClientCredentials {
-		s.logger.DebugWithContext(ctx, "UserInfo endpoint called with client_credentials grant token",
+		s.logger.Debug(ctx, "UserInfo endpoint called with client_credentials grant token",
 			log.String("grant_type", grantTypeString))
 		return &errorClientCredentialsNotSupported
 	}
@@ -375,7 +375,7 @@ func (s *userInfoService) extractScopes(claims map[string]interface{}) []string 
 // validateOpenIDScope validates that the access token contains the required 'openid' scope.
 func (s *userInfoService) validateOpenIDScope(ctx context.Context, scopes []string) *serviceerror.ServiceError {
 	if !slices.Contains(scopes, constants.ScopeOpenID) {
-		s.logger.DebugWithContext(ctx, "UserInfo request missing required 'openid' scope",
+		s.logger.Debug(ctx, "UserInfo request missing required 'openid' scope",
 			log.String("scopes", tokenservice.JoinScopes(scopes)))
 		return &errorInsufficientScope
 	}
@@ -459,7 +459,7 @@ func (s *userInfoService) extractClaimsRequest(ctx context.Context,
 
 	claimsRequest, err := oauth2utils.ParseClaimsRequest(claimsRequestStr)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to parse claims request from access token", log.Error(err))
+		s.logger.Error(ctx, "Failed to parse claims request from access token", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/openid4vp/handler.go
+++ b/backend/internal/openid4vp/handler.go
@@ -97,7 +97,7 @@ func (h *openID4VPHandler) HandleRequestObject(w http.ResponseWriter, r *http.Re
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
 	if _, werr := w.Write([]byte(jar)); werr != nil {
-		log.GetLogger().ErrorWithContext(r.Context(), "Failed to write request object response", log.Error(werr))
+		log.GetLogger().Error(r.Context(), "Failed to write request object response", log.Error(werr))
 	}
 }
 
@@ -144,7 +144,7 @@ func (h *openID4VPHandler) HandleInitiate(w http.ResponseWriter, r *http.Request
 			writeServiceErrorResponse(r.Context(), w, &ErrorUnknownDefinition)
 			return
 		}
-		log.GetLogger().ErrorWithContext(r.Context(), "Failed to initiate OpenID4VP transaction", log.Error(err))
+		log.GetLogger().Error(r.Context(), "Failed to initiate OpenID4VP transaction", log.Error(err))
 		writeServiceErrorResponse(r.Context(), w, toServiceError(err))
 		return
 	}
@@ -195,7 +195,7 @@ func (h *openID4VPHandler) HandleStatus(w http.ResponseWriter, r *http.Request) 
 		})
 	case StatusCompleted:
 		if h.issuer == nil {
-			log.GetLogger().ErrorWithContext(r.Context(), "Result token issuer not configured")
+			log.GetLogger().Error(r.Context(), "Result token issuer not configured")
 			writeServiceErrorResponse(r.Context(), w, &serviceerror.InternalServerError)
 			return
 		}
@@ -206,7 +206,7 @@ func (h *openID4VPHandler) HandleStatus(w http.ResponseWriter, r *http.Request) 
 		token, tokenErr := h.issuer.issueResultToken(
 			r.Context(), rpID, rs, int64(h.resultTokenValidity.Seconds()))
 		if tokenErr != nil {
-			log.GetLogger().ErrorWithContext(r.Context(), "Failed to issue result token", log.Error(tokenErr))
+			log.GetLogger().Error(r.Context(), "Failed to issue result token", log.Error(tokenErr))
 			writeServiceErrorResponse(r.Context(), w, &serviceerror.InternalServerError)
 			return
 		}

--- a/backend/internal/ou/cache_backed_store.go
+++ b/backend/internal/ou/cache_backed_store.go
@@ -189,7 +189,7 @@ func (s *cacheBackedOUStore) cacheOUByID(ctx context.Context, ou *OrganizationUn
 		return
 	}
 	if err := s.ouByIDCache.Set(ctx, cache.CacheKey{Key: ou.ID}, ou); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to cache OU by ID",
+		s.logger.Error(ctx, "Failed to cache OU by ID",
 			log.String("ouID", ou.ID), log.Error(err))
 	}
 }
@@ -200,7 +200,7 @@ func (s *cacheBackedOUStore) cacheOUByHandleParent(ctx context.Context, ou *Orga
 	}
 	key := handleParentCacheKey(ou.Handle, ou.Parent)
 	if err := s.ouByHandleParentCache.Set(ctx, cache.CacheKey{Key: key}, ou); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to cache OU by handle+parent",
+		s.logger.Error(ctx, "Failed to cache OU by handle+parent",
 			log.String("handle", ou.Handle), log.Error(err))
 	}
 }
@@ -210,7 +210,7 @@ func (s *cacheBackedOUStore) invalidateOUByID(ctx context.Context, id string) {
 		return
 	}
 	if err := s.ouByIDCache.Delete(ctx, cache.CacheKey{Key: id}); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to invalidate OU cache by ID",
+		s.logger.Error(ctx, "Failed to invalidate OU cache by ID",
 			log.String("ouID", id), log.Error(err))
 	}
 }
@@ -236,7 +236,7 @@ func (s *cacheBackedOUStore) getHandleParentKey(ctx context.Context, id string) 
 
 func (s *cacheBackedOUStore) deleteHandleParentCacheKey(ctx context.Context, key string) {
 	if err := s.ouByHandleParentCache.Delete(ctx, cache.CacheKey{Key: key}); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to invalidate OU cache by handle+parent",
+		s.logger.Error(ctx, "Failed to invalidate OU cache by handle+parent",
 			log.String("cacheKey", key), log.Error(err))
 	}
 }

--- a/backend/internal/ou/handler.go
+++ b/backend/internal/ou/handler.go
@@ -75,7 +75,7 @@ func (ouh *organizationUnitHandler) HandleOUListRequest(w http.ResponseWriter, r
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, ouListResponse)
 
-	logger.DebugWithContext(ctx, "Successfully listed organization units with pagination",
+	logger.Debug(ctx, "Successfully listed organization units with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", ouListResponse.TotalResults),
 		log.Int("count", ouListResponse.Count))
@@ -106,7 +106,7 @@ func (ouh *organizationUnitHandler) HandleOUPostRequest(w http.ResponseWriter, r
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdOU)
 
-	logger.DebugWithContext(ctx, "Successfully created organization unit", log.String("ouId", createdOU.ID))
+	logger.Debug(ctx, "Successfully created organization unit", log.String("ouId", createdOU.ID))
 }
 
 // HandleOUGetRequest handles the get organization unit by id request.
@@ -127,7 +127,7 @@ func (ouh *organizationUnitHandler) HandleOUGetRequest(w http.ResponseWriter, r 
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, ou)
 
-	logger.DebugWithContext(ctx, "Successfully retrieved organization unit", log.String("ouId", id))
+	logger.Debug(ctx, "Successfully retrieved organization unit", log.String("ouId", id))
 }
 
 // HandleOUPutRequest handles the update organization unit request.
@@ -153,7 +153,7 @@ func (ouh *organizationUnitHandler) HandleOUPutRequest(w http.ResponseWriter, r 
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, ou)
 
-	logger.DebugWithContext(ctx, "Successfully updated organization unit", log.String("ouId", id))
+	logger.Debug(ctx, "Successfully updated organization unit", log.String("ouId", id))
 }
 
 // HandleOUDeleteRequest handles the delete organization unit request.
@@ -173,7 +173,7 @@ func (ouh *organizationUnitHandler) HandleOUDeleteRequest(w http.ResponseWriter,
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
-	logger.DebugWithContext(ctx, "Successfully deleted organization unit", log.String("ouId", id))
+	logger.Debug(ctx, "Successfully deleted organization unit", log.String("ouId", id))
 }
 
 // HandleOUChildrenListRequest handles the list child organization units request.
@@ -358,7 +358,7 @@ func (ouh *organizationUnitHandler) handleResourceListRequest(
 		count = resp.Count
 	}
 
-	logger.DebugWithContext(r.Context(), "Successfully listed resources in organization unit",
+	logger.Debug(r.Context(), "Successfully listed resources in organization unit",
 		log.String("resourceType", resourceType),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", totalResults),
@@ -383,7 +383,7 @@ func (ouh *organizationUnitHandler) HandleOUGetByPathRequest(w http.ResponseWrit
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, ou)
 
-	logger.DebugWithContext(ctx, "Successfully retrieved organization unit by path", log.String("path", path))
+	logger.Debug(ctx, "Successfully retrieved organization unit by path", log.String("path", path))
 }
 
 // HandleOUPutByPathRequest handles the update organization unit by hierarchical handle path request.
@@ -409,7 +409,7 @@ func (ouh *organizationUnitHandler) HandleOUPutByPathRequest(w http.ResponseWrit
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, ou)
 
-	logger.DebugWithContext(ctx, "Successfully updated organization unit by path", log.String("path", path))
+	logger.Debug(ctx, "Successfully updated organization unit by path", log.String("path", path))
 }
 
 // HandleOUDeleteByPathRequest handles the delete organization unit by hierarchical handle path request.
@@ -429,7 +429,7 @@ func (ouh *organizationUnitHandler) HandleOUDeleteByPathRequest(w http.ResponseW
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
-	logger.DebugWithContext(ctx, "Successfully deleted organization unit by path", log.String("path", path))
+	logger.Debug(ctx, "Successfully deleted organization unit by path", log.String("path", path))
 }
 
 // handleResourceListByPathRequest is a generic handler for listing resources under an organization unit by path.
@@ -476,7 +476,7 @@ func (ouh *organizationUnitHandler) handleResourceListByPathRequest(
 			count = resp.Count
 		}
 
-		logger.DebugWithContext(r.Context(), "Successfully listed resources in organization unit by path",
+		logger.Debug(r.Context(), "Successfully listed resources in organization unit by path",
 			log.String("resourceType", resourceType), log.String("path", path),
 			log.Int("limit", limit), log.Int("offset", offset),
 			log.Int("totalResults", totalResults), log.Int("count", count))

--- a/backend/internal/ou/hierarchy_resolver.go
+++ b/backend/internal/ou/hierarchy_resolver.go
@@ -61,7 +61,7 @@ func (r *ouHierarchyAdapter) IsAncestor(
 	visited := make(map[string]struct{})
 	for {
 		if _, ok := visited[current]; ok {
-			logger.ErrorWithContext(ctx, "Cyclic organization unit parent chain detected during ancestry check",
+			logger.Error(ctx, "Cyclic organization unit parent chain detected during ancestry check",
 				log.String("ouID", current))
 			return false, nil
 		}
@@ -71,11 +71,11 @@ func (r *ouHierarchyAdapter) IsAncestor(
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
 				// Broken chain — cannot confirm ancestry; deny-safe.
-				logger.DebugWithContext(ctx, "Encountered missing organization unit during ancestry check",
+				logger.Debug(ctx, "Encountered missing organization unit during ancestry check",
 					log.String("ouID", current))
 				return false, nil
 			}
-			logger.ErrorWithContext(ctx, "Failed to traverse organization unit hierarchy during ancestry check",
+			logger.Error(ctx, "Failed to traverse organization unit hierarchy during ancestry check",
 				log.Error(err))
 			return false, &serviceerror.InternalServerError
 		}
@@ -112,7 +112,7 @@ func (r *ouHierarchyAdapter) GetAncestorOUIDs(
 
 	for {
 		if _, ok := visited[current]; ok {
-			logger.ErrorWithContext(ctx, "Cyclic organization unit parent chain detected while collecting ancestors",
+			logger.Error(ctx, "Cyclic organization unit parent chain detected while collecting ancestors",
 				log.String("ouID", current))
 			return nil, &serviceerror.InternalServerError
 		}
@@ -121,11 +121,11 @@ func (r *ouHierarchyAdapter) GetAncestorOUIDs(
 		ou, err := r.store.GetOrganizationUnit(ctx, current)
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
-				logger.DebugWithContext(ctx, "Encountered missing organization unit while collecting ancestors",
+				logger.Debug(ctx, "Encountered missing organization unit while collecting ancestors",
 					log.String("ouID", current))
 				return nil, &ErrorOrganizationUnitNotFound
 			}
-			logger.ErrorWithContext(ctx, "Failed to traverse organization unit hierarchy while collecting ancestors",
+			logger.Error(ctx, "Failed to traverse organization unit hierarchy while collecting ancestors",
 				log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}

--- a/backend/internal/ou/service.go
+++ b/backend/internal/ou/service.go
@@ -163,7 +163,7 @@ func (ous *organizationUnitService) listAllOrganizationUnits(
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
 	totalCount, err := ous.ouStore.GetOrganizationUnitListCount(ctx, f)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get organization unit count", log.Error(err))
+		logger.Error(ctx, "Failed to get organization unit count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -173,7 +173,7 @@ func (ous *organizationUnitService) listAllOrganizationUnits(
 		if errors.Is(err, ErrResultLimitExceededInCompositeMode) {
 			return nil, &ErrorResultLimitExceeded
 		}
-		logger.ErrorWithContext(ctx, "Failed to list organization units", log.Error(err))
+		logger.Error(ctx, "Failed to list organization units", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -209,7 +209,7 @@ func (ous *organizationUnitService) listAccessibleOrganizationUnits(
 		// reflects the filtered count, not the raw authorized-ID count.
 		allOUs, err := ous.ouStore.GetOrganizationUnitsByIDs(ctx, ids)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to get organization units by IDs", log.Error(err))
+			logger.Error(ctx, "Failed to get organization units by IDs", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 
@@ -264,7 +264,7 @@ func (ous *organizationUnitService) listAccessibleOrganizationUnits(
 
 	pageOUs, err := ous.ouStore.GetOrganizationUnitsByIDs(ctx, pageIDs)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get organization units by IDs", log.Error(err))
+		logger.Error(ctx, "Failed to get organization units by IDs", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -282,7 +282,7 @@ func (ous *organizationUnitService) CreateOrganizationUnit(
 	ctx context.Context, request OrganizationUnitRequestWithID,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Creating organization unit", log.String("name", request.Name))
+	logger.Debug(ctx, "Creating organization unit", log.String("name", request.Name))
 
 	// Fail if store is in declarative mode
 	if isDeclarativeModeEnabled() {
@@ -374,12 +374,12 @@ func (ous *organizationUnitService) CreateOrganizationUnit(
 		return OrganizationUnit{}, capturedSvcErr
 	}
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create organization unit",
+		logger.Error(ctx, "Failed to create organization unit",
 			log.Error(err), log.String("name", request.Name))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully created organization unit", log.String("ouID", createdOU.ID))
+	logger.Debug(ctx, "Successfully created organization unit", log.String("ouID", createdOU.ID))
 
 	return createdOU, nil
 }
@@ -389,7 +389,7 @@ func (ous *organizationUnitService) GetOrganizationUnit(
 	ctx context.Context, id string,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Getting organization unit", log.String("ouID", id))
+	logger.Debug(ctx, "Getting organization unit", log.String("ouID", id))
 
 	if svcErr := ous.checkOUAccess(ctx, security.ActionReadOU, id); svcErr != nil {
 		return OrganizationUnit{}, svcErr
@@ -400,7 +400,7 @@ func (ous *organizationUnitService) GetOrganizationUnit(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get organization unit", log.Error(err))
+		logger.Error(ctx, "Failed to get organization unit", log.Error(err))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 
@@ -412,7 +412,7 @@ func (ous *organizationUnitService) GetOrganizationUnitByPath(
 	ctx context.Context, handlePath string,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Getting organization unit by path", log.String("path", handlePath))
+	logger.Debug(ctx, "Getting organization unit by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -424,7 +424,7 @@ func (ous *organizationUnitService) GetOrganizationUnitByPath(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get organization unit by path", log.Error(err))
+		logger.Error(ctx, "Failed to get organization unit by path", log.Error(err))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 
@@ -440,11 +440,11 @@ func (ous *organizationUnitService) IsOrganizationUnitExists(
 	ctx context.Context, id string,
 ) (bool, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Checking if organization unit exists", log.String("ouID", id))
+	logger.Debug(ctx, "Checking if organization unit exists", log.String("ouID", id))
 
 	exists, err := ous.ouStore.IsOrganizationUnitExists(ctx, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check organization unit existence", log.Error(err))
+		logger.Error(ctx, "Failed to check organization unit existence", log.Error(err))
 		return false, &serviceerror.InternalServerError
 	}
 
@@ -475,11 +475,11 @@ func (ous *organizationUnitService) IsParent(
 		parentOU, err := ous.ouStore.GetOrganizationUnit(ctx, *currentParent)
 		if err != nil {
 			if errors.Is(err, ErrOrganizationUnitNotFound) {
-				logger.DebugWithContext(ctx, "Encountered missing organization unit in hierarchy",
+				logger.Debug(ctx, "Encountered missing organization unit in hierarchy",
 					log.String("ouID", *currentParent))
 				return false, &ErrorOrganizationUnitNotFound
 			}
-			logger.ErrorWithContext(ctx, "Failed to traverse organization unit hierarchy", log.Error(err))
+			logger.Error(ctx, "Failed to traverse organization unit hierarchy", log.Error(err))
 			return false, &serviceerror.InternalServerError
 		}
 
@@ -494,7 +494,7 @@ func (ous *organizationUnitService) UpdateOrganizationUnit(
 	ctx context.Context, id string, request OrganizationUnitRequestWithID,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Updating organization unit", log.String("ouID", id))
+	logger.Debug(ctx, "Updating organization unit", log.String("ouID", id))
 
 	if svcErr := ous.checkOUAccess(ctx, security.ActionUpdateOU, id); svcErr != nil {
 		return OrganizationUnit{}, svcErr
@@ -526,11 +526,11 @@ func (ous *organizationUnitService) UpdateOrganizationUnit(
 		return OrganizationUnit{}, capturedSvcErr
 	}
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to update organization unit", log.Error(err), log.String("ouID", id))
+		logger.Error(ctx, "Failed to update organization unit", log.Error(err), log.String("ouID", id))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully updated organization unit", log.String("ouID", id))
+	logger.Debug(ctx, "Successfully updated organization unit", log.String("ouID", id))
 	return updatedOU, nil
 }
 
@@ -539,7 +539,7 @@ func (ous *organizationUnitService) UpdateOrganizationUnitByPath(
 	ctx context.Context, handlePath string, request OrganizationUnitRequestWithID,
 ) (OrganizationUnit, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Updating organization unit by path", log.String("path", handlePath))
+	logger.Debug(ctx, "Updating organization unit by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -583,12 +583,12 @@ func (ous *organizationUnitService) UpdateOrganizationUnitByPath(
 		return OrganizationUnit{}, capturedSvcErr
 	}
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to update organization unit by path",
+		logger.Error(ctx, "Failed to update organization unit by path",
 			log.Error(err), log.String("path", handlePath))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully updated organization unit by path", log.String("ouID", updatedOU.ID))
+	logger.Debug(ctx, "Successfully updated organization unit by path", log.String("ouID", updatedOU.ID))
 	return updatedOU, nil
 }
 
@@ -615,7 +615,7 @@ func (ous *organizationUnitService) updateOUInternal(
 	if request.Parent != nil {
 		exists, err := ous.ouStore.IsOrganizationUnitExists(ctx, *request.Parent)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to check parent organization unit existence", log.Error(err))
+			logger.Error(ctx, "Failed to check parent organization unit existence", log.Error(err))
 			return OrganizationUnit{}, &serviceerror.InternalServerError
 		}
 		if !exists {
@@ -634,7 +634,7 @@ func (ous *organizationUnitService) updateOUInternal(
 	if parentChanged || existingOU.Name != request.Name {
 		nameConflict, err = ous.ouStore.CheckOrganizationUnitNameConflict(ctx, request.Name, request.Parent)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to check organization unit name conflict", log.Error(err))
+			logger.Error(ctx, "Failed to check organization unit name conflict", log.Error(err))
 			return OrganizationUnit{}, &serviceerror.InternalServerError
 		}
 	}
@@ -647,7 +647,7 @@ func (ous *organizationUnitService) updateOUInternal(
 	if parentChanged || existingOU.Handle != request.Handle {
 		handleConflict, err = ous.ouStore.CheckOrganizationUnitHandleConflict(ctx, request.Handle, request.Parent)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to check organization unit handle conflict", log.Error(err))
+			logger.Error(ctx, "Failed to check organization unit handle conflict", log.Error(err))
 			return OrganizationUnit{}, &serviceerror.InternalServerError
 		}
 	}
@@ -677,7 +677,7 @@ func (ous *organizationUnitService) updateOUInternal(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return OrganizationUnit{}, &ErrorOrganizationUnitNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to update organization unit", log.Error(err))
+		logger.Error(ctx, "Failed to update organization unit", log.Error(err))
 		return OrganizationUnit{}, &serviceerror.InternalServerError
 	}
 	return updatedOU, nil
@@ -687,7 +687,7 @@ func (ous *organizationUnitService) updateOUInternal(
 func (ous *organizationUnitService) DeleteOrganizationUnit(
 	ctx context.Context, id string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Deleting organization unit", log.String("ouID", id))
+	logger.Debug(ctx, "Deleting organization unit", log.String("ouID", id))
 
 	if svcErr := ous.checkOUAccess(ctx, security.ActionDeleteOU, id); svcErr != nil {
 		return svcErr
@@ -718,11 +718,11 @@ func (ous *organizationUnitService) DeleteOrganizationUnit(
 		return capturedSvcErr
 	}
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to delete organization unit", log.Error(err), log.String("ouID", id))
+		logger.Error(ctx, "Failed to delete organization unit", log.Error(err), log.String("ouID", id))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully deleted organization unit", log.String("ouID", id))
+	logger.Debug(ctx, "Successfully deleted organization unit", log.String("ouID", id))
 	return nil
 }
 
@@ -731,7 +731,7 @@ func (ous *organizationUnitService) DeleteOrganizationUnitByPath(
 	ctx context.Context, handlePath string,
 ) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Deleting organization unit by path", log.String("path", handlePath))
+	logger.Debug(ctx, "Deleting organization unit by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -775,12 +775,12 @@ func (ous *organizationUnitService) DeleteOrganizationUnitByPath(
 		return capturedSvcErr
 	}
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to delete organization unit by path",
+		logger.Error(ctx, "Failed to delete organization unit by path",
 			log.Error(err), log.String("path", handlePath))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully deleted organization unit by path", log.String("ouID", ouID))
+	logger.Debug(ctx, "Successfully deleted organization unit by path", log.String("ouID", ouID))
 	return nil
 }
 
@@ -796,7 +796,7 @@ func (ous *organizationUnitService) deleteOUInternal(
 	// Check child OUs (own table).
 	childCount, err := ous.ouStore.GetOrganizationUnitChildrenCount(ctx, id, nil)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check child organization units", log.Error(err))
+		logger.Error(ctx, "Failed to check child organization units", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if childCount > 0 {
@@ -805,12 +805,12 @@ func (ous *organizationUnitService) deleteOUInternal(
 
 	// Check users via resolver.
 	if ous.userResolver == nil {
-		logger.ErrorWithContext(ctx, "OUUserResolver not initialized")
+		logger.Error(ctx, "OUUserResolver not initialized")
 		return &serviceerror.InternalServerError
 	}
 	userCount, err := ous.userResolver.GetUserCountByOUID(ctx, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check organization unit users", log.Error(err))
+		logger.Error(ctx, "Failed to check organization unit users", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if userCount > 0 {
@@ -819,12 +819,12 @@ func (ous *organizationUnitService) deleteOUInternal(
 
 	// Check groups via resolver.
 	if ous.groupResolver == nil {
-		logger.ErrorWithContext(ctx, "OUGroupResolver not initialized")
+		logger.Error(ctx, "OUGroupResolver not initialized")
 		return &serviceerror.InternalServerError
 	}
 	groupCount, err := ous.groupResolver.GetGroupCountByOUID(ctx, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check organization unit groups", log.Error(err))
+		logger.Error(ctx, "Failed to check organization unit groups", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if groupCount > 0 {
@@ -836,7 +836,7 @@ func (ous *organizationUnitService) deleteOUInternal(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return &ErrorOrganizationUnitNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to delete organization unit", log.Error(err))
+		logger.Error(ctx, "Failed to delete organization unit", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil
@@ -884,7 +884,7 @@ func (ous *organizationUnitService) GetOrganizationUnitUsers(
 	users, ok := items.([]User)
 	if !ok {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-		logger.ErrorWithContext(ctx, "Failed to cast user list response for organization unit", log.String("ouID", id))
+		logger.Error(ctx, "Failed to cast user list response for organization unit", log.String("ouID", id))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -956,7 +956,7 @@ func (ous *organizationUnitService) GetOrganizationUnitChildrenByPath(
 	ctx context.Context, handlePath string, limit, offset int, f *filter.FilterGroup,
 ) (*OrganizationUnitListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Getting organization unit children by path", log.String("path", handlePath))
+	logger.Debug(ctx, "Getting organization unit children by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -968,7 +968,7 @@ func (ous *organizationUnitService) GetOrganizationUnitChildrenByPath(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get organization unit by path", log.Error(err))
+		logger.Error(ctx, "Failed to get organization unit by path", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -980,7 +980,7 @@ func (ous *organizationUnitService) GetOrganizationUnitUsersByPath(
 	ctx context.Context, handlePath string, limit, offset int, includeDisplay bool,
 ) (*UserListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Getting organization unit users by path", log.String("path", handlePath))
+	logger.Debug(ctx, "Getting organization unit users by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -992,7 +992,7 @@ func (ous *organizationUnitService) GetOrganizationUnitUsersByPath(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get organization unit by path", log.Error(err))
+		logger.Error(ctx, "Failed to get organization unit by path", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1004,7 +1004,7 @@ func (ous *organizationUnitService) GetOrganizationUnitGroupsByPath(
 	ctx context.Context, handlePath string, limit, offset int,
 ) (*GroupListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Getting organization unit groups by path", log.String("path", handlePath))
+	logger.Debug(ctx, "Getting organization unit groups by path", log.String("path", handlePath))
 
 	handles, serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -1016,7 +1016,7 @@ func (ous *organizationUnitService) GetOrganizationUnitGroupsByPath(
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to get organization unit by path", log.Error(err))
+		logger.Error(ctx, "Failed to get organization unit by path", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1119,7 +1119,7 @@ func (ous *organizationUnitService) getResourceListWithExistenceCheck(
 	mapCompositeError bool,
 ) (interface{}, int, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
-	logger.DebugWithContext(ctx, "Getting resource for organization unit", log.String("resource_type", resourceType),
+	logger.Debug(ctx, "Getting resource for organization unit", log.String("resource_type", resourceType),
 		log.String("ouID", id))
 
 	if err := validatePaginationParams(limit, offset); err != nil {
@@ -1129,7 +1129,7 @@ func (ous *organizationUnitService) getResourceListWithExistenceCheck(
 	// Check if the organization unit exists
 	exists, err := ous.ouStore.IsOrganizationUnitExists(ctx, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check organization unit existence", log.Error(err))
+		logger.Error(ctx, "Failed to check organization unit existence", log.Error(err))
 		return nil, 0, &serviceerror.InternalServerError
 	}
 	if !exists {
@@ -1142,14 +1142,14 @@ func (ous *organizationUnitService) getResourceListWithExistenceCheck(
 		if mapCompositeError && errors.Is(err, ErrResultLimitExceededInCompositeMode) {
 			return nil, 0, &ErrorResultLimitExceeded
 		}
-		logger.ErrorWithContext(ctx, "Failed to list resource",
+		logger.Error(ctx, "Failed to list resource",
 			log.String("resource_type", resourceType), log.Error(err))
 		return nil, 0, &serviceerror.InternalServerError
 	}
 
 	totalCount, err := getCountFunc(ctx, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get resource count",
+		logger.Error(ctx, "Failed to get resource count",
 			log.String("resource_type", resourceType), log.Error(err))
 		return nil, 0, &serviceerror.InternalServerError
 	}
@@ -1215,7 +1215,7 @@ func (ous *organizationUnitService) GetOrganizationUnitHandlesByIDs(
 
 	ouBasics, err := ous.ouStore.GetOrganizationUnitsByIDs(ctx, ids)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get organization units by IDs", log.Error(err))
+		logger.Error(ctx, "Failed to get organization units by IDs", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 

--- a/backend/internal/ou/store.go
+++ b/backend/internal/ou/store.go
@@ -297,7 +297,7 @@ func (s *organizationUnitStore) GetOrganizationUnitByPath(
 			if !errors.Is(err, ErrOrganizationUnitNotFound) {
 				return OrganizationUnit{}, err
 			}
-			logger.DebugWithContext(ctx, "Organization unit not found in path",
+			logger.Debug(ctx, "Organization unit not found in path",
 				log.String("handle", handle),
 				log.Int("pathIndex", i),
 				log.String("fullPath", fullPath))

--- a/backend/internal/resource/service.go
+++ b/backend/internal/resource/service.go
@@ -161,7 +161,7 @@ func (rs *resourceService) CreateResourceServer(
 	ctx context.Context,
 	resourceServer ResourceServer,
 ) (*ResourceServer, *serviceerror.ServiceError) {
-	rs.logger.DebugWithContext(ctx, "Creating resource server", log.String("name", resourceServer.Name))
+	rs.logger.Debug(ctx, "Creating resource server", log.String("name", resourceServer.Name))
 
 	if err := rs.validateResourceServerCreate(resourceServer); err != nil {
 		return nil, err
@@ -171,10 +171,10 @@ func (rs *resourceService) CreateResourceServer(
 	_, svcErr := rs.ouService.GetOrganizationUnit(ctx, resourceServer.OUID)
 	if svcErr != nil {
 		if svcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
-			rs.logger.DebugWithContext(ctx, "Organization unit not found", log.String("ouID", resourceServer.OUID))
+			rs.logger.Debug(ctx, "Organization unit not found", log.String("ouID", resourceServer.OUID))
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to validate organization unit",
+		rs.logger.Error(ctx, "Failed to validate organization unit",
 			log.String("error", svcErr.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -182,11 +182,11 @@ func (rs *resourceService) CreateResourceServer(
 	// Check name uniqueness
 	nameExists, err := rs.resourceStore.CheckResourceServerNameExists(ctx, resourceServer.Name)
 	if err != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to check resource server name", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check resource server name", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if nameExists {
-		rs.logger.DebugWithContext(ctx, "Resource server name already exists", log.String("name", resourceServer.Name))
+		rs.logger.Debug(ctx, "Resource server name already exists", log.String("name", resourceServer.Name))
 		return nil, &ErrorNameConflict
 	}
 
@@ -194,11 +194,11 @@ func (rs *resourceService) CreateResourceServer(
 	if resourceServer.Handle != "" {
 		handleExists, err := rs.resourceStore.CheckResourceServerHandleExists(ctx, resourceServer.Handle)
 		if err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to check resource server handle", log.Error(err))
+			rs.logger.Error(ctx, "Failed to check resource server handle", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		if handleExists {
-			rs.logger.DebugWithContext(ctx, "Resource server handle already exists",
+			rs.logger.Debug(ctx, "Resource server handle already exists",
 				log.String("handle", resourceServer.Handle))
 			return nil, &ErrorHandleConflict
 		}
@@ -208,11 +208,11 @@ func (rs *resourceService) CreateResourceServer(
 	if resourceServer.Identifier != "" {
 		identifierExists, err := rs.resourceStore.CheckResourceServerIdentifierExists(ctx, resourceServer.Identifier)
 		if err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to check resource server identifier", log.Error(err))
+			rs.logger.Error(ctx, "Failed to check resource server identifier", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		if identifierExists {
-			rs.logger.DebugWithContext(ctx, "Resource server identifier already exists",
+			rs.logger.Debug(ctx, "Resource server identifier already exists",
 				log.String("identifier", resourceServer.Identifier))
 			return nil, &ErrorIdentifierConflict
 		}
@@ -243,7 +243,7 @@ func (rs *resourceService) CreateResourceServer(
 		var err error
 		id, err = utils.GenerateUUIDv7()
 		if err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+			rs.logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	} else {
@@ -252,7 +252,7 @@ func (rs *resourceService) CreateResourceServer(
 			return nil, svcErr
 		}
 		if svcErr == nil {
-			rs.logger.DebugWithContext(ctx, "Resource server ID already exists", log.String("id", id))
+			rs.logger.Debug(ctx, "Resource server ID already exists", log.String("id", id))
 			return nil, &ErrorResourceServerIDConflict
 		}
 	}
@@ -261,7 +261,7 @@ func (rs *resourceService) CreateResourceServer(
 	var createdRS *ResourceServer
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.CreateResourceServer(txCtx, id, resourceServer); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to create resource server", log.Error(err))
+			rs.logger.Error(ctx, "Failed to create resource server", log.Error(err))
 			return err
 		}
 
@@ -280,7 +280,7 @@ func (rs *resourceService) CreateResourceServer(
 		return nil, &serviceerror.InternalServerError
 	}
 
-	rs.logger.DebugWithContext(ctx, "Successfully created resource server", log.String("id", id))
+	rs.logger.Debug(ctx, "Successfully created resource server", log.String("id", id))
 	return createdRS, nil
 }
 
@@ -295,10 +295,10 @@ func (rs *resourceService) GetResourceServer(
 	resourceServer, err := rs.resourceStore.GetResourceServer(ctx, id)
 	if err != nil {
 		if errors.Is(err, errResourceServerNotFound) {
-			rs.logger.DebugWithContext(ctx, "Resource server not found", log.String("id", id))
+			rs.logger.Debug(ctx, "Resource server not found", log.String("id", id))
 			return nil, &ErrorResourceServerNotFound
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to get resource server", log.Error(err))
+		rs.logger.Error(ctx, "Failed to get resource server", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -316,11 +316,11 @@ func (rs *resourceService) GetResourceServerByIdentifier(
 	resourceServer, err := rs.resourceStore.GetResourceServerByIdentifier(ctx, identifier)
 	if err != nil {
 		if errors.Is(err, errResourceServerNotFound) {
-			rs.logger.DebugWithContext(ctx, "Resource server not found for identifier",
+			rs.logger.Debug(ctx, "Resource server not found for identifier",
 				log.String("identifier", identifier))
 			return nil, &ErrorResourceServerNotFound
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to get resource server by identifier", log.Error(err))
+		rs.logger.Error(ctx, "Failed to get resource server by identifier", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -340,7 +340,7 @@ func (rs *resourceService) GetResourceServerList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to get resource server count", log.Error(err))
+		rs.logger.Error(ctx, "Failed to get resource server count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -349,7 +349,7 @@ func (rs *resourceService) GetResourceServerList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to list resource servers", log.Error(err))
+		rs.logger.Error(ctx, "Failed to list resource servers", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -380,16 +380,16 @@ func (rs *resourceService) UpdateResourceServer(
 	existingResServer, err := rs.resourceStore.GetResourceServer(ctx, id)
 	if err != nil {
 		if errors.Is(err, errResourceServerNotFound) {
-			rs.logger.DebugWithContext(ctx, "Resource server not found", log.String("id", id))
+			rs.logger.Debug(ctx, "Resource server not found", log.String("id", id))
 			return nil, &ErrorResourceServerNotFound
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to check resource server existence", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check resource server existence", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	// Check if resource server is declarative (immutable)
 	if rs.IsResourceServerDeclarative(id) {
-		rs.logger.DebugWithContext(ctx, "Cannot modify declarative resource server", log.String("id", id))
+		rs.logger.Debug(ctx, "Cannot modify declarative resource server", log.String("id", id))
 		return nil, serviceerror.CustomServiceError(ErrorImmutableResourceServer, core.I18nMessage{
 			Key:          ErrorImmutableResourceServer.ErrorDescription.Key,
 			DefaultValue: fmt.Sprintf(ErrorImmutableResourceServer.ErrorDescription.DefaultValue, id),
@@ -415,11 +415,11 @@ func (rs *resourceService) UpdateResourceServer(
 	} else if resourceServer.Identifier != existingResServer.Identifier {
 		identifierExists, err := rs.resourceStore.CheckResourceServerIdentifierExists(ctx, resourceServer.Identifier)
 		if err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to check resource server identifier", log.Error(err))
+			rs.logger.Error(ctx, "Failed to check resource server identifier", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		if identifierExists {
-			rs.logger.DebugWithContext(ctx, "Resource server identifier already exists",
+			rs.logger.Debug(ctx, "Resource server identifier already exists",
 				log.String("identifier", resourceServer.Identifier))
 			return nil, &ErrorIdentifierConflict
 		}
@@ -438,7 +438,7 @@ func (rs *resourceService) UpdateResourceServer(
 	if existingResServer.Name != resourceServer.Name {
 		nameExists, err := rs.resourceStore.CheckResourceServerNameExists(ctx, resourceServer.Name)
 		if err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to check resource server name", log.Error(err))
+			rs.logger.Error(ctx, "Failed to check resource server name", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		if nameExists {
@@ -449,7 +449,7 @@ func (rs *resourceService) UpdateResourceServer(
 	var updatedRS *ResourceServer
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.UpdateResourceServer(txCtx, id, resourceServer); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to update resource server", log.Error(err))
+			rs.logger.Error(ctx, "Failed to update resource server", log.Error(err))
 			return err
 		}
 
@@ -479,7 +479,7 @@ func (rs *resourceService) DeleteResourceServer(ctx context.Context, id string) 
 
 	// Check if resource server is declarative (immutable)
 	if rs.IsResourceServerDeclarative(id) {
-		rs.logger.DebugWithContext(ctx, "Cannot delete declarative resource server", log.String("id", id))
+		rs.logger.Debug(ctx, "Cannot delete declarative resource server", log.String("id", id))
 		return serviceerror.CustomServiceError(ErrorImmutableResourceServer, core.I18nMessage{
 			Key:          ErrorImmutableResourceServer.ErrorDescription.Key,
 			DefaultValue: fmt.Sprintf(ErrorImmutableResourceServer.ErrorDescription.DefaultValue, id),
@@ -491,14 +491,14 @@ func (rs *resourceService) DeleteResourceServer(ctx context.Context, id string) 
 		if errors.Is(err, errResourceServerNotFound) {
 			return nil // Idempotent delete
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to check resource server existence", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check resource server existence", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
 	// Check for dependencies
 	hasDeps, err := rs.resourceStore.CheckResourceServerHasDependencies(ctx, id)
 	if err != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to check dependencies", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check dependencies", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if hasDeps {
@@ -508,7 +508,7 @@ func (rs *resourceService) DeleteResourceServer(ctx context.Context, id string) 
 	// Use transaction for write operation
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.DeleteResourceServer(txCtx, id); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to delete resource server", log.Error(err))
+			rs.logger.Error(ctx, "Failed to delete resource server", log.Error(err))
 			return err
 		}
 		return nil
@@ -549,7 +549,7 @@ func (rs *resourceService) CreateResource(
 			if errors.Is(err, errResourceNotFound) {
 				return nil, &ErrorParentResourceNotFound
 			}
-			rs.logger.ErrorWithContext(ctx, "Failed to check parent resource", log.Error(err))
+			rs.logger.Error(ctx, "Failed to check parent resource", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		parentResource = &res
@@ -560,7 +560,7 @@ func (rs *resourceService) CreateResource(
 		ctx, resourceServerID, resource.Handle, resource.Parent,
 	)
 	if err != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to check resource handle", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check resource handle", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if handleExists {
@@ -572,7 +572,7 @@ func (rs *resourceService) CreateResource(
 
 	id, err := utils.GenerateUUIDv7()
 	if err != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+		rs.logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -582,14 +582,14 @@ func (rs *resourceService) CreateResource(
 		if err := rs.resourceStore.CreateResource(
 			txCtx, id, resourceServerID, resource.Parent, resource,
 		); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to create resource", log.Error(err))
+			rs.logger.Error(ctx, "Failed to create resource", log.Error(err))
 			return err
 		}
 
 		if err := rs.syncConsentOnPermissionCreate(
 			txCtx, resource.Permission, resource.Description,
 		); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for resource", log.Error(err))
+			rs.logger.Error(ctx, "Failed to sync consent element for resource", log.Error(err))
 			return err
 		}
 
@@ -628,7 +628,7 @@ func (rs *resourceService) GetResource(
 		if errors.Is(err, errResourceNotFound) {
 			return nil, &ErrorResourceNotFound
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to get resource", log.Error(err))
+		rs.logger.Error(ctx, "Failed to get resource", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -669,7 +669,7 @@ func (rs *resourceService) GetResourceList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to get top-level resource count", log.Error(err))
+		rs.logger.Error(ctx, "Failed to get top-level resource count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -678,7 +678,7 @@ func (rs *resourceService) GetResourceList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to list resources", log.Error(err))
+		rs.logger.Error(ctx, "Failed to list resources", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -707,7 +707,7 @@ func (rs *resourceService) GetAllResourceList(
 
 	totalCount, err := rs.resourceStore.GetResourceListCount(ctx, resourceServerID)
 	if err != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to get resource count", log.Error(err))
+		rs.logger.Error(ctx, "Failed to get resource count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if totalCount == 0 {
@@ -719,7 +719,7 @@ func (rs *resourceService) GetAllResourceList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to list all resources", log.Error(err))
+		rs.logger.Error(ctx, "Failed to list all resources", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return resources, nil
@@ -736,7 +736,7 @@ func (rs *resourceService) UpdateResource(
 
 	// Check if resource server is declarative (immutable)
 	if rs.IsResourceServerDeclarative(resourceServerID) {
-		rs.logger.DebugWithContext(ctx,
+		rs.logger.Debug(ctx,
 			"Cannot modify resource in declarative resource server",
 			log.String("resource_server_id", resourceServerID),
 		)
@@ -758,7 +758,7 @@ func (rs *resourceService) UpdateResource(
 		if errors.Is(err, errResourceNotFound) {
 			return nil, &ErrorResourceNotFound
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to check resource existence", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check resource existence", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -775,14 +775,14 @@ func (rs *resourceService) UpdateResource(
 	var updatedResource *Resource
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.UpdateResource(txCtx, id, resourceServerID, updateResource); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to update resource", log.Error(err))
+			rs.logger.Error(ctx, "Failed to update resource", log.Error(err))
 			return err
 		}
 
 		if err := rs.syncConsentOnPermissionUpdate(
 			txCtx, currentResource.Permission, updateResource.Description,
 		); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for resource", log.Error(err))
+			rs.logger.Error(ctx, "Failed to sync consent element for resource", log.Error(err))
 			return err
 		}
 
@@ -810,7 +810,7 @@ func (rs *resourceService) DeleteResource(
 
 	// Check if resource server is declarative (immutable)
 	if rs.IsResourceServerDeclarative(resourceServerID) {
-		rs.logger.DebugWithContext(ctx,
+		rs.logger.Debug(ctx,
 			"Cannot delete resource in declarative resource server",
 			log.String("resource_server_id", resourceServerID),
 		)
@@ -826,7 +826,7 @@ func (rs *resourceService) DeleteResource(
 		if errors.Is(err, errResourceServerNotFound) {
 			return nil // Idempotent delete
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to check resource server", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check resource server", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -836,14 +836,14 @@ func (rs *resourceService) DeleteResource(
 		if errors.Is(err, errResourceNotFound) {
 			return nil // Idempotent delete
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to check resource existence", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check resource existence", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
 	// Check for dependencies
 	hasDeps, err := rs.resourceStore.CheckResourceHasDependencies(ctx, id)
 	if err != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to check dependencies", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check dependencies", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if hasDeps {
@@ -853,13 +853,13 @@ func (rs *resourceService) DeleteResource(
 	// Use transaction for write operation
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.DeleteResource(txCtx, id, resourceServerID); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to delete resource", log.Error(err))
+			rs.logger.Error(ctx, "Failed to delete resource", log.Error(err))
 			return err
 		}
 		if err := rs.syncConsentOnPermissionDelete(
 			txCtx, currentResource.Permission,
 		); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for resource delete", log.Error(err))
+			rs.logger.Error(ctx, "Failed to sync consent element for resource delete", log.Error(err))
 			return err
 		}
 		return nil
@@ -904,7 +904,7 @@ func (rs *resourceService) CreateAction(
 		ctx, resourceServerID, resourceID, action.Handle,
 	)
 	if err != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to check action handle", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check action handle", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if handleExists {
@@ -916,7 +916,7 @@ func (rs *resourceService) CreateAction(
 
 	id, err := utils.GenerateUUIDv7()
 	if err != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+		rs.logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -924,14 +924,14 @@ func (rs *resourceService) CreateAction(
 	var createdAction *Action
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.CreateAction(txCtx, id, resourceServerID, resourceID, action); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to create action", log.Error(err))
+			rs.logger.Error(ctx, "Failed to create action", log.Error(err))
 			return err
 		}
 
 		if err := rs.syncConsentOnPermissionCreate(
 			txCtx, action.Permission, action.Description,
 		); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for action", log.Error(err))
+			rs.logger.Error(ctx, "Failed to sync consent element for action", log.Error(err))
 			return err
 		}
 
@@ -986,7 +986,7 @@ func (rs *resourceService) GetAction(
 		if errors.Is(err, errActionNotFound) {
 			return nil, &ErrorActionNotFound
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to get action", log.Error(err))
+		rs.logger.Error(ctx, "Failed to get action", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return &action, nil
@@ -1032,7 +1032,7 @@ func (rs *resourceService) GetActionList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to get action count", log.Error(err))
+		rs.logger.Error(ctx, "Failed to get action count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1041,7 +1041,7 @@ func (rs *resourceService) GetActionList(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ErrResultLimitExceededInCompositeMode
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to list actions", log.Error(err))
+		rs.logger.Error(ctx, "Failed to list actions", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1105,7 +1105,7 @@ func (rs *resourceService) UpdateAction(
 		if errors.Is(err, errActionNotFound) {
 			return nil, &ErrorActionNotFound
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to get action", log.Error(err))
+		rs.logger.Error(ctx, "Failed to get action", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -1122,14 +1122,14 @@ func (rs *resourceService) UpdateAction(
 		if err := rs.resourceStore.UpdateAction(
 			txCtx, id, resourceServerID, resID, updateAction,
 		); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to update action", log.Error(err))
+			rs.logger.Error(ctx, "Failed to update action", log.Error(err))
 			return err
 		}
 
 		if err := rs.syncConsentOnPermissionUpdate(
 			txCtx, currentAction.Permission, updateAction.Description,
 		); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for action", log.Error(err))
+			rs.logger.Error(ctx, "Failed to sync consent element for action", log.Error(err))
 			return err
 		}
 
@@ -1164,7 +1164,7 @@ func (rs *resourceService) DeleteAction(
 
 	// Check if resource server is declarative (immutable)
 	if rs.IsResourceServerDeclarative(resourceServerID) {
-		rs.logger.DebugWithContext(ctx,
+		rs.logger.Debug(ctx,
 			"Cannot delete action in declarative resource server",
 			log.String("resource_server_id", resourceServerID),
 		)
@@ -1199,7 +1199,7 @@ func (rs *resourceService) DeleteAction(
 	// Check if action exists
 	exists, err := rs.resourceStore.IsActionExist(ctx, id, resourceServerID, resID)
 	if err != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to check action existence", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check action existence", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if !exists {
@@ -1219,7 +1219,7 @@ func (rs *resourceService) DeleteAction(
 		default:
 			// Any other failure must abort: deleting without syncing would leave the consent
 			// element orphaned.
-			rs.logger.ErrorWithContext(ctx, "Failed to load action for consent sync", log.Error(getErr))
+			rs.logger.Error(ctx, "Failed to load action for consent sync", log.Error(getErr))
 			return &serviceerror.InternalServerError
 		}
 	}
@@ -1227,12 +1227,12 @@ func (rs *resourceService) DeleteAction(
 	// Use transaction for write operation
 	if err := rs.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		if err := rs.resourceStore.DeleteAction(txCtx, id, resourceServerID, resID); err != nil {
-			rs.logger.ErrorWithContext(ctx, "Failed to delete action", log.Error(err))
+			rs.logger.Error(ctx, "Failed to delete action", log.Error(err))
 			return err
 		}
 		if permissionToSync != "" {
 			if err := rs.syncConsentOnPermissionDelete(txCtx, permissionToSync); err != nil {
-				rs.logger.ErrorWithContext(ctx, "Failed to sync consent element for action delete", log.Error(err))
+				rs.logger.Error(ctx, "Failed to sync consent element for action delete", log.Error(err))
 				return err
 			}
 		}
@@ -1251,7 +1251,7 @@ func (rs *resourceService) ValidatePermissions(
 	resourceServerID string,
 	permissions []string,
 ) ([]string, *serviceerror.ServiceError) {
-	rs.logger.DebugWithContext(ctx, "Validating permissions",
+	rs.logger.Debug(ctx, "Validating permissions",
 		log.String("resourceServerId", resourceServerID),
 		log.Int("permissionCount", len(permissions)))
 
@@ -1263,12 +1263,12 @@ func (rs *resourceService) ValidatePermissions(
 	_, err := rs.resourceStore.GetResourceServer(ctx, resourceServerID)
 	if err != nil {
 		if !errors.Is(err, errResourceServerNotFound) {
-			rs.logger.ErrorWithContext(ctx, "Failed to validate resource server existence",
+			rs.logger.Error(ctx, "Failed to validate resource server existence",
 				log.String("resourceServerId", resourceServerID),
 				log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
-		rs.logger.DebugWithContext(ctx, "Resource server not found",
+		rs.logger.Debug(ctx, "Resource server not found",
 			log.String("resourceServerId", resourceServerID))
 		// Return all permissions as invalid if resource server doesn't exist
 		return permissions, nil
@@ -1277,7 +1277,7 @@ func (rs *resourceService) ValidatePermissions(
 	// Call store to validate permissions
 	invalidPermissions, storeErr := rs.resourceStore.ValidatePermissions(ctx, resourceServerID, permissions)
 	if storeErr != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to validate permissions in store",
+		rs.logger.Error(ctx, "Failed to validate permissions in store",
 			log.String("resourceServerId", resourceServerID),
 			log.Error(storeErr))
 		return nil, &serviceerror.InternalServerError
@@ -1298,7 +1298,7 @@ func (rs *resourceService) FindResourceServersByPermissions(
 
 	resourceServers, err := rs.resourceStore.FindResourceServersByPermissions(ctx, permissions)
 	if err != nil {
-		rs.logger.ErrorWithContext(ctx, "Failed to find resource servers by permissions", log.Error(err))
+		rs.logger.Error(ctx, "Failed to find resource servers by permissions", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return resourceServers, nil
@@ -1311,7 +1311,7 @@ func (rs *resourceService) ResolveResourceServerOUHandle(
 	ctx context.Context, server *ResourceServer,
 ) *serviceerror.ServiceError {
 	if server.OUID != "" && server.OUHandle != "" {
-		rs.logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided for resource server; ou_handle ignored",
+		rs.logger.Warn(ctx, "Both ou_id and ou_handle provided for resource server; ou_handle ignored",
 			log.String("resourceServerID", server.ID), log.String("name", server.Name))
 		return nil
 	}
@@ -1341,7 +1341,7 @@ func (rs *resourceService) validateAndGetResourceServer(
 		if errors.Is(err, errResourceServerNotFound) {
 			return ResourceServer{}, &ErrorResourceServerNotFound
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to check resource server", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check resource server", log.Error(err))
 		return ResourceServer{}, &serviceerror.InternalServerError
 	}
 	return resourceServer, nil
@@ -1358,7 +1358,7 @@ func (rs *resourceService) validateAndGetResourceByID(
 		if errors.Is(err, errResourceNotFound) {
 			return Resource{}, &ErrorResourceNotFound
 		}
-		rs.logger.ErrorWithContext(ctx, "Failed to check resource", log.Error(err))
+		rs.logger.Error(ctx, "Failed to check resource", log.Error(err))
 		return Resource{}, &serviceerror.InternalServerError
 	}
 	return resource, nil
@@ -1641,7 +1641,7 @@ func (rs *resourceService) wrapConsentServiceError(ctx context.Context, err *ser
 		return nil
 	}
 	if err.Type == serviceerror.ServerErrorType {
-		rs.logger.ErrorWithContext(ctx, "Consent service returned a server-class error during resource sync",
+		rs.logger.Error(ctx, "Consent service returned a server-class error during resource sync",
 			log.String("code", err.Code),
 			log.String("description", err.ErrorDescription.DefaultValue))
 	}

--- a/backend/internal/resource/service_test.go
+++ b/backend/internal/resource/service_test.go
@@ -5203,6 +5203,278 @@ func (suite *ResourceServiceTestSuite) TestResolveResourceServerOUHandle_NilOUSe
 
 // TestResourceServerYAML_OUHandleParsed verifies that ou_handle is parsed off the YAML
 // document into the ResourceServer struct.
+// newEnabledConsentServiceMock returns a consent service mock with IsEnabled returning true.
+func (suite *ResourceServiceTestSuite) newEnabledConsentServiceMock() *consentmock.ConsentServiceInterfaceMock {
+	cm := consentmock.NewConsentServiceInterfaceMock(suite.T())
+	cm.On("IsEnabled").Return(true).Maybe()
+	return cm
+}
+
+// newServiceWithConsent builds a resource service wired to the suite's store, OU, and
+// transactioner mocks but with the supplied consent service.
+func (suite *ResourceServiceTestSuite) newServiceWithConsent(
+	cm consent.ConsentServiceInterface,
+) ResourceServiceInterface {
+	return &resourceService{
+		logger:           *log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)),
+		resourceStore:    suite.mockStore,
+		ouService:        suite.mockOU,
+		consentService:   cm,
+		defaultDelimiter: ":",
+		transactioner:    suite.mockTransactioner,
+	}
+}
+
+func (suite *ResourceServiceTestSuite) TestCreateResourceServer_CheckHandleError() {
+	rs := ResourceServer{
+		Name:   "test-rs",
+		Handle: "test-handle",
+		OUID:   "ou-123",
+	}
+
+	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
+		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
+	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything, "test-rs").
+		Return(false, nil)
+	suite.mockStore.On("CheckResourceServerHandleExists", mock.Anything, "test-handle").
+		Return(false, errors.New("database error"))
+
+	result, err := suite.service.CreateResourceServer(context.Background(), rs)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestCreateResourceServer_IDConflict() {
+	rs := ResourceServer{
+		ID:   "rs-existing",
+		Name: "test-rs",
+		OUID: "ou-123",
+	}
+
+	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
+		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
+	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything, "test-rs").
+		Return(false, nil)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-existing").
+		Return(ResourceServer{ID: "rs-existing"}, nil)
+
+	result, err := suite.service.CreateResourceServer(context.Background(), rs)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(ErrorResourceServerIDConflict.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestGetResourceServerByIdentifier_NotFound() {
+	suite.mockStore.On("GetResourceServerByIdentifier", mock.Anything, "ident-1").
+		Return(ResourceServer{}, errResourceServerNotFound)
+
+	result, err := suite.service.GetResourceServerByIdentifier(context.Background(), "ident-1")
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(ErrorResourceServerNotFound.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestGetResourceServerByIdentifier_StoreError() {
+	suite.mockStore.On("GetResourceServerByIdentifier", mock.Anything, "ident-1").
+		Return(ResourceServer{}, errors.New("database error"))
+
+	result, err := suite.service.GetResourceServerByIdentifier(context.Background(), "ident-1")
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_CheckNameError() {
+	rs := ResourceServer{
+		Name: testUpdatedName,
+		OUID: "ou-123",
+	}
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").
+		Return(ResourceServer{ID: "rs-123", Name: testOriginalName, OUID: "ou-123"}, nil)
+	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
+		Return(oupkg.OrganizationUnit{ID: "ou-123"}, nil)
+	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything, testUpdatedName).
+		Return(false, errors.New("database error"))
+
+	result, err := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestFindResourceServersByPermissions_StoreError() {
+	perms := []string{"booking:read"}
+	suite.mockStore.On("FindResourceServersByPermissions", mock.Anything, perms).
+		Return([]ResourceServer(nil), errors.New("database error"))
+
+	result, err := suite.service.FindResourceServersByPermissions(context.Background(), perms)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestCreateResource_ConsentSyncError() {
+	cm := suite.newEnabledConsentServiceMock()
+	serverErr := &serviceerror.ServiceError{Type: serviceerror.ServerErrorType, Code: "CE-9999"}
+	cm.On("ValidateConsentElements", mock.Anything, "default", mock.Anything).
+		Return([]string(nil), serverErr)
+	svc := suite.newServiceWithConsent(cm)
+
+	res := Resource{Name: "test-resource", Handle: "test-handle"}
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").
+		Return(ResourceServer{ID: "rs-123"}, nil)
+	suite.mockStore.On("CheckResourceHandleExists", mock.Anything,
+		"rs-123", "test-handle", (*string)(nil)).Return(false, nil)
+	suite.mockStore.On("CreateResource", mock.Anything,
+		mock.AnythingOfType("string"), "rs-123", (*string)(nil), matchResource(res)).Return(nil)
+
+	result, err := svc.CreateResource(context.Background(), "rs-123", res)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateResource_ConsentSyncError() {
+	cm := suite.newEnabledConsentServiceMock()
+	serverErr := &serviceerror.ServiceError{Type: serviceerror.ServerErrorType, Code: "CE-9999"}
+	cm.On("ListConsentElements", mock.Anything, "default", consent.NamespacePermission, "perm-x").
+		Return([]consent.ConsentElement(nil), serverErr)
+	svc := suite.newServiceWithConsent(cm)
+
+	res := Resource{Name: testUpdatedName, Description: testNewDescription}
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").
+		Return(ResourceServer{ID: "rs-123"}, nil)
+	suite.mockStore.On("GetResource", mock.Anything, "res-123", "rs-123").
+		Return(Resource{ID: "res-123", Handle: testOriginalHandle, Permission: "perm-x"}, nil)
+	suite.mockStore.On("UpdateResource", mock.Anything,
+		"res-123", "rs-123", mock.AnythingOfType("Resource")).Return(nil)
+
+	result, err := svc.UpdateResource(context.Background(), "rs-123", "res-123", res)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestDeleteResource_ConsentSyncError() {
+	cm := suite.newEnabledConsentServiceMock()
+	serverErr := &serviceerror.ServiceError{Type: serviceerror.ServerErrorType, Code: "CE-9999"}
+	cm.On("ListConsentElements", mock.Anything, "default", consent.NamespacePermission, "perm-x").
+		Return([]consent.ConsentElement(nil), serverErr)
+	svc := suite.newServiceWithConsent(cm)
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").
+		Return(ResourceServer{ID: "rs-123"}, nil)
+	suite.mockStore.On("GetResource", mock.Anything, "res-123", "rs-123").
+		Return(Resource{ID: "res-123", Permission: "perm-x"}, nil)
+	suite.mockStore.On("CheckResourceHasDependencies", mock.Anything, "res-123").
+		Return(false, nil)
+	suite.mockStore.On("DeleteResource", mock.Anything, "res-123", "rs-123").Return(nil)
+
+	err := svc.DeleteResource(context.Background(), "rs-123", "res-123")
+
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestCreateAction_ConsentSyncError() {
+	cm := suite.newEnabledConsentServiceMock()
+	serverErr := &serviceerror.ServiceError{Type: serviceerror.ServerErrorType, Code: "CE-9999"}
+	cm.On("ValidateConsentElements", mock.Anything, "default", mock.Anything).
+		Return([]string(nil), serverErr)
+	svc := suite.newServiceWithConsent(cm)
+
+	action := Action{Name: "test-action", Handle: "test-handle"}
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").
+		Return(ResourceServer{ID: "rs-123"}, nil)
+	suite.mockStore.On("CheckActionHandleExists", mock.Anything,
+		"rs-123", (*string)(nil), "test-handle").Return(false, nil)
+	suite.mockStore.On("CreateAction", mock.Anything,
+		mock.AnythingOfType("string"), "rs-123", (*string)(nil), matchAction(action)).Return(nil)
+
+	result, err := svc.CreateAction(context.Background(), "rs-123", nil, action)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestUpdateAction_ConsentSyncError() {
+	cm := suite.newEnabledConsentServiceMock()
+	serverErr := &serviceerror.ServiceError{Type: serviceerror.ServerErrorType, Code: "CE-9999"}
+	cm.On("ListConsentElements", mock.Anything, "default", consent.NamespacePermission, "perm-x").
+		Return([]consent.ConsentElement(nil), serverErr)
+	svc := suite.newServiceWithConsent(cm)
+
+	action := Action{Name: testUpdatedName, Description: testNewDescription}
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").
+		Return(ResourceServer{ID: "rs-123"}, nil)
+	suite.mockStore.On("GetAction", mock.Anything, "action-123", "rs-123", (*string)(nil)).
+		Return(Action{ID: "action-123", Handle: testOriginalHandle, Permission: "perm-x"}, nil)
+	suite.mockStore.On("UpdateAction", mock.Anything,
+		"action-123", "rs-123", (*string)(nil), mock.AnythingOfType("Action")).Return(nil)
+
+	result, err := svc.UpdateAction(context.Background(), "rs-123", nil, "action-123", action)
+
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestDeleteAction_LoadForConsentSyncError() {
+	cm := suite.newEnabledConsentServiceMock()
+	svc := suite.newServiceWithConsent(cm)
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").
+		Return(ResourceServer{ID: "rs-123"}, nil)
+	suite.mockStore.On("IsActionExist", mock.Anything, "action-123", "rs-123", (*string)(nil)).
+		Return(true, nil)
+	suite.mockStore.On("GetAction", mock.Anything, "action-123", "rs-123", (*string)(nil)).
+		Return(Action{}, errors.New("database error"))
+
+	err := svc.DeleteAction(context.Background(), "rs-123", nil, "action-123")
+
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
+func (suite *ResourceServiceTestSuite) TestDeleteAction_ConsentSyncError() {
+	cm := suite.newEnabledConsentServiceMock()
+	serverErr := &serviceerror.ServiceError{Type: serviceerror.ServerErrorType, Code: "CE-9999"}
+	cm.On("ListConsentElements", mock.Anything, "default", consent.NamespacePermission, "perm-x").
+		Return([]consent.ConsentElement(nil), serverErr)
+	svc := suite.newServiceWithConsent(cm)
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").
+		Return(ResourceServer{ID: "rs-123"}, nil)
+	suite.mockStore.On("IsActionExist", mock.Anything, "action-123", "rs-123", (*string)(nil)).
+		Return(true, nil)
+	suite.mockStore.On("GetAction", mock.Anything, "action-123", "rs-123", (*string)(nil)).
+		Return(Action{ID: "action-123", Permission: "perm-x"}, nil)
+	suite.mockStore.On("DeleteAction", mock.Anything, "action-123", "rs-123", (*string)(nil)).
+		Return(nil)
+
+	err := svc.DeleteAction(context.Background(), "rs-123", nil, "action-123")
+
+	suite.NotNil(err)
+	suite.Equal(serviceerror.InternalServerError.Code, err.Code)
+}
+
 func TestResourceServerYAML_OUHandleParsed(t *testing.T) {
 	yamlData := []byte(`
 id: rs1

--- a/backend/internal/role/assignment_service.go
+++ b/backend/internal/role/assignment_service.go
@@ -92,11 +92,11 @@ func (as *roleAssignmentService) GetRoleAssignmentsByType(ctx context.Context, i
 
 	exists, err := as.roleStore.IsRoleExist(ctx, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if !exists {
-		logger.DebugWithContext(ctx, "Role not found", log.String("id", id))
+		logger.Debug(ctx, "Role not found", log.String("id", id))
 		return nil, &ErrorRoleNotFound
 	}
 
@@ -119,7 +119,7 @@ func (as *roleAssignmentService) GetRoleAssignmentsByType(ctx context.Context, i
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
 		}
-		logger.ErrorWithContext(ctx, "Failed to get role assignments count", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to get role assignments count", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -132,7 +132,7 @@ func (as *roleAssignmentService) GetRoleAssignmentsByType(ctx context.Context, i
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
 		}
-		logger.ErrorWithContext(ctx, "Failed to get role assignments", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to get role assignments", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -169,7 +169,7 @@ func (as *roleAssignmentService) getAssignmentsByEntityCategory(
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
 		}
-		logger.ErrorWithContext(ctx, "Failed to get entity assignments count", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to get entity assignments count", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -181,7 +181,7 @@ func (as *roleAssignmentService) getAssignmentsByEntityCategory(
 			if errors.Is(err, errResultLimitExceededInCompositeMode) {
 				return nil, &ResultLimitExceededInCompositeMode
 			}
-			logger.ErrorWithContext(ctx, "Failed to get entity assignments", log.String("id", id), log.Error(err))
+			logger.Error(ctx, "Failed to get entity assignments", log.String("id", id), log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -195,7 +195,7 @@ func (as *roleAssignmentService) getAssignmentsByEntityCategory(
 		}
 		entities, fetchErr := as.entityService.GetEntitiesByIDs(ctx, entityIDs)
 		if fetchErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to batch fetch entities for category filter", log.Error(fetchErr))
+			logger.Error(ctx, "Failed to batch fetch entities for category filter", log.Error(fetchErr))
 			return nil, &serviceerror.InternalServerError
 		}
 		for _, e := range entities {
@@ -245,7 +245,7 @@ func (as *roleAssignmentService) getAssignmentsByEntityCategory(
 func (as *roleAssignmentService) AddAssignments(
 	ctx context.Context, id string, assignments []RoleAssignment) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, assignmentLoggerComponentName))
-	logger.DebugWithContext(ctx, "Adding assignments to role", log.String("id", id))
+	logger.Debug(ctx, "Adding assignments to role", log.String("id", id))
 
 	normalized, svcErr := as.prepareAssignments(ctx, id, assignments)
 	if svcErr != nil {
@@ -255,11 +255,11 @@ func (as *roleAssignmentService) AddAssignments(
 	if err := as.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		return as.roleStore.AddAssignments(txCtx, id, normalized)
 	}); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to add assignments to role", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to add assignments to role", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully added assignments to role", log.String("id", id))
+	logger.Debug(ctx, "Successfully added assignments to role", log.String("id", id))
 	return nil
 }
 
@@ -268,7 +268,7 @@ func (as *roleAssignmentService) AddAssignments(
 func (as *roleAssignmentService) RemoveAssignments(
 	ctx context.Context, id string, assignments []RoleAssignment) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, assignmentLoggerComponentName))
-	logger.DebugWithContext(ctx, "Removing assignments from role", log.String("id", id))
+	logger.Debug(ctx, "Removing assignments from role", log.String("id", id))
 
 	normalized, svcErr := as.prepareAssignments(ctx, id, assignments)
 	if svcErr != nil {
@@ -278,11 +278,11 @@ func (as *roleAssignmentService) RemoveAssignments(
 	if err := as.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		return as.roleStore.RemoveAssignments(txCtx, id, normalized)
 	}); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to remove assignments from role", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to remove assignments from role", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully removed assignments from role", log.String("id", id))
+	logger.Debug(ctx, "Successfully removed assignments from role", log.String("id", id))
 	return nil
 }
 
@@ -304,11 +304,11 @@ func (as *roleAssignmentService) prepareAssignments(
 
 	exists, err := as.roleStore.IsRoleExist(ctx, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if !exists {
-		logger.DebugWithContext(ctx, "Role not found", log.String("id", id))
+		logger.Debug(ctx, "Role not found", log.String("id", id))
 		return nil, &ErrorRoleNotFound
 	}
 
@@ -381,7 +381,7 @@ func validateAssignmentIDs(
 
 		entities, err := entitySvc.GetEntitiesByIDs(ctx, entityIDs)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to fetch entities for assignment validation", log.Error(err))
+			logger.Error(ctx, "Failed to fetch entities for assignment validation", log.Error(err))
 			return &serviceerror.InternalServerError
 		}
 
@@ -393,7 +393,7 @@ func validateAssignmentIDs(
 			claimed := typeByID[e.ID]
 			actual := AssigneeType(e.Category)
 			if claimed != actual {
-				logger.DebugWithContext(ctx, "Assignment type mismatch", log.String("id", e.ID),
+				logger.Debug(ctx, "Assignment type mismatch", log.String("id", e.ID),
 					log.String("claimed", string(claimed)), log.String("actual", string(actual)))
 				return &ErrorInvalidAssignmentID
 			}
@@ -403,10 +403,10 @@ func validateAssignmentIDs(
 	if len(groupIDs) > 0 {
 		if err := groupSvc.ValidateGroupIDs(ctx, groupIDs); err != nil {
 			if err.Code == group.ErrorInvalidGroupMemberID.Code {
-				logger.DebugWithContext(ctx, "Invalid group member IDs found")
+				logger.Debug(ctx, "Invalid group member IDs found")
 				return &ErrorInvalidAssignmentID
 			}
-			logger.ErrorWithContext(ctx, "Failed to validate group IDs", log.String("error", err.Error.DefaultValue))
+			logger.Error(ctx, "Failed to validate group IDs", log.String("error", err.Error.DefaultValue))
 			return &serviceerror.InternalServerError
 		}
 	}
@@ -437,7 +437,7 @@ func (as *roleAssignmentService) resolveAssignments(
 	if len(entityIDs) > 0 {
 		entities, err := as.entityService.GetEntitiesByIDs(ctx, entityIDs)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to batch fetch entities for assignments", log.Error(err))
+			logger.Error(ctx, "Failed to batch fetch entities for assignments", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		entityMap = make(map[string]*entity.Entity, len(entities))
@@ -451,7 +451,7 @@ func (as *roleAssignmentService) resolveAssignments(
 		var svcErr *serviceerror.ServiceError
 		groupsMap, svcErr = as.groupService.GetGroupsByIDs(ctx, groupIDs)
 		if svcErr != nil {
-			logger.WarnWithContext(ctx, "Failed to batch fetch groups for display names", log.Any("error", svcErr))
+			logger.Warn(ctx, "Failed to batch fetch groups for display names", log.Any("error", svcErr))
 		}
 	}
 
@@ -475,7 +475,7 @@ func (as *roleAssignmentService) resolveAssignments(
 		case assigneeTypeEntity:
 			e, ok := entityMap[a.ID]
 			if !ok {
-				logger.WarnWithContext(ctx, "Skipping orphaned entity assignment", log.String("id", a.ID))
+				logger.Warn(ctx, "Skipping orphaned entity assignment", log.String("id", a.ID))
 				continue
 			}
 			ra.Type = AssigneeType(e.Category)
@@ -539,7 +539,7 @@ func resolveDisplayAttributePaths(
 	displayPaths, svcErr := schemaService.GetDisplayAttributesByNames(ctx, entitytype.TypeCategoryUser, uniqueTypes)
 	if svcErr != nil {
 		if logger != nil {
-			logger.WarnWithContext(ctx, "Failed to resolve display attribute paths, skipping display resolution",
+			logger.Warn(ctx, "Failed to resolve display attribute paths, skipping display resolution",
 				log.Any("error", svcErr))
 		}
 		return nil

--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -276,7 +276,7 @@ func (c *compositeRoleStore) getCompositeAssignmentsCount(
 
 	count := len(assignments)
 	if count > serverconst.MaxCompositeStoreRecords*9/10 {
-		log.GetLogger().WarnWithContext(ctx,
+		log.GetLogger().Warn(ctx,
 			"Role assignment count approaches composite store limit; consider API pagination",
 			log.String("id", id),
 			log.Int("count", count),
@@ -422,7 +422,7 @@ func (c *compositeRoleStore) crossStoreAuthorizedPermissions(
 			if errors.Is(err, ErrRoleNotFound) || errors.Is(err, ErrRoleDataCorrupted) {
 				continue
 			}
-			log.GetLogger().ErrorWithContext(ctx,
+			log.GetLogger().Error(ctx,
 				"Failed to load declarative role for cross-store permission resolution",
 				log.String("roleID", id), log.Error(err))
 			return nil, fmt.Errorf("composite role store: load declarative role %q: %w", id, err)

--- a/backend/internal/role/declarative_resource.go
+++ b/backend/internal/role/declarative_resource.go
@@ -165,7 +165,7 @@ func loadDeclarativeResources(
 			}
 			// Log error and return empty string if type assertion fails
 			// Declarative resource loading runs during startup, outside any request.
-			log.GetLogger().ErrorWithContext(context.Background(),
+			log.GetLogger().Error(context.Background(),
 				"IDExtractor: type assertion failed for RoleWithPermissionsAndAssignments")
 			return ""
 		},

--- a/backend/internal/role/file_based_store.go
+++ b/backend/internal/role/file_based_store.go
@@ -76,7 +76,7 @@ func (f *fileBasedStore) GetRoleList(ctx context.Context, limit, offset int) ([]
 		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
 			// Log warning for malformed declarative entry
-			log.GetLogger().WarnWithContext(ctx, "Skipping malformed role in GetRoleList",
+			log.GetLogger().Warn(ctx, "Skipping malformed role in GetRoleList",
 				log.String("roleID", item.ID.ID),
 				log.Error(err))
 			continue
@@ -277,7 +277,7 @@ func (f *fileBasedStore) CheckRoleNameExists(ctx context.Context, ouID, name str
 		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
 			// Log warning for malformed declarative entry
-			log.GetLogger().WarnWithContext(ctx, "Skipping malformed role in CheckRoleNameExists",
+			log.GetLogger().Warn(ctx, "Skipping malformed role in CheckRoleNameExists",
 				log.String("roleID", item.ID.ID),
 				log.Error(err))
 			continue
@@ -304,7 +304,7 @@ func (f *fileBasedStore) CheckRoleNameExistsExcludingID(
 		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
 			// Log warning for malformed declarative entry
-			log.GetLogger().WarnWithContext(ctx, "Skipping malformed role in CheckRoleNameExistsExcludingID",
+			log.GetLogger().Warn(ctx, "Skipping malformed role in CheckRoleNameExistsExcludingID",
 				log.String("roleID", item.ID.ID),
 				log.Error(err))
 			continue
@@ -354,7 +354,7 @@ func (f *fileBasedStore) GetAuthorizedPermissions(
 		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
 			// Log warning for malformed declarative entry
-			log.GetLogger().WarnWithContext(ctx, "Skipping malformed role in GetAuthorizedPermissions",
+			log.GetLogger().Warn(ctx, "Skipping malformed role in GetAuthorizedPermissions",
 				log.String("roleID", item.ID.ID),
 				log.Error(err))
 			continue
@@ -402,7 +402,7 @@ func (f *fileBasedStore) GetUserRoles(
 	for _, item := range list {
 		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
 		if err != nil {
-			log.GetLogger().WarnWithContext(ctx, "Skipping malformed role in GetUserRoles",
+			log.GetLogger().Warn(ctx, "Skipping malformed role in GetUserRoles",
 				log.String("roleID", item.ID.ID),
 				log.Error(err))
 			continue

--- a/backend/internal/role/handler.go
+++ b/backend/internal/role/handler.go
@@ -80,7 +80,7 @@ func (rh *roleHandler) HandleRoleListRequest(w http.ResponseWriter, r *http.Requ
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, roleListResponse)
 
-	logger.DebugWithContext(ctx, "Successfully listed roles with pagination",
+	logger.Debug(ctx, "Successfully listed roles with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", roleListResponse.TotalResults),
 		log.Int("count", roleListResponse.Count))
@@ -113,7 +113,7 @@ func (rh *roleHandler) HandleRolePostRequest(w http.ResponseWriter, r *http.Requ
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdRole)
 
-	logger.DebugWithContext(ctx, "Successfully created role", log.String("roleId", createdRole.ID))
+	logger.Debug(ctx, "Successfully created role", log.String("roleId", createdRole.ID))
 }
 
 // HandleRoleGetRequest handles the get role by id request.
@@ -133,7 +133,7 @@ func (rh *roleHandler) HandleRoleGetRequest(w http.ResponseWriter, r *http.Reque
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, role)
 
-	logger.DebugWithContext(ctx, "Successfully retrieved role", log.String("role id", id))
+	logger.Debug(ctx, "Successfully retrieved role", log.String("role id", id))
 }
 
 // HandleRolePutRequest handles the update role request.
@@ -164,7 +164,7 @@ func (rh *roleHandler) HandleRolePutRequest(w http.ResponseWriter, r *http.Reque
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, role)
 
-	logger.DebugWithContext(ctx, "Successfully updated role", log.String("role id", id))
+	logger.Debug(ctx, "Successfully updated role", log.String("role id", id))
 }
 
 // HandleRoleDeleteRequest handles the delete role request.
@@ -180,7 +180,7 @@ func (rh *roleHandler) HandleRoleDeleteRequest(w http.ResponseWriter, r *http.Re
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
-	logger.DebugWithContext(ctx, "Successfully deleted role", log.String("role id", id))
+	logger.Debug(ctx, "Successfully deleted role", log.String("role id", id))
 }
 
 // HandleRoleAssignmentsGetRequest handles the get role assignments request.
@@ -234,7 +234,7 @@ func (rh *roleHandler) HandleRoleAssignmentsGetRequest(w http.ResponseWriter, r 
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, assignmentListResponse)
 
-	logger.DebugWithContext(ctx, "Successfully retrieved role assignments", log.String("role id", id),
+	logger.Debug(ctx, "Successfully retrieved role assignments", log.String("role id", id),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Bool("includeDisplay", includeDisplay),
 		log.String("assigneeType", assigneeType),
@@ -266,7 +266,7 @@ func (rh *roleHandler) HandleRoleAddAssignmentsRequest(w http.ResponseWriter, r 
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
-	logger.DebugWithContext(ctx, "Successfully added assignments to role", log.String("role id", id))
+	logger.Debug(ctx, "Successfully added assignments to role", log.String("role id", id))
 }
 
 // HandleRoleRemoveAssignmentsRequest handles the remove assignments from role request.
@@ -293,7 +293,7 @@ func (rh *roleHandler) HandleRoleRemoveAssignmentsRequest(w http.ResponseWriter,
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
-	logger.DebugWithContext(ctx, "Successfully removed assignments from role", log.String("role id", id))
+	logger.Debug(ctx, "Successfully removed assignments from role", log.String("role id", id))
 }
 
 // handleError handles service errors and returns appropriate HTTP responses.

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -98,7 +98,7 @@ func (rs *roleService) GetRoleList(ctx context.Context, limit, offset int) (*Rol
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
 		}
-		logger.ErrorWithContext(ctx, "Failed to get role count", log.Error(err))
+		logger.Error(ctx, "Failed to get role count", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -107,7 +107,7 @@ func (rs *roleService) GetRoleList(ctx context.Context, limit, offset int) (*Rol
 		if errors.Is(err, errResultLimitExceededInCompositeMode) {
 			return nil, &ResultLimitExceededInCompositeMode
 		}
-		logger.ErrorWithContext(ctx, "Failed to list roles", log.Error(err))
+		logger.Error(ctx, "Failed to list roles", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -124,7 +124,7 @@ func (rs *roleService) GetRoleList(ctx context.Context, limit, offset int) (*Rol
 		}
 		ouHandles, svcErr := rs.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
 		if svcErr != nil {
-			logger.WarnWithContext(ctx, "Failed to resolve OU handles for roles, skipping", log.Any("error", svcErr))
+			logger.Warn(ctx, "Failed to resolve OU handles for roles, skipping", log.Any("error", svcErr))
 		} else {
 			for i := range roles {
 				roles[i].OUHandle = ouHandles[roles[i].OUID]
@@ -148,11 +148,11 @@ func (rs *roleService) CreateRole(
 	ctx context.Context, role RoleCreationDetail,
 ) (*RoleWithPermissionsAndAssignments, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Creating role", log.String("name", role.Name))
+	logger.Debug(ctx, "Creating role", log.String("name", role.Name))
 
 	// Check if role creation is allowed (not in declarative-only mode)
 	if isDeclarativeModeEnabled() {
-		logger.DebugWithContext(ctx, "Cannot create role in declarative-only mode")
+		logger.Debug(ctx, "Cannot create role in declarative-only mode")
 		return nil, &ErrorDeclarativeModeCreateNotAllowed
 	}
 
@@ -166,10 +166,10 @@ func (rs *roleService) CreateRole(
 	ou, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
 	if svcErr != nil {
 		if svcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
-			logger.DebugWithContext(ctx, "Organization unit not found", log.String("ouID", role.OUID))
+			logger.Debug(ctx, "Organization unit not found", log.String("ouID", role.OUID))
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to validate organization unit",
+		logger.Error(ctx, "Failed to validate organization unit",
 			log.String("error", svcErr.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -191,11 +191,11 @@ func (rs *roleService) CreateRole(
 	// Check if role name already exists in the organization unit
 	nameExists, err := rs.roleStore.CheckRoleNameExists(ctx, role.OUID, role.Name)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check role name existence", log.Error(err))
+		logger.Error(ctx, "Failed to check role name existence", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if nameExists {
-		logger.DebugWithContext(ctx, "Role name already exists in organization unit",
+		logger.Debug(ctx, "Role name already exists in organization unit",
 			log.String("name", role.Name), log.String("ouID", role.OUID))
 		return nil, &ErrorRoleNameConflict
 	}
@@ -204,17 +204,17 @@ func (rs *roleService) CreateRole(
 	if id == "" {
 		id, err = utils.GenerateUUIDv7()
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+			logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	} else {
 		_, err = rs.roleStore.GetRole(ctx, id)
 		if err != nil && !errors.Is(err, ErrRoleNotFound) {
-			logger.ErrorWithContext(ctx, "Failed to check role ID existence", log.Error(err))
+			logger.Error(ctx, "Failed to check role ID existence", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 		if err == nil {
-			logger.DebugWithContext(ctx, "Role ID already exists", log.String("id", id))
+			logger.Debug(ctx, "Role ID already exists", log.String("id", id))
 			return nil, &ErrorRoleIDConflict
 		}
 	}
@@ -237,11 +237,11 @@ func (rs *roleService) CreateRole(
 	})
 
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create role", log.Error(err))
+		logger.Error(ctx, "Failed to create role", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully created role", log.String("id", id), log.String("name", role.Name))
+	logger.Debug(ctx, "Successfully created role", log.String("id", id), log.String("name", role.Name))
 	return serviceRole, nil
 }
 
@@ -249,7 +249,7 @@ func (rs *roleService) CreateRole(
 func (rs *roleService) GetRoleWithPermissions(ctx context.Context, id string) (
 	*RoleWithPermissions, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Retrieving role", log.String("id", id))
+	logger.Debug(ctx, "Retrieving role", log.String("id", id))
 
 	if id == "" {
 		return nil, &ErrorMissingRoleID
@@ -258,22 +258,22 @@ func (rs *roleService) GetRoleWithPermissions(ctx context.Context, id string) (
 	role, err := rs.roleStore.GetRole(ctx, id)
 	if err != nil {
 		if errors.Is(err, ErrRoleNotFound) {
-			logger.DebugWithContext(ctx, "Role not found", log.String("id", id))
+			logger.Debug(ctx, "Role not found", log.String("id", id))
 			return nil, &ErrorRoleNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to retrieve role", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to retrieve role", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	ou, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
 	if svcErr != nil {
-		logger.WarnWithContext(ctx, "Failed to resolve OU handle for role, skipping",
+		logger.Warn(ctx, "Failed to resolve OU handle for role, skipping",
 			log.String("id", id), log.Any("error", svcErr))
 	} else {
 		role.OUHandle = ou.Handle
 	}
 
-	logger.DebugWithContext(ctx, "Successfully retrieved role",
+	logger.Debug(ctx, "Successfully retrieved role",
 		log.String("id", role.ID), log.String("name", role.Name))
 	return &role, nil
 }
@@ -282,7 +282,7 @@ func (rs *roleService) GetRoleWithPermissions(ctx context.Context, id string) (
 func (rs *roleService) UpdateRoleWithPermissions(
 	ctx context.Context, id string, role RoleUpdateDetail) (*RoleWithPermissions, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Updating role", log.String("id", id), log.String("name", role.Name))
+	logger.Debug(ctx, "Updating role", log.String("id", id), log.String("name", role.Name))
 
 	if id == "" {
 		return nil, &ErrorMissingRoleID
@@ -299,17 +299,17 @@ func (rs *roleService) UpdateRoleWithPermissions(
 
 	exists, err := rs.roleStore.IsRoleExist(ctx, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if !exists {
-		logger.DebugWithContext(ctx, "Role not found", log.String("id", id))
+		logger.Debug(ctx, "Role not found", log.String("id", id))
 		return nil, &ErrorRoleNotFound
 	}
 
 	// Check if role is declarative - cannot modify declarative roles
 	if rs.isRoleDeclarative(ctx, id) {
-		logger.DebugWithContext(ctx, "Cannot modify declarative role", log.String("id", id))
+		logger.Debug(ctx, "Cannot modify declarative role", log.String("id", id))
 		return nil, &ErrorImmutableRole
 	}
 
@@ -317,10 +317,10 @@ func (rs *roleService) UpdateRoleWithPermissions(
 	ou, svcErr := rs.ouService.GetOrganizationUnit(ctx, role.OUID)
 	if svcErr != nil {
 		if svcErr.Code == oupkg.ErrorOrganizationUnitNotFound.Code {
-			logger.DebugWithContext(ctx, "Organization unit not found", log.String("ouID", role.OUID))
+			logger.Debug(ctx, "Organization unit not found", log.String("ouID", role.OUID))
 			return nil, &ErrorOrganizationUnitNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to validate organization unit",
+		logger.Error(ctx, "Failed to validate organization unit",
 			log.String("error", svcErr.Error.DefaultValue))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -328,11 +328,11 @@ func (rs *roleService) UpdateRoleWithPermissions(
 	// Check if role name already exists in the organization unit (excluding the current role)
 	nameExists, err := rs.roleStore.CheckRoleNameExistsExcludingID(ctx, role.OUID, role.Name, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check role name existence", log.Error(err))
+		logger.Error(ctx, "Failed to check role name existence", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	if nameExists {
-		logger.DebugWithContext(ctx, "Role name already exists in organization unit",
+		logger.Debug(ctx, "Role name already exists in organization unit",
 			log.String("name", role.Name), log.String("ouID", role.OUID))
 		return nil, &ErrorRoleNameConflict
 	}
@@ -342,11 +342,11 @@ func (rs *roleService) UpdateRoleWithPermissions(
 	})
 
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to update role", log.Error(err))
+		logger.Error(ctx, "Failed to update role", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully updated role", log.String("id", id), log.String("name", role.Name))
+	logger.Debug(ctx, "Successfully updated role", log.String("id", id), log.String("name", role.Name))
 	return &RoleWithPermissions{
 		ID:          id,
 		Name:        role.Name,
@@ -360,7 +360,7 @@ func (rs *roleService) UpdateRoleWithPermissions(
 // DeleteRole delete the specified role by its id.
 func (rs *roleService) DeleteRole(ctx context.Context, id string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Deleting role", log.String("id", id))
+	logger.Debug(ctx, "Deleting role", log.String("id", id))
 
 	if id == "" {
 		return &ErrorMissingRoleID
@@ -368,17 +368,17 @@ func (rs *roleService) DeleteRole(ctx context.Context, id string) *serviceerror.
 
 	exists, err := rs.roleStore.IsRoleExist(ctx, id)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to check role existence", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	if !exists {
-		logger.DebugWithContext(ctx, "Role not found", log.String("id", id))
+		logger.Debug(ctx, "Role not found", log.String("id", id))
 		return nil
 	}
 
 	// Check if role is declarative - cannot delete declarative roles
 	if rs.isRoleDeclarative(ctx, id) {
-		logger.DebugWithContext(ctx, "Cannot delete declarative role", log.String("id", id))
+		logger.Debug(ctx, "Cannot delete declarative role", log.String("id", id))
 		return &ErrorImmutableRole
 	}
 
@@ -392,11 +392,11 @@ func (rs *roleService) DeleteRole(ctx context.Context, id string) *serviceerror.
 		return rs.roleStore.DeleteRole(txCtx, id)
 	})
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to delete role", log.String("id", id), log.Error(err))
+		logger.Error(ctx, "Failed to delete role", log.String("id", id), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Successfully deleted role", log.String("id", id))
+	logger.Debug(ctx, "Successfully deleted role", log.String("id", id))
 	return nil
 }
 
@@ -405,7 +405,7 @@ func (rs *roleService) GetAuthorizedPermissions(
 	ctx context.Context, entityID string, groups []string, requestedPermissions []string,
 ) ([]string, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Authorizing permissions",
+	logger.Debug(ctx, "Authorizing permissions",
 		log.MaskedString(log.LoggerKeyUserID, entityID), log.Int("groupCount", len(groups)))
 
 	// Handle nil groups slice
@@ -426,14 +426,14 @@ func (rs *roleService) GetAuthorizedPermissions(
 	// Get authorized permissions from store
 	authorizedPermissions, err := rs.roleStore.GetAuthorizedPermissions(ctx, entityID, groups, requestedPermissions)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get authorized permissions",
+		logger.Error(ctx, "Failed to get authorized permissions",
 			log.MaskedString(log.LoggerKeyUserID, entityID),
 			log.Int("groupCount", len(groups)),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
-	logger.DebugWithContext(ctx, "Retrieved authorized permissions",
+	logger.Debug(ctx, "Retrieved authorized permissions",
 		log.MaskedString(log.LoggerKeyUserID, entityID),
 		log.Int("groupCount", len(groups)),
 		log.Int("requestedCount", len(requestedPermissions)),
@@ -447,7 +447,7 @@ func (rs *roleService) GetUserRoles(
 	ctx context.Context, entityID string, groupIDs []string,
 ) ([]string, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Getting entity roles",
+	logger.Debug(ctx, "Getting entity roles",
 		log.MaskedString("entityID", entityID), log.Int("groupCount", len(groupIDs)))
 
 	if groupIDs == nil {
@@ -460,7 +460,7 @@ func (rs *roleService) GetUserRoles(
 
 	roles, err := rs.roleStore.GetUserRoles(ctx, entityID, groupIDs)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get entity roles",
+		logger.Error(ctx, "Failed to get entity roles",
 			log.MaskedString("entityID", entityID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -486,7 +486,7 @@ func (rs *roleService) ResolveRoleOUHandle(
 ) *serviceerror.ServiceError {
 	if role.OUID != "" && role.OUHandle != "" {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-		logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided for role; ou_handle ignored",
+		logger.Warn(ctx, "Both ou_id and ou_handle provided for role; ou_handle ignored",
 			log.String("roleID", role.ID), log.String("name", role.Name))
 		return nil
 	}
@@ -587,7 +587,7 @@ func (rs *roleService) validatePermissions(
 	// Validate each resource server's permissions
 	for _, resPerm := range permissions {
 		if resPerm.ResourceServerID == "" {
-			logger.DebugWithContext(ctx, "Empty resource server ID")
+			logger.Debug(ctx, "Empty resource server ID")
 			return &ErrorInvalidPermissions
 		}
 
@@ -603,7 +603,7 @@ func (rs *roleService) validatePermissions(
 		)
 
 		if svcErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to validate permissions",
+			logger.Error(ctx, "Failed to validate permissions",
 				log.String("resourceServerId", resPerm.ResourceServerID),
 				log.String("error", svcErr.Error.DefaultValue))
 			return &serviceerror.InternalServerError
@@ -611,7 +611,7 @@ func (rs *roleService) validatePermissions(
 
 		// If any permissions are invalid, return error
 		if len(invalidPerms) > 0 {
-			logger.DebugWithContext(ctx, "Invalid permissions found",
+			logger.Debug(ctx, "Invalid permissions found",
 				log.String("resourceServerId", resPerm.ResourceServerID),
 				log.Any("invalidPermissions", invalidPerms),
 				log.Int("count", len(invalidPerms)))
@@ -638,7 +638,7 @@ func (rs *roleService) isRoleDeclarative(ctx context.Context, roleID string) boo
 		// Log at Warn level and fail open - treat as non-declarative on error
 		// RISK: In composite mode, this could allow modification of declarative roles if the check fails
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-		logger.WarnWithContext(ctx, "Failed to check if role is declarative",
+		logger.Warn(ctx, "Failed to check if role is declarative",
 			log.String("roleID", roleID), log.Error(err))
 		return false
 	}

--- a/backend/internal/role/store.go
+++ b/backend/internal/role/store.go
@@ -341,7 +341,7 @@ func (s *roleStore) DeleteRole(ctx context.Context, id string) error {
 	}
 
 	if rowsAffected == 0 {
-		logger.DebugWithContext(ctx, "Role not found with id: "+id)
+		logger.Debug(ctx, "Role not found with id: "+id)
 	}
 
 	return nil

--- a/backend/internal/system/cache/cache.go
+++ b/backend/internal/system/cache/cache.go
@@ -56,7 +56,7 @@ func (c *Cache[T]) Set(ctx context.Context, key CacheKey, value T) error {
 
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
 		if err := c.cacheImpl.Set(ctx, key, value); err != nil {
-			logger.WarnWithContext(ctx, "Failed to set value in the cache",
+			logger.Warn(ctx, "Failed to set value in the cache",
 				log.String("key", key.ToString()), log.Error(err))
 		}
 	}
@@ -83,7 +83,7 @@ func (c *Cache[T]) Delete(ctx context.Context, key CacheKey) error {
 
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
 		if err := c.cacheImpl.Delete(ctx, key); err != nil {
-			logger.WarnWithContext(ctx, "Failed to delete value from the cache",
+			logger.Warn(ctx, "Failed to delete value from the cache",
 				log.String("key", key.ToString()), log.Error(err))
 		}
 	}
@@ -97,10 +97,10 @@ func (c *Cache[T]) Clear(ctx context.Context) error {
 		log.String("cacheName", c.cacheName))
 
 	if c.IsEnabled() && c.cacheImpl.IsEnabled() {
-		logger.DebugWithContext(ctx, "Clearing all entries in the cache")
+		logger.Debug(ctx, "Clearing all entries in the cache")
 
 		if err := c.cacheImpl.Clear(ctx); err != nil {
-			logger.WarnWithContext(ctx, "Failed to clear the cache", log.Error(err))
+			logger.Warn(ctx, "Failed to clear the cache", log.Error(err))
 		}
 	}
 

--- a/backend/internal/system/cache/inmemorycache.go
+++ b/backend/internal/system/cache/inmemorycache.go
@@ -117,7 +117,7 @@ func getEvictionPolicy(cacheConfig config.CacheConfig, cacheProperty config.Cach
 		return evictionPolicyLFU
 	default:
 		// Cache infrastructure logging has no request scope, so context.Background() is used.
-		log.GetLogger().WarnWithContext(context.Background(), "Unknown eviction policy, defaulting to LRU")
+		log.GetLogger().Warn(context.Background(), "Unknown eviction policy, defaulting to LRU")
 		return evictionPolicyLRU
 	}
 }
@@ -149,7 +149,7 @@ func newInMemoryCache[T any](name string, enabled bool,
 		log.String("name", name))
 
 	if !enabled {
-		logger.WarnWithContext(ctx, "In-memory cache is disabled, returning empty cache")
+		logger.Warn(ctx, "In-memory cache is disabled, returning empty cache")
 		return &inMemoryCache[T]{
 			name:    name,
 			enabled: false,
@@ -160,7 +160,7 @@ func newInMemoryCache[T any](name string, enabled bool,
 	size := getCacheSize(cacheConfig, cacheProperty)
 	evictionPolicy := getEvictionPolicy(cacheConfig, cacheProperty)
 
-	logger.DebugWithContext(ctx, "Initializing In-memory cache", log.String("evictionPolicy", string(evictionPolicy)),
+	logger.Debug(ctx, "Initializing In-memory cache", log.String("evictionPolicy", string(evictionPolicy)),
 		log.Int("size", size), log.Any("ttl", ttl))
 
 	lfuHeapInstance := &lfuHeap{}
@@ -238,11 +238,11 @@ func (c *inMemoryCache[T]) Set(ctx context.Context, key CacheKey, value T) error
 	}
 	c.cache[key] = inMemoryCacheEntry
 
-	logger.DebugWithContext(ctx, "Cache entry set", log.String("key", key.ToString()))
+	logger.Debug(ctx, "Cache entry set", log.String("key", key.ToString()))
 
 	// Check if there's a requirement to evict an entry
 	if len(c.cache) > c.size {
-		logger.DebugWithContext(ctx, "Cache size exceeded, evicting an entry")
+		logger.Debug(ctx, "Cache size exceeded, evicting an entry")
 		c.evict()
 	}
 
@@ -290,7 +290,7 @@ func (c *inMemoryCache[T]) Get(ctx context.Context, key CacheKey) (T, bool) {
 		heap.Fix(c.lfuHeap, entry.heapItem.index)
 	}
 
-	logger.DebugWithContext(ctx, "Cache hit", log.String("key", key.ToString()))
+	logger.Debug(ctx, "Cache hit", log.String("key", key.ToString()))
 	return entry.Value, true
 }
 
@@ -330,7 +330,7 @@ func (c *inMemoryCache[T]) Clear(ctx context.Context) error {
 	c.missCount.Store(0)
 	c.evictCount.Store(0)
 
-	logger.DebugWithContext(ctx, "Cleared all entries in the cache")
+	logger.Debug(ctx, "Cleared all entries in the cache")
 	return nil
 }
 
@@ -399,7 +399,7 @@ func (c *inMemoryCache[T]) evictOldest() {
 			c.deleteEntry(key, entry)
 			c.evictCount.Add(1)
 			// Cache eviction is infrastructure-scoped, not tied to a request.
-			logger.DebugWithContext(context.Background(), "Cache entry evicted", log.String("key", key.ToString()))
+			logger.Debug(context.Background(), "Cache entry evicted", log.String("key", key.ToString()))
 		}
 	}
 }
@@ -420,7 +420,7 @@ func (c *inMemoryCache[T]) evictLeastFrequent() {
 		c.deleteEntry(leastFrequentItem.key, entry)
 		c.evictCount.Add(1)
 		// Cache eviction is infrastructure-scoped, not tied to a request.
-		logger.DebugWithContext(context.Background(), "Cache entry evicted (LFU)",
+		logger.Debug(context.Background(), "Cache entry evicted (LFU)",
 			log.String("key", leastFrequentItem.key.ToString()),
 			log.Any("accessCount", leastFrequentItem.accessCount))
 	}
@@ -447,7 +447,7 @@ func (c *inMemoryCache[T]) CleanupExpired() {
 
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "InMemoryCache"),
 		log.String("name", c.GetName()))
-	logger.DebugWithContext(ctx, "Cleaning up expired entries from the cache")
+	logger.Debug(ctx, "Cleaning up expired entries from the cache")
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -463,9 +463,9 @@ func (c *inMemoryCache[T]) CleanupExpired() {
 
 	if logger.IsDebugEnabled() {
 		if cleaned > 0 {
-			logger.DebugWithContext(ctx, "Expired cache entries cleaned", log.Int("count", cleaned))
+			logger.Debug(ctx, "Expired cache entries cleaned", log.Int("count", cleaned))
 		} else {
-			logger.DebugWithContext(ctx, "No expired entries found in the cache")
+			logger.Debug(ctx, "No expired entries found in the cache")
 		}
 	}
 }

--- a/backend/internal/system/cache/manager.go
+++ b/backend/internal/system/cache/manager.go
@@ -65,7 +65,7 @@ func Initialize(cacheConfig config.CacheConfig, deploymentID string) CacheManage
 	// Cache infrastructure logging has no request scope, so context.Background() is used.
 	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
-	logger.DebugWithContext(ctx, "Initializing Cache Manager")
+	logger.Debug(ctx, "Initializing Cache Manager")
 
 	cm := &CacheManager{
 		cacheConfig:  cacheConfig,
@@ -74,7 +74,7 @@ func Initialize(cacheConfig config.CacheConfig, deploymentID string) CacheManage
 	}
 
 	if cacheConfig.Disabled {
-		logger.DebugWithContext(ctx, "Caching is disabled. Skipping initialization")
+		logger.Debug(ctx, "Caching is disabled. Skipping initialization")
 		return cm
 	}
 
@@ -94,22 +94,22 @@ func Initialize(cacheConfig config.CacheConfig, deploymentID string) CacheManage
 			WriteTimeout:    time.Duration(cacheConfig.Redis.WriteTimeoutMS) * time.Millisecond,
 		})
 		if err := cm.redisClient.Ping(context.Background()).Err(); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to connect to Redis. Cache initialization aborted.", log.Error(err))
+			logger.Error(ctx, "Failed to connect to Redis. Cache initialization aborted.", log.Error(err))
 			if closeErr := cm.redisClient.Close(); closeErr != nil {
-				logger.WarnWithContext(ctx, "Failed to close Redis client after ping failure", log.Error(closeErr))
+				logger.Warn(ctx, "Failed to close Redis client after ping failure", log.Error(closeErr))
 			}
 			cm.redisClient = nil
 			cm.enabled = false
 			return cm
 		}
-		logger.DebugWithContext(ctx, "Connected to Redis successfully",
+		logger.Debug(ctx, "Connected to Redis successfully",
 			log.String("address", cacheConfig.Redis.Address))
 	} else {
 		cm.cleanupInterval = getCleanupInterval(cacheConfig)
 		cm.startCleanupRoutine()
 	}
 
-	logger.DebugWithContext(ctx, "Cache Manager initialized", log.Bool("enabled", cm.enabled),
+	logger.Debug(ctx, "Cache Manager initialized", log.Bool("enabled", cm.enabled),
 		log.Any("cleanupInterval", cm.cleanupInterval))
 	return cm
 }
@@ -125,9 +125,9 @@ func (cm *CacheManager) Close() {
 
 	if cm.redisClient != nil {
 		if err := cm.redisClient.Close(); err != nil {
-			logger.WarnWithContext(ctx, "Failed to close Redis client", log.Error(err))
+			logger.Warn(ctx, "Failed to close Redis client", log.Error(err))
 		} else {
-			logger.DebugWithContext(ctx, "Redis client closed")
+			logger.Debug(ctx, "Redis client closed")
 		}
 		cm.redisClient = nil
 	}
@@ -157,7 +157,7 @@ func (cm *CacheManager) addCache(cacheKey string, cacheInstance interface{}) {
 	if _, exists := cm.caches[cacheKey]; !exists {
 		cm.caches[cacheKey] = cacheInstance
 		// Cache infrastructure logging has no request scope, so context.Background() is used.
-		log.GetLogger().DebugWithContext(context.Background(), "Cache added", log.String("cacheKey", cacheKey))
+		log.GetLogger().Debug(context.Background(), "Cache added", log.String("cacheKey", cacheKey))
 	}
 }
 
@@ -185,7 +185,7 @@ func (cm *CacheManager) startCleanupRoutine() {
 	}
 
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
-	logger.DebugWithContext(ctx, "Starting cleanup routine for caches")
+	logger.Debug(ctx, "Starting cleanup routine for caches")
 
 	go func() {
 		ticker := time.NewTicker(cm.cleanupInterval)
@@ -196,7 +196,7 @@ func (cm *CacheManager) startCleanupRoutine() {
 		}
 	}()
 
-	logger.DebugWithContext(ctx, "Cleanup routine started", log.Any("interval", cm.cleanupInterval))
+	logger.Debug(ctx, "Cleanup routine started", log.Any("interval", cm.cleanupInterval))
 }
 
 // cleanupAllCaches cleans up expired entries in all caches.
@@ -204,7 +204,7 @@ func (cm *CacheManager) cleanupAllCaches() {
 	// Cache infrastructure logging has no request scope, so context.Background() is used.
 	ctx := context.Background()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CacheManager"))
-	logger.DebugWithContext(ctx, "Cleaning up expired caches")
+	logger.Debug(ctx, "Cleaning up expired caches")
 
 	for _, cacheEntry := range cm.caches {
 		// Use type switch to handle different cache types
@@ -215,11 +215,11 @@ func (cm *CacheManager) cleanupAllCaches() {
 			CleanupExpired()
 		}:
 			if cache.IsEnabled() {
-				logger.DebugWithContext(ctx, "Cleaning up cache", log.String("cacheName", cache.GetName()))
+				logger.Debug(ctx, "Cleaning up cache", log.String("cacheName", cache.GetName()))
 				cache.CleanupExpired()
 			}
 		default:
-			logger.WarnWithContext(ctx, "Unknown cache type encountered", log.Any("type", reflect.TypeOf(cacheEntry)))
+			logger.Warn(ctx, "Unknown cache type encountered", log.Any("type", reflect.TypeOf(cacheEntry)))
 		}
 	}
 }
@@ -255,7 +255,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 
 	cacheConfig := cm.getCacheConfig()
 	if cacheConfig.Disabled {
-		logger.DebugWithContext(ctx, "Caching is disabled, returning empty")
+		logger.Debug(ctx, "Caching is disabled, returning empty")
 		return &Cache[T]{
 			enabled:   false,
 			cacheName: cacheName,
@@ -266,7 +266,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 	cacheProperty := getCacheProperty(cacheConfig, cacheName)
 
 	if cacheProperty.Disabled {
-		logger.DebugWithContext(ctx, "Individual cache is disabled, returning empty")
+		logger.Debug(ctx, "Individual cache is disabled, returning empty")
 		return &Cache[T]{
 			enabled:   false,
 			cacheName: cacheName,
@@ -274,7 +274,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 		}
 	}
 
-	logger.DebugWithContext(ctx, "Initializing the cache")
+	logger.Debug(ctx, "Initializing the cache")
 
 	var internalCache CacheInterface[T]
 	switch getCacheType(cacheConfig) {
@@ -288,7 +288,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 	case cacheTypeRedis:
 		redisClient := cm.getRedisClient()
 		if redisClient == nil {
-			logger.WarnWithContext(ctx, "Redis client not available, disabling cache")
+			logger.Warn(ctx, "Redis client not available, disabling cache")
 			return &Cache[T]{
 				enabled:   false,
 				cacheName: cacheName,
@@ -306,7 +306,7 @@ func newCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 			)
 		}
 	default:
-		logger.WarnWithContext(ctx, "Unknown cache type, defaulting to in-memory cache")
+		logger.Warn(ctx, "Unknown cache type, defaulting to in-memory cache")
 		internalCache = newInMemoryCache[T](
 			cacheName,
 			!cacheProperty.Disabled,
@@ -352,7 +352,7 @@ func GetInMemoryCache[T any](cm CacheManagerInterface, cacheName string) CacheIn
 	}
 
 	// Cache construction is infrastructure-scoped, not tied to a request.
-	logger.DebugWithContext(context.Background(), "Creating new in-memory cache",
+	logger.Debug(context.Background(), "Creating new in-memory cache",
 		log.String("cacheName", cacheName), log.String("type", typeName))
 
 	cacheConfig := cm.getCacheConfig()
@@ -392,7 +392,7 @@ func GetCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 		if retCache, ok := cache.(CacheInterface[T]); ok {
 			return retCache
 		}
-		logger.WarnWithContext(ctx, "Type mismatch for cache", log.String("cacheName", cacheName),
+		logger.Warn(ctx, "Type mismatch for cache", log.String("cacheName", cacheName),
 			log.String("expectedType", typeName), log.String("actualType", reflect.TypeOf(cache).String()))
 
 		return nil
@@ -407,14 +407,14 @@ func GetCache[T any](cm CacheManagerInterface, cacheName string) CacheInterface[
 		if retCache, ok := cache.(CacheInterface[T]); ok {
 			return retCache
 		}
-		logger.WarnWithContext(ctx, "Type mismatch for cache", log.String("cacheName", cacheName),
+		logger.Warn(ctx, "Type mismatch for cache", log.String("cacheName", cacheName),
 			log.String("expectedType", typeName), log.String("actualType", reflect.TypeOf(cache).String()))
 
 		return nil
 	}
 
 	// Create a new cache
-	logger.DebugWithContext(ctx, "Creating new cache", log.String("cacheName", cacheName), log.String("type", typeName))
+	logger.Debug(ctx, "Creating new cache", log.String("cacheName", cacheName), log.String("type", typeName))
 	newCacheInst := newCache[T](cm, cacheName)
 	cm.addCache(cacheKey, newCacheInst)
 
@@ -433,7 +433,7 @@ func getCacheType(cacheConfig config.CacheConfig) cacheType {
 		return cacheTypeRedis
 	default:
 		// Cache infrastructure logging has no request scope, so context.Background() is used.
-		log.GetLogger().WarnWithContext(context.Background(), "Unknown cache type, defaulting to in-memory cache")
+		log.GetLogger().Warn(context.Background(), "Unknown cache type, defaulting to in-memory cache")
 		return cacheTypeInMemory
 	}
 }

--- a/backend/internal/system/cache/redis_cache.go
+++ b/backend/internal/system/cache/redis_cache.go
@@ -51,7 +51,7 @@ func newRedisCache[T any](name string, enabled bool, client *redis.Client, keyPr
 		log.String("name", name))
 
 	if !enabled {
-		logger.WarnWithContext(ctx, "Redis cache is disabled, returning empty cache")
+		logger.Warn(ctx, "Redis cache is disabled, returning empty cache")
 		return &redisCache[T]{
 			name:    name,
 			enabled: false,
@@ -60,7 +60,7 @@ func newRedisCache[T any](name string, enabled bool, client *redis.Client, keyPr
 
 	ttl := getCacheTTL(cacheConfig, cacheProperty)
 
-	logger.DebugWithContext(ctx, "Initializing Redis cache", log.Any("ttl", ttl),
+	logger.Debug(ctx, "Initializing Redis cache", log.Any("ttl", ttl),
 		log.String("keyPrefix", keyPrefix))
 
 	return &redisCache[T]{
@@ -88,18 +88,18 @@ func (c *redisCache[T]) Set(ctx context.Context, key CacheKey, value T) error {
 
 	data, err := json.Marshal(value)
 	if err != nil {
-		logger.WarnWithContext(ctx, "Failed to marshal value for Redis cache", log.Error(err))
+		logger.Warn(ctx, "Failed to marshal value for Redis cache", log.Error(err))
 		return err
 	}
 
 	fullKey := c.buildKey(key)
 
 	if err := c.client.Set(ctx, fullKey, data, c.ttl).Err(); err != nil {
-		logger.WarnWithContext(ctx, "Failed to set value in Redis cache", log.Error(err))
+		logger.Warn(ctx, "Failed to set value in Redis cache", log.Error(err))
 		return err
 	}
 
-	logger.DebugWithContext(ctx, "Cache entry set in Redis", log.String("key", key.ToString()))
+	logger.Debug(ctx, "Cache entry set in Redis", log.String("key", key.ToString()))
 	return nil
 }
 
@@ -121,20 +121,20 @@ func (c *redisCache[T]) Get(ctx context.Context, key CacheKey) (T, bool) {
 			atomic.AddInt64(&c.missCount, 1)
 			return zero, false
 		}
-		logger.WarnWithContext(ctx, "Failed to get value from Redis cache", log.Error(err))
+		logger.Warn(ctx, "Failed to get value from Redis cache", log.Error(err))
 		atomic.AddInt64(&c.missCount, 1)
 		return zero, false
 	}
 
 	var value T
 	if err := json.Unmarshal(data, &value); err != nil {
-		logger.WarnWithContext(ctx, "Failed to unmarshal value from Redis cache", log.Error(err))
+		logger.Warn(ctx, "Failed to unmarshal value from Redis cache", log.Error(err))
 		atomic.AddInt64(&c.missCount, 1)
 		return zero, false
 	}
 
 	atomic.AddInt64(&c.hitCount, 1)
-	logger.DebugWithContext(ctx, "Cache hit from Redis", log.String("key", key.ToString()))
+	logger.Debug(ctx, "Cache hit from Redis", log.String("key", key.ToString()))
 	return value, true
 }
 
@@ -147,7 +147,7 @@ func (c *redisCache[T]) Delete(ctx context.Context, key CacheKey) error {
 	fullKey := c.buildKey(key)
 
 	if err := c.client.Del(ctx, fullKey).Err(); err != nil {
-		log.GetLogger().WarnWithContext(ctx, "Failed to delete value from Redis cache",
+		log.GetLogger().Warn(ctx, "Failed to delete value from Redis cache",
 			log.Error(err))
 		return err
 	}

--- a/backend/internal/system/config/runtimeconfig.go
+++ b/backend/internal/system/config/runtimeconfig.go
@@ -65,7 +65,7 @@ func InitializeServerRuntime(serverHome string, config *Config) error {
 		parsedPath, err := url.Parse(loginPath)
 		if err != nil || parsedPath == nil {
 			// Runtime initialization runs during application startup, outside any request.
-			log.GetLogger().WarnWithContext(context.Background(),
+			log.GetLogger().Warn(context.Background(),
 				"Invalid gate client login path configured. Falling back to default '/signin'",
 				log.String("configuredPath", loginPath),
 				log.Error(err),
@@ -75,7 +75,8 @@ func InitializeServerRuntime(serverHome string, config *Config) error {
 
 		parsedCallbackPath, err := url.Parse(callbackPath)
 		if err != nil || parsedCallbackPath == nil {
-			log.GetLogger().Warn(
+			// Runtime initialization runs during application startup, outside any request.
+			log.GetLogger().Warn(context.Background(),
 				"Invalid gate client callback path configured. Falling back to default '/callback'",
 				log.String("configuredPath", callbackPath),
 				log.Error(err),

--- a/backend/internal/system/cors/instance.go
+++ b/backend/internal/system/cors/instance.go
@@ -65,7 +65,7 @@ func InitializeMatcher(entries OriginEntries) error {
 		if !isRegexAnchored(rx.Pattern) {
 			logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CORS"))
 			// CORS matcher is initialized at startup, outside any request.
-			logger.WarnWithContext(context.Background(),
+			logger.Warn(context.Background(),
 				"cors.allowed_origins regex is not fully anchored; partial matches are likely",
 				log.Int("index", i),
 				log.String("pattern", rx.Pattern))

--- a/backend/internal/system/database/provider/dbclient.go
+++ b/backend/internal/system/database/provider/dbclient.go
@@ -79,7 +79,7 @@ func (client *DBClient) QueryContext(
 	args ...interface{},
 ) ([]map[string]interface{}, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DBClient"))
-	logger.DebugWithContext(ctx, "Executing query", log.String("queryID", query.GetID()))
+	logger.Debug(ctx, "Executing query", log.String("queryID", query.GetID()))
 
 	sqlQuery := query.GetQuery(client.dbType)
 
@@ -102,7 +102,7 @@ func (client *DBClient) QueryContext(
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
-			logger.ErrorWithContext(ctx, "Error closing rows", log.Error(closeErr))
+			logger.Error(ctx, "Error closing rows", log.Error(closeErr))
 		}
 	}()
 
@@ -147,7 +147,7 @@ func (client *DBClient) Execute(query model.DBQuery, args ...interface{}) (int64
 // If a transaction exists in the context, it will be used automatically.
 func (client *DBClient) ExecuteContext(ctx context.Context, query model.DBQuery, args ...interface{}) (int64, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DBClient"))
-	logger.DebugWithContext(ctx, "Executing query", log.String("queryID", query.GetID()))
+	logger.Debug(ctx, "Executing query", log.String("queryID", query.GetID()))
 
 	sqlQuery := query.GetQuery(client.dbType)
 

--- a/backend/internal/system/database/provider/dbprovider.go
+++ b/backend/internal/system/database/provider/dbprovider.go
@@ -166,21 +166,21 @@ func (d *dbProvider) initializeAllClients() {
 	configDBConfig := config.GetServerRuntime().Config.Database.Config
 	err := d.initializeClient(&d.configClient, configDBConfig, dbNameConfig)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to initialize config database client", log.Error(err))
+		logger.Error(ctx, "Failed to initialize config database client", log.Error(err))
 	}
 
 	runtimeDBConfig := config.GetServerRuntime().Config.Database.Runtime
 	if runtimeDBConfig.Type != DataSourceTypeRedis {
 		err = d.initializeClient(&d.runtimeClient, runtimeDBConfig, dbNameRuntime)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to initialize runtime database client", log.Error(err))
+			logger.Error(ctx, "Failed to initialize runtime database client", log.Error(err))
 		}
 	}
 
 	userDBConfig := config.GetServerRuntime().Config.Database.User
 	err = d.initializeClient(&d.userClient, userDBConfig, dbNameUser)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to initialize user database client", log.Error(err))
+		logger.Error(ctx, "Failed to initialize user database client", log.Error(err))
 	}
 }
 
@@ -314,7 +314,7 @@ func (d *dbProvider) getDBConfig(dataSource config.DataSource) dbConfig {
 func (d *dbProvider) Close() error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "DBProvider"))
 	// DB shutdown runs outside any request.
-	logger.DebugWithContext(context.Background(), "Closing database connections")
+	logger.Debug(context.Background(), "Closing database connections")
 
 	configErr := d.closeClient(&d.configClient, &d.configMutex, "config")
 	runtimeErr := d.closeClient(&d.runtimeClient, &d.runtimeMutex, "runtime")

--- a/backend/internal/system/database/provider/redisprovider.go
+++ b/backend/internal/system/database/provider/redisprovider.go
@@ -83,15 +83,15 @@ func initRedisProvider() {
 
 		if err := client.Ping(context.Background()).Err(); err != nil {
 			if closeErr := client.Close(); closeErr != nil {
-				logger.FatalWithContext(context.Background(),
+				logger.Fatal(context.Background(),
 					"Failed to connect to Redis runtime store; also failed to close client",
 					log.Error(err), log.String("closeError", closeErr.Error()))
 			}
-			logger.FatalWithContext(context.Background(), "Failed to connect to Redis runtime store", log.Error(err))
+			logger.Fatal(context.Background(), "Failed to connect to Redis runtime store", log.Error(err))
 		}
 
 		// Redis client is initialized at startup, outside any request.
-		logger.InfoWithContext(context.Background(), "Connected to Redis runtime store",
+		logger.Info(context.Background(), "Connected to Redis runtime store",
 			log.String("address", r.Address))
 		redisInstance = &redisProvider{
 			client:    client,

--- a/backend/internal/system/declarative_resource/exporter.go
+++ b/backend/internal/system/declarative_resource/exporter.go
@@ -86,7 +86,7 @@ func CreateTypeError(resourceType, resourceID string) *ExportError {
 func ValidateResourceName(
 	ctx context.Context, name, resourceType, resourceID, errorCode string, logger *log.Logger) *ExportError {
 	if name == "" {
-		logger.WarnWithContext(ctx, resourceType+" missing name, skipping export",
+		logger.Warn(ctx, resourceType+" missing name, skipping export",
 			log.String("resourceID", resourceID))
 		return &ExportError{
 			ResourceType: resourceType,

--- a/backend/internal/system/declarative_resource/manager.go
+++ b/backend/internal/system/declarative_resource/manager.go
@@ -47,7 +47,7 @@ func GetConfigsFromFile(filePath, resourceType string) ([][]byte, error) {
 	defer func() {
 		if cerr := file.Close(); cerr != nil {
 			// Declarative resource files are loaded at startup, outside any request.
-			log.GetLogger().WarnWithContext(context.Background(), "Failed to close resources file", log.Error(cerr))
+			log.GetLogger().Warn(context.Background(), "Failed to close resources file", log.Error(cerr))
 		}
 	}()
 	fileContent, err := io.ReadAll(file)
@@ -167,7 +167,7 @@ func GetConfigs(configDirectoryPath string) ([][]byte, error) {
 		if os.IsNotExist(err) {
 			return [][]byte{}, nil
 		}
-		logger.ErrorWithContext(ctx, "Failed to read configuration directory",
+		logger.Error(ctx, "Failed to read configuration directory",
 			log.String("path", absoluteDirectoryPath), log.Error(err))
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func GetConfigs(configDirectoryPath string) ([][]byte, error) {
 				// #nosec G304 -- File path is controlled and within a trusted directory
 				fileContent, err := os.ReadFile(filePath)
 				if err != nil {
-					logger.WarnWithContext(ctx, "Failed to read configuration file",
+					logger.Warn(ctx, "Failed to read configuration file",
 						log.String("filePath", fileName), log.Error(err))
 					configChan <- configResult{content: nil, err: err}
 					return
@@ -211,7 +211,7 @@ func GetConfigs(configDirectoryPath string) ([][]byte, error) {
 				// Substitute environment variables
 				processedContent, err := utils.SubstituteEnvironmentVariables(fileContent)
 				if err != nil {
-					logger.WarnWithContext(ctx, "Failed to substitute environment variables in configuration file",
+					logger.Warn(ctx, "Failed to substitute environment variables in configuration file",
 						log.String("filePath", fileName), log.Error(err))
 					configChan <- configResult{content: nil, err: err}
 					return

--- a/backend/internal/system/declarative_resource/store.go
+++ b/backend/internal/system/declarative_resource/store.go
@@ -121,7 +121,7 @@ func (s *GenericFileBasedStore) ClearByType() error {
 // LogTypeAssertionError logs a type assertion error.
 func LogTypeAssertionError(resourceType, id string) {
 	// Declarative resource ID extraction runs during startup loading, outside any request.
-	log.GetLogger().ErrorWithContext(context.Background(), "Type assertion failed while retrieving resource",
+	log.GetLogger().Error(context.Background(), "Type assertion failed while retrieving resource",
 		log.String("resourceType", resourceType),
 		log.String("id", id))
 }

--- a/backend/internal/system/email/smtp_client.go
+++ b/backend/internal/system/email/smtp_client.go
@@ -102,7 +102,7 @@ func (c *smtpClient) Send(ctx context.Context, emailData EmailData) error {
 		return err
 	}
 
-	logger.DebugWithContext(ctx, "Sending email via SMTP",
+	logger.Debug(ctx, "Sending email via SMTP",
 		log.MaskedString("from", c.config.from),
 		log.Int("recipientCount", len(emailData.To)))
 
@@ -116,7 +116,7 @@ func (c *smtpClient) Send(ctx context.Context, emailData EmailData) error {
 		return err
 	}
 
-	logger.DebugWithContext(ctx, "Email sent successfully")
+	logger.Debug(ctx, "Email sent successfully")
 	return nil
 }
 
@@ -257,7 +257,7 @@ func (c *smtpClient) sendViaSMTP(ctx context.Context, serverAddress string, reci
 
 	if err := client.Quit(); err != nil {
 		log.GetLogger().With(log.String(log.LoggerKeyComponentName, smtpLoggerComponentName)).
-			ErrorWithContext(ctx, "Failed to gracefully close SMTP client", log.Error(err))
+			Error(ctx, "Failed to gracefully close SMTP client", log.Error(err))
 	}
 
 	return nil

--- a/backend/internal/system/export/handler.go
+++ b/backend/internal/system/export/handler.go
@@ -63,7 +63,7 @@ func (eh *exportHandler) HandleExportRequest(w http.ResponseWriter, r *http.Requ
 	exportResponse, svcErr := eh.service.ExportResources(r.Context(), exportRequest)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
-			logger.ErrorWithContext(r.Context(), "Error exporting resources", log.Any("serviceError", svcErr))
+			logger.Error(r.Context(), "Error exporting resources", log.Any("serviceError", svcErr))
 		}
 		eh.handleError(r.Context(), w, svcErr)
 		return
@@ -116,7 +116,7 @@ func (eh *exportHandler) HandleExportZipRequest(w http.ResponseWriter, r *http.R
 	exportResponse, svcErr := eh.service.ExportResources(ctx, exportRequest)
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ServerErrorType {
-			logger.ErrorWithContext(ctx, "Error exporting resources", log.Any("serviceError", svcErr))
+			logger.Error(ctx, "Error exporting resources", log.Any("serviceError", svcErr))
 		}
 		eh.handleError(ctx, w, svcErr)
 		return
@@ -124,7 +124,7 @@ func (eh *exportHandler) HandleExportZipRequest(w http.ResponseWriter, r *http.R
 
 	// Generate ZIP file and send response
 	if err := eh.generateAndSendZipResponse(ctx, w, logger, exportResponse); err != nil {
-		logger.ErrorWithContext(ctx, "Error generating ZIP response", log.Error(err))
+		logger.Error(ctx, "Error generating ZIP response", log.Error(err))
 		errResp := apierror.ErrorResponse{
 			Code:        serviceerror.InternalServerError.Code,
 			Message:     serviceerror.InternalServerError.Error,
@@ -152,12 +152,12 @@ func (eh *exportHandler) generateAndSendZipResponse(ctx context.Context,
 
 		fileWriter, err := zipWriter.Create(zipPath)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Error creating file in ZIP", log.String("zipPath", zipPath), log.Error(err))
+			logger.Error(ctx, "Error creating file in ZIP", log.String("zipPath", zipPath), log.Error(err))
 			return fmt.Errorf("failed to create file in ZIP: %w", err)
 		}
 
 		if _, err := fileWriter.Write([]byte(file.Content)); err != nil {
-			logger.ErrorWithContext(ctx, "Error writing file content to ZIP",
+			logger.Error(ctx, "Error writing file content to ZIP",
 				log.String("zipPath", zipPath), log.Error(err))
 			return fmt.Errorf("failed to write content to ZIP: %w", err)
 		}
@@ -166,14 +166,14 @@ func (eh *exportHandler) generateAndSendZipResponse(ctx context.Context,
 	if exportResponse.EnvFile != nil {
 		envWriter, err := zipWriter.Create(exportResponse.EnvFile.FileName)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Error creating env file in ZIP",
+			logger.Error(ctx, "Error creating env file in ZIP",
 				log.String("fileName", exportResponse.EnvFile.FileName),
 				log.Error(err))
 			return fmt.Errorf("failed to create env file in ZIP: %w", err)
 		}
 
 		if _, err = envWriter.Write([]byte(exportResponse.EnvFile.Content)); err != nil {
-			logger.ErrorWithContext(ctx, "Error writing env file content to ZIP",
+			logger.Error(ctx, "Error writing env file content to ZIP",
 				log.String("fileName", exportResponse.EnvFile.FileName),
 				log.Error(err))
 			return fmt.Errorf("failed to write env file content to ZIP: %w", err)
@@ -182,7 +182,7 @@ func (eh *exportHandler) generateAndSendZipResponse(ctx context.Context,
 
 	// Close the ZIP writer
 	if err := zipWriter.Close(); err != nil {
-		logger.ErrorWithContext(ctx, "Error closing ZIP writer", log.Error(err))
+		logger.Error(ctx, "Error closing ZIP writer", log.Error(err))
 		return fmt.Errorf("failed to close ZIP writer: %w", err)
 	}
 
@@ -194,7 +194,7 @@ func (eh *exportHandler) generateAndSendZipResponse(ctx context.Context,
 
 	// Write the ZIP content
 	if _, err := w.Write(zipBuffer.Bytes()); err != nil {
-		logger.ErrorWithContext(ctx, "Error writing ZIP response", log.Error(err))
+		logger.Error(ctx, "Error writing ZIP response", log.Error(err))
 		return fmt.Errorf("failed to write ZIP response: %w", err)
 	}
 

--- a/backend/internal/system/export/parameterizer.go
+++ b/backend/internal/system/export/parameterizer.go
@@ -1047,7 +1047,7 @@ func (p *parameterizer) convertStructPathsToYAMLPaths(
 		yamlPath := p.convertPathToYAMLPath(objType, path)
 		converted.Variables[i] = yamlPath
 		// Debug log to help troubleshoot path resolution
-		logger.DebugWithContext(ctx, "Converted variable path",
+		logger.Debug(ctx, "Converted variable path",
 			log.String("original", path),
 			log.String("yaml", yamlPath))
 	}
@@ -1056,7 +1056,7 @@ func (p *parameterizer) convertStructPathsToYAMLPaths(
 		yamlPath := p.convertPathToYAMLPath(objType, path)
 		converted.ArrayVariables[i] = yamlPath
 		// Debug log to help troubleshoot path resolution
-		logger.DebugWithContext(ctx, "Converted array variable path",
+		logger.Debug(ctx, "Converted array variable path",
 			log.String("original", path),
 			log.String("yaml", yamlPath))
 	}

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -152,7 +152,7 @@ func (es *exportService) ExportResources(
 
 		exporter, exists := es.registry.Get(resourceType)
 		if !exists {
-			log.GetLogger().WarnWithContext(ctx, "No exporter registered for resource type",
+			log.GetLogger().Warn(ctx, "No exporter registered for resource type",
 				log.String("resourceType", resourceType))
 			continue
 		}
@@ -263,7 +263,7 @@ func (es *exportService) exportResourcesWithExporter(
 		// Export all resources
 		ids, err := exporter.GetAllResourceIDs(ctx)
 		if err != nil {
-			logger.WarnWithContext(ctx, "Failed to get all resources",
+			logger.Warn(ctx, "Failed to get all resources",
 				log.String("resourceType", resourceType), log.Any("error", err))
 			return []ExportFile{}, variableValues, []declarativeresource.ExportError{}
 		}
@@ -276,7 +276,7 @@ func (es *exportService) exportResourcesWithExporter(
 		// Get the resource
 		resource, _, svcErr := exporter.GetResourceByID(ctx, resourceID)
 		if svcErr != nil {
-			logger.WarnWithContext(ctx, "Failed to get resource for export",
+			logger.Warn(ctx, "Failed to get resource for export",
 				log.String("resourceType", resourceType),
 				log.String("resourceID", resourceID),
 				log.String("error", svcErr.Error.DefaultValue))
@@ -302,14 +302,14 @@ func (es *exportService) exportResourcesWithExporter(
 
 		if options.Format == formatJSON {
 			// Convert to JSON format (could be implemented later)
-			logger.WarnWithContext(ctx, "JSON format not yet implemented, falling back to YAML")
+			logger.Warn(ctx, "JSON format not yet implemented, falling back to YAML")
 			options.Format = formatYAML
 		}
 
 		templateContent, vars, err := es.generateTemplateFromStruct(ctx,
 			resource, exporter.GetParameterizerType(), validatedName, exporter)
 		if err != nil {
-			logger.WarnWithContext(ctx, "Failed to generate template from struct",
+			logger.Warn(ctx, "Failed to generate template from struct",
 				log.String("resourceType", resourceType),
 				log.String("resourceID", resourceID),
 				log.String("error", err.Error()))

--- a/backend/internal/system/healthcheck/handler/healthcheckhandler.go
+++ b/backend/internal/system/healthcheck/handler/healthcheckhandler.go
@@ -44,7 +44,7 @@ func NewHealthCheckHandler(svc service.HealthCheckServiceInterface) *HealthCheck
 func (hch *HealthCheckHandler) HandleLivenessRequest(w http.ResponseWriter, r *http.Request) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckHandler"))
 	w.WriteHeader(http.StatusOK)
-	logger.DebugWithContext(r.Context(), "Health Check Liveness response sent")
+	logger.Debug(r.Context(), "Health Check Liveness response sent")
 }
 
 // HandleReadinessRequest handles the health check readiness request.
@@ -56,15 +56,15 @@ func (hch *HealthCheckHandler) HandleReadinessRequest(w http.ResponseWriter, r *
 
 	statusCode := http.StatusOK
 	if serverstatus.Status != model.StatusUp {
-		logger.ErrorWithContext(ctx, "Readiness check failed",
+		logger.Error(ctx, "Readiness check failed",
 			log.String("serverstatus", string(serverstatus.Status)))
 		statusCode = http.StatusServiceUnavailable
 	} else {
-		logger.DebugWithContext(ctx, "Readiness check passed",
+		logger.Debug(ctx, "Readiness check passed",
 			log.String("serverstatus", string(serverstatus.Status)))
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, statusCode, serverstatus)
 
-	logger.DebugWithContext(ctx, "Health Check Readiness response sent")
+	logger.Debug(ctx, "Health Check Readiness response sent")
 }

--- a/backend/internal/system/healthcheck/service/healthcheckservice.go
+++ b/backend/internal/system/healthcheck/service/healthcheckservice.go
@@ -101,11 +101,11 @@ func (hcs *HealthCheckService) checkRuntimeDatabaseStatus(ctx context.Context, q
 func (hcs *HealthCheckService) checkRedisRuntimeStatus(ctx context.Context) model.Status {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckService"))
 	if hcs.RedisProvider == nil {
-		logger.ErrorWithContext(ctx, "Redis runtime provider is not initialized")
+		logger.Error(ctx, "Redis runtime provider is not initialized")
 		return model.StatusDown
 	}
 	if err := hcs.RedisProvider.GetRedisClient().Ping(context.Background()).Err(); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to ping Redis runtime store", log.Error(err))
+		logger.Error(ctx, "Failed to ping Redis runtime store", log.Error(err))
 		return model.StatusDown
 	}
 	return model.StatusUp
@@ -124,13 +124,13 @@ func (hcs *HealthCheckService) executeDatabaseHealthCheck(ctx context.Context,
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckService"))
 
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get database client", log.String("dbname", dbName), log.Error(err))
+		logger.Error(ctx, "Failed to get database client", log.String("dbname", dbName), log.Error(err))
 		return model.StatusDown
 	}
 
 	_, err = dbClient.Query(query)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to execute query", log.String("dbname", dbName), log.Error(err))
+		logger.Error(ctx, "Failed to execute query", log.String("dbname", dbName), log.Error(err))
 		return model.StatusDown
 	}
 	return model.StatusUp

--- a/backend/internal/system/i18n/mgt/handler.go
+++ b/backend/internal/system/i18n/mgt/handler.go
@@ -58,7 +58,7 @@ func (h *i18nHandler) HandleListLanguages(w http.ResponseWriter, r *http.Request
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
-	logger.DebugWithContext(ctx, "Successfully retrieved languages", log.Int("count", len(localeCodes)))
+	logger.Debug(ctx, "Successfully retrieved languages", log.Int("count", len(localeCodes)))
 }
 
 // HandleResolveTranslationsByLanguage handles GET /i18n/languages/{language}/translations/resolve
@@ -79,7 +79,7 @@ func (h *i18nHandler) HandleResolveTranslationsByLanguage(w http.ResponseWriter,
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
-	logger.DebugWithContext(ctx, "Successfully resolved translations",
+	logger.Debug(ctx, "Successfully resolved translations",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
 		log.Int("totalResults", resp.TotalResults))
@@ -106,7 +106,7 @@ func (h *i18nHandler) HandleSetOverrideTranslationsByLanguage(w http.ResponseWri
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
-	logger.DebugWithContext(ctx, "Successfully set override translations",
+	logger.Debug(ctx, "Successfully set override translations",
 		log.String("language", sanitizedLanguage),
 		log.Int("totalResults", resp.TotalResults))
 }
@@ -126,7 +126,7 @@ func (h *i18nHandler) HandleClearOverrideTranslationsByLanguage(w http.ResponseW
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	logger.DebugWithContext(ctx, "Successfully cleared override translations",
+	logger.Debug(ctx, "Successfully cleared override translations",
 		log.String("language", sanitizedLanguage))
 }
 
@@ -150,7 +150,7 @@ func (h *i18nHandler) HandleResolveTranslation(w http.ResponseWriter, r *http.Re
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
-	logger.DebugWithContext(ctx, "Successfully resolved translation",
+	logger.Debug(ctx, "Successfully resolved translation",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
 		log.String("key", sanitizedKey))
@@ -185,7 +185,7 @@ func (h *i18nHandler) HandleSetOverrideTranslation(w http.ResponseWriter, r *htt
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, resp)
-	logger.DebugWithContext(ctx, "Successfully set override translation",
+	logger.Debug(ctx, "Successfully set override translation",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
 		log.String("key", sanitizedKey))
@@ -212,7 +212,7 @@ func (h *i18nHandler) HandleClearOverrideTranslation(w http.ResponseWriter, r *h
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	logger.DebugWithContext(ctx, "Successfully cleared override translation",
+	logger.Debug(ctx, "Successfully cleared override translation",
 		log.String("language", sanitizedLanguage),
 		log.String("namespace", sanitizedNamespace),
 		log.String("key", sanitizedKey))

--- a/backend/internal/system/i18n/mgt/service.go
+++ b/backend/internal/system/i18n/mgt/service.go
@@ -77,7 +77,7 @@ func newI18nService(store i18nStoreInterface) I18nServiceInterface {
 func (s *i18nService) ListLanguages(ctx context.Context) ([]string, *serviceerror.ServiceError) {
 	localeCodes, err := s.store.GetDistinctLanguages()
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to get locales from store", log.Error(err))
+		s.logger.Error(ctx, "Failed to get locales from store", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -107,7 +107,7 @@ func (s *i18nService) ResolveTranslationsForKey(ctx context.Context,
 
 	trans, err := s.store.GetTranslationsByKey(key, namespace)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to get translation from store", log.Error(err))
+		s.logger.Error(ctx, "Failed to get translation from store", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -165,7 +165,7 @@ func (s *i18nService) SetTranslationOverrideForKey(ctx context.Context,
 
 	// Use upsert to create or update
 	if err := s.store.UpsertTranslation(trans); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to set translation override", log.Error(err))
+		s.logger.Error(ctx, "Failed to set translation override", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -215,7 +215,7 @@ func (s *i18nService) SetTranslationOverridesForNamespace(
 		return nil
 	}
 	if err := s.store.UpsertTranslations(ctx, translations); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to set translation overrides for namespace", log.Error(err))
+		s.logger.Error(ctx, "Failed to set translation overrides for namespace", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil
@@ -232,7 +232,7 @@ func (s *i18nService) ClearTranslationOverrideForKey(ctx context.Context,
 	}
 
 	if err := s.store.DeleteTranslation(language, key, namespace); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to clear translation override", log.Error(err))
+		s.logger.Error(ctx, "Failed to clear translation override", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -264,13 +264,13 @@ func (s *i18nService) ResolveTranslations(ctx context.Context,
 		// Get all namespaces
 		allTranslations, err = s.store.GetTranslations()
 		if err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to get translations from store", log.Error(err))
+			s.logger.Error(ctx, "Failed to get translations from store", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	} else {
 		allTranslations, err = s.store.GetTranslationsByNamespace(namespace)
 		if err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to get translations from store", log.Error(err))
+			s.logger.Error(ctx, "Failed to get translations from store", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -360,7 +360,7 @@ func (s *i18nService) SetTranslationOverrides(ctx context.Context,
 	}
 
 	if err := s.store.UpsertTranslationsByLanguage(language, flattenedTranslations); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to upsert translations", log.Error(err))
+		s.logger.Error(ctx, "Failed to upsert translations", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
@@ -385,7 +385,7 @@ func (s *i18nService) ClearTranslationOverrides(ctx context.Context, language st
 	}
 
 	if err := s.clearAllOverrides(language); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to clear overrides", log.Error(err))
+		s.logger.Error(ctx, "Failed to clear overrides", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 
@@ -402,7 +402,7 @@ func (s *i18nService) DeleteTranslationsByKey(
 		return &ErrorInvalidKey
 	}
 	if err := s.store.DeleteTranslationsByKey(ctx, namespace, key); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to delete translations by namespace and key", log.Error(err))
+		s.logger.Error(ctx, "Failed to delete translations by namespace and key", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil
@@ -416,7 +416,7 @@ func (s *i18nService) DeleteTranslationsByNamespace(
 		return &ErrorInvalidNamespace
 	}
 	if err := s.store.DeleteTranslationsByNamespace(ctx, namespace); err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to delete translations by namespace", log.Error(err))
+		s.logger.Error(ctx, "Failed to delete translations by namespace", log.Error(err))
 		return &serviceerror.InternalServerError
 	}
 	return nil
@@ -432,7 +432,7 @@ func (s *i18nService) GetTranslationsByNamespace(ctx context.Context,
 	}
 	byNs, err := s.store.GetTranslationsByNamespace(namespace)
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to get translations by namespace", log.Error(err))
+		s.logger.Error(ctx, "Failed to get translations by namespace", log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	result := make(map[string]map[string]string, len(byNs))

--- a/backend/internal/system/importer/handler.go
+++ b/backend/internal/system/importer/handler.go
@@ -89,7 +89,7 @@ func (ih *importHandler) handleError(ctx context.Context, w http.ResponseWriter,
 	}
 
 	if statusCode == http.StatusInternalServerError {
-		ih.logger.ErrorWithContext(ctx,
+		ih.logger.Error(ctx,
 			"Import request failed with server error",
 			log.String("code", svcErr.Code),
 			log.String("error", svcErr.Error.DefaultValue),

--- a/backend/internal/system/importer/service.go
+++ b/backend/internal/system/importer/service.go
@@ -284,14 +284,14 @@ func (s *importService) ImportResources(
 
 	resolvedContent, err := resolveTemplate(request.Content, request.Variables)
 	if err != nil {
-		log.GetLogger().WarnWithContext(ctx, "Import template resolution failed", log.String("error", err.Error()))
+		log.GetLogger().Warn(ctx, "Import template resolution failed", log.String("error", err.Error()))
 		return nil, serviceerror.CustomServiceError(ErrorTemplateResolutionFailed,
 			core.I18nMessage{Key: "error.import.dynamic", DefaultValue: err.Error()})
 	}
 
 	docs, err := parseDocuments(resolvedContent)
 	if err != nil {
-		log.GetLogger().WarnWithContext(ctx, "Import YAML parsing failed", log.String("error", err.Error()))
+		log.GetLogger().Warn(ctx, "Import YAML parsing failed", log.String("error", err.Error()))
 		return nil, serviceerror.CustomServiceError(ErrorInvalidYAMLContent,
 			core.I18nMessage{Key: "error.import.dynamic", DefaultValue: err.Error()})
 	}
@@ -780,10 +780,10 @@ func (s *importService) importApplication(
 			)
 		}
 
-		log.GetLogger().WarnWithContext(ctx, "Application import create failed", failureLogFields...)
+		log.GetLogger().Warn(ctx, "Application import create failed", failureLogFields...)
 
 		if svcErr.Code == invalidOAuthConfigurationCode {
-			log.GetLogger().DebugWithContext(ctx,
+			log.GetLogger().Debug(ctx,
 				"Application import failed due to invalid OAuth configuration", failureLogFields...)
 		}
 
@@ -896,7 +896,7 @@ func normalizeOAuthConfigForImport(ctx context.Context, appDTO *appmodel.Applica
 	if oauthConfig.PublicClient &&
 		oauthConfig.TokenEndpointAuthMethod == oauth2const.TokenEndpointAuthMethodNone &&
 		oauthConfig.ClientSecret != "" {
-		log.GetLogger().DebugWithContext(ctx,
+		log.GetLogger().Debug(ctx,
 			"Dropping client_secret for public client import with token endpoint auth method 'none'",
 			log.String("appID", appDTO.ID),
 			log.String("name", appDTO.Name),

--- a/backend/internal/system/importer/service_adapters.go
+++ b/backend/internal/system/importer/service_adapters.go
@@ -49,7 +49,7 @@ func (s *importService) resolveImportOUHandle(
 ) (string, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ImportService"))
 	if ouID != "" && ouHandle != "" {
-		logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided; ou_handle ignored",
+		logger.Warn(ctx, "Both ou_id and ou_handle provided; ou_handle ignored",
 			log.String("resourceType", resourceType),
 			log.String("resourceID", resourceID),
 			log.String("resourceName", resourceName))
@@ -1000,7 +1000,7 @@ func normalizeAgentOAuthConfigForImport(ctx context.Context, req *agentmodel.Age
 	if oauthConfig.PublicClient &&
 		oauthConfig.TokenEndpointAuthMethod == oauth2const.TokenEndpointAuthMethodNone &&
 		oauthConfig.ClientSecret != "" {
-		log.GetLogger().DebugWithContext(ctx,
+		log.GetLogger().Debug(ctx,
 			"Dropping client_secret for public agent import with token endpoint auth method 'none'",
 			log.String("agentID", req.ID),
 			log.String("name", req.Name),

--- a/backend/internal/system/jose/jwe/service.go
+++ b/backend/internal/system/jose/jwe/service.go
@@ -76,7 +76,7 @@ func (js *jweService) Encrypt(ctx context.Context, payload []byte, recipientPubl
 	// Establish the CEK via cryptolib key establishment.
 	encryptedKey, details, err := cryptolib.Encrypt(recipientPublicKey, &params, nil)
 	if err != nil {
-		js.logger.ErrorWithContext(ctx, "Failed to encrypt CEK: "+err.Error())
+		js.logger.Error(ctx, "Failed to encrypt CEK: "+err.Error())
 		return "", &ErrorUnsupportedJWEAlgorithm
 	}
 
@@ -99,7 +99,7 @@ func (js *jweService) Encrypt(ctx context.Context, payload []byte, recipientPubl
 	if details.EPK != nil {
 		epkMap, epkErr := epkToMap(details.EPK)
 		if epkErr != nil {
-			js.logger.ErrorWithContext(ctx, "Failed to encode EPK: "+epkErr.Error())
+			js.logger.Error(ctx, "Failed to encode EPK: "+epkErr.Error())
 			return "", &serviceerror.InternalServerError
 		}
 		header["epk"] = epkMap
@@ -113,7 +113,7 @@ func (js *jweService) Encrypt(ctx context.Context, payload []byte, recipientPubl
 
 	headerJSON, jsonErr := json.Marshal(header)
 	if jsonErr != nil {
-		js.logger.ErrorWithContext(ctx, "Failed to marshal JWE header: "+jsonErr.Error())
+		js.logger.Error(ctx, "Failed to marshal JWE header: "+jsonErr.Error())
 		return "", &serviceerror.InternalServerError
 	}
 	headerBase64 := base64.RawURLEncoding.EncodeToString(headerJSON)
@@ -121,7 +121,7 @@ func (js *jweService) Encrypt(ctx context.Context, payload []byte, recipientPubl
 	// Encrypt the content payload.
 	iv, ciphertext, tag, err := encryptContent(payload, cek, enc, []byte(headerBase64))
 	if err != nil {
-		js.logger.ErrorWithContext(ctx, "Failed to encrypt content: "+err.Error())
+		js.logger.Error(ctx, "Failed to encrypt content: "+err.Error())
 		return "", &serviceerror.InternalServerError
 	}
 
@@ -141,7 +141,7 @@ func (js *jweService) Encrypt(ctx context.Context, payload []byte, recipientPubl
 func (js *jweService) Decrypt(ctx context.Context, jweToken string) ([]byte, *serviceerror.ServiceError) {
 	header, headerBase64, encryptedKey, iv, ciphertext, tag, err := DecodeJWE(jweToken)
 	if err != nil {
-		js.logger.DebugWithContext(ctx, "Failed to decode JWE: "+err.Error())
+		js.logger.Debug(ctx, "Failed to decode JWE: "+err.Error())
 		return nil, &ErrorDecodingJWE
 	}
 
@@ -160,21 +160,21 @@ func (js *jweService) Decrypt(ctx context.Context, jweToken string) ([]byte, *se
 	// Build cryptolib params for CEK decryption using the server's key.
 	params, paramsErr := buildDecryptParams(alg, enc, header)
 	if paramsErr != nil {
-		js.logger.DebugWithContext(ctx, "Failed to build decrypt params: "+paramsErr.Error())
+		js.logger.Debug(ctx, "Failed to build decrypt params: "+paramsErr.Error())
 		return nil, &ErrorUnsupportedJWEAlgorithm
 	}
 
 	// Decrypt CEK via the runtime crypto provider (uses server's private key).
 	cek, err := js.cryptoProvider.Decrypt(ctx, &js.keyRef, params, encryptedKey)
 	if err != nil {
-		js.logger.ErrorWithContext(ctx, "Failed to decrypt CEK: "+err.Error())
+		js.logger.Error(ctx, "Failed to decrypt CEK: "+err.Error())
 		return nil, &ErrorJWEDecryptionFailed
 	}
 
 	// Decrypt content.
 	payload, err := decryptContent(ciphertext, iv, tag, cek, enc, []byte(headerBase64))
 	if err != nil {
-		js.logger.ErrorWithContext(ctx, "Failed to decrypt content: "+err.Error())
+		js.logger.Error(ctx, "Failed to decrypt content: "+err.Error())
 		return nil, &ErrorJWEDecryptionFailed
 	}
 

--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -125,21 +125,21 @@ func (js *jwtService) GenerateJWT(
 		jwsAlg = jws.Algorithm(alg)
 	}
 	if js.cryptoProvider == nil {
-		js.logger.ErrorWithContext(ctx, "Crypto provider not initialized for JWT generation")
+		js.logger.Error(ctx, "Crypto provider not initialized for JWT generation")
 		return "", 0, &serviceerror.InternalServerError
 	}
 
 	// Validate that claims["aud"] is present and of an accepted type.
 	audValue, hasAud := claims["aud"]
 	if !hasAud {
-		js.logger.ErrorWithContext(ctx, "GenerateJWT called without aud in claims")
+		js.logger.Error(ctx, "GenerateJWT called without aud in claims")
 		return "", 0, &serviceerror.InternalServerError
 	}
 	switch audValue.(type) {
 	case string, []string:
 		// valid
 	default:
-		js.logger.ErrorWithContext(ctx, "GenerateJWT called with unsupported aud type in claims")
+		js.logger.Error(ctx, "GenerateJWT called with unsupported aud type in claims")
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -157,7 +157,7 @@ func (js *jwtService) GenerateJWT(
 
 	headerJSON, err := json.Marshal(header)
 	if err != nil {
-		js.logger.ErrorWithContext(ctx, "Failed to marshal JWT header: "+err.Error())
+		js.logger.Error(ctx, "Failed to marshal JWT header: "+err.Error())
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -175,7 +175,7 @@ func (js *jwtService) GenerateJWT(
 
 	jti, err := utils.GenerateUUIDv7()
 	if err != nil {
-		js.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+		js.logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -198,7 +198,7 @@ func (js *jwtService) GenerateJWT(
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		js.logger.ErrorWithContext(ctx, "Failed to marshal JWT payload: "+err.Error())
+		js.logger.Error(ctx, "Failed to marshal JWT payload: "+err.Error())
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -210,7 +210,7 @@ func (js *jwtService) GenerateJWT(
 	signingInput := headerBase64 + "." + payloadBase64
 	signature, err := js.cryptoProvider.Sign(ctx, js.keyRef, js.signAlg, []byte(signingInput))
 	if err != nil {
-		js.logger.ErrorWithContext(ctx, "Failed to sign JWT: "+err.Error())
+		js.logger.Error(ctx, "Failed to sign JWT: "+err.Error())
 		return "", 0, &serviceerror.InternalServerError
 	}
 
@@ -225,7 +225,7 @@ func (js *jwtService) VerifyJWT(
 	ctx context.Context, jwtToken string, expectedAud, expectedIss string,
 ) *serviceerror.ServiceError {
 	if js.cryptoProvider == nil {
-		js.logger.ErrorWithContext(ctx, "Crypto provider not initialized for JWT verification")
+		js.logger.Error(ctx, "Crypto provider not initialized for JWT verification")
 		return &serviceerror.InternalServerError
 	}
 
@@ -271,7 +271,7 @@ func (js *jwtService) VerifyJWTWithJWKS(ctx context.Context,
 // VerifyJWTSignature verifies the signature of a JWT token using the server's public key.
 func (js *jwtService) VerifyJWTSignature(ctx context.Context, jwtToken string) *serviceerror.ServiceError {
 	if js.cryptoProvider == nil {
-		js.logger.ErrorWithContext(ctx, "Crypto provider not initialized for JWT verification")
+		js.logger.Error(ctx, "Crypto provider not initialized for JWT verification")
 		return &serviceerror.InternalServerError
 	}
 	parts := strings.Split(jwtToken, ".")
@@ -303,7 +303,7 @@ func (js *jwtService) VerifyJWTSignature(ctx context.Context, jwtToken string) *
 	// Retrieve all public keys from the provider and match by thumbprint
 	keys, providerErr := js.cryptoProvider.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
 	if providerErr != nil {
-		js.logger.ErrorWithContext(ctx, "Failed to retrieve public keys for JWT verification: "+providerErr.Error())
+		js.logger.Error(ctx, "Failed to retrieve public keys for JWT verification: "+providerErr.Error())
 		return &serviceerror.InternalServerError
 	}
 	var matchedKey *kmprovider.PublicKeyInfo
@@ -395,7 +395,7 @@ func (js *jwtService) VerifyJWTSignatureWithJWKS(
 	// Convert JWK to public key
 	pubKey, err := jws.JWKToPublicKey(jwk)
 	if err != nil {
-		js.logger.DebugWithContext(ctx, "Failed to convert JWK to public key: "+err.Error())
+		js.logger.Debug(ctx, "Failed to convert JWK to public key: "+err.Error())
 		return &ErrorFailedToParseJWKS
 	}
 
@@ -419,23 +419,23 @@ func (js *jwtService) getJWKSKeys(
 
 	resp, err := js.httpClient.Get(jwksURL)
 	if err != nil {
-		js.logger.DebugWithContext(ctx, "Failed to fetch JWKS from URL: "+err.Error())
+		js.logger.Debug(ctx, "Failed to fetch JWKS from URL: "+err.Error())
 		return nil, &ErrorFailedToGetJWKS
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			js.logger.ErrorWithContext(ctx, "Failed to close response body", log.Error(closeErr))
+			js.logger.Error(ctx, "Failed to close response body", log.Error(closeErr))
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		js.logger.DebugWithContext(ctx, "Failed to fetch JWKS, HTTP status: "+resp.Status)
+		js.logger.Debug(ctx, "Failed to fetch JWKS, HTTP status: "+resp.Status)
 		return nil, &ErrorFailedToGetJWKS
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		js.logger.DebugWithContext(ctx, "Failed to read JWKS response body: "+err.Error())
+		js.logger.Debug(ctx, "Failed to read JWKS response body: "+err.Error())
 		return nil, &ErrorFailedToParseJWKS
 	}
 
@@ -443,7 +443,7 @@ func (js *jwtService) getJWKSKeys(
 		Keys []map[string]interface{} `json:"keys"`
 	}
 	if err := json.Unmarshal(body, &jwks); err != nil {
-		js.logger.DebugWithContext(ctx, "Failed to parse JWKS JSON: "+err.Error())
+		js.logger.Debug(ctx, "Failed to parse JWKS JSON: "+err.Error())
 		return nil, &ErrorFailedToParseJWKS
 	}
 
@@ -462,7 +462,7 @@ func (js *jwtService) verifyJWTClaims(
 	// Decode the JWT payload
 	payload, err := DecodeJWTPayload(jwtToken)
 	if err != nil {
-		js.logger.DebugWithContext(ctx, "Failed to decode JWT payload: "+err.Error())
+		js.logger.Debug(ctx, "Failed to decode JWT payload: "+err.Error())
 		return &ErrorDecodingJWTPayload
 	}
 
@@ -474,11 +474,11 @@ func (js *jwtService) verifyJWTClaims(
 
 	if exp, ok := payload["exp"].(float64); ok {
 		if now >= int64(exp)+leeway {
-			js.logger.DebugWithContext(ctx, "JWT token has expired")
+			js.logger.Debug(ctx, "JWT token has expired")
 			return &ErrorTokenExpired
 		}
 	} else {
-		js.logger.DebugWithContext(ctx, "JWT token missing 'exp' claim or it is not a number")
+		js.logger.Debug(ctx, "JWT token missing 'exp' claim or it is not a number")
 		return &ErrorInvalidJWTFormat
 	}
 
@@ -486,11 +486,11 @@ func (js *jwtService) verifyJWTClaims(
 	if nbfRaw, ok := payload["nbf"]; ok {
 		nbf, isNumber := nbfRaw.(float64)
 		if !isNumber {
-			js.logger.DebugWithContext(ctx, "JWT token 'nbf' claim present but not a number")
+			js.logger.Debug(ctx, "JWT token 'nbf' claim present but not a number")
 			return &ErrorInvalidJWTFormat
 		}
 		if now < int64(nbf)-leeway {
-			js.logger.DebugWithContext(ctx, "JWT token is not valid yet (nbf claim)")
+			js.logger.Debug(ctx, "JWT token is not valid yet (nbf claim)")
 			return &ErrorInvalidJWTFormat
 		}
 	}
@@ -499,7 +499,7 @@ func (js *jwtService) verifyJWTClaims(
 		switch aud := payload["aud"].(type) {
 		case string:
 			if aud != expectedAud {
-				js.logger.DebugWithContext(ctx, "Invalid audience: expected "+expectedAud+", got "+aud)
+				js.logger.Debug(ctx, "Invalid audience: expected "+expectedAud+", got "+aud)
 				return &ErrorInvalidJWTFormat
 			}
 		case []interface{}:
@@ -511,11 +511,11 @@ func (js *jwtService) verifyJWTClaims(
 				}
 			}
 			if !found {
-				js.logger.DebugWithContext(ctx, "Invalid audience: expected "+expectedAud+" not found in aud array")
+				js.logger.Debug(ctx, "Invalid audience: expected "+expectedAud+" not found in aud array")
 				return &ErrorInvalidJWTFormat
 			}
 		default:
-			js.logger.DebugWithContext(ctx, "Missing or invalid 'aud' claim")
+			js.logger.Debug(ctx, "Missing or invalid 'aud' claim")
 			return &ErrorInvalidJWTFormat
 		}
 	}
@@ -523,11 +523,11 @@ func (js *jwtService) verifyJWTClaims(
 	if expectedIss != "" {
 		if iss, ok := payload["iss"].(string); ok {
 			if iss != expectedIss {
-				js.logger.DebugWithContext(ctx, "Invalid issuer: expected "+expectedIss+", got "+iss)
+				js.logger.Debug(ctx, "Invalid issuer: expected "+expectedIss+", got "+iss)
 				return &ErrorInvalidJWTFormat
 			}
 		} else {
-			js.logger.DebugWithContext(ctx, "Missing 'iss' claim or it is not a string")
+			js.logger.Debug(ctx, "Missing 'iss' claim or it is not a string")
 			return &ErrorInvalidJWTFormat
 		}
 	}

--- a/backend/internal/system/kmprovider/defaultkm/pki/service.go
+++ b/backend/internal/system/kmprovider/defaultkm/pki/service.go
@@ -116,7 +116,7 @@ func newPKIService() (PKIServiceInterface, error) {
 func (s *pkiService) GetPrivateKey(ctx context.Context, id string) (crypto.PrivateKey, *serviceerror.ServiceError) {
 	cert, exists := s.certificates[id]
 	if !exists || cert.PrivateKey == nil {
-		s.logger.ErrorWithContext(ctx, "Private key not found for certificate ID: "+id)
+		s.logger.Error(ctx, "Private key not found for certificate ID: "+id)
 		return nil, &serviceerror.InternalServerError
 	}
 	return cert.PrivateKey, nil
@@ -145,16 +145,16 @@ func (s *pkiService) GetX509Certificate(
 	ctx context.Context, id string) (*x509.Certificate, *serviceerror.ServiceError) {
 	cert, exists := s.certificates[id]
 	if !exists {
-		s.logger.ErrorWithContext(ctx, "Certificate not found for certificate ID: "+id)
+		s.logger.Error(ctx, "Certificate not found for certificate ID: "+id)
 		return nil, &serviceerror.InternalServerError
 	}
 	if len(cert.Certificate.Certificate) == 0 {
-		s.logger.ErrorWithContext(ctx, "Certificate data is empty for certificate ID: "+id)
+		s.logger.Error(ctx, "Certificate data is empty for certificate ID: "+id)
 		return nil, &serviceerror.InternalServerError
 	}
 	parsedCert, err := x509.ParseCertificate(cert.Certificate.Certificate[0])
 	if err != nil {
-		s.logger.ErrorWithContext(ctx, "Failed to parse x509 certificate for ID: "+id+" Error: "+err.Error())
+		s.logger.Error(ctx, "Failed to parse x509 certificate for ID: "+id+" Error: "+err.Error())
 		return nil, &serviceerror.InternalServerError
 	}
 	return parsedCert, nil
@@ -166,12 +166,12 @@ func (s *pkiService) GetAllX509Certificates(
 	result := make(map[string]*x509.Certificate)
 	for id, cert := range s.certificates {
 		if len(cert.Certificate.Certificate) == 0 {
-			s.logger.ErrorWithContext(ctx, "Certificate data is empty for certificate ID: "+id)
+			s.logger.Error(ctx, "Certificate data is empty for certificate ID: "+id)
 			return nil, &serviceerror.InternalServerError
 		}
 		parsedCert, err := x509.ParseCertificate(cert.Certificate.Certificate[0])
 		if err != nil {
-			s.logger.ErrorWithContext(ctx, "Failed to parse x509 certificate for ID: "+id+" Error: "+err.Error())
+			s.logger.Error(ctx, "Failed to parse x509 certificate for ID: "+id+" Error: "+err.Error())
 			return nil, &serviceerror.InternalServerError
 		}
 		result[id] = parsedCert

--- a/backend/internal/system/kmprovider/defaultkm/pki/utils.go
+++ b/backend/internal/system/kmprovider/defaultkm/pki/utils.go
@@ -56,11 +56,11 @@ func LoadTLSConfig(cfg *config.Config, certFilePath string, keyFilePath string) 
 
 	cert, err := tls.LoadX509KeyPair(certFilePath, keyFilePath)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to load X509 key pair", log.Error(err))
+		logger.Error(ctx, "Failed to load X509 key pair", log.Error(err))
 		return nil, err
 	}
 
-	logger.DebugWithContext(ctx, "Successfully loaded TLS certificate",
+	logger.Debug(ctx, "Successfully loaded TLS certificate",
 		log.String("certFile", certFilePath),
 		log.String("keyFile", keyFilePath))
 

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
@@ -160,7 +160,7 @@ func (s *runtimeCryptoService) GetPublicKeys(
 			case "P-521":
 				alg = cryptolib.AlgorithmES512
 			default:
-				s.logger.WarnWithContext(ctx, "Unsupported EC curve; skipping",
+				s.logger.Warn(ctx, "Unsupported EC curve; skipping",
 					log.String("keyID", id),
 					log.String("curve", pub.Curve.Params().Name))
 				continue
@@ -168,7 +168,7 @@ func (s *runtimeCryptoService) GetPublicKeys(
 		case ed25519.PublicKey:
 			alg = cryptolib.AlgorithmEdDSA
 		default:
-			s.logger.DebugWithContext(ctx, "Unsupported public key type; skipping", log.String("keyID", id))
+			s.logger.Debug(ctx, "Unsupported public key type; skipping", log.String("keyID", id))
 			continue
 		}
 

--- a/backend/internal/system/log/accesslog.go
+++ b/backend/internal/system/log/accesslog.go
@@ -50,7 +50,7 @@ func AccessLogHandler(logger *Logger, next http.Handler) http.Handler {
 
 		// Apache CLF-style format with correlation ID and response time
 		// Format: host - - [timestamp] method uri protocol status size elapsed_ms correlation_id
-		logger.InfoWithContext(r.Context(), fmt.Sprintf(
+		logger.Info(r.Context(), fmt.Sprintf(
 			"%s - - [%s] %s %s %s %d %d %d %s",
 			host,
 			start.Format("02/Jan/2006:15:04:05 -0700"),

--- a/backend/internal/system/log/log.go
+++ b/backend/internal/system/log/log.go
@@ -139,74 +139,33 @@ func (l *Logger) IsDebugEnabled() bool {
 	return l.internal.Handler().Enabled(context.Background(), slog.LevelDebug)
 }
 
-// Info logs an informational message with custom fields.
-//
-// Deprecated: Info does not propagate the request context, so log entries
-// miss the trace ID (correlation ID). Use InfoWithContext instead. Refs #2038.
-func (l *Logger) Info(msg string, fields ...Field) {
-	l.internal.Info(msg, convertFields(fields)...)
-}
-
-// Debug logs a debug message with custom fields.
-//
-// Deprecated: Debug does not propagate the request context, so log entries
-// miss the trace ID (correlation ID). Use DebugWithContext instead. Refs #2038.
-func (l *Logger) Debug(msg string, fields ...Field) {
-	l.internal.Debug(msg, convertFields(fields)...)
-}
-
-// Warn logs a warning message with custom fields.
-//
-// Deprecated: Warn does not propagate the request context, so log entries
-// miss the trace ID (correlation ID). Use WarnWithContext instead. Refs #2038.
-func (l *Logger) Warn(msg string, fields ...Field) {
-	l.internal.Warn(msg, convertFields(fields)...)
-}
-
-// Error logs an error message with custom fields.
-//
-// Deprecated: Error does not propagate the request context, so log entries
-// miss the trace ID (correlation ID). Use ErrorWithContext instead. Refs #2038.
-func (l *Logger) Error(msg string, fields ...Field) {
-	l.internal.Error(msg, convertFields(fields)...)
-}
-
-// InfoWithContext logs an informational message with custom fields, automatically
+// Info logs an informational message with custom fields, automatically
 // including the trace ID (correlation ID) from the context if present.
-func (l *Logger) InfoWithContext(ctx context.Context, msg string, fields ...Field) {
+func (l *Logger) Info(ctx context.Context, msg string, fields ...Field) {
 	l.internal.InfoContext(ctx, msg, convertFields(fields)...)
 }
 
-// DebugWithContext logs a debug message with custom fields, automatically
+// Debug logs a debug message with custom fields, automatically
 // including the trace ID (correlation ID) from the context if present.
-func (l *Logger) DebugWithContext(ctx context.Context, msg string, fields ...Field) {
+func (l *Logger) Debug(ctx context.Context, msg string, fields ...Field) {
 	l.internal.DebugContext(ctx, msg, convertFields(fields)...)
 }
 
-// WarnWithContext logs a warning message with custom fields, automatically
+// Warn logs a warning message with custom fields, automatically
 // including the trace ID (correlation ID) from the context if present.
-func (l *Logger) WarnWithContext(ctx context.Context, msg string, fields ...Field) {
+func (l *Logger) Warn(ctx context.Context, msg string, fields ...Field) {
 	l.internal.WarnContext(ctx, msg, convertFields(fields)...)
 }
 
-// ErrorWithContext logs an error message with custom fields, automatically
+// Error logs an error message with custom fields, automatically
 // including the trace ID (correlation ID) from the context if present.
-func (l *Logger) ErrorWithContext(ctx context.Context, msg string, fields ...Field) {
+func (l *Logger) Error(ctx context.Context, msg string, fields ...Field) {
 	l.internal.ErrorContext(ctx, msg, convertFields(fields)...)
 }
 
-// Fatal logs a fatal message with custom fields and exits the application.
-//
-// Deprecated: Fatal does not propagate the request context, so log entries
-// miss the trace ID (correlation ID). Use FatalWithContext instead. Refs #2038.
-func (l *Logger) Fatal(msg string, fields ...Field) {
-	l.internal.Error(msg, convertFields(fields)...)
-	os.Exit(1)
-}
-
-// FatalWithContext logs a fatal message with custom fields and exits the application,
+// Fatal logs a fatal message with custom fields and exits the application,
 // automatically including the trace ID (correlation ID) from the context if present.
-func (l *Logger) FatalWithContext(ctx context.Context, msg string, fields ...Field) {
+func (l *Logger) Fatal(ctx context.Context, msg string, fields ...Field) {
 	l.internal.ErrorContext(ctx, msg, convertFields(fields)...)
 	os.Exit(1)
 }

--- a/backend/internal/system/log/log_test.go
+++ b/backend/internal/system/log/log_test.go
@@ -165,10 +165,10 @@ func (suite *LogTestSuite) TestLogMethods() {
 	log := logger
 
 	ctx := context.Background()
-	log.DebugWithContext(ctx, "Debug message", Field{Key: "test", Value: "debug"})
-	log.InfoWithContext(ctx, "Info message", Field{Key: "test", Value: "info"})
-	log.WarnWithContext(ctx, "Warning message", Field{Key: "test", Value: "warn"})
-	log.ErrorWithContext(ctx, "Error message", Field{Key: "test", Value: "error"})
+	log.Debug(ctx, "Debug message", Field{Key: "test", Value: "debug"})
+	log.Info(ctx, "Info message", Field{Key: "test", Value: "info"})
+	log.Warn(ctx, "Warning message", Field{Key: "test", Value: "warn"})
+	log.Error(ctx, "Error message", Field{Key: "test", Value: "error"})
 
 	output := buf.String()
 	assert.Contains(suite.T(), output, "Debug message")
@@ -200,7 +200,7 @@ func (suite *LogTestSuite) TestLoggerWith() {
 	contextLogger := log.With(Field{Key: "context", Value: "test"})
 	assert.NotNil(suite.T(), contextLogger)
 
-	contextLogger.InfoWithContext(context.Background(), "Context log message")
+	contextLogger.Info(context.Background(), "Context log message")
 
 	output := buf.String()
 	assert.Contains(suite.T(), output, "context=test")
@@ -343,10 +343,10 @@ func (suite *LogTestSuite) TestContextLogMethodsWithTraceID() {
 
 	ctx := sysContext.WithTraceID(context.Background(), "test-trace-123")
 
-	log.DebugWithContext(ctx, "Debug message", Field{Key: "test", Value: "debug"})
-	log.InfoWithContext(ctx, "Info message", Field{Key: "test", Value: "info"})
-	log.WarnWithContext(ctx, "Warning message", Field{Key: "test", Value: "warn"})
-	log.ErrorWithContext(ctx, "Error message", Field{Key: "test", Value: "error"})
+	log.Debug(ctx, "Debug message", Field{Key: "test", Value: "debug"})
+	log.Info(ctx, "Info message", Field{Key: "test", Value: "info"})
+	log.Warn(ctx, "Warning message", Field{Key: "test", Value: "warn"})
+	log.Error(ctx, "Error message", Field{Key: "test", Value: "error"})
 
 	output := buf.String()
 	assert.Contains(suite.T(), output, "Debug message")
@@ -367,21 +367,10 @@ func (suite *LogTestSuite) TestContextLogMethodsWithoutTraceID() {
 
 	ctx := context.Background()
 
-	log.DebugWithContext(ctx, "Debug message")
-	log.InfoWithContext(ctx, "Info message")
-	log.WarnWithContext(ctx, "Warning message")
-	log.ErrorWithContext(ctx, "Error message")
-
-	output := buf.String()
-	assert.Contains(suite.T(), output, "Info message")
-	assert.NotContains(suite.T(), output, LoggerKeyTraceID+"=")
-}
-
-func (suite *LogTestSuite) TestDeprecatedMethodsEmitNoTraceID() {
-	var buf bytes.Buffer
-	log := newContextTestLogger(&buf)
-
-	log.Info("Info message") //nolint:staticcheck // Deprecated method must keep working until removal
+	log.Debug(ctx, "Debug message")
+	log.Info(ctx, "Info message")
+	log.Warn(ctx, "Warning message")
+	log.Error(ctx, "Error message")
 
 	output := buf.String()
 	assert.Contains(suite.T(), output, "Info message")
@@ -395,7 +384,7 @@ func (suite *LogTestSuite) TestContextHandlerPreservedByWith() {
 	ctx := sysContext.WithTraceID(context.Background(), "test-trace-456")
 
 	derivedLogger := log.With(Field{Key: "component", Value: "TestComponent"})
-	derivedLogger.InfoWithContext(ctx, "Derived log message")
+	derivedLogger.Info(ctx, "Derived log message")
 
 	output := buf.String()
 	assert.Contains(suite.T(), output, "Derived log message")

--- a/backend/internal/system/mcp/auth/token_verifier.go
+++ b/backend/internal/system/mcp/auth/token_verifier.go
@@ -44,14 +44,14 @@ func NewTokenVerifier(
 	return func(ctx context.Context, token string, req *http.Request) (*auth.TokenInfo, error) {
 		// Verify JWT signature and claims (iss, aud, exp, nbf)
 		if err := jwtService.VerifyJWT(ctx, token, mcpURL, issuer); err != nil {
-			logger.ErrorWithContext(ctx, "JWT verification failed", log.String("error", err.Error.DefaultValue))
+			logger.Error(ctx, "JWT verification failed", log.String("error", err.Error.DefaultValue))
 			return nil, auth.ErrInvalidToken
 		}
 
 		// Decode payload to extract claims for TokenInfo
 		payload, err := jwt.DecodeJWTPayload(token)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to decode JWT payload", log.Error(err))
+			logger.Error(ctx, "Failed to decode JWT payload", log.Error(err))
 			return nil, auth.ErrInvalidToken
 		}
 
@@ -65,11 +65,11 @@ func NewTokenVerifier(
 		var scopes []string
 		if scopeStr, ok := payload["scope"].(string); ok && scopeStr != "" {
 			scopes = strings.Fields(scopeStr)
-			logger.DebugWithContext(ctx, "Token scopes extracted",
+			logger.Debug(ctx, "Token scopes extracted",
 				log.String("scopes", strings.Join(scopes, ",")),
 				log.String("path", req.URL.Path))
 		} else {
-			logger.WarnWithContext(ctx, "Token missing 'scope' claim", log.String("path", req.URL.Path))
+			logger.Warn(ctx, "Token missing 'scope' claim", log.String("path", req.URL.Path))
 		}
 
 		// Extract user ID from 'sub' claim

--- a/backend/internal/system/mcp/tool/utils.go
+++ b/backend/internal/system/mcp/tool/utils.go
@@ -36,7 +36,7 @@ func GenerateSchema[T any](modifiers ...func(*jsonschema.Schema)) *jsonschema.Sc
 	schema, err := jsonschema.For[T](&jsonschema.ForOptions{})
 	if err != nil {
 		// Schema generation runs during MCP tool registration at startup, outside any request.
-		log.GetLogger().ErrorWithContext(context.Background(), "Failed to generate schema",
+		log.GetLogger().Error(context.Background(), "Failed to generate schema",
 			log.String("type", fmt.Sprintf("%T", *new(T))),
 			log.Error(err))
 		return nil

--- a/backend/internal/system/middleware/cors.go
+++ b/backend/internal/system/middleware/cors.go
@@ -83,7 +83,7 @@ func applyCORSHeaders(w http.ResponseWriter, r *http.Request, opts CORSOptions) 
 		return
 	}
 	if len(origins) > 1 {
-		logger().DebugWithContext(r.Context(), "CORS: multiple Origin headers; refusing to evaluate")
+		logger().Debug(r.Context(), "CORS: multiple Origin headers; refusing to evaluate")
 		w.Header().Add("Vary", "Origin")
 		return
 	}
@@ -103,14 +103,14 @@ func applyCORSHeaders(w http.ResponseWriter, r *http.Request, opts CORSOptions) 
 
 	parsed, err := cors.ParseOrigin(requestOrigin)
 	if err != nil {
-		logger().DebugWithContext(r.Context(), "CORS origin rejected by parser",
+		logger().Debug(r.Context(), "CORS origin rejected by parser",
 			log.String("origin", requestOrigin), log.Error(err))
 		return
 	}
 
 	allow, echo := matcher.Match(parsed)
 	if !allow {
-		logger().DebugWithContext(r.Context(), "CORS origin rejected by matcher",
+		logger().Debug(r.Context(), "CORS origin rejected by matcher",
 			log.String("origin", requestOrigin))
 		return
 	}

--- a/backend/internal/system/observability/adapter/file_adapter.go
+++ b/backend/internal/system/observability/adapter/file_adapter.go
@@ -147,14 +147,14 @@ func NewFileAdapterWithConfig(config *Config) (*FileAdapter, error) {
 	// Adapter construction runs during subscriber initialization, outside any request.
 	ctx := context.Background()
 	if fa.isRotationEnabled() {
-		logger.InfoWithContext(ctx, "File adapter initialized with rotation",
+		logger.Info(ctx, "File adapter initialized with rotation",
 			log.String("filePath", config.Path),
 			log.Int("maxFileSizeMB", config.MaxFileSizeMB),
 			log.Int("maxBackups", config.MaxBackups),
 			log.Int("maxAgeDays", config.MaxAgeDays),
 			log.Bool("compress", config.Compress))
 	} else {
-		logger.InfoWithContext(ctx, "File adapter initialized",
+		logger.Info(ctx, "File adapter initialized",
 			log.String("filePath", config.Path))
 	}
 
@@ -184,7 +184,7 @@ func (fa *FileAdapter) Write(data []byte) error {
 				logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 				// The file adapter is infrastructure with no request-scoped context.
 				ctx := context.Background()
-				logger.ErrorWithContext(ctx, "Failed to rotate file", log.Error(err))
+				logger.Error(ctx, "Failed to rotate file", log.Error(err))
 				// Continue writing to current file even if rotation fails
 			}
 		}
@@ -215,10 +215,10 @@ func (fa *FileAdapter) rotate() error {
 
 	// Flush and close current writer and file
 	if err := fa.writer.Flush(); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to flush before rotation", log.Error(err))
+		logger.Error(ctx, "Failed to flush before rotation", log.Error(err))
 	}
 	if err := fa.file.Close(); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to close file during rotation", log.Error(err))
+		logger.Error(ctx, "Failed to close file during rotation", log.Error(err))
 	}
 
 	// Generate rotated filename with timestamp
@@ -227,7 +227,7 @@ func (fa *FileAdapter) rotate() error {
 
 	// Rename current file
 	if err := os.Rename(fa.config.Path, rotatedPath); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to rename file during rotation", log.Error(err))
+		logger.Error(ctx, "Failed to rename file during rotation", log.Error(err))
 		// Try to reopen original file
 		file, err := os.OpenFile(fa.config.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, filePermissions)
 		if err != nil {
@@ -254,7 +254,7 @@ func (fa *FileAdapter) rotate() error {
 	fa.writer = bufio.NewWriterSize(file, defaultBufferSize)
 	fa.currentSize = 0
 
-	logger.InfoWithContext(ctx, "File rotated successfully", log.String("rotatedFile", rotatedPath))
+	logger.Info(ctx, "File rotated successfully", log.String("rotatedFile", rotatedPath))
 
 	// Clean up old files
 	go fa.cleanup()
@@ -271,13 +271,13 @@ func (fa *FileAdapter) compressFile(filePath string) {
 	// Open source file
 	src, err := os.Open(filePath) // #nosec G304 -- File path is controlled internally by rotation logic
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to open file for compression",
+		logger.Error(ctx, "Failed to open file for compression",
 			log.String("filePath", filePath), log.Error(err))
 		return
 	}
 	defer func() {
 		if closeErr := src.Close(); closeErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to close source file", log.Error(closeErr))
+			logger.Error(ctx, "Failed to close source file", log.Error(closeErr))
 		}
 	}()
 
@@ -285,13 +285,13 @@ func (fa *FileAdapter) compressFile(filePath string) {
 	compressedPath := filePath + ".gz"
 	dst, err := os.Create(compressedPath) // #nosec G304 -- File path is derived from controlled internal path
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to create compressed file",
+		logger.Error(ctx, "Failed to create compressed file",
 			log.String("compressedPath", compressedPath), log.Error(err))
 		return
 	}
 	defer func() {
 		if closeErr := dst.Close(); closeErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to close destination file", log.Error(closeErr))
+			logger.Error(ctx, "Failed to close destination file", log.Error(closeErr))
 		}
 	}()
 
@@ -299,30 +299,30 @@ func (fa *FileAdapter) compressFile(filePath string) {
 	gzWriter := gzip.NewWriter(dst)
 	defer func() {
 		if closeErr := gzWriter.Close(); closeErr != nil {
-			logger.ErrorWithContext(ctx, "Failed to close gzip writer", log.Error(closeErr))
+			logger.Error(ctx, "Failed to close gzip writer", log.Error(closeErr))
 		}
 	}()
 
 	// Copy and compress
 	if _, err := io.Copy(gzWriter, src); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to compress file", log.String("filePath", filePath), log.Error(err))
+		logger.Error(ctx, "Failed to compress file", log.String("filePath", filePath), log.Error(err))
 		return
 	}
 
 	// Close gzip writer to flush
 	if err := gzWriter.Close(); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to close gzip writer", log.Error(err))
+		logger.Error(ctx, "Failed to close gzip writer", log.Error(err))
 		return
 	}
 
 	// Remove original file
 	if err := os.Remove(filePath); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to remove original file after compression",
+		logger.Error(ctx, "Failed to remove original file after compression",
 			log.String("filePath", filePath), log.Error(err))
 		return
 	}
 
-	logger.InfoWithContext(ctx, "File compressed successfully", log.String("compressedPath", compressedPath))
+	logger.Info(ctx, "File compressed successfully", log.String("compressedPath", compressedPath))
 }
 
 // cleanup removes old log files based on maxBackups and maxAge.
@@ -337,7 +337,7 @@ func (fa *FileAdapter) cleanup() {
 	// Find all rotated log files
 	files, err := filepath.Glob(filepath.Join(dir, baseName+".*"))
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to list rotated files", log.Error(err))
+		logger.Error(ctx, "Failed to list rotated files", log.Error(err))
 		return
 	}
 
@@ -380,7 +380,7 @@ func (fa *FileAdapter) cleanup() {
 
 		if shouldRemove {
 			if err := os.Remove(file); err != nil {
-				logger.ErrorWithContext(ctx, "Failed to remove old log file",
+				logger.Error(ctx, "Failed to remove old log file",
 					log.String("filePath", file), log.Error(err))
 			} else {
 				removed++
@@ -389,7 +389,7 @@ func (fa *FileAdapter) cleanup() {
 	}
 
 	if removed > 0 {
-		logger.InfoWithContext(ctx, "Cleaned up old log files", log.Int("removedCount", removed))
+		logger.Info(ctx, "Cleaned up old log files", log.Int("removedCount", removed))
 	}
 }
 
@@ -425,7 +425,7 @@ func (fa *FileAdapter) periodicFlush() {
 		select {
 		case <-fa.flushTicker.C:
 			if err := fa.Flush(); err != nil {
-				logger.ErrorWithContext(ctx, "Failed to flush file", log.Error(err))
+				logger.Error(ctx, "Failed to flush file", log.Error(err))
 			}
 		case <-fa.stopFlush:
 			return
@@ -446,7 +446,7 @@ func (fa *FileAdapter) Close() error {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	// Adapter shutdown runs during application teardown, outside any request.
 	ctx := context.Background()
-	logger.InfoWithContext(ctx, "Closing file adapter", log.String("filePath", fa.config.Path))
+	logger.Info(ctx, "Closing file adapter", log.String("filePath", fa.config.Path))
 
 	// Stop periodic flushing
 	fa.flushTicker.Stop()
@@ -455,7 +455,7 @@ func (fa *FileAdapter) Close() error {
 
 	// Final flush
 	if err := fa.Flush(); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to perform final flush", log.Error(err))
+		logger.Error(ctx, "Failed to perform final flush", log.Error(err))
 	}
 
 	// Close file
@@ -463,7 +463,7 @@ func (fa *FileAdapter) Close() error {
 		return fmt.Errorf("failed to close file: %w", err)
 	}
 
-	logger.InfoWithContext(ctx, "File adapter closed")
+	logger.Info(ctx, "File adapter closed")
 	return nil
 }
 

--- a/backend/internal/system/observability/init.go
+++ b/backend/internal/system/observability/init.go
@@ -46,13 +46,13 @@ func Initialize() ObservabilityServiceInterface {
 	// Service construction runs during application startup, outside any request.
 	ctx := context.Background()
 
-	logger.DebugWithContext(ctx, "Initializing observability service")
+	logger.Debug(ctx, "Initializing observability service")
 
 	// Get configuration
 	cfg := config.GetServerRuntime().Config.Observability
 
 	if !cfg.Enabled {
-		logger.DebugWithContext(ctx, "Observability is disabled in configuration")
+		logger.Debug(ctx, "Observability is disabled in configuration")
 		// Return a disabled service (handles all operations as no-ops)
 		return &Service{
 			logger: logger,
@@ -65,7 +65,7 @@ func Initialize() ObservabilityServiceInterface {
 
 	// Log initialization status
 	activeSubscribers := svc.GetActiveSubscribers()
-	logger.DebugWithContext(ctx, "Observability service initialized successfully",
+	logger.Debug(ctx, "Observability service initialized successfully",
 		log.Int("activeSubscribers", len(activeSubscribers)))
 
 	return svc

--- a/backend/internal/system/observability/publisher/publisher.go
+++ b/backend/internal/system/observability/publisher/publisher.go
@@ -92,14 +92,14 @@ func (p *categoryEventPublisher) Publish(ctx context.Context, evt *event.Event) 
 
 	// Validate event
 	if err := evt.Validate(); err != nil {
-		p.logger.WarnWithContext(ctx, "Invalid event, skipping publish", log.Error(err))
+		p.logger.Warn(ctx, "Invalid event, skipping publish", log.Error(err))
 		return
 	}
 
 	p.mu.RLock()
 	if p.isShutdown {
 		p.mu.RUnlock()
-		p.logger.WarnWithContext(ctx, "Attempted to publish event after shutdown",
+		p.logger.Warn(ctx, "Attempted to publish event after shutdown",
 			log.String("eventType", evt.Type))
 		return
 	}
@@ -117,7 +117,7 @@ func (p *categoryEventPublisher) Publish(ctx context.Context, evt *event.Event) 
 		defer p.wg.Done()
 		defer func() {
 			if r := recover(); r != nil {
-				p.logger.ErrorWithContext(eventCtx, "Panic in event publisher dispatcher",
+				p.logger.Error(eventCtx, "Panic in event publisher dispatcher",
 					log.String("eventType", evt.Type),
 					log.Any("panic", r))
 			}
@@ -126,7 +126,7 @@ func (p *categoryEventPublisher) Publish(ctx context.Context, evt *event.Event) 
 		// Get event category
 		category, err := evt.GetCategory()
 		if err != nil {
-			p.logger.ErrorWithContext(eventCtx, "Failed to get event category, skipping publish",
+			p.logger.Error(eventCtx, "Failed to get event category, skipping publish",
 				log.String("eventType", evt.Type),
 				log.Error(err))
 			return
@@ -147,7 +147,7 @@ func (p *categoryEventPublisher) Publish(ctx context.Context, evt *event.Event) 
 			// No subscribers for this category - skip it!
 			p.mu.RUnlock()
 			if p.logger.IsDebugEnabled() {
-				p.logger.DebugWithContext(eventCtx, "No subscribers for event category, skipping",
+				p.logger.Debug(eventCtx, "No subscribers for event category, skipping",
 					log.String("eventType", evt.Type),
 					log.String("category", string(category)))
 			}
@@ -170,7 +170,7 @@ func (p *categoryEventPublisher) Publish(ctx context.Context, evt *event.Event) 
 				defer p.wg.Done() // Ensure WaitGroup is decremented when goroutine completes
 				defer func() {
 					if r := recover(); r != nil {
-						p.logger.ErrorWithContext(eventCtx, "Subscriber panicked while handling event",
+						p.logger.Error(eventCtx, "Subscriber panicked while handling event",
 							log.String("subscriberID", s.GetID()),
 							log.Any("panic", r))
 					}
@@ -178,7 +178,7 @@ func (p *categoryEventPublisher) Publish(ctx context.Context, evt *event.Event) 
 
 				// Subscriber will filter the event itself based on its interests
 				if err := s.OnEvent(evt); err != nil {
-					p.logger.ErrorWithContext(eventCtx, "Subscriber failed to handle event",
+					p.logger.Error(eventCtx, "Subscriber failed to handle event",
 						log.String("subscriberID", s.GetID()),
 						log.String("eventType", evt.Type),
 						log.Error(err))
@@ -211,7 +211,7 @@ func (p *categoryEventPublisher) Subscribe(sub subscriber.SubscriberInterface) {
 	}
 
 	// Subscriber registration happens during service startup, outside any request.
-	p.logger.DebugWithContext(context.Background(), "Subscriber registered",
+	p.logger.Debug(context.Background(), "Subscriber registered",
 		log.String("subscriberID", subscriberID),
 		log.Int("categoryCount", len(categories)),
 		log.Any("categories", categories))
@@ -248,7 +248,7 @@ func (p *categoryEventPublisher) Unsubscribe(sub subscriber.SubscriberInterface)
 	}
 
 	// Subscriber removal happens during service shutdown, outside any request.
-	p.logger.DebugWithContext(context.Background(), "Subscriber unregistered",
+	p.logger.Debug(context.Background(), "Subscriber unregistered",
 		log.String("subscriberID", subscriberID))
 }
 
@@ -293,7 +293,7 @@ func (p *categoryEventPublisher) Shutdown() {
 	// Shutdown runs during application teardown, outside any request.
 	ctx := context.Background()
 
-	p.logger.DebugWithContext(ctx, "Shutting down event publisher")
+	p.logger.Debug(ctx, "Shutting down event publisher")
 
 	// Signal all goroutines to stop accepting new events
 	p.cancel()
@@ -306,18 +306,18 @@ func (p *categoryEventPublisher) Shutdown() {
 	p.mu.Unlock()
 
 	// Wait for all in-flight event processing to complete
-	p.logger.DebugWithContext(ctx, "Waiting for in-flight event processing to complete")
+	p.logger.Debug(ctx, "Waiting for in-flight event processing to complete")
 	p.wg.Wait()
-	p.logger.DebugWithContext(ctx, "All in-flight events processed")
+	p.logger.Debug(ctx, "All in-flight events processed")
 
 	// Close all subscribers
 	for _, sub := range subscribers {
 		if err := sub.Close(); err != nil {
-			p.logger.ErrorWithContext(ctx, "Error closing subscriber",
+			p.logger.Error(ctx, "Error closing subscriber",
 				log.String("subscriberID", sub.GetID()),
 				log.Error(err))
 		}
 	}
 
-	p.logger.DebugWithContext(ctx, "Event bus shutdown complete")
+	p.logger.Debug(ctx, "Event bus shutdown complete")
 }

--- a/backend/internal/system/observability/service.go
+++ b/backend/internal/system/observability/service.go
@@ -62,10 +62,10 @@ func newServiceWithConfig() *Service {
 
 	// Check if observability is disabled
 
-	logger.DebugWithContext(ctx, "Initializing observability service")
+	logger.Debug(ctx, "Initializing observability service")
 	config := config.GetServerRuntime().Config.Observability
 	if !config.Enabled {
-		logger.DebugWithContext(ctx, "Observability is disabled in configuration")
+		logger.Debug(ctx, "Observability is disabled in configuration")
 		return &Service{
 			logger: logger,
 			config: config,
@@ -85,7 +85,7 @@ func newServiceWithConfig() *Service {
 	subscribers, err := subscriber.Initialize(config)
 	if err != nil {
 		// This only happens in strict mode
-		logger.ErrorWithContext(ctx, "Failed to initialize subscribers in strict mode", log.Error(err))
+		logger.Error(ctx, "Failed to initialize subscribers in strict mode", log.Error(err))
 		// In strict mode, we could return an error service, but for now we continue
 		// with no subscribers (observability will be disabled)
 		return svc
@@ -94,11 +94,11 @@ func newServiceWithConfig() *Service {
 	// Subscribe all initialized subscribers to the publisher
 	for _, sub := range subscribers {
 		pub.Subscribe(sub)
-		logger.DebugWithContext(ctx, "Subscriber subscribed to publisher",
+		logger.Debug(ctx, "Subscriber subscribed to publisher",
 			log.String("subscriberID", sub.GetID()))
 	}
 
-	logger.DebugWithContext(ctx, "Observability service initialized successfully",
+	logger.Debug(ctx, "Observability service initialized successfully",
 		log.Int("activeSubscribers", len(subscribers)))
 	return svc
 }
@@ -112,14 +112,14 @@ func (s *Service) RegisterSubscriber(sub subscriber.SubscriberInterface) {
 
 	// Skip registration if service is not enabled or has no publisher
 	if !s.config.Enabled || s.publisher == nil {
-		s.logger.DebugWithContext(ctx, "Subscriber registration skipped - service not enabled",
+		s.logger.Debug(ctx, "Subscriber registration skipped - service not enabled",
 			log.String("subscriberType", fmt.Sprintf("%T", sub)))
 		return
 	}
 
 	// Check if subscriber is enabled in config
 	if !sub.IsEnabled() {
-		s.logger.DebugWithContext(ctx, "Subscriber registration skipped - disabled by config",
+		s.logger.Debug(ctx, "Subscriber registration skipped - disabled by config",
 			log.String("subscriberType", fmt.Sprintf("%T", sub)))
 		return
 	}
@@ -127,12 +127,12 @@ func (s *Service) RegisterSubscriber(sub subscriber.SubscriberInterface) {
 	// Initialize the subscriber
 	if err := sub.Initialize(); err != nil {
 		if s.config.FailureMode == "strict" {
-			s.logger.ErrorWithContext(ctx, "Failed to initialize subscriber in strict mode",
+			s.logger.Error(ctx, "Failed to initialize subscriber in strict mode",
 				log.String("subscriberType", fmt.Sprintf("%T", sub)),
 				log.Error(err))
 			// In strict mode, we could panic or store error for later retrieval
 		} else {
-			s.logger.WarnWithContext(ctx, "Failed to initialize subscriber, skipping",
+			s.logger.Warn(ctx, "Failed to initialize subscriber, skipping",
 				log.String("subscriberType", fmt.Sprintf("%T", sub)),
 				log.Error(err))
 		}
@@ -142,7 +142,7 @@ func (s *Service) RegisterSubscriber(sub subscriber.SubscriberInterface) {
 	// Subscribe to publisher (publisher now owns the subscriber list)
 	s.publisher.Subscribe(sub)
 
-	s.logger.DebugWithContext(ctx, "Subscriber registered and activated successfully",
+	s.logger.Debug(ctx, "Subscriber registered and activated successfully",
 		log.String("subscriberType", fmt.Sprintf("%T", sub)),
 		log.String("subscriberID", sub.GetID()))
 }
@@ -161,7 +161,7 @@ func (s *Service) PublishEvent(ctx context.Context, evt *event.Event) {
 
 	// Only log if event is not nil (avoid panic on evt.Type access)
 	if evt != nil {
-		s.logger.DebugWithContext(ctx, "Event published",
+		s.logger.Debug(ctx, "Event published",
 			log.String("eventType", evt.Type),
 			log.String("eventID", evt.EventID),
 			log.String("traceID", evt.TraceID))
@@ -205,7 +205,7 @@ func (s *Service) Shutdown() {
 	// Shutdown runs during application teardown, outside any request.
 	ctx := context.Background()
 
-	s.logger.DebugWithContext(ctx, "Shutting down observability service")
+	s.logger.Debug(ctx, "Shutting down observability service")
 
 	if s.publisher != nil {
 		// Publisher handles all subscriber cleanup (unsubscribe, close)
@@ -214,5 +214,5 @@ func (s *Service) Shutdown() {
 		// Set publisher to nil to mark service as disabled
 		s.publisher = nil
 	}
-	s.logger.DebugWithContext(ctx, "Observability service shutdown complete")
+	s.logger.Debug(ctx, "Observability service shutdown complete")
 }

--- a/backend/internal/system/observability/subscriber/console_subscriber.go
+++ b/backend/internal/system/observability/subscriber/console_subscriber.go
@@ -86,7 +86,7 @@ func (cs *ConsoleSubscriber) Initialize() error {
 
 	id, err := utils.GenerateUUIDv7()
 	if err != nil {
-		cs.logger.ErrorWithContext(ctx, "failed to generate UUID for console subscriber", log.Error(err))
+		cs.logger.Error(ctx, "failed to generate UUID for console subscriber", log.Error(err))
 		return err
 	}
 	cs.id = id
@@ -94,7 +94,7 @@ func (cs *ConsoleSubscriber) Initialize() error {
 	cs.formatter = fmtr
 	cs.adapter = adptr
 
-	cs.logger.DebugWithContext(ctx, "Console subscriber initialized",
+	cs.logger.Debug(ctx, "Console subscriber initialized",
 		log.String("format", consoleConfig.Format),
 		log.Int("categories", len(cs.categories)))
 
@@ -125,20 +125,20 @@ func (cs *ConsoleSubscriber) Close() error {
 	// Subscriber shutdown runs during application teardown, outside any request.
 	ctx := context.Background()
 
-	cs.logger.InfoWithContext(ctx, "Closing console subscriber", log.String("subscriberID", cs.id))
+	cs.logger.Info(ctx, "Closing console subscriber", log.String("subscriberID", cs.id))
 
 	// Flush and close adapter
 	if cs.adapter != nil {
 		if err := cs.adapter.Flush(); err != nil {
-			cs.logger.ErrorWithContext(ctx, "Failed to flush console adapter", log.Error(err))
+			cs.logger.Error(ctx, "Failed to flush console adapter", log.Error(err))
 		}
 
 		if err := cs.adapter.Close(); err != nil {
-			cs.logger.ErrorWithContext(ctx, "Failed to close console adapter", log.Error(err))
+			cs.logger.Error(ctx, "Failed to close console adapter", log.Error(err))
 			return err
 		}
 	}
 
-	cs.logger.InfoWithContext(ctx, "Console subscriber closed", log.String("subscriberID", cs.id))
+	cs.logger.Info(ctx, "Console subscriber closed", log.String("subscriberID", cs.id))
 	return nil
 }

--- a/backend/internal/system/observability/subscriber/file_subscriber.go
+++ b/backend/internal/system/observability/subscriber/file_subscriber.go
@@ -84,7 +84,7 @@ func (fs *FileSubscriber) Initialize() error {
 
 	if fs.adapter != nil {
 		if err := fs.adapter.Close(); err != nil {
-			fs.logger.WarnWithContext(ctx, "failed to close existing file adapter", log.Error(err))
+			fs.logger.Warn(ctx, "failed to close existing file adapter", log.Error(err))
 		}
 	}
 	// Create file adapter using the Initialize pattern
@@ -109,7 +109,7 @@ func (fs *FileSubscriber) Initialize() error {
 	fs.adapter = adptr
 	fs.logger = log.GetLogger().With(log.String(log.LoggerKeyComponentName, fileSubscriberComponentName))
 
-	fs.logger.DebugWithContext(ctx, "File subscriber initialized",
+	fs.logger.Debug(ctx, "File subscriber initialized",
 		log.String("filePath", filePath),
 		log.String("format", fileConfig.Format),
 		log.Int("categories", len(fs.categories)))
@@ -141,20 +141,20 @@ func (fs *FileSubscriber) Close() error {
 	// Subscriber shutdown runs during application teardown, outside any request.
 	ctx := context.Background()
 
-	fs.logger.InfoWithContext(ctx, "Closing file subscriber", log.String("subscriberID", fs.id))
+	fs.logger.Info(ctx, "Closing file subscriber", log.String("subscriberID", fs.id))
 
 	// Flush and close adapter
 	if fs.adapter != nil {
 		if err := fs.adapter.Flush(); err != nil {
-			fs.logger.ErrorWithContext(ctx, "Failed to flush file adapter", log.Error(err))
+			fs.logger.Error(ctx, "Failed to flush file adapter", log.Error(err))
 		}
 
 		if err := fs.adapter.Close(); err != nil {
-			fs.logger.ErrorWithContext(ctx, "Failed to close file adapter", log.Error(err))
+			fs.logger.Error(ctx, "Failed to close file adapter", log.Error(err))
 			return err
 		}
 	}
 
-	fs.logger.InfoWithContext(ctx, "File subscriber closed", log.String("subscriberID", fs.id))
+	fs.logger.Info(ctx, "File subscriber closed", log.String("subscriberID", fs.id))
 	return nil
 }

--- a/backend/internal/system/observability/subscriber/init.go
+++ b/backend/internal/system/observability/subscriber/init.go
@@ -67,11 +67,11 @@ func Initialize(observabilityConfig config.ObservabilityConfig) ([]SubscriberInt
 	factories := getAllFactories()
 
 	if len(factories) == 0 {
-		logger.WarnWithContext(ctx, "No subscriber factories registered, observability will have no outputs")
+		logger.Warn(ctx, "No subscriber factories registered, observability will have no outputs")
 		return []SubscriberInterface{}, nil
 	}
 
-	logger.DebugWithContext(ctx, "Initializing subscribers from registry",
+	logger.Debug(ctx, "Initializing subscribers from registry",
 		log.Int("factoryCount", len(factories)))
 
 	activeSubscribers := make([]SubscriberInterface, 0, len(factories))
@@ -79,13 +79,13 @@ func Initialize(observabilityConfig config.ObservabilityConfig) ([]SubscriberInt
 
 	// Iterate through all registered factories
 	for name, factory := range factories {
-		logger.DebugWithContext(ctx, "Processing subscriber factory",
+		logger.Debug(ctx, "Processing subscriber factory",
 			log.String("subscriberType", name))
 
 		// Create subscriber instance
 		instance := factory()
 		if instance == nil {
-			logger.ErrorWithContext(ctx, "Factory returned nil instance",
+			logger.Error(ctx, "Factory returned nil instance",
 				log.String("subscriberType", name))
 			initErrors = append(initErrors, fmt.Errorf("factory %s returned nil instance", name))
 			continue
@@ -93,14 +93,14 @@ func Initialize(observabilityConfig config.ObservabilityConfig) ([]SubscriberInt
 
 		// Check if subscriber is enabled in configuration
 		if !instance.IsEnabled() {
-			logger.DebugWithContext(ctx, "Subscriber disabled in configuration, skipping",
+			logger.Debug(ctx, "Subscriber disabled in configuration, skipping",
 				log.String("subscriberType", name))
 			continue
 		}
 
 		// Initialize the subscriber (setup resources, validate config, etc.)
 		if err := instance.Initialize(); err != nil {
-			logger.ErrorWithContext(ctx, "Failed to initialize subscriber",
+			logger.Error(ctx, "Failed to initialize subscriber",
 				log.String("subscriberType", name),
 				log.Error(err))
 
@@ -112,26 +112,26 @@ func Initialize(observabilityConfig config.ObservabilityConfig) ([]SubscriberInt
 			}
 
 			// In lenient mode, log and continue
-			logger.WarnWithContext(ctx, "Continuing subscriber initialization despite error (lenient mode)",
+			logger.Warn(ctx, "Continuing subscriber initialization despite error (lenient mode)",
 				log.String("subscriberType", name))
 			continue
 		}
 
 		// Successfully initialized - add to active list
 		activeSubscribers = append(activeSubscribers, instance)
-		logger.DebugWithContext(ctx, "Subscriber initialized successfully",
+		logger.Debug(ctx, "Subscriber initialized successfully",
 			log.String("subscriberType", name),
 			log.String("subscriberID", instance.GetID()))
 	}
 
-	logger.DebugWithContext(ctx, "Subscriber initialization complete",
+	logger.Debug(ctx, "Subscriber initialization complete",
 		log.Int("total", len(factories)),
 		log.Int("active", len(activeSubscribers)),
 		log.Int("errors", len(initErrors)))
 
 	// If we have errors but reached here, we're in lenient mode
 	if len(initErrors) > 0 && observabilityConfig.FailureMode != "strict" {
-		logger.WarnWithContext(ctx, "Some subscribers failed to initialize but continuing in lenient mode",
+		logger.Warn(ctx, "Some subscribers failed to initialize but continuing in lenient mode",
 			log.Int("failedCount", len(initErrors)))
 	}
 

--- a/backend/internal/system/observability/subscriber/otel_subscriber.go
+++ b/backend/internal/system/observability/subscriber/otel_subscriber.go
@@ -83,7 +83,7 @@ func (o *OTelSubscriber) Initialize() error {
 	// Subscriber initialization runs during application startup, outside any request.
 	ctx := context.Background()
 
-	o.logger.DebugWithContext(ctx, "Initializing OpenTelemetry subscriber",
+	o.logger.Debug(ctx, "Initializing OpenTelemetry subscriber",
 		log.String("exporterType", otelConfig.ExporterType),
 		log.String("endpoint", otelConfig.OTLPEndpoint))
 
@@ -112,11 +112,11 @@ func (o *OTelSubscriber) Initialize() error {
 	o.tracer = otel.Tracer("thunderid-observability")
 	o.id, err = utils.GenerateUUIDv7()
 	if err != nil {
-		o.logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+		o.logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 		return fmt.Errorf("Failed to generate UUID: %w", err)
 	}
 
-	o.logger.DebugWithContext(ctx, "OpenTelemetry subscriber initialized successfully",
+	o.logger.Debug(ctx, "OpenTelemetry subscriber initialized successfully",
 		log.String("exporterType", otelConfig.ExporterType),
 		log.String("serviceName", otelConfig.ServiceName))
 
@@ -169,7 +169,7 @@ func (o *OTelSubscriber) createSpan(evt *event.Event) error {
 	traceID, err := trace.TraceIDFromHex(cleanTraceID)
 	if err != nil {
 		// If invalid TraceID, log warning and let OTel generate a new one
-		o.logger.WarnWithContext(ctx, "Invalid TraceID in event, generating new one",
+		o.logger.Warn(ctx, "Invalid TraceID in event, generating new one",
 			log.String("traceID", evt.TraceID),
 			log.Error(err))
 	} else {
@@ -253,7 +253,7 @@ func (o *OTelSubscriber) createSpan(evt *event.Event) error {
 	// it took for the event to be processed by this subscriber.
 	span.End()
 
-	o.logger.DebugWithContext(ctx, "Created span with event",
+	o.logger.Debug(ctx, "Created span with event",
 		log.String("spanName", spanName),
 		log.String("eventType", evt.Type),
 		log.String("status", evt.Status))
@@ -343,20 +343,20 @@ func (o *OTelSubscriber) Close() error {
 	// Subscriber shutdown runs during application teardown, outside any request.
 	ctx := context.Background()
 
-	o.logger.InfoWithContext(ctx, "Closing OTel subscriber", log.String("subscriberID", o.id))
+	o.logger.Info(ctx, "Closing OTel subscriber", log.String("subscriberID", o.id))
 
 	if o.tracerProvider != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		if err := o.tracerProvider.Shutdown(shutdownCtx); err != nil {
-			o.logger.ErrorWithContext(ctx, "Failed to shutdown OpenTelemetry provider", log.Error(err))
+			o.logger.Error(ctx, "Failed to shutdown OpenTelemetry provider", log.Error(err))
 			return err
 		}
-		o.logger.DebugWithContext(ctx, "OpenTelemetry provider shutdown successfully")
+		o.logger.Debug(ctx, "OpenTelemetry provider shutdown successfully")
 		o.tracerProvider = nil
 	}
 
-	o.logger.InfoWithContext(ctx, "OTel subscriber closed successfully", log.String("subscriberID", o.id))
+	o.logger.Info(ctx, "OTel subscriber closed successfully", log.String("subscriberID", o.id))
 	return nil
 }

--- a/backend/internal/system/observability/subscriber/registry.go
+++ b/backend/internal/system/observability/subscriber/registry.go
@@ -59,7 +59,7 @@ func RegisterSubscriberFactory(name string, factory SubscriberFactory) {
 	if _, exists := factoryRegistry[name]; exists {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "SubscriberRegistry"))
 		// Factory registration runs during package init, outside any request.
-		logger.WarnWithContext(context.Background(), "Subscriber factory already registered, replacing",
+		logger.Warn(context.Background(), "Subscriber factory already registered, replacing",
 			log.String("subscriberType", name))
 	}
 

--- a/backend/internal/system/observability/subscriber/utils.go
+++ b/backend/internal/system/observability/subscriber/utils.go
@@ -69,7 +69,7 @@ func processEvent(
 	// Format the event
 	formattedData, err := fmtr.Format(evt)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to format event",
+		logger.Error(ctx, "Failed to format event",
 			log.String("eventType", evt.Type),
 			log.String("eventID", evt.EventID),
 			log.Error(err))
@@ -78,14 +78,14 @@ func processEvent(
 
 	// Write using adapter
 	if err := adapter.Write(formattedData); err != nil {
-		logger.ErrorWithContext(ctx, fmt.Sprintf("Failed to write event to %s", outputType),
+		logger.Error(ctx, fmt.Sprintf("Failed to write event to %s", outputType),
 			log.String("eventType", evt.Type),
 			log.String("eventID", evt.EventID),
 			log.Error(err))
 		return fmt.Errorf("failed to write to %s: %w", outputType, err)
 	}
 
-	logger.DebugWithContext(ctx, fmt.Sprintf("Event processed successfully to %s", outputType),
+	logger.Debug(ctx, fmt.Sprintf("Event processed successfully to %s", outputType),
 		log.String("eventType", evt.Type),
 		log.String("eventID", evt.EventID),
 		log.String("traceID", evt.TraceID))

--- a/backend/internal/system/security/service.go
+++ b/backend/internal/system/security/service.go
@@ -75,14 +75,14 @@ func newSecurityService(authenticators []AuthenticatorInterface, publicPaths []s
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
 	if skipSecurity {
-		logger.WarnWithContext(ctx, "============================================================")
-		logger.WarnWithContext(ctx, "|       WARNING: SECURITY ENFORCEMENT DISABLED             |")
-		logger.WarnWithContext(ctx, "|                                                          |")
-		logger.WarnWithContext(ctx, "|        SKIP_SECURITY is set to 'true'            |")
-		logger.WarnWithContext(ctx, "|  This is NOT RECOMMENDED for production environments!    |")
-		logger.WarnWithContext(ctx, "| Endpoints accessible without auth, but tokens processed  |")
-		logger.WarnWithContext(ctx, "|                                                          |")
-		logger.WarnWithContext(ctx, "============================================================")
+		logger.Warn(ctx, "============================================================")
+		logger.Warn(ctx, "|       WARNING: SECURITY ENFORCEMENT DISABLED             |")
+		logger.Warn(ctx, "|                                                          |")
+		logger.Warn(ctx, "|        SKIP_SECURITY is set to 'true'            |")
+		logger.Warn(ctx, "|  This is NOT RECOMMENDED for production environments!    |")
+		logger.Warn(ctx, "| Endpoints accessible without auth, but tokens processed  |")
+		logger.Warn(ctx, "|                                                          |")
+		logger.Warn(ctx, "============================================================")
 	}
 
 	return &securityService{
@@ -175,7 +175,7 @@ func (s *securityService) getRequiredPermissionForAPI(method, path string) strin
 // isPublicPath checks if the given request path matches any of the configured public path patterns.
 func (s *securityService) isPublicPath(ctx context.Context, requestPath string) bool {
 	if len(requestPath) > maxPublicPathLength {
-		s.logger.WarnWithContext(ctx, "Path length exceeds maximum allowed length",
+		s.logger.Warn(ctx, "Path length exceeds maximum allowed length",
 			log.Int("limit", maxPublicPathLength),
 			log.Int("length", len(requestPath)))
 		return false
@@ -205,7 +205,7 @@ func (s *securityService) handleAuthError(
 	}
 
 	if skipSecurity {
-		s.logger.DebugWithContext(ctx,
+		s.logger.Debug(ctx,
 			"Proceeding without authentication/authorization enforcement as skipSecurity is enabled",
 			log.Error(err),
 			log.String("path", path))

--- a/backend/internal/system/sysauthz/service.go
+++ b/backend/internal/system/sysauthz/service.go
@@ -95,14 +95,14 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 
 	// Step 1: Check if SKIP_SECURITY flag is set.
 	if security.IsSecuritySkipped(ctx) {
-		logger.DebugWithContext(ctx, "Authorization skipped: SKIP_SECURITY is enabled",
+		logger.Debug(ctx, "Authorization skipped: SKIP_SECURITY is enabled",
 			log.String("action", string(action)))
 		return true, nil
 	}
 
 	// Step 2: Check if this is an internal runtime caller.
 	if security.IsRuntimeContext(ctx) {
-		logger.DebugWithContext(ctx, "Authorization granted: runtime context for the action",
+		logger.Debug(ctx, "Authorization granted: runtime context for the action",
 			log.String("action", string(action)))
 		return true, nil
 	}
@@ -110,7 +110,7 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 	// Step 3: Verify the caller is authenticated.
 	subject := security.GetSubject(ctx)
 	if subject == "" {
-		logger.DebugWithContext(ctx, "Authorization denied: unauthenticated caller",
+		logger.Debug(ctx, "Authorization denied: unauthenticated caller",
 			log.String("action", string(action)))
 		return false, nil
 	}
@@ -125,7 +125,7 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 	// Step 5: Allow resource owners to access their own resources (self-service).
 	if isResourceOwner(ctx, actionCtx) {
 		if logger.IsDebugEnabled() {
-			logger.DebugWithContext(ctx, "Authorization granted: resource owner",
+			logger.Debug(ctx, "Authorization granted: resource owner",
 				log.String("action", string(action)),
 				log.MaskedString("subject", subject))
 		}
@@ -136,7 +136,7 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 	requiredPermission := security.ResolveActionPermission(action)
 	if !security.HasSufficientPermission(permissions, requiredPermission) {
 		if logger.IsDebugEnabled() {
-			logger.DebugWithContext(ctx, "Authorization denied: insufficient permissions",
+			logger.Debug(ctx, "Authorization denied: insufficient permissions",
 				log.String("action", string(action)),
 				log.MaskedString("subject", subject))
 		}
@@ -150,7 +150,7 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 	}
 	if !allowed {
 		if logger.IsDebugEnabled() {
-			logger.DebugWithContext(ctx, "Authorization denied: policy evaluation failed",
+			logger.Debug(ctx, "Authorization denied: policy evaluation failed",
 				log.String("action", string(action)),
 				log.MaskedString("subject", subject))
 		}
@@ -158,7 +158,7 @@ func (s *systemAuthorizationService) IsActionAllowed(ctx context.Context, action
 	}
 
 	if logger.IsDebugEnabled() {
-		logger.DebugWithContext(ctx, "Authorization granted",
+		logger.Debug(ctx, "Authorization granted",
 			log.String("action", string(action)),
 			log.MaskedString("subject", subject))
 	}
@@ -195,7 +195,7 @@ func (s *systemAuthorizationService) GetAccessibleResources(ctx context.Context,
 
 	// Step 1: Check if SKIP_SECURITY flag is set.
 	if security.IsSecuritySkipped(ctx) {
-		logger.DebugWithContext(ctx, "GetAccessibleResources skipped: SKIP_SECURITY is enabled",
+		logger.Debug(ctx, "GetAccessibleResources skipped: SKIP_SECURITY is enabled",
 			log.String("action", string(action)),
 			log.String("resourceType", string(resourceType)))
 		return &AccessibleResources{AllAllowed: true}, nil
@@ -203,7 +203,7 @@ func (s *systemAuthorizationService) GetAccessibleResources(ctx context.Context,
 
 	// Step 2: Check if this is an internal runtime caller — return all resources.
 	if security.IsRuntimeContext(ctx) {
-		logger.DebugWithContext(ctx, "GetAccessibleResources: runtime context, returning all resources",
+		logger.Debug(ctx, "GetAccessibleResources: runtime context, returning all resources",
 			log.String("action", string(action)),
 			log.String("resourceType", string(resourceType)))
 		return &AccessibleResources{AllAllowed: true}, nil
@@ -212,7 +212,7 @@ func (s *systemAuthorizationService) GetAccessibleResources(ctx context.Context,
 	// Step 3: Verify the caller is authenticated.
 	subject := security.GetSubject(ctx)
 	if subject == "" {
-		logger.DebugWithContext(ctx, "GetAccessibleResources denied: unauthenticated caller",
+		logger.Debug(ctx, "GetAccessibleResources denied: unauthenticated caller",
 			log.String("action", string(action)),
 			log.String("resourceType", string(resourceType)))
 		return &AccessibleResources{AllAllowed: false, IDs: []string{}}, nil
@@ -229,7 +229,7 @@ func (s *systemAuthorizationService) GetAccessibleResources(ctx context.Context,
 	requiredPermission := security.ResolveActionPermission(action)
 	if !security.HasSufficientPermission(permissions, requiredPermission) {
 		if logger.IsDebugEnabled() {
-			logger.DebugWithContext(ctx, "GetAccessibleResources denied: insufficient permissions",
+			logger.Debug(ctx, "GetAccessibleResources denied: insufficient permissions",
 				log.String("action", string(action)),
 				log.String("resourceType", string(resourceType)),
 				log.MaskedString("subject", subject))
@@ -243,7 +243,7 @@ func (s *systemAuthorizationService) GetAccessibleResources(ctx context.Context,
 		return nil, svcErr
 	}
 	if logger.IsDebugEnabled() && !result.AllAllowed {
-		logger.DebugWithContext(ctx, "GetAccessibleResources: restricted by policy",
+		logger.Debug(ctx, "GetAccessibleResources: restricted by policy",
 			log.String("action", string(action)),
 			log.String("resourceType", string(resourceType)),
 			log.MaskedString("subject", subject),

--- a/backend/internal/system/template/service.go
+++ b/backend/internal/system/template/service.go
@@ -49,7 +49,7 @@ func (s *templateService) GetTemplateByScenario(
 	scenario ScenarioType,
 	tmplType TemplateType,
 ) (*TemplateDTO, *serviceerror.ServiceError) {
-	s.logger.DebugWithContext(ctx, "Retrieving template by scenario and type",
+	s.logger.Debug(ctx, "Retrieving template by scenario and type",
 		log.String("scenario", string(scenario)),
 		log.String("type", string(tmplType)))
 	tmpl, err := s.store.GetTemplateByScenario(ctx, scenario, tmplType)
@@ -57,7 +57,7 @@ func (s *templateService) GetTemplateByScenario(
 		if errors.Is(err, errTemplateNotFound) {
 			return nil, &ErrorTemplateNotFound
 		}
-		s.logger.ErrorWithContext(ctx, "Failed to retrieve template by scenario",
+		s.logger.Error(ctx, "Failed to retrieve template by scenario",
 			log.String("scenario", string(scenario)),
 			log.Error(err))
 		return nil, &serviceerror.InternalServerError
@@ -73,7 +73,7 @@ func (s *templateService) Render(
 	tmplType TemplateType,
 	data TemplateData,
 ) (*RenderedTemplate, *serviceerror.ServiceError) {
-	s.logger.DebugWithContext(ctx, "Rendering template", log.String("scenario", string(scenario)))
+	s.logger.Debug(ctx, "Rendering template", log.String("scenario", string(scenario)))
 	tmpl, svcErr := s.GetTemplateByScenario(ctx, scenario, tmplType)
 	if svcErr != nil {
 		return nil, svcErr
@@ -100,12 +100,12 @@ func (s *templateService) Render(
 		IsHTML:  tmpl.ContentType == "text/html",
 	}
 
-	s.logger.DebugWithContext(ctx, "Template rendered successfully",
+	s.logger.Debug(ctx, "Template rendered successfully",
 		log.String("scenario", string(scenario)),
 		log.String("templateID", tmpl.ID))
 
 	if tmpl.Type == TemplateTypeSMS && len(rendered.Body) > 160 {
-		s.logger.WarnWithContext(ctx,
+		s.logger.Warn(ctx,
 			"Rendered SMS body exceeds 160 characters; message may be split into multiple segments",
 			log.Int("length", len(rendered.Body)))
 	}

--- a/backend/internal/system/transaction/transactioner.go
+++ b/backend/internal/system/transaction/transactioner.go
@@ -68,7 +68,7 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 	// 1. Begin transaction
 	tx, err := t.db.BeginTx(ctx, nil)
 	if err != nil {
-		log.GetLogger().ErrorWithContext(ctx, "failed to begin transaction",
+		log.GetLogger().Error(ctx, "failed to begin transaction",
 			log.String("dbName", t.dbName),
 			log.Error(err),
 		)
@@ -80,7 +80,7 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 		if p := recover(); p != nil {
 			// Capture stack trace
 			stack := string(debug.Stack())
-			log.GetLogger().ErrorWithContext(ctx, "panic occurred during transaction",
+			log.GetLogger().Error(ctx, "panic occurred during transaction",
 				log.String("dbName", t.dbName),
 				log.Any("panic", p),
 				log.String("stack", stack),
@@ -88,7 +88,7 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 
 			// Panic occurred - rollback and convert panic to error
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				log.GetLogger().ErrorWithContext(ctx, "failed to rollback transaction after unexpected error",
+				log.GetLogger().Error(ctx, "failed to rollback transaction after unexpected error",
 					log.String("dbName", t.dbName),
 					log.Error(rollbackErr),
 				)
@@ -111,7 +111,7 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 		} else if err != nil {
 			// Error occurred - rollback
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				log.GetLogger().ErrorWithContext(ctx, "failed to rollback transaction",
+				log.GetLogger().Error(ctx, "failed to rollback transaction",
 					log.String("dbName", t.dbName),
 					log.Error(rollbackErr),
 				)
@@ -121,7 +121,7 @@ func (t *dbTransactioner) Transact(ctx context.Context, txFunc func(context.Cont
 			// Success - commit
 			err = tx.Commit()
 			if err != nil {
-				log.GetLogger().ErrorWithContext(ctx, "failed to commit transaction",
+				log.GetLogger().Error(ctx, "failed to commit transaction",
 					log.String("dbName", t.dbName),
 					log.Error(err),
 				)

--- a/backend/internal/system/utils/configutil.go
+++ b/backend/internal/system/utils/configutil.go
@@ -88,7 +88,7 @@ func SubstituteFilePaths(content []byte, baseDir string) ([]byte, error) {
 			path = sub[2]
 		}
 		if path == "" {
-			logger.WarnWithContext(ctx, "Empty file path in placeholder", log.String("placeholder", match))
+			logger.Warn(ctx, "Empty file path in placeholder", log.String("placeholder", match))
 			return ""
 		}
 
@@ -99,7 +99,7 @@ func SubstituteFilePaths(content []byte, baseDir string) ([]byte, error) {
 
 		data, err := readFileContent(path)
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to read file content", log.String("filePath", path), log.Error(err))
+			logger.Error(ctx, "Failed to read file content", log.String("filePath", path), log.Error(err))
 			isError = true
 			return ""
 		}

--- a/backend/internal/system/utils/http_util.go
+++ b/backend/internal/system/utils/http_util.go
@@ -40,7 +40,7 @@ import (
 func WriteJSONError(ctx context.Context, w http.ResponseWriter, code, desc string, statusCode int,
 	respHeaders []map[string]string) {
 	logger := log.GetLogger()
-	logger.ErrorWithContext(ctx, "Error in HTTP response",
+	logger.Error(ctx, "Error in HTTP response",
 		log.String("error", code), log.String("description", desc))
 
 	// Set the response headers.
@@ -57,7 +57,7 @@ func WriteJSONError(ctx context.Context, w http.ResponseWriter, code, desc strin
 		"error_description": desc,
 	})
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to write JSON error response", log.Error(err))
+		logger.Error(ctx, "Failed to write JSON error response", log.Error(err))
 		return
 	}
 }
@@ -391,7 +391,7 @@ func WriteSuccessResponse(ctx context.Context, w http.ResponseWriter, statusCode
 	// Encode to buffer first to ensure encoding succeeds before sending headers
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(data); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to encode response", log.Error(err))
+		logger.Error(ctx, "Failed to encode response", log.Error(err))
 		errResp := apierror.ErrorResponse{
 			Code:        serviceerror.ErrorEncodingError.Code,
 			Message:     serviceerror.ErrorEncodingError.Error,
@@ -417,7 +417,7 @@ func WriteErrorResponse(ctx context.Context, w http.ResponseWriter, statusCode i
 	w.WriteHeader(statusCode)
 
 	if err := json.NewEncoder(w).Encode(errorResp); err != nil {
-		logger.ErrorWithContext(ctx, "Failed to encode i18n error response", log.Error(err))
+		logger.Error(ctx, "Failed to encode i18n error response", log.Error(err))
 		errResp := apierror.ErrorResponse{
 			Code:        serviceerror.ErrorEncodingError.Code,
 			Message:     serviceerror.ErrorEncodingError.Error,

--- a/backend/internal/user/declarative_resource.go
+++ b/backend/internal/user/declarative_resource.go
@@ -158,7 +158,7 @@ func (e *userExporter) ValidateResource(ctx context.Context,
 	}
 
 	if username == "" {
-		logger.WarnWithContext(ctx, "USER_VALIDATION_ERROR: Missing username",
+		logger.Warn(ctx, "USER_VALIDATION_ERROR: Missing username",
 			log.MaskedString(log.LoggerKeyUserID, id))
 		return "", &declarativeresource.ExportError{
 			ResourceType: resourceTypeUser,

--- a/backend/internal/user/display_util.go
+++ b/backend/internal/user/display_util.go
@@ -45,7 +45,7 @@ func ResolveDisplayAttributePaths(
 	displayPaths, svcErr := schemaService.GetDisplayAttributesByNames(ctx, entitytype.TypeCategoryUser, uniqueTypes)
 	if svcErr != nil {
 		if logger != nil {
-			logger.WarnWithContext(ctx, "Failed to resolve display attribute paths, skipping display resolution",
+			logger.Warn(ctx, "Failed to resolve display attribute paths, skipping display resolution",
 				log.Any("error", svcErr))
 		}
 		return nil

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -83,7 +83,7 @@ func (uh *userHandler) HandleUserListRequest(w http.ResponseWriter, r *http.Requ
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, userListResponse)
 
-	logger.DebugWithContext(ctx, "Successfully listed users with pagination",
+	logger.Debug(ctx, "Successfully listed users with pagination",
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", userListResponse.TotalResults),
 		log.Int("count", userListResponse.Count),
@@ -122,7 +122,7 @@ func (uh *userHandler) HandleUserPostRequest(w http.ResponseWriter, r *http.Requ
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, createdUser)
 
 	// Log the user creation response.
-	logger.DebugWithContext(ctx, "User POST response sent", log.MaskedString(log.LoggerKeyUserID, createdUser.ID))
+	logger.Debug(ctx, "User POST response sent", log.MaskedString(log.LoggerKeyUserID, createdUser.ID))
 }
 
 // HandleUserGetRequest handles the user request.
@@ -154,7 +154,7 @@ func (uh *userHandler) HandleUserGetRequest(w http.ResponseWriter, r *http.Reque
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, user)
 
 	// Log the user response.
-	logger.DebugWithContext(ctx, "User GET response sent", log.MaskedString(log.LoggerKeyUserID, id))
+	logger.Debug(ctx, "User GET response sent", log.MaskedString(log.LoggerKeyUserID, id))
 }
 
 // HandleUserGroupsGetRequest handles the get user groups request.
@@ -186,7 +186,7 @@ func (ah *userHandler) HandleUserGroupsGetRequest(w http.ResponseWriter, r *http
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, groupListResponse)
 
-	logger.DebugWithContext(ctx, "Successfully retrieved user groups", log.MaskedString(log.LoggerKeyUserID, id),
+	logger.Debug(ctx, "Successfully retrieved user groups", log.MaskedString(log.LoggerKeyUserID, id),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", groupListResponse.TotalResults),
 		log.Int("count", groupListResponse.Count))
@@ -230,7 +230,7 @@ func (uh *userHandler) HandleUserPutRequest(w http.ResponseWriter, r *http.Reque
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, user)
 
 	// Log the user response.
-	logger.DebugWithContext(ctx, "User PUT response sent", log.MaskedString(log.LoggerKeyUserID, id))
+	logger.Debug(ctx, "User PUT response sent", log.MaskedString(log.LoggerKeyUserID, id))
 }
 
 // HandleUserDeleteRequest handles the delete user request.
@@ -259,7 +259,7 @@ func (uh *userHandler) HandleUserDeleteRequest(w http.ResponseWriter, r *http.Re
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 
 	// Log the user response.
-	logger.DebugWithContext(ctx, "User DELETE response sent", log.MaskedString(log.LoggerKeyUserID, id))
+	logger.Debug(ctx, "User DELETE response sent", log.MaskedString(log.LoggerKeyUserID, id))
 }
 
 // HandleUserListByPathRequest handles the list users by OU path request.
@@ -299,7 +299,7 @@ func (uh *userHandler) HandleUserListByPathRequest(w http.ResponseWriter, r *htt
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, userListResponse)
 
-	logger.DebugWithContext(ctx, "Successfully listed users by path", log.String("path", path),
+	logger.Debug(ctx, "Successfully listed users by path", log.String("path", path),
 		log.Int("limit", limit), log.Int("offset", offset),
 		log.Int("totalResults", userListResponse.TotalResults),
 		log.Int("count", userListResponse.Count),
@@ -338,7 +338,7 @@ func (uh *userHandler) HandleUserPostByPathRequest(w http.ResponseWriter, r *htt
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusCreated, user)
 
-	logger.DebugWithContext(ctx, "Successfully created user by path",
+	logger.Debug(ctx, "Successfully created user by path",
 		log.String("path", path), log.String("userType", user.Type))
 }
 
@@ -364,7 +364,7 @@ func (uh *userHandler) HandleSelfUserGetRequest(w http.ResponseWriter, r *http.R
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, user)
 
-	logger.DebugWithContext(ctx, "Self user GET response sent", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Self user GET response sent", log.MaskedString(log.LoggerKeyUserID, userID))
 }
 
 // HandleSelfUserPutRequest handles the self user update.
@@ -397,7 +397,7 @@ func (uh *userHandler) HandleSelfUserPutRequest(w http.ResponseWriter, r *http.R
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, updatedUser)
 
-	logger.DebugWithContext(ctx, "Self user PUT response sent", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Self user PUT response sent", log.MaskedString(log.LoggerKeyUserID, userID))
 }
 
 // HandleSelfUserCredentialUpdateRequest handles the credential update for the authenticated user.
@@ -428,7 +428,7 @@ func (uh *userHandler) HandleSelfUserCredentialUpdateRequest(w http.ResponseWrit
 	}
 
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
-	logger.DebugWithContext(ctx, "Self user credential update response sent",
+	logger.Debug(ctx, "Self user credential update response sent",
 		log.MaskedString(log.LoggerKeyUserID, userID))
 }
 

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -99,7 +99,7 @@ func (us *userService) GetUserList(ctx context.Context, limit, offset int,
 	accessible, svcErr := us.authzService.GetAccessibleResources(
 		ctx, security.ActionListUsers, security.ResourceTypeOU)
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to resolve accessible resources for listing users",
+		logger.Error(ctx, "Failed to resolve accessible resources for listing users",
 			log.Any("error", svcErr))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -185,7 +185,7 @@ func (us *userService) GetUsersByPath(
 	includeDisplay bool,
 ) (*UserListResponse, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Getting users by path", log.String("path", handlePath))
+	logger.Debug(ctx, "Getting users by path", log.String("path", handlePath))
 
 	serviceError := validateAndProcessHandlePath(handlePath)
 	if serviceError != nil {
@@ -245,7 +245,7 @@ func (us *userService) GetUsersByPath(
 		}
 		fetchedEntities, err := us.entityService.GetEntitiesByIDs(ctx, userIDs)
 		if err != nil {
-			logger.WarnWithContext(ctx, "Failed to batch fetch users for display names, skipping display resolution",
+			logger.Warn(ctx, "Failed to batch fetch users for display names, skipping display resolution",
 				log.Error(err))
 			// Fall back to bare IDs without display — partial display is worse than none.
 			users = make([]User, len(ouResponse.Users))
@@ -322,7 +322,7 @@ func (us *userService) CreateUser(ctx context.Context, user *User) (*User, *serv
 	if user.ID == "" {
 		user.ID, err = us.uuidGenerator()
 		if err != nil {
-			logger.ErrorWithContext(ctx, "Failed to generate UUID", log.Error(err))
+			logger.Error(ctx, "Failed to generate UUID", log.Error(err))
 			return nil, &serviceerror.InternalServerError
 		}
 	}
@@ -339,7 +339,7 @@ func (us *userService) CreateUser(ctx context.Context, user *User) (*User, *serv
 	// Sync cleaned attributes back — entity service removed credential fields from Attributes.
 	user.Attributes = created.Attributes
 
-	logger.DebugWithContext(ctx, "Successfully created user", log.MaskedString(log.LoggerKeyUserID, user.ID))
+	logger.Debug(ctx, "Successfully created user", log.MaskedString(log.LoggerKeyUserID, user.ID))
 	return user, nil
 }
 
@@ -348,7 +348,7 @@ func (us *userService) CreateUserByPath(
 	ctx context.Context, handlePath string, request CreateUserByPathRequest,
 ) (*User, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Creating user by path",
+	logger.Debug(ctx, "Creating user by path",
 		log.String("path", handlePath), log.String("type", request.Type))
 
 	serviceError := validateAndProcessHandlePath(handlePath)
@@ -384,7 +384,7 @@ func (us *userService) GetUser(
 	ctx context.Context, userID string, includeDisplay bool,
 ) (*User, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Retrieving user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Retrieving user", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	if userID == "" {
 		return nil, &ErrorMissingUserID
@@ -393,7 +393,7 @@ func (us *userService) GetUser(
 	e, err := us.entityService.GetEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.Debug(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
 		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
@@ -417,14 +417,14 @@ func (us *userService) GetUser(
 
 		handleMap, svcErr := us.ouService.GetOrganizationUnitHandlesByIDs(ctx, []string{user.OUID})
 		if svcErr != nil {
-			logger.WarnWithContext(ctx, "Failed to resolve OU handle for user, skipping",
+			logger.Warn(ctx, "Failed to resolve OU handle for user, skipping",
 				log.Any("error", svcErr))
 		} else if handle, ok := handleMap[user.OUID]; ok {
 			user.OUHandle = handle
 		}
 	}
 
-	logger.DebugWithContext(ctx, "Successfully retrieved user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Successfully retrieved user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return &user, nil
 }
 
@@ -445,7 +445,7 @@ func (as *userService) GetUserGroups(ctx context.Context, userID string, limit, 
 	userEntity, err := as.entityService.GetEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.Debug(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
 		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
@@ -463,14 +463,14 @@ func (as *userService) GetUserGroups(ctx context.Context, userID string, limit, 
 
 	totalCount, err := as.entityService.GetGroupCountForEntity(ctx, userID)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get group count for user",
+		logger.Error(ctx, "Failed to get group count for user",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 
 	entityGroups, err := as.entityService.GetEntityGroups(ctx, userID, limit, offset)
 	if err != nil {
-		logger.ErrorWithContext(ctx, "Failed to get user groups",
+		logger.Error(ctx, "Failed to get user groups",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
@@ -492,7 +492,7 @@ func (as *userService) GetUserGroups(ctx context.Context, userID string, limit, 
 func (us *userService) UpdateUser(
 	ctx context.Context, userID string, user *User) (*User, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Updating user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Updating user", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	if userID == "" {
 		return nil, &ErrorMissingUserID
@@ -506,7 +506,7 @@ func (us *userService) UpdateUser(
 	existingEntity, err := us.entityService.GetEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.Debug(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
 		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
@@ -558,7 +558,7 @@ func (us *userService) UpdateUser(
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
-	logger.DebugWithContext(ctx, "Successfully updated user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Successfully updated user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return user, nil
 }
 
@@ -567,7 +567,7 @@ func (us *userService) UpdateUserAttributes(
 	ctx context.Context, userID string, attributes json.RawMessage,
 ) (*User, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Updating user attributes", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Updating user attributes", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	if strings.TrimSpace(userID) == "" {
 		return nil, &ErrorMissingUserID
@@ -581,7 +581,7 @@ func (us *userService) UpdateUserAttributes(
 	existingEntity, getErr := us.entityService.GetEntity(ctx, userID)
 	if getErr != nil {
 		if errors.Is(getErr, entity.ErrEntityNotFound) {
-			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.Debug(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return nil, &ErrorUserNotFound
 		}
 		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to get user", getErr,
@@ -595,7 +595,7 @@ func (us *userService) UpdateUserAttributes(
 	// Reject credential fields here: this endpoint is for attribute updates only.
 	// Credentials must go through UpdateUserCredentials, which enforces its own authz and validation.
 	if us.entityTypeService == nil {
-		logger.ErrorWithContext(ctx, "Entity type service is not configured for user operations")
+		logger.Error(ctx, "Entity type service is not configured for user operations")
 		return nil, &serviceerror.InternalServerError
 	}
 	schemaCredentialInfos, svcErr := us.entityTypeService.GetAttributes(ctx,
@@ -641,7 +641,7 @@ func (us *userService) UpdateUserAttributes(
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
-	logger.DebugWithContext(ctx, "Successfully updated user attributes", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Successfully updated user attributes", log.MaskedString(log.LoggerKeyUserID, userID))
 	return &existingUser, nil
 }
 
@@ -652,7 +652,7 @@ func (us *userService) UpdateUserCredentials(
 	credentials json.RawMessage,
 ) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Updating user credentials", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Updating user credentials", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	if strings.TrimSpace(userID) == "" {
 		return &ErrorAuthenticationFailed
@@ -665,7 +665,7 @@ func (us *userService) UpdateUserCredentials(
 	// Parse credentials to extract credential types
 	var credentialsMap map[string]json.RawMessage
 	if err := json.Unmarshal(credentials, &credentialsMap); err != nil {
-		logger.DebugWithContext(ctx, "Failed to parse credentials", log.Error(err))
+		logger.Debug(ctx, "Failed to parse credentials", log.Error(err))
 		return &ErrorInvalidRequestFormat
 	}
 
@@ -677,7 +677,7 @@ func (us *userService) UpdateUserCredentials(
 	existingEntity, err := us.entityService.GetEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.Debug(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return &ErrorUserNotFound
 		}
 		return logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
@@ -726,7 +726,7 @@ func (us *userService) UpdateUserCredentials(
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
-	logger.DebugWithContext(ctx, "Successfully updated user credentials",
+	logger.Debug(ctx, "Successfully updated user credentials",
 		log.MaskedString(log.LoggerKeyUserID, userID),
 		log.Int("credentialTypesCount", len(credentialsMap)))
 	return nil
@@ -735,7 +735,7 @@ func (us *userService) UpdateUserCredentials(
 // DeleteUser delete the user for given user id.
 func (us *userService) DeleteUser(ctx context.Context, userID string) *serviceerror.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-	logger.DebugWithContext(ctx, "Deleting user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Deleting user", log.MaskedString(log.LoggerKeyUserID, userID))
 
 	if userID == "" {
 		return &ErrorMissingUserID
@@ -745,7 +745,7 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *serviceer
 	existingEntity, err := us.entityService.GetEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.Debug(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return &ErrorUserNotFound
 		}
 		return logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
@@ -770,14 +770,14 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *serviceer
 	err = us.entityService.DeleteEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			logger.DebugWithContext(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
+			logger.Debug(ctx, "User not found", log.MaskedString(log.LoggerKeyUserID, userID))
 			return &ErrorUserNotFound
 		}
 		return logErrorAndReturnServerError(ctx, logger, "Failed to delete user", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
-	logger.DebugWithContext(ctx, "Successfully deleted user", log.MaskedString(log.LoggerKeyUserID, userID))
+	logger.Debug(ctx, "Successfully deleted user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return nil
 }
 
@@ -814,7 +814,7 @@ func (us *userService) populateOUHandles(ctx context.Context, users []User, logg
 
 	handleMap, svcErr := us.ouService.GetOrganizationUnitHandlesByIDs(ctx, ouIDs)
 	if svcErr != nil {
-		logger.WarnWithContext(ctx, "Failed to resolve OU handles, skipping", log.Any("error", svcErr))
+		logger.Warn(ctx, "Failed to resolve OU handles, skipping", log.Any("error", svcErr))
 		return
 	}
 
@@ -838,7 +838,7 @@ func (us *userService) validateOrganizationUnitForUserType(
 	}
 
 	if us.ouService == nil {
-		logger.ErrorWithContext(ctx, "Organization unit service is not configured for user operations")
+		logger.Error(ctx, "Organization unit service is not configured for user operations")
 		return &serviceerror.InternalServerError
 	}
 
@@ -861,7 +861,7 @@ func (us *userService) validateOrganizationUnitForUserType(
 	}
 
 	if us.entityTypeService == nil {
-		logger.ErrorWithContext(ctx, "Entity type service is not configured for user operations")
+		logger.Error(ctx, "Entity type service is not configured for user operations")
 		return &serviceerror.InternalServerError
 	}
 
@@ -871,13 +871,13 @@ func (us *userService) validateOrganizationUnitForUserType(
 		if svcErr.Code == entitytype.ErrorEntityTypeNotFound.Code {
 			return &ErrorEntityTypeNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to retrieve user type",
+		logger.Error(ctx, "Failed to retrieve user type",
 			log.String("userType", userType), log.Any("error", svcErr))
 		return &serviceerror.InternalServerError
 	}
 
 	if entityType == nil {
-		logger.ErrorWithContext(ctx, "Entity type service returned nil response", log.String("userType", userType))
+		logger.Error(ctx, "Entity type service returned nil response", log.String("userType", userType))
 		return &serviceerror.InternalServerError
 	}
 
@@ -901,7 +901,7 @@ func (us *userService) validateOrganizationUnitForUserType(
 	}
 
 	if !isParent {
-		logger.DebugWithContext(ctx, "Organization unit mismatch for user type",
+		logger.Debug(ctx, "Organization unit mismatch for user type",
 			log.String("userType", userType),
 			log.String("oUID", oUID),
 			log.String("schemaOUID", entityType.OUID))
@@ -952,7 +952,7 @@ func logErrorAndReturnServerError(ctx context.Context,
 	if err != nil {
 		fields = append(fields, log.Error(err))
 	}
-	logger.ErrorWithContext(ctx, message, fields...)
+	logger.Error(ctx, message, fields...)
 	return &serviceerror.InternalServerError
 }
 
@@ -994,14 +994,14 @@ func mapOUServiceError(ctx context.Context,
 	if svcErr.Type == serviceerror.ClientErrorType {
 		logFields := append([]log.Field{}, fields...)
 		logFields = append(logFields, log.Any("error", svcErr))
-		logger.ErrorWithContext(ctx, fmt.Sprintf("Unexpected organization unit client error while %s", context),
+		logger.Error(ctx, fmt.Sprintf("Unexpected organization unit client error while %s", context),
 			logFields...)
 		return &serviceerror.InternalServerError
 	}
 
 	logFields := append([]log.Field{}, fields...)
 	logFields = append(logFields, log.Any("error", svcErr))
-	logger.ErrorWithContext(ctx, fmt.Sprintf("Organization unit service error while %s", context), logFields...)
+	logger.Error(ctx, fmt.Sprintf("Organization unit service error while %s", context), logFields...)
 	return &serviceerror.InternalServerError
 }
 
@@ -1014,7 +1014,7 @@ func (us *userService) checkUserDeclarative(
 		if errors.Is(err, entity.ErrEntityNotFound) {
 			return &ErrorUserNotFound
 		}
-		logger.ErrorWithContext(ctx, "Failed to check if user is declarative",
+		logger.Error(ctx, "Failed to check if user is declarative",
 			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
 		return &serviceerror.InternalServerError
 	}
@@ -1033,7 +1033,7 @@ func (us *userService) checkUserAccess(
 	allowed, svcErr := us.authzService.IsActionAllowed(ctx, action,
 		&sysauthz.ActionContext{ResourceType: security.ResourceTypeUser, OUID: ouID, ResourceID: resourceID})
 	if svcErr != nil {
-		logger.ErrorWithContext(ctx, "Failed to check authorization for action",
+		logger.Error(ctx, "Failed to check authorization for action",
 			log.String("action", string(action)), log.Any("error", svcErr))
 		return &serviceerror.InternalServerError
 	}
@@ -1057,7 +1057,7 @@ func (us *userService) ResolveUserOUHandle(
 ) *serviceerror.ServiceError {
 	if user.OUID != "" && user.OUHandle != "" {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-		logger.WarnWithContext(ctx, "Both ou_id and ou_handle provided for user; ou_handle ignored",
+		logger.Warn(ctx, "Both ou_id and ou_handle provided for user; ou_handle ignored",
 			log.MaskedString(log.LoggerKeyUserID, user.ID))
 		return nil
 	}

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -3292,6 +3292,172 @@ func TestResolveUserOUHandle_NilOUService(t *testing.T) {
 	require.Equal(t, serviceerror.InternalServerError.Code, svcErr.Code)
 }
 
+// TestUserService_GetUser_DisplayOUHandleError verifies that GetUser falls back gracefully
+// when resolving the OU handle for display fails.
+func TestUserService_GetUser_DisplayOUHandleError(t *testing.T) {
+	userID := svcTestUserID1
+	expectedEntity := &entitypkg.Entity{
+		Category:   entitypkg.EntityCategoryUser,
+		ID:         userID,
+		OUID:       testOrgID,
+		Type:       "employee",
+		Attributes: json.RawMessage(`{"email":"alice@example.com"}`),
+	}
+
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("GetEntity", mock.Anything, userID).Return(expectedEntity, nil).Once()
+
+	mockSchema := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockSchema.On("GetDisplayAttributesByNames", mock.Anything, mock.Anything, []string{"employee"}).
+		Return(map[string]string{"employee": "email"}, (*serviceerror.ServiceError)(nil)).Once()
+
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("GetOrganizationUnitHandlesByIDs", mock.Anything, []string{testOrgID}).
+		Return(map[string]string(nil), &serviceerror.InternalServerError).Once()
+
+	service := &userService{
+		entityService:     storeMock,
+		authzService:      newAllowAllAuthz(t),
+		entityTypeService: mockSchema,
+		ouService:         ouServiceMock,
+	}
+
+	user, err := service.GetUser(context.Background(), userID, true)
+	require.Nil(t, err)
+	require.Equal(t, "alice@example.com", user.Display)
+	require.Empty(t, user.OUHandle)
+}
+
+// TestUserService_GetUserGroups_GroupsStoreError verifies that an error from GetEntityGroups
+// surfaces as an internal server error.
+func TestUserService_GetUserGroups_GroupsStoreError(t *testing.T) {
+	userID := svcTestUserID123
+	limit, offset := 10, 0
+
+	mockStore := entitymock.NewEntityServiceInterfaceMock(t)
+	mockStore.On("GetEntity", mock.Anything, userID).
+		Return(&entitypkg.Entity{
+			Category: entitypkg.EntityCategoryUser, ID: userID, OUID: testOrgID,
+		}, nil).Once()
+	mockStore.On("GetGroupCountForEntity", mock.Anything, userID).Return(5, nil).Once()
+	mockStore.On("GetEntityGroups", mock.Anything, userID, limit, offset).
+		Return(([]entitypkg.EntityGroup)(nil), errors.New("db error")).Once()
+
+	service := &userService{
+		entityService: mockStore,
+		authzService:  newAllowAllAuthz(t),
+	}
+
+	_, err := service.GetUserGroups(context.Background(), userID, limit, offset)
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+// TestUserService_DeleteUser_NotFoundOnDelete verifies that a not-found error from the
+// delete call is mapped to the user-not-found error.
+func TestUserService_DeleteUser_NotFoundOnDelete(t *testing.T) {
+	userID := svcTestUserID1
+
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	storeMock.On("GetEntity", mock.Anything, userID).
+		Return(&entitypkg.Entity{
+			Category: entitypkg.EntityCategoryUser, ID: userID, OUID: testOrgID,
+		}, nil).Once()
+	storeMock.On("DeleteEntity", mock.Anything, userID).Return(entitypkg.ErrEntityNotFound).Once()
+
+	service := &userService{
+		entityService: storeMock,
+		authzService:  newAllowAllAuthz(t),
+	}
+
+	err := service.DeleteUser(context.Background(), userID)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorUserNotFound.Code, err.Code)
+}
+
+// TestPopulateOUHandles_HandleResolutionError verifies that populateOUHandles returns early
+// without setting handles when the OU service fails.
+func TestPopulateOUHandles_HandleResolutionError(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("GetOrganizationUnitHandlesByIDs", mock.Anything, []string{testOrgID}).
+		Return(map[string]string(nil), &serviceerror.InternalServerError).Once()
+
+	service := &userService{ouService: ouServiceMock}
+	users := []User{{ID: "user-1", OUID: testOrgID}}
+
+	service.populateOUHandles(context.Background(), users, log.GetLogger())
+	require.Empty(t, users[0].OUHandle)
+}
+
+// TestValidateOrganizationUnitForUserType_NilEntityTypeService verifies that a missing entity
+// type service yields an internal server error after the OU existence check passes.
+func TestValidateOrganizationUnitForUserType_NilEntityTypeService(t *testing.T) {
+	ouID := "2b4f9c1e-2222-4c19-9a94-5866df9b6bf5"
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, ouID).
+		Return(true, (*serviceerror.ServiceError)(nil)).Once()
+
+	service := &userService{ouService: ouServiceMock, entityTypeService: nil}
+
+	err := service.validateOrganizationUnitForUserType(context.Background(), testUserType, ouID, log.GetLogger())
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+// TestValidateOrganizationUnitForUserType_EntityTypeLookupError verifies that an unexpected
+// entity type service error yields an internal server error.
+func TestValidateOrganizationUnitForUserType_EntityTypeLookupError(t *testing.T) {
+	ouID := "3c5fa02d-3333-4ea0-a317-3d8579346d86"
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, ouID).
+		Return(true, (*serviceerror.ServiceError)(nil)).Once()
+
+	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+		Return((*entitytype.EntityType)(nil), &serviceerror.InternalServerError).Once()
+
+	service := &userService{ouService: ouServiceMock, entityTypeService: entityTypeMock}
+
+	err := service.validateOrganizationUnitForUserType(context.Background(), testUserType, ouID, log.GetLogger())
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+// TestValidateOrganizationUnitForUserType_NilEntityType verifies that a nil entity type
+// response yields an internal server error.
+func TestValidateOrganizationUnitForUserType_NilEntityType(t *testing.T) {
+	ouID := "4d60b13e-4444-4ea0-a317-3d8579346d86"
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, ouID).
+		Return(true, (*serviceerror.ServiceError)(nil)).Once()
+
+	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+		Return((*entitytype.EntityType)(nil), (*serviceerror.ServiceError)(nil)).Once()
+
+	service := &userService{ouService: ouServiceMock, entityTypeService: entityTypeMock}
+
+	err := service.validateOrganizationUnitForUserType(context.Background(), testUserType, ouID, log.GetLogger())
+	require.NotNil(t, err)
+	require.Equal(t, serviceerror.InternalServerError.Code, err.Code)
+}
+
+// TestMapOUServiceError_UnmappedClientError verifies that an unmapped client-type OU error is
+// logged and mapped to an internal server error.
+func TestMapOUServiceError_UnmappedClientError(t *testing.T) {
+	clientErr := &serviceerror.ServiceError{
+		Type: serviceerror.ClientErrorType,
+		Code: "OU-UNMAPPED-1",
+	}
+
+	result := mapOUServiceError(context.Background(), clientErr, log.GetLogger(),
+		"performing an operation", map[string]*serviceerror.ServiceError{})
+
+	require.NotNil(t, result)
+	require.Equal(t, serviceerror.InternalServerError.Code, result.Code)
+}
+
 // TestUserDeclarativeYAML_OUHandleParsed verifies that ou_handle is parsed off the YAML
 // document into the user declarative resource.
 func TestUserDeclarativeYAML_OUHandleParsed(t *testing.T) {

--- a/docs/content/community/contributing/contributing-code/backend-development/overview.mdx
+++ b/docs/content/community/contributing/contributing-code/backend-development/overview.mdx
@@ -28,7 +28,7 @@ Each domain package under `internal/` follows a flat structure:
 
 - **File naming**: `snake_case` (e.g., `error_constants.go`)
 - **Exports**: Only export service interface and models used in service. Keep implementations, constants, queries unexported.
-- **Logging**: Use `log` package from `internal/system`. Avoid PII; use `MaskString` for sensitive data.
+- **Logging**: Use the `log` package from `internal/system`. Pass the request `context.Context` as the first argument to the logging methods (e.g. `Info(ctx, …)`/`Error(ctx, …)`) so entries carry the correlation (trace) ID. For non-request code (startup, shutdown, detached goroutines), pass `context.Background()` — or `context.WithoutCancel(ctx)` to keep the trace ID across a goroutine — with a short comment explaining why no request context is available. Avoid PII; use `MaskString` for sensitive data.
 
 ## Mock Generation
 


### PR DESCRIPTION
### Purpose

Final phase of the correlation-ID logging work (#2038). Now that every backend call site has migrated to the context-aware logging methods (completed in#3238), this PR locks the migration in and removes the transitional API:

  - Deletes the deprecated non-context `Logger.Info/Debug/Warn/Error/Fatal` methods and removes the temporary `staticcheck`/SA1019 `exclude-rule` from `backend/.golangci.yml` that suppressed their deprecation warnings.
  - Renames the context-aware `*WithContext` methods back to the clean names `Info`/`Debug`/`Warn`/`Error`/`Fatal`, each now taking `context.Context` as its first argument.

End state: `logger.Info(ctx, "msg")`. A log call without a context is now a **compile error**, so logs can no longer silently lose the correlation (trace) ID.

This touches the `internal/system/log` package only — there is no external or public API impact.

### Approach

Two mechanical, compiler-verified steps:

1. **Lock-in (deprecation removal).** Verified zero remaining usages of the deprecated methods (SA1019 with the exclude-rule neutralised), then deleted the five methods, removed the SA1019 exclude-rule, and dropped the now-obsolete `TestDeprecatedMethodsEmitNoTraceID` test.
  2. **Rename to the clean API.** Renamed `InfoWithContext` → `Info`,`DebugWithContext` → `Debug`, `WarnWithContext` → `Warn`, `ErrorWithContext` → `Error`, `FatalWithContext` → `Fatal` across all call sites (the names were freed by step 1). `Logger.WithContext` (then derived-logger helper) is a distinct method and is untouched.

The backend contribution guide's logging guidance was updated to the final `Info(ctx, …)` form.

Verified with `go build ./...`, `go vet ./...`, `gofmt`, the full unit test suite, and `golangci-lint run ./...` (0 issues) — the compiler guarantees the rename is complete.

### Related Issues
 - Refs #2038

### Related PRs
- #3238 (Phase 2 — migrated all call sites to the context-aware methods)

### Checklist
  - [x] Followed the contribution guidelines.
  - [ ] Manual test round performed and verified.
  - [x] Documentation provided. (Updated the backend logging guidance in `docs/.../backend-development/overview.mdx`)
      - [ ] Ran Vale and fixed all errors and warnings
  - [x] Tests provided. (Updated existing `internal/system/log` tests; rename completeness is compiler-enforced)
      - [x] Unit Tests
      - [ ] Integration Tests
  - [ ] Breaking changes. (Internal `internal/system/log` API only — no external impact)
      - [ ] Breaking changes section filled.
      - [ ] `breaking change` label added.

### Security checks
  - [x] Followed secure coding standards in [WSO2 Secure Coding 
  Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.