### PR TITLE
Fix b2c try it out flows

### DIFF
--- a/docs/content/use-cases/b2c/try-it-out/onboard-internal-users.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/onboard-internal-users.mdx
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 # Onboard Internal Users
 
-In this walkthrough, Alex Carter signs in to the <ProductName /> Console as the operations admin. He invites two new staff members: Sam Rivera onto the support team and Maya Patel onto the destinations team. Each invitee receives an email, opens the link, fills in a few additional attributes, and gets onboarded.
+In this walkthrough, you sign in to the <ProductName /> Console as your admin user and invite two new staff members: Sam Rivera onto the support team and Maya Patel onto the destinations team. Each invitee receives an email, opens the link, fills in a few additional attributes, and gets onboarded.
 
 Onboarding internal users happens entirely in the <ProductName /> Console, so this walkthrough applies regardless of which solution pattern the app uses.
 
@@ -35,10 +35,10 @@ Complete [Set Up Your Environment](../../try-it-out#set-up-your-environment) bef
 
 The Wayfinder onboarding flow prompts the admin to pick the staff role (Support or DestinationsAdmin), then collects the invitee's email and sends the invitation. When the invitee accepts, the matching role is attached automatically, with no separate role-assignment step.
 
-1. Sign in to the <ProductName /> Console as Alex Carter (`alex.carter` / `alex.carter`).
-2. Navigate to **Users** and select **Invite User**.
+1. Sign in to the <ProductName /> Console at <ConsoleUrl /> as your admin user.
+2. Navigate to **Users** and select **Add User**.
 3. Select `Staff` as the user type.
-4. Pick **Support** as the role, enter Sam Rivera's email (`sam.rivera@example.com`), and send the invitation. <ProductName /> emails Sam an invite link.
+4. Pick **Support** as the role, enter Sam Rivera's email (`sam.rivera@example.com`), and click **Send invitation**. <ProductName /> emails Sam an invite link.
 5. Open the email in Sam's inbox and open the link. The browser opens a **Complete Your Profile** page.
 6. Fill in the additional attributes (username `sam.rivera`, display name `Sam Rivera`, a password) and submit. Sam's account is now active with the `Support` role attached.
 7. Repeat the flow for Maya Patel (email `maya.patel@example.com`, username `maya.patel`), picking **DestinationsAdmin** as the role.

--- a/docs/content/use-cases/b2c/try-it-out/self-sign-up.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/self-sign-up.mdx
@@ -28,9 +28,9 @@ In the redirect-based pattern, the consumer app sends the user to <ProductName /
 1. Open <WayFinderSampleUrl />. The Wayfinder home page loads.
 2. Select **Sign in**. The browser navigates to <ProductName />.
 3. Select **Sign up**. The browser navigates to the <ProductName /> sign-up page.
-4. Fill in Emma's details (username `emma.wilson`, email `emma.wilson@example.com`, given name `Emma`, family name `Wilson`, and a password), then submit.
-5. <ProductName /> runs the sign-up flow: it creates a `Customer` user, records her terms acceptance, and assigns the `Traveler` role.
-6. The browser returns to Wayfinder. Emma arrives at the dashboard, ready to make her first booking.
+4. Fill in Emma's details (username `emma.wilson`, email `emma.wilson@example.com`, first name `Emma`, last name `Wilson`, mobile number `+15550148812`, and a password), then submit.
+5. <ProductName /> runs the sign-up flow: it creates a `Customer` user and assigns the `Traveler` role.
+6. The browser returns to Wayfinder.
 
 **Try a Variant**
 

--- a/frontend/apps/console/src/features/welcome/components/WayfinderConfigImport.tsx
+++ b/frontend/apps/console/src/features/welcome/components/WayfinderConfigImport.tsx
@@ -192,7 +192,7 @@ export default function WayfinderConfigImport({onSuccess = undefined}: Wayfinder
           onClick={() => void handleImport()}
           disabled={!bundle?.configs.declarative}
         >
-          {t('common:welcome.wayfinderFolderImport.actions.importConfig')}
+          {t('common:welcome.wayfinderFolderImport.actions.importConfig', {productName})}
         </Button>
       </Box>
 

--- a/frontend/apps/console/src/features/welcome/components/__tests__/WayfinderConfigImport.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/WayfinderConfigImport.test.tsx
@@ -87,13 +87,17 @@ describe('WayfinderConfigImport', () => {
 
   it('renders the import button when idle', () => {
     render(<WayfinderConfigImport />);
-    expect(screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig')).toBeInTheDocument();
+    expect(
+      screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig:{"productName":"ThunderID"}'),
+    ).toBeInTheDocument();
   });
 
   it('disables the button when the bundle is missing declarative content', () => {
     mockUseGetSampleBundle.mockReturnValueOnce(undefined);
     render(<WayfinderConfigImport />);
-    const button = screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig').closest('button');
+    const button = screen
+      .getByText('common:welcome.wayfinderFolderImport.actions.importConfig:{"productName":"ThunderID"}')
+      .closest('button');
     expect(button).toBeDisabled();
   });
 
@@ -105,7 +109,9 @@ describe('WayfinderConfigImport', () => {
     const onSuccess = vi.fn();
     render(<WayfinderConfigImport onSuccess={onSuccess} />);
 
-    await userEvent.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig'));
+    await userEvent.click(
+      screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig:{"productName":"ThunderID"}'),
+    );
 
     await waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledWith({
@@ -130,7 +136,9 @@ describe('WayfinderConfigImport', () => {
     mockMutateAsync.mockRejectedValueOnce(new Error('boom'));
     render(<WayfinderConfigImport />);
 
-    await userEvent.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig'));
+    await userEvent.click(
+      screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig:{"productName":"ThunderID"}'),
+    );
 
     await waitFor(() => {
       expect(screen.getByText('common:welcome.wayfinderFolderImport.errors.importFailed')).toBeInTheDocument();
@@ -149,7 +157,9 @@ describe('WayfinderConfigImport', () => {
     const onSuccess = vi.fn();
     render(<WayfinderConfigImport onSuccess={onSuccess} />);
 
-    await userEvent.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig'));
+    await userEvent.click(
+      screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig:{"productName":"ThunderID"}'),
+    );
 
     await waitFor(() => {
       expect(
@@ -173,7 +183,9 @@ describe('WayfinderConfigImport', () => {
 
     await userEvent.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.reconfigure'));
 
-    expect(screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig')).toBeInTheDocument();
+    expect(
+      screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig:{"productName":"ThunderID"}'),
+    ).toBeInTheDocument();
   });
 
   it('skips comments and blank lines when parsing the env bundle', async () => {
@@ -186,7 +198,9 @@ describe('WayfinderConfigImport', () => {
     mockMutateAsync.mockResolvedValueOnce({summary: {imported: 1, failed: 0}, results: []});
     render(<WayfinderConfigImport />);
 
-    await userEvent.click(screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig'));
+    await userEvent.click(
+      screen.getByText('common:welcome.wayfinderFolderImport.actions.importConfig:{"productName":"ThunderID"}'),
+    );
 
     await waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledWith({

--- a/frontend/apps/console/src/features/welcome/pages/TryoutSecuringApplicationPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/TryoutSecuringApplicationPage.tsx
@@ -412,12 +412,12 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
                 {scenarioTab === 'signup' && (
                   <Stack spacing={2}>
                     <Typography variant="body2" color="text.secondary">
-                      {t('common:welcome.applicationTryout.scenarios.signup.description')}
+                      {t('common:welcome.applicationTryout.scenarios.signup.description', {productName})}
                     </Typography>
                     <StepList
                       steps={[
                         tLink('welcome.applicationTryout.scenarios.signup.step1'),
-                        t('common:welcome.applicationTryout.scenarios.signup.step2'),
+                        t('common:welcome.applicationTryout.scenarios.signup.step2', {productName}),
                         t('common:welcome.applicationTryout.scenarios.signup.step3'),
                       ]}
                     />
@@ -439,12 +439,16 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
                           label: t('common:welcome.applicationTryout.scenarios.signup.sampleFields.familyName'),
                           value: 'Wilson',
                         },
+                        {
+                          label: t('common:welcome.applicationTryout.scenarios.signup.sampleFields.mobileNumber'),
+                          value: '+15550148812',
+                        },
                       ]}
                     />
                     <StepList
                       startFrom={4}
                       steps={[
-                        t('common:welcome.applicationTryout.scenarios.signup.step4'),
+                        t('common:welcome.applicationTryout.scenarios.signup.step4', {productName}),
                         t('common:welcome.applicationTryout.scenarios.signup.step5'),
                       ]}
                     />
@@ -460,7 +464,7 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
                       steps={[
                         tLink('welcome.applicationTryout.scenarios.profile.step1'),
                         t('common:welcome.applicationTryout.scenarios.profile.step2'),
-                        t('common:welcome.applicationTryout.scenarios.profile.step3'),
+                        t('common:welcome.applicationTryout.scenarios.profile.step3', {productName}),
                       ]}
                     />
                     <CredentialsBlock username="john.doe" password="john.doe" />
@@ -478,9 +482,9 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
                     <StepList
                       steps={[
                         tLink('welcome.applicationTryout.scenarios.recovery.step1'),
-                        t('common:welcome.applicationTryout.scenarios.recovery.step2'),
+                        t('common:welcome.applicationTryout.scenarios.recovery.step2', {productName}),
                         t('common:welcome.applicationTryout.scenarios.recovery.step3'),
-                        t('common:welcome.applicationTryout.scenarios.recovery.step4'),
+                        t('common:welcome.applicationTryout.scenarios.recovery.step4', {productName}),
                         t('common:welcome.applicationTryout.scenarios.recovery.step5'),
                         t('common:welcome.applicationTryout.scenarios.recovery.step6'),
                       ]}
@@ -491,19 +495,20 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
                 {scenarioTab === 'onboard' && (
                   <Stack spacing={2}>
                     <Typography variant="body2" color="text.secondary">
-                      {t('common:welcome.applicationTryout.scenarios.onboard.description')}
+                      {t('common:welcome.applicationTryout.scenarios.onboard.description', {productName})}
                     </Typography>
                     <Alert severity="info" sx={{fontSize: '0.8rem'}}>
                       {t('common:welcome.applicationTryout.scenarios.onboard.smtpNote', {productName})}
                     </Alert>
-                    <StepList steps={[tLink('welcome.applicationTryout.scenarios.onboard.step1')]} />
-                    <CredentialsBlock username="alex.carter" password="alex.carter" />
                     <StepList
-                      startFrom={2}
                       steps={[
+                        t('common:welcome.applicationTryout.scenarios.onboard.step1', {productName}),
                         t('common:welcome.applicationTryout.scenarios.onboard.step2'),
                         t('common:welcome.applicationTryout.scenarios.onboard.step3'),
                         t('common:welcome.applicationTryout.scenarios.onboard.step4'),
+                        t('common:welcome.applicationTryout.scenarios.onboard.step5'),
+                        t('common:welcome.applicationTryout.scenarios.onboard.step6'),
+                        t('common:welcome.applicationTryout.scenarios.onboard.step7'),
                       ]}
                     />
                   </Stack>

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringApplicationPage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringApplicationPage.test.tsx
@@ -213,7 +213,9 @@ describe('TryoutSecuringApplicationPage', () => {
 
     await user.click(screen.getByText('common:welcome.applicationTryout.scenarios.tabs.signup'));
 
-    expect(screen.getByText('common:welcome.applicationTryout.scenarios.signup.description')).toBeInTheDocument();
+    expect(
+      screen.getByText('common:welcome.applicationTryout.scenarios.signup.description:ThunderID'),
+    ).toBeInTheDocument();
   });
 
   it('shows profile scenario when profile tab is clicked', async () => {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -203,7 +203,7 @@ const translations = {
 
     'welcome.wayfinderFolderImport.actions.selectFolder': 'Select Wayfinder Sample Folder',
     'welcome.wayfinderFolderImport.actions.change': 'Change',
-    'welcome.wayfinderFolderImport.actions.importConfig': 'Configure in ThunderID',
+    'welcome.wayfinderFolderImport.actions.importConfig': 'Configure in {{productName}}',
     'welcome.wayfinderFolderImport.actions.reconfigure': 'Reconfigure',
     'welcome.wayfinderFolderImport.actions.reSelectFolder': 'Re-select Folder',
     'welcome.wayfinderFolderImport.status.importing': 'Importing configuration…',
@@ -269,18 +269,19 @@ const translations = {
     'welcome.applicationTryout.scenarios.login.step2': 'Click Sign in and use the credentials below.',
 
     'welcome.applicationTryout.scenarios.signup.description':
-      'Register a new customer account and see ThunderID assign the Traveler role automatically on completion.',
+      'Register a new customer account and see {{productName}} assign the Traveler role automatically on completion.',
     'welcome.applicationTryout.scenarios.signup.step1': 'Open <a>http://localhost:5173</a> and click Sign in.',
-    'welcome.applicationTryout.scenarios.signup.step2': 'On the ThunderID page, click Sign up.',
-    'welcome.applicationTryout.scenarios.signup.step3': 'Fill in the registration form using the sample details below.',
+    'welcome.applicationTryout.scenarios.signup.step2': 'On the {{productName}} page, click Sign up.',
+    'welcome.applicationTryout.scenarios.signup.step3':
+      'Fill in the registration form using the sample details below. Enter a password of your choice.',
     'welcome.applicationTryout.scenarios.signup.sampleFields.username': 'Username',
     'welcome.applicationTryout.scenarios.signup.sampleFields.email': 'Email',
-    'welcome.applicationTryout.scenarios.signup.sampleFields.givenName': 'Given name',
-    'welcome.applicationTryout.scenarios.signup.sampleFields.familyName': 'Family name',
+    'welcome.applicationTryout.scenarios.signup.sampleFields.givenName': 'First name',
+    'welcome.applicationTryout.scenarios.signup.sampleFields.familyName': 'Last name',
+    'welcome.applicationTryout.scenarios.signup.sampleFields.mobileNumber': 'Mobile number',
     'welcome.applicationTryout.scenarios.signup.step4':
-      'Submit. ThunderID creates a Customer user, records terms acceptance, and assigns the Traveler role.',
-    'welcome.applicationTryout.scenarios.signup.step5':
-      'The browser redirects back to Wayfinder with the new account authenticated.',
+      'Submit. {{productName}} creates a Customer user and assigns the Traveler role.',
+    'welcome.applicationTryout.scenarios.signup.step5': 'The browser redirects back to Wayfinder.',
 
     'welcome.applicationTryout.scenarios.profile.description':
       'Explore the self-service profile page — view account details, edit attributes, and change your password.',
@@ -288,32 +289,35 @@ const translations = {
     'welcome.applicationTryout.scenarios.profile.step2':
       'Click the username in the top-right corner and select Profile.',
     'welcome.applicationTryout.scenarios.profile.step3':
-      'View account details, edit profile attributes, or change your password. The page calls the identity provider directly with your session token.',
+      'View account details, edit profile attributes, or change your password. The page calls {{productName}} directly with your session token.',
 
     'welcome.applicationTryout.scenarios.recovery.description':
       'Walk through the password recovery flow — John forgets his password and resets it via email.',
     'welcome.applicationTryout.scenarios.recovery.smtpNote':
       "Recovery emails require a configured SMTP server. Add your SMTP settings under email.smtp in {{productName}}'s deployment.yaml and restart the server before trying this flow.",
     'welcome.applicationTryout.scenarios.recovery.step1': 'Open <a>http://localhost:5173</a> and click Sign in.',
-    'welcome.applicationTryout.scenarios.recovery.step2': 'On the ThunderID sign-in page, click Forgot password?',
+    'welcome.applicationTryout.scenarios.recovery.step2': 'On the {{productName}} sign-in page, click Forgot password?',
     'welcome.applicationTryout.scenarios.recovery.step3': 'Enter john.doe as the username and submit.',
     'welcome.applicationTryout.scenarios.recovery.step4':
-      "ThunderID sends a recovery email to John's registered address.",
+      "{{productName}} sends a recovery email to John's registered address.",
     'welcome.applicationTryout.scenarios.recovery.step5': 'Open the link in the email and set a new password.',
     'welcome.applicationTryout.scenarios.recovery.step6': 'Sign in again with the new credentials.',
 
     'welcome.applicationTryout.scenarios.onboard.description':
-      'Invite and onboard a new staff member using the staff invitation flow. The invited user selects a role (Support or DestinationsAdmin) during onboarding.',
+      'Invite and onboard two new staff members entirely from the {{productName}} Console: Sam Rivera (Support) and Maya Patel (DestinationsAdmin). The admin picks the staff role and sends the invitation, and the matching role is attached automatically when the invitee completes their profile.',
     'welcome.applicationTryout.scenarios.onboard.smtpNote':
-      "Staff invitation emails require a configured SMTP server. Add your SMTP settings under email.smtp in {{productName}}'s deployment.yaml and restart the server before trying this flow.",
-    'welcome.applicationTryout.scenarios.onboard.step1':
-      'Sign in as alex.carter (OpsAdmin) at <a>http://localhost:5173</a> using the credentials below.',
-    'welcome.applicationTryout.scenarios.onboard.step2':
-      'Navigate to the staff management section and invite a new staff member by email.',
-    'welcome.applicationTryout.scenarios.onboard.step3':
-      'The invited user receives an onboarding email. They open the link and complete the onboarding flow, choosing between the Support and DestinationsAdmin roles.',
+      "Staff invitation requires a configured SMTP server and the user onboarding flow enabled. Add your SMTP settings under email.smtp and set flow.user_onboarding_flow_handle to wayfinder-onboarding-flow in {{productName}}'s deployment.yaml, then restart the server before trying this flow.",
+    'welcome.applicationTryout.scenarios.onboard.step1': 'Sign in to the {{productName}} Console as your admin user.',
+    'welcome.applicationTryout.scenarios.onboard.step2': 'Navigate to Users and select Add User.',
+    'welcome.applicationTryout.scenarios.onboard.step3': 'Select Staff as the user type.',
     'welcome.applicationTryout.scenarios.onboard.step4':
-      'Once onboarded, the new staff member can sign in to the app with their chosen role permissions active.',
+      "Pick Support as the role, enter Sam Rivera's email (sam.rivera@example.com), and click Send invitation. An invite link is emailed to Sam.",
+    'welcome.applicationTryout.scenarios.onboard.step5':
+      "Open the email in Sam's inbox and open the link. The browser opens a Complete Your Profile page.",
+    'welcome.applicationTryout.scenarios.onboard.step6':
+      "Fill in the additional attributes and submit. Sam's account is now active with the Support role attached.",
+    'welcome.applicationTryout.scenarios.onboard.step7':
+      'Repeat the flow for Maya Patel (email maya.patel@example.com), picking DestinationsAdmin as the role.',
 
     'welcome.aiAgentsTryout.breadcrumb': 'Tryout Securing AI Agents',
     'welcome.aiAgentsTryout.overline': 'Securing AI Agents',

--- a/samples/apps/wayfinder-sample/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/thunderid-config.yaml
@@ -36,11 +36,6 @@ schema: {
       "displayName": "Last Name",
       "required": false
     },
-    "sub": {
-      "type": "string",
-      "displayName": "Federated Subject",
-      "required": false
-    },
     "mobileNumber": {
       "type": "string",
       "displayName": "Mobile Number",
@@ -241,6 +236,7 @@ nodes:
     type: TASK_EXECUTION
     properties:
       assignRole: wayfinder-traveler-role
+      includeOptional: true
     executor:
       name: ProvisioningExecutor
       inputs:
@@ -650,7 +646,7 @@ nodes:
         - align: center
           type: TEXT
           id: text_header_user_details_s
-          label: Complete your profile
+          label: Complete Your Profile
           variant: HEADING_1
         - type: BLOCK
           id: block_user_details_s
@@ -770,7 +766,7 @@ nodes:
         - align: center
           type: TEXT
           id: text_header_user_details_d
-          label: Complete your profile
+          label: Complete Your Profile
           variant: HEADING_1
         - type: BLOCK
           id: block_user_details_d
@@ -831,7 +827,6 @@ assertion:
     - family_name
     - email
     - groups
-    - sub
     - username
 allowed_user_types:
   - Customer
@@ -870,7 +865,6 @@ inbound_auth_config:
           - username
           - given_name
           - family_name
-          - sub
         group:
           - groups
 


### PR DESCRIPTION
### Purpose
This pull request updates both the documentation and b2c try it out configs to improve clarity and accuracy of the onboarding and self-sign-up flows. The changes clarify steps for onboarding internal users, update sample user data, and align terminology across the product, documentation, and sample configuration.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mobile number field to signup and sample forms; "Invite User" label changed to "Add User" in walkthroughs.

* **Documentation**
  * Updated B2C onboarding and self-sign-up walkthroughs with first/last name wording, streamlined post-signup outcomes, and clearer Console sign-in/text.
  * Rewrote staff onboarding into a two-invite flow with explicit invitees, roles, and step-by-step Console guidance.
  * Sample copy now consistently interpolates the product name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->