### PR TITLE
Add permission assingment UI for role management

### DIFF
--- a/frontend/apps/console/src/features/roles/api/__tests__/useUpdateRole.test.tsx
+++ b/frontend/apps/console/src/features/roles/api/__tests__/useUpdateRole.test.tsx
@@ -21,7 +21,7 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import RoleQueryKeys from '../../constants/role-query-keys';
 import type {UpdateRoleRequest} from '../../models/requests';
 import type {Role} from '../../models/role';
-import useUpdateRole from '../useUpdateRole';
+import useUpdateRole, {ROLE_MUTATION_KEY} from '../useUpdateRole';
 
 // Mock the dependencies
 vi.mock('@thunderid/react', () => ({
@@ -305,5 +305,47 @@ describe('useUpdateRole', () => {
     });
 
     expect(result.current.error).toBeNull();
+  });
+
+  it('should merge PUT response into cache while preserving display-only fields like ouHandle', async () => {
+    const responseRole: Role = {
+      id: 'role-1',
+      name: 'Updated Role',
+      description: 'Updated description',
+      ouId: 'ou-1',
+      permissions: [{resourceServerId: 'rs-1', permissions: ['read']}],
+    };
+    mockHttpRequest.mockResolvedValueOnce({data: responseRole});
+
+    const {result, queryClient} = renderHook(() => useUpdateRole());
+
+    const cachedRoleWithDisplay: Role = {
+      id: 'role-1',
+      name: 'Original Role',
+      description: 'Original description',
+      ouId: 'ou-1',
+      ouHandle: 'my-org',
+      permissions: [{resourceServerId: 'rs-1', permissions: ['read', 'write']}],
+    };
+    queryClient.setQueryData([RoleQueryKeys.ROLE, 'role-1'], cachedRoleWithDisplay);
+
+    result.current.mutate({roleId: 'role-1', data: mockUpdateRequest});
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const cached = queryClient.getQueryData<Role>([RoleQueryKeys.ROLE, 'role-1']);
+    expect(cached?.name).toBe('Updated Role');
+    expect(cached?.description).toBe('Updated description');
+    expect(cached?.permissions).toEqual([{resourceServerId: 'rs-1', permissions: ['read']}]);
+    expect(cached?.ouHandle).toBe('my-org');
+  });
+
+  it('should register the mutation under ROLE_MUTATION_KEY', () => {
+    const {result} = renderHook(() => useUpdateRole());
+
+    expect(result.current).toBeDefined();
+    expect(ROLE_MUTATION_KEY).toEqual(['update-role']);
   });
 });

--- a/frontend/apps/console/src/features/roles/api/useUpdateRole.ts
+++ b/frontend/apps/console/src/features/roles/api/useUpdateRole.ts
@@ -24,6 +24,8 @@ import RoleQueryKeys from '../constants/role-query-keys';
 import type {UpdateRoleRequest} from '../models/requests';
 import type {Role} from '../models/role';
 
