### PR TITLE
Block direct HTTP flow initiation for authorization_code grant type apps

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -731,6 +731,23 @@ jobs:
           fi
           echo "✅ React SDK Sample resources imported successfully"
 
+          echo "Importing E2E test infrastructure resources..."
+          YAML_CONTENT=$(cat tests/e2e/thunderid-config.yaml)
+          HTTP_STATUS=$(curl -k -s -o /tmp/import_response.json -w "%{http_code}" \
+            -X POST https://localhost:8090/import \
+            -H 'Content-Type: application/json' \
+            -d "{
+              \"content\": $(echo "$YAML_CONTENT" | jq -Rs .),
+              \"options\": {\"upsert\": true}
+            }")
+          echo "Import HTTP status: $HTTP_STATUS"
+          cat /tmp/import_response.json | jq . || cat /tmp/import_response.json
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "❌ Failed to import E2E test infrastructure resources (HTTP $HTTP_STATUS)"
+            exit 1
+          fi
+          echo "✅ E2E test infrastructure resources imported successfully"
+
       - name: 🔍 Extract Sample App ID
         id: extract-app-id
         run: |

--- a/backend/internal/actorprovider/ActorProviderInterface_mock_test.go
+++ b/backend/internal/actorprovider/ActorProviderInterface_mock_test.go
@@ -307,3 +307,73 @@ func (_c *ActorProviderInterfaceMock_GetOAuthClientByID_Call) RunAndReturn(run f
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetOAuthProfileByID provides a mock function for the type ActorProviderInterfaceMock
+func (_mock *ActorProviderInterfaceMock) GetOAuthProfileByID(ctx context.Context, id string) (*model.OAuthProfile, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOAuthProfileByID")
+	}
+
+	var r0 *model.OAuthProfile
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*model.OAuthProfile, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *model.OAuthProfile); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.OAuthProfile)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// ActorProviderInterfaceMock_GetOAuthProfileByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOAuthProfileByID'
+type ActorProviderInterfaceMock_GetOAuthProfileByID_Call struct {
+	*mock.Call
+}
+
+// GetOAuthProfileByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *ActorProviderInterfaceMock_Expecter) GetOAuthProfileByID(ctx interface{}, id interface{}) *ActorProviderInterfaceMock_GetOAuthProfileByID_Call {
+	return &ActorProviderInterfaceMock_GetOAuthProfileByID_Call{Call: _e.mock.On("GetOAuthProfileByID", ctx, id)}
+}
+
+func (_c *ActorProviderInterfaceMock_GetOAuthProfileByID_Call) Run(run func(ctx context.Context, id string)) *ActorProviderInterfaceMock_GetOAuthProfileByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ActorProviderInterfaceMock_GetOAuthProfileByID_Call) Return(oAuthProfile *model.OAuthProfile, serviceError *serviceerror.ServiceError) *ActorProviderInterfaceMock_GetOAuthProfileByID_Call {
+	_c.Call.Return(oAuthProfile, serviceError)
+	return _c
+}
+
+func (_c *ActorProviderInterfaceMock_GetOAuthProfileByID_Call) RunAndReturn(run func(ctx context.Context, id string) (*model.OAuthProfile, *serviceerror.ServiceError)) *ActorProviderInterfaceMock_GetOAuthProfileByID_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/backend/internal/actorprovider/ActorProviderInterface_mock_test.go
+++ b/backend/internal/actorprovider/ActorProviderInterface_mock_test.go
@@ -238,28 +238,28 @@ func (_c *ActorProviderInterfaceMock_GetInboundClientByID_Call) RunAndReturn(run
 	return _c
 }
 
