### PR TITLE
Update wayfinder self signup with a registration completion page

### DIFF
--- a/docs/content/use-cases/b2c/configure-it-yourself.mdx
+++ b/docs/content/use-cases/b2c/configure-it-yourself.mdx
@@ -116,7 +116,7 @@ The registration flow drives [Self Sign-Up](../try-it-out/self-sign-up). It:
 - Prompts for username and password.
 - Runs basic-auth and provisioning, with `properties.assignRole` set to attach the `Traveler` role automatically.
 - Prompts for any remaining required schema attributes (rendered dynamically from the user type).
-- Returns an auth assertion so the new user lands signed in.
+- Ends on a confirmation screen with a link back to the application, where the user can sign in with their new credentials.
 
 1. Save the JSON below as `wayfinder-registration-flow.json` and POST it to the flows API:
 
@@ -203,7 +203,7 @@ The registration flow drives [Self Sign-Up](../try-it-out/self-sign-up). It:
        {
          "id": "provisioning",
          "type": "TASK_EXECUTION",
-         "properties": { "assignRole": "wayfinder-traveler-role" },
+         "properties": { "assignRole": "wayfinder-traveler-role", "includeOptional": true },
          "executor": {
            "name": "ProvisioningExecutor",
            "inputs": [
@@ -211,7 +211,7 @@ The registration flow drives [Self Sign-Up](../try-it-out/self-sign-up). It:
              { "ref": "input_password", "identifier": "password", "type": "PASSWORD_INPUT", "required": true }
            ]
          },
-         "onSuccess": "auth_assert",
+         "onSuccess": "registration_complete",
          "onIncomplete": "prompt_schema_attrs"
        },
        {
@@ -235,10 +235,31 @@ The registration flow drives [Self Sign-Up](../try-it-out/self-sign-up). It:
          ]
        },
        {
-         "id": "auth_assert",
-         "type": "TASK_EXECUTION",
-         "executor": { "name": "AuthAssertExecutor" },
-         "onSuccess": "end"
+         "id": "registration_complete",
+         "type": "PROMPT",
+         "meta": {
+           "components": [
+             { "align": "center", "type": "TEXT", "id": "registration_complete_icon", "label": "✅", "variant": "HEADING_1" },
+             { "align": "center", "type": "TEXT", "id": "registration_complete_heading", "label": "Account Created", "variant": "HEADING_1" },
+             { "align": "center", "type": "TEXT", "id": "registration_complete_message", "label": "Your Wayfinder account is ready. Sign in to start exploring.", "variant": "HEADING_6" },
+             {
+               "type": "STACK",
+               "id": "registration_complete_link_stack",
+               "category": "BLOCK",
+               "align": "center",
+               "direction": "row",
+               "justify": "center",
+               "gap": 2,
+               "items": 1,
+               "resourceType": "ELEMENT",
+               "components": [
+                 { "type": "RICH_TEXT", "id": "registration_complete_link", "category": "DISPLAY", "resourceType": "ELEMENT", "label": "<h3 class=\"rich-text-heading-h3\"><a href=\"{{meta(application.url)}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Go to Wayfinder</span></a></h3>" }
+               ]
+             }
+           ]
+         },
+         "message": "Registration complete",
+         "next": "end"
        },
        { "id": "end", "type": "END" }
      ]

--- a/docs/content/use-cases/b2c/try-it-out/self-sign-up.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/self-sign-up.mdx
@@ -30,7 +30,7 @@ In the redirect-based pattern, the consumer app sends the user to <ProductName /
 3. Select **Sign up**. The browser navigates to the <ProductName /> sign-up page.
 4. Fill in Emma's details (username `emma.wilson`, email `emma.wilson@example.com`, first name `Emma`, last name `Wilson`, mobile number `+15550148812`, and a password), then submit.
 5. <ProductName /> runs the sign-up flow: it creates a `Customer` user and assigns the `Traveler` role.
-6. The browser returns to Wayfinder.
+6. <ProductName /> shows a confirmation screen with a link to redirect back to the Wayfinder app.
 
 **Try a Variant**
 

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -290,7 +290,7 @@ const translations = {
     'welcome.applicationTryout.scenarios.signup.step4':
       'Fill in the registration form using these sample details and click Submit.',
     'welcome.applicationTryout.scenarios.signup.step5':
-      '{{productName}} will create a Customer user and assign the Traveler role. And browser redirects back to Wayfinder.',
+      '{{productName}} will create a Customer user and assign the Traveler role. The browser shows a confirmation screen with a link to redirect back to the Wayfinder app.',
     'welcome.applicationTryout.scenarios.profile.description':
       'Explore the self-service profile page - view account details, edit attributes, and change your password.',
     'welcome.applicationTryout.scenarios.profile.step1': 'Sign in as John at <a>http://localhost:5173</a>.',

--- a/samples/apps/wayfinder-sample/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/thunderid-config.yaml
@@ -248,7 +248,7 @@ nodes:
           identifier: password
           type: PASSWORD_INPUT
           required: true
-    onSuccess: auth_assert
+    onSuccess: registration_complete
     onIncomplete: prompt_schema_attrs
   - id: prompt_schema_attrs
     type: PROMPT
@@ -274,11 +274,42 @@ nodes:
         action:
           ref: action_schema_attrs
           nextNode: provisioning
-  - id: auth_assert
-    type: TASK_EXECUTION
-    executor:
-      name: AuthAssertExecutor
-    onSuccess: end
+  - id: registration_complete
+    type: PROMPT
+    meta:
+      components:
+        - align: center
+          type: TEXT
+          id: registration_complete_icon
+          label: "✅"
+          variant: HEADING_1
+        - align: center
+          type: TEXT
+          id: registration_complete_heading
+          label: Account Created
+          variant: HEADING_1
+        - align: center
+          type: TEXT
+          id: registration_complete_message
+          label: Your Wayfinder account is ready. Sign in to start exploring.
+          variant: HEADING_6
+        - type: STACK
+          id: registration_complete_link_stack
+          category: BLOCK
+          align: center
+          direction: row
+          justify: center
+          gap: 2
+          items: 1
+          resourceType: ELEMENT
+          components:
+            - type: RICH_TEXT
+              id: registration_complete_link
+              category: DISPLAY
+              resourceType: ELEMENT
+              label: '<h3 class="rich-text-heading-h3"><a href="{{meta(application.url)}}" target="_blank" rel="noopener noreferrer" class="rich-text-link"><span class="rich-text-pre-wrap">Go to Wayfinder</span></a></h3>'
+    message: Registration complete
+    next: end
   - id: end
     type: END
 


### PR DESCRIPTION
### Purpose
This pull request updates the self sign-up registration flow for the Wayfinder app to improve the user experience after account creation. Instead of automatically redirecting to the app, the flow now ends with a confirmation screen that provides a link back to the application, where the user can sign in with their new credentials. Documentation, configuration samples, and UI text have been updated to reflect this new flow.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3284

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated B2C registration documentation to reflect confirmation screen after account creation
  * Updated self sign-up walkthrough to show confirmation experience with redirect link

* **Localization**
  * Updated English translations to describe account confirmation screen in onboarding flow

* **Configuration**
  * Updated sample registration flow to display "Account Created" confirmation screen with redirect back to application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->