### PR TITLE
Use camelCase for declarative resource attributes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Clone the SDK repository only if you are developing or debugging the SDK itself,
 - Write tests for new features and bug fixes (target 80%+ coverage).
 - Ensure proper error handling and logging at appropriate layers — not everywhere, just where failures are expected and actionable.
 - Ensure all identity-related code aligns with relevant RFC specifications.
+- Declarative resource attributes use camelCase, matching the REST API. The `yaml` struct tag must use the same camelCase name as the field's `json` tag (for example `yaml:"ouId"`, not `yaml:"ou_id"`). This does not apply to non-declarative YAML such as `deployment.yaml` server config, or to `json` tags for protocol payloads (OAuth, DCR) that follow their own RFC conventions.
 - Use `make lint` and `make test` to verify code quality and correctness before committing.
 
 ## Git and PR Conventions

--- a/backend/internal/agent/declarative_resource_internal_test.go
+++ b/backend/internal/agent/declarative_resource_internal_test.go
@@ -48,16 +48,16 @@ func TestParseToAgentRequestTestSuite(t *testing.T) {
 func (s *ParseToAgentRequestTestSuite) TestParseToAgentRequest_AllFieldsParsed() {
 	yamlData := `
 id: test-agent-001
-ou_id: ou-123
+ouId: ou-123
 type: service-agent
 name: Test Agent
 description: A test agent
 owner: owner-id-123
-auth_flow_id: flow-abc
-registration_flow_id: flow-reg-xyz
-theme_id: theme-blue
-layout_id: layout-standard
-allowed_user_types:
+authFlowId: flow-abc
+registrationFlowId: flow-reg-xyz
+themeId: theme-blue
+layoutId: layout-standard
+allowedUserTypes:
   - person
   - external
 attributes:
@@ -84,7 +84,7 @@ attributes:
 func (s *ParseToAgentRequestTestSuite) TestParseToAgentRequest_MinimalFields() {
 	yamlData := `
 id: min-agent
-ou_id: ou-1
+ouId: ou-1
 type: bot
 name: Minimal Agent
 `
@@ -105,17 +105,17 @@ name: Minimal Agent
 func (s *ParseToAgentRequestTestSuite) TestParseToAgentRequest_WithOAuthConfig() {
 	yamlData := `
 id: oauth-agent
-ou_id: ou-1
+ouId: ou-1
 type: service-agent
 name: OAuth Agent
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: client-abc
-      grant_types:
+      clientId: client-abc
+      grantTypes:
         - client_credentials
-      token_endpoint_auth_method: client_secret_basic
-      public_client: false
+      tokenEndpointAuthMethod: client_secret_basic
+      publicClient: false
 `
 	var req model.AgentRequestWithID
 	err := yaml.Unmarshal([]byte(yamlData), &req)
@@ -153,7 +153,7 @@ func TestMakeAgentEntityParserTestSuite(t *testing.T) {
 func (s *MakeAgentEntityParserTestSuite) TestMakeAgentEntityParser_NoOAuthConfig() {
 	yamlData := []byte(`
 id: no-oauth-agent
-ou_id: ou-1
+ouId: ou-1
 type: service-agent
 name: No OAuth Agent
 `)
@@ -177,16 +177,16 @@ name: No OAuth Agent
 func (s *MakeAgentEntityParserTestSuite) TestMakeAgentEntityParser_WithOAuthPublicClient() {
 	yamlData := []byte(`
 id: public-agent
-ou_id: ou-1
+ouId: ou-1
 type: service-agent
 name: Public Agent
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: public-client-id
-      public_client: true
-      token_endpoint_auth_method: "none"
-      grant_types:
+      clientId: public-client-id
+      publicClient: true
+      tokenEndpointAuthMethod: "none"
+      grantTypes:
         - client_credentials
 `)
 	mockSvc := agentmock.NewAgentServiceInterfaceMock(s.T())
@@ -208,16 +208,16 @@ inbound_auth_config:
 func (s *MakeAgentEntityParserTestSuite) TestMakeAgentEntityParser_WithOAuthConfidentialClient() {
 	yamlData := []byte(`
 id: conf-agent
-ou_id: ou-1
+ouId: ou-1
 type: service-agent
 name: Confidential Agent
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: conf-client-id
-      client_secret: conf-client-secret
-      public_client: false
-      grant_types:
+      clientId: conf-client-id
+      clientSecret: conf-client-secret
+      publicClient: false
+      grantTypes:
         - client_credentials
 `)
 	mockSvc := agentmock.NewAgentServiceInterfaceMock(s.T())
@@ -242,7 +242,7 @@ inbound_auth_config:
 
 func (s *MakeAgentEntityParserTestSuite) TestMakeAgentEntityParser_NilService() {
 	parser := makeAgentEntityParser(nil)
-	_, _, _, err := parser([]byte("id: x\nou_id: ou-1\ntype: t\nname: n\n"))
+	_, _, _, err := parser([]byte("id: x\nouId: ou-1\ntype: t\nname: n\n"))
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "agent service is required for declarative entity parsing")
 }
@@ -256,7 +256,7 @@ func (s *MakeAgentEntityParserTestSuite) TestMakeAgentEntityParser_InvalidYAML()
 }
 
 func (s *MakeAgentEntityParserTestSuite) TestMakeAgentEntityParser_ValidateAgentError() {
-	yamlData := []byte("id: err-agent\nou_id: ou-1\ntype: t\nname: Err Agent\n")
+	yamlData := []byte("id: err-agent\nouId: ou-1\ntype: t\nname: Err Agent\n")
 	mockSvc := agentmock.NewAgentServiceInterfaceMock(s.T())
 	mockSvc.EXPECT().ValidateAgent(mock.Anything, mock.Anything, "err-agent").
 		Return("", "", inboundmodel.InboundClient{}, &serviceerror.ServiceError{
@@ -290,7 +290,7 @@ func (s *MakeAgentInboundParserTestSuite) TestMakeAgentInboundParser_InvalidYAML
 }
 
 func (s *MakeAgentInboundParserTestSuite) TestMakeAgentInboundParser_ValidateAgentError() {
-	yamlData := []byte("id: inbound-err-agent\nou_id: ou-1\ntype: t\nname: Inbound Err Agent\n")
+	yamlData := []byte("id: inbound-err-agent\nouId: ou-1\ntype: t\nname: Inbound Err Agent\n")
 	mockSvc := agentmock.NewAgentServiceInterfaceMock(s.T())
 	mockSvc.EXPECT().ValidateAgent(mock.Anything, mock.Anything, "inbound-err-agent").
 		Return("", "", inboundmodel.InboundClient{}, &serviceerror.ServiceError{

--- a/backend/internal/agent/model/agent.go
+++ b/backend/internal/agent/model/agent.go
@@ -33,8 +33,8 @@ import (
 // deserialize nested maps; the entity parser converts it to json.RawMessage before storage.
 type AgentRequestWithID struct {
 	ID          string                 `json:"id"                    yaml:"id"`
-	OUID        string                 `json:"ouId,omitempty"        yaml:"ou_id,omitempty"`
-	OUHandle    string                 `json:"ouHandle,omitempty"    yaml:"ou_handle,omitempty"`
+	OUID        string                 `json:"ouId,omitempty"        yaml:"ouId,omitempty"`
+	OUHandle    string                 `json:"ouHandle,omitempty"    yaml:"ouHandle,omitempty"`
 	Type        string                 `json:"type"                  yaml:"type"`
 	Name        string                 `json:"name"                  yaml:"name"`
 	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
@@ -42,7 +42,7 @@ type AgentRequestWithID struct {
 	Attributes  map[string]interface{} `json:"attributes,omitempty"  yaml:"attributes,omitempty"`
 
 	inboundmodel.InboundAuthProfile `yaml:",inline"`
-	InboundAuthConfig               []inboundmodel.InboundAuthConfigWithSecret `json:"inboundAuthConfig,omitempty" yaml:"inbound_auth_config,omitempty"`
+	InboundAuthConfig               []inboundmodel.InboundAuthConfigWithSecret `json:"inboundAuthConfig,omitempty" yaml:"inboundAuthConfig,omitempty"`
 }
 
 // Agent is the service-level model for agent create operations.
@@ -107,7 +107,7 @@ type AgentCompleteResponse struct {
 // AgentGetResponse is returned on read operations. Excludes secrets (no clientSecret).
 type AgentGetResponse struct {
 	ID          string `json:"id,omitempty"          yaml:"id,omitempty"`
-	OUID        string `json:"ouId,omitempty"        yaml:"ou_id,omitempty"`
+	OUID        string `json:"ouId,omitempty"        yaml:"ouId,omitempty"`
 	OUHandle    string `json:"ouHandle,omitempty"    yaml:"-"`
 	Type        string `json:"type,omitempty"        yaml:"type,omitempty"`
 	Name        string `json:"name,omitempty"        yaml:"name,omitempty"`
@@ -120,7 +120,7 @@ type AgentGetResponse struct {
 	AttributesYAML map[string]interface{} `json:"-"                    yaml:"attributes,omitempty"`
 
 	inboundmodel.InboundAuthProfile `yaml:",inline"`
-	InboundAuthConfig               []inboundmodel.InboundAuthConfigWithSecret `json:"inboundAuthConfig,omitempty" yaml:"inbound_auth_config,omitempty"`
+	InboundAuthConfig               []inboundmodel.InboundAuthConfigWithSecret `json:"inboundAuthConfig,omitempty" yaml:"inboundAuthConfig,omitempty"`
 }
 
 // BasicAgentResponse is the summary view used in list responses.

--- a/backend/internal/application/declarative_resource_internal_test.go
+++ b/backend/internal/application/declarative_resource_internal_test.go
@@ -48,22 +48,22 @@ func (s *ParseToApplicationDTOTestSuite) TestParseToApplicationDTO_AllFieldsPars
 id: test-app-001
 name: Test Application
 description: A test application
-auth_flow_id: flow-123
-registration_flow_id: flow-reg-456
-is_registration_flow_enabled: true
-theme_id: theme-blue
-layout_id: layout-standard
+authFlowId: flow-123
+registrationFlowId: flow-reg-456
+isRegistrationFlowEnabled: true
+themeId: theme-blue
+layoutId: layout-standard
 template: web
 url: https://example.com
-logo_url: https://example.com/logo.png
-tos_uri: https://example.com/tos
-policy_uri: https://example.com/policy
+logoUrl: https://example.com/logo.png
+tosUri: https://example.com/tos
+policyUri: https://example.com/policy
 contacts:
   - admin@example.com
   - support@example.com
 assertion:
-  validity_period: 3600
-  user_attributes:
+  validityPeriod: 3600
+  userAttributes:
     - email
     - username
 certificate:
@@ -72,7 +72,7 @@ certificate:
     -----BEGIN CERTIFICATE-----
     MIIDazCCAlOgAwIBAgI...
     -----END CERTIFICATE-----
-allowed_user_types:
+allowedUserTypes:
   - internal
   - external
 `
@@ -129,8 +129,8 @@ func (s *ParseToApplicationDTOTestSuite) TestParseToApplicationDTO_ThemeAndLayou
 	yamlData := `
 id: themed-app
 name: Themed Application
-theme_id: modern-theme
-layout_id: two-column
+themeId: modern-theme
+layoutId: two-column
 `
 
 	appDTO, err := parseToApplicationDTO([]byte(yamlData))
@@ -146,8 +146,8 @@ func (s *ParseToApplicationDTOTestSuite) TestParseToApplicationDTO_URIFieldsPars
 	yamlData := `
 id: legal-app
 name: Legal Application
-tos_uri: https://example.com/terms-of-service
-policy_uri: https://example.com/privacy-policy
+tosUri: https://example.com/terms-of-service
+policyUri: https://example.com/privacy-policy
 `
 
 	appDTO, err := parseToApplicationDTO([]byte(yamlData))
@@ -197,23 +197,23 @@ func (s *ParseToApplicationDTOTestSuite) TestParseToApplicationDTO_WithOAuthConf
 	yamlData := `
 id: oauth-app
 name: OAuth Application
-auth_flow_id: flow-123
+authFlowId: flow-123
 url: https://example.com
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: client-123
-      client_secret: secret-456
-      redirect_uris:
+      clientId: client-123
+      clientSecret: secret-456
+      redirectUris:
         - https://example.com/callback
-      grant_types:
+      grantTypes:
         - authorization_code
         - refresh_token
-      response_types:
+      responseTypes:
         - code
-      token_endpoint_auth_method: client_secret_basic
-      pkce_required: true
-      public_client: false
+      tokenEndpointAuthMethod: client_secret_basic
+      pkceRequired: true
+      publicClient: false
       scopes:
         - openid
         - email
@@ -248,10 +248,10 @@ func (s *ParseToApplicationDTOTestSuite) TestParseToApplicationDTO_TemplateAndOt
 id: template-app
 name: Template Application
 template: single-page-app
-theme_id: corporate-theme
-layout_id: horizontal
-tos_uri: https://example.com/tos
-policy_uri: https://example.com/policy
+themeId: corporate-theme
+layoutId: horizontal
+tosUri: https://example.com/tos
+policyUri: https://example.com/policy
 contacts:
   - admin@example.com
 `
@@ -288,12 +288,12 @@ func (s *ParseToApplicationDTOTestSuite) TestParseToApplicationDTO_PreservesOrde
 	yamlData := `
 id: type-test-app
 name: Type Test App
-is_registration_flow_enabled: false
-theme_id: ""
-layout_id: default
+isRegistrationFlowEnabled: false
+themeId: ""
+layoutId: default
 contacts:
   - test@example.com
-allowed_user_types:
+allowedUserTypes:
   - internal
   - external
   - guest
@@ -332,12 +332,12 @@ func (s *ParseToApplicationDTOTestSuite) TestMakeAppEntityParser_PublicClientWit
 	yamlData := []byte(`
 id: public-oauth-app
 name: Public OAuth Application
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: public-client-id-123
-      pkce_required: true
-      public_client: true
+      clientId: public-client-id-123
+      pkceRequired: true
+      publicClient: true
 `)
 
 	mockAppService := NewApplicationServiceInterfaceMock(s.T())
@@ -370,11 +370,11 @@ func (s *ParseToApplicationDTOTestSuite) TestMakeAppEntityParser_ConfidentialCli
 	yamlData := []byte(`
 id: confidential-oauth-app
 name: Confidential OAuth Application
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: confidential-client-id-123
-      client_secret: confidential-secret-456
+      clientId: confidential-client-id-123
+      clientSecret: confidential-secret-456
 `)
 
 	mockAppService := NewApplicationServiceInterfaceMock(s.T())
@@ -412,10 +412,10 @@ func (s *ParseToApplicationDTOTestSuite) TestMakeAppEntityParser_UsesValidatedGe
 	yamlData := []byte(`
 id: generated-credentials-app
 name: Generated Credentials App
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      grant_types:
+      grantTypes:
         - client_credentials
 `)
 
@@ -459,13 +459,13 @@ func (s *ParseToApplicationDTOTestSuite) TestMakeAppEntityParser_SelectsOAuthCon
 	yamlData := []byte(`
 id: mixed-inbound-app
 name: Mixed Inbound App
-inbound_auth_config:
+inboundAuthConfig:
   - type: saml
     config: {}
   - type: oauth2
     config:
-      client_id: oauth-client-id
-      client_secret: oauth-client-secret
+      clientId: oauth-client-id
+      clientSecret: oauth-client-secret
 `)
 
 	mockAppService := NewApplicationServiceInterfaceMock(s.T())
@@ -506,7 +506,7 @@ inbound_auth_config:
 }
 
 func (s *ParseToApplicationDTOTestSuite) TestParseToApplicationDTO_OUHandlePassedThrough() {
-	yamlData := []byte("id: app-1\nname: My App\nou_handle: default\n")
+	yamlData := []byte("id: app-1\nname: My App\nouHandle: default\n")
 
 	appDTO, err := parseToApplicationDTO(yamlData)
 

--- a/backend/internal/application/init_test.go
+++ b/backend/internal/application/init_test.go
@@ -216,36 +216,36 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_ValidYAML() {
 	yamlData := `
 name: test-app
 description: Test application
-auth_flow_id: test-auth-flow
-registration_flow_id: test-reg-flow
-is_registration_flow_enabled: true
+authFlowId: test-auth-flow
+registrationFlowId: test-reg-flow
+isRegistrationFlowEnabled: true
 url: https://example.com
-logo_url: https://example.com/logo.png
+logoUrl: https://example.com/logo.png
 assertion:
-  validity_period: 3600
-  user_attributes:
+  validityPeriod: 3600
+  userAttributes:
     - email
     - username
 certificate:
   type: JWKS
   value: test-cert-value
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: test-client-id
-      client_secret: test-client-secret
-      redirect_uris:
+      clientId: test-client-id
+      clientSecret: test-client-secret
+      redirectUris:
         - https://example.com/callback
-      grant_types:
+      grantTypes:
         - authorization_code
-      response_types:
+      responseTypes:
         - code
-      token_endpoint_auth_method: client_secret_basic
-      pkce_required: true
-      public_client: false
+      tokenEndpointAuthMethod: client_secret_basic
+      pkceRequired: true
+      publicClient: false
       token:
-        access_token:
-          validity_period: 3600
+        accessToken:
+          validityPeriod: 3600
 `
 
 	// Execute
@@ -302,7 +302,7 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_MinimalYAML() {
 	yamlData := `
 name: minimal-app
 description: Minimal application
-is_registration_flow_enabled: false
+isRegistrationFlowEnabled: false
 `
 
 	// Execute
@@ -328,15 +328,15 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_WithNonOAuthInboundAuth() 
 	yamlData := `
 name: test-app
 description: Test application
-is_registration_flow_enabled: true
-inbound_auth_config:
+isRegistrationFlowEnabled: true
+inboundAuthConfig:
   - type: saml2
     config:
       issuer: test-saml-issuer
   - type: oauth2
     config:
-      client_id: test-client-id
-      client_secret: test-client-secret
+      clientId: test-client-id
+      clientSecret: test-client-secret
 `
 
 	// Execute
@@ -356,8 +356,8 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_WithOAuthConfigWithoutConf
 	yamlData := `
 name: test-app
 description: Test application
-is_registration_flow_enabled: true
-inbound_auth_config:
+isRegistrationFlowEnabled: true
+inboundAuthConfig:
   - type: oauth2
 `
 
@@ -376,7 +376,7 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_InvalidYAML() {
 	invalidYaml := `
 name: test-app
 description: Test application
-invalid_yaml_structure: [
+invalidYamlStructure: [
 `
 
 	// Execute
@@ -392,8 +392,8 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_EmptyInboundAuthConfig() {
 	yamlData := `
 name: test-app
 description: Test application
-is_registration_flow_enabled: true
-inbound_auth_config: []
+isRegistrationFlowEnabled: true
+inboundAuthConfig: []
 `
 
 	// Execute
@@ -410,24 +410,24 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_WithCompleteOAuthConfig() 
 	yamlData := `
 name: oauth-app
 description: OAuth application
-is_registration_flow_enabled: true
-inbound_auth_config:
+isRegistrationFlowEnabled: true
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: oauth-client
-      client_secret: oauth-secret
-      redirect_uris:
+      clientId: oauth-client
+      clientSecret: oauth-secret
+      redirectUris:
         - https://app.example.com/callback
         - https://app.example.com/redirect
-      grant_types:
+      grantTypes:
         - authorization_code
         - refresh_token
-      response_types:
+      responseTypes:
         - code
         - token
-      token_endpoint_auth_method: client_secret_post
-      pkce_required: false
-      public_client: true
+      tokenEndpointAuthMethod: client_secret_post
+      pkceRequired: false
+      publicClient: true
 `
 
 	// Execute
@@ -463,13 +463,13 @@ func BenchmarkParseToApplicationDTO(b *testing.B) {
 	yamlData := `
 name: benchmark-app
 description: Benchmark application
-is_registration_flow_enabled: true
-inbound_auth_config:
+isRegistrationFlowEnabled: true
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: benchmark-client
-      client_secret: benchmark-secret
-      redirect_uris:
+      clientId: benchmark-client
+      clientSecret: benchmark-secret
+      redirectUris:
         - https://example.com/callback
 `
 
@@ -488,8 +488,8 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_WithSpecialCharacters() {
 name: "app-with-special-chars-!@#$%"
 description: "Description with 'quotes' and \"double quotes\""
 url: "https://example.com/path?param=value&other=123"
-logo_url: "https://cdn.example.com/logos/app-logo_v2.png"
-is_registration_flow_enabled: true
+logoUrl: "https://cdn.example.com/logos/app-logo_v2.png"
+isRegistrationFlowEnabled: true
 `
 
 	// Execute
@@ -511,17 +511,17 @@ func TestParseToApplicationDTO_Standalone(t *testing.T) {
 	yamlData := `
 name: test-app
 description: Test application
-is_registration_flow_enabled: true
-inbound_auth_config:
+isRegistrationFlowEnabled: true
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: test-client-id
-      client_secret: test-client-secret
-      redirect_uris:
+      clientId: test-client-id
+      clientSecret: test-client-secret
+      redirectUris:
         - https://example.com/callback
-      grant_types:
+      grantTypes:
         - authorization_code
-      response_types:
+      responseTypes:
         - code
 `
 
@@ -544,7 +544,7 @@ func TestParseToApplicationDTO_InvalidYAML_Standalone(t *testing.T) {
 	invalidYaml := `
 name: test-app
 description: Test application
-invalid_yaml_structure: [
+invalidYamlStructure: [
 `
 
 	// Execute
@@ -661,11 +661,11 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_WithScopeClaims() {
 	yamlData := `
 id: "test-app-scope-claims"
 name: "App With Scope Claims"
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: "client-456"
-      scope_claims:
+      clientId: "client-456"
+      scopeClaims:
         profile:
           - "name"
           - "email"
@@ -698,10 +698,10 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_WithScopes() {
 	yamlData := `
 id: "test-app-scopes"
 name: "App With Scopes"
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: "client-123"
+      clientId: "client-123"
       scopes:
         - "openid"
         - "profile"
@@ -728,12 +728,12 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_WithUserInfo() {
 	yamlData := `
 id: "test-app-userinfo"
 name: "App With UserInfo"
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: "client-789"
-      user_info:
-        user_attributes:
+      clientId: "client-789"
+      userInfo:
+        userAttributes:
           - "sub"
           - "email"
           - "name"
@@ -760,31 +760,31 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_WithAllOAuthFieldsIncludin
 	yamlData := `
 id: "test-app-complete"
 name: "Complete OAuth App"
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: "complete-client"
-      client_secret: "secret-value"
-      redirect_uris:
+      clientId: "complete-client"
+      clientSecret: "secret-value"
+      redirectUris:
         - "https://example.com/callback"
-      grant_types:
+      grantTypes:
         - "authorization_code"
-      response_types:
+      responseTypes:
         - "code"
-      token_endpoint_auth_method: "client_secret_basic"
-      pkce_required: true
-      public_client: false
+      tokenEndpointAuthMethod: "client_secret_basic"
+      pkceRequired: true
+      publicClient: false
       token:
-        id_token:
-          user_attributes:
+        idToken:
+          userAttributes:
             - "sub"
             - "email"
       scopes:
         - "openid"
-      user_info:
-        user_attributes:
+      userInfo:
+        userAttributes:
           - "profile"
-      scope_claims:
+      scopeClaims:
         profile:
           - "name"
 `
@@ -819,17 +819,17 @@ func (suite *InitTestSuite) TestParseToApplicationDTO_GithubIssue1445_CustomClai
 	yamlData := `
 id: "test-app-custom-claims"
 name: "App With Custom Claims"
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: "MY_APP"
+      clientId: "MY_APP"
       token:
-        id_token:
-          user_attributes:
+        idToken:
+          userAttributes:
             - "email"
             - "name"
             - "customClaim"
-      scope_claims:
+      scopeClaims:
         profile:
           - "name"
           - "customClaim"

--- a/backend/internal/application/model/application.go
+++ b/backend/internal/application/model/application.go
@@ -66,38 +66,38 @@ type BasicApplicationDTO struct {
 // Application represents the structure for application which returns in GetApplicationById.
 type Application struct {
 	ID          string `yaml:"id,omitempty" json:"id,omitempty" jsonschema:"Application ID. Auto-generated unique identifier."`
-	OUID        string `yaml:"ou_id,omitempty" json:"ouId,omitempty" jsonschema:"Organization unit ID. The OU this application belongs to."`
+	OUID        string `yaml:"ouId,omitempty" json:"ouId,omitempty" jsonschema:"Organization unit ID. The OU this application belongs to."`
 	Name        string `yaml:"name,omitempty" json:"name,omitempty" jsonschema:"Application name."`
 	Description string `yaml:"description,omitempty" json:"description,omitempty" jsonschema:"Optional description of the application's purpose."`
 	Template    string `yaml:"template,omitempty" json:"template,omitempty" jsonschema:"Template used to create the application."`
 
 	URL       string   `yaml:"url,omitempty" json:"url,omitempty" jsonschema:"Application home URL."`
-	LogoURL   string   `yaml:"logo_url,omitempty" json:"logoUrl,omitempty" jsonschema:"Application logo URL."`
-	TosURI    string   `yaml:"tos_uri,omitempty" json:"tosUri,omitempty" jsonschema:"Terms of Service URI."`
-	PolicyURI string   `yaml:"policy_uri,omitempty" json:"policyUri,omitempty" jsonschema:"Privacy Policy URI."`
+	LogoURL   string   `yaml:"logoUrl,omitempty" json:"logoUrl,omitempty" jsonschema:"Application logo URL."`
+	TosURI    string   `yaml:"tosUri,omitempty" json:"tosUri,omitempty" jsonschema:"Terms of Service URI."`
+	PolicyURI string   `yaml:"policyUri,omitempty" json:"policyUri,omitempty" jsonschema:"Privacy Policy URI."`
 	Contacts  []string `yaml:"contacts,omitempty" json:"contacts,omitempty"`
 
 	inboundmodel.InboundAuthProfile `yaml:",inline"`
-	InboundAuthConfig               []inboundmodel.InboundAuthConfigWithSecret `yaml:"inbound_auth_config,omitempty" json:"inboundAuthConfig,omitempty" jsonschema:"Inbound authentication configuration (OAuth2/OIDC settings)."`
+	InboundAuthConfig               []inboundmodel.InboundAuthConfigWithSecret `yaml:"inboundAuthConfig,omitempty" json:"inboundAuthConfig,omitempty" jsonschema:"Inbound authentication configuration (OAuth2/OIDC settings)."`
 	Metadata                        map[string]interface{}                     `yaml:"metadata,omitempty" json:"metadata,omitempty" jsonschema:"Generic metadata key-value pairs."`
 }
 
 // ApplicationProcessedDTO represents the processed data transfer object for application service operations.
 type ApplicationProcessedDTO struct {
 	ID          string `yaml:"id,omitempty"`
-	OUID        string `yaml:"ou_id,omitempty"`
+	OUID        string `yaml:"ouId,omitempty"`
 	Name        string `yaml:"name,omitempty"`
 	Description string `yaml:"description,omitempty"`
 	Template    string `yaml:"template,omitempty"`
 
 	URL       string `yaml:"url,omitempty"`
-	LogoURL   string `yaml:"logo_url,omitempty"`
-	TosURI    string `yaml:"tos_uri,omitempty"`
-	PolicyURI string `yaml:"policy_uri,omitempty"`
+	LogoURL   string `yaml:"logoUrl,omitempty"`
+	TosURI    string `yaml:"tosUri,omitempty"`
+	PolicyURI string `yaml:"policyUri,omitempty"`
 	Contacts  []string
 
 	inboundmodel.InboundAuthProfile `yaml:",inline"`
-	InboundAuthConfig               []inboundmodel.InboundAuthConfigProcessed `yaml:"inbound_auth_config,omitempty"`
+	InboundAuthConfig               []inboundmodel.InboundAuthConfigProcessed `yaml:"inboundAuthConfig,omitempty"`
 	Metadata                        map[string]interface{}                    `yaml:"metadata,omitempty"`
 }
 
@@ -106,37 +106,37 @@ type ApplicationCertificate = inboundmodel.Certificate
 
 // ApplicationRequest represents the request structure for creating or updating an application.
 type ApplicationRequest struct {
-	OUID        string   `json:"ouId,omitempty" yaml:"ou_id,omitempty"`
+	OUID        string   `json:"ouId,omitempty" yaml:"ouId,omitempty"`
 	Name        string   `json:"name" yaml:"name"`
 	Description string   `json:"description" yaml:"description"`
 	Template    string   `json:"template,omitempty" yaml:"template,omitempty"`
 	URL         string   `json:"url,omitempty" yaml:"url,omitempty"`
-	LogoURL     string   `json:"logoUrl,omitempty" yaml:"logo_url,omitempty"`
-	TosURI      string   `json:"tosUri,omitempty" yaml:"tos_uri,omitempty"`
-	PolicyURI   string   `json:"policyUri,omitempty" yaml:"policy_uri,omitempty"`
+	LogoURL     string   `json:"logoUrl,omitempty" yaml:"logoUrl,omitempty"`
+	TosURI      string   `json:"tosUri,omitempty" yaml:"tosUri,omitempty"`
+	PolicyURI   string   `json:"policyUri,omitempty" yaml:"policyUri,omitempty"`
 	Contacts    []string `json:"contacts,omitempty" yaml:"contacts,omitempty"`
 
 	inboundmodel.InboundAuthProfile `yaml:",inline"`
-	InboundAuthConfig               []inboundmodel.InboundAuthConfigWithSecret `json:"inboundAuthConfig,omitempty" yaml:"inbound_auth_config,omitempty"`
+	InboundAuthConfig               []inboundmodel.InboundAuthConfigWithSecret `json:"inboundAuthConfig,omitempty" yaml:"inboundAuthConfig,omitempty"`
 	Metadata                        map[string]interface{}                     `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 // ApplicationRequestWithID represents the request structure for importing an application using file based runtime.
 type ApplicationRequestWithID struct {
 	ID          string   `json:"id" yaml:"id"`
-	OUID        string   `json:"ouId,omitempty" yaml:"ou_id,omitempty"`
-	OUHandle    string   `json:"ouHandle,omitempty" yaml:"ou_handle,omitempty"`
+	OUID        string   `json:"ouId,omitempty" yaml:"ouId,omitempty"`
+	OUHandle    string   `json:"ouHandle,omitempty" yaml:"ouHandle,omitempty"`
 	Name        string   `json:"name" yaml:"name"`
 	Description string   `json:"description" yaml:"description"`
 	Template    string   `json:"template,omitempty" yaml:"template,omitempty"`
 	URL         string   `json:"url,omitempty" yaml:"url,omitempty"`
-	LogoURL     string   `json:"logoUrl,omitempty" yaml:"logo_url,omitempty"`
-	TosURI      string   `json:"tosUri,omitempty" yaml:"tos_uri,omitempty"`
-	PolicyURI   string   `json:"policyUri,omitempty" yaml:"policy_uri,omitempty"`
+	LogoURL     string   `json:"logoUrl,omitempty" yaml:"logoUrl,omitempty"`
+	TosURI      string   `json:"tosUri,omitempty" yaml:"tosUri,omitempty"`
+	PolicyURI   string   `json:"policyUri,omitempty" yaml:"policyUri,omitempty"`
 	Contacts    []string `json:"contacts,omitempty" yaml:"contacts,omitempty"`
 
 	inboundmodel.InboundAuthProfile `yaml:",inline"`
-	InboundAuthConfig               []inboundmodel.InboundAuthConfigWithSecret `json:"inboundAuthConfig,omitempty" yaml:"inbound_auth_config,omitempty"`
+	InboundAuthConfig               []inboundmodel.InboundAuthConfigWithSecret `json:"inboundAuthConfig,omitempty" yaml:"inboundAuthConfig,omitempty"`
 	Metadata                        map[string]interface{}                     `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 

--- a/backend/internal/entity/declarative_resource_test.go
+++ b/backend/internal/entity/declarative_resource_test.go
@@ -121,7 +121,7 @@ func (s *DeclarativeResourceTestSuite) TestLoadDeclarativeResources_WithValidato
 	s.Require().NoError(os.MkdirAll(resourceDir, 0750))
 
 	entityYAML := []byte(`id: "item-1"
-ou_id: "ou-1"
+ouId: "ou-1"
 type: "thing"
 category: "user"
 attributes: {}

--- a/backend/internal/entitytype/declarative_resource.go
+++ b/backend/internal/entitytype/declarative_resource.go
@@ -242,7 +242,7 @@ func validateEntityType(schemaDTO *EntityType) error {
 	}
 
 	if strings.TrimSpace(schemaDTO.OUID) == "" {
-		return fmt.Errorf("organization_unit_id or ou_handle is required for entity type '%s'", schemaDTO.Name)
+		return fmt.Errorf("ouId or ouHandle is required for entity type '%s'", schemaDTO.Name)
 	}
 
 	// Validate schema definition is present and valid.

--- a/backend/internal/entitytype/declarative_resource_internal_test.go
+++ b/backend/internal/entitytype/declarative_resource_internal_test.go
@@ -99,7 +99,7 @@ func TestValidateEntityType(t *testing.T) {
 				OUID: "",
 			},
 			wantErr: true,
-			errMsg:  "organization_unit_id or ou_handle is required",
+			errMsg:  "ouId or ouHandle is required",
 		},
 		{
 			name: "whitespace only organization unit ID",
@@ -109,7 +109,7 @@ func TestValidateEntityType(t *testing.T) {
 				OUID: "   ",
 			},
 			wantErr: true,
-			errMsg:  "organization_unit_id or ou_handle is required",
+			errMsg:  "ouId or ouHandle is required",
 		},
 		{
 			name: "invalid schema JSON",
@@ -236,8 +236,8 @@ func TestParseToEntityTypeDTO(t *testing.T) {
 			yaml: `
 id: schema-1
 name: Test Schema
-organization_unit_id: ou-1
-allow_self_registration: true
+ouId: ou-1
+allowSelfRegistration: true
 schema: '{"type": "object"}'
 `,
 			want: &EntityType{
@@ -254,7 +254,7 @@ schema: '{"type": "object"}'
 			yaml: `
 id: schema-2
 name: Minimal Schema
-organization_unit_id: ou-1
+ouId: ou-1
 schema: '{}'
 `,
 			want: &EntityType{
@@ -278,7 +278,7 @@ invalid: [yaml
 			yaml: `
 id: schema-1
 name: Test Schema
-organization_unit_id: ou-1
+ouId: ou-1
 schema: '{invalid json}'
 `,
 			wantErr: true,
@@ -289,7 +289,7 @@ schema: '{invalid json}'
 			yaml: `
 id: schema-1
 name: Test Schema
-organization_unit_id: ou-1
+ouId: ou-1
 schema:
   username:
     type: string
@@ -311,7 +311,7 @@ schema:
 			yaml: `
 id: schema-1
 name: Test Schema
-organization_unit_id: ou-1
+ouId: ou-1
 `,
 			wantErr: true,
 			errMsg:  "schema field contains invalid JSON",

--- a/backend/internal/entitytype/init_test.go
+++ b/backend/internal/entitytype/init_test.go
@@ -365,8 +365,8 @@ func (suite *InitTestSuite) TestParseToEntityTypeDTO_ValidYAML() {
 	yamlData := `
 id: "schema-001"
 name: "Employee Schema"
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
-allow_self_registration: true
+ouId: "550e8400-e29b-41d4-a716-446655440000"
+allowSelfRegistration: true
 schema: |
   {
     "type": "object",
@@ -394,7 +394,7 @@ func (suite *InitTestSuite) TestParseToEntityTypeDTO_MinimalYAML() {
 	yamlData := `
 id: "minimal-schema"
 name: "Minimal Schema"
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
+ouId: "550e8400-e29b-41d4-a716-446655440000"
 schema: |
   {
     "type": "object",
@@ -433,8 +433,8 @@ func (suite *InitTestSuite) TestParseToEntityTypeDTO_ComplexSchema() {
 	yamlData := `
 id: "complex-schema"
 name: "Complex Schema"
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
-allow_self_registration: true
+ouId: "550e8400-e29b-41d4-a716-446655440000"
+allowSelfRegistration: true
 schema: |
   {
     "type": "object",
@@ -479,7 +479,7 @@ func BenchmarkParseToEntityTypeDTO(b *testing.B) {
 	yamlData := `
 id: "benchmark-schema"
 name: "Benchmark Schema"
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
+ouId: "550e8400-e29b-41d4-a716-446655440000"
 schema: |
   {
     "type": "object",
@@ -503,8 +503,8 @@ func TestParseToEntityTypeDTO_Standalone(t *testing.T) {
 	yamlData := `
 id: "standalone-schema"
 name: "Standalone Schema"
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
-allow_self_registration: false
+ouId: "550e8400-e29b-41d4-a716-446655440000"
+allowSelfRegistration: false
 schema: |
   {
     "type": "object",
@@ -793,7 +793,7 @@ func TestParseToEntityTypeDTO_InvalidJSONSchema(t *testing.T) {
 	yamlData := `
 id: "invalid-json-schema"
 name: "Invalid JSON Schema"
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
+ouId: "550e8400-e29b-41d4-a716-446655440000"
 schema: |
   {invalid json here}
 `
@@ -810,7 +810,7 @@ func TestParseToEntityTypeDTO_EmptySchemaField(t *testing.T) {
 	yamlData := `
 id: "empty-schema"
 name: "Empty Schema"
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
+ouId: "550e8400-e29b-41d4-a716-446655440000"
 schema: ""
 `
 
@@ -1019,7 +1019,7 @@ func TestParseAndValidateEntityTypeFlow(t *testing.T) {
 			yamlData: `
 id: "flow-test-001"
 name: "Flow Test Schema"
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
+ouId: "550e8400-e29b-41d4-a716-446655440000"
 schema: |
   {
     "email": {"type": "string", "required": true}
@@ -1033,7 +1033,7 @@ schema: |
 			yamlData: `
 id: "flow-test-002"
 name: "Invalid Schema"
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
+ouId: "550e8400-e29b-41d4-a716-446655440000"
 schema: |
   {
     "email": {"required": true}
@@ -1048,7 +1048,7 @@ schema: |
 			yamlData: `
 id: "flow-test-003"
 name: ""
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
+ouId: "550e8400-e29b-41d4-a716-446655440000"
 schema: |
   {
     "email": {"type": "string"}
@@ -1166,7 +1166,7 @@ func TestInitialize_WithDeclarativeResourcesEnabled_ValidationFailure(t *testing
 	// Create a YAML file with invalid configuration (empty name)
 	invalidSchemaYAML := `id: "invalid-schema"
 name: ""
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
+ouId: "550e8400-e29b-41d4-a716-446655440000"
 schema: |
   {
     "email": {"type": "string"}
@@ -1225,8 +1225,8 @@ func TestInitialize_WithDeclarativeResourcesEnabled_OUHandleNotFound(t *testing.
 	// Create a YAML file that uses an ou_handle that cannot be resolved
 	validSchemaYAML := `id: "test-schema"
 name: "Test Schema"
-ou_handle: "nonexistent-handle"
-allow_self_registration: true
+ouHandle: "nonexistent-handle"
+allowSelfRegistration: true
 schema: |
   {
     "email": {"type": "string", "required": true}
@@ -1302,7 +1302,7 @@ func TestInitialize_WithDeclarativeResourcesEnabled_InvalidJSONSchema(t *testing
 	// Create a YAML file with invalid JSON in schema field
 	invalidJSONYAML := `id: "invalid-json-schema"
 name: "Invalid JSON Schema"
-organization_unit_id: "550e8400-e29b-41d4-a716-446655440000"
+ouId: "550e8400-e29b-41d4-a716-446655440000"
 schema: |
   {invalid json here}
 `

--- a/backend/internal/entitytype/model.go
+++ b/backend/internal/entitytype/model.go
@@ -56,10 +56,10 @@ type EntityType struct {
 	ID                    string            `json:"id,omitempty" yaml:"id,omitempty"`
 	Category              TypeCategory      `json:"-" yaml:"category,omitempty"`
 	Name                  string            `json:"name,omitempty" yaml:"name"`
-	OUID                  string            `json:"ouId" yaml:"organization_unit_id"`
+	OUID                  string            `json:"ouId" yaml:"ouId"`
 	OUHandle              string            `json:"ouHandle,omitempty" yaml:"-"`
-	AllowSelfRegistration bool              `json:"allowSelfRegistration" yaml:"allow_self_registration,omitempty"`
-	SystemAttributes      *SystemAttributes `json:"systemAttributes,omitempty" yaml:"system_attributes,omitempty"`
+	AllowSelfRegistration bool              `json:"allowSelfRegistration" yaml:"allowSelfRegistration,omitempty"`
+	SystemAttributes      *SystemAttributes `json:"systemAttributes,omitempty" yaml:"systemAttributes,omitempty"`
 	Schema                json.RawMessage   `json:"schema,omitempty" yaml:"schema"`
 }
 
@@ -128,9 +128,9 @@ type EntityTypeRequestWithID struct {
 	ID                    string            `yaml:"id"`
 	Category              TypeCategory      `yaml:"category,omitempty"`
 	Name                  string            `yaml:"name"`
-	OUID                  string            `yaml:"organization_unit_id,omitempty"`
-	OUHandle              string            `yaml:"ou_handle,omitempty"`
-	AllowSelfRegistration bool              `yaml:"allow_self_registration,omitempty"`
-	SystemAttributes      *SystemAttributes `yaml:"system_attributes,omitempty"`
+	OUID                  string            `yaml:"ouId,omitempty"`
+	OUHandle              string            `yaml:"ouHandle,omitempty"`
+	AllowSelfRegistration bool              `yaml:"allowSelfRegistration,omitempty"`
+	SystemAttributes      *SystemAttributes `yaml:"systemAttributes,omitempty"`
 	Schema                interface{}       `yaml:"schema"`
 }

--- a/backend/internal/entitytype/service.go
+++ b/backend/internal/entitytype/service.go
@@ -778,7 +778,7 @@ func (us *entityTypeService) resolveEntityTypeOUHandle(
 ) *serviceerror.ServiceError {
 	if entityType.OUID != "" && entityType.OUHandle != "" {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, entityTypeLoggerComponentName))
-		logger.Warn(ctx, "Both ou_id and ou_handle provided for entity type; ou_handle ignored",
+		logger.Warn(ctx, "Both ouId and ouHandle provided for entity type; ouHandle ignored",
 			log.String("entityTypeID", entityType.ID), log.String("name", entityType.Name))
 		return nil
 	}

--- a/backend/internal/group/declarative_resource.go
+++ b/backend/internal/group/declarative_resource.go
@@ -171,8 +171,8 @@ type groupDeclarativeResource struct {
 	ID          string   `yaml:"id"`
 	Name        string   `yaml:"name"`
 	Description string   `yaml:"description,omitempty"`
-	OUID        string   `yaml:"ou_id,omitempty"`
-	OUHandle    string   `yaml:"ou_handle,omitempty"`
+	OUID        string   `yaml:"ouId,omitempty"`
+	OUHandle    string   `yaml:"ouHandle,omitempty"`
 	Members     []Member `yaml:"members,omitempty"`
 }
 
@@ -261,7 +261,7 @@ func validateGroupWrapper(
 	}
 
 	if grp.OUID == "" {
-		return fmt.Errorf("ou_id or ou_handle is required for group '%s'", grp.Name)
+		return fmt.Errorf("ouId or ouHandle is required for group '%s'", grp.Name)
 	}
 
 	if fileStore != nil {

--- a/backend/internal/group/declarative_resource_test.go
+++ b/backend/internal/group/declarative_resource_test.go
@@ -343,7 +343,7 @@ func (suite *GroupExporterTestSuite) TestParseToGroup_ValidYAML() {
 id: group1
 name: Admins
 description: Admin group
-ou_id: ou1
+ouId: ou1
 members:
   - id: user1
     type: user
@@ -383,7 +383,7 @@ func (suite *GroupExporterTestSuite) TestParseToGroup_OptionalFieldsOmitted() {
 	yamlData := []byte(`
 id: group1
 name: Admins
-ou_id: ou1
+ouId: ou1
 `)
 
 	grp, err := parseToGroup(yamlData)
@@ -400,7 +400,7 @@ func (suite *GroupExporterTestSuite) TestParseToGroup_WithOUHandle() {
 	yamlData := []byte(`
 id: group1
 name: Admins
-ou_handle: /root/engineering
+ouHandle: /root/engineering
 `)
 
 	grp, err := parseToGroup(yamlData)
@@ -416,7 +416,7 @@ func (suite *GroupExporterTestSuite) TestParseToGroup_EntityTypesTranslated() {
 	yamlData := []byte(`
 id: group1
 name: Mixed
-ou_id: ou1
+ouId: ou1
 members:
   - id: u1
     type: user
@@ -443,7 +443,7 @@ func (suite *GroupExporterTestSuite) TestParseToGroupWrapper() {
 	yamlData := []byte(`
 id: group1
 name: Admins
-ou_id: ou1
+ouId: ou1
 `)
 
 	result, err := parseToGroupWrapper(yamlData)
@@ -529,7 +529,7 @@ func (suite *GroupExporterTestSuite) TestValidateGroupWrapper_MissingOUID() {
 	err := validateGroupWrapper(grp, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "ou_id or ou_handle is required")
+	assert.Contains(suite.T(), err.Error(), "ouId or ouHandle is required")
 }
 
 // Test validateGroupWrapper - duplicate ID in DB store
@@ -611,7 +611,7 @@ func (suite *GroupDeclarativeResourceLoaderTestSuite) TestLoadDeclarativeResourc
 id: group1
 name: Admins
 description: Admin group
-ou_id: ou1
+ouId: ou1
 `)
 	suite.Require().NoError(os.WriteFile(filepath.Join(resourceDir, "group1.yaml"), yamlData, 0o600))
 
@@ -635,7 +635,7 @@ func (suite *GroupDeclarativeResourceLoaderTestSuite) TestLoadDeclarativeResourc
 	yamlData := []byte(`
 id: group1
 name: Admins
-ou_id: ou1
+ouId: ou1
 members:
   - id: user1
     type: user
@@ -661,7 +661,7 @@ func (suite *GroupDeclarativeResourceLoaderTestSuite) TestLoadDeclarativeResourc
 	resourceDir := suite.createGroupsDir()
 
 	for _, g := range []struct{ id, name string }{{"group1", "Admins"}, {"group2", "Engineers"}} {
-		yaml := []byte("id: " + g.id + "\nname: " + g.name + "\nou_id: ou1\n")
+		yaml := []byte("id: " + g.id + "\nname: " + g.name + "\nouId: ou1\n")
 		suite.Require().NoError(os.WriteFile(filepath.Join(resourceDir, g.id+".yaml"), yaml, 0o600))
 	}
 
@@ -698,7 +698,7 @@ func (suite *GroupDeclarativeResourceLoaderTestSuite) TestLoadDeclarativeResourc
 	resourceDir := suite.createGroupsDir()
 
 	suite.Require().NoError(
-		os.WriteFile(filepath.Join(resourceDir, "noID.yaml"), []byte("name: Admins\nou_id: ou1\n"), 0o600),
+		os.WriteFile(filepath.Join(resourceDir, "noID.yaml"), []byte("name: Admins\nouId: ou1\n"), 0o600),
 	)
 
 	fileStore := suite.newFileStore()
@@ -729,8 +729,8 @@ func (suite *GroupDeclarativeResourceLoaderTestSuite) TestLoadDeclarativeResourc
 	suite.initRuntime()
 	resourceDir := suite.createGroupsDir()
 
-	yaml1 := []byte("id: group1\nname: Admins\nou_id: ou1\n")
-	yaml2 := []byte("id: group1\nname: AdminsDuplicate\nou_id: ou2\n")
+	yaml1 := []byte("id: group1\nname: Admins\nouId: ou1\n")
+	yaml2 := []byte("id: group1\nname: AdminsDuplicate\nouId: ou2\n")
 	suite.Require().NoError(os.WriteFile(filepath.Join(resourceDir, "group1a.yaml"), yaml1, 0o600))
 	suite.Require().NoError(os.WriteFile(filepath.Join(resourceDir, "group1b.yaml"), yaml2, 0o600))
 
@@ -749,7 +749,7 @@ func (suite *GroupDeclarativeResourceLoaderTestSuite) TestLoadDeclarativeResourc
 	suite.Require().NoError(
 		os.WriteFile(
 			filepath.Join(resourceDir, "group1.yaml"),
-			[]byte("id: group1\nname: Admins\nou_id: ou1\n"),
+			[]byte("id: group1\nname: Admins\nouId: ou1\n"),
 			0o600,
 		),
 	)

--- a/backend/internal/idp/init_test.go
+++ b/backend/internal/idp/init_test.go
@@ -153,10 +153,10 @@ type: "GOOGLE"
 properties:
   - name: "client_id"
     value: "test_client_id"
-    is_secret: false
+    isSecret: false
   - name: "client_secret"
     value: "test_secret"
-    is_secret: false
+    isSecret: false
 `
 
 	idp, err := parseToIDPDTO([]byte(yamlData))
@@ -427,13 +427,13 @@ type: GOOGLE
 properties:
   - name: client_id
     value: google-client-id
-    is_secret: false
+    isSecret: false
   - name: client_secret
     value: google-client-secret
-    is_secret: true
+    isSecret: true
   - name: redirect_uri
     value: http://localhost:3000/callback
-    is_secret: false
+    isSecret: false
 `
 	err = os.WriteFile(idpDir+"/google_idp.yaml", []byte(googleIDPYAML), 0600)
 	assert.NoError(t, err)
@@ -446,13 +446,13 @@ type: GITHUB
 properties:
   - name: client_id
     value: github-client-id
-    is_secret: false
+    isSecret: false
   - name: client_secret
     value: github-client-secret
-    is_secret: true
+    isSecret: true
   - name: redirect_uri
     value: http://localhost:3000/callback
-    is_secret: false
+    isSecret: false
 `
 	err = os.WriteFile(idpDir+"/github_idp.yaml", []byte(githubIDPYAML), 0600)
 	assert.NoError(t, err)
@@ -580,7 +580,7 @@ type: GOOGLE
 properties:
   - name: "client_id"
     value: "test"
-    is_secret: false
+    isSecret: false
 `
 	err = os.WriteFile(idpDir+"/invalid-idp.yaml", []byte(invalidIDPYAML), 0600)
 	assert.NoError(t, err)
@@ -641,7 +641,7 @@ type: "UNSUPPORTED_TYPE"
 properties:
   - name: "client_id"
     value: "test"
-    is_secret: false
+    isSecret: false
 `
 	err = os.WriteFile(idpDir+"/invalid-type.yaml", []byte(invalidTypeYAML), 0600)
 	assert.NoError(t, err)

--- a/backend/internal/inboundclient/model/inbound_client.go
+++ b/backend/internal/inboundclient/model/inbound_client.go
@@ -44,31 +44,31 @@ type InboundClient struct {
 
 // InboundAuthProfile is the wire field block embedded in entity DTOs (requests and responses).
 type InboundAuthProfile struct {
-	AuthFlowID                string              `json:"authFlowId,omitempty"           yaml:"auth_flow_id,omitempty"           jsonschema:"Authentication flow ID. Optional. Specifies which login flow to use (e.g., MFA, passwordless). If omitted, the default authentication flow is used."`
-	AuthFlowHandle            string              `json:"authFlowHandle,omitempty"       yaml:"auth_flow_handle,omitempty"       jsonschema:"Authentication flow handle. Optional. Alternative to authFlowId — resolved to an ID at import time."`
-	RegistrationFlowID        string              `json:"registrationFlowId,omitempty"   yaml:"registration_flow_id,omitempty"   jsonschema:"Registration flow ID. Optional. Specifies the user registration/signup flow."`
-	RegistrationFlowHandle    string              `json:"registrationFlowHandle,omitempty" yaml:"registration_flow_handle,omitempty" jsonschema:"Registration flow handle. Optional. Alternative to registrationFlowId — resolved to an ID at import time."`
-	IsRegistrationFlowEnabled bool                `json:"isRegistrationFlowEnabled"      yaml:"is_registration_flow_enabled"     jsonschema:"Enable self-service registration. Set to true to allow users to sign up themselves. Requires registrationFlowId or registrationFlowHandle to be set."`
-	RecoveryFlowID            string              `json:"recoveryFlowId,omitempty"        yaml:"recovery_flow_id,omitempty"        jsonschema:"Recovery flow ID. Optional. Specifies the user recovery flow."`
-	RecoveryFlowHandle        string              `json:"recoveryFlowHandle,omitempty"   yaml:"recovery_flow_handle,omitempty"   jsonschema:"Recovery flow handle. Optional. Alternative to recoveryFlowId — resolved to an ID at import time."`
-	IsRecoveryFlowEnabled     bool                `json:"isRecoveryFlowEnabled"          yaml:"is_recovery_flow_enabled"       jsonschema:"Enable self-service recovery. Set to true to allow users to recover their accounts (e.g., password reset). Requires recoveryFlowId or recoveryFlowHandle to be set."`
-	ThemeID                   string              `json:"themeId,omitempty"              yaml:"theme_id,omitempty"               jsonschema:"Theme configuration ID. Optional. Customizes the visual styling of login pages."`
-	LayoutID                  string              `json:"layoutId,omitempty"             yaml:"layout_id,omitempty"              jsonschema:"Layout configuration ID. Optional. Customizes the screen structure and component positioning of login pages."`
+	AuthFlowID                string              `json:"authFlowId,omitempty"           yaml:"authFlowId,omitempty"           jsonschema:"Authentication flow ID. Optional. Specifies which login flow to use (e.g., MFA, passwordless). If omitted, the default authentication flow is used."`
+	AuthFlowHandle            string              `json:"authFlowHandle,omitempty"       yaml:"authFlowHandle,omitempty"       jsonschema:"Authentication flow handle. Optional. Alternative to authFlowId — resolved to an ID at import time."`
+	RegistrationFlowID        string              `json:"registrationFlowId,omitempty"   yaml:"registrationFlowId,omitempty"   jsonschema:"Registration flow ID. Optional. Specifies the user registration/signup flow."`
+	RegistrationFlowHandle    string              `json:"registrationFlowHandle,omitempty" yaml:"registrationFlowHandle,omitempty" jsonschema:"Registration flow handle. Optional. Alternative to registrationFlowId — resolved to an ID at import time."`
+	IsRegistrationFlowEnabled bool                `json:"isRegistrationFlowEnabled"      yaml:"isRegistrationFlowEnabled"     jsonschema:"Enable self-service registration. Set to true to allow users to sign up themselves. Requires registrationFlowId or registrationFlowHandle to be set."`
+	RecoveryFlowID            string              `json:"recoveryFlowId,omitempty"        yaml:"recoveryFlowId,omitempty"        jsonschema:"Recovery flow ID. Optional. Specifies the user recovery flow."`
+	RecoveryFlowHandle        string              `json:"recoveryFlowHandle,omitempty"   yaml:"recoveryFlowHandle,omitempty"   jsonschema:"Recovery flow handle. Optional. Alternative to recoveryFlowId — resolved to an ID at import time."`
+	IsRecoveryFlowEnabled     bool                `json:"isRecoveryFlowEnabled"          yaml:"isRecoveryFlowEnabled"       jsonschema:"Enable self-service recovery. Set to true to allow users to recover their accounts (e.g., password reset). Requires recoveryFlowId or recoveryFlowHandle to be set."`
+	ThemeID                   string              `json:"themeId,omitempty"              yaml:"themeId,omitempty"               jsonschema:"Theme configuration ID. Optional. Customizes the visual styling of login pages."`
+	LayoutID                  string              `json:"layoutId,omitempty"             yaml:"layoutId,omitempty"              jsonschema:"Layout configuration ID. Optional. Customizes the screen structure and component positioning of login pages."`
 	Assertion                 *AssertionConfig    `json:"assertion,omitempty"            yaml:"assertion,omitempty"              jsonschema:"Assertion configuration. Optional. Customize assertion validity periods and included user attributes."`
-	LoginConsent              *LoginConsentConfig `json:"loginConsent,omitempty"         yaml:"login_consent,omitempty"          jsonschema:"Login consent configuration settings."`
-	AllowedUserTypes          []string            `json:"allowedUserTypes,omitempty"     yaml:"allowed_user_types,omitempty"     jsonschema:"Allowed user types. Optional. Restricts which user types can authenticate to and register against this resource."`
+	LoginConsent              *LoginConsentConfig `json:"loginConsent,omitempty"         yaml:"loginConsent,omitempty"          jsonschema:"Login consent configuration settings."`
+	AllowedUserTypes          []string            `json:"allowedUserTypes,omitempty"     yaml:"allowedUserTypes,omitempty"     jsonschema:"Allowed user types. Optional. Restricts which user types can authenticate to and register against this resource."`
 	Certificate               *Certificate        `json:"certificate,omitempty"          yaml:"certificate,omitempty"            jsonschema:"Resource-level certificate. Optional. For certificate-based authentication or JWT validation."`
 }
 
 // AssertionConfig is the entity-level assertion config; token configs fall back to it.
 type AssertionConfig struct {
-	ValidityPeriod int64    `json:"validityPeriod,omitempty" yaml:"validity_period,omitempty" jsonschema:"Assertion validity period in seconds."`
-	UserAttributes []string `json:"userAttributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to include in the assertion."`
+	ValidityPeriod int64    `json:"validityPeriod,omitempty" yaml:"validityPeriod,omitempty" jsonschema:"Assertion validity period in seconds."`
+	UserAttributes []string `json:"userAttributes,omitempty" yaml:"userAttributes,omitempty" jsonschema:"User attributes to include in the assertion."`
 }
 
 // LoginConsentConfig is the login consent configuration.
 type LoginConsentConfig struct {
-	ValidityPeriod int64 `json:"validityPeriod" yaml:"validity_period" jsonschema:"Consent validity period in seconds. 0 means never expire."`
+	ValidityPeriod int64 `json:"validityPeriod" yaml:"validityPeriod" jsonschema:"Consent validity period in seconds. 0 means never expire."`
 }
 
 // Certificate is a user-supplied certificate input.

--- a/backend/internal/inboundclient/model/oauth.go
+++ b/backend/internal/inboundclient/model/oauth.go
@@ -47,29 +47,29 @@ const (
 
 // OAuthTokenConfig wraps access and ID token configs.
 type OAuthTokenConfig struct {
-	AccessToken  *AccessTokenConfig  `json:"accessToken,omitempty" yaml:"access_token,omitempty" jsonschema:"Access token configuration."`
-	IDToken      *IDTokenConfig      `json:"idToken,omitempty"    yaml:"id_token,omitempty"     jsonschema:"ID token configuration."`
-	RefreshToken *RefreshTokenConfig `json:"refreshToken,omitempty" yaml:"refresh_token,omitempty" jsonschema:"Refresh token configuration."`
+	AccessToken  *AccessTokenConfig  `json:"accessToken,omitempty" yaml:"accessToken,omitempty" jsonschema:"Access token configuration."`
+	IDToken      *IDTokenConfig      `json:"idToken,omitempty"    yaml:"idToken,omitempty"     jsonschema:"ID token configuration."`
+	RefreshToken *RefreshTokenConfig `json:"refreshToken,omitempty" yaml:"refreshToken,omitempty" jsonschema:"Refresh token configuration."`
 }
 
 // AccessTokenConfig is the access token configuration.
 type AccessTokenConfig struct {
-	ValidityPeriod int64    `json:"validityPeriod,omitempty" yaml:"validity_period,omitempty" jsonschema:"Access token validity period in seconds."`
-	UserAttributes []string `json:"userAttributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to embed in the access token."`
+	ValidityPeriod int64    `json:"validityPeriod,omitempty" yaml:"validityPeriod,omitempty" jsonschema:"Access token validity period in seconds."`
+	UserAttributes []string `json:"userAttributes,omitempty" yaml:"userAttributes,omitempty" jsonschema:"User attributes to embed in the access token."`
 }
 
 // IDTokenConfig is the ID token configuration.
 type IDTokenConfig struct {
-	ValidityPeriod int64               `json:"validityPeriod,omitempty" yaml:"validity_period,omitempty" jsonschema:"ID token validity period in seconds."`
-	UserAttributes []string            `json:"userAttributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to embed in the ID token."`
-	ResponseType   IDTokenResponseType `json:"responseType,omitempty"   yaml:"response_type,omitempty"   jsonschema:"ID token response type (JWT, JWE, NESTED_JWT). Defaults to JWT."`
-	EncryptionAlg  string              `json:"encryptionAlg,omitempty"  yaml:"encryption_alg,omitempty"  jsonschema:"JWE key-management algorithm. Required when responseType is JWE or NESTED_JWT."`
-	EncryptionEnc  string              `json:"encryptionEnc,omitempty"  yaml:"encryption_enc,omitempty"  jsonschema:"JWE content-encryption algorithm. Required when responseType is JWE or NESTED_JWT."`
+	ValidityPeriod int64               `json:"validityPeriod,omitempty" yaml:"validityPeriod,omitempty" jsonschema:"ID token validity period in seconds."`
+	UserAttributes []string            `json:"userAttributes,omitempty" yaml:"userAttributes,omitempty" jsonschema:"User attributes to embed in the ID token."`
+	ResponseType   IDTokenResponseType `json:"responseType,omitempty"   yaml:"responseType,omitempty"   jsonschema:"ID token response type (JWT, JWE, NESTED_JWT). Defaults to JWT."`
+	EncryptionAlg  string              `json:"encryptionAlg,omitempty"  yaml:"encryptionAlg,omitempty"  jsonschema:"JWE key-management algorithm. Required when responseType is JWE or NESTED_JWT."`
+	EncryptionEnc  string              `json:"encryptionEnc,omitempty"  yaml:"encryptionEnc,omitempty"  jsonschema:"JWE content-encryption algorithm. Required when responseType is JWE or NESTED_JWT."`
 }
 
 // RefreshTokenConfig is the refresh token configuration.
 type RefreshTokenConfig struct {
-	ValidityPeriod int64 `json:"validityPeriod,omitempty" yaml:"validity_period,omitempty" jsonschema:"Refresh token validity period in seconds."`
+	ValidityPeriod int64 `json:"validityPeriod,omitempty" yaml:"validityPeriod,omitempty" jsonschema:"Refresh token validity period in seconds."`
 }
 
 // IDTokenResponseType is the response format of the ID token.
@@ -86,11 +86,11 @@ const (
 
 // UserInfoConfig is the user info endpoint configuration.
 type UserInfoConfig struct {
-	ResponseType   UserInfoResponseType `json:"responseType,omitempty"   yaml:"response_type,omitempty"   jsonschema:"UserInfo response type (JSON, JWS, JWE, NESTED_JWT). Required algorithm fields must match the selected response type."`
-	UserAttributes []string             `json:"userAttributes,omitempty" yaml:"user_attributes,omitempty" jsonschema:"User attributes to include in the userinfo response."`
-	SigningAlg     string               `json:"signingAlg,omitempty"     yaml:"signing_alg,omitempty"     jsonschema:"JWS algorithm for signed userinfo responses (e.g. RS256)."`
-	EncryptionAlg  string               `json:"encryptionAlg,omitempty"  yaml:"encryption_alg,omitempty"  jsonschema:"JWE key-management algorithm for encrypted userinfo responses (e.g. RSA-OAEP-256)."`
-	EncryptionEnc  string               `json:"encryptionEnc,omitempty"  yaml:"encryption_enc,omitempty"  jsonschema:"JWE content-encryption algorithm (e.g. A256GCM). Required when encryptionAlg is set."`
+	ResponseType   UserInfoResponseType `json:"responseType,omitempty"   yaml:"responseType,omitempty"   jsonschema:"UserInfo response type (JSON, JWS, JWE, NESTED_JWT). Required algorithm fields must match the selected response type."`
+	UserAttributes []string             `json:"userAttributes,omitempty" yaml:"userAttributes,omitempty" jsonschema:"User attributes to include in the userinfo response."`
+	SigningAlg     string               `json:"signingAlg,omitempty"     yaml:"signingAlg,omitempty"     jsonschema:"JWS algorithm for signed userinfo responses (e.g. RS256)."`
+	EncryptionAlg  string               `json:"encryptionAlg,omitempty"  yaml:"encryptionAlg,omitempty"  jsonschema:"JWE key-management algorithm for encrypted userinfo responses (e.g. RSA-OAEP-256)."`
+	EncryptionEnc  string               `json:"encryptionEnc,omitempty"  yaml:"encryptionEnc,omitempty"  jsonschema:"JWE content-encryption algorithm (e.g. A256GCM). Required when encryptionAlg is set."`
 }
 
 // UserInfoResponseType is the response format of the UserInfo endpoint.
@@ -137,45 +137,45 @@ type OAuthProfile struct {
 // OAuthConfigWithSecret is the wire input shape and the create/update echo response shape.
 // Carries ClientSecret (omitempty) so it appears only when freshly issued.
 type OAuthConfigWithSecret struct {
-	ClientID                           string                              `json:"clientId,omitempty"                          yaml:"client_id,omitempty"                          jsonschema:"OAuth client ID (auto-generated if not provided)"`
-	ClientSecret                       string                              `json:"clientSecret,omitempty"                      yaml:"client_secret,omitempty"                      jsonschema:"OAuth client secret (auto-generated if not provided)"`
-	RedirectURIs                       []string                            `json:"redirectUris,omitempty"                      yaml:"redirect_uris,omitempty"                      jsonschema:"Allowed redirect URIs. Required for Public (SPA/Mobile) and Confidential (Server) clients. Omit for M2M."`
-	GrantTypes                         []oauth2const.GrantType             `json:"grantTypes,omitempty"                        yaml:"grant_types,omitempty"                        jsonschema:"OAuth grant types. Common: [authorization_code, refresh_token] for user apps, [client_credentials] for M2M."`
-	ResponseTypes                      []oauth2const.ResponseType          `json:"responseTypes,omitempty"                     yaml:"response_types,omitempty"                     jsonschema:"OAuth response types. Common: [code] for user apps. Omit for M2M."`
-	TokenEndpointAuthMethod            oauth2const.TokenEndpointAuthMethod `json:"tokenEndpointAuthMethod,omitempty"           yaml:"token_endpoint_auth_method,omitempty"         jsonschema:"Client authentication method. Use 'none' for Public clients, 'client_secret_basic' for Confidential/M2M."`
-	PKCERequired                       bool                                `json:"pkceRequired"                                yaml:"pkce_required"                                jsonschema:"Require PKCE for security. Recommended for all user-interactive flows."`
-	PublicClient                       bool                                `json:"publicClient"                                yaml:"public_client"                                jsonschema:"Identify if client is public (cannot store secrets). Set true for SPA/Mobile."`
-	RequirePushedAuthorizationRequests bool                                `json:"requirePushedAuthorizationRequests"          yaml:"require_pushed_authorization_requests"        jsonschema:"Require Pushed Authorization Requests (PAR) per RFC 9126."`
-	DPoPBoundAccessTokens              bool                                `json:"dpopBoundAccessTokens"                       yaml:"dpop_bound_access_tokens"                     jsonschema:"Require DPoP-bound access tokens (RFC 9449)."`
-	IncludeActClaim                    bool                                `json:"includeActClaim"                             yaml:"include_act_claim"                            jsonschema:"Include an implicit on-behalf-of 'act' claim (identifying the application entity) in access tokens issued through this client's authorization code flow. Agents always include it regardless of this setting."`
+	ClientID                           string                              `json:"clientId,omitempty"                          yaml:"clientId,omitempty"                          jsonschema:"OAuth client ID (auto-generated if not provided)"`
+	ClientSecret                       string                              `json:"clientSecret,omitempty"                      yaml:"clientSecret,omitempty"                      jsonschema:"OAuth client secret (auto-generated if not provided)"`
+	RedirectURIs                       []string                            `json:"redirectUris,omitempty"                      yaml:"redirectUris,omitempty"                      jsonschema:"Allowed redirect URIs. Required for Public (SPA/Mobile) and Confidential (Server) clients. Omit for M2M."`
+	GrantTypes                         []oauth2const.GrantType             `json:"grantTypes,omitempty"                        yaml:"grantTypes,omitempty"                        jsonschema:"OAuth grant types. Common: [authorization_code, refresh_token] for user apps, [client_credentials] for M2M."`
+	ResponseTypes                      []oauth2const.ResponseType          `json:"responseTypes,omitempty"                     yaml:"responseTypes,omitempty"                     jsonschema:"OAuth response types. Common: [code] for user apps. Omit for M2M."`
+	TokenEndpointAuthMethod            oauth2const.TokenEndpointAuthMethod `json:"tokenEndpointAuthMethod,omitempty"           yaml:"tokenEndpointAuthMethod,omitempty"         jsonschema:"Client authentication method. Use 'none' for Public clients, 'client_secret_basic' for Confidential/M2M."`
+	PKCERequired                       bool                                `json:"pkceRequired"                                yaml:"pkceRequired"                                jsonschema:"Require PKCE for security. Recommended for all user-interactive flows."`
+	PublicClient                       bool                                `json:"publicClient"                                yaml:"publicClient"                                jsonschema:"Identify if client is public (cannot store secrets). Set true for SPA/Mobile."`
+	RequirePushedAuthorizationRequests bool                                `json:"requirePushedAuthorizationRequests"          yaml:"requirePushedAuthorizationRequests"        jsonschema:"Require Pushed Authorization Requests (PAR) per RFC 9126."`
+	DPoPBoundAccessTokens              bool                                `json:"dpopBoundAccessTokens"                       yaml:"dpopBoundAccessTokens"                     jsonschema:"Require DPoP-bound access tokens (RFC 9449)."`
+	IncludeActClaim                    bool                                `json:"includeActClaim"                             yaml:"includeActClaim"                            jsonschema:"Include an implicit on-behalf-of 'act' claim (identifying the application entity) in access tokens issued through this client's authorization code flow. Agents always include it regardless of this setting."`
 	Token                              *OAuthTokenConfig                   `json:"token,omitempty"                             yaml:"token,omitempty"                              jsonschema:"Token configuration for access tokens and ID tokens"`
 	Scopes                             []string                            `json:"scopes,omitempty"                            yaml:"scopes,omitempty"                             jsonschema:"Allowed OAuth scopes. Add custom scopes as needed for your application."`
-	UserInfo                           *UserInfoConfig                     `json:"userInfo,omitempty"                          yaml:"user_info,omitempty"                          jsonschema:"UserInfo endpoint configuration. Configure user attributes returned from the OIDC userinfo endpoint."`
-	ScopeClaims                        map[string][]string                 `json:"scopeClaims,omitempty"                       yaml:"scope_claims,omitempty"                       jsonschema:"Scope-to-claims mapping. Maps OAuth scopes to user claims for both ID token and userinfo."`
+	UserInfo                           *UserInfoConfig                     `json:"userInfo,omitempty"                          yaml:"userInfo,omitempty"                          jsonschema:"UserInfo endpoint configuration. Configure user attributes returned from the OIDC userinfo endpoint."`
+	ScopeClaims                        map[string][]string                 `json:"scopeClaims,omitempty"                       yaml:"scopeClaims,omitempty"                       jsonschema:"Scope-to-claims mapping. Maps OAuth scopes to user claims for both ID token and userinfo."`
 	Certificate                        *Certificate                        `json:"certificate,omitempty"                       yaml:"certificate,omitempty"                        jsonschema:"Application certificate. Optional. For certificate-based authentication or JWT validation."`
-	AcrValues                          []string                            `json:"acrValues,omitempty"                         yaml:"acr_values,omitempty"                         jsonschema:"Default ACR values applied when the request does not specify acr_values."`
+	AcrValues                          []string                            `json:"acrValues,omitempty"                         yaml:"acrValues,omitempty"                         jsonschema:"Default ACR values applied when the request does not specify acr_values."`
 }
 
 // OAuthConfig is the wire output shape (GET responses). ClientSecret is structurally absent.
 // Empty slice/map fields are omitted; booleans are always serialized in both JSON and YAML for
 // explicit semantics.
 type OAuthConfig struct {
-	ClientID                           string                              `json:"clientId,omitempty"                 yaml:"client_id,omitempty"`
-	RedirectURIs                       []string                            `json:"redirectUris,omitempty"             yaml:"redirect_uris,omitempty"`
-	GrantTypes                         []oauth2const.GrantType             `json:"grantTypes,omitempty"               yaml:"grant_types,omitempty"`
-	ResponseTypes                      []oauth2const.ResponseType          `json:"responseTypes,omitempty"            yaml:"response_types,omitempty"`
-	TokenEndpointAuthMethod            oauth2const.TokenEndpointAuthMethod `json:"tokenEndpointAuthMethod,omitempty"  yaml:"token_endpoint_auth_method,omitempty"`
-	PKCERequired                       bool                                `json:"pkceRequired"                       yaml:"pkce_required"`
-	PublicClient                       bool                                `json:"publicClient"                       yaml:"public_client"`
-	RequirePushedAuthorizationRequests bool                                `json:"requirePushedAuthorizationRequests" yaml:"require_pushed_authorization_requests"`
-	DPoPBoundAccessTokens              bool                                `json:"dpopBoundAccessTokens"              yaml:"dpop_bound_access_tokens"`
-	IncludeActClaim                    bool                                `json:"includeActClaim"                    yaml:"include_act_claim"`
+	ClientID                           string                              `json:"clientId,omitempty"                 yaml:"clientId,omitempty"`
+	RedirectURIs                       []string                            `json:"redirectUris,omitempty"             yaml:"redirectUris,omitempty"`
+	GrantTypes                         []oauth2const.GrantType             `json:"grantTypes,omitempty"               yaml:"grantTypes,omitempty"`
+	ResponseTypes                      []oauth2const.ResponseType          `json:"responseTypes,omitempty"            yaml:"responseTypes,omitempty"`
+	TokenEndpointAuthMethod            oauth2const.TokenEndpointAuthMethod `json:"tokenEndpointAuthMethod,omitempty"  yaml:"tokenEndpointAuthMethod,omitempty"`
+	PKCERequired                       bool                                `json:"pkceRequired"                       yaml:"pkceRequired"`
+	PublicClient                       bool                                `json:"publicClient"                       yaml:"publicClient"`
+	RequirePushedAuthorizationRequests bool                                `json:"requirePushedAuthorizationRequests" yaml:"requirePushedAuthorizationRequests"`
+	DPoPBoundAccessTokens              bool                                `json:"dpopBoundAccessTokens"              yaml:"dpopBoundAccessTokens"`
+	IncludeActClaim                    bool                                `json:"includeActClaim"                    yaml:"includeActClaim"`
 	Token                              *OAuthTokenConfig                   `json:"token,omitempty"                    yaml:"token,omitempty"`
 	Scopes                             []string                            `json:"scopes,omitempty"                   yaml:"scopes,omitempty"`
-	UserInfo                           *UserInfoConfig                     `json:"userInfo,omitempty"                 yaml:"user_info,omitempty"`
-	ScopeClaims                        map[string][]string                 `json:"scopeClaims,omitempty"              yaml:"scope_claims,omitempty"`
+	UserInfo                           *UserInfoConfig                     `json:"userInfo,omitempty"                 yaml:"userInfo,omitempty"`
+	ScopeClaims                        map[string][]string                 `json:"scopeClaims,omitempty"              yaml:"scopeClaims,omitempty"`
 	Certificate                        *Certificate                        `json:"certificate,omitempty"              yaml:"certificate,omitempty"`
-	AcrValues                          []string                            `json:"acrValues,omitempty"                yaml:"acr_values,omitempty"`
+	AcrValues                          []string                            `json:"acrValues,omitempty"                yaml:"acrValues,omitempty"`
 }
 
 // SupportedIDTokenEncryptionAlgs lists JWE key-management algorithms supported for ID token encryption.
@@ -187,24 +187,24 @@ var SupportedIDTokenEncryptionEncs = []string{string(jwe.A128CBCHS256), string(j
 // OAuthClient is the resolved runtime view.
 type OAuthClient struct {
 	ID                                 string                              `yaml:"id,omitempty"`
-	OUID                               string                              `yaml:"ou_id,omitempty"`
-	ClientID                           string                              `yaml:"client_id,omitempty"`
-	RedirectURIs                       []string                            `yaml:"redirect_uris,omitempty"`
-	GrantTypes                         []oauth2const.GrantType             `yaml:"grant_types,omitempty"`
-	ResponseTypes                      []oauth2const.ResponseType          `yaml:"response_types,omitempty"`
-	TokenEndpointAuthMethod            oauth2const.TokenEndpointAuthMethod `yaml:"token_endpoint_auth_method,omitempty"`
-	PKCERequired                       bool                                `yaml:"pkce_required,omitempty"`
-	PublicClient                       bool                                `yaml:"public_client,omitempty"`
-	RequirePushedAuthorizationRequests bool                                `yaml:"require_pushed_authorization_requests,omitempty"`
-	DPoPBoundAccessTokens              bool                                `yaml:"dpop_bound_access_tokens,omitempty"`
-	IncludeActClaim                    bool                                `yaml:"include_act_claim,omitempty"`
-	EntityCategory                     entity.EntityCategory               `yaml:"entity_category,omitempty"`
+	OUID                               string                              `yaml:"ouId,omitempty"`
+	ClientID                           string                              `yaml:"clientId,omitempty"`
+	RedirectURIs                       []string                            `yaml:"redirectUris,omitempty"`
+	GrantTypes                         []oauth2const.GrantType             `yaml:"grantTypes,omitempty"`
+	ResponseTypes                      []oauth2const.ResponseType          `yaml:"responseTypes,omitempty"`
+	TokenEndpointAuthMethod            oauth2const.TokenEndpointAuthMethod `yaml:"tokenEndpointAuthMethod,omitempty"`
+	PKCERequired                       bool                                `yaml:"pkceRequired,omitempty"`
+	PublicClient                       bool                                `yaml:"publicClient,omitempty"`
+	RequirePushedAuthorizationRequests bool                                `yaml:"requirePushedAuthorizationRequests,omitempty"`
+	DPoPBoundAccessTokens              bool                                `yaml:"dpopBoundAccessTokens,omitempty"`
+	IncludeActClaim                    bool                                `yaml:"includeActClaim,omitempty"`
+	EntityCategory                     entity.EntityCategory               `yaml:"entityCategory,omitempty"`
 	Token                              *OAuthTokenConfig                   `yaml:"token,omitempty"`
 	Scopes                             []string                            `yaml:"scopes,omitempty"`
-	UserInfo                           *UserInfoConfig                     `yaml:"user_info,omitempty"`
-	ScopeClaims                        map[string][]string                 `yaml:"scope_claims,omitempty"`
+	UserInfo                           *UserInfoConfig                     `yaml:"userInfo,omitempty"`
+	ScopeClaims                        map[string][]string                 `yaml:"scopeClaims,omitempty"`
 	Certificate                        *Certificate                        `yaml:"certificate,omitempty"`
-	AcrValues                          []string                            `yaml:"acr_values,omitempty"`
+	AcrValues                          []string                            `yaml:"acrValues,omitempty"`
 }
 
 // IsAllowedGrantType reports whether the given grant type is allowed for this client.

--- a/backend/internal/notification/init_test.go
+++ b/backend/internal/notification/init_test.go
@@ -114,13 +114,13 @@ provider: "twilio"
 properties:
   - name: "account_sid"
     value: "AC00112233445566778899aabbccddeeff"
-    is_secret: true
+    isSecret: true
   - name: "auth_token"
     value: "test-auth-token"
-    is_secret: true
+    isSecret: true
   - name: "sender_id"
     value: "+15551234567"
-    is_secret: false
+    isSecret: false
 `
 	err = os.WriteFile(filepath.Join(senderDir, "twilio-sender.yaml"), []byte(twilioYAML), 0600)
 	suite.NoError(err)
@@ -132,13 +132,13 @@ provider: "vonage"
 properties:
   - name: "api_key"
     value: "test-api-key"
-    is_secret: true
+    isSecret: true
   - name: "api_secret"
     value: "test-api-secret"
-    is_secret: true
+    isSecret: true
   - name: "sender_id"
     value: "VonageTest"
-    is_secret: false
+    isSecret: false
 `
 	err = os.WriteFile(filepath.Join(senderDir, "vonage-sender.yaml"), []byte(vonageYAML), 0600)
 	suite.NoError(err)
@@ -332,13 +332,13 @@ provider: "twilio"
 properties:
   - name: "account_sid"
     value: "{{.TWILIO_ACCOUNT_SID}}"
-    is_secret: false
+    isSecret: false
   - name: "auth_token"
     value: "{{.TWILIO_AUTH_TOKEN}}"
-    is_secret: true
+    isSecret: true
   - name: "sender_id"
     value: "{{.TWILIO_FROM_NUMBER}}"
-    is_secret: false
+    isSecret: false
 `
 
 	sender, err := parseToNotificationSenderDTO([]byte(yamlData))
@@ -428,13 +428,13 @@ provider: "vonage"
 properties:
   - name: "api_key"
     value: "{{.VONAGE_API_KEY}}"
-    is_secret: false
+    isSecret: false
   - name: "api_secret"
     value: "{{.VONAGE_API_SECRET}}"
-    is_secret: true
+    isSecret: true
   - name: "sender_id"
     value: "{{.VONAGE_FROM_NUMBER}}"
-    is_secret: false
+    isSecret: false
 `
 
 	sender, err := parseToNotificationSenderDTO([]byte(yamlData))
@@ -561,7 +561,7 @@ provider: "twilio"
 properties:
   - name: "account_sid"
     value: "test"
-    is_secret: false
+    isSecret: false
 `
 	err = os.WriteFile(filepath.Join(senderDir, "invalid-sender.yaml"), []byte(invalidSenderYAML), 0600)
 	suite.NoError(err)

--- a/backend/internal/ou/model.go
+++ b/backend/internal/ou/model.go
@@ -44,14 +44,14 @@ type OrganizationUnit struct {
 	Name            string    `json:"name" yaml:"name"`
 	Description     string    `json:"description,omitempty" yaml:"description,omitempty"`
 	Parent          *string   `json:"parent" yaml:"parent"`
-	ThemeID         string    `json:"themeId,omitempty" yaml:"theme_id,omitempty"`
-	LayoutID        string    `json:"layoutId,omitempty" yaml:"layout_id,omitempty"`
-	LogoURL         string    `json:"logoUrl,omitempty" yaml:"logo_url,omitempty"`
-	TosURI          string    `json:"tosUri,omitempty" yaml:"tos_uri,omitempty"`
-	PolicyURI       string    `json:"policyUri,omitempty" yaml:"policy_uri,omitempty"`
-	CookiePolicyURI string    `json:"cookiePolicyUri,omitempty" yaml:"cookie_policy_uri,omitempty"`
-	CreatedAt       time.Time `json:"createdAt" yaml:"created_at"`
-	UpdatedAt       time.Time `json:"updatedAt" yaml:"updated_at"`
+	ThemeID         string    `json:"themeId,omitempty" yaml:"themeId,omitempty"`
+	LayoutID        string    `json:"layoutId,omitempty" yaml:"layoutId,omitempty"`
+	LogoURL         string    `json:"logoUrl,omitempty" yaml:"logoUrl,omitempty"`
+	TosURI          string    `json:"tosUri,omitempty" yaml:"tosUri,omitempty"`
+	PolicyURI       string    `json:"policyUri,omitempty" yaml:"policyUri,omitempty"`
+	CookiePolicyURI string    `json:"cookiePolicyUri,omitempty" yaml:"cookiePolicyUri,omitempty"`
+	CreatedAt       time.Time `json:"createdAt" yaml:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt" yaml:"updatedAt"`
 }
 
 // OrganizationUnitRequest represents the request body for creating an organization unit.
@@ -76,12 +76,12 @@ type OrganizationUnitRequestWithID struct {
 	Name            string  `json:"name" yaml:"name"`
 	Description     string  `json:"description,omitempty" yaml:"description,omitempty"`
 	Parent          *string `json:"parent" yaml:"parent"`
-	ThemeID         string  `json:"themeId,omitempty" yaml:"theme_id,omitempty"`
-	LayoutID        string  `json:"layoutId,omitempty" yaml:"layout_id,omitempty"`
-	LogoURL         string  `json:"logoUrl,omitempty" yaml:"logo_url,omitempty"`
-	TosURI          string  `json:"tosUri,omitempty" yaml:"tos_uri,omitempty"`
-	PolicyURI       string  `json:"policyUri,omitempty" yaml:"policy_uri,omitempty"`
-	CookiePolicyURI string  `json:"cookiePolicyUri,omitempty" yaml:"cookie_policy_uri,omitempty"`
+	ThemeID         string  `json:"themeId,omitempty" yaml:"themeId,omitempty"`
+	LayoutID        string  `json:"layoutId,omitempty" yaml:"layoutId,omitempty"`
+	LogoURL         string  `json:"logoUrl,omitempty" yaml:"logoUrl,omitempty"`
+	TosURI          string  `json:"tosUri,omitempty" yaml:"tosUri,omitempty"`
+	PolicyURI       string  `json:"policyUri,omitempty" yaml:"policyUri,omitempty"`
+	CookiePolicyURI string  `json:"cookiePolicyUri,omitempty" yaml:"cookiePolicyUri,omitempty"`
 }
 
 // OrganizationUnitListResponse represents the response for listing organization units with pagination.

--- a/backend/internal/resource/declarative_resource_test.go
+++ b/backend/internal/resource/declarative_resource_test.go
@@ -244,7 +244,7 @@ id: "rs1"
 name: "Test Server"
 description: "Test description"
 identifier: "test-server"
-ou_id: "ou1"
+ouId: "ou1"
 delimiter: ":"
 resources:
   - name: "Users"
@@ -272,7 +272,7 @@ resources:
 func TestParseToResourceServer_MissingID(t *testing.T) {
 	yamlData := []byte(`
 name: "Test Server"
-ou_id: "ou1"
+ouId: "ou1"
 `)
 
 	dto, err := parseToResourceServer(yamlData)
@@ -285,7 +285,7 @@ ou_id: "ou1"
 func TestParseToResourceServer_MissingName(t *testing.T) {
 	yamlData := []byte(`
 id: "rs1"
-ou_id: "ou1"
+ouId: "ou1"
 `)
 
 	dto, err := parseToResourceServer(yamlData)
@@ -300,7 +300,7 @@ func TestParseToResourceServer_TypeMCP(t *testing.T) {
 id: "rs1"
 name: "Test Server"
 type: "MCP"
-ou_id: "ou1"
+ouId: "ou1"
 `)
 
 	dto, err := parseToResourceServer(yamlData)
@@ -314,7 +314,7 @@ func TestParseToResourceServer_TypeDefaultsToCustom(t *testing.T) {
 	yamlData := []byte(`
 id: "rs1"
 name: "Test Server"
-ou_id: "ou1"
+ouId: "ou1"
 `)
 
 	dto, err := parseToResourceServer(yamlData)
@@ -329,7 +329,7 @@ func TestParseToResourceServer_InvalidType(t *testing.T) {
 id: "rs1"
 name: "Test Server"
 type: "BOGUS"
-ou_id: "ou1"
+ouId: "ou1"
 `)
 
 	dto, err := parseToResourceServer(yamlData)
@@ -345,7 +345,7 @@ id: "rs1"
 name: "Test Server"
 handle: "test-api"
 type: "MCP"
-ou_id: "ou1"
+ouId: "ou1"
 `)
 
 	parser := parseAndValidateResourceServerWrapper(nil)
@@ -363,7 +363,7 @@ id: "rs1"
 name: "Test Server"
 handle: "test-api"
 type: "BOGUS"
-ou_id: "ou1"
+ouId: "ou1"
 `)
 
 	parser := parseAndValidateResourceServerWrapper(nil)
@@ -554,7 +554,7 @@ id: "rs1"
 name: "Test Server"
 handle: "test-api"
 identifier: "api"
-ou_id: "ou1"
+ouId: "ou1"
 resources:
   - name: "Users"
     handle: "users"

--- a/backend/internal/resource/model.go
+++ b/backend/internal/resource/model.go
@@ -229,8 +229,8 @@ type ResourceServer struct {
 	Handle      string             `yaml:"handle" json:"handle"`
 	Identifier  string             `yaml:"identifier,omitempty" json:"identifier,omitempty"`
 	Type        ResourceServerType `yaml:"type,omitempty" json:"type,omitempty"`
-	OUID        string             `yaml:"ou_id,omitempty" json:"ouId"`
-	OUHandle    string             `yaml:"ou_handle,omitempty" json:"-"`
+	OUID        string             `yaml:"ouId,omitempty" json:"ouId"`
+	OUHandle    string             `yaml:"ouHandle,omitempty" json:"-"`
 	Delimiter   string             `yaml:"delimiter,omitempty" json:"delimiter,omitempty" yamlfmt:"quoted"`
 	IsReadOnly  bool               `yaml:"-" json:"-"`
 	Resources   []Resource         `yaml:"resources,omitempty" json:"resources,omitempty"`

--- a/backend/internal/resource/service_test.go
+++ b/backend/internal/resource/service_test.go
@@ -5529,7 +5529,7 @@ func TestResourceServerYAML_OUHandleParsed(t *testing.T) {
 id: rs1
 name: Server
 handle: server
-ou_handle: default
+ouHandle: default
 `)
 	rs, err := parseToResourceServer(yamlData)
 

--- a/backend/internal/role/declarative_resource.go
+++ b/backend/internal/role/declarative_resource.go
@@ -190,8 +190,8 @@ type roleDeclarativeResource struct {
 	ID          string                      `yaml:"id"`
 	Name        string                      `yaml:"name"`
 	Description string                      `yaml:"description,omitempty"`
-	OUID        string                      `yaml:"ou_id,omitempty"`
-	OUHandle    string                      `yaml:"ou_handle,omitempty"`
+	OUID        string                      `yaml:"ouId,omitempty"`
+	OUHandle    string                      `yaml:"ouHandle,omitempty"`
 	Permissions []roleDeclarativePermission `yaml:"permissions"`
 	Assignments []RoleAssignment            `yaml:"assignments,omitempty"`
 }
@@ -256,7 +256,7 @@ func validateRoleWrapper(
 		}
 	}
 	if role.OUID == "" {
-		return fmt.Errorf("ou_id or ou_handle is required for role '%s'", role.Name)
+		return fmt.Errorf("ouId or ouHandle is required for role '%s'", role.Name)
 	}
 
 	for _, assignment := range role.Assignments {

--- a/backend/internal/role/declarative_resource_test.go
+++ b/backend/internal/role/declarative_resource_test.go
@@ -277,9 +277,9 @@ func (suite *RoleExporterTestSuite) TestParseToRole_ValidYAML() {
 id: role1
 name: Admin
 description: Admin role
-ou_id: ou1
+ouId: ou1
 permissions:
-  - resource_server_id: rs1
+  - resourceServerId: rs1
     permissions:
       - read
       - write
@@ -317,7 +317,7 @@ func (suite *RoleExporterTestSuite) TestParseToRole_OptionalFieldsOmitted() {
 	yamlData := []byte(`
 id: role1
 name: Admin
-ou_id: ou1
+ouId: ou1
 `)
 
 	role, err := parseToRole(yamlData)
@@ -385,7 +385,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingOUID() {
 	err := validateRoleWrapper(role, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "ou_id or ou_handle is required for role 'Admin'")
+	assert.Contains(suite.T(), err.Error(), "ouId or ouHandle is required for role 'Admin'")
 }
 
 // Test validateRoleWrapper - invalid assignment type
@@ -459,7 +459,7 @@ func (suite *RoleExporterTestSuite) TestParseToRoleWrapper() {
 	yamlData := []byte(`
 id: role1
 name: Admin
-ou_id: ou1
+ouId: ou1
 `)
 
 	result, err := parseToRoleWrapper(yamlData)

--- a/backend/internal/role/init_test.go
+++ b/backend/internal/role/init_test.go
@@ -328,9 +328,9 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesPars
 id: parser-test-role
 name: Parser Test Role
 description: Testing YAML parser
-ou_id: ou-default
+ouId: ou-default
 permissions:
-  - resource_server_id: api-server
+  - resourceServerId: api-server
     permissions:
       - read
       - write
@@ -386,7 +386,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 	}
 	err = validateRoleWrapper(roleNoOU, fileStore, nil, nil)
 	suite.Error(err)
-	suite.Contains(err.Error(), "ou_id or ou_handle is required for role 'Test Role'")
+	suite.Contains(err.Error(), "ouId or ouHandle is required for role 'Test Role'")
 }
 
 // TestLoadDeclarativeResourcesValidateAssignmentTypes tests validation of assignment types.

--- a/backend/internal/role/model.go
+++ b/backend/internal/role/model.go
@@ -138,7 +138,7 @@ type AssignmentListResponse struct {
 
 // ResourcePermissions represents permissions grouped by resource server.
 type ResourcePermissions struct {
-	ResourceServerID string   `json:"resourceServerId" yaml:"resource_server_id"`
+	ResourceServerID string   `json:"resourceServerId" yaml:"resourceServerId"`
 	Permissions      []string `json:"permissions" yaml:"permissions"`
 }
 

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -486,7 +486,7 @@ func (rs *roleService) ResolveRoleOUHandle(
 ) *serviceerror.ServiceError {
 	if role.OUID != "" && role.OUHandle != "" {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-		logger.Warn(ctx, "Both ou_id and ou_handle provided for role; ou_handle ignored",
+		logger.Warn(ctx, "Both ouId and ouHandle provided for role; ouHandle ignored",
 			log.String("roleID", role.ID), log.String("name", role.Name))
 		return nil
 	}

--- a/backend/internal/role/service_test.go
+++ b/backend/internal/role/service_test.go
@@ -1534,9 +1534,9 @@ func TestRoleDeclarativeYAML_OUHandleParsed(t *testing.T) {
 	yamlData := []byte(`
 id: role-1
 name: Admin
-ou_handle: default
+ouHandle: default
 permissions:
-  - resource_server_id: rs1
+  - resourceServerId: rs1
     permissions:
       - read
 `)

--- a/backend/internal/system/cmodels/property.go
+++ b/backend/internal/system/cmodels/property.go
@@ -38,7 +38,7 @@ type Property struct {
 type PropertyDTO struct {
 	Name     string `json:"name" yaml:"name"`
 	Value    string `json:"value" yaml:"value"`
-	IsSecret bool   `json:"isSecret" yaml:"is_secret,omitempty"`
+	IsSecret bool   `json:"isSecret" yaml:"isSecret,omitempty"`
 }
 
 // NewProperty creates a new Property instance with the given parameters.

--- a/backend/internal/system/declarative_resource/manager_file_test.go
+++ b/backend/internal/system/declarative_resource/manager_file_test.go
@@ -177,7 +177,7 @@ func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_SubstitutesEnvVars() {
 
 	content := `# resource_type: identity_provider
 name: oauth-idp
-client_id: {{.TEST_IDP_CLIENT_ID}}
+clientId: {{.TEST_IDP_CLIENT_ID}}
 `
 	filePath := s.writeResourcesFile(content)
 
@@ -230,7 +230,7 @@ func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_EnvVarAndNonGoTemplateIn
 
 	content := `# resource_type: application
 name: My App
-client_id: {{.TEST_CLIENT_ID}}
+clientId: {{.TEST_CLIENT_ID}}
 ---
 # resource_type: flow
 handle: signin
@@ -252,7 +252,7 @@ meta: '{"label":"{{ t(signin:title) }}"}'
 func (s *ResourcesFileTestSuite) TestGetConfigsFromFile_MissingEnvVar_ReturnsError() {
 	content := `# resource_type: identity_provider
 name: oauth-idp
-client_id: {{.MISSING_ENV_VAR_XYZ}}
+clientId: {{.MISSING_ENV_VAR_XYZ}}
 `
 	filePath := s.writeResourcesFile(content)
 

--- a/backend/internal/system/export/parameterizer.go
+++ b/backend/internal/system/export/parameterizer.go
@@ -628,7 +628,7 @@ func (p *parameterizer) propertyToYAMLNode(propValue reflect.Value, resourceName
 	// Generate template variable name
 	propValueStr := fmt.Sprintf("{{.%s}}", p.generatePropertyVarName(resourceName, propName))
 
-	// Build the YAML node: {name: "...", value: "...", is_secret: true/false}
+	// Build the YAML node: {name: "...", value: "...", isSecret: true/false}
 	// Add name
 	node.Content = append(node.Content,
 		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "name"},
@@ -641,10 +641,10 @@ func (p *parameterizer) propertyToYAMLNode(propValue reflect.Value, resourceName
 		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: propValueStr},
 	)
 
-	// Add is_secret if true (omit if false for cleaner YAML)
+	// Add isSecret if true (omit if false for cleaner YAML)
 	if isSecret {
 		node.Content = append(node.Content,
-			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "is_secret"},
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "isSecret"},
 			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
 		)
 	}
@@ -1028,7 +1028,7 @@ func (p *parameterizer) convertFieldToInterface(v reflect.Value) interface{} {
 }
 
 // convertStructPathsToYAMLPaths converts Go struct field paths to YAML field paths
-// e.g., "InboundAuthConfig[].OAuthConfig.ClientID" -> "inbound_auth_config[].config.client_id"
+// e.g., "InboundAuthConfig[].OAuthConfig.ClientID" -> "inboundAuthConfig[].config.clientId"
 func (p *parameterizer) convertStructPathsToYAMLPaths(
 	ctx context.Context, obj interface{}, rules *resourceRules) *resourceRules {
 	logger := log.GetLogger().With(log.String("component", "Parameterizer"))

--- a/backend/internal/system/export/parameterizer_test.go
+++ b/backend/internal/system/export/parameterizer_test.go
@@ -1696,8 +1696,8 @@ func TestEntityTypeImportExportSymmetry(t *testing.T) {
 	type EntityType struct {
 		ID                    string          `yaml:"id"`
 		Name                  string          `yaml:"name"`
-		OUID                  string          `yaml:"organization_unit_id"`
-		AllowSelfRegistration bool            `yaml:"allow_self_registration,omitempty"`
+		OUID                  string          `yaml:"ouId"`
+		AllowSelfRegistration bool            `yaml:"allowSelfRegistration,omitempty"`
 		Schema                json.RawMessage `yaml:"schema"`
 	}
 
@@ -1705,8 +1705,8 @@ func TestEntityTypeImportExportSymmetry(t *testing.T) {
 	type EntityTypeRequestWithID struct {
 		ID                    string `yaml:"id"`
 		Name                  string `yaml:"name"`
-		OUID                  string `yaml:"organization_unit_id"`
-		AllowSelfRegistration bool   `yaml:"allow_self_registration,omitempty"`
+		OUID                  string `yaml:"ouId"`
+		AllowSelfRegistration bool   `yaml:"allowSelfRegistration,omitempty"`
 		Schema                string `yaml:"schema"` // Note: This is a string, not json.RawMessage
 	}
 
@@ -1856,8 +1856,8 @@ func TestEntityTypeExportFormat(t *testing.T) {
 	type EntityType struct {
 		ID                    string          `yaml:"id"`
 		Name                  string          `yaml:"name"`
-		OUID                  string          `yaml:"organization_unit_id"`
-		AllowSelfRegistration bool            `yaml:"allow_self_registration,omitempty"`
+		OUID                  string          `yaml:"ouId"`
+		AllowSelfRegistration bool            `yaml:"allowSelfRegistration,omitempty"`
 		Schema                json.RawMessage `yaml:"schema"`
 	}
 
@@ -1911,10 +1911,10 @@ func TestResourceServerExport_IdentifierAndOUIDNotParameterized(t *testing.T) {
 		"identifier must not be parameterized")
 
 	// ou_id must be the literal value, not a template variable
-	assert.Contains(t, result, "ou_id: 019ddcf3-c5d8-7375-80e3-c5bf524257c8",
-		"ou_id should be emitted as a literal value")
+	assert.Contains(t, result, "ouId: 019ddcf3-c5d8-7375-80e3-c5bf524257c8",
+		"ouId should be emitted as a literal value")
 	assert.NotContains(t, result, "{{.SYSTEM_OU_ID}}",
-		"ou_id must not be parameterized")
+		"ouId must not be parameterized")
 
 	// no variables should be extracted since rules are nil
 	assert.Empty(t, vars)

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -273,9 +273,9 @@ func (suite *ExportServiceTestSuite) TestExportResources_CompleteOAuthApplicatio
 	assert.Equal(suite.T(), "OAuth_Test_App_oauth-app-id.yaml", file.FileName)
 	assert.Equal(suite.T(), "applications", file.FolderPath)
 	assert.Contains(suite.T(), file.Content, "name: OAuth Test App")
-	assert.Contains(suite.T(), file.Content, "client_id: {{.O_AUTH_TEST_APP_CLIENT_ID}}")
-	assert.Contains(suite.T(), file.Content, "client_secret: {{.O_AUTH_TEST_APP_CLIENT_SECRET}}")
-	assert.Contains(suite.T(), file.Content, "redirect_uris:")
+	assert.Contains(suite.T(), file.Content, "clientId: {{.O_AUTH_TEST_APP_CLIENT_ID}}")
+	assert.Contains(suite.T(), file.Content, "clientSecret: {{.O_AUTH_TEST_APP_CLIENT_SECRET}}")
+	assert.Contains(suite.T(), file.Content, "redirectUris:")
 	assert.Contains(suite.T(), file.Content, "{{- range .O_AUTH_TEST_APP_REDIRECT_URIS}}")
 	assert.NotNil(suite.T(), result.EnvFile)
 	assert.Equal(suite.T(), ".env", result.EnvFile.FileName)
@@ -847,7 +847,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Proper
 	assert.Contains(suite.T(), yamlContent, "name: redirect_uri")
 
 	// Verify secret flags are preserved (YAML uses 'is_secret' field name)
-	assert.Contains(suite.T(), yamlContent, "is_secret: true")
+	assert.Contains(suite.T(), yamlContent, "isSecret: true")
 
 	// Verify basic IDP fields
 	assert.Contains(suite.T(), yamlContent, "name: Export Test IDP")
@@ -904,8 +904,8 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Proper
 	assert.Contains(suite.T(), yamlContent, "value:")
 
 	// Verify secret flags are preserved for secret properties
-	// Count occurrences of "is_secret: true" - should be 2 (client_secret and api_key)
-	secretCount := strings.Count(yamlContent, "is_secret: true")
+	// Count occurrences of "isSecret: true" - should be 2 (client_secret and api_key)
+	secretCount := strings.Count(yamlContent, "isSecret: true")
 	assert.Equal(suite.T(), 2, secretCount, "Should have exactly 2 secret properties")
 
 	// Verify the properties section exists and has proper structure

--- a/backend/internal/system/importer/parser.go
+++ b/backend/internal/system/importer/parser.go
@@ -181,7 +181,7 @@ func classifyResourceType(node *yaml.Node) string {
 		matches = append(matches, resourceTypeTranslation)
 	}
 
-	if hasAllKeys(node, "schema") && hasAnyKey(node, "organization_unit_id", "ou_handle") {
+	if hasAllKeys(node, "schema") && hasAnyKey(node, "ouId", "ouHandle") {
 		matches = append(matches, resourceTypeEntityType)
 	}
 
@@ -201,7 +201,7 @@ func classifyResourceType(node *yaml.Node) string {
 		matches = append(matches, resourceTypeLayout)
 	}
 
-	if hasAllKeys(node, "type", "attributes") && hasAnyKey(node, "ou_id", "ou_handle") {
+	if hasAllKeys(node, "type", "attributes") && hasAnyKey(node, "ouId", "ouHandle") {
 		matches = append(matches, resourceTypeUser)
 	}
 
@@ -215,27 +215,27 @@ func classifyResourceType(node *yaml.Node) string {
 
 	if hasAnyKey(node, "owner") ||
 		(hasAnyKey(node, "type") &&
-			hasAnyKey(node, "auth_flow_id", "registration_flow_id", "inbound_auth_config", "allowed_user_types") &&
+			hasAnyKey(node, "authFlowId", "registrationFlowId", "inboundAuthConfig", "allowedUserTypes") &&
 			!hasAnyKey(node, "properties")) {
 		matches = append(matches, resourceTypeAgent)
 	}
 
 	if !hasAnyKey(node, "owner") &&
 		!(hasAnyKey(node, "type") &&
-			hasAnyKey(node, "auth_flow_id", "registration_flow_id", "inbound_auth_config", "allowed_user_types") &&
+			hasAnyKey(node, "authFlowId", "registrationFlowId", "inboundAuthConfig", "allowedUserTypes") &&
 			!hasAnyKey(node, "properties")) &&
-		hasAnyKey(node, "auth_flow_id", "registration_flow_id", "inbound_auth_config", "allowed_user_types") {
+		hasAnyKey(node, "authFlowId", "registrationFlowId", "inboundAuthConfig", "allowedUserTypes") {
 		matches = append(matches, resourceTypeApplication)
 	}
 
-	if hasAllKeys(node, "name") && hasAnyKey(node, "ou_id", "ou_handle") &&
+	if hasAllKeys(node, "name") && hasAnyKey(node, "ouId", "ouHandle") &&
 		!hasAnyKey(node, "handle", "permissions", "identifier", "type", "flowType",
 			"displayName", "properties", "schema") {
 		matches = append(matches, resourceTypeGroup)
 	}
 
 	if hasAllKeys(node, "handle", "name") &&
-		!hasAnyKey(node, "flowType", "nodes", "auth_flow_id", "registration_flow_id", "inbound_auth_config") {
+		!hasAnyKey(node, "flowType", "nodes", "authFlowId", "registrationFlowId", "inboundAuthConfig") {
 		matches = append(matches, resourceTypeOrganizationUnit)
 	}
 

--- a/backend/internal/system/importer/parser_resolver_test.go
+++ b/backend/internal/system/importer/parser_resolver_test.go
@@ -27,15 +27,15 @@ import (
 )
 
 func TestResolveTemplate(t *testing.T) {
-	content := "name: test\nclient_id: {{.CLIENT_ID}}\n"
+	content := "name: test\nclientId: {{.CLIENT_ID}}\n"
 
 	resolved, err := resolveTemplate(content, map[string]interface{}{"CLIENT_ID": "abc"})
 	require.NoError(t, err)
-	assert.Contains(t, resolved, "client_id: abc")
+	assert.Contains(t, resolved, "clientId: abc")
 }
 
 func TestResolveTemplate_MissingKey(t *testing.T) {
-	content := "client_id: {{.CLIENT_ID}}\n"
+	content := "clientId: {{.CLIENT_ID}}\n"
 
 	_, err := resolveTemplate(content, map[string]interface{}{})
 	require.Error(t, err)
@@ -68,8 +68,8 @@ func TestResolveTemplate_PreservesHelperStyleLiteralExpressionWithArgs(t *testin
 }
 
 func TestResolveTemplate_ResolvesVariablesAndRangeWhilePreservingLiterals(t *testing.T) {
-	content := "client_id: {{.CLIENT_ID}}\n" +
-		"redirect_uris:\n" +
+	content := "clientId: {{.CLIENT_ID}}\n" +
+		"redirectUris:\n" +
 		"{{- range .REDIRECT_URIS}}\n" +
 		"- {{.}}\n" +
 		"{{- end}}\n" +
@@ -80,7 +80,7 @@ func TestResolveTemplate_ResolvesVariablesAndRangeWhilePreservingLiterals(t *tes
 		"REDIRECT_URIS": []string{"https://localhost:8090/console", "https://localhost:3000/callback"},
 	})
 	require.NoError(t, err)
-	assert.Contains(t, resolved, "client_id: console")
+	assert.Contains(t, resolved, "clientId: console")
 	assert.Contains(t, resolved, "- https://localhost:8090/console")
 	assert.Contains(t, resolved, "- https://localhost:3000/callback")
 	assert.Contains(t, resolved, "{{ t(signin:forms.credentials.title) }}")
@@ -103,7 +103,7 @@ func TestResolveTemplate_DoesNotCollideWithLiteralPlaceholderLookingText(t *test
 func TestParseDocuments(t *testing.T) {
 	content := strings.Join([]string{
 		"name: app-one",
-		"auth_flow_id: flow-1",
+		"authFlowId: flow-1",
 		"---",
 		"name: idp-one",
 		"type: GOOGLE",
@@ -140,12 +140,12 @@ func TestClassifyResourceType_AdditionalResources(t *testing.T) {
 		},
 		{
 			name:     "user type with organization_unit_id",
-			yamlDoc:  "id: sch-1\nname: Schema\norganization_unit_id: ou-1\nschema: '{}'\n",
+			yamlDoc:  "id: sch-1\nname: Schema\nouId: ou-1\nschema: '{}'\n",
 			expected: resourceTypeEntityType,
 		},
 		{
 			name:     "user type with ou_handle",
-			yamlDoc:  "id: sch-1\nname: Schema\nou_handle: customers\nschema: '{}'\n",
+			yamlDoc:  "id: sch-1\nname: Schema\nouHandle: customers\nschema: '{}'\n",
 			expected: resourceTypeEntityType,
 		},
 		{
@@ -156,28 +156,28 @@ func TestClassifyResourceType_AdditionalResources(t *testing.T) {
 		{name: "role", yamlDoc: "id: role-1\nname: Admin\npermissions: []\n", expected: resourceTypeRole},
 		{name: "theme", yamlDoc: "id: th-1\ndisplayName: Theme\ntheme: {}\n", expected: resourceTypeTheme},
 		{name: "layout", yamlDoc: "id: ly-1\ndisplayName: Layout\nlayout: {}\n", expected: resourceTypeLayout},
-		{name: "user", yamlDoc: "id: u-1\ntype: person\nou_id: ou-1\nattributes: {}\n", expected: resourceTypeUser},
+		{name: "user", yamlDoc: "id: u-1\ntype: person\nouId: ou-1\nattributes: {}\n", expected: resourceTypeUser},
 		{name: "translation", yamlDoc: "language: en-US\ntranslations: {}\n", expected: resourceTypeTranslation},
 		{
 			name:     "agent with owner",
-			yamlDoc:  "id: agt-1\nou_id: ou-1\ntype: default\nname: Test Agent\nowner: owner-id-1\n",
+			yamlDoc:  "id: agt-1\nouId: ou-1\ntype: default\nname: Test Agent\nowner: owner-id-1\n",
 			expected: resourceTypeAgent,
 		},
 		{
 			name: "agent with auth_flow_id is still agent not application",
-			yamlDoc: "id: agt-2\nou_id: ou-1\ntype: default\nname: OAuth Agent\n" +
-				"owner: owner-id-1\nauth_flow_id: flow-1\n",
+			yamlDoc: "id: agt-2\nouId: ou-1\ntype: default\nname: OAuth Agent\n" +
+				"owner: owner-id-1\nauthFlowId: flow-1\n",
 			expected: resourceTypeAgent,
 		},
 		{
 			name: "agent without owner but with type and auth_flow_id",
-			yamlDoc: "id: agt-3\nou_id: ou-1\ntype: default\nname: Auth Agent\n" +
-				"auth_flow_id: flow-1\n",
+			yamlDoc: "id: agt-3\nouId: ou-1\ntype: default\nname: Auth Agent\n" +
+				"authFlowId: flow-1\n",
 			expected: resourceTypeAgent,
 		},
 		{
 			name:     "application without top-level type is still application",
-			yamlDoc:  "name: app-one\nauth_flow_id: flow-1\n",
+			yamlDoc:  "name: app-one\nauthFlowId: flow-1\n",
 			expected: resourceTypeApplication,
 		},
 	}
@@ -195,7 +195,7 @@ func TestClassifyResourceType_AdditionalResources(t *testing.T) {
 func TestParseDocuments_AgentDocument(t *testing.T) {
 	content := strings.Join([]string{
 		"id: agt-1",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"type: default",
 		"name: Test Agent",
 		"owner: owner-id-1",
@@ -211,15 +211,15 @@ func TestParseDocuments_AgentDocument(t *testing.T) {
 func TestParseDocuments_AgentWithOAuthNotClassifiedAsApplication(t *testing.T) {
 	content := strings.Join([]string{
 		"id: agt-2",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"type: default",
 		"name: OAuth Agent",
 		"owner: owner-id-1",
-		"auth_flow_id: flow-1",
-		"inbound_auth_config:",
+		"authFlowId: flow-1",
+		"inboundAuthConfig:",
 		"- type: oauth2",
 		"  config:",
-		"    client_id: client-1",
+		"    clientId: client-1",
 		"",
 	}, "\n")
 
@@ -239,7 +239,7 @@ func TestParseDocuments_UsesResourceTypeComment(t *testing.T) {
 }
 
 func TestParseDocuments_UsesResourceTypeCommentWithFileHeader(t *testing.T) {
-	content := "# File: app-one.yaml\n# resource_type: application\nname: app-one\nauth_flow_id: flow-1\n"
+	content := "# File: app-one.yaml\n# resource_type: application\nname: app-one\nauthFlowId: flow-1\n"
 
 	docs, err := parseDocuments(content)
 	require.NoError(t, err)

--- a/backend/internal/system/importer/service_adapters.go
+++ b/backend/internal/system/importer/service_adapters.go
@@ -49,7 +49,7 @@ func (s *importService) resolveImportOUHandle(
 ) (string, *serviceerror.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ImportService"))
 	if ouID != "" && ouHandle != "" {
-		logger.Warn(ctx, "Both ou_id and ou_handle provided; ou_handle ignored",
+		logger.Warn(ctx, "Both ouId and ouHandle provided; ouHandle ignored",
 			log.String("resourceType", resourceType),
 			log.String("resourceID", resourceID),
 			log.String("resourceName", resourceName))
@@ -72,8 +72,8 @@ type roleDeclarativeYAML struct {
 	ID          string                     `yaml:"id"`
 	Name        string                     `yaml:"name"`
 	Description string                     `yaml:"description,omitempty"`
-	OUID        string                     `yaml:"ou_id,omitempty"`
-	OUHandle    string                     `yaml:"ou_handle,omitempty"`
+	OUID        string                     `yaml:"ouId,omitempty"`
+	OUHandle    string                     `yaml:"ouHandle,omitempty"`
 	Permissions []role.ResourcePermissions `yaml:"permissions"`
 	Assignments []role.RoleAssignment      `yaml:"assignments,omitempty"`
 }
@@ -81,8 +81,8 @@ type roleDeclarativeYAML struct {
 type userDeclarativeYAML struct {
 	ID          string                 `yaml:"id"`
 	Type        string                 `yaml:"type"`
-	OUID        string                 `yaml:"ou_id,omitempty"`
-	OUHandle    string                 `yaml:"ou_handle,omitempty"`
+	OUID        string                 `yaml:"ouId,omitempty"`
+	OUHandle    string                 `yaml:"ouHandle,omitempty"`
 	Attributes  map[string]interface{} `yaml:"attributes"`
 	Credentials map[string]interface{} `yaml:"credentials,omitempty"`
 }
@@ -91,10 +91,10 @@ type entityTypeDeclarativeYAML struct {
 	ID                    string                       `yaml:"id"`
 	Category              entitytype.TypeCategory      `yaml:"category,omitempty"`
 	Name                  string                       `yaml:"name"`
-	OUID                  string                       `yaml:"organization_unit_id,omitempty"`
-	OUHandle              string                       `yaml:"ou_handle,omitempty"`
-	AllowSelfRegistration bool                         `yaml:"allow_self_registration,omitempty"`
-	SystemAttributes      *entitytype.SystemAttributes `yaml:"system_attributes,omitempty"`
+	OUID                  string                       `yaml:"ouId,omitempty"`
+	OUHandle              string                       `yaml:"ouHandle,omitempty"`
+	AllowSelfRegistration bool                         `yaml:"allowSelfRegistration,omitempty"`
+	SystemAttributes      *entitytype.SystemAttributes `yaml:"systemAttributes,omitempty"`
 	Schema                interface{}                  `yaml:"schema"`
 }
 
@@ -382,8 +382,8 @@ func (s *importService) importGroup(
 		ID          string         `yaml:"id"`
 		Name        string         `yaml:"name"`
 		Description string         `yaml:"description,omitempty"`
-		OUID        string         `yaml:"ou_id,omitempty"`
-		OUHandle    string         `yaml:"ou_handle,omitempty"`
+		OUID        string         `yaml:"ouId,omitempty"`
+		OUHandle    string         `yaml:"ouHandle,omitempty"`
 		Members     []group.Member `yaml:"members,omitempty"`
 	}
 	if err := doc.Node.Decode(&raw); err != nil {

--- a/backend/internal/system/importer/service_test.go
+++ b/backend/internal/system/importer/service_test.go
@@ -730,7 +730,7 @@ func TestImportResources_CreateApplication(t *testing.T) {
 	svc := newTestImportService(nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauth_flow_id: flow-1\n",
+		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetRuntime},
 	})
 
@@ -749,7 +749,7 @@ func TestImportResources_UpdateApplication(t *testing.T) {
 	})
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauth_flow_id: flow-1\n",
+		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetRuntime},
 	})
 
@@ -765,7 +765,7 @@ func TestImportResources_DryRunCreateApplicationWithoutWrite(t *testing.T) {
 	svc := newTestImportService(appSvc)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauth_flow_id: flow-1\n",
+		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
 		DryRun:  true,
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetRuntime},
 	})
@@ -787,7 +787,7 @@ func TestImportResources_DryRunUpdateApplicationWithoutWrite(t *testing.T) {
 	svc := newTestImportService(appSvc)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauth_flow_id: flow-1\n",
+		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
 		DryRun:  true,
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetRuntime},
 	})
@@ -804,7 +804,7 @@ func TestImportResources_DryRunValidationFailure(t *testing.T) {
 	svc := newTestImportService(nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id:\n- app-1\nname: My App\nauth_flow_id: flow-1\n",
+		Content: "id:\n- app-1\nname: My App\nauthFlowId: flow-1\n",
 		DryRun:  true,
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetRuntime},
 	})
@@ -848,7 +848,7 @@ func TestImportResources_DefaultsToRuntimeTarget(t *testing.T) {
 	svc := newTestImportService(appSvc)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauth_flow_id: flow-1\n",
+		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
 	})
 
 	require.Nil(t, err)
@@ -865,8 +865,8 @@ func TestImportResources_PreservesExplicitFalseOptions(t *testing.T) {
 
 	falseVal := false
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauth_flow_id: flow-1\n" +
-			"---\nid: app-2\nname: My App 2\nauth_flow_id: flow-1\n",
+		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n" +
+			"---\nid: app-2\nname: My App 2\nauthFlowId: flow-1\n",
 		Options: &ImportOptions{
 			Upsert:          &falseVal,
 			ContinueOnError: &falseVal,
@@ -885,7 +885,7 @@ func TestImportResources_ApplicationAdapterNotConfigured(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauth_flow_id: flow-1\n",
+		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
 	})
 
 	require.Nil(t, err)
@@ -904,7 +904,7 @@ func TestImportResources_RoleImportIncludesAssignments(t *testing.T) {
 	content := strings.Join([]string{
 		"id: role-1",
 		"name: Admin",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"permissions:",
 		"  - resource: api",
 		"    actions:",
@@ -934,7 +934,7 @@ func TestImportResources_GroupImportIncludesMembers(t *testing.T) {
 	content := strings.Join([]string{
 		"id: group-new",
 		"name: Engineers",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"members:",
 		"  - id: user-1",
 		"    type: user",
@@ -961,7 +961,7 @@ func TestImportResources_RoleImportNoAssignments(t *testing.T) {
 	content := strings.Join([]string{
 		"id: role-new",
 		"name: Viewer",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"permissions: []",
 		"",
 	}, "\n")
@@ -983,7 +983,7 @@ func TestImportResources_RoleUpsertUpdateIncludesAssignments(t *testing.T) {
 	content := strings.Join([]string{
 		"id: role-1",
 		"name: Admin",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"permissions: []",
 		"assignments:",
 		"  - type: group",
@@ -1017,7 +1017,7 @@ func TestImportResources_RoleAssignmentFailureReturnsError(t *testing.T) {
 	content := strings.Join([]string{
 		"id: role-1",
 		"name: Admin",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"permissions: []",
 		"assignments:",
 		"  - type: group",
@@ -1039,7 +1039,7 @@ func TestImportResources_GroupImportNoMembers(t *testing.T) {
 	content := strings.Join([]string{
 		"id: group-new",
 		"name: Empty",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"",
 	}, "\n")
 
@@ -1059,7 +1059,7 @@ func TestImportResources_GroupUpsertUpdateIncludesMembers(t *testing.T) {
 	content := strings.Join([]string{
 		"id: group-1",
 		"name: Admins",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"members:",
 		"  - id: u-99",
 		"    type: user",
@@ -1091,7 +1091,7 @@ func TestImportResources_GroupMemberFailureReturnsError(t *testing.T) {
 	content := strings.Join([]string{
 		"id: group-new",
 		"name: Engineers",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"members:",
 		"  - id: u1",
 		"    type: user",
@@ -1112,7 +1112,7 @@ func TestImportResources_UserCredentialFailureRollsBackCreate(t *testing.T) {
 	content := strings.Join([]string{
 		"id: user-1",
 		"type: customer",
-		"ou_id: ou-1",
+		"ouId: ou-1",
 		"attributes:",
 		"  username: alice",
 		"credentials:",
@@ -1251,8 +1251,8 @@ func TestImportResources_ApplicationFlowReferencesAreRemappedFromFlowAlias(t *te
 		"---",
 		"# resource_type: application",
 		"name: My App",
-		"auth_flow_id: auth-flow-1",
-		"registration_flow_id: missing-registration-flow-id",
+		"authFlowId: auth-flow-1",
+		"registrationFlowId: missing-registration-flow-id",
 		"",
 	}, "\n")
 
@@ -1308,7 +1308,7 @@ func TestImportResources_EntityTypeUpsertCreatePreservesID(t *testing.T) {
 	content := strings.Join([]string{
 		"id: usrs-123",
 		"name: customer",
-		"organization_unit_id: ou-1",
+		"ouId: ou-1",
 		"schema:",
 		"  type: object",
 		"  properties: {}",
@@ -1358,7 +1358,7 @@ func TestImportResources_UpsertCreatePreservesIDsAcrossResourceTypes(t *testing.
 		"---",
 		"id: usrs-123",
 		"name: customer",
-		"organization_unit_id: ou-123",
+		"ouId: ou-123",
 		"schema:",
 		"  type: object",
 		"  properties: {}",
@@ -1420,7 +1420,7 @@ func TestImportResources_EntityTypeOUHandlePassedToService(t *testing.T) {
 	content := strings.Join([]string{
 		"id: usrs-123",
 		"name: customer",
-		"ou_handle: default",
+		"ouHandle: default",
 		"schema:",
 		"  type: object",
 		"  properties: {}",
@@ -1441,21 +1441,21 @@ func TestImportResources_StripsClientSecretForPublicClientWithNoneAuthMethod(t *
 	content := strings.Join([]string{
 		"id: app-1",
 		"name: My App",
-		"auth_flow_id: flow-1",
-		"inbound_auth_config:",
+		"authFlowId: flow-1",
+		"inboundAuthConfig:",
 		"  - type: oauth2",
 		"    config:",
-		"      client_id: app-client",
-		"      client_secret: should-be-removed",
-		"      redirect_uris:",
+		"      clientId: app-client",
+		"      clientSecret: should-be-removed",
+		"      redirectUris:",
 		"        - https://localhost:3000/callback",
-		"      grant_types:",
+		"      grantTypes:",
 		"        - authorization_code",
-		"      response_types:",
+		"      responseTypes:",
 		"        - code",
-		"      token_endpoint_auth_method: none",
-		"      pkce_required: true",
-		"      public_client: true",
+		"      tokenEndpointAuthMethod: none",
+		"      pkceRequired: true",
+		"      publicClient: true",
 		"",
 	}, "\n")
 	appSvc, resp, err := runOAuthClientSecretImport(t, content)
@@ -1473,20 +1473,20 @@ func TestImportResources_KeepsClientSecretForConfidentialClient(t *testing.T) {
 	content := strings.Join([]string{
 		"id: app-1",
 		"name: My App",
-		"auth_flow_id: flow-1",
-		"inbound_auth_config:",
+		"authFlowId: flow-1",
+		"inboundAuthConfig:",
 		"  - type: oauth2",
 		"    config:",
-		"      client_id: app-client",
-		"      client_secret: keep-me",
-		"      redirect_uris:",
+		"      clientId: app-client",
+		"      clientSecret: keep-me",
+		"      redirectUris:",
 		"        - https://localhost:3000/callback",
-		"      grant_types:",
+		"      grantTypes:",
 		"        - authorization_code",
-		"      response_types:",
+		"      responseTypes:",
 		"        - code",
-		"      token_endpoint_auth_method: client_secret_basic",
-		"      public_client: false",
+		"      tokenEndpointAuthMethod: client_secret_basic",
+		"      publicClient: false",
 		"",
 	}, "\n")
 	appSvc, resp, err := runOAuthClientSecretImport(t, content)
@@ -1526,7 +1526,7 @@ func TestImportResources_FileTargetReturnsError(t *testing.T) {
 	svc := newImportService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
-		Content: "id: app-1\nname: My App\nauth_flow_id: flow-1\n",
+		Content: "id: app-1\nname: My App\nauthFlowId: flow-1\n",
 		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true), Target: importTargetFile},
 	})
 
@@ -1551,7 +1551,7 @@ func TestDeleteResource_RemovesDeclarativeFile(t *testing.T) {
 	require.NoError(t, os.MkdirAll(resourceDir, 0o750))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(resourceDir, "app-1.yaml"),
-		[]byte("# resource_type: application\nid: app-1\nname: My App\nauth_flow_id: flow-1\n"),
+		[]byte("# resource_type: application\nid: app-1\nname: My App\nauthFlowId: flow-1\n"),
 		0o600,
 	))
 
@@ -1577,7 +1577,7 @@ func TestImportResources_ApplicationOUHandlePassedToService(t *testing.T) {
 		Content: strings.Join([]string{
 			"# resource_type: application",
 			"name: My App",
-			"ou_handle: default",
+			"ouHandle: default",
 			"",
 		}, "\n"),
 	})
@@ -1597,7 +1597,7 @@ func TestImportResources_ApplicationAuthFlowHandlePassedToService(t *testing.T) 
 		Content: strings.Join([]string{
 			"# resource_type: application",
 			"name: My App",
-			"auth_flow_handle: login-flow",
+			"authFlowHandle: login-flow",
 			"",
 		}, "\n"),
 	})
@@ -1617,8 +1617,8 @@ func TestImportResources_ApplicationRegistrationFlowHandlePassedToService(t *tes
 		Content: strings.Join([]string{
 			"# resource_type: application",
 			"name: My App",
-			"registration_flow_handle: reg-flow",
-			"is_registration_flow_enabled: true",
+			"registrationFlowHandle: reg-flow",
+			"isRegistrationFlowEnabled: true",
 			"",
 		}, "\n"),
 	})
@@ -1639,8 +1639,8 @@ func TestImportResources_ApplicationRecoveryFlowHandlePassedToService(t *testing
 		Content: strings.Join([]string{
 			"# resource_type: application",
 			"name: My App",
-			"recovery_flow_handle: recovery-flow",
-			"is_recovery_flow_enabled: true",
+			"recoveryFlowHandle: recovery-flow",
+			"isRecoveryFlowEnabled: true",
 			"",
 		}, "\n"),
 	})
@@ -1662,8 +1662,8 @@ func TestImportResources_DryRunSkipsApplicationHandleResolution(t *testing.T) {
 		Content: strings.Join([]string{
 			"# resource_type: application",
 			"name: My App",
-			"ou_handle: nonexistent-ou",
-			"auth_flow_handle: nonexistent-flow",
+			"ouHandle: nonexistent-ou",
+			"authFlowHandle: nonexistent-flow",
 			"",
 		}, "\n"),
 		DryRun: true,
@@ -1724,7 +1724,7 @@ func (f *fakeAgentService) UpdateAgent(
 }
 
 const agentYAML = "# resource_type: agent\n" +
-	"id: agent-1\ntype: default\nou_id: root\nname: Test Agent\ndescription: desc\n"
+	"id: agent-1\ntype: default\nouId: root\nname: Test Agent\ndescription: desc\n"
 
 func TestImportAgent_Create(t *testing.T) {
 	agentSvc := &fakeAgentService{existing: map[string]*agentmodel.AgentGetResponse{}}
@@ -1971,7 +1971,7 @@ func TestImportAgent_FlowAliasRemapsFlowIDs(t *testing.T) {
 			flowType:     "AUTHENTICATION",
 			agentID:      "agent-2",
 			agentName:    "Flow Agent",
-			agentFlowKey: "auth_flow_id",
+			agentFlowKey: "authFlowId",
 			getFlowID:    func(r *agentmodel.Agent) string { return r.AuthFlowID },
 		},
 		{
@@ -1982,7 +1982,7 @@ func TestImportAgent_FlowAliasRemapsFlowIDs(t *testing.T) {
 			flowType:     "REGISTRATION",
 			agentID:      "agent-3",
 			agentName:    "Reg Agent",
-			agentFlowKey: "registration_flow_id",
+			agentFlowKey: "registrationFlowId",
 			getFlowID:    func(r *agentmodel.Agent) string { return r.RegistrationFlowID },
 		},
 	}
@@ -2007,7 +2007,7 @@ func TestImportAgent_FlowAliasRemapsFlowIDs(t *testing.T) {
 				"# resource_type: agent",
 				"id: " + tc.agentID,
 				"type: default",
-				"ou_id: root",
+				"ouId: root",
 				"name: " + tc.agentName,
 				tc.agentFlowKey + ": " + tc.flowID,
 				"",
@@ -2032,15 +2032,15 @@ func TestImportAgent_StripsClientSecretForPublicAgentWithNoneAuthMethod(t *testi
 		"# resource_type: agent",
 		"id: agent-pub",
 		"type: default",
-		"ou_id: root",
+		"ouId: root",
 		"name: Public Agent",
-		"inbound_auth_config:",
+		"inboundAuthConfig:",
 		"  - type: oauth2",
 		"    config:",
-		"      client_id: pub-client",
-		"      client_secret: should-be-removed",
-		"      token_endpoint_auth_method: none",
-		"      public_client: true",
+		"      clientId: pub-client",
+		"      clientSecret: should-be-removed",
+		"      tokenEndpointAuthMethod: none",
+		"      publicClient: true",
 		"",
 	}, "\n")
 
@@ -2121,7 +2121,7 @@ func TestImportRole_OUHandleResolved(t *testing.T) {
 	content := strings.Join([]string{
 		"id: role-new",
 		"name: Viewer",
-		"ou_handle: default",
+		"ouHandle: default",
 		"permissions: []",
 		"",
 	}, "\n")
@@ -2146,7 +2146,7 @@ func TestImportRole_OUHandleNotFound(t *testing.T) {
 	content := strings.Join([]string{
 		"id: role-new",
 		"name: Viewer",
-		"ou_handle: missing",
+		"ouHandle: missing",
 		"permissions: []",
 		"",
 	}, "\n")
@@ -2170,8 +2170,8 @@ func TestImportRole_OUIDWinsOverHandle(t *testing.T) {
 	content := strings.Join([]string{
 		"id: role-new",
 		"name: Viewer",
-		"ou_id: ou-explicit",
-		"ou_handle: default",
+		"ouId: ou-explicit",
+		"ouHandle: default",
 		"permissions: []",
 		"",
 	}, "\n")
@@ -2197,7 +2197,7 @@ func TestImportGroup_OUHandleResolved(t *testing.T) {
 	content := strings.Join([]string{
 		"id: group-new",
 		"name: Engineers",
-		"ou_handle: default",
+		"ouHandle: default",
 		"",
 	}, "\n")
 
@@ -2220,7 +2220,7 @@ func TestImportGroup_OUHandleNotFound(t *testing.T) {
 	content := strings.Join([]string{
 		"id: group-new",
 		"name: Engineers",
-		"ou_handle: missing",
+		"ouHandle: missing",
 		"",
 	}, "\n")
 
@@ -2242,8 +2242,8 @@ func TestImportGroup_OUIDWinsOverHandle(t *testing.T) {
 	content := strings.Join([]string{
 		"id: group-new",
 		"name: Engineers",
-		"ou_id: ou-explicit",
-		"ou_handle: default",
+		"ouId: ou-explicit",
+		"ouHandle: default",
 		"",
 	}, "\n")
 
@@ -2268,7 +2268,7 @@ func TestImportUser_OUHandleResolved(t *testing.T) {
 	content := strings.Join([]string{
 		"id: user-new",
 		"type: person",
-		"ou_handle: default",
+		"ouHandle: default",
 		"attributes:",
 		"  username: alice",
 		"",
@@ -2296,7 +2296,7 @@ func TestImportUser_OUHandleNotFound(t *testing.T) {
 	content := strings.Join([]string{
 		"id: user-new",
 		"type: person",
-		"ou_handle: missing",
+		"ouHandle: missing",
 		"attributes:",
 		"  username: alice",
 		"",
@@ -2320,8 +2320,8 @@ func TestImportUser_OUIDWinsOverHandle(t *testing.T) {
 	content := strings.Join([]string{
 		"id: user-new",
 		"type: person",
-		"ou_id: ou-explicit",
-		"ou_handle: default",
+		"ouId: ou-explicit",
+		"ouHandle: default",
 		"attributes:",
 		"  username: alice",
 		"",
@@ -2354,7 +2354,7 @@ func TestImportResourceServer_OUHandleResolved(t *testing.T) {
 		"name: Test RS",
 		"handle: test-rs",
 		"identifier: test-rs",
-		"ou_handle: default",
+		"ouHandle: default",
 		"resources: []",
 		"",
 	}, "\n")
@@ -2384,7 +2384,7 @@ func TestImportResourceServer_OUHandleNotFound(t *testing.T) {
 		"name: Test RS",
 		"handle: test-rs",
 		"identifier: test-rs",
-		"ou_handle: missing",
+		"ouHandle: missing",
 		"resources: []",
 		"",
 	}, "\n")
@@ -2410,8 +2410,8 @@ func TestImportResourceServer_OUIDWinsOverHandle(t *testing.T) {
 		"name: Test RS",
 		"handle: test-rs",
 		"identifier: test-rs",
-		"ou_id: ou-explicit",
-		"ou_handle: default",
+		"ouId: ou-explicit",
+		"ouHandle: default",
 		"resources: []",
 		"",
 	}, "\n")
@@ -2440,7 +2440,7 @@ func TestImportResources_IDPPropertiesArePassedToService(t *testing.T) {
 		"- name: client_id",
 		"  value: my-client-id",
 		"- name: client_secret",
-		"  is_secret: true",
+		"  isSecret: true",
 		"",
 	}, "\n")
 

--- a/backend/internal/user/declarative_resource.go
+++ b/backend/internal/user/declarative_resource.go
@@ -230,7 +230,7 @@ func makeUserValidator() func(e *entity.Entity, svc entity.EntityServiceInterfac
 			return fmt.Errorf("user type is required")
 		}
 		if e.OUID == "" {
-			return fmt.Errorf("ou_id or ou_handle is required for user '%s'", e.ID)
+			return fmt.Errorf("ouId or ouHandle is required for user '%s'", e.ID)
 		}
 		if len(e.Attributes) == 0 {
 			return fmt.Errorf("user attributes are required")
@@ -262,8 +262,8 @@ func makeUserValidator() func(e *entity.Entity, svc entity.EntityServiceInterfac
 type userDeclarativeResource struct {
 	ID          string                 `yaml:"id"`
 	Type        string                 `yaml:"type"`
-	OUID        string                 `yaml:"ou_id,omitempty"`
-	OUHandle    string                 `yaml:"ou_handle,omitempty"`
+	OUID        string                 `yaml:"ouId,omitempty"`
+	OUHandle    string                 `yaml:"ouHandle,omitempty"`
 	Attributes  map[string]interface{} `yaml:"attributes"`
 	Credentials map[string]interface{} `yaml:"credentials,omitempty"` // Flexible format for YAML
 }

--- a/backend/internal/user/declarative_resource_test.go
+++ b/backend/internal/user/declarative_resource_test.go
@@ -150,7 +150,7 @@ func (suite *DeclarativeResourceTestSuite) TestParseToUser_HashesCredentials() {
 	yamlData := []byte("" +
 		"id: user-1\n" +
 		"type: person\n" +
-		"ou_id: ou-1\n" +
+		"ouId: ou-1\n" +
 		"attributes:\n" +
 		"  username: alice\n" +
 		"  email: alice@example.com\n" +
@@ -169,7 +169,7 @@ func (suite *DeclarativeResourceTestSuite) TestParseToUserWrapper() {
 	yamlData := []byte("" +
 		"id: user-1\n" +
 		"type: person\n" +
-		"ou_id: ou-1\n" +
+		"ouId: ou-1\n" +
 		"attributes:\n" +
 		"  username: alice\n" +
 		"  email: alice@example.com\n")
@@ -227,7 +227,7 @@ func (suite *DeclarativeResourceTestSuite) TestMakeUserParser_ParsesYAMLToEntity
 	userYAML := []byte("" +
 		"id: user-1\n" +
 		"type: person\n" +
-		"ou_id: ou-1\n" +
+		"ouId: ou-1\n" +
 		"attributes:\n" +
 		"  username: alice\n" +
 		"  email: alice@example.com\n" +

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -1057,7 +1057,7 @@ func (us *userService) ResolveUserOUHandle(
 ) *serviceerror.ServiceError {
 	if user.OUID != "" && user.OUHandle != "" {
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
-		logger.Warn(ctx, "Both ou_id and ou_handle provided for user; ou_handle ignored",
+		logger.Warn(ctx, "Both ouId and ouHandle provided for user; ouHandle ignored",
 			log.MaskedString(log.LoggerKeyUserID, user.ID))
 		return nil
 	}

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -3464,7 +3464,7 @@ func TestUserDeclarativeYAML_OUHandleParsed(t *testing.T) {
 	yamlData := []byte("" +
 		"id: user-1\n" +
 		"type: person\n" +
-		"ou_handle: default\n" +
+		"ouHandle: default\n" +
 		"attributes:\n" +
 		"  username: alice\n")
 

--- a/docs/content/guides/declarative-configurations/import-resources.mdx
+++ b/docs/content/guides/declarative-configurations/import-resources.mdx
@@ -7,6 +7,10 @@ description: Import declarative YAML resources into runtime stores and control m
 
 <ProductName /> provides the `POST /import` API to import declarative YAML content into runtime stores.
 
+:::note
+Declarative resource attributes use camelCase (for example `ouId`, `authFlowId`, `clientId`), matching the REST API.
+:::
+
 Use this API when you want to:
 
 - Bootstrap resources from a YAML bundle.
@@ -99,7 +103,7 @@ curl -X POST "https://localhost:8090/import" \
   -H "Authorization: Bearer <access_token>" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": "# resource_type: application\nname: Console\nauth_flow_id: {{.AUTH_FLOW_ID}}\n",
+    "content": "# resource_type: application\nname: Console\nauthFlowId: {{.AUTH_FLOW_ID}}\n",
     "variables": {
       "AUTH_FLOW_ID": "edc013d0-e893-4dc0-990c-3e1d203e005b"
     },
@@ -120,11 +124,11 @@ The following handle fields are supported:
 
 | Resource type | Handle field | Resolves to |
 |---|---|---|
-| Application | `ou_handle` | `ou_id` |
-| Application | `auth_flow_handle` | `auth_flow_id` |
-| Application | `registration_flow_handle` | `registration_flow_id` |
-| Application | `recovery_flow_handle` | `recovery_flow_id` |
-| User type | `ou_handle` | `organization_unit_id` |
+| Application | `ouHandle` | `ouId` |
+| Application | `authFlowHandle` | `authFlowId` |
+| Application | `registrationFlowHandle` | `registrationFlowId` |
+| Application | `recoveryFlowHandle` | `recoveryFlowId` |
+| User type | `ouHandle` | `ouId` |
 
 If you provide both a handle field and the corresponding ID field, the ID takes precedence and the handle is ignored.
 
@@ -135,10 +139,10 @@ If a handle cannot be resolved — because the target resource does not exist or
 ```yaml
 # resource_type: application
 name: My App
-ou_handle: default
-auth_flow_handle: default-basic-flow
-registration_flow_handle: default-registration-flow
-is_registration_flow_enabled: true
+ouHandle: default
+authFlowHandle: default-basic-flow
+registrationFlowHandle: default-registration-flow
+isRegistrationFlowEnabled: true
 ```
 
 ### Dry-Run Behavior

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -427,8 +427,8 @@ Example single file:
 ```yaml
 # resource_type: application
 name: My App
-ou_handle: default
-auth_flow_handle: default-basic-flow
+ouHandle: default
+authFlowHandle: default-basic-flow
 ---
 # resource_type: group
 name: admins

--- a/samples/apps/react-api-based-sample/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/react-api-based-sample/thunderid-config/thunderid-config.yaml
@@ -2,9 +2,9 @@
 id: 019e3a5c-04ea-7d18-8ae6-f828b1f3d60f
 category: user
 name: Customer
-ou_handle: default
-allow_self_registration: true
-system_attributes:
+ouHandle: default
+allowSelfRegistration: true
+systemAttributes:
   display: username
 schema: {
     "username": {

--- a/samples/apps/react-sdk-sample/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/react-sdk-sample/thunderid-config/thunderid-config.yaml
@@ -2,9 +2,9 @@
 id: 019e3a5c-04ea-7d18-8ae6-f828b1f3d60f
 category: user
 name: Customer
-ou_handle: default
-allow_self_registration: true
-system_attributes:
+ouHandle: default
+allowSelfRegistration: true
+systemAttributes:
   display: username
 schema: {
     "username": {
@@ -51,67 +51,67 @@ schema: {
 ---
 # resource_type: application
 id: 019e3a5c-0532-7b06-aa66-ec42ad05784e
-ou_handle: default
+ouHandle: default
 name: React SDK Sample
 description: Sample React application using ThunderID React SDK
 url: https://localhost:3000
-logo_url: emoji:🛍️
-tos_uri: https://localhost:3000/terms
-policy_uri: https://localhost:3000/privacy
+logoUrl: emoji:🛍️
+tosUri: https://localhost:3000/terms
+policyUri: https://localhost:3000/privacy
 contacts:
   - admin@example.com
-auth_flow_handle: default-basic-flow
-is_registration_flow_enabled: true
-is_recovery_flow_enabled: false
+authFlowHandle: default-basic-flow
+isRegistrationFlowEnabled: true
+isRecoveryFlowEnabled: false
 assertion:
-  validity_period: 3600
-login_consent:
-  validity_period: 0
-allowed_user_types:
+  validityPeriod: 3600
+loginConsent:
+  validityPeriod: 0
+allowedUserTypes:
   - Customer
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: {{.REACT_SDK_SAMPLE_CLIENT_ID}}
-      redirect_uris:
+      clientId: {{.REACT_SDK_SAMPLE_CLIENT_ID}}
+      redirectUris:
         {{- range .REACT_SDK_SAMPLE_REDIRECT_URIS}}
         - {{.}}
         {{- end}}
-      grant_types:
+      grantTypes:
         - authorization_code
-      response_types:
+      responseTypes:
         - code
-      token_endpoint_auth_method: none
-      pkce_required: true
-      public_client: true
-      require_pushed_authorization_requests: false
+      tokenEndpointAuthMethod: none
+      pkceRequired: true
+      publicClient: true
+      requirePushedAuthorizationRequests: false
       token:
-        access_token:
-          validity_period: 3600
-          user_attributes:
+        accessToken:
+          validityPeriod: 3600
+          userAttributes:
             - given_name
             - family_name
             - email
             - groups
             - name
-        id_token:
-          validity_period: 3600
-          user_attributes:
+        idToken:
+          validityPeriod: 3600
+          userAttributes:
             - given_name
             - family_name
             - email
             - groups
             - name
-          response_type: JWT
-      user_info:
-        response_type: JSON
-        user_attributes:
+          responseType: JWT
+      userInfo:
+        responseType: JSON
+        userAttributes:
           - given_name
           - family_name
           - email
           - groups
           - name
-      scope_claims:
+      scopeClaims:
         email:
           - email
           - email_verified

--- a/samples/apps/react-vanilla-sample/thunderid-config/basic/thunderid-config.yaml
+++ b/samples/apps/react-vanilla-sample/thunderid-config/basic/thunderid-config.yaml
@@ -2,9 +2,9 @@
 id: 019e3a5c-04ea-7d18-8ae6-f828b1f3d60f
 category: user
 name: Customer
-ou_handle: default
-allow_self_registration: true
-system_attributes:
+ouHandle: default
+allowSelfRegistration: true
+systemAttributes:
   display: username
 schema: {
     "username": {
@@ -51,70 +51,70 @@ schema: {
 ---
 # resource_type: application
 id: 019e3a5c-0500-7f3e-a66e-66fc7918c3a7
-ou_handle: default
+ouHandle: default
 name: Sample App
 description: Sample application for testing
 url: https://localhost:3000
-logo_url: emoji:🎁
-tos_uri: https://localhost:3000/terms
-policy_uri: https://localhost:3000/privacy
+logoUrl: emoji:🎁
+tosUri: https://localhost:3000/terms
+policyUri: https://localhost:3000/privacy
 contacts:
   - admin@example.com
   - support@example.com
-auth_flow_handle: default-basic-flow
-registration_flow_handle: default-basic-flow
-is_registration_flow_enabled: true
-is_recovery_flow_enabled: false
+authFlowHandle: default-basic-flow
+registrationFlowHandle: default-basic-flow
+isRegistrationFlowEnabled: true
+isRecoveryFlowEnabled: false
 assertion:
-  validity_period: 3600
-login_consent:
-  validity_period: 0
-allowed_user_types:
+  validityPeriod: 3600
+loginConsent:
+  validityPeriod: 0
+allowedUserTypes:
   - Customer
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: {{.SAMPLE_APP_CLIENT_ID}}
-      redirect_uris:
+      clientId: {{.SAMPLE_APP_CLIENT_ID}}
+      redirectUris:
         {{- range .SAMPLE_APP_REDIRECT_URIS}}
         - {{.}}
         {{- end}}
-      grant_types:
+      grantTypes:
         - authorization_code
-      response_types:
+      responseTypes:
         - code
-      token_endpoint_auth_method: none
-      pkce_required: true
-      public_client: true
-      require_pushed_authorization_requests: false
+      tokenEndpointAuthMethod: none
+      pkceRequired: true
+      publicClient: true
+      requirePushedAuthorizationRequests: false
       token:
-        access_token:
-          validity_period: 3600
-          user_attributes:
+        accessToken:
+          validityPeriod: 3600
+          userAttributes:
             - given_name
             - family_name
             - email
             - groups
-        id_token:
-          validity_period: 3600
-          user_attributes:
+        idToken:
+          validityPeriod: 3600
+          userAttributes:
             - given_name
             - family_name
             - email
             - groups
-          response_type: JWT
+          responseType: JWT
       scopes:
         - openid
         - profile
         - email
-      user_info:
-        response_type: JSON
-        user_attributes:
+      userInfo:
+        responseType: JSON
+        userAttributes:
           - given_name
           - family_name
           - email
           - groups
-      scope_claims:
+      scopeClaims:
         email:
           - email
           - email_verified

--- a/samples/apps/react-vanilla-sample/thunderid-config/multi-auth/thunderid-config.yaml
+++ b/samples/apps/react-vanilla-sample/thunderid-config/multi-auth/thunderid-config.yaml
@@ -12,9 +12,9 @@
 id: 019e3a5c-04ea-7d18-8ae6-f828b1f3d60f
 category: user
 name: Customer
-ou_handle: default
-allow_self_registration: true
-system_attributes:
+ouHandle: default
+allowSelfRegistration: true
+systemAttributes:
   display: username
 schema: {
     "username": {
@@ -75,7 +75,7 @@ properties:
     value: "{{.SAMPLE_APP_GOOGLE_CLIENT_ID}}"
   - name: client_secret
     value: "{{.SAMPLE_APP_GOOGLE_CLIENT_SECRET}}"
-    is_secret: true
+    isSecret: true
   - name: redirect_uri
     value: "{{.SAMPLE_APP_GOOGLE_REDIRECT_URI}}"
   - name: scopes
@@ -92,7 +92,7 @@ properties:
     value: "{{.SAMPLE_APP_GITHUB_CLIENT_ID}}"
   - name: client_secret
     value: "{{.SAMPLE_APP_GITHUB_CLIENT_SECRET}}"
-    is_secret: true
+    isSecret: true
   - name: redirect_uri
     value: "{{.SAMPLE_APP_GITHUB_REDIRECT_URI}}"
 
@@ -1392,70 +1392,70 @@ nodes:
 ---
 # resource_type: application
 id: 019e3a5c-0500-7f3e-a66e-66fc7918c3a7
-ou_handle: default
+ouHandle: default
 name: Sample App
 description: Sample vanilla application for testing
 url: https://localhost:3000
-logo_url: emoji:🎁
-tos_uri: https://localhost:3000/terms
-policy_uri: https://localhost:3000/privacy
+logoUrl: emoji:🎁
+tosUri: https://localhost:3000/terms
+policyUri: https://localhost:3000/privacy
 contacts:
   - admin@example.com
   - support@example.com
-auth_flow_handle: sample-vanilla-multi-auth-single-step-sms
-registration_flow_handle: sample-vanilla-multi-auth-single-step-sms
-is_registration_flow_enabled: true
-is_recovery_flow_enabled: false
+authFlowHandle: sample-vanilla-multi-auth-single-step-sms
+registrationFlowHandle: sample-vanilla-multi-auth-single-step-sms
+isRegistrationFlowEnabled: true
+isRecoveryFlowEnabled: false
 assertion:
-  validity_period: 3600
-login_consent:
-  validity_period: 0
-allowed_user_types:
+  validityPeriod: 3600
+loginConsent:
+  validityPeriod: 0
+allowedUserTypes:
   - Customer
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: {{.SAMPLE_APP_CLIENT_ID}}
-      redirect_uris:
+      clientId: {{.SAMPLE_APP_CLIENT_ID}}
+      redirectUris:
         {{- range .SAMPLE_APP_REDIRECT_URIS}}
         - {{.}}
         {{- end}}
-      grant_types:
+      grantTypes:
         - authorization_code
-      response_types:
+      responseTypes:
         - code
-      token_endpoint_auth_method: none
-      pkce_required: true
-      public_client: true
-      require_pushed_authorization_requests: false
+      tokenEndpointAuthMethod: none
+      pkceRequired: true
+      publicClient: true
+      requirePushedAuthorizationRequests: false
       token:
-        access_token:
-          validity_period: 3600
-          user_attributes:
+        accessToken:
+          validityPeriod: 3600
+          userAttributes:
             - given_name
             - family_name
             - email
             - groups
-        id_token:
-          validity_period: 3600
-          user_attributes:
+        idToken:
+          validityPeriod: 3600
+          userAttributes:
             - given_name
             - family_name
             - email
             - groups
-          response_type: JWT
+          responseType: JWT
       scopes:
         - openid
         - profile
         - email
-      user_info:
-        response_type: JSON
-        user_attributes:
+      userInfo:
+        responseType: JSON
+        userAttributes:
           - given_name
           - family_name
           - email
           - groups
-      scope_claims:
+      scopeClaims:
         email:
           - email
           - email_verified

--- a/samples/apps/wayfinder-sample/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/thunderid-config.yaml
@@ -2,9 +2,9 @@
 id: wayfinder-customer-type
 category: user
 name: Customer
-ou_handle: default
-allow_self_registration: true
-system_attributes:
+ouHandle: default
+allowSelfRegistration: true
+systemAttributes:
   display: username
 schema: {
     "username": {
@@ -48,9 +48,9 @@ schema: {
 id: wayfinder-staff-type
 category: user
 name: Staff
-ou_handle: default
-allow_self_registration: false
-system_attributes:
+ouHandle: default
+allowSelfRegistration: false
+systemAttributes:
   display: username
 schema: {
     "username": {
@@ -85,7 +85,7 @@ id: wayfinder-agent-rs
 name: Wayfinder Agent
 description: Controls access to the Wayfinder Concierge agent
 identifier: wayfinder-agent
-ou_handle: default
+ouHandle: default
 delimiter: ":"
 resources:
   - name: Agent
@@ -105,7 +105,7 @@ description: Protects the Wayfinder booking domain — same scopes guard the RES
 # MCP Inspector reads that metadata and passes the value back as resource=...
 # on /token; Thunder rejects with invalid_target unless this identifier matches.
 identifier: http://localhost:8787/mcp
-ou_handle: default
+ouHandle: default
 delimiter: ":"
 resources:
   - name: Booking
@@ -844,52 +844,52 @@ nodes:
 id: wayfinder-app
 name: Wayfinder
 description: Wayfinder Travel sample application
-ou_handle: default
+ouHandle: default
 url: http://localhost:5173
-logo_url: "emoji:✈️"
-registration_flow_handle: wayfinder-registration-flow
-recovery_flow_handle: wayfinder-recovery-flow
-is_registration_flow_enabled: true
-is_recovery_flow_enabled: true
+logoUrl: "emoji:✈️"
+registrationFlowHandle: wayfinder-registration-flow
+recoveryFlowHandle: wayfinder-recovery-flow
+isRegistrationFlowEnabled: true
+isRecoveryFlowEnabled: true
 assertion:
-  validity_period: 3600
-  user_attributes:
+  validityPeriod: 3600
+  userAttributes:
     - given_name
     - family_name
     - email
     - groups
     - username
-allowed_user_types:
+allowedUserTypes:
   - Customer
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: "{{.WAYFINDER_CLIENT_ID}}"
-      redirect_uris:
+      clientId: "{{.WAYFINDER_CLIENT_ID}}"
+      redirectUris:
         - http://localhost:5173
-      grant_types:
+      grantTypes:
         - authorization_code
-      response_types:
+      responseTypes:
         - code
-      token_endpoint_auth_method: none
-      pkce_required: true
-      public_client: true
+      tokenEndpointAuthMethod: none
+      pkceRequired: true
+      publicClient: true
       token:
-        access_token:
-          validity_period: 3600
-          user_attributes:
+        accessToken:
+          validityPeriod: 3600
+          userAttributes:
             - given_name
             - family_name
             - email
             - groups
-        id_token:
-          validity_period: 3600
-          user_attributes:
+        idToken:
+          validityPeriod: 3600
+          userAttributes:
             - given_name
             - family_name
             - email
             - groups
-      scope_claims:
+      scopeClaims:
         email:
           - email
         profile:
@@ -1448,29 +1448,29 @@ nodes:
 id: wayfinder-concierge
 name: WAYFINDER-CONCIERGE
 description: Wayfinder Concierge AI agent for the Wayfinder Travel sample
-ou_handle: default
+ouHandle: default
 type: default
-logo_url: "emoji:✈️"
-auth_flow_handle: wayfinder-agent-auth-flow
-inbound_auth_config:
+logoUrl: "emoji:✈️"
+authFlowHandle: wayfinder-agent-auth-flow
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: "{{.AGENT_CLIENT_ID}}"
-      client_secret: "{{.AGENT_CLIENT_SECRET}}"
-      redirect_uris:
+      clientId: "{{.AGENT_CLIENT_ID}}"
+      clientSecret: "{{.AGENT_CLIENT_SECRET}}"
+      redirectUris:
         - http://localhost:5173/agent-callback
-      grant_types:
+      grantTypes:
         - client_credentials
         - authorization_code
-      response_types:
+      responseTypes:
         - code
-      token_endpoint_auth_method: client_secret_basic
-      pkce_required: false
-      public_client: false
+      tokenEndpointAuthMethod: client_secret_basic
+      pkceRequired: false
+      publicClient: false
       token:
-        access_token:
-          validity_period: 3600
-          user_attributes:
+        accessToken:
+          validityPeriod: 3600
+          userAttributes:
             - email
 
 ---
@@ -1484,26 +1484,26 @@ inbound_auth_config:
 id: wayfinder-upgrade-agent
 name: WAYFINDER-UPGRADE-AGENT
 description: Upgrade scheduler agent — initiates CIBA for users with pending flight upgrade requests
-ou_handle: default
+ouHandle: default
 type: default
-logo_url: "emoji:✈️"
-auth_flow_handle: wayfinder-ciba-email-flow
-allowed_user_types:
+logoUrl: "emoji:✈️"
+authFlowHandle: wayfinder-ciba-email-flow
+allowedUserTypes:
   - Customer
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: "{{.UPGRADE_AGENT_CLIENT_ID}}"
-      client_secret: "{{.UPGRADE_AGENT_CLIENT_SECRET}}"
-      grant_types:
+      clientId: "{{.UPGRADE_AGENT_CLIENT_ID}}"
+      clientSecret: "{{.UPGRADE_AGENT_CLIENT_SECRET}}"
+      grantTypes:
         - client_credentials
         - urn:openid:params:grant-type:ciba
-      token_endpoint_auth_method: client_secret_basic
-      public_client: false
+      tokenEndpointAuthMethod: client_secret_basic
+      publicClient: false
       token:
-        access_token:
-          validity_period: 3600
-          user_attributes:
+        accessToken:
+          validityPeriod: 3600
+          userAttributes:
             - given_name
             - family_name
             - email
@@ -1518,42 +1518,42 @@ inbound_auth_config:
 id: external-mcp-client
 name: External MCP Client
 description: Public OAuth client for external MCP clients connecting to the Wayfinder MCP server.
-ou_handle: default
+ouHandle: default
 url: http://localhost:8787/mcp
 # Reuse the Concierge's auth flow so the OAuth consent screen surfaces the
 # requested booking:* scopes during the MCP Authorization tryout. Without
 # this, Thunder falls back to the default sign-in-only flow and no consent
 # step is shown.
-auth_flow_handle: wayfinder-agent-auth-flow
-allowed_user_types:
+authFlowHandle: wayfinder-agent-auth-flow
+allowedUserTypes:
   - Customer
-inbound_auth_config:
+inboundAuthConfig:
   - type: oauth2
     config:
-      client_id: EXTERNAL-MCP-CLIENT
-      redirect_uris:
+      clientId: EXTERNAL-MCP-CLIENT
+      redirectUris:
         - http://localhost:6274/oauth/callback/debug
         - http://localhost:6274/oauth/callback
-      grant_types:
+      grantTypes:
         - authorization_code
         - refresh_token
-      response_types:
+      responseTypes:
         - code
-      token_endpoint_auth_method: none
-      pkce_required: true
-      public_client: true
+      tokenEndpointAuthMethod: none
+      pkceRequired: true
+      publicClient: true
       token:
-        access_token:
-          validity_period: 3600
+        accessToken:
+          validityPeriod: 3600
 
 ---
 # resource_type: role
 id: wayfinder-traveler-role
 name: Traveler
 description: Consumer role with full booking permissions
-ou_handle: default
+ouHandle: default
 permissions:
-  - resource_server_id: wayfinder-booking-rs
+  - resourceServerId: wayfinder-booking-rs
     permissions:
       - booking:read
       - booking:create
@@ -1569,21 +1569,21 @@ assignments:
 id: wayfinder-support-role
 name: Support
 description: Staff role for consumer support workflows
-ou_handle: default
+ouHandle: default
 
 ---
 # resource_type: role
 id: wayfinder-destinations-admin-role
 name: DestinationsAdmin
 description: Staff role for curating featured destinations
-ou_handle: default
+ouHandle: default
 
 ---
 # resource_type: role
 id: wayfinder-ops-admin-role
 name: OpsAdmin
 description: Staff role for inviting and managing other staff
-ou_handle: default
+ouHandle: default
 assignments:
   - id: wayfinder-alex-carter
     type: user
@@ -1593,12 +1593,12 @@ assignments:
 id: chat-user-role
 name: Chat User
 description: Grants access to use the Wayfinder Concierge agent and request flight upgrades through it
-ou_handle: default
+ouHandle: default
 permissions:
-  - resource_server_id: wayfinder-agent-rs
+  - resourceServerId: wayfinder-agent-rs
     permissions:
       - agent:access
-  - resource_server_id: wayfinder-booking-rs
+  - resourceServerId: wayfinder-booking-rs
     permissions:
       - booking:upgrade
       - upgrade:process
@@ -1611,9 +1611,9 @@ assignments:
 id: booking-user-role
 name: Booking User
 description: Grants booking permissions for the Wayfinder sample
-ou_handle: default
+ouHandle: default
 permissions:
-  - resource_server_id: wayfinder-booking-rs
+  - resourceServerId: wayfinder-booking-rs
     permissions:
       - booking:read
       - booking:create
@@ -1629,9 +1629,9 @@ assignments:
 id: recommender-role
 name: Recommender
 description: Grants access to booking:recommend and upgrade:search permissions, assigned to the Wayfinder Concierge agent
-ou_handle: default
+ouHandle: default
 permissions:
-  - resource_server_id: wayfinder-booking-rs
+  - resourceServerId: wayfinder-booking-rs
     permissions:
       - booking:recommend
       - upgrade:search
@@ -1644,9 +1644,9 @@ assignments:
 id: upgrade-scheduler-role
 name: Upgrade Scheduler
 description: Grants upgrade:read to the upgrade scheduler agent so its M2M token can list pending upgrade requests
-ou_handle: default
+ouHandle: default
 permissions:
-  - resource_server_id: wayfinder-booking-rs
+  - resourceServerId: wayfinder-booking-rs
     permissions:
       - upgrade:read
       - upgrade:search
@@ -1658,7 +1658,7 @@ assignments:
 # resource_type: user
 id: wayfinder-john-doe
 type: Customer
-ou_handle: default
+ouHandle: default
 attributes:
   username: john.doe
   given_name: John
@@ -1672,7 +1672,7 @@ credentials:
 # resource_type: user
 id: wayfinder-jane-smith
 type: Customer
-ou_handle: default
+ouHandle: default
 attributes:
   username: jane.smith
   given_name: Jane
@@ -1686,7 +1686,7 @@ credentials:
 # resource_type: user
 id: wayfinder-alex-carter
 type: Staff
-ou_handle: default
+ouHandle: default
 attributes:
   username: alex.carter
   email: alex.carter@example.com

--- a/tests/integration/agent/agent_import_export_test.go
+++ b/tests/integration/agent/agent_import_export_test.go
@@ -160,7 +160,7 @@ func (s *AgentImportExportSuite) TestExportImportRoundTrip_EntityOnlyAgent() {
 
 	s.Assert().Contains(yamlContent, "# resource_type: agent")
 	s.Assert().Contains(yamlContent, "id: "+createdID)
-	s.Assert().Contains(yamlContent, "ou_id: "+s.ouID)
+	s.Assert().Contains(yamlContent, "ouId: "+s.ouID)
 	s.Assert().Contains(yamlContent, "name: "+agentName)
 	s.Assert().Contains(yamlContent, "description: Round-trip entity-only agent")
 
@@ -235,8 +235,8 @@ func (s *AgentImportExportSuite) TestExportImportRoundTrip_AgentWithConfidential
 	}
 
 	vars := s.extractTemplateVariables(yamlContent, map[string]interface{}{
-		"client_id":     clientID,
-		"client_secret": clientSecret,
+		"clientId":     clientID,
+		"clientSecret": clientSecret,
 	})
 
 	s.Require().NoError(s.deleteAgent(createdID))
@@ -339,25 +339,25 @@ func (s *AgentImportExportSuite) TestExportImportRoundTrip_AgentWithAllFields() 
 	// Assert every significant field appears in the exported YAML.
 	s.Assert().Contains(yamlContent, "# resource_type: agent")
 	s.Assert().Contains(yamlContent, "id: "+createdID)
-	s.Assert().Contains(yamlContent, "ou_id: "+s.ouID)
+	s.Assert().Contains(yamlContent, "ouId: "+s.ouID)
 	s.Assert().Contains(yamlContent, "name: "+agentName)
 	s.Assert().Contains(yamlContent, "description: Round-trip all-fields agent")
-	s.Assert().Contains(yamlContent, "auth_flow_id: "+s.authFlowID)
-	s.Assert().Contains(yamlContent, "registration_flow_id: "+s.registrationFlowID)
-	s.Assert().Contains(yamlContent, "is_registration_flow_enabled: true")
+	s.Assert().Contains(yamlContent, "authFlowId: "+s.authFlowID)
+	s.Assert().Contains(yamlContent, "registrationFlowId: "+s.registrationFlowID)
+	s.Assert().Contains(yamlContent, "isRegistrationFlowEnabled: true")
 	s.Assert().Contains(yamlContent, "attributes:")
 	s.Assert().Contains(yamlContent, "eng-team")
-	s.Assert().Contains(yamlContent, "inbound_auth_config:")
+	s.Assert().Contains(yamlContent, "inboundAuthConfig:")
 	s.Assert().Contains(yamlContent, "client_credentials")
-	s.Assert().Contains(yamlContent, "token_endpoint_auth_method: client_secret_basic")
+	s.Assert().Contains(yamlContent, "tokenEndpointAuthMethod: client_secret_basic")
 	s.Assert().NotContains(yamlContent, clientSecret, "client secret must not appear in exported YAML")
 	s.Assert().Contains(yamlContent, "{{", "client_id should be parameterized")
 
 	s.Require().NoError(s.deleteAgent(createdID))
 
 	vars := s.extractTemplateVariables(yamlContent, map[string]interface{}{
-		"client_id":     clientID,
-		"client_secret": clientSecret,
+		"clientId":     clientID,
+		"clientSecret": clientSecret,
 	})
 
 	importResp, err := s.importAgents(agentImportRequest{

--- a/tests/integration/application/application_api_test.go
+++ b/tests/integration/application/application_api_test.go
@@ -759,7 +759,7 @@ func (ts *ApplicationAPITestSuite) TestApplicationCreationWithInvalidTokenEndpoi
 
 	appID, err := createApplication(appWithEmptyAuthMethod)
 	if err != nil {
-		ts.T().Fatalf("Failed to create application with empty token_endpoint_auth_method: %v", err)
+		ts.T().Fatalf("Failed to create application with empty tokenEndpointAuthMethod: %v", err)
 	}
 
 	req, err := http.NewRequest("GET", testServerURL+"/applications/"+appID, nil)

--- a/tests/integration/application/application_import_export_test.go
+++ b/tests/integration/application/application_import_export_test.go
@@ -205,31 +205,31 @@ func (s *ApplicationImportExportSuite) TestExportImportRoundTrip_ConfidentialOAu
 
 	s.Assert().Contains(yamlContent, "# resource_type: application")
 	s.Assert().Contains(yamlContent, "id: "+createdID)
-	s.Assert().Contains(yamlContent, "ou_id: "+s.ouID)
+	s.Assert().Contains(yamlContent, "ouId: "+s.ouID)
 	s.Assert().Contains(yamlContent, "name: "+appName)
 	s.Assert().Contains(yamlContent, "description: Round-trip confidential application")
 	s.Assert().Contains(yamlContent, "template: web")
 
 	// Inline-embedded fields appear at the top level (flattened, not nested).
-	s.Assert().Contains(yamlContent, "auth_flow_id: "+s.authFlowID)
-	s.Assert().Contains(yamlContent, "registration_flow_id: "+s.registrationFlowID)
-	s.Assert().Contains(yamlContent, "is_registration_flow_enabled: true")
+	s.Assert().Contains(yamlContent, "authFlowId: "+s.authFlowID)
+	s.Assert().Contains(yamlContent, "registrationFlowId: "+s.registrationFlowID)
+	s.Assert().Contains(yamlContent, "isRegistrationFlowEnabled: true")
 	s.Assert().Contains(yamlContent, "assertion:")
-	s.Assert().Contains(yamlContent, "validity_period: 3600")
-	s.Assert().Contains(yamlContent, "login_consent:")
-	s.Assert().Contains(yamlContent, "validity_period: 86400")
-	s.Assert().Contains(yamlContent, "inbound_auth_config:")
+	s.Assert().Contains(yamlContent, "validityPeriod: 3600")
+	s.Assert().Contains(yamlContent, "loginConsent:")
+	s.Assert().Contains(yamlContent, "validityPeriod: 86400")
+	s.Assert().Contains(yamlContent, "inboundAuthConfig:")
 	s.Assert().Contains(yamlContent, "authorization_code")
-	s.Assert().Contains(yamlContent, "token_endpoint_auth_method: client_secret_basic")
+	s.Assert().Contains(yamlContent, "tokenEndpointAuthMethod: client_secret_basic")
 	s.Assert().NotContains(yamlContent, "app-rt-conf-secret-"+s.handleSuffix)
 	s.Assert().Contains(yamlContent, "{{")
 
 	s.Require().NoError(deleteApplication(createdID))
 
 	vars := s.extractTemplateVariables(yamlContent, map[string]interface{}{
-		"client_id":     "app-rt-conf-client-" + s.handleSuffix,
-		"client_secret": "app-rt-conf-secret-" + s.handleSuffix,
-		"redirect_uris": []string{"https://app-rt-conf.example.com/callback"},
+		"clientId":     "app-rt-conf-client-" + s.handleSuffix,
+		"clientSecret": "app-rt-conf-secret-" + s.handleSuffix,
+		"redirectUris": []string{"https://app-rt-conf.example.com/callback"},
 	})
 
 	importResp, err := s.importApps(appImportRequest{
@@ -344,24 +344,24 @@ func (s *ApplicationImportExportSuite) TestExportImportRoundTrip_PublicClientAut
 			"exported YAML must not contain a bare `:` key")
 	}
 
-	s.Assert().Contains(yamlContent, "auth_flow_id: "+s.authFlowID)
-	s.Assert().Contains(yamlContent, "public_client: true")
-	s.Assert().Contains(yamlContent, "pkce_required: true")
-	s.Assert().Contains(yamlContent, "token_endpoint_auth_method: none")
-	s.Assert().Contains(yamlContent, "redirect_uris:")
+	s.Assert().Contains(yamlContent, "authFlowId: "+s.authFlowID)
+	s.Assert().Contains(yamlContent, "publicClient: true")
+	s.Assert().Contains(yamlContent, "pkceRequired: true")
+	s.Assert().Contains(yamlContent, "tokenEndpointAuthMethod: none")
+	s.Assert().Contains(yamlContent, "redirectUris:")
 	s.Assert().Contains(yamlContent, "{{- range .",
 		"redirect_uris should be parameterized as a template range")
 
 	// Public client carve-out: ClientSecret variable is omitted, literal client_id is replaced.
 	s.Assert().NotContains(strings.ToLower(yamlContent), "client_secret")
-	s.Assert().NotContains(yamlContent, "client_id: "+clientIDLiteral)
+	s.Assert().NotContains(yamlContent, "clientId: "+clientIDLiteral)
 	s.Assert().Contains(yamlContent, "{{")
 
 	s.Require().NoError(deleteApplication(createdID))
 
 	vars := s.extractTemplateVariables(yamlContent, map[string]interface{}{
-		"client_id":     clientIDLiteral,
-		"redirect_uris": []string{redirectURI},
+		"clientId":     clientIDLiteral,
+		"redirectUris": []string{redirectURI},
 	})
 	importResp, err := s.importApps(appImportRequest{
 		Content:   yamlContent,
@@ -479,8 +479,8 @@ func (s *ApplicationImportExportSuite) importApps(reqBody appImportRequest) (*ap
 // extractTemplateVariables walks the exported YAML and discovers the variable names emitted
 // by the parameterizer. It handles two forms:
 //
-//  1. Scalar:   client_id: {{.X_CLIENT_ID}}
-//  2. Array:    redirect_uris:
+//  1. Scalar:   clientId: {{.X_CLIENT_ID}}
+//  2. Array:    redirectUris:
 //                 {{- range .X_REDIRECT_URIS}}
 //                 - {{.}}
 //                 {{- end}}

--- a/tests/integration/declarativesinglefile/single_file_mode_test.go
+++ b/tests/integration/declarativesinglefile/single_file_mode_test.go
@@ -70,13 +70,13 @@ type: GITHUB
 properties:
   - name: client_id
     value: {{.SF_TEST_GITHUB_CLIENT_ID}}
-    is_secret: false
+    isSecret: false
   - name: client_secret
     value: sf-test-github-secret
-    is_secret: true
+    isSecret: true
   - name: redirect_uri
     value: https://localhost:8095/callback
-    is_secret: false
+    isSecret: false
 ---
 # resource_type: identity_provider
 id: sf-decl-idp-2
@@ -86,13 +86,13 @@ type: GOOGLE
 properties:
   - name: client_id
     value: sf-test-google-client
-    is_secret: false
+    isSecret: false
   - name: client_secret
     value: sf-test-google-secret
-    is_secret: true
+    isSecret: true
   - name: redirect_uri
     value: https://localhost:8095/callback
-    is_secret: false
+    isSecret: false
 `
 
 // envVars are set in the test process before the server starts so they are inherited

--- a/tests/integration/export/export_api_test.go
+++ b/tests/integration/export/export_api_test.go
@@ -113,7 +113,7 @@ func (ts *ExportAPITestSuite) TestApplicationExportYAML() {
 	// Verify the exported YAML content
 	ts.Assert().Contains(yamlContent, "name: Export Test App")
 	ts.Assert().Contains(yamlContent, "description: Test application for export functionality")
-	ts.Assert().Contains(yamlContent, "client_id: {{.EXPORT_TEST_APP_CLIENT_ID}}")
+	ts.Assert().Contains(yamlContent, "clientId: {{.EXPORT_TEST_APP_CLIENT_ID}}")
 	ts.Assert().NotContains(yamlContent, "export_test_secret") // Client secret should not be exported
 	ts.Assert().Contains(yamlContent, "# File: Export_Test_App.yaml")
 
@@ -214,7 +214,7 @@ func (ts *ExportAPITestSuite) TestIdentityProviderExportYAML() {
 	ts.Assert().Contains(yamlContent, "value: {{.EXPORT_TEST_IDP_CLIENT_ID}}")
 	ts.Assert().Contains(yamlContent, "name: client_secret")
 	ts.Assert().Contains(yamlContent, "value: {{.EXPORT_TEST_IDP_CLIENT_SECRET}}")
-	ts.Assert().Contains(yamlContent, "is_secret: true")
+	ts.Assert().Contains(yamlContent, "isSecret: true")
 	ts.Assert().Contains(yamlContent, "# File: Export_Test_IDP.yaml")
 }
 
@@ -530,7 +530,7 @@ func (ts *ExportAPITestSuite) TestIdentityProviderExportWithProperties() {
 	ts.Assert().Contains(yamlContent, "name: scopes")
 	ts.Assert().Contains(yamlContent, "value: {{.PROPERTIES_TEST_IDP_SCOPES}}")
 	// Verify is_secret flag is preserved
-	ts.Assert().Contains(yamlContent, "is_secret: true")
+	ts.Assert().Contains(yamlContent, "isSecret: true")
 }
 
 // TestExportWithInvalidIdentityProviderID tests export with invalid IDP ID.

--- a/tests/integration/importexport/import_export_fresh_pack_test.go
+++ b/tests/integration/importexport/import_export_fresh_pack_test.go
@@ -575,7 +575,7 @@ func (s *GroupRoleResourceImportExportSuite) TestGroupExportIncludesMembers() {
 
 	// Verify exported YAML contains expected group fields
 	s.Assert().Contains(yamlContent, "name: Export Members Group "+s.handleSuffix)
-	s.Assert().Contains(yamlContent, "ou_id: "+s.ouID)
+	s.Assert().Contains(yamlContent, "ouId: "+s.ouID)
 	s.Assert().Contains(yamlContent, "members:")
 	s.Assert().Contains(yamlContent, "id: "+s.userID)
 	s.Assert().Contains(yamlContent, "type: user")
@@ -633,7 +633,7 @@ func (s *GroupRoleResourceImportExportSuite) TestImportGroupWithMembers() {
 
 	yamlContent := fmt.Sprintf(`name: %s
 description: Imported group with a member
-ou_id: %s
+ouId: %s
 members:
   - id: %s
     type: user
@@ -675,7 +675,7 @@ func (s *GroupRoleResourceImportExportSuite) TestImportGroupWithoutMembers() {
 
 	yamlContent := fmt.Sprintf(`name: %s
 description: Imported group without members
-ou_id: %s
+ouId: %s
 `, groupName, s.ouID)
 
 	resp, err := s.importResources(importRequest{
@@ -716,7 +716,7 @@ func (s *GroupRoleResourceImportExportSuite) TestImportGroupUpsertUpdateWithMemb
 	yamlContent := fmt.Sprintf(`id: %s
 name: Upsert Members Group %s
 description: Updated via import
-ou_id: %s
+ouId: %s
 members:
   - id: %s
     type: user
@@ -762,7 +762,7 @@ func (s *GroupRoleResourceImportExportSuite) TestImportRoleWithAssignmentsCreate
 
 	yamlContent := fmt.Sprintf(`name: %s
 description: Imported role with group assignment
-ou_id: %s
+ouId: %s
 permissions: []
 assignments:
   - id: %s
@@ -823,7 +823,7 @@ func (s *GroupRoleResourceImportExportSuite) TestImportRoleWithAssignmentsUpdate
 	yamlContent := fmt.Sprintf(`id: %s
 name: Upsert Role %s
 description: Updated via import with assignment
-ou_id: %s
+ouId: %s
 permissions: []
 assignments:
   - id: %s
@@ -868,7 +868,7 @@ func (s *GroupRoleResourceImportExportSuite) TestImportRoleNoAssignments() {
 
 	yamlContent := fmt.Sprintf(`name: %s
 description: Imported role without assignments
-ou_id: %s
+ouId: %s
 permissions: []
 `, roleName, s.ouID)
 
@@ -906,7 +906,7 @@ func (s *GroupRoleResourceImportExportSuite) TestImportResourceServerWithNestedR
 name: Nested Resource Server %s
 description: Resource server with nested resources
 handle: %s
-ou_id: %s
+ouId: %s
 delimiter: ":"
 resources:
   - name: Parent Resource
@@ -981,7 +981,7 @@ func (s *GroupRoleResourceImportExportSuite) TestImportResourceServerUpsertNeste
 %sname: Upsert Resource Server %s
 description: Resource server for upsert test
 handle: %s
-ou_id: %s
+ouId: %s
 delimiter: ":"
 resources:
   - name: Upsert Parent

--- a/tests/integration/resources/declarative_resources/agents/agent-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/agents/agent-declarative-1.yaml
@@ -1,9 +1,9 @@
 id: decl-agent-1
-ou_id: decl-ou-1
+ouId: decl-ou-1
 type: default
 name: Declarative Test Agent
 description: A declarative test agent for integration testing
-auth_flow_id: decl-flow-1
+authFlowId: decl-flow-1
 attributes:
   department: engineering
   environment: test

--- a/tests/integration/resources/declarative_resources/agents/agent-declarative-confidential.yaml
+++ b/tests/integration/resources/declarative_resources/agents/agent-declarative-confidential.yaml
@@ -1,15 +1,15 @@
 id: decl-agent-confidential-1
-ou_id: decl-ou-1
+ouId: decl-ou-1
 type: default
 name: Declarative Confidential Test Agent
 description: A declarative confidential test agent for integration testing
-auth_flow_id: decl-flow-1
-inbound_auth_config:
+authFlowId: decl-flow-1
+inboundAuthConfig:
   - type: "oauth2"
     config:
-      client_id: "decl-agent-conf-client-1"
-      client_secret: "decl-agent-conf-secret-1"
-      grant_types:
+      clientId: "decl-agent-conf-client-1"
+      clientSecret: "decl-agent-conf-secret-1"
+      grantTypes:
         - "client_credentials"
-      token_endpoint_auth_method: "client_secret_basic"
-      public_client: false
+      tokenEndpointAuthMethod: "client_secret_basic"
+      publicClient: false

--- a/tests/integration/resources/declarative_resources/applications/app-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/applications/app-declarative-1.yaml
@@ -1,24 +1,24 @@
 id: decl-app-1
 name: Declarative Test Application
 description: A declarative test application for integration testing
-ou_id: decl-ou-1
+ouId: decl-ou-1
 template: web
-auth_flow_id: decl-flow-1
-registration_flow_id: decl-reg-flow-1
-recovery_flow_id: decl-recovery-flow-1
+authFlowId: decl-flow-1
+registrationFlowId: decl-reg-flow-1
+recoveryFlowId: decl-recovery-flow-1
 url: https://example.com
 contacts:
   - test@example.com
-inbound_auth_config:
+inboundAuthConfig:
   - type: "oauth2"
     config:
-      client_id: "decl-public-client-1"
-      redirect_uris:
+      clientId: "decl-public-client-1"
+      redirectUris:
         - "https://localhost:3000"
-      grant_types:
+      grantTypes:
         - "authorization_code"
-      response_types:
+      responseTypes:
         - "code"
-      token_endpoint_auth_method: "none"
-      pkce_required: true
-      public_client: true
+      tokenEndpointAuthMethod: "none"
+      pkceRequired: true
+      publicClient: true

--- a/tests/integration/resources/declarative_resources/applications/app-declarative-confidential.yaml
+++ b/tests/integration/resources/declarative_resources/applications/app-declarative-confidential.yaml
@@ -1,26 +1,26 @@
 id: decl-app-confidential-1
 name: Declarative Test Confidential Application
 description: A declarative confidential test application for integration testing
-ou_id: decl-ou-1
+ouId: decl-ou-1
 template: web
-auth_flow_id: decl-flow-1
-registration_flow_id: decl-reg-flow-1
-recovery_flow_id: decl-recovery-flow-1
+authFlowId: decl-flow-1
+registrationFlowId: decl-reg-flow-1
+recoveryFlowId: decl-recovery-flow-1
 url: https://example.com
 contacts:
   - test@example.com
-inbound_auth_config:
+inboundAuthConfig:
   - type: "oauth2"
     config:
-      client_id: "decl-conf-client-1"
-      client_secret: "decl-conf-secret-1"
-      redirect_uris:
+      clientId: "decl-conf-client-1"
+      clientSecret: "decl-conf-secret-1"
+      redirectUris:
         - "https://localhost:3000"
-      grant_types:
+      grantTypes:
         - "authorization_code"
         - "client_credentials"
-      response_types:
+      responseTypes:
         - "code"
-      token_endpoint_auth_method: "client_secret_basic"
-      pkce_required: false
-      public_client: false
+      tokenEndpointAuthMethod: "client_secret_basic"
+      pkceRequired: false
+      publicClient: false

--- a/tests/integration/resources/declarative_resources/identity_providers/idp-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/identity_providers/idp-declarative-1.yaml
@@ -5,10 +5,10 @@ type: GOOGLE
 properties:
   - name: client_id
     value: test-client-id
-    is_secret: false
+    isSecret: false
   - name: client_secret
     value: test-client-secret
-    is_secret: true
+    isSecret: true
   - name: redirect_uri
     value: https://localhost:8095/callback
-    is_secret: false
+    isSecret: false

--- a/tests/integration/resources/declarative_resources/resource_servers/resource-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/resource_servers/resource-declarative-1.yaml
@@ -2,7 +2,7 @@ id: decl-rs-1
 name: Declarative Resource Server
 description: A declarative test resource server
 handle: decl-rs-1
-ou_id: decl-ou-1
+ouId: decl-ou-1
 delimiter: ":"
 resources:
   - name: Test Resource

--- a/tests/integration/resources/declarative_resources/roles/role-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/roles/role-declarative-1.yaml
@@ -1,6 +1,6 @@
 id: decl-role-1
 name: Declarative Test Role
 description: A declarative test role for integration testing
-ou_id: decl-ou-1
+ouId: decl-ou-1
 permissions: []
 assignments: []

--- a/tests/integration/resources/declarative_resources/user_types/usertype-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/user_types/usertype-declarative-1.yaml
@@ -1,8 +1,8 @@
 id: decl-schema-1
 name: Declarative Test Schema
-organization_unit_id: decl-ou-1
-allow_self_registration: false
-system_attributes:
+ouId: decl-ou-1
+allowSelfRegistration: false
+systemAttributes:
   display: "username"
 schema: |
   {

--- a/tests/integration/resources/declarative_resources/users/user-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/users/user-declarative-1.yaml
@@ -1,6 +1,6 @@
 id: decl-user-1
 type: person
-ou_id: decl-ou-1
+ouId: decl-ou-1
 attributes:
   username: decl-user-1
   email: decl-user-1@example.com


### PR DESCRIPTION
### Purpose

Declarative resources are YAML files that ThunderID loads at startup, such as applications, agents, identity providers, roles, and users. Until now most of these files used snake_case attribute names (for example `client_id`, `redirect_uris`, `auth_flow_id`), while the REST API used camelCase for the exact same fields (`clientId`, `redirectUris`, `authFlowId`). That meant a single field had two different names depending on whether you created the resource through the API or through a declarative file.

The declarative files were also inconsistent with each other. Flows and themes already used camelCase, while applications, agents, identity providers, roles, and users still used snake_case.

This PR moves every declarative resource attribute to camelCase so that declarative files line up with the REST API and with each other.

Fixes #3302

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
Declarative resource attribute names changed from snake_case to camelCase. For example `ou_id` becomes `ouId`, `auth_flow_id` becomes `authFlowId`, `inbound_auth_config` becomes `inboundAuthConfig`, and `client_id` becomes `clientId`. The old snake_case names are no longer accepted.

#### 💥 Impact
Anyone with existing declarative YAML files (mounted resources, single-file bundles, or content sent to the import API) is affected. Files that still use snake_case attribute names will no longer populate those fields, and required-field validation will fail on import or startup.

#### 🔄 Migration Guide
Rename the attribute keys in your declarative files to camelCase. The values do not change.

Before:
```yaml
# resource_type: application
name: My App
ou_id: default-ou
auth_flow_id: default-basic-flow
inbound_auth_config:
  - type: oauth2
    config:
      client_id: my-client
      redirect_uris:
        - https://localhost:3000
      token_endpoint_auth_method: none
      pkce_required: true
      public_client: true
```

After:
```yaml
# resource_type: application
name: My App
ouId: default-ou
authFlowId: default-basic-flow
inboundAuthConfig:
  - type: oauth2
    config:
      clientId: my-client
      redirectUris:
        - https://localhost:3000
      tokenEndpointAuthMethod: none
      pkceRequired: true
      publicClient: true
```

Full list of renamed attributes:

| Old (snake_case) | New (camelCase) |
|---|---|
| `access_token` | `accessToken` |
| `acr_values` | `acrValues` |
| `allow_self_registration` | `allowSelfRegistration` |
| `allowed_user_types` | `allowedUserTypes` |
| `auth_flow_handle` | `authFlowHandle` |
| `auth_flow_id` | `authFlowId` |
| `client_id` | `clientId` |
| `client_secret` | `clientSecret` |
| `cookie_policy_uri` | `cookiePolicyUri` |
| `created_at` | `createdAt` |
| `dpop_bound_access_tokens` | `dpopBoundAccessTokens` |
| `encryption_alg` | `encryptionAlg` |
| `encryption_enc` | `encryptionEnc` |
| `entity_category` | `entityCategory` |
| `grant_types` | `grantTypes` |
| `id_token` | `idToken` |
| `inbound_auth_config` | `inboundAuthConfig` |
| `include_act_claim` | `includeActClaim` |
| `is_recovery_flow_enabled` | `isRecoveryFlowEnabled` |
| `is_registration_flow_enabled` | `isRegistrationFlowEnabled` |
| `is_secret` | `isSecret` |
| `layout_id` | `layoutId` |
| `login_consent` | `loginConsent` |
| `logo_url` | `logoUrl` |
| `organization_unit_id` | `ouId` |
| `ou_handle` | `ouHandle` |
| `ou_id` | `ouId` |
| `pkce_required` | `pkceRequired` |
| `policy_uri` | `policyUri` |
| `public_client` | `publicClient` |
| `recovery_flow_handle` | `recoveryFlowHandle` |
| `recovery_flow_id` | `recoveryFlowId` |
| `redirect_uris` | `redirectUris` |
| `refresh_token` | `refreshToken` |
| `registration_flow_handle` | `registrationFlowHandle` |
| `registration_flow_id` | `registrationFlowId` |
| `require_pushed_authorization_requests` | `requirePushedAuthorizationRequests` |
| `resource_server_id` | `resourceServerId` |
| `response_type` | `responseType` |
| `response_types` | `responseTypes` |
| `scope_claims` | `scopeClaims` |
| `signing_alg` | `signingAlg` |
| `system_attributes` | `systemAttributes` |
| `theme_id` | `themeId` |
| `token_endpoint_auth_method` | `tokenEndpointAuthMethod` |
| `tos_uri` | `tosUri` |
| `updated_at` | `updatedAt` |
| `user_attributes` | `userAttributes` |
| `user_info` | `userInfo` |
| `validity_period` | `validityPeriod` |

Note: the user type attribute `organization_unit_id` and the `ou_id` used by other resources both become `ouId`, matching the REST API.

The `# resource_type:` comment directive is unchanged. Identity provider property names (`client_id`, `client_secret`, `redirect_uri` inside the `properties` list) are connector data and are unchanged. The only identity provider attribute that changed is `is_secret`, which is now `isSecret`.

### Approach

The change is mostly mechanical: every `yaml:"..."` struct tag that used snake_case now uses the same camelCase name already present in the field's `json` tag. A few places needed manual attention.

Key points and decisions:

- The YAML struct tags across the resource models were updated to match their JSON tags (application, agent, inbound client and OAuth config, identity provider property, role, user, user type, resource server, group, and organization unit).
- `organization_unit_id` maps to `ouId` (the existing JSON name), not `organizationUnitId`, so the API and declarative names stay identical.
- The import resource-type classifier in `parser.go` detects resource types by inspecting YAML keys, so it was updated to look for the camelCase keys.
- Identity provider property export in `parameterizer.go` built the property YAML node by hand with a hardcoded `is_secret` key, so that was changed to `isSecret`. The export path that converts struct field paths to YAML paths reads the struct tags through reflection, so it picked up the new names automatically.
- Validation and log messages that named the attributes (for example "ou_id or ou_handle is required") were updated to the new names.
- Sample declarative configs shipped with the sample apps and the console welcome bundle were updated, since they are loaded as declarative resources.

Intentionally left as snake_case, because they are not declarative resource attributes:

- Dynamic Client Registration request bodies and the `DCRRegistrationRequest` OpenAPI schema, which use snake_case JSON per RFC 7591.
- OAuth and OIDC protocol parameters (for example `client_id` in token, authorization, and discovery requests).
- Identity provider connector property values and user profile attribute keys (for example `given_name`), which are schema-defined data rather than fixed attributes.
- Database column names.
- The console runtime JavaScript config generated by the OpenChoreo chart.

### Related Issues
- Fixes #3302

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized declarative YAML field naming from snake_case to camelCase across agents, applications, entity types, identity providers, roles, users, and resource servers (e.g., `ouId`, `ouHandle`, `authFlowId`, `registrationFlowId`, `inboundAuthConfig`, `clientId`, `redirectUris`, `tokenEndpointAuthMethod`, `isSecret`, and related OAuth/inbound-auth keys).
* **Documentation**
  * Updated import/export docs, getting-started examples, AGENTS guidance, and sample configuration files to use camelCase.
* **Bug Fixes**
  * Updated declarative validation and warning messages to reference the new camelCase fields.
* **Tests**
  * Refreshed unit/integration fixtures and assertions to match the renamed YAML keys and exported YAML output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->