-// GetOAuthClientByID provides a mock function for the type ActorProviderInterfaceMock
-func (_mock *ActorProviderInterfaceMock) GetOAuthClientByID(ctx context.Context, id string) (*model.OAuthClient, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, id)
+// GetOAuthClientByClientID provides a mock function for the type ActorProviderInterfaceMock
+func (_mock *ActorProviderInterfaceMock) GetOAuthClientByClientID(ctx context.Context, clientID string) (*model.OAuthClient, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, clientID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetOAuthClientByID")
+		panic("no return value specified for GetOAuthClientByClientID")
 	}
 
 	var r0 *model.OAuthClient
 	var r1 *serviceerror.ServiceError
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*model.OAuthClient, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, id)
+		return returnFunc(ctx, clientID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *model.OAuthClient); ok {
-		r0 = returnFunc(ctx, id)
+		r0 = returnFunc(ctx, clientID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.OAuthClient)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, id)
+		r1 = returnFunc(ctx, clientID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -268,19 +268,19 @@ func (_mock *ActorProviderInterfaceMock) GetOAuthClientByID(ctx context.Context,
 	return r0, r1
 }
 
-// ActorProviderInterfaceMock_GetOAuthClientByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOAuthClientByID'
-type ActorProviderInterfaceMock_GetOAuthClientByID_Call struct {
+// ActorProviderInterfaceMock_GetOAuthClientByClientID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOAuthClientByClientID'
+type ActorProviderInterfaceMock_GetOAuthClientByClientID_Call struct {
 	*mock.Call
 }
 
-// GetOAuthClientByID is a helper method to define mock.On call
+// GetOAuthClientByClientID is a helper method to define mock.On call
 //   - ctx context.Context
-//   - id string
-func (_e *ActorProviderInterfaceMock_Expecter) GetOAuthClientByID(ctx interface{}, id interface{}) *ActorProviderInterfaceMock_GetOAuthClientByID_Call {
-	return &ActorProviderInterfaceMock_GetOAuthClientByID_Call{Call: _e.mock.On("GetOAuthClientByID", ctx, id)}
+//   - clientID string
+func (_e *ActorProviderInterfaceMock_Expecter) GetOAuthClientByClientID(ctx interface{}, clientID interface{}) *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call {
+	return &ActorProviderInterfaceMock_GetOAuthClientByClientID_Call{Call: _e.mock.On("GetOAuthClientByClientID", ctx, clientID)}
 }
 
-func (_c *ActorProviderInterfaceMock_GetOAuthClientByID_Call) Run(run func(ctx context.Context, id string)) *ActorProviderInterfaceMock_GetOAuthClientByID_Call {
+func (_c *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call) Run(run func(ctx context.Context, clientID string)) *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -298,12 +298,12 @@ func (_c *ActorProviderInterfaceMock_GetOAuthClientByID_Call) Run(run func(ctx c
 	return _c
 }
 
-func (_c *ActorProviderInterfaceMock_GetOAuthClientByID_Call) Return(oAuthClient *model.OAuthClient, serviceError *serviceerror.ServiceError) *ActorProviderInterfaceMock_GetOAuthClientByID_Call {
+func (_c *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call) Return(oAuthClient *model.OAuthClient, serviceError *serviceerror.ServiceError) *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call {
 	_c.Call.Return(oAuthClient, serviceError)
 	return _c
 }
 
-func (_c *ActorProviderInterfaceMock_GetOAuthClientByID_Call) RunAndReturn(run func(ctx context.Context, id string) (*model.OAuthClient, *serviceerror.ServiceError)) *ActorProviderInterfaceMock_GetOAuthClientByID_Call {
+func (_c *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call) RunAndReturn(run func(ctx context.Context, clientID string) (*model.OAuthClient, *serviceerror.ServiceError)) *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/actorprovider/interface.go
+++ b/backend/internal/actorprovider/interface.go
@@ -33,6 +33,9 @@ type ActorProviderInterface interface {
 	GetOAuthClientByID(
 		ctx context.Context, id string,
 	) (*inboundmodel.OAuthClient, *serviceerror.ServiceError)
+	GetOAuthProfileByID(
+		ctx context.Context, id string,
+	) (*inboundmodel.OAuthProfile, *serviceerror.ServiceError)
 	GetInboundClientByID(
 		ctx context.Context, id string,
 	) (*inboundmodel.InboundClient, *serviceerror.ServiceError)

--- a/backend/internal/actorprovider/interface.go
+++ b/backend/internal/actorprovider/interface.go
@@ -30,8 +30,8 @@ import (
 
 // ActorProviderInterface resolves inbound actors and exposes their OAuth and membership data.
 type ActorProviderInterface interface {
-	GetOAuthClientByID(
-		ctx context.Context, id string,
+	GetOAuthClientByClientID(
+		ctx context.Context, clientID string,
 	) (*inboundmodel.OAuthClient, *serviceerror.ServiceError)
 	GetOAuthProfileByID(
 		ctx context.Context, id string,

--- a/backend/internal/actorprovider/service.go
+++ b/backend/internal/actorprovider/service.go
@@ -48,16 +48,16 @@ func newActorProvider(
 	}
 }
 
-// GetOAuthClientByID returns the OAuth client registered for the given ID.
-func (p *actorProvider) GetOAuthClientByID(
-	ctx context.Context, id string,
+// GetOAuthClientByClientID returns the OAuth client registered for the given ID.
+func (p *actorProvider) GetOAuthClientByClientID(
+	ctx context.Context, clientID string,
 ) (*inboundmodel.OAuthClient, *serviceerror.ServiceError) {
-	client, err := p.inboundClient.GetOAuthClientByClientID(ctx, id)
+	client, err := p.inboundClient.GetOAuthClientByClientID(ctx, clientID)
 	if err != nil {
 		if errors.Is(err, inboundclient.ErrInboundClientNotFound) {
 			return nil, &ErrorActorNotFound
 		}
-		p.logger.Error(ctx, "Failed to fetch OAuth client", log.String("id", id), log.Error(err))
+		p.logger.Error(ctx, "Failed to fetch OAuth client", log.String("clientID", clientID), log.Error(err))
 		return nil, &serviceerror.InternalServerError
 	}
 	return client, nil

--- a/backend/internal/actorprovider/service.go
+++ b/backend/internal/actorprovider/service.go
@@ -63,6 +63,22 @@ func (p *actorProvider) GetOAuthClientByID(
 	return client, nil
 }
 
+// GetOAuthProfileByID returns the stored OAuth profile for the given entity UUID.
+func (p *actorProvider) GetOAuthProfileByID(
+	ctx context.Context, id string,
+) (*inboundmodel.OAuthProfile, *serviceerror.ServiceError) {
+	profile, err := p.inboundClient.GetOAuthProfileByEntityID(ctx, id)
+	if err != nil {
+		if errors.Is(err, inboundclient.ErrInboundClientNotFound) {
+			return nil, &ErrorActorNotFound
+		}
+		p.logger.Error(ctx, "Failed to fetch OAuth profile by entity ID",
+			log.String("id", id), log.Error(err))
+		return nil, &serviceerror.InternalServerError
+	}
+	return profile, nil
+}
+
 // GetInboundClientByID returns the inbound-client row for the given ID.
 func (p *actorProvider) GetInboundClientByID(
 	ctx context.Context, id string,

--- a/backend/internal/actorprovider/service_test.go
+++ b/backend/internal/actorprovider/service_test.go
@@ -51,31 +51,31 @@ func (s *ActorProviderTestSuite) SetupTest() {
 	s.provider = Initialize(s.mockInbound, s.mockEntity)
 }
 
-func (s *ActorProviderTestSuite) TestGetOAuthClientByID_Delegates() {
+func (s *ActorProviderTestSuite) TestGetOAuthClientByClientID_Delegates() {
 	expected := &inboundmodel.OAuthClient{ID: "app-1", ClientID: "client-1"}
 	s.mockInbound.On("GetOAuthClientByClientID", mock.Anything, "client-1").Return(expected, nil)
 
-	client, svcErr := s.provider.GetOAuthClientByID(context.Background(), "client-1")
+	client, svcErr := s.provider.GetOAuthClientByClientID(context.Background(), "client-1")
 
 	s.Nil(svcErr)
 	s.Equal(expected, client)
 }
 
-func (s *ActorProviderTestSuite) TestGetOAuthClientByID_NotFound() {
+func (s *ActorProviderTestSuite) TestGetOAuthClientByClientID_NotFound() {
 	s.mockInbound.On("GetOAuthClientByClientID", mock.Anything, "missing").
 		Return((*inboundmodel.OAuthClient)(nil), inboundclient.ErrInboundClientNotFound)
 
-	client, svcErr := s.provider.GetOAuthClientByID(context.Background(), "missing")
+	client, svcErr := s.provider.GetOAuthClientByClientID(context.Background(), "missing")
 
 	s.Nil(client)
 	s.Equal(ErrorActorNotFound.Code, svcErr.Code)
 }
 
-func (s *ActorProviderTestSuite) TestGetOAuthClientByID_FetchFailed() {
+func (s *ActorProviderTestSuite) TestGetOAuthClientByClientID_FetchFailed() {
 	s.mockInbound.On("GetOAuthClientByClientID", mock.Anything, "client-1").
 		Return((*inboundmodel.OAuthClient)(nil), errors.New("db error"))
 
-	client, svcErr := s.provider.GetOAuthClientByID(context.Background(), "client-1")
+	client, svcErr := s.provider.GetOAuthClientByClientID(context.Background(), "client-1")
 
 	s.Nil(client)
 	s.Equal(serviceerror.InternalServerError.Code, svcErr.Code)

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -19,7 +19,9 @@
 package flowexec
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -34,6 +36,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/observability/event"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
+	"github.com/thunder-id/thunderid/tests/mocks/flow/executormock"
 	"github.com/thunder-id/thunderid/tests/mocks/observability/observabilitymock"
 )
 
@@ -1715,4 +1718,767 @@ func (s *EngineTestSuite) TestProcessServiceErrorForEventPublish_ReturnsErrorDet
 func (s *EngineTestSuite) TestProcessServiceErrorForEventPublish_NilError() {
 	result := processServiceErrorForEventPublish(nil)
 	s.Nil(result)
+}
+
+// --- newFlowEngine ---
+
+func (s *EngineTestSuite) TestNewFlowEngine() {
+	t := s.T()
+	mockRegistry := executormock.NewExecutorRegistryInterfaceMock(t)
+	mockObs := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+
+	engine := newFlowEngine(mockRegistry, mockObs)
+	s.NotNil(engine)
+}
+
+// --- setCurrentExecutionNode ---
+
+func (s *EngineTestSuite) TestSetCurrentExecutionNode_NilGraph() {
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background()}
+	err := fe.setCurrentExecutionNode(ctx, log.GetLogger())
+	s.NotNil(err)
+}
+
+func (s *EngineTestSuite) TestSetCurrentExecutionNode_GetStartNodeError() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetStartNode").Return(nil, errors.New("no start node"))
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context: context.Background(),
+		Graph:   mockGraph,
+	}
+	err := fe.setCurrentExecutionNode(ctx, log.GetLogger())
+	s.NotNil(err)
+}
+
+func (s *EngineTestSuite) TestSetCurrentExecutionNode_ExistingNode() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockNode := coremock.NewNodeInterfaceMock(t)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:          context.Background(),
+		Graph:            mockGraph,
+		CurrentNode:      mockNode,
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+	}
+	err := fe.setCurrentExecutionNode(ctx, log.GetLogger())
+	s.Nil(err)
+}
+
+// --- getExecutorByName ---
+
+func (s *EngineTestSuite) TestGetExecutorByName_Success() {
+	t := s.T()
+	mockRegistry := executormock.NewExecutorRegistryInterfaceMock(t)
+	mockExec := coremock.NewExecutorInterfaceMock(t)
+	mockRegistry.EXPECT().GetExecutor("myExecutor").Return(mockExec, nil)
+
+	fe := &flowEngine{executorRegistry: mockRegistry, logger: log.GetLogger()}
+	exec, err := fe.getExecutorByName("myExecutor")
+	s.Nil(err)
+	s.Equal(mockExec, exec)
+}
+
+func (s *EngineTestSuite) TestGetExecutorByName_Error() {
+	t := s.T()
+	mockRegistry := executormock.NewExecutorRegistryInterfaceMock(t)
+	mockRegistry.EXPECT().GetExecutor("unknown").Return(nil, errors.New("not found"))
+
+	fe := &flowEngine{executorRegistry: mockRegistry, logger: log.GetLogger()}
+	exec, err := fe.getExecutorByName("unknown")
+	s.Nil(exec)
+	s.NotNil(err)
+}
+
+// --- resolveToNextNode ---
+
+func (s *EngineTestSuite) TestResolveToNextNode_NilResponse() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background(), Graph: mockGraph}
+
+	next, err := fe.resolveToNextNode(ctx, nil)
+	s.Nil(err)
+	s.Nil(next)
+}
+
+func (s *EngineTestSuite) TestResolveToNextNode_EmptyNextNodeID() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background(), Graph: mockGraph}
+
+	next, err := fe.resolveToNextNode(ctx, &common.NodeResponse{NextNodeID: ""})
+	s.Nil(err)
+	s.Nil(next)
+}
+
+func (s *EngineTestSuite) TestResolveToNextNode_NodeNotFound() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetNode", "missing-node").Return(nil, false)
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background(), Graph: mockGraph}
+
+	next, err := fe.resolveToNextNode(ctx, &common.NodeResponse{NextNodeID: "missing-node"})
+	s.Nil(next)
+	s.NotNil(err)
+}
+
+func (s *EngineTestSuite) TestResolveToNextNode_Success() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("next-node")
+	mockGraph.On("GetNode", "next-node").Return(mockNode, true)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background(), Graph: mockGraph}
+
+	next, err := fe.resolveToNextNode(ctx, &common.NodeResponse{NextNodeID: "next-node"})
+	s.Nil(err)
+	s.Equal(mockNode, next)
+}
+
+// --- handleCompletedResponse ---
+
+func (s *EngineTestSuite) TestHandleCompletedResponse_NoNextNode() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetNode", mock.Anything).Return(nil, false)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context: context.Background(),
+		Graph:   mockGraph,
+	}
+	nodeResp := &common.NodeResponse{
+		Status:     common.NodeStatusComplete,
+		NextNodeID: "end-node",
+	}
+	next, err := fe.handleCompletedResponse(ctx, nodeResp, log.GetLogger())
+	s.Nil(next)
+	s.NotNil(err)
+}
+
+func (s *EngineTestSuite) TestHandleCompletedResponse_WithNextNode() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("next-node")
+	mockGraph.On("GetNode", "next-node").Return(mockNode, true)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context: context.Background(),
+		Graph:   mockGraph,
+	}
+	nodeResp := &common.NodeResponse{
+		Status:     common.NodeStatusComplete,
+		NextNodeID: "next-node",
+	}
+	next, err := fe.handleCompletedResponse(ctx, nodeResp, log.GetLogger())
+	s.Nil(err)
+	s.Equal(mockNode, next)
+}
+
+// --- handleIncompleteResponse ---
+
+func (s *EngineTestSuite) TestHandleIncompleteResponse_RedirectionType() {
+	fe := &flowEngine{logger: log.GetLogger()}
+	flowStep := &FlowStep{}
+	ctx := &EngineContext{Context: context.Background()}
+	nodeResp := &common.NodeResponse{
+		Status:      common.NodeStatusIncomplete,
+		Type:        common.NodeResponseTypeRedirection,
+		RedirectURL: "https://example.com/redirect",
+	}
+	err := fe.handleIncompleteResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.Nil(err)
+	s.Equal(common.FlowStatusIncomplete, flowStep.Status)
+	s.Equal(common.StepTypeRedirection, flowStep.Type)
+}
+
+func (s *EngineTestSuite) TestHandleIncompleteResponse_UnsupportedType() {
+	fe := &flowEngine{logger: log.GetLogger()}
+	flowStep := &FlowStep{}
+	ctx := &EngineContext{Context: context.Background()}
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusIncomplete,
+		Type:   "UNSUPPORTED_TYPE",
+	}
+	err := fe.handleIncompleteResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.NotNil(err)
+}
+
+// --- handleForwardResponse ---
+
+func (s *EngineTestSuite) TestHandleForwardResponse_Success() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("forward-node")
+	mockGraph.On("GetNode", "forward-node").Return(mockNode, true)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context: context.Background(),
+		Graph:   mockGraph,
+	}
+	nodeResp := &common.NodeResponse{
+		Status:     common.NodeStatusForward,
+		NextNodeID: "forward-node",
+	}
+	next, err := fe.handleForwardResponse(ctx, nodeResp, log.GetLogger())
+	s.Nil(err)
+	s.Equal(mockNode, next)
+}
+
+func (s *EngineTestSuite) TestHandleForwardResponse_NodeNotFound() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetNode", "missing").Return(nil, false)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context: context.Background(),
+		Graph:   mockGraph,
+	}
+	nodeResp := &common.NodeResponse{
+		Status:     common.NodeStatusForward,
+		NextNodeID: "missing",
+	}
+	next, err := fe.handleForwardResponse(ctx, nodeResp, log.GetLogger())
+	s.Nil(next)
+	s.NotNil(err)
+}
+
+// --- skipToNextNode ---
+
+func (s *EngineTestSuite) TestSkipToNextNode_NoCondition() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetCondition").Return((*core.NodeCondition)(nil))
+	mockNode.On("GetID").Return("node-1")
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background()}
+
+	next, err := fe.skipToNextNode(ctx, mockNode, log.GetLogger())
+	s.Nil(next)
+	s.NotNil(err)
+}
+
+func (s *EngineTestSuite) TestSkipToNextNode_EmptyOnSkip() {
+	t := s.T()
+	cond := &core.NodeCondition{OnSkip: ""}
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetCondition").Return(cond)
+	mockNode.On("GetID").Return("node-1")
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background()}
+
+	next, err := fe.skipToNextNode(ctx, mockNode, log.GetLogger())
+	s.Nil(next)
+	s.NotNil(err)
+}
+
+func (s *EngineTestSuite) TestSkipToNextNode_NodeNotFound() {
+	t := s.T()
+	cond := &core.NodeCondition{OnSkip: "skip-target"}
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetCondition").Return(cond)
+	mockNode.On("GetID").Return("node-1")
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetNode", "skip-target").Return(nil, false)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background(), Graph: mockGraph}
+
+	next, err := fe.skipToNextNode(ctx, mockNode, log.GetLogger())
+	s.Nil(next)
+	s.NotNil(err)
+}
+
+// --- processNodeResponse ---
+
+func (s *EngineTestSuite) TestProcessNodeResponse_EmptyStatus() {
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background()}
+	nodeResp := &common.NodeResponse{Status: ""}
+	flowStep := &FlowStep{}
+	_, _, err := fe.processNodeResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.NotNil(err)
+}
+
+func (s *EngineTestSuite) TestProcessNodeResponse_FailureStatus() {
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background()}
+	svcErr := &serviceerror.ServiceError{Code: "err-1"}
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusFailure,
+		Error:  svcErr,
+	}
+	flowStep := &FlowStep{}
+	next, continueExec, err := fe.processNodeResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.Nil(err)
+	s.False(continueExec)
+	s.Nil(next)
+	s.Equal(common.FlowStatusError, flowStep.Status)
+}
+
+func (s *EngineTestSuite) TestProcessNodeResponse_CompleteStatus() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockNextNode := coremock.NewNodeInterfaceMock(t)
+	mockNextNode.On("GetID").Return("next-node")
+	mockGraph.On("GetNode", "next-node").Return(mockNextNode, true)
+
+	// Use a NodeInterface mock — type assertion to PromptNodeInterface will fail (it's not one),
+	// so isDisplayOnlyPromptNode returns false without calling GetType.
+	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:     context.Background(),
+		Graph:       mockGraph,
+		CurrentNode: mockCurrentNode,
+	}
+	nodeResp := &common.NodeResponse{
+		Status:     common.NodeStatusComplete,
+		NextNodeID: "next-node",
+	}
+	flowStep := &FlowStep{}
+	next, continueExec, err := fe.processNodeResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.Nil(err)
+	s.True(continueExec)
+	s.Equal(mockNextNode, next)
+}
+
+func (s *EngineTestSuite) TestProcessNodeResponse_IncompleteViewStatus() {
+	t := s.T()
+	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:     context.Background(),
+		CurrentNode: mockCurrentNode,
+	}
+	nodeResp := &common.NodeResponse{
+		Status:      common.NodeStatusIncomplete,
+		Type:        common.NodeResponseTypeRedirection,
+		RedirectURL: "https://example.com",
+	}
+	flowStep := &FlowStep{}
+	next, continueExec, err := fe.processNodeResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.Nil(err)
+	s.False(continueExec)
+	s.Nil(next)
+}
+
+func (s *EngineTestSuite) TestProcessNodeResponse_UnsupportedStatus() {
+	t := s.T()
+	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:     context.Background(),
+		CurrentNode: mockCurrentNode,
+	}
+	nodeResp := &common.NodeResponse{
+		Status: "UNKNOWN_STATUS",
+	}
+	flowStep := &FlowStep{}
+	_, _, err := fe.processNodeResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.NotNil(err)
+}
+
+// --- rotateChallengeToken ---
+
+func (s *EngineTestSuite) TestRotateChallengeToken() {
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{Context: context.Background(), ExecutionID: "exec-1"}
+	flowStep := &FlowStep{}
+
+	err := fe.rotateChallengeToken(ctx, flowStep)
+	s.Nil(err)
+	s.NotEmpty(flowStep.ChallengeToken)
+	s.NotEmpty(ctx.ChallengeTokenHash)
+}
+
+// --- recordNodeExecution ---
+
+func (s *EngineTestSuite) TestRecordNodeExecution_NewRecord() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("node-1")
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+
+	ctx := &EngineContext{
+		Context:          context.Background(),
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+	}
+	nodeResp := &common.NodeResponse{Status: common.NodeStatusComplete}
+	recordNodeExecution(ctx, mockNode, nodeResp, nil, 100, 200)
+
+	record, exists := ctx.ExecutionHistory["node-1"]
+	s.True(exists)
+	s.NotNil(record)
+	s.Equal(1, len(record.Executions))
+}
+
+func (s *EngineTestSuite) TestRecordNodeExecution_ExistingRecord() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("node-1")
+
+	existing := &common.NodeExecutionRecord{
+		NodeID:     "node-1",
+		Executions: make([]common.ExecutionAttempt, 0),
+	}
+	ctx := &EngineContext{
+		Context: context.Background(),
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{
+			"node-1": existing,
+		},
+	}
+	nodeResp := &common.NodeResponse{Status: common.NodeStatusIncomplete}
+	recordNodeExecution(ctx, mockNode, nodeResp, nil, 100, 200)
+
+	s.Equal(1, len(existing.Executions))
+}
+
+// --- createExecutionRecord ---
+
+func (s *EngineTestSuite) TestCreateExecutionRecord_BasicNode() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("node-1")
+	// Return a non-task-execution type so we skip executor-related code
+	mockNode.On("GetType").Return(common.NodeTypePrompt)
+
+	record := createExecutionRecord(mockNode, 1)
+	s.Equal("node-1", record.NodeID)
+	s.Equal(1, record.Step)
+}
+
+// --- createExecutionAttempt ---
+
+func (s *EngineTestSuite) TestCreateExecutionAttempt_WithError() {
+	nodeRecord := &common.NodeExecutionRecord{Executions: make([]common.ExecutionAttempt, 0)}
+	svcErr := &serviceerror.ServiceError{Code: "err-1"}
+
+	attempt := createExecutionAttempt(nodeRecord, nil, svcErr, 100, 200)
+	s.Equal(common.FlowStatusError, attempt.Status)
+	s.Equal(1, attempt.Attempt)
+}
+
+func (s *EngineTestSuite) TestCreateExecutionAttempt_CompleteResponse() {
+	nodeRecord := &common.NodeExecutionRecord{Executions: make([]common.ExecutionAttempt, 0)}
+	nodeResp := &common.NodeResponse{Status: common.NodeStatusComplete}
+
+	attempt := createExecutionAttempt(nodeRecord, nodeResp, nil, 100, 200)
+	s.Equal(common.FlowStatusComplete, attempt.Status)
+}
+
+func (s *EngineTestSuite) TestCreateExecutionAttempt_IncompleteResponse() {
+	nodeRecord := &common.NodeExecutionRecord{Executions: make([]common.ExecutionAttempt, 0)}
+	nodeResp := &common.NodeResponse{Status: common.NodeStatusIncomplete}
+
+	attempt := createExecutionAttempt(nodeRecord, nodeResp, nil, 100, 200)
+	s.Equal(common.FlowStatusIncomplete, attempt.Status)
+}
+
+func (s *EngineTestSuite) TestCreateExecutionAttempt_FailureResponse() {
+	nodeRecord := &common.NodeExecutionRecord{Executions: make([]common.ExecutionAttempt, 0)}
+	nodeResp := &common.NodeResponse{Status: common.NodeStatusFailure}
+
+	attempt := createExecutionAttempt(nodeRecord, nodeResp, nil, 100, 200)
+	s.Equal(common.FlowStatusError, attempt.Status)
+}
+
+// --- setNodeExecutor ---
+
+func (s *EngineTestSuite) TestSetNodeExecutor_NonTaskNode() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypePrompt)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	err := fe.setNodeExecutor(context.Background(), mockNode, log.GetLogger())
+	s.Nil(err)
+}
+
+func (s *EngineTestSuite) TestSetNodeExecutor_NotExecutorBacked() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetID").Return("node-1")
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	err := fe.setNodeExecutor(context.Background(), mockNode, log.GetLogger())
+	s.NotNil(err)
+}
+
+func (s *EngineTestSuite) TestSetNodeExecutor_ExecutorAlreadySet() {
+	t := s.T()
+	mockExec := coremock.NewExecutorInterfaceMock(t)
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExec)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	err := fe.setNodeExecutor(context.Background(), mockNode, log.GetLogger())
+	s.Nil(err)
+}
+
+func (s *EngineTestSuite) TestSetNodeExecutor_ExecutorNameEmpty() {
+	t := s.T()
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(nil)
+	mockNode.On("GetExecutorName").Return("")
+	mockNode.On("GetID").Return("node-1")
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	err := fe.setNodeExecutor(context.Background(), mockNode, log.GetLogger())
+	s.NotNil(err)
+}
+
+func (s *EngineTestSuite) TestSetNodeExecutor_RegistryError() {
+	t := s.T()
+	mockRegistry := executormock.NewExecutorRegistryInterfaceMock(t)
+	mockRegistry.EXPECT().GetExecutor("myExec").Return(nil, errors.New("not found"))
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(nil)
+	mockNode.On("GetExecutorName").Return("myExec")
+	mockNode.On("GetID").Return("node-1")
+
+	fe := &flowEngine{executorRegistry: mockRegistry, logger: log.GetLogger()}
+	err := fe.setNodeExecutor(context.Background(), mockNode, log.GetLogger())
+	s.NotNil(err)
+}
+
+// --- handleIncompleteResponse (view type) ---
+
+func (s *EngineTestSuite) TestHandleIncompleteResponse_ViewType() {
+	t := s.T()
+	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:     context.Background(),
+		CurrentNode: mockCurrentNode,
+	}
+	flowStep := &FlowStep{}
+	nodeResp := &common.NodeResponse{
+		Status: common.NodeStatusIncomplete,
+		Type:   common.NodeResponseTypeView,
+		Inputs: []common.Input{{Identifier: "username", Required: true}},
+	}
+	err := fe.handleIncompleteResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.Nil(err)
+	s.Equal(common.FlowStatusIncomplete, flowStep.Status)
+}
+
+func (s *EngineTestSuite) TestHandleIncompleteResponse_RedirectionError() {
+	fe := &flowEngine{logger: log.GetLogger()}
+	flowStep := &FlowStep{}
+	ctx := &EngineContext{Context: context.Background()}
+	// Empty RedirectURL will cause resolveStepForRedirection to return an error.
+	nodeResp := &common.NodeResponse{
+		Status:      common.NodeStatusIncomplete,
+		Type:        common.NodeResponseTypeRedirection,
+		RedirectURL: "",
+	}
+	err := fe.handleIncompleteResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.NotNil(err)
+}
+
+func (s *EngineTestSuite) TestHandleIncompleteResponse_ViewTypeError() {
+	t := s.T()
+	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:     context.Background(),
+		CurrentNode: mockCurrentNode,
+	}
+	flowStep := &FlowStep{}
+	// Empty Inputs and Actions will cause resolveStepDetailsForPrompt to return an error.
+	nodeResp := &common.NodeResponse{
+		Status:  common.NodeStatusIncomplete,
+		Type:    common.NodeResponseTypeView,
+		Inputs:  nil,
+		Actions: nil,
+	}
+	err := fe.handleIncompleteResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.NotNil(err)
+}
+
+// --- createExecutionRecord with executor ---
+
+func (s *EngineTestSuite) TestCreateExecutionRecord_TaskNodeWithExecutor() {
+	t := s.T()
+	mockExec := coremock.NewExecutorInterfaceMock(t)
+	mockExec.On("GetName").Return("PasswordExecutor")
+	mockExec.On("GetType").Return(common.ExecutorType("AUTHENTICATOR"))
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("node-exec")
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution)
+	mockNode.On("GetExecutor").Return(mockExec)
+	mockNode.On("GetMode").Return("").Maybe()
+
+	record := createExecutionRecord(mockNode, 2)
+	s.Equal("node-exec", record.NodeID)
+	s.Equal(2, record.Step)
+	s.Equal("PasswordExecutor", record.ExecutorName)
+}
+
+// --- processNodeResponse (Forward status) ---
+
+func (s *EngineTestSuite) TestProcessNodeResponse_ForwardStatus() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockNextNode := coremock.NewNodeInterfaceMock(t)
+	mockNextNode.On("GetID").Return("forward-node")
+	mockGraph.On("GetNode", "forward-node").Return(mockNextNode, true)
+
+	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:     context.Background(),
+		Graph:       mockGraph,
+		CurrentNode: mockCurrentNode,
+	}
+	nodeResp := &common.NodeResponse{
+		Status:     common.NodeStatusForward,
+		NextNodeID: "forward-node",
+	}
+	flowStep := &FlowStep{}
+	next, continueExec, err := fe.processNodeResponse(ctx, nodeResp, flowStep, log.GetLogger())
+	s.Nil(err)
+	s.True(continueExec)
+	s.Equal(mockNextNode, next)
+}
+
+// --- setCurrentExecutionNode (with nil history) ---
+
+func (s *EngineTestSuite) TestSetCurrentExecutionNode_InitializesHistory() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockGraph.On("GetStartNode").Return(mockNode, nil)
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:          context.Background(),
+		Graph:            mockGraph,
+		ExecutionHistory: nil,
+	}
+	err := fe.setCurrentExecutionNode(ctx, log.GetLogger())
+	s.Nil(err)
+	s.NotNil(ctx.ExecutionHistory)
+	s.Equal(mockNode, ctx.CurrentNode)
+}
+
+// --- handleForwardResponse with error in nodeResp ---
+
+func (s *EngineTestSuite) TestHandleForwardResponse_WithErrorMsg() {
+	t := s.T()
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockNextNode := coremock.NewNodeInterfaceMock(t)
+	mockNextNode.On("GetID").Return("next")
+	mockGraph.On("GetNode", "next").Return(mockNextNode, true)
+
+	svcErr := &serviceerror.ServiceError{Code: "err-1"}
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context: context.Background(),
+		Graph:   mockGraph,
+	}
+	nodeResp := &common.NodeResponse{
+		Status:     common.NodeStatusForward,
+		NextNodeID: "next",
+		Error:      svcErr,
+	}
+	next, err := fe.handleForwardResponse(ctx, nodeResp, log.GetLogger())
+	s.Nil(err)
+	s.Equal(mockNextNode, next)
+}
+
+// --- publishNodeExecutionCompletedEvent ---
+
+func (s *EngineTestSuite) TestPublishNodeExecutionCompletedEvent_NilRecord() {
+	t := s.T()
+	mockObs := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObs.EXPECT().IsEnabled().Return(true)
+	// No PublishEvent call expected because record is nil.
+
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("node-no-record")
+
+	ctx := &EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "exec-1",
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+	}
+	// Calling with nil nodeResp and nil nodeErr, but no history entry for the node.
+	publishNodeExecutionCompletedEvent(ctx, mockNode, nil, nil, 1000, 1100, mockObs)
+}
+
+func (s *EngineTestSuite) TestPublishNodeExecutionCompletedEvent_DefaultStatus() {
+	t := s.T()
+	mockObs := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObs.EXPECT().IsEnabled().Return(true)
+	mockObs.EXPECT().PublishEvent(mock.Anything, mock.Anything).Maybe()
+
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("node-default")
+	mockNode.On("GetType").Return(common.NodeTypePrompt)
+
+	ctx := &EngineContext{
+		Context:     context.Background(),
+		ExecutionID: "exec-1",
+		FlowType:    common.FlowTypeAuthentication,
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{
+			"node-default": {NodeID: "node-default", Step: 1, Executions: []common.ExecutionAttempt{{Attempt: 1}}},
+		},
+	}
+	// Use an unrecognized NodeStatus to hit the default branch.
+	nodeResp := &common.NodeResponse{Status: common.NodeStatus("UNKNOWN_STATUS")}
+	publishNodeExecutionCompletedEvent(ctx, mockNode, nodeResp, nil, 1000, 1100, mockObs)
+}
+
+// --- Execute (flowEngine) ---
+
+func (s *EngineTestSuite) TestFlowEngineExecute_NilGraph() {
+	t := s.T()
+	mockObs := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockObs.EXPECT().IsEnabled().Return(false).Maybe()
+
+	fe := &flowEngine{
+		logger:           log.GetLogger(),
+		observabilitySvc: mockObs,
+	}
+	ctx := &EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "exec-1",
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+	}
+
+	_, err := fe.Execute(ctx)
+	s.NotNil(err)
 }

