### PR TITLE
Make OTP length, character set, and validity period configurable

### DIFF
--- a/backend/cmd/server/config/default.json
+++ b/backend/cmd/server/config/default.json
@@ -138,6 +138,13 @@
     "auto_infer_registration": false,
     "store": "composite"
   },
+  "notification": {
+    "otp": {
+      "length": 6,
+      "use_numeric_only": true,
+      "validity_period_seconds": 120
+    }
+  },
   "user": {
     "indexed_attributes": [
       "username",

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -36,9 +36,6 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/template"
 )
 
-// otpUseOnlyNumericChars indicates whether to use only numeric characters for OTP generation.
-var otpUseOnlyNumericChars = true
-
 // OTPServiceInterface defines the interface for OTP operations.
 type OTPServiceInterface interface {
 	SendOTP(ctx context.Context, request common.SendOTPDTO) (*common.SendOTPResultDTO, *serviceerror.ServiceError)
@@ -234,22 +231,24 @@ func (s *otpService) getOTPCharset() string {
 	return "KIGXHOYSPRWCEFMVUQLZDNABJT9245378016"
 }
 
+// resolveOTPConfig returns the effective OTP configuration for this otpService.
+func (s *otpService) resolveOTPConfig() config.OTPConfig {
+	return config.GetServerRuntime().Config.Notification.OTP
+}
+
 // getOTPLength returns the length of the OTP.
 func (s *otpService) getOTPLength() int {
-	// TODO: This needs to be configured as a property
-	return 6
+	return s.resolveOTPConfig().Length
 }
 
 // useOnlyNumericChars determines whether to use only numeric characters.
 func (s *otpService) useOnlyNumericChars() bool {
-	// TODO: This needs to be configured as a property
-	return otpUseOnlyNumericChars
+	return s.resolveOTPConfig().UseNumericOnly
 }
 
 // getOTPValidityPeriodInMillis returns the validity period of the OTP in milliseconds.
 func (s *otpService) getOTPValidityPeriodInMillis() int64 {
-	// TODO: This needs to be configured as a property
-	return 120000 // 2 minutes
+	return int64(s.resolveOTPConfig().ValidityPeriodSeconds) * 1000
 }
 
 // sendSMSOTP sends an SMS OTP to the recipient.

--- a/backend/internal/notification/otp_service_test.go
+++ b/backend/internal/notification/otp_service_test.go
@@ -66,6 +66,13 @@ func (suite *OTPServiceTestSuite) SetupSuite() {
 				Key: "0579f866ac7c9273580d0ff163fa01a7b2401a7ff3ddc3e3b14ae3136fa6025e",
 			},
 		},
+		Notification: config.NotificationConfig{
+			OTP: config.OTPConfig{
+				Length:                6,
+				UseNumericOnly:        true,
+				ValidityPeriodSeconds: 120,
+			},
+		},
 	}
 	err := config.InitializeServerRuntime("", testConfig)
 	if err != nil {
@@ -74,6 +81,11 @@ func (suite *OTPServiceTestSuite) SetupSuite() {
 }
 
 func (suite *OTPServiceTestSuite) SetupTest() {
+	config.GetServerRuntime().Config.Notification.OTP = config.OTPConfig{
+		Length:                6,
+		UseNumericOnly:        true,
+		ValidityPeriodSeconds: 120,
+	}
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.mockSenderService = NewNotificationSenderMgtSvcInterfaceMock(suite.T())
 	suite.mockTemplateService = templatemock.NewTemplateServiceInterfaceMock(suite.T())
@@ -267,15 +279,28 @@ func (suite *OTPServiceTestSuite) TestGetOTPValidityPeriodInMillis() {
 }
 
 func (suite *OTPServiceTestSuite) TestGetOTPCharset_NonNumeric() {
-	// toggle package variable to force non-numeric branch
-	prev := otpUseOnlyNumericChars
-	otpUseOnlyNumericChars = false
-	defer func() { otpUseOnlyNumericChars = prev }()
+	otpCfg := &config.GetServerRuntime().Config.Notification.OTP
+	prev := otpCfg.UseNumericOnly
+	otpCfg.UseNumericOnly = false
+	defer func() { otpCfg.UseNumericOnly = prev }()
 
 	charset := suite.service.getOTPCharset()
 	suite.NotEmpty(charset)
 	suite.NotEqual("9245378016", charset)
 	suite.Equal("KIGXHOYSPRWCEFMVUQLZDNABJT9245378016", charset)
+}
+
+func (suite *OTPServiceTestSuite) TestAccessors_ReadFromLiveConfig() {
+	otpCfg := &config.GetServerRuntime().Config.Notification.OTP
+	prev := *otpCfg
+	otpCfg.Length = 8
+	otpCfg.UseNumericOnly = false
+	otpCfg.ValidityPeriodSeconds = 300
+	defer func() { *otpCfg = prev }()
+
+	suite.Equal(8, suite.service.getOTPLength())
+	suite.False(suite.service.useOnlyNumericChars())
+	suite.Equal(int64(300000), suite.service.getOTPValidityPeriodInMillis())
 }
 
 // SendOTP when OTP generation fails (force rand.Reader to error)

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -285,6 +285,35 @@ type OAuthConfig struct {
 	AllowWildcardRedirectURI bool `yaml:"allow_wildcard_redirect_uri" json:"allow_wildcard_redirect_uri"`
 }
 
+// NotificationConfig holds the notification configuration details.
+type NotificationConfig struct {
+	OTP OTPConfig `yaml:"otp" json:"otp"`
+}
+
+// Validate checks the notification configuration for correctness.
+func (c *NotificationConfig) Validate() error {
+	return c.OTP.Validate()
+}
+
+// OTPConfig holds the OTP generation configuration details.
+type OTPConfig struct {
+	Length                int  `yaml:"length" json:"length"`
+	UseNumericOnly        bool `yaml:"use_numeric_only" json:"use_numeric_only"`
+	ValidityPeriodSeconds int  `yaml:"validity_period_seconds" json:"validity_period_seconds"`
+}
+
+// Validate ensures OTP configuration values are within accepted bounds.
+func (c *OTPConfig) Validate() error {
+	if c.Length < 4 || c.Length > 10 {
+		return fmt.Errorf("notification.otp.length must be in [4, 10] (got %d)", c.Length)
+	}
+	if c.ValidityPeriodSeconds < 30 || c.ValidityPeriodSeconds > 600 {
+		return fmt.Errorf("notification.otp.validity_period_seconds must be in [30, 600] (got %d)",
+			c.ValidityPeriodSeconds)
+	}
+	return nil
+}
+
 // FlowConfig holds the configuration details for the flow service.
 type FlowConfig struct {
 	DefaultAuthFlowHandle    string `yaml:"default_auth_flow_handle" json:"default_auth_flow_handle"`
@@ -785,6 +814,7 @@ type Config struct {
 	Layout               LayoutConfig           `yaml:"layout" json:"layout"`
 	Translation          TranslationConfig      `yaml:"translation" json:"translation"`
 	Email                EmailConfig            `yaml:"email" json:"email"`
+	Notification         NotificationConfig     `yaml:"notification" json:"notification"`
 	Consent              ConsentConfig          `yaml:"consent" json:"consent"`
 }
 
@@ -840,6 +870,9 @@ func LoadConfig(configPath string, defaultPath string, serverHome string) (*Conf
 		return nil, err
 	}
 	if err := cfg.OAuth.DPoP.Validate(); err != nil {
+		return nil, err
+	}
+	if err := cfg.Notification.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/system/config/config_test.go
+++ b/backend/internal/system/config/config_test.go
@@ -101,6 +101,13 @@ func (suite *ConfigTestSuite) TestLoadConfigWithDefaults() {
       "renew_on_grant": false,
       "validity_period": 86400
     }
+  },
+  "notification": {
+    "otp": {
+      "length": 6,
+      "use_numeric_only": true,
+      "validity_period_seconds": 120
+    }
   }
 }`, cryptoPath)
 
@@ -147,6 +154,11 @@ database:
     type: "sqlite"
     sqlite:
       path: "{{.TestVar}}"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `
 
 	tempDir := suite.T().TempDir()
@@ -585,6 +597,11 @@ func (suite *ConfigTestSuite) TestLoadConfig_FileClosingErrors() {
 server:
   hostname: "test-host"
   port: 8080
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `
 
 	tempDir := suite.T().TempDir()
@@ -669,6 +686,11 @@ server:
       issuer: "https://auth.example.com"
       jwks_url: "https://auth.example.com/oauth2/jwks"
       audience: "https://thunder.example.com"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `,
 			expectError: false,
 		},
@@ -714,6 +736,25 @@ func (suite *ConfigTestSuite) TestLoadConfig_InvalidYAML() {
 	assert.Error(suite.T(), err)
 }
 
+func (suite *ConfigTestSuite) TestLoadConfig_NotificationValidation() {
+	tempDir := suite.T().TempDir()
+	userContent := `
+server:
+  hostname: "test-host"
+  port: 8080
+notification:
+  otp:
+    length: 3
+    validity_period_seconds: 120
+`
+	userFile := suite.createTempFile(tempDir, "notification-validation*.yaml", userContent)
+
+	cfg, err := LoadConfig(userFile, "", tempDir)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), cfg)
+	assert.Contains(suite.T(), err.Error(), "notification.otp.length")
+}
+
 func (suite *ConfigTestSuite) TestLoadConfigWithDerivedIssuer() {
 	tempDir := suite.T().TempDir()
 
@@ -723,6 +764,11 @@ server:
   hostname: "auth.example.com"
   port: 443
   http_only: false
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `
 	userFile1 := suite.createTempFile(tempDir, "user1*.yaml", userContent1)
 
@@ -737,6 +783,11 @@ server:
   port: 443
 jwt:
   issuer: "custom-issuer"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `
 	userFile2 := suite.createTempFile(tempDir, "user2*.yaml", userContent2)
 
@@ -750,6 +801,11 @@ server:
   hostname: "internal-host"
   port: 8090
   public_url: "https://auth.public.com"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `
 	userFile3 := suite.createTempFile(tempDir, "user3*.yaml", userContent3)
 
@@ -763,6 +819,11 @@ server:
   hostname: "localhost"
   port: 8080
   http_only: true
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `
 	userFile4 := suite.createTempFile(tempDir, "user4*.yaml", userContent4)
 
@@ -778,6 +839,11 @@ func (suite *ConfigTestSuite) TestLoadConfigWithDerivedPaths() {
 	userContent1 := `
 gate_client:
   path: "/app"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `
 	userFile1 := suite.createTempFile(tempDir, "user1*.yaml", userContent1)
 
@@ -792,6 +858,11 @@ gate_client:
 gate_client:
   path: "/app"
   login_path: "/custom/login"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `
 	userFile2 := suite.createTempFile(tempDir, "user2*.yaml", userContent2)
 
@@ -806,6 +877,11 @@ gate_client:
 gate_client:
   path: "/app"
   error_path: "/custom/error"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `
 	userFile3 := suite.createTempFile(tempDir, "user3*.yaml", userContent3)
 
@@ -821,6 +897,11 @@ gate_client:
   path: "/app"
   login_path: "/custom/login"
   error_path: "/custom/error"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
 `
 	userFile4 := suite.createTempFile(tempDir, "user4*.yaml", userContent4)
 
@@ -834,6 +915,13 @@ gate_client:
 	defaultContent := `{
   "gate_client": {
     "path": "/gate"
+  },
+  "notification": {
+    "otp": {
+      "length": 6,
+      "use_numeric_only": true,
+      "validity_period_seconds": 120
+    }
   }
 }`
 	defaultFile := suite.createTempFile(tempDir, "default*.json", defaultContent)
@@ -1104,4 +1192,48 @@ flow:
 	suite.Require().NoError(err)
 	suite.Equal([]string{"BasicAuthExecutor", "InviteExecutor"}, cfg.Flow.Executors)
 	suite.Equal(3, cfg.Flow.MaxVersionHistory)
+}
+
+func (suite *ConfigTestSuite) TestOTPConfig_Validate_Defaults() {
+	cfg := &OTPConfig{
+		Length:                6,
+		UseNumericOnly:        true,
+		ValidityPeriodSeconds: 120,
+	}
+	assert.NoError(suite.T(), cfg.Validate())
+}
+
+func (suite *ConfigTestSuite) TestOTPConfig_Validate_LengthBelowMin() {
+	cfg := &OTPConfig{Length: 3, ValidityPeriodSeconds: 120}
+	err := cfg.Validate()
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "notification.otp.length")
+}
+
+func (suite *ConfigTestSuite) TestOTPConfig_Validate_LengthAboveMax() {
+	cfg := &OTPConfig{Length: 11, ValidityPeriodSeconds: 120}
+	err := cfg.Validate()
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "notification.otp.length")
+}
+
+func (suite *ConfigTestSuite) TestOTPConfig_Validate_ValidityBelowMin() {
+	cfg := &OTPConfig{Length: 6, ValidityPeriodSeconds: 29}
+	err := cfg.Validate()
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "notification.otp.validity_period_seconds")
+}
+
+func (suite *ConfigTestSuite) TestOTPConfig_Validate_ValidityAboveMax() {
+	cfg := &OTPConfig{Length: 6, ValidityPeriodSeconds: 601}
+	err := cfg.Validate()
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "notification.otp.validity_period_seconds")
+}
+
+func (suite *ConfigTestSuite) TestNotificationConfig_Validate_DelegatesToOTP() {
+	cfg := &NotificationConfig{OTP: OTPConfig{Length: 3, ValidityPeriodSeconds: 120}}
+	err := cfg.Validate()
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "notification.otp.length")
 }

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -673,6 +673,16 @@ email:
 
 For the full property reference and provider-specific examples, see [Configure SMTP Server](../../guides/smtp-server/smtp-server-configuration).
 
+## Notification Configuration
+
+Controls notification delivery behaviour, including OTP generation parameters.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `notification.otp.length` | `6` | OTP character length. Must be in `[4, 10]`. |
+| `notification.otp.use_numeric_only` | `true` | If `true`, OTPs use digits only; if `false`, OTPs use a mixed alphanumeric character set. |
+| `notification.otp.validity_period_seconds` | `120` | OTP validity period in seconds. Must be in `[30, 600]`. |
+
 ## Authentication Provider Configuration
 
 External authentication provider settings.


### PR DESCRIPTION
### Purpose
  Move three hardcoded OTP generation values out of `backend/internal/notification/otp_service.go` (length, numeric-only flag, validity period) into deployment-level configuration, resolving the three `// TODO: This needs to be configured as a property` comments.

  ### Approach
  - New `NotificationConfig` / `OTPConfig` structs under `backend/internal/system/config/config.go`, validated at startup (`length` in `[4, 10]`, `validity_period_seconds` in `[30, 600]`).
    Follows the `IsConfigured()` pattern from `DPoPConfig` so deployments
    that omit the notification section are still valid.
  - Defaults in `default.json` (`length: 6`, `use_numeric_only: true`, `validity_period_seconds: 120`) preserve current behavior, so existing deployments don't change behavior.
  - `otpService` reads via a single `resolveOTPConfig` method instead of reading each field directly. The three accessors           (`getOTPLength`, `useOnlyNumericChars`, `getOTPValidityPeriodInMillis`) go through it.
    When the agreed-upon notification-provider and flow level overrides land later, only `resolveOTPConfig` grows to consult lower priority layers; the call sites don't change.
  - Removed the dead `otpUseOnlyNumericChars` package variable.

  Note on key naming: the design discussion used camelCase YAML keys; this PR uses snake_case to match the existing project convention (`oauth.refresh_token.validity_period`, etc.). Behavior is identical.

  ### Related Issues
  - Fixes #3232 

  ### Related Discussions
  - Design discussion: #3233 

 ### Alignment with the discussion

  Per the design discussion (linked above), the long term shape is `server config → notification provider config → flow config` with most specific wins. This PR delivers the server level layer only. The `resolveOTPConfig` method on `otpService` is positioned so the provider level override (via existing `NotificationSenderDTO.Properties`) and the flow level override (via flow node properties) can be added as later PRs without changing the three accessor call sites.

  ### Checklist
  - [x] Followed the contribution guidelines.
  - [x] Manual test round performed and verified.
  - [x] Documentation provided. 
      - [ ] Ran Vale and fixed all errors and warnings
  - [x] Tests provided. 
      - [x] Unit Tests
      - [ ] Integration Tests
  - [ ] Breaking changes. 
      - [ ] Breaking changes section filled.
      - [ ] `breaking change` label added.

  ### Security checks
  - [x] Followed secure coding standards in [WSO2 Secure Coding  Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OTP settings are now configurable via runtime configuration, including length (4–10 characters), character set (numeric-only or mixed), and expiry period (30–600 seconds).

* **Documentation**
  * Added configuration guide documentation for OTP notification settings.

* **Tests**
  * Added comprehensive test coverage for OTP configuration validation and runtime configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->