### PR TITLE
Remove duplicate node property rendering in flow builder executor panel

### DIFF
--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/ResourceProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/ResourceProperties.tsx
@@ -150,7 +150,6 @@ function ResourceProperties({
         <>
           {renderElementId()}
           <ExecutionExtendedProperties resource={resource} onChange={handleChange} />
-          {renderElementPropertyFactory()}
         </>
       );
     case ElementCategories.Display:


### PR DESCRIPTION
### Purpose
In the console flow builder, executor nodes (e.g., Google OAuth, SMS OTP, Federation) displayed duplicate entries for every node property in the properties panel. Each property was rendered twice — once by the executor-specific property component (e.g., FederationProperties, SmsOtpProperties) and once by the generic property factory.

### Approach
The root cause was in the StepCategories.Workflow branch of the login-flow ResourceProperties component. It called both ExecutionExtendedProperties and renderElementPropertyFactory(). The generic factory received filteredProperties, which includes all data.properties.* keys collected from the executor node's data. Since executor-specific components (FederationProperties, SmsOtpProperties, etc.) already render those same data.properties.* fields with purpose-built UI, the factory was rendering them a second time as plain generic inputs.

The fix removes the renderElementPropertyFactory() call from the StepCategories.Workflow case. Executor nodes are step nodes, not UI elements — they never carry TOP_LEVEL_EDITABLE_PROPS (label, hint, placeholder, etc.) or a config object, so filteredProperties for them contains only data.properties.* keys. All of those are already handled by ExecutionExtendedProperties, making the generic factory call redundant and the source of the duplicates.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3257