--- a/backend/internal/flow/flowexec/error_constants.go
+++ b/backend/internal/flow/flowexec/error_constants.go
@@ -164,3 +164,18 @@ var ErrorInvalidChallengeToken = serviceerror.ServiceError{
 		DefaultValue: "The challenge token is missing or invalid",
 	},
 }
+
+// ErrorDirectFlowInitiationNotPermitted defines the error for applications that do not allow
+// direct flow initiation via the HTTP endpoint (e.g. authorization_code grant type apps).
+var ErrorDirectFlowInitiationNotPermitted = serviceerror.ServiceError{
+	Code: "FES-1011",
+	Type: serviceerror.ClientErrorType,
+	Error: core.I18nMessage{
+		Key:          "error.flowexecservice.direct_flow_initiation_not_permitted",
+		DefaultValue: "Direct flow initiation not permitted",
+	},
+	ErrorDescription: core.I18nMessage{
+		Key:          "error.flowexecservice.direct_flow_initiation_not_permitted_description",
+		DefaultValue: "Direct flow initiation is not permitted for this application type",
+	},
+}

--- a/backend/internal/flow/flowexec/handler.go
+++ b/backend/internal/flow/flowexec/handler.go
@@ -100,7 +100,12 @@ func handleFlowError(ctx context.Context, w http.ResponseWriter, flowErr *servic
 
 	statusCode := http.StatusInternalServerError
 	if flowErr.Type == serviceerror.ClientErrorType {
-		statusCode = http.StatusBadRequest
+		switch flowErr.Code {
+		case ErrorDirectFlowInitiationNotPermitted.Code:
+			statusCode = http.StatusForbidden
+		default:
+			statusCode = http.StatusBadRequest
+		}
 	}
 
 	sysutils.WriteErrorResponse(ctx, w, statusCode, errResp)

--- a/backend/internal/flow/flowexec/handler_test.go
+++ b/backend/internal/flow/flowexec/handler_test.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package flowexec
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/internal/flow/common"
+	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
+	i18ncore "github.com/thunder-id/thunderid/internal/system/i18n/core"
+)
+
+const testFlowExecRequestBody = `{"applicationId":"app-1","flowType":"AUTHENTICATION","action":"submit"}`
+
+type HandlerTestSuite struct {
+	suite.Suite
+}
+
+func TestHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(HandlerTestSuite))
+}
+
+func (s *HandlerTestSuite) TestNewFlowExecutionHandler() {
+	t := s.T()
+	mockSvc := NewFlowExecServiceInterfaceMock(t)
+	h := newFlowExecutionHandler(mockSvc)
+	s.NotNil(h)
+	s.Equal(mockSvc, h.flowExecService)
+}
+
+func (s *HandlerTestSuite) TestHandleFlowError_ClientError_Returns400() {
+	w := httptest.NewRecorder()
+	svcErr := &serviceerror.ServiceError{
+		Code: "FES-4001",
+		Type: serviceerror.ClientErrorType,
+		Error: i18ncore.I18nMessage{
+			Key:          "client.error",
+			DefaultValue: "bad request",
+		},
+	}
+	handleFlowError(context.Background(), w, svcErr)
+	s.Equal(http.StatusBadRequest, w.Code)
+}
+
+func (s *HandlerTestSuite) TestHandleFlowError_ForbiddenError_Returns403() {
+	w := httptest.NewRecorder()
+	handleFlowError(context.Background(), w, &ErrorDirectFlowInitiationNotPermitted)
+	s.Equal(http.StatusForbidden, w.Code)
+}
+
+func (s *HandlerTestSuite) TestHandleFlowError_ServerError_Returns500() {
+	w := httptest.NewRecorder()
+	svcErr := &serviceerror.ServiceError{
+		Code: "FES-5001",
+		Type: serviceerror.ServerErrorType,
+		Error: i18ncore.I18nMessage{
+			Key:          "server.error",
+			DefaultValue: "internal error",
+		},
+	}
+	handleFlowError(context.Background(), w, svcErr)
+	s.Equal(http.StatusInternalServerError, w.Code)
+}
+
+func (s *HandlerTestSuite) TestConvertToAPIError() {
+	svcErr := &serviceerror.ServiceError{
+		Code: "FES-1234",
+		Error: i18ncore.I18nMessage{
+			Key:          "test.error",
+			DefaultValue: "test message",
+		},
+		ErrorDescription: i18ncore.I18nMessage{
+			Key:          "test.error.desc",
+			DefaultValue: "test description",
+		},
+	}
+	resp := convertToAPIError(svcErr)
+	s.Equal("FES-1234", resp.Code)
+}
+
+func (s *HandlerTestSuite) TestHandleFlowExecutionRequest_InvalidJSON() {
+	t := s.T()
+	mockSvc := NewFlowExecServiceInterfaceMock(t)
+	h := newFlowExecutionHandler(mockSvc)
+
+	req := httptest.NewRequest(http.MethodPost, "/flow/execute", bytes.NewBufferString("not-json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.HandleFlowExecutionRequest(w, req)
+	s.Equal(http.StatusBadRequest, w.Code)
+}
+
+func (s *HandlerTestSuite) TestHandleFlowExecutionRequest_ServiceError() {
+	t := s.T()
+	mockSvc := NewFlowExecServiceInterfaceMock(t)
+	mockSvc.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, &ErrorDirectFlowInitiationNotPermitted)
+
+	h := newFlowExecutionHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/flow/execute", bytes.NewBufferString(testFlowExecRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.HandleFlowExecutionRequest(w, req)
+	s.Equal(http.StatusForbidden, w.Code)
+}
+
+func (s *HandlerTestSuite) TestHandleFlowExecutionRequest_Success() {
+	t := s.T()
+	mockSvc := NewFlowExecServiceInterfaceMock(t)
+	flowStep := &FlowStep{
+		ExecutionID: "exec-1",
+		Status:      common.FlowStatusIncomplete,
+	}
+	mockSvc.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(flowStep, (*serviceerror.ServiceError)(nil))
+
+	h := newFlowExecutionHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/flow/execute", bytes.NewBufferString(testFlowExecRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.HandleFlowExecutionRequest(w, req)
+	s.Equal(http.StatusOK, w.Code)
+}
+
+func (s *HandlerTestSuite) TestHandleFlowExecutionRequest_StepWithError() {
+	t := s.T()
+	mockSvc := NewFlowExecServiceInterfaceMock(t)
+	stepErr := &serviceerror.ServiceError{
+		Code: "FES-9999",
+		Error: i18ncore.I18nMessage{
+			Key:          "step.error",
+			DefaultValue: "step failed",
+		},
+	}
+	flowStep := &FlowStep{
+		ExecutionID: "exec-1",
+		Status:      common.FlowStatusError,
+		Error:       stepErr,
+	}
+	mockSvc.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(flowStep, (*serviceerror.ServiceError)(nil))
+
+	h := newFlowExecutionHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/flow/execute", bytes.NewBufferString(testFlowExecRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.HandleFlowExecutionRequest(w, req)
+	s.Equal(http.StatusOK, w.Code)
+}

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -23,10 +23,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/thunder-id/thunderid/internal/actorprovider"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	flowconfig "github.com/thunder-id/thunderid/internal/flow/config"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
@@ -176,6 +178,10 @@ func (s *flowExecService) loadNewContext(ctx context.Context, appID, flowTypeStr
 		return nil, err
 	}
 
+	if svcErr := s.checkDirectFlowInitiationAllowed(ctx, appID, logger); svcErr != nil {
+		return nil, svcErr
+	}
+
 	engineCtx, err := s.initContext(ctx, appID, flowType, verbose, logger)
 	if err != nil {
 		return nil, err
@@ -183,6 +189,34 @@ func (s *flowExecService) loadNewContext(ctx context.Context, appID, flowTypeStr
 
 	prepareContext(engineCtx, action, inputs)
 	return engineCtx, nil
+}
+
+// checkDirectFlowInitiationAllowed returns an error if the application's grant type does not
+// permit direct HTTP flow initiation. Applications configured with the authorization_code grant
+// type must have their flows initiated by the OAuth component, not via a direct HTTP call.
+func (s *flowExecService) checkDirectFlowInitiationAllowed(ctx context.Context, appID string,
+	logger *log.Logger) *serviceerror.ServiceError {
+	if appID == "" {
+		return nil
+	}
+
+	oauthProfile, svcErr := s.actorProvider.GetOAuthProfileByID(ctx, appID)
+	if svcErr != nil {
+		if svcErr.Code == actorprovider.ErrorActorNotFound.Code {
+			return nil
+		}
+		logger.Error(ctx, "Failed to retrieve OAuth profile for flow initiation guard",
+			log.String("appID", appID))
+		return &serviceerror.InternalServerError
+	}
+	if oauthProfile == nil {
+		return nil
+	}
+
+	if slices.Contains(oauthProfile.GrantTypes, string(oauth2const.GrantTypeAuthorizationCode)) {
+		return &ErrorDirectFlowInitiationNotPermitted
+	}
+	return nil
 }
 
 // initContext initializes a new flow context with the given details.

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -50,7 +50,9 @@ import (
 	"github.com/thunder-id/thunderid/tests/mocks/actorprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 	"github.com/thunder-id/thunderid/tests/mocks/entityprovidermock"
+	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
 	"github.com/thunder-id/thunderid/tests/mocks/inboundclientmock"
+	"github.com/thunder-id/thunderid/tests/mocks/observability/observabilitymock"
 )
 
 // txMarkerKey is an unexported type used as a context key for the transaction marker in tests.
@@ -1185,6 +1187,7 @@ func TestExecute_EngineError_NewFlow_ContextNeverRemoved(t *testing.T) {
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
 
+	mockInboundClient.EXPECT().GetOAuthProfileByEntityID(mock.Anything, "test-app").Return(nil, nil)
 	mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, "test-app").Return(
 		&inboundmodel.InboundClient{ID: "test-app", AuthFlowID: "auth-graph-1"}, nil).Times(2)
 	mockEntityProvider.EXPECT().GetEntity("test-app").Return(
@@ -1857,6 +1860,7 @@ func (s *ServiceTestSuite) TestExecute_NewFlow_IncompleteStoresContext() {
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(s.T())
 	mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(s.T())
 
+	mockInboundClient.EXPECT().GetOAuthProfileByEntityID(mock.Anything, appID).Return(nil, nil)
 	mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, appID).Return(
 		&inboundmodel.InboundClient{ID: appID, AuthFlowID: "auth-graph-new"}, nil)
 	mockEntityProvider.EXPECT().GetEntity(appID).Return(
@@ -2068,4 +2072,315 @@ func (s *ServiceTestSuite) TestSetApplicationToContext_BuildApplicationError() {
 
 	s.NotNil(svcErr)
 	s.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+// --- checkDirectFlowInitiationAllowed ---
+
+func (s *ServiceTestSuite) TestExecute_NewFlow_AuthCodeApp_Blocked() {
+	t := s.T()
+	testConfig := &config.Config{}
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+
+	mockActorProvider := actorprovidermock.NewActorProviderInterfaceMock(t)
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockActorProvider.EXPECT().GetOAuthProfileByID(mock.Anything, "test-app").Return(
+		&inboundmodel.OAuthProfile{GrantTypes: []string{"authorization_code"}}, nil)
+	mockObservability.EXPECT().IsEnabled().Return(false)
+
+	service := &flowExecService{
+		actorProvider:    mockActorProvider,
+		observabilitySvc: mockObservability,
+		transactioner:    &stubTransactioner{},
+	}
+
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "")
+
+	s.Nil(flowStep)
+	s.NotNil(svcErr)
+	s.Equal(ErrorDirectFlowInitiationNotPermitted.Code, svcErr.Code)
+	s.Equal(serviceerror.ClientErrorType, svcErr.Type)
+}
+
+func (s *ServiceTestSuite) TestExecute_NewFlow_NonAuthCodeApp_Allowed() {
+	t := s.T()
+	testConfig := &config.Config{}
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowProvider := NewFlowProviderInterfaceMock(t)
+	mockEngine := newFlowEngineInterfaceMock(t)
+	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
+	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
+
+	mockInboundClient.EXPECT().GetOAuthProfileByEntityID(mock.Anything, "test-app").Return(
+		&inboundmodel.OAuthProfile{GrantTypes: []string{"client_credentials"}}, nil)
+	mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, "test-app").Return(
+		&inboundmodel.InboundClient{ID: "test-app", AuthFlowID: "auth-graph-1"}, nil).Times(2)
+	mockEntityProvider.EXPECT().GetEntity("test-app").Return(
+		&entityprovider.Entity{ID: "test-app", Category: entityprovider.EntityCategoryApp},
+		(*entityprovider.EntityProviderError)(nil))
+	mockFlowProvider.EXPECT().GetGraph(mock.Anything, "auth-graph-1").Return(testGraph, nil)
+
+	completedStep := FlowStep{Status: common.FlowStatusComplete}
+	mockEngine.EXPECT().Execute(mock.Anything).Return(completedStep, (*serviceerror.ServiceError)(nil))
+
+	service := &flowExecService{
+		flowStore:     mockStore,
+		flowProvider:  mockFlowProvider,
+		flowEngine:    mockEngine,
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider),
+		transactioner: &stubTransactioner{},
+	}
+
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "")
+
+	s.Nil(svcErr)
+	s.NotNil(flowStep)
+}
+
+func (s *ServiceTestSuite) TestExecute_NewFlow_OAuthProfileError_InternalError() {
+	t := s.T()
+	testConfig := &config.Config{}
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+
+	mockActorProvider := actorprovidermock.NewActorProviderInterfaceMock(t)
+	mockObservability := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	mockActorProvider.EXPECT().GetOAuthProfileByID(mock.Anything, "test-app").Return(
+		nil, &serviceerror.InternalServerError)
+	mockObservability.EXPECT().IsEnabled().Return(false)
+
+	service := &flowExecService{
+		actorProvider:    mockActorProvider,
+		observabilitySvc: mockObservability,
+		transactioner:    &stubTransactioner{},
+	}
+
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "")
+
+	s.Nil(flowStep)
+	s.NotNil(svcErr)
+	s.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (s *ServiceTestSuite) TestExecute_NewFlow_OAuthProfileNil_Allowed() {
+	t := s.T()
+	testConfig := &config.Config{}
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowProvider := NewFlowProviderInterfaceMock(t)
+	mockEngine := newFlowEngineInterfaceMock(t)
+	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
+	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
+
+	mockInboundClient.EXPECT().GetOAuthProfileByEntityID(mock.Anything, "test-app").Return(nil, nil)
+	mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, "test-app").Return(
+		&inboundmodel.InboundClient{ID: "test-app", AuthFlowID: "auth-graph-1"}, nil).Times(2)
+	mockEntityProvider.EXPECT().GetEntity("test-app").Return(
+		&entityprovider.Entity{ID: "test-app", Category: entityprovider.EntityCategoryApp},
+		(*entityprovider.EntityProviderError)(nil))
+	mockFlowProvider.EXPECT().GetGraph(mock.Anything, "auth-graph-1").Return(testGraph, nil)
+
+	completedStep := FlowStep{Status: common.FlowStatusComplete}
+	mockEngine.EXPECT().Execute(mock.Anything).Return(completedStep, (*serviceerror.ServiceError)(nil))
+
+	service := &flowExecService{
+		flowStore:     mockStore,
+		flowProvider:  mockFlowProvider,
+		flowEngine:    mockEngine,
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider),
+		transactioner: &stubTransactioner{},
+	}
+
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "")
+
+	s.Nil(svcErr)
+	s.NotNil(flowStep)
+}
+
+func (s *ServiceTestSuite) TestExecute_ContinuationFlow_AuthCodeApp_NotBlocked() {
+	t := s.T()
+	testConfig := &config.Config{}
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowProvider := NewFlowProviderInterfaceMock(t)
+	mockEngine := newFlowEngineInterfaceMock(t)
+	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
+	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
+
+	engineCtx := EngineContext{
+		ExecutionID:      "existing-execution-id",
+		AppID:            "test-app",
+		FlowType:         common.FlowTypeAuthentication,
+		Graph:            testGraph,
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*common.NodeExecutionRecord{},
+	}
+	storedCtx, err := FromEngineContext(engineCtx)
+	s.NoError(err)
+
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "existing-execution-id").Return(storedCtx, nil)
+	mockFlowProvider.EXPECT().GetGraph(mock.Anything, "auth-graph-1").Return(testGraph, nil)
+	mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, "test-app").Return(
+		&inboundmodel.InboundClient{ID: "test-app", AuthFlowID: "auth-graph-1"}, nil)
+	mockEntityProvider.EXPECT().GetEntity("test-app").Return(
+		&entityprovider.Entity{ID: "test-app", Category: entityprovider.EntityCategoryApp},
+		(*entityprovider.EntityProviderError)(nil))
+
+	completedStep := FlowStep{Status: common.FlowStatusComplete}
+	mockEngine.EXPECT().Execute(mock.Anything).Return(completedStep, (*serviceerror.ServiceError)(nil))
+	mockStore.EXPECT().DeleteFlowContext(mock.Anything, "existing-execution-id").Return(nil)
+
+	service := &flowExecService{
+		flowStore:     mockStore,
+		flowProvider:  mockFlowProvider,
+		flowEngine:    mockEngine,
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider),
+		transactioner: &stubTransactioner{},
+	}
+
+	flowStep, svcErr := service.Execute(context.Background(), "test-app", "existing-execution-id",
+		string(common.FlowTypeAuthentication), false, "submit", map[string]string{}, "valid-token")
+
+	s.Nil(svcErr)
+	s.NotNil(flowStep)
+}
+
+// --- updateContext ---
+
+func (s *ServiceTestSuite) TestUpdateContext_IncompleteEmptyExecutionID() {
+	service := &flowExecService{cfg: testFlowExecCfg}
+	engineCtx := &EngineContext{ExecutionID: ""}
+	flowStep := &FlowStep{Status: common.FlowStatusIncomplete}
+
+	err := service.updateContext(context.Background(), engineCtx, flowStep, log.GetLogger())
+	s.Error(err)
+}
+
+// --- checkDirectFlowInitiationAllowed ---
+
+func (s *ServiceTestSuite) TestCheckDirectFlowInitiationAllowed_ClientNotFound() {
+	t := s.T()
+	mockActorProvider := actorprovidermock.NewActorProviderInterfaceMock(t)
+	mockActorProvider.EXPECT().GetOAuthProfileByID(mock.Anything, "app-notfound").Return(
+		(*inboundmodel.OAuthProfile)(nil), &actorprovider.ErrorActorNotFound)
+
+	service := &flowExecService{
+		actorProvider: mockActorProvider,
+		cfg:           testFlowExecCfg,
+	}
+
+	svcErr := service.checkDirectFlowInitiationAllowed(context.Background(), "app-notfound", log.GetLogger())
+	s.Nil(svcErr)
+}
+
+// --- getFlowContext ---
+
+func (s *ServiceTestSuite) TestGetFlowContext_NilDbModel() {
+	t := s.T()
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "exec-nil").Return(nil, nil)
+
+	service := &flowExecService{
+		flowStore: mockStore,
+		cfg:       testFlowExecCfg,
+	}
+
+	result, svcErr := service.getFlowContext(context.Background(), "exec-nil", log.GetLogger())
+	s.Nil(result)
+	s.NotNil(svcErr)
+	s.Equal(ErrorInvalidExecutionID.Code, svcErr.Code)
+}
+
+func (s *ServiceTestSuite) TestGetFlowContext_StoreError() {
+	t := s.T()
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "exec-err").Return(nil, errors.New("store failure"))
+
+	service := &flowExecService{
+		flowStore: mockStore,
+		cfg:       testFlowExecCfg,
+	}
+
+	result, svcErr := service.getFlowContext(context.Background(), "exec-err", log.GetLogger())
+	s.Nil(result)
+	s.NotNil(svcErr)
+	s.Equal(serviceerror.InternalServerError.Code, svcErr.Code)
+}
+
+func (s *ServiceTestSuite) TestLoadContextFromStore_ToEngineContextError() {
+	t := s.T()
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowProvider := NewFlowProviderInterfaceMock(t)
+
+	// Context has invalid JSON for userInputs to force ToEngineContext error.
+	rawCtx := "{\"executionID\":\"exec-2\",\"appID\":\"app-1\",\"flowType\":\"AUTHENTICATION\"," +
+		"\"graphID\":\"graph-1\",\"currentNodeID\":\"node-1\",\"userInputs\":\"not-valid-json\"," +
+		"\"runtimeData\":\"{}\",\"executionHistory\":\"{}\"}"
+	dbModel := &FlowContextDB{
+		ExecutionID: "exec-2",
+		Context:     rawCtx,
+	}
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "exec-2").Return(dbModel, nil)
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.EXPECT().GetNode(mock.Anything).Return(nil, false).Maybe()
+	mockGraph.EXPECT().GetType().Return(common.FlowType("AUTHENTICATION")).Maybe()
+	mockFlowProvider.EXPECT().GetGraph(mock.Anything, mock.Anything).Return(mockGraph, nil)
+
+	service := &flowExecService{
+		flowStore:    mockStore,
+		flowProvider: mockFlowProvider,
+		cfg:          testFlowExecCfg,
+	}
+
+	result, svcErr := service.loadContextFromStore(context.Background(), "exec-2", log.GetLogger())
+	s.Nil(result)
+	s.NotNil(svcErr)
+}
+
+func (s *ServiceTestSuite) TestLoadContextFromStore_GetFlowGraphError() {
+	t := s.T()
+	mockStore := newFlowStoreInterfaceMock(t)
+	mockFlowProvider := NewFlowProviderInterfaceMock(t)
+
+	rawCtx := "{\"executionID\":\"exec-1\",\"appID\":\"app-1\",\"flowType\":\"AUTHENTICATION\"," +
+		"\"graphID\":\"graph-1\",\"currentNodeID\":\"node-1\",\"userInputs\":\"{}\"," +
+		"\"runtimeData\":\"{}\",\"executionHistory\":\"{}\"}"
+	dbModel := &FlowContextDB{
+		ExecutionID: "exec-1",
+		Context:     rawCtx,
+	}
+	mockStore.EXPECT().GetFlowContext(mock.Anything, "exec-1").Return(dbModel, nil)
+	mockFlowProvider.EXPECT().GetGraph(mock.Anything, mock.Anything).Return(nil, &serviceerror.InternalServerError)
+
+	service := &flowExecService{
+		flowStore:    mockStore,
+		flowProvider: mockFlowProvider,
+		cfg:          testFlowExecCfg,
+	}
+
+	result, svcErr := service.loadContextFromStore(context.Background(), "exec-1", log.GetLogger())
+	s.Nil(result)
+	s.NotNil(svcErr)
 }

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -147,7 +147,7 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 	}
 
 	// Retrieve the OAuth client based on the client ID.
