### PR TITLE
Document bundling Monaco locally to avoid the CDN

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -59,6 +59,18 @@ reviews:
         For JSX string content, prefer the `<ProductName />` component if it is available in this context.
         Do not flag occurrences inside comments, type names, or import paths.
 
+    - path: "frontend/apps/**/*.{ts,tsx}"
+      instructions: |
+        Flag any direct import of `@monaco-editor/react` or `monaco-editor` in application code.
+        Monaco editor usage must go through the local wrapper `@/lib/MonacoEditor`
+        (e.g. `import Editor from '@/lib/MonacoEditor';`), which runs the worker setup and calls
+        `loader.config({monaco})` so Monaco and its language workers are bundled locally instead of
+        loaded from the jsDelivr CDN. A direct import bypasses this setup and reintroduces the CDN
+        dependency, which breaks in air-gapped / no-internet deployments.
+        EXEMPT the wrapper and setup files themselves — `**/lib/MonacoEditor.ts` and
+        `**/lib/monaco-setup.ts` are the only files allowed to import `@monaco-editor/react` or
+        `monaco-editor` directly. Do not flag these files.
+
     - path: "docs/**"
       instructions: |
         Scan for hardcoded occurrences of the string literals `Thunder` or `ThunderID`.

--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -193,3 +193,4 @@ EUDI
 [Vv]erifiable
 [Kk]rakenD
 [Gg]oroutines?
+jsDelivr

--- a/docs/content/community/contributing/contributing-code/frontend-development/overview.mdx
+++ b/docs/content/community/contributing/contributing-code/frontend-development/overview.mdx
@@ -34,6 +34,65 @@ my-feature/
 └── utils/        # Utility functions
 ```
 
+## Monaco Editor
+
+By default `@monaco-editor/react` loads the Monaco editor **and** its language workers from the jsDelivr CDN. This breaks in air-gapped or no-internet deployments, so Monaco is bundled locally and all editor usage goes through a local wrapper.
+
+### Using Monaco in an Existing Console Page
+
+Always import the editor from the local wrapper — never from `@monaco-editor/react` directly:
+
+```tsx
+import Editor, {type OnMount, type EditorProps} from '@/lib/MonacoEditor';
+```
+
+Importing from `@/lib/MonacoEditor` (`frontend/apps/console/src/lib/MonacoEditor.ts`) runs `monaco-setup` as a side effect, which bundles Monaco and its workers locally and calls `loader.config({monaco})`. Importing `@monaco-editor/react` directly skips that setup and falls back to loading Monaco from the CDN, which fails offline.
+
+For a **lazy-loaded** page or feature that pulls in Monaco, import `./lib/monaco-setup` before the lazy chunk so setup runs first — see the `TranslationsEditPage` pattern in `App.tsx`:
+
+```tsx
+const TranslationsEditPage = lazy(() =>
+  import('./lib/monaco-setup').then(() =>
+    import('@thunderid/configure-translations').then((m) => ({default: m.TranslationsEditPage})),
+  ),
+);
+```
+
+### Setting Up Monaco in a New App
+
+Replicate the same pattern:
+
+- Add `monaco-editor` to `dependencies` (not `devDependencies`, so it ships in the build) alongside `@monaco-editor/react` (`catalog:`).
+- Create `src/lib/monaco-setup.ts` that imports the workers via Vite's `?worker` suffix, maps them by `label`, and points the loader at the bundled instance:
+
+  ```ts
+  import {loader} from '@monaco-editor/react';
+  import * as monaco from 'monaco-editor';
+  import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+  import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
+  import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+
+  self.MonacoEnvironment = {
+    getWorker(_, label) {
+      if (label === 'json') return new jsonWorker();
+      if (label === 'css' || label === 'scss' || label === 'less') return new cssWorker();
+      return new editorWorker();
+    },
+  };
+
+  loader.config({monaco});
+  ```
+
+- Create `src/lib/MonacoEditor.ts` that imports `./monaco-setup` then re-exports the `@monaco-editor/react` default and types:
+
+  ```ts
+  import './monaco-setup';
+  export {default} from '@monaco-editor/react';
+  export type {BeforeMount, EditorProps, OnChange, OnMount} from '@monaco-editor/react';
+  ```
+
+Only `json` and `css`/`scss`/`less` get dedicated workers; everything else (`yaml`, `shell`, …) uses the generic `editor.worker`. To add richer support for another language, add its `*.worker?worker` import and a matching `getWorker` branch.
+
 ## Scaffolding Tool
 
 <ProductName /> includes a CLI scaffolding tool (`@thunderid/create`) that generates production-ready feature packages. See the [Scaffolding Tool](scaffolding-tool.mdx) guide for details.


### PR DESCRIPTION
### Purpose

The recent commit [`56729fc7`](https://github.com/thunder-id/thunderid/commit/56729fc72ad06b983b701609ed05aecc3fa3cc59) ("Bundle Monaco editor locally to support no-internet environments") changed the Console app to bundle the Monaco editor locally instead of loading it from the jsDelivr CDN, so it works in air-gapped / no-internet deployments. The mechanism is undocumented, so a contributor adding an editor to a Console page — or scaffolding a new frontend app — can easily reintroduce the CDN dependency by importing `@monaco-editor/react` directly.

This PR captures the pattern in agent-referenced contribution guidance and adds a CodeRabbit rule to enforce it in review.

### Approach

- **Frontend contribution guide** (`docs/.../frontend-development/overview.mdx`): added a **Monaco Editor** section covering both cases:
  - *Using Monaco in an existing Console page* — always import `Editor` from `@/lib/MonacoEditor` (never `@monaco-editor/react` directly), and the lazy-load ordering for pages that pull in Monaco.
  - *Setting up Monaco in a new app* — replicate `monaco-setup.ts` (Vite `?worker` imports + `MonacoEnvironment.getWorker` + `loader.config({monaco})`) and the `MonacoEditor.ts` wrapper, and keep `monaco-editor` in `dependencies`.
- **CodeRabbit** (`.coderabbit.yaml`): added a `path_instructions` entry for `frontend/apps/**/*.{ts,tsx}` that flags direct `@monaco-editor/react` / `monaco-editor` imports and requires the local wrapper, while exempting the wrapper/setup files themselves.
- **Vale vocabulary** (`accept.txt`): added `jsDelivr` so the docs pass Vale.

No application code is changed — documentation and review configuration only.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Monaco Editor development guidelines and setup instructions for frontend development.

* **Chores**
  * Updated development tooling to enforce Monaco Editor import standards and local bundling practices.
  * Added an acceptance vocabulary term to linting configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->