+export const ROLE_MUTATION_KEY = ['update-role'] as const;
+
 export interface UpdateRoleVariables {
   roleId: string;
   data: UpdateRoleRequest;
@@ -42,6 +44,7 @@ export default function useUpdateRole(): UseMutationResult<Role, Error, UpdateRo
   const {showToast} = useToast();
 
   return useMutation<Role, Error, UpdateRoleVariables>({
+    mutationKey: ROLE_MUTATION_KEY,
     mutationFn: async ({roleId, data}: UpdateRoleVariables): Promise<Role> => {
       const serverUrl: string = getServerUrl();
       const response: {data: Role} = await http.request({
@@ -53,7 +56,10 @@ export default function useUpdateRole(): UseMutationResult<Role, Error, UpdateRo
 
       return response.data;
     },
-    onSuccess: (_data, {roleId}) => {
+    onSuccess: (data, {roleId}) => {
+      queryClient.setQueryData<Role>([RoleQueryKeys.ROLE, roleId], (old) =>
+        old ? {...old, name: data.name, description: data.description, permissions: data.permissions ?? []} : data,
+      );
       queryClient.invalidateQueries({queryKey: [RoleQueryKeys.ROLE, roleId]}).catch(() => {
         /* noop */
       });

--- a/frontend/apps/console/src/features/roles/components/create-role/ConfigurePermissions.tsx
+++ b/frontend/apps/console/src/features/roles/components/create-role/ConfigurePermissions.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {PermissionCatalog, SelectedScopesField, type ResourcePermissions} from '@thunderid/configure-resource-servers';
+import {Box, Divider, FormLabel, Stack, Typography} from '@wso2/oxygen-ui';
+import type {JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+
+interface ConfigurePermissionsProps {
+  permissions: ResourcePermissions[];
+  onPermissionsChange: (permissions: ResourcePermissions[]) => void;
+}
+
+export default function ConfigurePermissions({
+  permissions,
+  onPermissionsChange,
+}: ConfigurePermissionsProps): JSX.Element {
+  const {t} = useTranslation();
+
+  return (
+    <Stack spacing={3} sx={{width: '100%'}}>
+      <Box>
+        <Typography variant="h4" sx={{mb: 1}}>
+          {t('roles:createWizard.permissions.title')}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {t('roles:createWizard.permissions.subtitle')}
+        </Typography>
+      </Box>
+      <PermissionCatalog selected={permissions} onChange={onPermissionsChange} />
+      <Divider />
+      <Box>
+        <FormLabel sx={{display: 'block', mb: 1, fontWeight: 'medium'}}>
+          {t('roles:createWizard.permissions.scopes.label')}
+        </FormLabel>
+        <SelectedScopesField selected={permissions} />
+      </Box>
+    </Stack>
+  );
+}

--- a/frontend/apps/console/src/features/roles/components/create-role/__tests__/ConfigurePermissions.test.tsx
+++ b/frontend/apps/console/src/features/roles/components/create-role/__tests__/ConfigurePermissions.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import userEvent from '@testing-library/user-event';
+import {render, screen} from '@thunderid/test-utils';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import ConfigurePermissions from '../ConfigurePermissions';
+
+vi.mock('@thunderid/configure-resource-servers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/configure-resource-servers')>();
+  return {
+    ...actual,
+    PermissionCatalog: ({
+      selected,
+      onChange,
+    }: {
+      selected: {resourceServerId: string; permissions: string[]}[];
+      onChange: (s: {resourceServerId: string; permissions: string[]}[]) => void;
+    }) => (
+      <div data-testid="permission-catalog" data-selected={JSON.stringify(selected)}>
+        <button
+          type="button"
+          data-testid="fire-change"
+          onClick={() => onChange([{resourceServerId: 'rs-1', permissions: ['bookings']}])}
+        >
+          Fire Change
+        </button>
+      </div>
+    ),
+    SelectedScopesField: ({selected}: {selected: {resourceServerId: string; permissions: string[]}[]}) => (
+      <div data-testid="selected-scopes-field" data-selected={JSON.stringify(selected)} />
+    ),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (key: string, fallback?: string) => fallback ?? key}),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ConfigurePermissions', () => {
+  it('should render the heading and subtitle', () => {
+    render(<ConfigurePermissions permissions={[]} onPermissionsChange={vi.fn()} />);
+
+    expect(screen.getByText('roles:createWizard.permissions.title')).toBeInTheDocument();
+    expect(screen.getByText('roles:createWizard.permissions.subtitle')).toBeInTheDocument();
+  });
+
+  it('should render the PermissionCatalog stub', () => {
+    render(<ConfigurePermissions permissions={[]} onPermissionsChange={vi.fn()} />);
+
+    expect(screen.getByTestId('permission-catalog')).toBeInTheDocument();
+  });
+
+  it('should render the SelectedScopesField as a separate section', () => {
+    render(<ConfigurePermissions permissions={[]} onPermissionsChange={vi.fn()} />);
+
+    expect(screen.getByTestId('selected-scopes-field')).toBeInTheDocument();
+  });
+
+  it('should render the scopes section label', () => {
+    render(<ConfigurePermissions permissions={[]} onPermissionsChange={vi.fn()} />);
+
+    expect(screen.getByText('roles:createWizard.permissions.scopes.label')).toBeInTheDocument();
+  });
+
+  it('should pass the permissions prop as selected to PermissionCatalog', () => {
+    const permissions = [{resourceServerId: 'rs-1', permissions: ['bookings', 'bookings:create']}];
+    render(<ConfigurePermissions permissions={permissions} onPermissionsChange={vi.fn()} />);
+
+    const catalog = screen.getByTestId('permission-catalog');
+    expect(JSON.parse(catalog.getAttribute('data-selected')!)).toEqual(permissions);
+  });
+
+  it('should pass the permissions prop as selected to SelectedScopesField', () => {
+    const permissions = [{resourceServerId: 'rs-1', permissions: ['bookings', 'bookings:create']}];
+    render(<ConfigurePermissions permissions={permissions} onPermissionsChange={vi.fn()} />);
+
+    const scopesField = screen.getByTestId('selected-scopes-field');
+    expect(JSON.parse(scopesField.getAttribute('data-selected')!)).toEqual(permissions);
+  });
+
+  it('should propagate PermissionCatalog onChange to onPermissionsChange', async () => {
+    const onPermissionsChange = vi.fn();
+    render(<ConfigurePermissions permissions={[]} onPermissionsChange={onPermissionsChange} />);
+
+    await userEvent.click(screen.getByTestId('fire-change'));
+
+    expect(onPermissionsChange).toHaveBeenCalledWith([{resourceServerId: 'rs-1', permissions: ['bookings']}]);
+  });
+
+  it('should not render chip delete buttons even with non-empty permissions', () => {
+    render(
+      <ConfigurePermissions
+        permissions={[{resourceServerId: 'rs-1', permissions: ['bookings']}]}
+        onPermissionsChange={vi.fn()}
+      />,
+    );
+
+    expect(document.querySelectorAll('.MuiChip-deleteIcon')).toHaveLength(0);
+  });
+});

--- a/frontend/apps/console/src/features/roles/components/edit-role/permissions-settings/EditPermissionsSettings.tsx
+++ b/frontend/apps/console/src/features/roles/components/edit-role/permissions-settings/EditPermissionsSettings.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {SettingsCard} from '@thunderid/components';
+import {PermissionCatalog, SelectedScopesField, type ResourcePermissions} from '@thunderid/configure-resource-servers';
+import {Stack} from '@wso2/oxygen-ui';
+import type {JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+
+interface EditPermissionsSettingsProps {
+  /** Permissions currently staged for this role, grouped by resource server */
+  permissions: ResourcePermissions[];
+  /** Called whenever the user changes the permission selection */
+  onPermissionsChange: (permissions: ResourcePermissions[]) => void;
+  /** When true, all checkboxes are disabled */
+  isReadOnly?: boolean;
+}
+
+export default function EditPermissionsSettings({
+  permissions,
+  onPermissionsChange,
+  isReadOnly = false,
+}: EditPermissionsSettingsProps): JSX.Element {
+  const {t} = useTranslation();
+
+  return (
+    <Stack spacing={3}>
+      <SettingsCard title={t('roles:edit.permissions.title')} description={t('roles:edit.permissions.description')}>
+        <PermissionCatalog selected={permissions} onChange={onPermissionsChange} readOnly={isReadOnly} />
+      </SettingsCard>
+      <SettingsCard
+        title={t('roles:edit.permissions.scopes.title')}
+        description={t('roles:edit.permissions.scopes.description')}
+      >
+        <SelectedScopesField selected={permissions} />
+      </SettingsCard>
+    </Stack>
+  );
+}

--- a/frontend/apps/console/src/features/roles/components/edit-role/permissions-settings/__tests__/EditPermissionsSettings.test.tsx
+++ b/frontend/apps/console/src/features/roles/components/edit-role/permissions-settings/__tests__/EditPermissionsSettings.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import userEvent from '@testing-library/user-event';
+import type {ResourcePermissions} from '@thunderid/configure-resource-servers';
+import {render, screen} from '@thunderid/test-utils';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import EditPermissionsSettings from '../EditPermissionsSettings';
+
+vi.mock('@thunderid/configure-resource-servers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/configure-resource-servers')>();
+  return {
+    ...actual,
+    PermissionCatalog: ({
+      selected,
+      onChange,
+      readOnly = false,
+    }: {
+      selected: ResourcePermissions[];
+      onChange: (s: ResourcePermissions[]) => void;
+      readOnly?: boolean;
+    }) => (
+      <div data-testid="permission-catalog" data-readonly={readOnly}>
+        <span data-testid="catalog-selected">{JSON.stringify(selected)}</span>
+        <button
+          type="button"
+          data-testid="catalog-change"
+          onClick={() => onChange([{resourceServerId: 'rs-2', permissions: ['payments:refund']}])}
+        >
+          Change
+        </button>
+      </div>
+    ),
+    SelectedScopesField: ({selected}: {selected: ResourcePermissions[]}) => (
+      <div data-testid="selected-scopes-field">
+        <span data-testid="scopes-selected">{JSON.stringify(selected)}</span>
+      </div>
+    ),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}));
+
+const permissions: ResourcePermissions[] = [{resourceServerId: 'rs-1', permissions: ['bookings', 'bookings:create']}];
+
+describe('EditPermissionsSettings', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the Permissions SettingsCard title and description', () => {
+    render(<EditPermissionsSettings permissions={permissions} onPermissionsChange={vi.fn()} />);
+    expect(screen.getByText('roles:edit.permissions.title')).toBeInTheDocument();
+    expect(screen.getByText('roles:edit.permissions.description')).toBeInTheDocument();
+  });
+
+  it('renders the Selected scopes SettingsCard title and description', () => {
+    render(<EditPermissionsSettings permissions={permissions} onPermissionsChange={vi.fn()} />);
+    expect(screen.getByText('roles:edit.permissions.scopes.title')).toBeInTheDocument();
+    expect(screen.getByText('roles:edit.permissions.scopes.description')).toBeInTheDocument();
+  });
+
+  it('passes permissions through to PermissionCatalog as selected', () => {
+    render(<EditPermissionsSettings permissions={permissions} onPermissionsChange={vi.fn()} />);
+    expect(screen.getByTestId('catalog-selected')).toHaveTextContent(JSON.stringify(permissions));
+  });
+
+  it('passes permissions through to SelectedScopesField as selected', () => {
+    render(<EditPermissionsSettings permissions={permissions} onPermissionsChange={vi.fn()} />);
+    expect(screen.getByTestId('scopes-selected')).toHaveTextContent(JSON.stringify(permissions));
+  });
+
+  it('calls onPermissionsChange when the catalog fires onChange', async () => {
+    const user = userEvent.setup();
+    const onPermissionsChange = vi.fn();
+    render(<EditPermissionsSettings permissions={permissions} onPermissionsChange={onPermissionsChange} />);
+    await user.click(screen.getByTestId('catalog-change'));
+    expect(onPermissionsChange).toHaveBeenCalledWith([{resourceServerId: 'rs-2', permissions: ['payments:refund']}]);
+  });
+
+  it('passes readOnly to PermissionCatalog when isReadOnly is true', () => {
+    render(<EditPermissionsSettings permissions={permissions} onPermissionsChange={vi.fn()} isReadOnly />);
+    expect(screen.getByTestId('permission-catalog')).toHaveAttribute('data-readonly', 'true');
+  });
+
+  it('passes readOnly as false by default', () => {
+    render(<EditPermissionsSettings permissions={permissions} onPermissionsChange={vi.fn()} />);
+    expect(screen.getByTestId('permission-catalog')).toHaveAttribute('data-readonly', 'false');
+  });
+});

--- a/frontend/apps/console/src/features/roles/contexts/RoleCreate/RoleCreateContext.tsx
+++ b/frontend/apps/console/src/features/roles/contexts/RoleCreate/RoleCreateContext.tsx
@@ -18,6 +18,7 @@
 
 import type {Context} from 'react';
 import {createContext} from 'react';
+import type {ResourcePermissions} from '../../models/role';
 import type {RoleCreateFlowStep} from '../../models/role-create-flow';
 
 /**
@@ -37,6 +38,9 @@ export interface RoleCreateContextType {
 
   error: string | null;
   setError: (error: string | null) => void;
+
+  permissions: ResourcePermissions[];
+  setPermissions: (permissions: ResourcePermissions[]) => void;
 
   reset: () => void;
 }

--- a/frontend/apps/console/src/features/roles/contexts/RoleCreate/RoleCreateProvider.tsx
+++ b/frontend/apps/console/src/features/roles/contexts/RoleCreate/RoleCreateProvider.tsx
@@ -19,6 +19,7 @@
 import type {PropsWithChildren} from 'react';
 import {useState, useMemo, useCallback} from 'react';
 import RoleCreateContext, {type RoleCreateContextType} from './RoleCreateContext';
+import type {ResourcePermissions} from '../../models/role';
 import {RoleCreateFlowStep} from '../../models/role-create-flow';
 
 const INITIAL_STATE = {
@@ -26,6 +27,7 @@ const INITIAL_STATE = {
   name: '',
   ouId: '',
   error: null as string | null,
+  permissions: [] as ResourcePermissions[],
 };
 
 /**
@@ -39,12 +41,14 @@ export default function RoleCreateProvider({children}: PropsWithChildren) {
   const [name, setName] = useState<string>(INITIAL_STATE.name);
   const [ouId, setOuId] = useState<string>(INITIAL_STATE.ouId);
   const [error, setError] = useState<string | null>(INITIAL_STATE.error);
+  const [permissions, setPermissions] = useState<ResourcePermissions[]>(INITIAL_STATE.permissions);
 
   const reset = useCallback((): void => {
     setCurrentStep(INITIAL_STATE.currentStep);
     setName(INITIAL_STATE.name);
     setOuId(INITIAL_STATE.ouId);
     setError(INITIAL_STATE.error);
+    setPermissions(INITIAL_STATE.permissions);
   }, []);
 
   const contextValue: RoleCreateContextType = useMemo(
@@ -57,9 +61,11 @@ export default function RoleCreateProvider({children}: PropsWithChildren) {
       setOuId,
       error,
       setError,
+      permissions,
+      setPermissions,
       reset,
     }),
-    [currentStep, name, ouId, error, reset],
+    [currentStep, name, ouId, error, permissions, reset],
   );
 
   return <RoleCreateContext.Provider value={contextValue}>{children}</RoleCreateContext.Provider>;

--- a/frontend/apps/console/src/features/roles/contexts/RoleCreate/__tests__/useRoleCreate.test.tsx
+++ b/frontend/apps/console/src/features/roles/contexts/RoleCreate/__tests__/useRoleCreate.test.tsx
@@ -16,11 +16,18 @@
  * under the License.
  */
 
+import {act, renderHook} from '@testing-library/react';
 import {render, screen} from '@thunderid/test-utils';
 import React from 'react';
 import {describe, expect, it, vi} from 'vitest';
 import RoleCreateProvider from '../RoleCreateProvider';
 import useRoleCreate from '../useRoleCreate';
+
+function renderUseRoleCreate() {
+  return renderHook(() => useRoleCreate(), {
+    wrapper: ({children}: {children: React.ReactNode}) => <RoleCreateProvider>{children}</RoleCreateProvider>,
+  });
+}
 
 function TestConsumer() {
   const context = useRoleCreate();
@@ -76,6 +83,8 @@ describe('useRoleCreate', () => {
         'setOuId',
         'error',
         'setError',
+        'permissions',
+        'setPermissions',
         'reset',
       ];
 
@@ -126,7 +135,7 @@ describe('useRoleCreate', () => {
 
   it('provides functions that are properly typed', () => {
     function TestFunctionTypes() {
-      const {setCurrentStep, setName, setOuId, setError, reset} = useRoleCreate();
+      const {setCurrentStep, setName, setOuId, setError, setPermissions, reset} = useRoleCreate();
 
       return (
         <div>
@@ -134,6 +143,7 @@ describe('useRoleCreate', () => {
           <div data-testid="setName-type">{typeof setName}</div>
           <div data-testid="setOuId-type">{typeof setOuId}</div>
           <div data-testid="setError-type">{typeof setError}</div>
+          <div data-testid="setPermissions-type">{typeof setPermissions}</div>
           <div data-testid="reset-type">{typeof reset}</div>
         </div>
       );
@@ -151,6 +161,7 @@ describe('useRoleCreate', () => {
     expect(screen.getByTestId('setName-type')).toHaveTextContent('function');
     expect(screen.getByTestId('setOuId-type')).toHaveTextContent('function');
     expect(screen.getByTestId('setError-type')).toHaveTextContent('function');
+    expect(screen.getByTestId('setPermissions-type')).toHaveTextContent('function');
     expect(screen.getByTestId('reset-type')).toHaveTextContent('function');
   });
 
@@ -173,7 +184,22 @@ describe('useRoleCreate', () => {
     errorSpy.mockRestore();
   });
 
-  it('has exactly 9 properties in the context interface', () => {
+  it('exposes permissions state, defaults to empty, and resets it', () => {
+    const {result} = renderUseRoleCreate();
+    expect(result.current.permissions).toEqual([]);
+
+    act(() => {
+      result.current.setPermissions([{resourceServerId: 'rs-1', permissions: ['bookings']}]);
+    });
+    expect(result.current.permissions).toEqual([{resourceServerId: 'rs-1', permissions: ['bookings']}]);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.permissions).toEqual([]);
+  });
+
+  it('has exactly 11 properties in the context interface', () => {
     function TestContextProperties() {
       const context = useRoleCreate();
 
@@ -192,6 +218,6 @@ describe('useRoleCreate', () => {
       </TestWrapper>,
     );
 
-    expect(screen.getByTestId('property-count')).toHaveTextContent('9');
+    expect(screen.getByTestId('property-count')).toHaveTextContent('11');
   });
 });

--- a/frontend/apps/console/src/features/roles/models/role-create-flow.ts
+++ b/frontend/apps/console/src/features/roles/models/role-create-flow.ts
@@ -25,6 +25,7 @@
 export const RoleCreateFlowStep = {
   BASIC_INFO: 'BASIC_INFO',
   ORGANIZATION_UNIT: 'ORGANIZATION_UNIT',
+  PERMISSIONS: 'PERMISSIONS',
 } as const;
 
 /**

--- a/frontend/apps/console/src/features/roles/models/role.ts
+++ b/frontend/apps/console/src/features/roles/models/role.ts
@@ -16,15 +16,9 @@
  * under the License.
  */
 
-/**
- * Permissions grouped by resource server.
- */
-export interface ResourcePermissions {
-  /** ID of the resource server */
-  resourceServerId: string;
-  /** Array of permission strings */
-  permissions: string[];
-}
+import type {ResourcePermissions} from '@thunderid/configure-resource-servers';
+
+export type {ResourcePermissions};
 
 /**
  * An assignment of a user, group, or app to a role.

--- a/frontend/apps/console/src/features/roles/pages/CreateRolePage.tsx
+++ b/frontend/apps/console/src/features/roles/pages/CreateRolePage.tsx
@@ -27,6 +27,7 @@ import {useNavigate} from 'react-router';
 import useCreateRole from '../api/useCreateRole';
 import ConfigureBasicInfo from '../components/create-role/ConfigureBasicInfo';
 import ConfigureOrganizationUnit from '../components/create-role/ConfigureOrganizationUnit';
+import ConfigurePermissions from '../components/create-role/ConfigurePermissions';
 import useRoleCreate from '../contexts/RoleCreate/useRoleCreate';
 import type {CreateRoleRequest} from '../models/requests';
 import {RoleCreateFlowStep} from '../models/role-create-flow';
@@ -38,7 +39,8 @@ export default function CreateRolePage(): JSX.Element {
   const logger = useLogger('CreateRolePage');
   const createRole = useCreateRole();
 
-  const {currentStep, setCurrentStep, name, setName, ouId, setOuId, error, setError} = useRoleCreate();
+  const {currentStep, setCurrentStep, name, setName, ouId, setOuId, error, setError, permissions, setPermissions} =
+    useRoleCreate();
 
   const {hasMultipleOUs, isLoading: isOuLoading, ouList} = useHasMultipleOUs();
 
@@ -48,6 +50,7 @@ export default function CreateRolePage(): JSX.Element {
   const [stepReady, setStepReady] = useState<Record<RoleCreateFlowStep, boolean>>({
     BASIC_INFO: false,
     ORGANIZATION_UNIT: false,
+    PERMISSIONS: true,
   });
 
   const activeSteps = useMemo((): RoleCreateFlowStep[] => {
@@ -55,6 +58,7 @@ export default function CreateRolePage(): JSX.Element {
     if (hasMultipleOUs) {
       base.push(RoleCreateFlowStep.ORGANIZATION_UNIT);
     }
+    base.push(RoleCreateFlowStep.PERMISSIONS);
     return base;
   }, [hasMultipleOUs]);
 
@@ -65,6 +69,7 @@ export default function CreateRolePage(): JSX.Element {
     if (hasMultipleOUs) {
       map.ORGANIZATION_UNIT = {label: t('roles:createWizard.steps.organizationUnit')};
     }
+    map.PERMISSIONS = {label: t('roles:createWizard.steps.permissions')};
     return map;
   }, [t, hasMultipleOUs]);
 
@@ -113,6 +118,7 @@ export default function CreateRolePage(): JSX.Element {
     const requestData: CreateRoleRequest = {
       name: name.trim(),
       ouId: selectedOuId,
+      ...(permissions.length > 0 ? {permissions} : {}),
     };
 
     try {
@@ -127,15 +133,12 @@ export default function CreateRolePage(): JSX.Element {
     switch (currentStep) {
       case RoleCreateFlowStep.BASIC_INFO:
         if (isOuLoading) return;
-        if (hasMultipleOUs) {
-          setCurrentStep(RoleCreateFlowStep.ORGANIZATION_UNIT);
-        } else {
-          handleSubmit().catch(() => {
-            /* noop */
-          });
-        }
+        setCurrentStep(hasMultipleOUs ? RoleCreateFlowStep.ORGANIZATION_UNIT : RoleCreateFlowStep.PERMISSIONS);
         break;
       case RoleCreateFlowStep.ORGANIZATION_UNIT:
+        setCurrentStep(RoleCreateFlowStep.PERMISSIONS);
+        break;
+      case RoleCreateFlowStep.PERMISSIONS:
         handleSubmit().catch(() => {
           /* noop */
         });
@@ -146,7 +149,9 @@ export default function CreateRolePage(): JSX.Element {
   };
 
   const handlePrevStep = (): void => {
-    if (currentStep === RoleCreateFlowStep.ORGANIZATION_UNIT) {
+    if (currentStep === RoleCreateFlowStep.PERMISSIONS) {
+      setCurrentStep(hasMultipleOUs ? RoleCreateFlowStep.ORGANIZATION_UNIT : RoleCreateFlowStep.BASIC_INFO);
+    } else if (currentStep === RoleCreateFlowStep.ORGANIZATION_UNIT) {
       setCurrentStep(RoleCreateFlowStep.BASIC_INFO);
     }
   };
@@ -163,6 +168,8 @@ export default function CreateRolePage(): JSX.Element {
             onReadyChange={handleOuStepReadyChange}
           />
         );
+      case RoleCreateFlowStep.PERMISSIONS:
+        return <ConfigurePermissions permissions={permissions} onPermissionsChange={setPermissions} />;
       default:
         return null;
     }

--- a/frontend/apps/console/src/features/roles/pages/RoleEditPage.tsx
+++ b/frontend/apps/console/src/features/roles/pages/RoleEditPage.tsx
@@ -16,7 +16,9 @@
  * under the License.
  */
 
+import {useIsMutating} from '@tanstack/react-query';
 import {PageLoadingAnimation} from '@thunderid/components';
+import {arePermissionsEqual, type ResourcePermissions} from '@thunderid/configure-resource-servers';
 import {useToast} from '@thunderid/contexts';
 import {useLogger} from '@thunderid/logger/react';
 import {
@@ -39,9 +41,10 @@ import type {ReactNode, SyntheticEvent, JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Link, useNavigate, useParams} from 'react-router';
 import useGetRole from '../api/useGetRole';
-import useUpdateRole from '../api/useUpdateRole';
+import useUpdateRole, {ROLE_MUTATION_KEY} from '../api/useUpdateRole';
 import EditAssignmentsSettings from '../components/edit-role/assignments-settings/EditAssignmentsSettings';
 import EditGeneralSettings from '../components/edit-role/general-settings/EditGeneralSettings';
+import EditPermissionsSettings from '../components/edit-role/permissions-settings/EditPermissionsSettings';
 import RoleDeleteDialog from '../components/RoleDeleteDialog';
 import type {Role} from '../models/role';
 
@@ -75,6 +78,7 @@ export default function RoleEditPage(): JSX.Element {
 
   const {data: role, isLoading, error: fetchError, refetch} = useGetRole(roleId ?? '');
   const updateRole = useUpdateRole();
+  const isRoleUpdating = useIsMutating({mutationKey: ROLE_MUTATION_KEY}) > 0;
 
   const [activeTab, setActiveTab] = useState(0);
   const [editedRole, setEditedRole] = useState<Partial<Role>>({});
@@ -97,6 +101,22 @@ export default function RoleEditPage(): JSX.Element {
     setEditedRole((prev) => ({...prev, [field]: value}));
   }, []);
 
+  const serverPermissions = useMemo(() => role?.permissions ?? [], [role]);
+
+  const handlePermissionsChange = useCallback(
+    (next: ResourcePermissions[]): void => {
+      setEditedRole((prev) => {
+        if (arePermissionsEqual(next, serverPermissions)) {
+          const {permissions: _permissions, ...rest} = prev;
+          void _permissions;
+          return rest;
+        }
+        return {...prev, permissions: next};
+      });
+    },
+    [serverPermissions],
+  );
+
   const handleSave = useCallback(async (): Promise<void> => {
     if (!role || !roleId) return;
 
@@ -104,7 +124,7 @@ export default function RoleEditPage(): JSX.Element {
       name: editedRole.name ?? role.name,
       description: 'description' in editedRole ? editedRole.description : role.description,
       ouId: role.ouId,
-      permissions: role.permissions ?? [],
+      permissions: editedRole.permissions ?? role.permissions ?? [],
     };
 
     try {
@@ -293,9 +313,15 @@ export default function RoleEditPage(): JSX.Element {
           sx={{textTransform: 'none'}}
         />
         <Tab
-          label={t('roles:edit.page.tabs.assignments')}
+          label={t('roles:edit.page.tabs.permissions')}
           id="role-tab-1"
           aria-controls="role-tabpanel-1"
+          sx={{textTransform: 'none'}}
+        />
+        <Tab
+          label={t('roles:edit.page.tabs.assignments')}
+          id="role-tab-2"
+          aria-controls="role-tabpanel-2"
           sx={{textTransform: 'none'}}
         />
       </Tabs>
@@ -310,6 +336,14 @@ export default function RoleEditPage(): JSX.Element {
         </TabPanel>
 
         <TabPanel value={activeTab} index={1}>
+          <EditPermissionsSettings
+            permissions={editedRole.permissions ?? serverPermissions}
+            onPermissionsChange={handlePermissionsChange}
+            isReadOnly={role.isReadOnly}
+          />
+        </TabPanel>
+
+        <TabPanel value={activeTab} index={2}>
           <EditAssignmentsSettings roleId={role.id} isReadOnly={role.isReadOnly} />
         </TabPanel>
       </>
@@ -378,7 +412,7 @@ export default function RoleEditPage(): JSX.Element {
                   /* noop */
                 });
               }}
-              disabled={updateRole.isPending || role.isReadOnly === true}
+              disabled={updateRole.isPending || isRoleUpdating || role.isReadOnly === true}
             >
               {updateRole.isPending ? t('roles:edit.page.saving') : t('roles:edit.page.save')}
             </Button>

--- a/frontend/apps/console/src/features/roles/pages/__tests__/CreateRolePage.test.tsx
+++ b/frontend/apps/console/src/features/roles/pages/__tests__/CreateRolePage.test.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import {fireEvent} from '@testing-library/react';
 import {render, screen} from '@thunderid/test-utils';
 import type {NavigateFunction} from 'react-router';
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
@@ -33,6 +34,24 @@ vi.mock('../../components/create-role/ConfigureBasicInfo', () => ({
 
 vi.mock('../../components/create-role/ConfigureOrganizationUnit', () => ({
   default: () => <div data-testid="configure-organization-unit">Configure Organization Unit</div>,
+}));
+
+vi.mock('../../components/create-role/ConfigurePermissions', () => ({
+  default: ({
+    onPermissionsChange,
+  }: {
+    onPermissionsChange: (permissions: {resourceServerId: string; permissions: string[]}[]) => void;
+  }) => (
+    <div data-testid="configure-permissions">
+      <button
+        type="button"
+        data-testid="stage-permissions"
+        onClick={() => onPermissionsChange([{resourceServerId: 'rs-1', permissions: ['bookings']}])}
+      >
+        Stage
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('react-router', async () => {
@@ -63,6 +82,7 @@ describe('CreateRolePage', () => {
   let mockSetName: ReturnType<typeof vi.fn>;
   let mockSetOuId: ReturnType<typeof vi.fn>;
   let mockSetError: ReturnType<typeof vi.fn>;
+  let mockSetPermissions: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     mockNavigate = vi.fn();
@@ -70,6 +90,7 @@ describe('CreateRolePage', () => {
     mockSetName = vi.fn();
     mockSetOuId = vi.fn();
     mockSetError = vi.fn();
+    mockSetPermissions = vi.fn();
 
     vi.mocked(useNavigate).mockReturnValue(mockNavigate as unknown as NavigateFunction);
 
@@ -82,6 +103,8 @@ describe('CreateRolePage', () => {
       setOuId: mockSetOuId,
       error: null,
       setError: mockSetError,
+      permissions: [],
+      setPermissions: mockSetPermissions,
       reset: vi.fn(),
     } as unknown as ReturnType<typeof useRoleCreate>);
 
@@ -155,6 +178,8 @@ describe('CreateRolePage', () => {
       setOuId: mockSetOuId,
       error: null,
       setError: mockSetError,
+      permissions: [],
+      setPermissions: mockSetPermissions,
       reset: vi.fn(),
     } as unknown as ReturnType<typeof useRoleCreate>);
 
@@ -182,6 +207,8 @@ describe('CreateRolePage', () => {
       setOuId: mockSetOuId,
       error: null,
       setError: mockSetError,
+      permissions: [],
+      setPermissions: mockSetPermissions,
       reset: vi.fn(),
     } as unknown as ReturnType<typeof useRoleCreate>);
 
@@ -199,6 +226,46 @@ describe('CreateRolePage', () => {
     expect(screen.getByRole('button', {name: /back/i})).toBeInTheDocument();
   });
 
+  it('should render ConfigurePermissions on permissions step', () => {
+    vi.mocked(useRoleCreate).mockReturnValue({
+      currentStep: RoleCreateFlowStep.PERMISSIONS,
+      setCurrentStep: mockSetCurrentStep,
+      name: 'Test Role',
+      setName: mockSetName,
+      ouId: '',
+      setOuId: mockSetOuId,
+      error: null,
+      setError: mockSetError,
+      permissions: [],
+      setPermissions: mockSetPermissions,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useRoleCreate>);
+
+    render(<CreateRolePage />);
+
+    expect(screen.getByTestId('configure-permissions')).toBeInTheDocument();
+  });
+
+  it('should render Back button on permissions step', () => {
+    vi.mocked(useRoleCreate).mockReturnValue({
+      currentStep: RoleCreateFlowStep.PERMISSIONS,
+      setCurrentStep: mockSetCurrentStep,
+      name: 'Test Role',
+      setName: mockSetName,
+      ouId: '',
+      setOuId: mockSetOuId,
+      error: null,
+      setError: mockSetError,
+      permissions: [],
+      setPermissions: mockSetPermissions,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useRoleCreate>);
+
+    render(<CreateRolePage />);
+
+    expect(screen.getByRole('button', {name: /back/i})).toBeInTheDocument();
+  });
+
   it('should render context error alert when error is set', () => {
     vi.mocked(useRoleCreate).mockReturnValue({
       currentStep: RoleCreateFlowStep.BASIC_INFO,
@@ -209,6 +276,8 @@ describe('CreateRolePage', () => {
       setOuId: mockSetOuId,
       error: 'Something went wrong',
       setError: mockSetError,
+      permissions: [],
+      setPermissions: mockSetPermissions,
       reset: vi.fn(),
     } as unknown as ReturnType<typeof useRoleCreate>);
 
@@ -265,5 +334,100 @@ describe('CreateRolePage', () => {
     render(<CreateRolePage />);
 
     expect(screen.getByRole('button', {name: /saving/i})).toBeDisabled();
+  });
+
+  it('should submit with permissions in POST payload when permissions are selected on the permissions step', async () => {
+    const mockMutateAsync = vi.fn().mockResolvedValue({});
+    vi.mocked(useCreateRole).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+      data: undefined,
+      reset: vi.fn(),
+      context: undefined,
+      failureCount: 0,
+      failureReason: null,
+      isIdle: true,
+      isPaused: false,
+      status: 'idle',
+      submittedAt: 0,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useCreateRole>);
+
+    vi.mocked(useRoleCreate).mockReturnValue({
+      currentStep: RoleCreateFlowStep.PERMISSIONS,
+      setCurrentStep: mockSetCurrentStep,
+      name: 'Test Role',
+      setName: mockSetName,
+      ouId: '',
+      setOuId: mockSetOuId,
+      error: null,
+      setError: mockSetError,
+      permissions: [{resourceServerId: 'rs-1', permissions: ['bookings']}],
+      setPermissions: mockSetPermissions,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useRoleCreate>);
+
+    render(<CreateRolePage />);
+
+    fireEvent.click(screen.getByRole('button', {name: /continue/i}));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          permissions: [{resourceServerId: 'rs-1', permissions: ['bookings']}],
+        }),
+      );
+    });
+  });
+
+  it('should submit without a permissions field when no permissions are selected on the permissions step', async () => {
+    const mockMutateAsync = vi.fn().mockResolvedValue({});
+    vi.mocked(useCreateRole).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+      data: undefined,
+      reset: vi.fn(),
+      context: undefined,
+      failureCount: 0,
+      failureReason: null,
+      isIdle: true,
+      isPaused: false,
+      status: 'idle',
+      submittedAt: 0,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useCreateRole>);
+
+    vi.mocked(useRoleCreate).mockReturnValue({
+      currentStep: RoleCreateFlowStep.PERMISSIONS,
+      setCurrentStep: mockSetCurrentStep,
+      name: 'Test Role',
+      setName: mockSetName,
+      ouId: '',
+      setOuId: mockSetOuId,
+      error: null,
+      setError: mockSetError,
+      permissions: [],
+      setPermissions: mockSetPermissions,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useRoleCreate>);
+
+    render(<CreateRolePage />);
+
+    fireEvent.click(screen.getByRole('button', {name: /continue/i}));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        name: 'Test Role',
+        ouId: 'ou-1',
+      });
+    });
   });
 });

--- a/frontend/apps/console/src/features/roles/pages/__tests__/RoleEditPage.test.tsx
+++ b/frontend/apps/console/src/features/roles/pages/__tests__/RoleEditPage.test.tsx
@@ -17,15 +17,25 @@
  */
 
 import userEvent from '@testing-library/user-event';
+import type {ResourcePermissions} from '@thunderid/configure-resource-servers';
 import {render, screen} from '@thunderid/test-utils';
 import type {NavigateFunction} from 'react-router';
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import type {UpdateRoleRequest} from '../../models/requests';
 import type {Role} from '../../models/role';
 import RoleEditPage from '../RoleEditPage';
 
 // Mock dependencies
 vi.mock('../../api/useGetRole');
 vi.mock('../../api/useUpdateRole');
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>();
+  return {
+    ...actual,
+    useIsMutating: vi.fn().mockReturnValue(0),
+  };
+});
 
 vi.mock('../../components/RoleDeleteDialog', () => ({
   default: ({open}: {open: boolean}) => (open ? <div data-testid="delete-dialog">Delete Dialog</div> : null),
@@ -43,6 +53,35 @@ vi.mock('../../components/edit-role/general-settings/EditGeneralSettings', () =>
 
 vi.mock('../../components/edit-role/assignments-settings/EditAssignmentsSettings', () => ({
   default: () => <div data-testid="edit-assignments-settings">Assignments Settings</div>,
+}));
+
+vi.mock('../../components/edit-role/permissions-settings/EditPermissionsSettings', () => ({
+  default: ({
+    permissions,
+    onPermissionsChange,
+  }: {
+    permissions: ResourcePermissions[];
+    onPermissionsChange: (p: ResourcePermissions[]) => void;
+    isReadOnly?: boolean;
+  }) => (
+    <div data-testid="permissions-settings">
+      <span data-testid="permissions-selected">{JSON.stringify(permissions)}</span>
+      <button
+        type="button"
+        data-testid="permissions-change"
+        onClick={() => onPermissionsChange([{resourceServerId: 'rs-1', permissions: ['a', 'b']}])}
+      >
+        Change
+      </button>
+      <button
+        type="button"
+        data-testid="permissions-restore"
+        onClick={() => onPermissionsChange([{resourceServerId: 'rs-1', permissions: ['a']}])}
+      >
+        Restore
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('@thunderid/components', () => ({
@@ -80,6 +119,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
 const {default: useGetRole} = await import('../../api/useGetRole');
 const {default: useUpdateRole} = await import('../../api/useUpdateRole');
 const {useParams, useNavigate} = await import('react-router');
+const {useIsMutating} = await import('@tanstack/react-query');
 
 describe('RoleEditPage', () => {
   let mockNavigate: ReturnType<typeof vi.fn>;
@@ -89,7 +129,7 @@ describe('RoleEditPage', () => {
     name: 'Admin Role',
     description: 'Administrator role',
     ouId: 'ou-1',
-    permissions: [],
+    permissions: [{resourceServerId: 'rs-1', permissions: ['a']}],
   };
 
   beforeEach(() => {
@@ -97,6 +137,7 @@ describe('RoleEditPage', () => {
 
     vi.mocked(useParams).mockReturnValue({roleId: 'role-1'});
     vi.mocked(useNavigate).mockReturnValue(mockNavigate as unknown as NavigateFunction);
+    vi.mocked(useIsMutating).mockReturnValue(0);
 
     vi.mocked(useGetRole).mockReturnValue({
       data: mockRole,
@@ -172,11 +213,11 @@ describe('RoleEditPage', () => {
       expect(screen.getByText('Administrator role')).toBeInTheDocument();
     });
 
-    it('should render two tabs', () => {
+    it('should render three tabs', () => {
       render(<RoleEditPage />);
 
       const tabs = screen.getAllByRole('tab');
-      expect(tabs).toHaveLength(2);
+      expect(tabs).toHaveLength(3);
     });
 
     it('should show General tab panel by default', () => {
@@ -187,12 +228,27 @@ describe('RoleEditPage', () => {
   });
 
   describe('Tab Navigation', () => {
+    it('shows the permissions tab between General and Assignments', async () => {
+      const user = userEvent.setup();
+      render(<RoleEditPage />);
+
+      const tabs = await screen.findAllByRole('tab');
+      expect(tabs.map((tab) => tab.textContent)).toEqual([
+        'edit.page.tabs.general',
+        'edit.page.tabs.permissions',
+        'edit.page.tabs.assignments',
+      ]);
+
+      await user.click(tabs[1]);
+      expect(screen.getByTestId('permissions-settings')).toBeInTheDocument();
+    });
+
     it('should switch to Assignments tab panel when Assignments tab clicked', async () => {
       const user = userEvent.setup();
       render(<RoleEditPage />);
 
       const tabs = screen.getAllByRole('tab');
-      await user.click(tabs[1]);
+      await user.click(tabs[2]);
 
       expect(screen.getByTestId('edit-assignments-settings')).toBeInTheDocument();
     });
@@ -207,6 +263,123 @@ describe('RoleEditPage', () => {
       await user.click(deleteButton);
 
       expect(screen.getByTestId('delete-dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('Save Bar concurrency gate', () => {
+    it('should disable Save button while a role mutation is in flight even when updateRole.isPending is false', async () => {
+      const user = userEvent.setup();
+      vi.mocked(useIsMutating).mockReturnValue(1);
+
+      render(<RoleEditPage />);
+
+      const nameEditButton = screen.getByRole('button', {name: /edit.page.editName/i});
+      await user.click(nameEditButton);
+
+      const nameInput = screen.getByRole('textbox');
+      await user.clear(nameInput);
+      await user.type(nameInput, 'New Name');
+      await user.tab();
+
+      const saveButton = screen.getByRole('button', {name: /edit.page.save/i});
+      expect(saveButton).toBeDisabled();
+    });
+  });
+
+  describe('Permissions staged save', () => {
+    it('shows the save bar when permissions change and saves them in one PUT', async () => {
+      const user = userEvent.setup();
+      const mockMutateAsync = vi.fn().mockResolvedValue({});
+      const mockRefetch = vi.fn().mockResolvedValue({});
+      vi.mocked(useGetRole).mockReturnValue({
+        data: mockRole,
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      } as unknown as ReturnType<typeof useGetRole>);
+      vi.mocked(useUpdateRole).mockReturnValue({
+        mutate: vi.fn(),
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+        isError: false,
+        isSuccess: false,
+        error: null,
+        data: undefined,
+        reset: vi.fn(),
+        context: undefined,
+        failureCount: 0,
+        failureReason: null,
+        isIdle: true,
+        isPaused: false,
+        status: 'idle',
+        submittedAt: 0,
+        variables: undefined,
+      });
+
+      render(<RoleEditPage />);
+
+      // Switch to Permissions tab
+      const tabs = screen.getAllByRole('tab');
+      await user.click(tabs[1]);
+
+      // Fire the catalog's onChange via the stub
+      await user.click(screen.getByTestId('permissions-change'));
+
+      // Save bar should be visible
+      const saveButton = screen.getByRole('button', {name: /edit.page.save/i});
+      expect(saveButton).toBeInTheDocument();
+
+      // Click Save
+      await user.click(saveButton);
+
+      // Expect mutateAsync called with General fields + changed permissions
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        roleId: 'role-1',
+        data: expect.objectContaining({
+          name: 'Admin Role',
+          ouId: 'ou-1',
+          permissions: [{resourceServerId: 'rs-1', permissions: ['a', 'b']}],
+        }) as UpdateRoleRequest,
+      });
+    });
+
+    it('clears staged permissions when edits return to the server state', async () => {
+      const user = userEvent.setup();
+      render(<RoleEditPage />);
+
+      // Switch to Permissions tab
+      const tabs = screen.getAllByRole('tab');
+      await user.click(tabs[1]);
+
+      // Change permissions → save bar appears
+      await user.click(screen.getByTestId('permissions-change'));
+      expect(screen.getByRole('button', {name: /edit.page.save/i})).toBeInTheDocument();
+
+      // Restore to original (order-insensitively equal) → save bar hides
+      await user.click(screen.getByTestId('permissions-restore'));
+      expect(screen.queryByRole('button', {name: /edit.page.save/i})).not.toBeInTheDocument();
+    });
+
+    it('reset discards staged permission changes', async () => {
+      const user = userEvent.setup();
+      render(<RoleEditPage />);
+
+      // Switch to Permissions tab
+      const tabs = screen.getAllByRole('tab');
+      await user.click(tabs[1]);
+
+      // Change permissions
+      await user.click(screen.getByTestId('permissions-change'));
+      expect(screen.getByTestId('permissions-selected')).toHaveTextContent(
+        JSON.stringify([{resourceServerId: 'rs-1', permissions: ['a', 'b']}]),
+      );
+
+      // Click Reset
+      const resetButton = screen.getByRole('button', {name: /edit.page.reset/i});
+      await user.click(resetButton);
+
+      // Catalog selected should return to role.permissions
+      expect(screen.getByTestId('permissions-selected')).toHaveTextContent(JSON.stringify(mockRole.permissions));
     });
   });
 });

--- a/frontend/packages/configure-resource-servers/src/api/useGetResourceActions.ts
+++ b/frontend/packages/configure-resource-servers/src/api/useGetResourceActions.ts
@@ -22,6 +22,20 @@ import {useThunderID} from '@thunderid/react';
 import ResourceServerQueryKeys from '../constants/resource-server-query-keys';
 import type {ActionListResponse} from '../models/resource-server';
 
+export async function fetchResourceActions(
+  http: {request: (config: unknown) => Promise<{data: ActionListResponse}>},
+  serverUrl: string,
+  resourceServerId: string,
+  resourceId: string,
+): Promise<ActionListResponse> {
+  const response = await http.request({
+    url: `${serverUrl}/resource-servers/${resourceServerId}/resources/${resourceId}/actions?limit=100&offset=0`,
+    method: 'GET',
+  });
+
+  return response.data;
+}
+
 export default function useGetResourceActions(
   resourceServerId: string,
   resourceId: string,
@@ -34,13 +48,12 @@ export default function useGetResourceActions(
     queryKey: [ResourceServerQueryKeys.RESOURCE_ACTIONS, resourceServerId, resourceId],
     queryFn: async (): Promise<ActionListResponse> => {
       const serverUrl = getServerUrl();
-
-      const response: {data: ActionListResponse} = await http.request({
-        url: `${serverUrl}/resource-servers/${resourceServerId}/resources/${resourceId}/actions?limit=100&offset=0`,
-        method: 'GET',
-      } as unknown as Parameters<typeof http.request>[0]);
-
-      return response.data;
+      return fetchResourceActions(
+        http as {request: (config: unknown) => Promise<{data: ActionListResponse}>},
+        serverUrl,
+        resourceServerId,
+        resourceId,
+      );
     },
     enabled: Boolean(resourceServerId) && Boolean(resourceId) && enabled,
   });

--- a/frontend/packages/configure-resource-servers/src/api/useGetResources.ts
+++ b/frontend/packages/configure-resource-servers/src/api/useGetResources.ts
@@ -22,9 +22,27 @@ import {useThunderID} from '@thunderid/react';
 import ResourceServerQueryKeys from '../constants/resource-server-query-keys';
 import type {ResourceListResponse} from '../models/resource-server';
 
+export async function fetchResources(
+  http: {request: (config: unknown) => Promise<{data: ResourceListResponse}>},
+  serverUrl: string,
+  resourceServerId: string,
+  parentId?: string,
+): Promise<ResourceListResponse> {
+  const queryParams = new URLSearchParams({limit: '100', offset: '0'});
+  if (parentId) queryParams.set('parentId', parentId);
+
+  const response = await http.request({
+    url: `${serverUrl}/resource-servers/${resourceServerId}/resources?${queryParams.toString()}`,
+    method: 'GET',
+  });
+
+  return response.data;
+}
+
 export default function useGetResources(
   resourceServerId: string,
   parentId?: string,
+  enabled = true,
 ): UseQueryResult<ResourceListResponse> {
   const {http} = useThunderID();
   const {getServerUrl} = useConfig();
@@ -33,16 +51,13 @@ export default function useGetResources(
     queryKey: [ResourceServerQueryKeys.RESOURCES, resourceServerId, {parentId: parentId ?? null}],
     queryFn: async (): Promise<ResourceListResponse> => {
       const serverUrl = getServerUrl();
-      const queryParams = new URLSearchParams({limit: '100', offset: '0'});
-      if (parentId) queryParams.set('parentId', parentId);
-
-      const response: {data: ResourceListResponse} = await http.request({
-        url: `${serverUrl}/resource-servers/${resourceServerId}/resources?${queryParams.toString()}`,
-        method: 'GET',
-      } as unknown as Parameters<typeof http.request>[0]);
-
-      return response.data;
+      return fetchResources(
+        http as {request: (config: unknown) => Promise<{data: ResourceListResponse}>},
+        serverUrl,
+        resourceServerId,
+        parentId,
+      );
     },
-    enabled: Boolean(resourceServerId),
+    enabled: Boolean(resourceServerId) && enabled,
   });
 }

--- a/frontend/packages/configure-resource-servers/src/api/useGetServerActions.ts
+++ b/frontend/packages/configure-resource-servers/src/api/useGetServerActions.ts
@@ -22,6 +22,18 @@ import {useThunderID} from '@thunderid/react';
 import ResourceServerQueryKeys from '../constants/resource-server-query-keys';
 import type {ActionListResponse} from '../models/resource-server';
 
+export async function fetchServerActions(
+  http: {request: (config: unknown) => Promise<{data: ActionListResponse}>},
+  serverUrl: string,
+  resourceServerId: string,
+): Promise<ActionListResponse> {
+  const response = await http.request({
+    url: `${serverUrl}/resource-servers/${resourceServerId}/actions?limit=100&offset=0`,
+    method: 'GET',
+  });
+  return response.data;
+}
+
 export default function useGetServerActions(resourceServerId: string): UseQueryResult<ActionListResponse> {
   const {http} = useThunderID();
   const {getServerUrl} = useConfig();
@@ -30,13 +42,11 @@ export default function useGetServerActions(resourceServerId: string): UseQueryR
     queryKey: [ResourceServerQueryKeys.SERVER_ACTIONS, resourceServerId],
     queryFn: async (): Promise<ActionListResponse> => {
       const serverUrl = getServerUrl();
-
-      const response: {data: ActionListResponse} = await http.request({
-        url: `${serverUrl}/resource-servers/${resourceServerId}/actions?limit=100&offset=0`,
-        method: 'GET',
-      } as unknown as Parameters<typeof http.request>[0]);
-
-      return response.data;
+      return fetchServerActions(
+        http as {request: (config: unknown) => Promise<{data: ActionListResponse}>},
+        serverUrl,
+        resourceServerId,
+      );
     },
     enabled: Boolean(resourceServerId),
   });

--- a/frontend/packages/configure-resource-servers/src/api/useSubtreePermissions.ts
+++ b/frontend/packages/configure-resource-servers/src/api/useSubtreePermissions.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useQueryClient} from '@tanstack/react-query';
+import {useConfig} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import {fetchResourceActions} from './useGetResourceActions';
+import {fetchResources} from './useGetResources';
+import {fetchServerActions} from './useGetServerActions';
+import ResourceServerQueryKeys from '../constants/resource-server-query-keys';
+import type {ActionListResponse, Resource, ResourceListResponse} from '../models/resource-server';
+
+interface HttpClient {
+  request: (config: unknown) => Promise<{data: unknown}>;
+}
+
+export default function useSubtreePermissions(resourceServerId: string): {
+  collectSubtreePermissions: (resource: Resource) => Promise<string[]>;
+  getCachedSubtreePermissions: (resource: Resource) => string[] | null;
+  collectServerPermissions: () => Promise<string[]>;
+  getCachedServerPermissions: () => string[] | null;
+} {
+  const queryClient = useQueryClient();
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+
+  async function collectSubtreePermissions(resource: Resource): Promise<string[]> {
+    const serverUrl = getServerUrl();
+    const typedHttp = http as HttpClient;
+    const permissions: string[] = [resource.permission];
+
+    const actionsData = await queryClient.fetchQuery<ActionListResponse>({
+      queryKey: [ResourceServerQueryKeys.RESOURCE_ACTIONS, resourceServerId, resource.id],
+      queryFn: () =>
+        fetchResourceActions(
+          typedHttp as {request: (config: unknown) => Promise<{data: ActionListResponse}>},
+          serverUrl,
+          resourceServerId,
+          resource.id,
+        ),
+    });
+    for (const action of actionsData.actions) {
+      permissions.push(action.permission);
+    }
+
+    const childData = await queryClient.fetchQuery<ResourceListResponse>({
+      queryKey: [ResourceServerQueryKeys.RESOURCES, resourceServerId, {parentId: resource.id}],
+      queryFn: () =>
+        fetchResources(
+          typedHttp as {request: (config: unknown) => Promise<{data: ResourceListResponse}>},
+          serverUrl,
+          resourceServerId,
+          resource.id,
+        ),
+    });
+    for (const child of childData.resources) {
+      const childPerms = await collectSubtreePermissions(child);
+      permissions.push(...childPerms);
+    }
+
+    return permissions;
+  }
+
+  function getCachedSubtreePermissions(resource: Resource): string[] | null {
+    const permissions: string[] = [resource.permission];
+
+    const actionsData = queryClient.getQueryData<ActionListResponse>([
+      ResourceServerQueryKeys.RESOURCE_ACTIONS,
+      resourceServerId,
+      resource.id,
+    ]);
+    if (actionsData === undefined) return null;
+    for (const action of actionsData.actions) {
+      permissions.push(action.permission);
+    }
+
+    const childData = queryClient.getQueryData<ResourceListResponse>([
+      ResourceServerQueryKeys.RESOURCES,
+      resourceServerId,
+      {parentId: resource.id},
+    ]);
+    if (childData === undefined) return null;
+    for (const child of childData.resources) {
+      const childPerms = getCachedSubtreePermissions(child);
+      if (childPerms === null) return null;
+      permissions.push(...childPerms);
+    }
+
+    return permissions;
+  }
+
+  async function collectServerPermissions(): Promise<string[]> {
+    const serverUrl = getServerUrl();
+    const typedHttp = http as HttpClient;
+    const permissions: string[] = [];
+
+    const actionsData = await queryClient.fetchQuery<ActionListResponse>({
+      queryKey: [ResourceServerQueryKeys.SERVER_ACTIONS, resourceServerId],
+      queryFn: () =>
+        fetchServerActions(
+          typedHttp as {request: (config: unknown) => Promise<{data: ActionListResponse}>},
+          serverUrl,
+          resourceServerId,
+        ),
+    });
+    for (const action of actionsData.actions) {
+      permissions.push(action.permission);
+    }
+
+    const rootData = await queryClient.fetchQuery<ResourceListResponse>({
+      queryKey: [ResourceServerQueryKeys.RESOURCES, resourceServerId, {parentId: null}],
+      queryFn: () =>
+        fetchResources(
+          typedHttp as {request: (config: unknown) => Promise<{data: ResourceListResponse}>},
+          serverUrl,
+          resourceServerId,
+        ),
+    });
+    for (const resource of rootData.resources) {
+      const subtree = await collectSubtreePermissions(resource);
+      permissions.push(...subtree);
+    }
+
+    return permissions;
+  }
+
+  function getCachedServerPermissions(): string[] | null {
+    const permissions: string[] = [];
+
+    const actionsData = queryClient.getQueryData<ActionListResponse>([
+      ResourceServerQueryKeys.SERVER_ACTIONS,
+      resourceServerId,
+    ]);
+    if (actionsData === undefined) return null;
+    for (const action of actionsData.actions) {
+      permissions.push(action.permission);
+    }
+
+    const rootData = queryClient.getQueryData<ResourceListResponse>([
+      ResourceServerQueryKeys.RESOURCES,
+      resourceServerId,
+      {parentId: null},
+    ]);
+    if (rootData === undefined) return null;
+    for (const resource of rootData.resources) {
+      const subtree = getCachedSubtreePermissions(resource);
+      if (subtree === null) return null;
+      permissions.push(...subtree);
+    }
+
+    return permissions;
+  }
+
+  return {collectSubtreePermissions, getCachedSubtreePermissions, collectServerPermissions, getCachedServerPermissions};
+}

--- a/frontend/packages/configure-resource-servers/src/components/permission-catalog/PermissionCatalog.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/permission-catalog/PermissionCatalog.tsx
@@ -1,0 +1,499 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Alert,
+  Box,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  Collapse,
+  IconButton,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import {ChevronDown, ChevronRight} from '@wso2/oxygen-ui-icons-react';
+import {useState, type JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import useGetResourceActions from '../../api/useGetResourceActions';
+import useGetResources from '../../api/useGetResources';
+import useGetResourceServers from '../../api/useGetResourceServers';
+import useGetServerActions from '../../api/useGetServerActions';
+import useSubtreePermissions from '../../api/useSubtreePermissions';
+import type {Resource, ResourcePermissions, ResourceServer} from '../../models/resource-server';
+import {
+  getSubtreeSelectionState,
+  isPermissionSelected,
+  mergePermissions,
+  removePermissions,
+  togglePermission,
+  type SelectionState,
+} from '../../utils/permissionSelection';
+
+export interface PermissionCatalogProps {
+  selected: ResourcePermissions[];
+  onChange: (selected: ResourcePermissions[]) => void;
+  readOnly?: boolean;
+}
+
+/* ---------- Row ---------- */
+
+interface CatalogRowProps {
+  name: string;
+  permission: string;
+  depth: number;
+  checked: boolean;
+  indeterminate?: boolean;
+  disabled: boolean;
+  loading?: boolean;
+  onToggle: () => void;
+  expandControl?: JSX.Element;
+}
+
+function CatalogRow({
+  name,
+  permission,
+  depth,
+  checked,
+  indeterminate = false,
+  disabled,
+  loading = false,
+  onToggle,
+  expandControl = undefined,
+}: CatalogRowProps): JSX.Element {
+  return (
+    <Stack direction="row" alignItems="center" spacing={1} sx={{pl: depth * 3, py: 0.25}}>
+      <Box sx={{width: 28, display: 'flex', justifyContent: 'center'}}>{expandControl}</Box>
+      {loading ? (
+        <Box sx={{width: 38, display: 'flex', justifyContent: 'center'}}>
+          <CircularProgress size={16} />
+        </Box>
+      ) : (
+        <Checkbox
+          size="small"
+          checked={checked}
+          indeterminate={indeterminate}
+          disabled={disabled}
+          onChange={onToggle}
+          inputProps={{'aria-label': permission}}
+        />
+      )}
+      <Typography variant="body2">{name}</Typography>
+      <Chip label={permission} size="small" sx={{fontFamily: 'monospace'}} />
+    </Stack>
+  );
+}
+
+/* ---------- Resource node (recursive, tri-state) ---------- */
+
+interface CatalogResourceNodeProps {
+  resourceServerId: string;
+  resource: Resource;
+  depth: number;
+  selected: ResourcePermissions[];
+  readOnly: boolean;
+  delimiter: string;
+  onChange: (selected: ResourcePermissions[]) => void;
+  collectSubtree: (resource: Resource) => Promise<string[]>;
+  getCachedSubtree: (resource: Resource) => string[] | null;
+}
+
+function CatalogResourceNode({
+  resourceServerId,
+  resource,
+  depth,
+  selected,
+  readOnly,
+  delimiter,
+  onChange,
+  collectSubtree,
+  getCachedSubtree,
+}: CatalogResourceNodeProps): JSX.Element | null {
+  const {t} = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const [cascading, setCascading] = useState(false);
+  const [cascadeError, setCascadeError] = useState(false);
+  const isOpen = expanded;
+  const {data: childResourcesData} = useGetResources(resourceServerId, resource.id, isOpen);
+  const {data: resourceActionsData} = useGetResourceActions(resourceServerId, resource.id, isOpen);
+
+  const childResources = childResourcesData?.resources ?? [];
+  const resourceActions = resourceActionsData?.actions ?? [];
+
+  const cached = getCachedSubtree(resource);
+  let state: SelectionState;
+  if (cached !== null) {
+    state = getSubtreeSelectionState(selected, resourceServerId, cached);
+  } else {
+    const serverEntry = selected.find((e) => e.resourceServerId === resourceServerId);
+    const anyUnder =
+      serverEntry?.permissions.some(
+        (p) => p === resource.permission || p.startsWith(`${resource.permission}${delimiter}`),
+      ) ?? false;
+    state = anyUnder ? 'some' : 'none';
+  }
+
+  const handleCascadeToggle = (): void => {
+    if (state === 'all' && cached !== null) {
+      onChange(removePermissions(selected, resourceServerId, cached));
+      return;
+    }
+    setCascading(true);
+    setCascadeError(false);
+    collectSubtree(resource)
+      .then((all) => {
+        onChange(mergePermissions(selected, [{resourceServerId, permissions: all}]));
+        setCascading(false);
+      })
+      .catch(() => {
+        setCascadeError(true);
+        setCascading(false);
+      });
+  };
+
+  return (
+    <>
+      <CatalogRow
+        name={resource.name}
+        permission={resource.permission}
+        depth={depth}
+        checked={state === 'all'}
+        indeterminate={state === 'some'}
+        disabled={readOnly}
+        loading={cascading}
+        onToggle={handleCascadeToggle}
+        expandControl={
+          <IconButton size="small" onClick={() => setExpanded((v) => !v)} aria-label={resource.handle}>
+            {isOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+          </IconButton>
+        }
+      />
+      {cascadeError && (
+        <Alert severity="error" sx={{mx: 2, my: 0.5}}>
+          {t('resourceServers:permissionCatalog.loadError', 'Failed to load permissions for this resource server.')}
+        </Alert>
+      )}
+      <Collapse in={isOpen}>
+        {resourceActions.map((action) => (
+          <CatalogRow
+            key={action.id}
+            name={action.name}
+            permission={action.permission}
+            depth={depth + 1}
+            checked={isPermissionSelected(selected, resourceServerId, action.permission)}
+            disabled={readOnly}
+            onToggle={() => onChange(togglePermission(selected, resourceServerId, action.permission))}
+          />
+        ))}
+        {childResources.map((child) => (
+          <CatalogResourceNode
+            key={child.id}
+            resourceServerId={resourceServerId}
+            resource={child}
+            depth={depth + 1}
+            selected={selected}
+            readOnly={readOnly}
+            delimiter={delimiter}
+            onChange={onChange}
+            collectSubtree={collectSubtree}
+            getCachedSubtree={getCachedSubtree}
+          />
+        ))}
+      </Collapse>
+    </>
+  );
+}
+
+/* ---------- Server section ---------- */
+
+interface ServerSectionProps {
+  server: ResourceServer;
+  selected: ResourcePermissions[];
+  readOnly: boolean;
+  onChange: (selected: ResourcePermissions[]) => void;
+}
+
+function ServerSectionContent({
+  server,
+  selected,
+  readOnly,
+  onChange,
+  collectSubtree,
+  getCachedSubtree,
+}: ServerSectionProps & {
+  collectSubtree: (resource: Resource) => Promise<string[]>;
+  getCachedSubtree: (resource: Resource) => string[] | null;
+}): JSX.Element {
+  const delimiter = server.delimiter;
+  const {t} = useTranslation();
+  const {data: resourcesData, isLoading: loadingResources, error: resourcesError} = useGetResources(server.id);
+  const {data: actionsData, isLoading: loadingActions, error: actionsError} = useGetServerActions(server.id);
+
+  if (loadingResources || loadingActions) {
+    return (
+      <Box sx={{display: 'flex', justifyContent: 'center', py: 3}}>
+        <CircularProgress size={20} />
+      </Box>
+    );
+  }
+
+  if (resourcesError ?? actionsError) {
+    return (
+      <Alert severity="error" sx={{my: 1}}>
+        {t('resourceServers:permissionCatalog.loadError', 'Failed to load permissions for this resource server.')}
+      </Alert>
+    );
+  }
+
+  const resources = resourcesData?.resources ?? [];
+  const serverActions = actionsData?.actions ?? [];
+
+  if (resources.length === 0 && serverActions.length === 0) {
+    return (
+      <Alert severity="info" sx={{my: 1}}>
+        {t('resourceServers:permissionCatalog.noPermissions', 'No permissions defined for this resource server.')}
+      </Alert>
+    );
+  }
+
+  return (
+    <>
+      {serverActions.map((action) => (
+        <CatalogRow
+          key={action.id}
+          name={action.name}
+          permission={action.permission}
+          depth={1}
+          checked={isPermissionSelected(selected, server.id, action.permission)}
+          disabled={readOnly}
+          onToggle={() => onChange(togglePermission(selected, server.id, action.permission))}
+        />
+      ))}
+      {resources.map((resource) => (
+        <CatalogResourceNode
+          key={resource.id}
+          resourceServerId={server.id}
+          resource={resource}
+          depth={1}
+          selected={selected}
+          readOnly={readOnly}
+          delimiter={delimiter}
+          onChange={onChange}
+          collectSubtree={collectSubtree}
+          getCachedSubtree={getCachedSubtree}
+        />
+      ))}
+    </>
+  );
+}
+
+function ServerSection({server, selected, readOnly, onChange}: ServerSectionProps): JSX.Element {
+  const {t} = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const [hasExpanded, setHasExpanded] = useState(false);
+  const [cascading, setCascading] = useState(false);
+  const [cascadeError, setCascadeError] = useState(false);
+
+  const {collectSubtreePermissions, getCachedSubtreePermissions, collectServerPermissions, getCachedServerPermissions} =
+    useSubtreePermissions(server.id);
+
+  const serverEntry = selected.find((e) => e.resourceServerId === server.id);
+  const selectedCount = serverEntry?.permissions.length ?? 0;
+
+  const cachedAll = getCachedServerPermissions();
+  const isEmpty = cachedAll !== null && cachedAll.length === 0 && selectedCount === 0;
+  let state: SelectionState;
+  if (cachedAll !== null) {
+    state = getSubtreeSelectionState(selected, server.id, cachedAll);
+    if (state === 'all' && serverEntry?.permissions.some((p) => !cachedAll.includes(p))) {
+      state = 'some';
+    }
+    if (cachedAll.length === 0 && selectedCount > 0) state = 'some';
+  } else {
+    state = selectedCount > 0 ? 'some' : 'none';
+  }
+
+  const handleToggleExpand = (): void => {
+    setExpanded((v) => !v);
+    setHasExpanded(true);
+  };
+
+  const handleCascadeToggle = (): void => {
+    if (state === 'all') {
+      onChange(selected.filter((e) => e.resourceServerId !== server.id));
+      return;
+    }
+    setCascading(true);
+    setCascadeError(false);
+    collectServerPermissions()
+      .then((all) => {
+        onChange(mergePermissions(selected, [{resourceServerId: server.id, permissions: all}]));
+        setCascading(false);
+      })
+      .catch(() => {
+        setCascadeError(true);
+        setCascading(false);
+      });
+  };
+
+  return (
+    <Box sx={{borderBottom: '1px solid', borderColor: 'divider'}}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{py: 0.5}}>
+        <IconButton size="small" onClick={handleToggleExpand} aria-label={server.handle}>
+          {expanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        </IconButton>
+        {cascading ? (
+          <Box sx={{width: 38, display: 'flex', justifyContent: 'center'}}>
+            <CircularProgress size={16} />
+          </Box>
+        ) : (
+          <Tooltip
+            title={
+              isEmpty
+                ? t(
+                    'resourceServers:permissionCatalog.noPermissions',
+                    'No permissions defined for this resource server.',
+                  )
+                : ''
+            }
+          >
+            <Checkbox
+              size="small"
+              checked={state === 'all'}
+              indeterminate={state === 'some'}
+              disabled={readOnly || isEmpty}
+              onChange={handleCascadeToggle}
+              inputProps={{'aria-label': server.name}}
+            />
+          </Tooltip>
+        )}
+        <Typography variant="subtitle2">{server.name}</Typography>
+        {selectedCount > 0 && <Chip size="small" label={selectedCount} />}
+      </Stack>
+      {cascadeError && (
+        <Alert severity="error" sx={{mx: 2, my: 0.5}}>
+          {t('resourceServers:permissionCatalog.loadError', 'Failed to load permissions for this resource server.')}
+        </Alert>
+      )}
+      <Collapse in={expanded}>
+        {hasExpanded && (
+          <ServerSectionContent
+            server={server}
+            selected={selected}
+            readOnly={readOnly}
+            onChange={onChange}
+            collectSubtree={collectSubtreePermissions}
+            getCachedSubtree={getCachedSubtreePermissions}
+          />
+        )}
+      </Collapse>
+    </Box>
+  );
+}
+
+/* ---------- Unknown servers ---------- */
+
+function UnknownServerGroups({
+  entries,
+  readOnly,
+  selected,
+  onChange,
+}: {
+  entries: ResourcePermissions[];
+  readOnly: boolean;
+  selected: ResourcePermissions[];
+  onChange: (selected: ResourcePermissions[]) => void;
+}): JSX.Element {
+  const {t} = useTranslation();
+  return (
+    <>
+      {entries.map((entry) => (
+        <Box key={entry.resourceServerId} sx={{borderBottom: '1px solid', borderColor: 'divider', py: 0.5}}>
+          <Stack direction="row" alignItems="center" spacing={1} sx={{pl: 1}}>
+            <Typography variant="subtitle2">{entry.resourceServerId}</Typography>
+            <Chip
+              size="small"
+              color="warning"
+              label={t('resourceServers:permissionCatalog.serverNotFound', 'Resource server not found')}
+            />
+          </Stack>
+          {entry.permissions.map((permission) => (
+            <CatalogRow
+              key={permission}
+              name={permission}
+              permission={permission}
+              depth={1}
+              checked
+              disabled={readOnly}
+              onToggle={() => onChange(togglePermission(selected, entry.resourceServerId, permission))}
+            />
+          ))}
+        </Box>
+      ))}
+    </>
+  );
+}
+
+/* ---------- Catalog ---------- */
+
+export default function PermissionCatalog({selected, onChange, readOnly = false}: PermissionCatalogProps): JSX.Element {
+  const {t} = useTranslation();
+
+  const {data: serversData, isLoading: loadingServers, error: serversError} = useGetResourceServers({limit: 100});
+  const servers = serversData?.resourceServers ?? [];
+
+  if (serversError) {
+    return (
+      <Alert severity="error">
+        {t('resourceServers:permissionCatalog.loadServersError', 'Failed to load resource servers.')}
+      </Alert>
+    );
+  }
+
+  if (loadingServers) {
+    return (
+      <Box sx={{display: 'flex', justifyContent: 'center', py: 4}}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  const unknownEntries = selected.filter((entry) => !servers.some((s) => s.id === entry.resourceServerId));
+
+  if (servers.length === 0 && unknownEntries.length === 0) {
+    return (
+      <Alert severity="info">
+        {t(
+          'resourceServers:permissionCatalog.noResourceServers',
+          'No resource servers found. Create a resource server first.',
+        )}
+      </Alert>
+    );
+  }
+
+  return (
+    <Paper variant="outlined" sx={{p: 2}}>
+      {servers.map((server) => (
+        <ServerSection key={server.id} server={server} selected={selected} readOnly={readOnly} onChange={onChange} />
+      ))}
+      <UnknownServerGroups entries={unknownEntries} readOnly={readOnly} selected={selected} onChange={onChange} />
+    </Paper>
+  );
+}

--- a/frontend/packages/configure-resource-servers/src/components/permission-catalog/SelectedScopesField.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/permission-catalog/SelectedScopesField.tsx
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {FormControl, IconButton, InputAdornment, TextField, Tooltip} from '@wso2/oxygen-ui';
+import {Check, Copy} from '@wso2/oxygen-ui-icons-react';
+import {useEffect, useRef, useState, type JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import type {ResourcePermissions} from '../../models/resource-server';
+
+export interface SelectedScopesFieldProps {
+  /** Permissions currently selected, grouped by resource server. */
+  selected: ResourcePermissions[];
+}
+
+export default function SelectedScopesField({selected}: SelectedScopesFieldProps): JSX.Element {
+  const {t} = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  const scopes = selected.flatMap((entry) => entry.permissions).join(' ');
+
+  const handleCopy = (): void => {
+    navigator.clipboard
+      .writeText(scopes)
+      .then(() => {
+        setCopied(true);
+        clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {
+        /* clipboard unavailable; no-op */
+      });
+  };
+
+  return (
+    <FormControl fullWidth>
+      <TextField
+        id="permission-catalog-scopes"
+        size="small"
+        value={scopes}
+        placeholder={t('resourceServers:permissionCatalog.scopes.placeholder', 'No permissions selected')}
+        InputProps={{
+          readOnly: true,
+          sx: {fontFamily: 'monospace'},
+          endAdornment: (
+            <InputAdornment position="end">
+              <Tooltip
+                title={copied ? t('resourceServers:permissionCatalog.scopes.copied', 'Copied') : ''}
+                open={copied}
+              >
+                <span>
+                  <IconButton
+                    size="small"
+                    disabled={scopes === ''}
+                    onClick={handleCopy}
+                    aria-label={t('resourceServers:permissionCatalog.scopes.copy', 'Copy scopes')}
+                  >
+                    {copied ? <Check size={16} /> : <Copy size={16} />}
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </InputAdornment>
+          ),
+        }}
+      />
+    </FormControl>
+  );
+}

--- a/frontend/packages/configure-resource-servers/src/components/permission-catalog/__tests__/PermissionCatalog.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/permission-catalog/__tests__/PermissionCatalog.test.tsx
@@ -1,0 +1,448 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {renderWithProviders, screen, waitFor, userEvent} from '@thunderid/test-utils';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import * as useGetResourceActionsModule from '../../../api/useGetResourceActions';
+import * as useGetResourcesModule from '../../../api/useGetResources';
+import * as useGetResourceServersModule from '../../../api/useGetResourceServers';
+import * as useGetServerActionsModule from '../../../api/useGetServerActions';
+import * as useSubtreePermissionsModule from '../../../api/useSubtreePermissions';
+import type {ResourcePermissions} from '../../../models/resource-server';
+import PermissionCatalog from '../PermissionCatalog';
+
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({http: {request: vi.fn()}}),
+}));
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({getServerUrl: () => 'http://localhost:8090'}),
+    useToast: () => ({showToast: vi.fn()}),
+  };
+});
+
+vi.mock('@thunderid/logger/react', () => ({
+  useLogger: () => ({error: vi.fn(), info: vi.fn(), debug: vi.fn()}),
+}));
+
+vi.mock('../../../api/useGetResourceServers');
+vi.mock('../../../api/useGetResources');
+vi.mock('../../../api/useGetServerActions');
+vi.mock('../../../api/useGetResourceActions');
+vi.mock('../../../api/useSubtreePermissions');
+
+/* ---------- Fixture ---------- */
+
+const servers = [
+  {id: 'rs-1', name: 'Booking API', handle: 'booking-api', ouId: 'ou-1', delimiter: ':', type: 'API' as const},
+  {id: 'rs-2', name: 'Payments API', handle: 'payments-api', ouId: 'ou-1', delimiter: ':', type: 'API' as const},
+];
+
+const dotServer = {
+  id: 'rs-dot',
+  name: 'Ecommerce API',
+  handle: 'ecommerce-api',
+  ouId: 'ou-1',
+  delimiter: '.',
+  type: 'API' as const,
+};
+
+const dotRootResources = [
+  {id: 'dot-res-1', name: 'Products', handle: 'products', permission: 'ecommerce.products', parent: null},
+];
+
+const rootResources = [{id: 'res-1', name: 'Bookings', handle: 'bookings', permission: 'bookings', parent: null}];
+
+const childResources = [
+  {id: 'res-2', name: 'Reservations', handle: 'reservations', permission: 'bookings:reservations', parent: 'res-1'},
+];
+
+const serverActions = [{id: 'act-health', name: 'Health Ping', handle: 'health-ping', permission: 'health:ping'}];
+
+const resourceActionsForBookings = [{id: 'act-1', name: 'Create', handle: 'create', permission: 'bookings:create'}];
+
+const resourceActionsForReservations = [
+  {id: 'act-2', name: 'Update', handle: 'update', permission: 'bookings:reservations:update'},
+];
+
+const serverActionsRs2 = [{id: 'act-refund', name: 'Refund', handle: 'refund', permission: 'payments:refund'}];
+
+/* ---------- The full subtree for rs-1 ---------- */
+const rs1AllPermissions = [
+  'health:ping',
+  'bookings',
+  'bookings:create',
+  'bookings:reservations',
+  'bookings:reservations:update',
+];
+
+/* ---------- Helpers ---------- */
+
+function queryResult<T>(data: T) {
+  return {data, isLoading: false, error: null} as never;
+}
+
+function emptyQueryResult() {
+  return {data: undefined, isLoading: false, error: null} as never;
+}
+
+const mockCollectSubtreePermissions = vi.fn();
+const mockGetCachedSubtreePermissions = vi.fn();
+const mockCollectServerPermissions = vi.fn();
+const mockGetCachedServerPermissions = vi.fn();
+
+function setupDefaultMocks(): void {
+  vi.mocked(useGetResourceServersModule.default).mockReturnValue(
+    queryResult({totalResults: 2, startIndex: 1, count: 2, resourceServers: servers}),
+  );
+
+  vi.mocked(useGetResourcesModule.default).mockImplementation(
+    (_serverId: string, parentId?: string, enabled = true) => {
+      if (!parentId) {
+        if (_serverId === 'rs-1') {
+          return queryResult({totalResults: 1, startIndex: 1, count: 1, resources: rootResources});
+        }
+        return queryResult({totalResults: 0, startIndex: 1, count: 0, resources: []});
+      }
+      if (!enabled) return emptyQueryResult();
+      if (parentId === 'res-1') {
+        return queryResult({totalResults: 1, startIndex: 1, count: 1, resources: childResources});
+      }
+      return queryResult({totalResults: 0, startIndex: 1, count: 0, resources: []});
+    },
+  );
+
+  vi.mocked(useGetServerActionsModule.default).mockImplementation((_serverId: string) => {
+    if (_serverId === 'rs-1') {
+      return queryResult({totalResults: 1, startIndex: 1, count: 1, actions: serverActions});
+    }
+    if (_serverId === 'rs-2') {
+      return queryResult({totalResults: 1, startIndex: 1, count: 1, actions: serverActionsRs2});
+    }
+    return queryResult({totalResults: 0, startIndex: 1, count: 0, actions: []});
+  });
+
+  vi.mocked(useGetResourceActionsModule.default).mockImplementation(
+    (_resourceServerId: string, resourceId: string, enabled?: boolean) => {
+      if (!enabled) return emptyQueryResult();
+      if (resourceId === 'res-1') {
+        return queryResult({totalResults: 1, startIndex: 1, count: 1, actions: resourceActionsForBookings});
+      }
+      if (resourceId === 'res-2') {
+        return queryResult({totalResults: 1, startIndex: 1, count: 1, actions: resourceActionsForReservations});
+      }
+      return queryResult({totalResults: 0, startIndex: 1, count: 0, actions: []});
+    },
+  );
+
+  // By default, cached variants return the full rs-1 subtree; collect variants resolve them
+  mockCollectSubtreePermissions.mockResolvedValue([
+    'bookings',
+    'bookings:create',
+    'bookings:reservations',
+    'bookings:reservations:update',
+  ]);
+  mockGetCachedSubtreePermissions.mockReturnValue([
+    'bookings',
+    'bookings:create',
+    'bookings:reservations',
+    'bookings:reservations:update',
+  ]);
+  mockCollectServerPermissions.mockResolvedValue(rs1AllPermissions);
+  mockGetCachedServerPermissions.mockReturnValue(rs1AllPermissions);
+
+  vi.mocked(useSubtreePermissionsModule.default).mockReturnValue({
+    collectSubtreePermissions: mockCollectSubtreePermissions,
+    getCachedSubtreePermissions: mockGetCachedSubtreePermissions,
+    collectServerPermissions: mockCollectServerPermissions,
+    getCachedServerPermissions: mockGetCachedServerPermissions,
+  });
+}
+
+function renderCatalog(props: {
+  selected: ResourcePermissions[];
+  onChange?: ReturnType<typeof vi.fn>;
+  readOnly?: boolean;
+}) {
+  const onChange = props.onChange ?? vi.fn();
+  renderWithProviders(<PermissionCatalog selected={props.selected} onChange={onChange} readOnly={props.readOnly} />);
+  return onChange;
+}
+
+/* ---------- Tests ---------- */
+
+describe('PermissionCatalog', () => {
+  beforeEach(() => {
+    setupDefaultMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lazy-loads a server section only after expanding it', async () => {
+    const user = userEvent.setup();
+    renderCatalog({selected: []});
+    // Before expand: Bookings resource row absent
+    expect(screen.queryByText('Bookings')).not.toBeInTheDocument();
+    // Click the rs-1 header expand button
+    await user.click(screen.getByRole('button', {name: 'booking-api'}));
+    // After expand: Bookings row visible
+    expect(await screen.findByText('Bookings')).toBeInTheDocument();
+  });
+
+  it('clicking an unchecked resource checkbox cascades the whole subtree', async () => {
+    const user = userEvent.setup();
+    const onChange = renderCatalog({selected: []});
+    // Expand rs-1 server
+    await user.click(screen.getByRole('button', {name: 'booking-api'}));
+    await screen.findByRole('checkbox', {name: 'Booking API'});
+    await waitFor(() => expect(screen.getByText('Bookings')).toBeInTheDocument());
+    const allBookingsCheckboxes = screen.getAllByRole('checkbox', {name: 'bookings'});
+    await user.click(allBookingsCheckboxes[0]);
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        {
+          resourceServerId: 'rs-1',
+          permissions: expect.arrayContaining([
+            'bookings',
+            'bookings:create',
+            'bookings:reservations',
+            'bookings:reservations:update',
+          ]) as string[],
+        },
+      ]);
+    });
+  });
+
+  it('clicking a fully-selected resource checkbox clears the subtree', async () => {
+    const user = userEvent.setup();
+    const fullySelected: ResourcePermissions[] = [
+      {
+        resourceServerId: 'rs-1',
+        permissions: ['bookings', 'bookings:create', 'bookings:reservations', 'bookings:reservations:update'],
+      },
+    ];
+    const onChange = renderCatalog({selected: fullySelected});
+    // Expand rs-1 server
+    await user.click(screen.getByRole('button', {name: 'booking-api'}));
+    await waitFor(() => expect(screen.getByText('Bookings')).toBeInTheDocument());
+    // The bookings node checkbox should be in 'all' state — click to clear
+    const allBookingsCheckboxes = screen.getAllByRole('checkbox', {name: 'bookings'});
+    await user.click(allBookingsCheckboxes[0]);
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  it('shows indeterminate state when only part of a subtree is selected', async () => {
+    const user = userEvent.setup();
+    // Only bookings:create selected — partial subtree
+    renderCatalog({selected: [{resourceServerId: 'rs-1', permissions: ['bookings:create']}]});
+    // Expand rs-1 to see the resource node
+    await user.click(screen.getByRole('button', {name: 'booking-api'}));
+    await waitFor(() => expect(screen.getByText('Bookings')).toBeInTheDocument());
+    // The bookings node checkbox should be indeterminate
+    const allBookingsCheckboxes = screen.getAllByRole('checkbox', {name: 'bookings'});
+    expect(allBookingsCheckboxes[0]).toHaveAttribute('data-indeterminate', 'true');
+  });
+
+  it('server header checkbox cascades the entire server', async () => {
+    const user = userEvent.setup();
+    const onChange = renderCatalog({selected: []});
+    // Click the Booking API server-level checkbox
+    const bookingApiCheckbox = screen.getByRole('checkbox', {name: 'Booking API'});
+    await user.click(bookingApiCheckbox);
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        {
+          resourceServerId: 'rs-1',
+          permissions: expect.arrayContaining(rs1AllPermissions) as string[],
+        },
+      ]);
+    });
+  });
+
+  it('unchecking a fully-selected server drops its entry including unknown strings', async () => {
+    const user = userEvent.setup();
+    const cleanSelected: ResourcePermissions[] = [{resourceServerId: 'rs-1', permissions: [...rs1AllPermissions]}];
+    const onChange = renderCatalog({selected: cleanSelected});
+    const bookingApiCheckbox = screen.getByRole('checkbox', {name: 'Booking API'});
+    // Should be checked (all state) since selected matches cached exactly
+    expect(bookingApiCheckbox).toBeChecked();
+    await user.click(bookingApiCheckbox);
+    await waitFor(() => {
+      // The whole rs-1 entry should be dropped
+      expect(onChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  it('renders unknown-server entries as a warning group with uncheckable rows', async () => {
+    const user = userEvent.setup();
+    const selected: ResourcePermissions[] = [{resourceServerId: 'rs-gone', permissions: ['ghost:perm']}];
+    const onChange = renderCatalog({selected});
+    // Warning chip for unknown server should be visible
+    expect(await screen.findByText('Resource server not found')).toBeInTheDocument();
+    // The ghost:perm row should be checked
+    const ghostCheckbox = screen.getByRole('checkbox', {name: 'ghost:perm'});
+    expect(ghostCheckbox).toBeChecked();
+    // Clicking the ghost:perm checkbox should remove it
+    await user.click(ghostCheckbox);
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  it('shows indeterminate on a dot-delimited resource node when only a descendant is selected and cache is null', async () => {
+    const user = userEvent.setup();
+
+    // Override server list to include only the dot-delimiter server
+    vi.mocked(useGetResourceServersModule.default).mockReturnValue(
+      queryResult({totalResults: 1, startIndex: 1, count: 1, resourceServers: [dotServer]}),
+    );
+
+    // Root resources for the dot server
+    vi.mocked(useGetResourcesModule.default).mockImplementation((serverId: string, parentId?: string) => {
+      if (serverId === 'rs-dot' && !parentId) {
+        return queryResult({totalResults: 1, startIndex: 1, count: 1, resources: dotRootResources});
+      }
+      return queryResult({totalResults: 0, startIndex: 1, count: 0, resources: []});
+    });
+
+    vi.mocked(useGetServerActionsModule.default).mockReturnValue(
+      queryResult({totalResults: 0, startIndex: 1, count: 0, actions: []}),
+    );
+
+    vi.mocked(useGetResourceActionsModule.default).mockReturnValue(emptyQueryResult());
+
+    // Cache returns null — subtree not yet fetched (tree not fully expanded)
+    mockGetCachedSubtreePermissions.mockReturnValue(null);
+    mockGetCachedServerPermissions.mockReturnValue(null);
+
+    // Only a descendant action is selected (dot-delimited)
+    const selected: ResourcePermissions[] = [{resourceServerId: 'rs-dot', permissions: ['ecommerce.products.read']}];
+
+    renderCatalog({selected});
+
+    // Expand the dot server
+    await user.click(screen.getByRole('button', {name: 'ecommerce-api'}));
+    await waitFor(() => expect(screen.getByText('Products')).toBeInTheDocument());
+
+    // The Products resource node checkbox should be indeterminate because
+    // 'ecommerce.products.read' starts with 'ecommerce.products' + '.' (dot delimiter)
+    const allProductsCheckboxes = screen.getAllByRole('checkbox', {name: 'ecommerce.products'});
+    expect(allProductsCheckboxes[0]).toHaveAttribute('data-indeterminate', 'true');
+  });
+
+  it('does NOT show indeterminate when a colon-prefixed descendant is selected under a dot-delimiter server (wrong delimiter is excluded)', async () => {
+    const user = userEvent.setup();
+
+    // Override server list to include only the dot-delimiter server
+    vi.mocked(useGetResourceServersModule.default).mockReturnValue(
+      queryResult({totalResults: 1, startIndex: 1, count: 1, resourceServers: [dotServer]}),
+    );
+
+    vi.mocked(useGetResourcesModule.default).mockImplementation((serverId: string, parentId?: string) => {
+      if (serverId === 'rs-dot' && !parentId) {
+        return queryResult({totalResults: 1, startIndex: 1, count: 1, resources: dotRootResources});
+      }
+      return queryResult({totalResults: 0, startIndex: 1, count: 0, resources: []});
+    });
+
+    vi.mocked(useGetServerActionsModule.default).mockReturnValue(
+      queryResult({totalResults: 0, startIndex: 1, count: 0, actions: []}),
+    );
+
+    vi.mocked(useGetResourceActionsModule.default).mockReturnValue(emptyQueryResult());
+
+    mockGetCachedSubtreePermissions.mockReturnValue(null);
+    mockGetCachedServerPermissions.mockReturnValue(null);
+
+    // A colon-based permission that looks like a descendant with colon but NOT with dot
+    // Under the dot server, 'ecommerce.products:read' does NOT start with 'ecommerce.products.'
+    const selected: ResourcePermissions[] = [{resourceServerId: 'rs-dot', permissions: ['ecommerce.products:read']}];
+
+    renderCatalog({selected});
+
+    await user.click(screen.getByRole('button', {name: 'ecommerce-api'}));
+    await waitFor(() => expect(screen.getByText('Products')).toBeInTheDocument());
+
+    // Should be 'none' state (neither checked nor indeterminate)
+    const allProductsCheckboxes = screen.getAllByRole('checkbox', {name: 'ecommerce.products'});
+    expect(allProductsCheckboxes[0]).not.toBeChecked();
+    expect(allProductsCheckboxes[0]).not.toHaveAttribute('data-indeterminate', 'true');
+  });
+
+  it('disables every checkbox in readOnly mode', async () => {
+    const user = userEvent.setup();
+    const selected: ResourcePermissions[] = [{resourceServerId: 'rs-1', permissions: ['bookings']}];
+    renderCatalog({selected, readOnly: true});
+    // The server-level checkbox should be disabled
+    const bookingApiCheckbox = screen.getByRole('checkbox', {name: 'Booking API'});
+    expect(bookingApiCheckbox).toBeDisabled();
+    // Expand the server and check the resource-level checkboxes
+    await user.click(screen.getByRole('button', {name: 'booking-api'}));
+    await waitFor(() => expect(screen.getByText('Bookings')).toBeInTheDocument());
+    const allBookingsCheckboxes = screen.getAllByRole('checkbox', {name: 'bookings'});
+    allBookingsCheckboxes.forEach((cb) => expect(cb).toBeDisabled());
+  });
+
+  it('disables the server checkbox when the server has no resources and no actions', async () => {
+    const user = userEvent.setup();
+    const emptyServer = {
+      id: 'rs-empty',
+      name: 'Empty API',
+      handle: 'empty-api',
+      ouId: 'ou-1',
+      delimiter: ':',
+      type: 'API' as const,
+    };
+
+    vi.mocked(useGetResourceServersModule.default).mockReturnValue(
+      queryResult({totalResults: 1, startIndex: 1, count: 1, resourceServers: [emptyServer]}),
+    );
+
+    vi.mocked(useGetResourcesModule.default).mockReturnValue(
+      queryResult({totalResults: 0, startIndex: 1, count: 0, resources: []}),
+    );
+
+    vi.mocked(useGetServerActionsModule.default).mockReturnValue(
+      queryResult({totalResults: 0, startIndex: 1, count: 0, actions: []}),
+    );
+
+    vi.mocked(useGetResourceActionsModule.default).mockReturnValue(
+      queryResult({totalResults: 0, startIndex: 1, count: 0, actions: []}),
+    );
+
+    mockGetCachedServerPermissions.mockReturnValue([]);
+    mockCollectServerPermissions.mockResolvedValue([]);
+
+    renderCatalog({selected: []});
+
+    // Expand the server to trigger data fetch and populate the cache
+    await user.click(screen.getByRole('button', {name: 'empty-api'}));
+
+    // After expansion the cache returns [] — the checkbox should be disabled
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', {name: 'Empty API'})).toBeDisabled();
+    });
+  });
+});

--- a/frontend/packages/configure-resource-servers/src/components/permission-catalog/__tests__/SelectedScopesField.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/permission-catalog/__tests__/SelectedScopesField.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {renderWithProviders, screen, userEvent} from '@thunderid/test-utils';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import type {ResourcePermissions} from '../../../models/resource-server';
+import SelectedScopesField from '../SelectedScopesField';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (_key: string, fallback?: string) => fallback ?? _key}),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SelectedScopesField', () => {
+  it('should render the scope string with all selected permissions space-separated', () => {
+    const selected: ResourcePermissions[] = [{resourceServerId: 'rs-1', permissions: ['bookings', 'bookings:create']}];
+    renderWithProviders(<SelectedScopesField selected={selected} />);
+    expect(screen.getByDisplayValue('bookings bookings:create')).toBeInTheDocument();
+  });
+
+  it('should render an empty value when nothing is selected', () => {
+    renderWithProviders(<SelectedScopesField selected={[]} />);
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  it('should show the placeholder when nothing is selected', () => {
+    renderWithProviders(<SelectedScopesField selected={[]} />);
+    expect(screen.getByPlaceholderText('No permissions selected')).toBeInTheDocument();
+  });
+
+  it('should disable the copy button when nothing is selected', () => {
+    renderWithProviders(<SelectedScopesField selected={[]} />);
+    expect(screen.getByRole('button', {name: /copy scopes/i})).toBeDisabled();
+  });
+
+  it('should enable the copy button when permissions are selected', () => {
+    const selected: ResourcePermissions[] = [{resourceServerId: 'rs-1', permissions: ['bookings']}];
+    renderWithProviders(<SelectedScopesField selected={selected} />);
+    expect(screen.getByRole('button', {name: /copy scopes/i})).not.toBeDisabled();
+  });
+
+  it('should copy the scope string to the clipboard', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {value: {writeText}, writable: true, configurable: true});
+    const selected: ResourcePermissions[] = [{resourceServerId: 'rs-1', permissions: ['bookings']}];
+    renderWithProviders(<SelectedScopesField selected={selected} />);
+    await user.click(screen.getByRole('button', {name: /copy scopes/i}));
+    expect(writeText).toHaveBeenCalledWith('bookings');
+  });
+
+  it('should flatten permissions from multiple resource servers', () => {
+    const selected: ResourcePermissions[] = [
+      {resourceServerId: 'rs-1', permissions: ['bookings', 'bookings:create']},
+      {resourceServerId: 'rs-2', permissions: ['payments:refund']},
+    ];
+    renderWithProviders(<SelectedScopesField selected={selected} />);
+    expect(screen.getByDisplayValue('bookings bookings:create payments:refund')).toBeInTheDocument();
+  });
+
+  it('should render the field as readonly', () => {
+    const selected: ResourcePermissions[] = [{resourceServerId: 'rs-1', permissions: ['bookings']}];
+    renderWithProviders(<SelectedScopesField selected={selected} />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('readonly');
+  });
+});

--- a/frontend/packages/configure-resource-servers/src/index.ts
+++ b/frontend/packages/configure-resource-servers/src/index.ts
@@ -33,6 +33,10 @@ export {default as useUpdateAction} from './api/useUpdateAction';
 export {default as useDeleteAction} from './api/useDeleteAction';
 
 // Components
+export {default as PermissionCatalog} from './components/permission-catalog/PermissionCatalog';
+export type {PermissionCatalogProps} from './components/permission-catalog/PermissionCatalog';
+export {default as SelectedScopesField} from './components/permission-catalog/SelectedScopesField';
+export type {SelectedScopesFieldProps} from './components/permission-catalog/SelectedScopesField';
 export {default as ResourceServersList} from './components/ResourceServersList';
 export {default as ResourceServerDeleteDialog} from './components/ResourceServerDeleteDialog';
 export type {ResourceServerDeleteDialogProps} from './components/ResourceServerDeleteDialog';
@@ -54,7 +58,19 @@ export type {
   UpdateResourceRequest,
   CreateActionRequest,
   UpdateActionRequest,
+  ResourcePermissions,
 } from './models/resource-server';
+
+// Utils
+export {
+  isPermissionSelected,
+  togglePermission,
+  mergePermissions,
+  removePermissions,
+  getSubtreeSelectionState,
+  arePermissionsEqual,
+} from './utils/permissionSelection';
+export type {SelectionState} from './utils/permissionSelection';
 
 // Pages
 export {default as ResourceServersListPage} from './pages/ResourceServersListPage';

--- a/frontend/packages/configure-resource-servers/src/models/resource-server.ts
+++ b/frontend/packages/configure-resource-servers/src/models/resource-server.ts
@@ -111,3 +111,8 @@ export interface UpdateActionRequest {
   name?: string;
   description?: string | null;
 }
+
+export interface ResourcePermissions {
+  resourceServerId: string;
+  permissions: string[];
+}

--- a/frontend/packages/configure-resource-servers/src/utils/__tests__/permissionSelection.test.ts
+++ b/frontend/packages/configure-resource-servers/src/utils/__tests__/permissionSelection.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import type {ResourcePermissions} from '../../models/resource-server';
+import {
+  isPermissionSelected,
+  togglePermission,
+  mergePermissions,
+  removePermissions,
+  getSubtreeSelectionState,
+  arePermissionsEqual,
+} from '../permissionSelection';
+
+describe('permissionSelection utils', () => {
+  const base: ResourcePermissions[] = [
+    {resourceServerId: 'rs-1', permissions: ['bookings', 'bookings:create']},
+    {resourceServerId: 'rs-2', permissions: ['payments:refund']},
+  ];
+
+  describe('isPermissionSelected', () => {
+    it('returns true when the permission exists for the server', () => {
+      expect(isPermissionSelected(base, 'rs-1', 'bookings:create')).toBe(true);
+    });
+
+    it('returns false for an unknown permission or server', () => {
+      expect(isPermissionSelected(base, 'rs-1', 'bookings:delete')).toBe(false);
+      expect(isPermissionSelected(base, 'rs-9', 'bookings')).toBe(false);
+    });
+  });
+
+  describe('togglePermission', () => {
+    it('adds a permission for a new server', () => {
+      const result = togglePermission([], 'rs-1', 'bookings');
+      expect(result).toEqual([{resourceServerId: 'rs-1', permissions: ['bookings']}]);
+    });
+
+    it('adds a permission to an existing server entry', () => {
+      const result = togglePermission(base, 'rs-2', 'payments:charge');
+      expect(result.find((e) => e.resourceServerId === 'rs-2')?.permissions).toEqual([
+        'payments:refund',
+        'payments:charge',
+      ]);
+    });
+
+    it('removes a permission that is already selected', () => {
+      const result = togglePermission(base, 'rs-1', 'bookings');
+      expect(result.find((e) => e.resourceServerId === 'rs-1')?.permissions).toEqual(['bookings:create']);
+    });
+
+    it('drops the server entry entirely when its last permission is removed', () => {
+      const result = togglePermission(base, 'rs-2', 'payments:refund');
+      expect(result.find((e) => e.resourceServerId === 'rs-2')).toBeUndefined();
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not mutate the input', () => {
+      const snapshot: ResourcePermissions[] = JSON.parse(JSON.stringify(base)) as ResourcePermissions[];
+      togglePermission(base, 'rs-1', 'bookings');
+      expect(base).toEqual(snapshot);
+    });
+  });
+
+  describe('mergePermissions', () => {
+    it('appends entries for servers not present in the base', () => {
+      const result = mergePermissions(base, [{resourceServerId: 'rs-3', permissions: ['notify:send']}]);
+      expect(result).toHaveLength(3);
+      expect(result.find((e) => e.resourceServerId === 'rs-3')?.permissions).toEqual(['notify:send']);
+    });
+
+    it('merges and de-duplicates permissions for an existing server', () => {
+      const result = mergePermissions(base, [{resourceServerId: 'rs-1', permissions: ['bookings', 'bookings:delete']}]);
+      expect(result.find((e) => e.resourceServerId === 'rs-1')?.permissions).toEqual([
+        'bookings',
+        'bookings:create',
+        'bookings:delete',
+      ]);
+    });
+
+    it('does not mutate the inputs', () => {
+      const snapshot: ResourcePermissions[] = JSON.parse(JSON.stringify(base)) as ResourcePermissions[];
+      mergePermissions(base, [{resourceServerId: 'rs-1', permissions: ['x']}]);
+      expect(base).toEqual(snapshot);
+    });
+  });
+
+  describe('removePermissions', () => {
+    it('removes a subset of permissions from the server entry', () => {
+      const result = removePermissions(base, 'rs-1', ['bookings']);
+      expect(result.find((e) => e.resourceServerId === 'rs-1')?.permissions).toEqual(['bookings:create']);
+    });
+
+    it('drops the server entry entirely when all its permissions are removed', () => {
+      const result = removePermissions(base, 'rs-2', ['payments:refund']);
+      expect(result.find((e) => e.resourceServerId === 'rs-2')).toBeUndefined();
+      expect(result).toHaveLength(1);
+    });
+
+    it('returns the original list when the server is not found', () => {
+      const result = removePermissions(base, 'rs-99', ['bookings']);
+      expect(result).toBe(base);
+    });
+
+    it('does not mutate the input', () => {
+      const snapshot: ResourcePermissions[] = JSON.parse(JSON.stringify(base)) as ResourcePermissions[];
+      removePermissions(base, 'rs-1', ['bookings']);
+      expect(base).toEqual(snapshot);
+    });
+  });
+});
+
+describe('getSubtreeSelectionState', () => {
+  const list = [{resourceServerId: 'rs-1', permissions: ['bookings', 'bookings:create']}];
+
+  it('returns all when every subtree permission is selected', () => {
+    expect(getSubtreeSelectionState(list, 'rs-1', ['bookings', 'bookings:create'])).toBe('all');
+  });
+
+  it('returns some when only part of the subtree is selected', () => {
+    expect(getSubtreeSelectionState(list, 'rs-1', ['bookings', 'bookings:create', 'bookings:delete'])).toBe('some');
+  });
+
+  it('returns none when nothing in the subtree is selected', () => {
+    expect(getSubtreeSelectionState(list, 'rs-1', ['payments:refund'])).toBe('none');
+  });
+
+  it('returns none for an empty subtree', () => {
+    expect(getSubtreeSelectionState(list, 'rs-1', [])).toBe('none');
+  });
+
+  it('scopes matching to the given resource server', () => {
+    expect(getSubtreeSelectionState(list, 'rs-2', ['bookings'])).toBe('none');
+  });
+});
+
+describe('arePermissionsEqual', () => {
+  it('treats reordered servers and permissions as equal', () => {
+    const a = [
+      {resourceServerId: 'rs-1', permissions: ['x', 'y']},
+      {resourceServerId: 'rs-2', permissions: ['z']},
+    ];
+    const b = [
+      {resourceServerId: 'rs-2', permissions: ['z']},
+      {resourceServerId: 'rs-1', permissions: ['y', 'x']},
+    ];
+    expect(arePermissionsEqual(a, b)).toBe(true);
+  });
+
+  it('detects differing permissions', () => {
+    expect(
+      arePermissionsEqual(
+        [{resourceServerId: 'rs-1', permissions: ['x']}],
+        [{resourceServerId: 'rs-1', permissions: ['x', 'y']}],
+      ),
+    ).toBe(false);
+  });
+
+  it('detects differing server sets', () => {
+    expect(arePermissionsEqual([{resourceServerId: 'rs-1', permissions: ['x']}], [])).toBe(false);
+  });
+
+  it('treats two empty lists as equal', () => {
+    expect(arePermissionsEqual([], [])).toBe(true);
+  });
+});

--- a/frontend/packages/configure-resource-servers/src/utils/permissionSelection.ts
+++ b/frontend/packages/configure-resource-servers/src/utils/permissionSelection.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {ResourcePermissions} from '../models/resource-server';
+
+export type SelectionState = 'all' | 'some' | 'none';
+
+export function isPermissionSelected(
+  list: ResourcePermissions[],
+  resourceServerId: string,
+  permission: string,
+): boolean {
+  return list.some((entry) => entry.resourceServerId === resourceServerId && entry.permissions.includes(permission));
+}
+
+export function togglePermission(
+  list: ResourcePermissions[],
+  resourceServerId: string,
+  permission: string,
+): ResourcePermissions[] {
+  const existing = list.find((entry) => entry.resourceServerId === resourceServerId);
+  if (!existing) {
+    return [...list, {resourceServerId, permissions: [permission]}];
+  }
+
+  const updatedPermissions = existing.permissions.includes(permission)
+    ? existing.permissions.filter((p) => p !== permission)
+    : [...existing.permissions, permission];
+
+  if (updatedPermissions.length === 0) {
+    return list.filter((entry) => entry.resourceServerId !== resourceServerId);
+  }
+
+  return list.map((entry) =>
+    entry.resourceServerId === resourceServerId ? {...entry, permissions: updatedPermissions} : entry,
+  );
+}
+
+export function mergePermissions(base: ResourcePermissions[], additions: ResourcePermissions[]): ResourcePermissions[] {
+  const result = base.map((entry) => ({...entry, permissions: [...entry.permissions]}));
+
+  for (const addition of additions) {
+    const existing = result.find((entry) => entry.resourceServerId === addition.resourceServerId);
+    if (!existing) {
+      result.push({resourceServerId: addition.resourceServerId, permissions: [...addition.permissions]});
+      continue;
+    }
+    for (const permission of addition.permissions) {
+      if (!existing.permissions.includes(permission)) {
+        existing.permissions.push(permission);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function removePermissions(
+  list: ResourcePermissions[],
+  resourceServerId: string,
+  permissions: string[],
+): ResourcePermissions[] {
+  const entry = list.find((e) => e.resourceServerId === resourceServerId);
+  if (!entry) return list;
+
+  const updatedPermissions = entry.permissions.filter((p) => !permissions.includes(p));
+  if (updatedPermissions.length === 0) {
+    return list.filter((e) => e.resourceServerId !== resourceServerId);
+  }
+
+  return list.map((e) => (e.resourceServerId === resourceServerId ? {...e, permissions: updatedPermissions} : e));
+}
+
+export function getSubtreeSelectionState(
+  list: ResourcePermissions[],
+  resourceServerId: string,
+  subtreePermissions: string[],
+): SelectionState {
+  if (subtreePermissions.length === 0) return 'none';
+  const selectedCount = subtreePermissions.filter((p) => isPermissionSelected(list, resourceServerId, p)).length;
+  if (selectedCount === 0) return 'none';
+  return selectedCount === subtreePermissions.length ? 'all' : 'some';
+}
+
+export function arePermissionsEqual(a: ResourcePermissions[], b: ResourcePermissions[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((entryA) => {
+    const entryB = b.find((e) => e.resourceServerId === entryA.resourceServerId);
+    if (entryA.permissions.length !== entryB?.permissions.length) return false;
+    return entryA.permissions.every((p) => entryB.permissions.includes(p));
+  });
+}

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1375,10 +1375,15 @@ const translations = {
     // Create wizard
     'createWizard.steps.basicInfo': 'Create a Role',
     'createWizard.steps.organizationUnit': 'Organization Unit',
+    'createWizard.steps.permissions': 'Permissions',
     'createWizard.basicInfo.title': "Let's give a name to your role",
     'createWizard.basicInfo.suggestions.label': 'In a hurry? Pick a random name:',
     'createWizard.organizationUnit.title': 'Select an organization unit',
     'createWizard.organizationUnit.subtitle': 'Choose the organization unit this role will belong to.',
+    'createWizard.permissions.title': 'Assign permissions (optional)',
+    'createWizard.permissions.subtitle':
+      'Choose what this role grants. You can skip this step and add permissions later.',
+    'createWizard.permissions.scopes.label': 'Selected scopes',
 
     // Edit page
     'edit.page.back': 'Back to Roles',
@@ -1409,15 +1414,11 @@ const translations = {
     'edit.general.sections.dangerZone.deleteRoleDescription': 'Deleting this role is permanent and cannot be undone.',
 
     // Permissions settings
-    'edit.permissions.description':
-      'Select the permissions this role grants. Changes are saved when you click Save Changes.',
-    'edit.permissions.resourcesLabel': 'Resources',
-    'edit.permissions.actionsLabel': 'Actions',
-    'edit.permissions.noPermissions': 'No permissions defined for this resource server.',
-    'edit.permissions.noResourceServers': 'No resource servers found. Create a resource server first.',
-    'edit.permissions.loadError': 'Failed to load permissions for this resource server.',
-    'edit.permissions.loadResourceServersError': 'Failed to load resource servers.',
-    'edit.permissions.selectedCount': '{{count}} selected',
+    'edit.permissions.title': 'Permissions',
+    'edit.permissions.description': 'Select the permissions this role grants, grouped by resource server',
+    'edit.permissions.scopes.title': 'Selected scopes',
+    'edit.permissions.scopes.description':
+      'The OAuth scopes granted by these permissions. Copy them for use in your application.',
 
     // Assignments settings
     'edit.assignments.sections.manage.title': 'Assigned Users, Groups, Apps & Agents',
@@ -3529,6 +3530,15 @@ const translations = {
     'tree.deleteAction.success': 'Action deleted.',
     'tree.deleteAction.error': 'Failed to delete action.',
     'tree.copyPermission': 'Copy permission string',
+    // Permission catalog
+    'permissionCatalog.scopes.placeholder': 'No permissions selected',
+    'permissionCatalog.scopes.copy': 'Copy scopes',
+    'permissionCatalog.scopes.copied': 'Copied',
+    'permissionCatalog.noResourceServers': 'No resource servers found. Create a resource server first.',
+    'permissionCatalog.noPermissions': 'No permissions defined for this resource server.',
+    'permissionCatalog.loadError': 'Failed to load permissions for this resource server.',
+    'permissionCatalog.loadServersError': 'Failed to load resource servers.',
+    'permissionCatalog.serverNotFound': 'Resource server not found',
   },
 } as const;
 


### PR DESCRIPTION
### Purpose
$subject

<img width="2043" height="1203" alt="Screenshot 2026-06-12 at 9 53 12 AM" src="https://github.com/user-attachments/assets/4e5134cc-9e7e-411c-baac-3c80cdf0bbbb" />

<img width="1384" height="1070" alt="Screenshot 2026-06-12 at 9 53 26 AM" src="https://github.com/user-attachments/assets/5bf74511-0043-4a7b-8ad1-a30bc9d9c9fb" />


### Related Issues
- https://github.com/thunder-id/thunderid/issues/2412

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Permissions step to role creation (scope selection, plus a read-only “selected scopes” field with copy-to-clipboard).
  * Introduced a Permission Catalog UI with tri-state/cascade selection and handling for missing servers.
  * Added a Permissions tab to role editing with change/restore staging.
* **Bug Fixes / Improvements**
  * Role updates now update cached permission data immediately and keep non-editable fields intact; Save is disabled while an update is in progress.
* **Documentation**
  * Updated i18n strings for the new wizard step, permissions tab, and permission catalog/scope display.
* **Tests**
  * Expanded test coverage for wizard navigation, create payloads, catalog interactions, and edit save/restore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->