-	app, lookupErr := as.inboundClient.GetOAuthClientByID(ctx, clientID)
+	app, lookupErr := as.inboundClient.GetOAuthClientByClientID(ctx, clientID)
 	if lookupErr != nil {
 		as.logger.Error(ctx, "Failed to retrieve OAuth client",
 			log.String("error", lookupErr.Error.DefaultValue))

--- a/backend/internal/oauth/oauth2/ciba/service.go
+++ b/backend/internal/oauth/oauth2/ciba/service.go
@@ -328,7 +328,7 @@ func (s *cibaService) HandleCallback(ctx context.Context, authReqID, assertion s
 // as the assertion `aud`. It returns an empty string (skipping the audience check) on lookup
 // failure; the ciba_auth_req_id binding remains the primary protection in that case.
 func (s *cibaService) resolveExpectedAudience(ctx context.Context, clientID string) string {
-	app, svcErr := s.inboundClient.GetOAuthClientByID(ctx, clientID)
+	app, svcErr := s.inboundClient.GetOAuthClientByClientID(ctx, clientID)
 	if svcErr != nil {
 		s.logger.Warn(ctx, "Failed to resolve client for audience validation; skipping audience check",
 			log.String("error", svcErr.Error.DefaultValue))

--- a/backend/internal/oauth/oauth2/clientauth/clientauth.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth.go
@@ -130,7 +130,7 @@ func authenticate(
 		return nil, errClientIDMismatch
 	}
 
-	oauthApp, svcErr := actorProvider.GetOAuthClientByID(ctx, clientID)
+	oauthApp, svcErr := actorProvider.GetOAuthClientByClientID(ctx, clientID)
 	if svcErr != nil {
 		logger.Error(ctx, "Failed to retrieve OAuth client",
 			log.String("error", svcErr.Error.DefaultValue), log.MaskedString("clientID", clientID))

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -393,7 +393,7 @@ func (s *userInfoService) getOAuthApp(
 		return nil
 	}
 
-	app, svcErr := s.inboundClient.GetOAuthClientByID(ctx, clientID)
+	app, svcErr := s.inboundClient.GetOAuthClientByClientID(ctx, clientID)
 	if svcErr != nil || app == nil {
 		return nil
 	}

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -532,6 +532,8 @@ var defaultMessages = map[string]string{
 	"error.flow.core.prompt_invalid_action_description": "The action provided is not valid for the current flow step",
 	"error.flowexecservice.application_retrieval_error": "Application retrieval error",
 	"error.flowexecservice.application_retrieval_error_description": "Error while retrieving application details",
+	"error.flowexecservice.direct_flow_initiation_not_permitted": "Direct flow initiation not permitted",
+	"error.flowexecservice.direct_flow_initiation_not_permitted_description": "Direct flow initiation is not permitted for this application type",
 	"error.flowexecservice.invalid_app_id": "Invalid request",
 	"error.flowexecservice.invalid_app_id_description": "Invalid app ID provided in the request",
 	"error.flowexecservice.invalid_challenge_token": "Invalid challenge token",

--- a/backend/tests/mocks/actorprovidermock/ActorProviderInterface_mock.go
+++ b/backend/tests/mocks/actorprovidermock/ActorProviderInterface_mock.go
@@ -307,3 +307,73 @@ func (_c *ActorProviderInterfaceMock_GetOAuthClientByID_Call) RunAndReturn(run f
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetOAuthProfileByID provides a mock function for the type ActorProviderInterfaceMock
+func (_mock *ActorProviderInterfaceMock) GetOAuthProfileByID(ctx context.Context, id string) (*model.OAuthProfile, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOAuthProfileByID")
+	}
+
+	var r0 *model.OAuthProfile
+	var r1 *serviceerror.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*model.OAuthProfile, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *model.OAuthProfile); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.OAuthProfile)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*serviceerror.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// ActorProviderInterfaceMock_GetOAuthProfileByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOAuthProfileByID'
+type ActorProviderInterfaceMock_GetOAuthProfileByID_Call struct {
+	*mock.Call
+}
+
+// GetOAuthProfileByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *ActorProviderInterfaceMock_Expecter) GetOAuthProfileByID(ctx interface{}, id interface{}) *ActorProviderInterfaceMock_GetOAuthProfileByID_Call {
+	return &ActorProviderInterfaceMock_GetOAuthProfileByID_Call{Call: _e.mock.On("GetOAuthProfileByID", ctx, id)}
+}
+
+func (_c *ActorProviderInterfaceMock_GetOAuthProfileByID_Call) Run(run func(ctx context.Context, id string)) *ActorProviderInterfaceMock_GetOAuthProfileByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ActorProviderInterfaceMock_GetOAuthProfileByID_Call) Return(oAuthProfile *model.OAuthProfile, serviceError *serviceerror.ServiceError) *ActorProviderInterfaceMock_GetOAuthProfileByID_Call {
+	_c.Call.Return(oAuthProfile, serviceError)
+	return _c
+}
+
+func (_c *ActorProviderInterfaceMock_GetOAuthProfileByID_Call) RunAndReturn(run func(ctx context.Context, id string) (*model.OAuthProfile, *serviceerror.ServiceError)) *ActorProviderInterfaceMock_GetOAuthProfileByID_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/backend/tests/mocks/actorprovidermock/ActorProviderInterface_mock.go
+++ b/backend/tests/mocks/actorprovidermock/ActorProviderInterface_mock.go
@@ -238,28 +238,28 @@ func (_c *ActorProviderInterfaceMock_GetInboundClientByID_Call) RunAndReturn(run
 	return _c
 }
 
-// GetOAuthClientByID provides a mock function for the type ActorProviderInterfaceMock
-func (_mock *ActorProviderInterfaceMock) GetOAuthClientByID(ctx context.Context, id string) (*model.OAuthClient, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, id)
+// GetOAuthClientByClientID provides a mock function for the type ActorProviderInterfaceMock
+func (_mock *ActorProviderInterfaceMock) GetOAuthClientByClientID(ctx context.Context, clientID string) (*model.OAuthClient, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, clientID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetOAuthClientByID")
+		panic("no return value specified for GetOAuthClientByClientID")
 	}
 
 	var r0 *model.OAuthClient
 	var r1 *serviceerror.ServiceError
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*model.OAuthClient, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, id)
+		return returnFunc(ctx, clientID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *model.OAuthClient); ok {
-		r0 = returnFunc(ctx, id)
+		r0 = returnFunc(ctx, clientID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.OAuthClient)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, id)
+		r1 = returnFunc(ctx, clientID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -268,19 +268,19 @@ func (_mock *ActorProviderInterfaceMock) GetOAuthClientByID(ctx context.Context,
 	return r0, r1
 }
 
-// ActorProviderInterfaceMock_GetOAuthClientByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOAuthClientByID'
-type ActorProviderInterfaceMock_GetOAuthClientByID_Call struct {
+// ActorProviderInterfaceMock_GetOAuthClientByClientID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOAuthClientByClientID'
+type ActorProviderInterfaceMock_GetOAuthClientByClientID_Call struct {
 	*mock.Call
 }
 
-// GetOAuthClientByID is a helper method to define mock.On call
+// GetOAuthClientByClientID is a helper method to define mock.On call
 //   - ctx context.Context
-//   - id string
-func (_e *ActorProviderInterfaceMock_Expecter) GetOAuthClientByID(ctx interface{}, id interface{}) *ActorProviderInterfaceMock_GetOAuthClientByID_Call {
-	return &ActorProviderInterfaceMock_GetOAuthClientByID_Call{Call: _e.mock.On("GetOAuthClientByID", ctx, id)}
+//   - clientID string
+func (_e *ActorProviderInterfaceMock_Expecter) GetOAuthClientByClientID(ctx interface{}, clientID interface{}) *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call {
+	return &ActorProviderInterfaceMock_GetOAuthClientByClientID_Call{Call: _e.mock.On("GetOAuthClientByClientID", ctx, clientID)}
 }
 
-func (_c *ActorProviderInterfaceMock_GetOAuthClientByID_Call) Run(run func(ctx context.Context, id string)) *ActorProviderInterfaceMock_GetOAuthClientByID_Call {
+func (_c *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call) Run(run func(ctx context.Context, clientID string)) *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -298,12 +298,12 @@ func (_c *ActorProviderInterfaceMock_GetOAuthClientByID_Call) Run(run func(ctx c
 	return _c
 }
 
-func (_c *ActorProviderInterfaceMock_GetOAuthClientByID_Call) Return(oAuthClient *model.OAuthClient, serviceError *serviceerror.ServiceError) *ActorProviderInterfaceMock_GetOAuthClientByID_Call {
+func (_c *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call) Return(oAuthClient *model.OAuthClient, serviceError *serviceerror.ServiceError) *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call {
 	_c.Call.Return(oAuthClient, serviceError)
 	return _c
 }
 
-func (_c *ActorProviderInterfaceMock_GetOAuthClientByID_Call) RunAndReturn(run func(ctx context.Context, id string) (*model.OAuthClient, *serviceerror.ServiceError)) *ActorProviderInterfaceMock_GetOAuthClientByID_Call {
+func (_c *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call) RunAndReturn(run func(ctx context.Context, clientID string) (*model.OAuthClient, *serviceerror.ServiceError)) *ActorProviderInterfaceMock_GetOAuthClientByClientID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -2344,6 +2344,7 @@ const translations = {
     'errors.signin.failed.message': 'Error',
     'errors.signin.failed.description': 'We are sorry, something has gone wrong here. Please try again.',
     'errors.signin.timeout': 'Time allowed to complete the step has expired.',
+    'errors.signin.session.expired': 'Your session has expired. Please return to the application and sign in again.',
     'errors.passkey.failed': 'Passkey authentication failed. Please try again.',
     'redirect.to.signup': "Don't have an account? <1>Sign up</1>",
     heading: 'Sign In',

--- a/sdks/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
+++ b/sdks/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
@@ -18,6 +18,7 @@
 
 import {
   ThunderIDRuntimeError,
+  ThunderIDAPIError,
   EmbeddedFlowComponentV2 as EmbeddedFlowComponent,
   EmbeddedFlowType,
   EmbeddedSignInFlowResponseV2,
@@ -217,8 +218,7 @@ const SignIn: FC<SignInProps> = ({
   variant,
   children,
 }: SignInProps): ReactElement => {
-  const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading, meta, getStorageManager, scopes} =
-    useThunderID();
+  const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading, meta, getStorageManager, scopes} = useThunderID();
   const {t} = useTranslation(preferences?.i18n);
 
   // State management for the flow
@@ -332,7 +332,9 @@ const SignIn: FC<SignInProps> = ({
   };
 
   /**
-   * Handle authId from URL and store it in sessionStorage.
+   * Handle authId from URL and persist it via the storage manager so it survives URL cleanup.
+   * ThunderIDReactClient.signIn() reads authId from storageManager.getHybridDataParameter('authId'),
+   * not from raw sessionStorage, so we must use the same storage path here.
    */
   const handleAuthId = async (authId: string | null): Promise<void> => {
     if (authId) {
@@ -410,7 +412,7 @@ const SignIn: FC<SignInProps> = ({
         await setChallengeToken(response.challengeToken ?? null);
 
         const urlParams: any = getUrlParams();
-        handleAuthId(urlParams.authId);
+        await handleAuthId(urlParams.authId);
 
         initiateOAuthRedirect(redirectURL);
         return true;
@@ -429,11 +431,19 @@ const SignIn: FC<SignInProps> = ({
     // Reset OAuth code processed ref when starting a new flow
     oauthCodeProcessedRef.current = false;
 
-    handleAuthId(urlParams.authId);
+    await handleAuthId(urlParams.authId);
 
     const effectiveApplicationId: any = applicationId || urlParams.applicationId;
 
-    if (!urlParams.executionId && !effectiveApplicationId) {
+    // On a page refresh the executionId is no longer in the URL (it is scrubbed by
+    // cleanupFlowUrlParams after the first load). Fall back to the executionId persisted in
+    // sessionStorage so the in-progress flow can be resumed instead of starting a new flow.
+    // This is required for authorization_code apps where direct new-flow initiation is blocked
+    // server-side and the flow must be initiated through the OAuth /authorize endpoint.
+    const storedExecutionId: any = !urlParams.executionId ? sessionStorage.getItem('thunderid_execution_id') : null;
+    const resumeExecutionId: any = urlParams.executionId || storedExecutionId;
+
+    if (!resumeExecutionId && !effectiveApplicationId) {
       const error: any = new ThunderIDRuntimeError(
         'Either executionId or applicationId is required for authentication',
         'SIGN_IN_ERROR',
@@ -448,11 +458,49 @@ const SignIn: FC<SignInProps> = ({
 
       let response: EmbeddedSignInFlowResponseV2;
 
-      if (urlParams.executionId) {
-        response = (await signIn({
-          executionId: urlParams.executionId,
-          ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
-        })) as EmbeddedSignInFlowResponseV2;
+      if (resumeExecutionId) {
+        try {
+          response = (await signIn({
+            executionId: resumeExecutionId,
+            ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
+          })) as EmbeddedSignInFlowResponseV2;
+        } catch (resumeError) {
+          // Only treat a stale/expired session (HTTP 400 from the server, meaning the stored
+          // executionId is no longer valid) as a recoverable condition. Transient failures
+          // such as 5xx server errors or network errors are rethrown so they surface correctly.
+          const isStaleSession: boolean =
+            storedExecutionId &&
+            resumeExecutionId === storedExecutionId &&
+            resumeError instanceof ThunderIDAPIError &&
+            resumeError.statusCode === 400;
+
+          if (isStaleSession) {
+            setExecutionId(null);
+            try {
+              const storageManager: any = await getStorageManager();
+              await storageManager?.removeHybridDataParameter?.('authId');
+            } catch {
+              logger.warn('Failed to clear authId from hybrid storage.');
+            }
+            if (!effectiveApplicationId) {
+              const expiredError: any = new ThunderIDRuntimeError(
+                t('errors.signin.session.expired') ||
+                  'Your session has expired. Please return to the application and sign in again.',
+                'SIGN_IN_ERROR',
+                'react',
+              );
+              setError(expiredError);
+              return;
+            }
+            response = (await signIn({
+              applicationId: effectiveApplicationId,
+              flowType: EmbeddedFlowType.Authentication,
+              ...(scopes && {scopes}),
+            })) as EmbeddedSignInFlowResponseV2;
+          } else {
+            throw resumeError;
+          }
+        }
       } else {
         response = (await signIn({
           applicationId: effectiveApplicationId,
@@ -517,12 +565,14 @@ const SignIn: FC<SignInProps> = ({
   }, []);
 
   useEffect(() => {
-    // Only initialize if we're not processing an OAuth callback or submission
+    // Only initialize if we're not processing an OAuth callback or submission.
+    // Wait for isStorageReady so the challenge token is restored from storage before
+    // we attempt to resume a persisted executionId — the server requires it.
     const currentUrlParams: any = getUrlParams();
     if (
       isInitialized &&
-      !isLoading &&
       isStorageReady &&
+      !isLoading &&
       !isFlowInitialized &&
       !initializationAttemptedRef.current &&
       !currentExecutionId &&
@@ -534,7 +584,7 @@ const SignIn: FC<SignInProps> = ({
       initializationAttemptedRef.current = true;
       initializeFlow();
     }
-  }, [isInitialized, isLoading, isStorageReady, isFlowInitialized, currentExecutionId]);
+  }, [isInitialized, isStorageReady, isLoading, isFlowInitialized, currentExecutionId]);
 
   /**
    * Handle step timeout if configured in additionalData.

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -246,6 +246,31 @@ print(d.get('summary', {}).get('failed', 0))
     echo "  Imported $sample resources."
 done
 
+# Import E2E test infrastructure resources (e.g. admin native app for direct flow execution).
+e2e_config="$SCRIPT_DIR/thunderid-config.yaml"
+if [ -f "$e2e_config" ]; then
+    content=$(jq -Rs . < "$e2e_config")
+    http_status=$(curl -sk -o /tmp/import_response.json -w "%{http_code}" \
+        -X POST "$SERVER_URL/import" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $ADMIN_TOKEN" \
+        -d "{\"content\": $content, \"options\": {\"upsert\": true}}")
+    if [ "$http_status" != "200" ]; then
+        echo "ERROR: import returned HTTP $http_status for E2E config:"
+        cat /tmp/import_response.json; echo ""; exit 1
+    fi
+    failed_count=$(python3 -c "
+import sys, json
+d = json.load(open('/tmp/import_response.json'))
+print(d.get('summary', {}).get('failed', 0))
+" 2>/dev/null || echo "0")
+    if [ "$failed_count" != "0" ]; then
+        echo "ERROR: E2E config import had $failed_count failed resource(s):"
+        cat /tmp/import_response.json; echo ""; exit 1
+    fi
+    echo "Imported E2E test infrastructure resources."
+fi
+
 # Use the vanilla "Sample App" ID (stable UUID v7 from react-vanilla-sample/thunderid-config/basic).
 # The vanilla sample is unaffected by MFA test setup/teardown, unlike the SDK sample.
 SAMPLE_APP_ID="019e3a5c-0500-7f3e-a66e-66fc7918c3a7"

--- a/tests/e2e/thunderid-config.yaml
+++ b/tests/e2e/thunderid-config.yaml
@@ -1,0 +1,19 @@
+---
+# resource_type: application
+# Native application used exclusively by E2E test infrastructure for admin API authentication.
+# Uses only the client_credentials grant type so it is not subject to the redirect-based
+# flow initiation guard introduced for authorization_code apps.
+id: 019e3a5c-0501-7f3e-a66e-66fc7918c3a7
+ouHandle: default
+name: E2E Admin Native App
+description: Native application for E2E test infrastructure admin authentication
+authFlowHandle: default-basic-flow
+allowedUserTypes:
+  - Customer
+inboundAuthConfig:
+  - type: oauth2
+    config:
+      clientId: thunder_e2e_admin_client
+      grantTypes:
+        - client_credentials
+      tokenEndpointAuthMethod: client_secret_basic

--- a/tests/e2e/utils/authentication/admin-api-auth.ts
+++ b/tests/e2e/utils/authentication/admin-api-auth.ts
@@ -16,15 +16,21 @@
  * under the License.
  */
 
+// Application ID of the native app used for E2E admin authentication.
+// Declared in the vanilla sample thunderid-config with a fixed UUID. Uses only the
+// client_credentials grant type and is therefore not subject to the redirect-based
+// flow initiation guard.
+const E2E_ADMIN_NATIVE_APP_ID = "019e3a5c-0501-7f3e-a66e-66fc7918c3a7";
+
 /**
  * Obtain a short-lived admin bearer token via the flow execution API.
- * Reads SERVER_URL, ADMIN_USERNAME, ADMIN_PASSWORD, and SAMPLE_APP_ID from environment variables.
+ * Reads SERVER_URL, ADMIN_USERNAME, and ADMIN_PASSWORD from environment variables.
  */
 export async function getAdminToken(request: import("@playwright/test").APIRequestContext): Promise<string> {
   const serverUrl = process.env.SERVER_URL || "https://localhost:8090";
   const adminUsername = process.env.ADMIN_USERNAME || "admin";
   const adminPassword = process.env.ADMIN_PASSWORD || "admin";
-  const applicationId = process.env.SAMPLE_APP_ID || "";
+  const applicationId = E2E_ADMIN_NATIVE_APP_ID;
 
   const flowResponse = await request.post(`${serverUrl}/flow/execute`, {
     data: { applicationId, flowType: "AUTHENTICATION" },

--- a/tests/e2e/utils/server-setup/mfa-setup.ts
+++ b/tests/e2e/utils/server-setup/mfa-setup.ts
@@ -179,10 +179,14 @@ export class MFASetup {
    * Get admin authentication token
    */
   private async getAdminToken(): Promise<string> {
+    // Use the native app declared in the vanilla sample thunderid-config with a fixed UUID.
+    // It uses only client_credentials so it is not subject to the redirect-based flow guard.
+    const adminAppId = "019e3a5c-0501-7f3e-a66e-66fc7918c3a7";
+
     // Step 1: Start authentication flow
     const flowResponse = await this.request.post(`${this.config.serverUrl}/flow/execute`, {
       data: {
-        applicationId: this.config.applicationId,
+        applicationId: adminAppId,
         flowType: "AUTHENTICATION",
       },
       ignoreHTTPSErrors: true,

--- a/tests/integration/flow/authentication/acr_options_flow_test.go
+++ b/tests/integration/flow/authentication/acr_options_flow_test.go
@@ -217,7 +217,9 @@ var acrOptionsFlow = testutils.Flow{
 	},
 }
 
-// acrOptionsTestApp is a minimal OAuth2 application used across ACR options tests.
+// acrOptionsTestApp is the OAuth2 application used for ACR options tests that go through
+// the OAuth authorize endpoint (response_type=code). It must have the authorization_code
+// grant type so that /oauth2/authorize accepts it.
 var acrOptionsTestApp = testutils.Application{
 	Name:                      "ACR Options Flow Test Application",
 	Description:               "Application for testing login_options flow behaviour",
@@ -235,6 +237,34 @@ var acrOptionsTestApp = testutils.Application{
 				"redirectUris":            []string{"https://localhost:3000/acr-options-callback"},
 				"grantTypes":              []string{"authorization_code"},
 				"responseTypes":           []string{"code"},
+				"tokenEndpointAuthMethod": "client_secret_basic",
+				"acrValues": []string{
+					"urn:thunder:acr:password",
+					"urn:thunder:acr:generated-code",
+					"urn:thunder:acr:biometrics",
+				},
+			},
+		},
+	},
+}
+
+// acrOptionsNativeTestApp is a native (non-redirect) application used for ACR options
+// tests that call /flow/execute directly. It must not have the authorization_code grant
+// type so that the redirect-app guard allows direct flow initiation.
+var acrOptionsNativeTestApp = testutils.Application{
+	Name:                      "ACR Options Native Test Application",
+	Description:               "Native application for direct flow execution in ACR options tests",
+	IsRegistrationFlowEnabled: false,
+	ClientID:                  "acr_options_native_test_client",
+	ClientSecret:              "acr_options_native_test_secret",
+	AllowedUserTypes:          []string{"acr_options_test_person"},
+	InboundAuthConfig: []map[string]interface{}{
+		{
+			"type": "oauth2",
+			"config": map[string]interface{}{
+				"clientId":                "acr_options_native_test_client",
+				"clientSecret":            "acr_options_native_test_secret",
+				"grantTypes":              []string{"client_credentials"},
 				"tokenEndpointAuthMethod": "client_secret_basic",
 				"acrValues": []string{
 					"urn:thunder:acr:password",
@@ -272,10 +302,11 @@ var acrOptionsTestUser = testutils.User{
 }
 
 var (
-	acrOptionsTestAppID  string
-	acrOptionsTestOUID   string
-	acrOptionsFlowID     string
-	acrOptionsUserTypeID string
+	acrOptionsTestAppID        string
+	acrOptionsNativeTestAppID  string
+	acrOptionsTestOUID         string
+	acrOptionsFlowID           string
+	acrOptionsUserTypeID       string
 )
 
 // AcrOptionsFlowTestSuite tests the login_options PROMPT node filtering, ordering,
@@ -317,6 +348,12 @@ func (ts *AcrOptionsFlowTestSuite) SetupSuite() {
 	appID, err := testutils.CreateApplication(acrOptionsTestApp)
 	ts.Require().NoError(err, "failed to create ACR options test application")
 	acrOptionsTestAppID = appID
+
+	acrOptionsNativeTestApp.AuthFlowID = flowID
+	acrOptionsNativeTestApp.OUID = acrOptionsTestOUID
+	nativeAppID, err := testutils.CreateApplication(acrOptionsNativeTestApp)
+	ts.Require().NoError(err, "failed to create ACR options native test application")
+	acrOptionsNativeTestAppID = nativeAppID
 }
 
 func (ts *AcrOptionsFlowTestSuite) TearDownSuite() {
@@ -326,6 +363,11 @@ func (ts *AcrOptionsFlowTestSuite) TearDownSuite() {
 	if acrOptionsTestAppID != "" {
 		if err := testutils.DeleteApplication(acrOptionsTestAppID); err != nil {
 			ts.T().Logf("failed to delete test application: %v", err)
+		}
+	}
+	if acrOptionsNativeTestAppID != "" {
+		if err := testutils.DeleteApplication(acrOptionsNativeTestAppID); err != nil {
+			ts.T().Logf("failed to delete native test application: %v", err)
 		}
 	}
 	for _, id := range ts.config.CreatedFlowIDs {
@@ -346,7 +388,7 @@ func (ts *AcrOptionsFlowTestSuite) TearDownSuite() {
 }
 
 func (ts *AcrOptionsFlowTestSuite) TestAcrOptions_NodeValidInFlowGraph() {
-	flowStep, err := common.InitiateAuthenticationFlow(acrOptionsTestAppID, false, nil, "")
+	flowStep, err := common.InitiateAuthenticationFlow(acrOptionsNativeTestAppID, false, nil, "")
 	ts.Require().NoError(err, "flow initiation should succeed")
 
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
@@ -426,7 +468,7 @@ func (ts *AcrOptionsFlowTestSuite) TestAcrOptions_AutoSelectsWhenSingleACR() {
 
 func (ts *AcrOptionsFlowTestSuite) TestAcrOptions_AcrInAuthAssertionJWT() {
 	// Step 1: Start the flow without acr filtering so the chooser is shown.
-	flowStep, err := common.InitiateAuthenticationFlow(acrOptionsTestAppID, false, nil, "")
+	flowStep, err := common.InitiateAuthenticationFlow(acrOptionsNativeTestAppID, false, nil, "")
 	ts.Require().NoError(err)
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus)
 	ts.Require().NotEmpty(flowStep.Data.Actions)

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -370,6 +370,7 @@ func CreateApplication(app Application) (string, error) {
 					"clientId":     app.ClientID,
 					"clientSecret": app.ClientSecret,
 					"redirectUris": redirectURIs,
+					"grantTypes":   []string{"client_credentials"},
 				},
 			},
 		}


### PR DESCRIPTION
### Purpose

Applications configured with the `authorization_code` grant type (browser SPAs) must have their flows initiated by the OAuth component via `/authorize`, not via a direct `POST /flow/execute` call. Previously the endpoint was fully open — any caller could start a new flow for any application. This PR adds a guard that blocks new-flow initiation for such applications, while leaving continuation requests (those carrying an `executionId`) and the OAuth component's internal `InitiateFlow()` path unaffected.

It also fixes a UX regression the guard introduces: when a user refreshes the gate app mid-flow, the React SDK was attempting to start a new flow directly (now blocked), causing an error page. The SDK is updated to rehydrate and resume the in-progress flow on refresh instead.

Closes #3215
Design discussion: #2744

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes

`POST /flow/execute` now rejects new-flow initiation for applications configured with the `authorization_code` grant type.

#### 💥 Impact

Callers that send a request with no `executionId` for an `authorization_code` application now receive `403 Forbidden` with error code `FES-1011`. Continuation requests (with a valid `executionId`) are unaffected.

#### 🔄 Migration Guide

Direct the user to `GET /oauth2/authorize`. The OAuth component will call `InitiateFlow()` internally and redirect the browser to the SPA with an `executionId`. The SPA then calls `POST /flow/execute` with that `executionId` to continue — this path is unaffected.

---

### Approach

**Guard placement — `loadNewContext()`, not `initContext()`**

`Execute()` branches on the presence of an `executionId`:

```
Execute()
  ├── empty executionId  →  loadNewContext()   ← guard lives here
  └── non-empty executionId  →  loadPrevContext()   (unaffected)

InitiateFlow() [OAuth component]  →  initContext()   (unaffected)
```

Placing the guard in `loadNewContext()` avoids blocking the OAuth component's legitimate `InitiateFlow()` path, which calls `initContext()` directly.

**`checkDirectFlowInitiationAllowed()` — the guard**

Resolves the app's OAuth profile via `actorProvider.GetOAuthProfileByEntityID` (routed through the existing `actorProvider` dependency — no new service dependencies added to `flowexec`) and checks whether `authorization_code` is in `GrantTypes`. Returns `ErrorDirectFlowInitiationNotPermitted` (error code `FES-1011`, type `ForbiddenErrorType`) if so.

`GetOAuthProfileByEntityID` was added to `ActorProviderInterface` and implemented in `actorprovider.service` to keep the OAuth profile lookup consolidated behind `actorProvider`, consistent with the intent of #3306.

Fail-open cases (guard passes silently):
- `appID` is empty (app-independent flows such as user onboarding).
- App has no OAuth profile registered — `actorProvider` returns `ErrorActorNotFound`, nothing to enforce.
- `nil` OAuth profile returned.

Fail-closed: any unexpected store/infrastructure error returns HTTP 500 rather than accidentally allowing the request through.

**New `ForbiddenErrorType` + HTTP 403 mapping**

The error type system previously only mapped `ClientErrorType → 400` and `ServerErrorType → 500`. A new `ForbiddenErrorType` was added to the `serviceerror` package and `handleFlowError` updated to map it to HTTP 403.

**React SDK — refresh fix (`SignIn` v2)**

On page refresh, the SDK lost its React state and `executionId` was already cleaned from the URL. The component now:
1. Falls back to `sessionStorage.thunderid_execution_id` to rehydrate the `executionId`.
2. Resumes the in-progress flow via `signIn({ executionId, ...challengeToken })` instead of initiating a new flow.
3. Shows a user-friendly "session expired" message if the stored `executionId` is stale. A stale session is detected when the resume request fails with HTTP `400` (a `ThunderIDAPIError` with `statusCode === 400`); transient failures (5xx / network errors) are rethrown so they surface normally.

**Test fixes**

- *Integration tests:* `CreateApplication` in `testutils/api_utils.go` was omitting `grantTypes`, causing the server to default to `["authorization_code"]` for every test app. Fixed by explicitly setting `"grantTypes": ["client_credentials"]` so test apps are not subject to the guard. `acr_options_flow_test.go` previously used a single `authorization_code` app for all ACR tests; it now adds a dedicated native app (`acrOptionsNativeTestApp`, `grant_types: ["client_credentials"]`) for the two tests that call `/flow/execute` directly, while keeping the `authorization_code` app for the tests that go through `/oauth2/authorize`.
- *E2E tests:* `admin-api-auth.ts` and `mfa-setup.ts` were calling `/flow/execute` directly using `SAMPLE_APP_ID` (an `authorization_code` app). Fixed by adding a dedicated native app (`thunder_e2e_admin_client`, `grant_types: ["client_credentials"]`) with a fixed UUID to `tests/e2e/thunderid-config.yaml`, and referencing that UUID in the E2E helpers.

**Test coverage**

Additional tests were added to bring `flowexec` package coverage from 61% to 80%+, covering:
- All handler paths, including the new 403 mapping (converted to `HandlerTestSuite`).
- Previously uncovered engine internals (converted to `EngineTestSuite`).
- `checkDirectFlowInitiationAllowed` and related service paths (in `ServiceTestSuite`).

### Related Issues
- Fixes #3215
- Design: https://github.com/thunder-id/thunderid/discussions/2744

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided.
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [x] Integration Tests
- [x] Breaking changes.
    - [x] Breaking changes section filled.
    - [x] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.