### PR TITLE
Add Kong Konnect STS integration guide

### DIFF
--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -204,3 +204,5 @@ Jetpack
 Gradle
 Keystore
 thunderid_flutter
+Kong
+[Kk]onnect

--- a/docs/content/use-cases/sts/kong.mdx
+++ b/docs/content/use-cases/sts/kong.mdx
@@ -1,0 +1,306 @@
+---
+title: Protect APIs on Kong Konnect with {{ProductName}}
+description: Configure Kong Konnect to validate JWT access tokens issued by {{ProductName}} and enforce scope-based authorization on your upstream APIs.
+sidebar_position: 2
+---
+
+# Protect APIs on Kong Konnect with <ProductName />
+
+This guide shows you how to use <ProductName /> as the Security Token Service (STS) for [Kong Konnect](https://konghq.com/products/kong-konnect). By the end, Kong will accept only valid <ProductName />-issued JWTs and, optionally, enforce scope-based authorization on your upstream APIs.
+
+Kong Konnect's [OpenID Connect plugin](https://developer.konghq.com/plugins/openid-connect/) validates bearer access tokens natively. It discovers <ProductName />'s JWKS endpoint, verifies each token's signature, issuer, and expiry, and asserts required scopes and audiences — no custom code and no introspection round-trip. Because <ProductName /> issues self-contained JWT access tokens (`typ: at+jwt`, `alg: RS256`), Kong verifies them locally against the keys it fetches from <ProductName />.
+
+## Prerequisites
+
+- <ProductName /> is installed and configured, and reachable from the Kong data plane container. See [Get <ProductName />](/docs/next/guides/getting-started/get-thunderid).
+- A [Kong Konnect](https://konghq.com/products/kong-konnect) account. The OpenID Connect plugin is available on Konnect-managed data planes.
+- Docker is installed on your machine (required to run the Konnect data plane).
+- `curl` and `jq` are available in your terminal.
+
+## JWT Authentication
+
+JWT authentication is the foundation of API security with Kong Konnect and <ProductName />. In this section, you register an application in <ProductName /> to obtain credentials, configure Kong to validate tokens using <ProductName />'s discovery endpoint and JWKS, and verify that unauthenticated requests are rejected.
+
+### Configure <ProductName />
+
+#### Create an Application
+
+1. Sign in to the <ProductName /> Console at `https://<THUNDER_HOST>:8090/console`.
+2. Navigate to **Applications** → **New Application**.
+3. Enter an **Application Name** (for example, `kong-api-client`).
+4. Select **Backend Service** as the application type.
+5. Click **Create Application**.
+6. Note the application **ID** (`<APP_ID>`), **Client ID**, and **Client Secret** from the application details page.
+
+#### Obtain an Access Token
+
+Use the client credentials grant to request an access token:
+
+```bash
+curl --location 'https://<THUNDER_HOST>:8090/oauth2/token' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'grant_type=client_credentials' \
+  --data-urlencode 'client_id=<CLIENT_ID>' \
+  --data-urlencode 'client_secret=<CLIENT_SECRET>'
+```
+
+The response contains an `access_token`:
+
+```json
+{
+  "access_token": "<ACCESS_TOKEN>",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+The token is a JWT signed with RS256. Its `iss` claim is `https://<THUNDER_HOST>:8090`, which matches the `issuer` you configure on the plugin. Copy the `access_token` value. You will use it to call the protected route.
+
+### Configure Kong Konnect
+
+#### Create a Control Plane and Data Plane
+
+1. Sign in to [Kong Konnect](https://cloud.konghq.com/).
+2. Open **Gateway Manager** and create a new **Control Plane** (for example, `thunder-demo`).
+3. Konnect displays a `docker run` command, pre-filled with your control plane's cluster endpoints and the generated mTLS certificates, to start a data plane node. Copy that command, and add the following so the data plane can proxy HTTPS traffic and resolve <ProductName />:
+
+   - `-p 8443:8443` — publishes the HTTPS proxy port.
+   - `--add-host=<THUNDER_HOST>:host-gateway` — maps the issuer hostname to the Docker host from inside the data plane container.
+
+   The resulting command looks similar to this (use the exact endpoints and certificate values from Konnect):
+
+   ```bash
+   docker run -d --name kong-dp \
+     -e "KONG_ROLE=data_plane" \
+     -e "KONG_DATABASE=off" \
+     -e "KONG_CLUSTER_MTLS=pki" \
+     -e "KONG_CLUSTER_CONTROL_PLANE=<CP_ENDPOINT>:443" \
+     -e "KONG_CLUSTER_SERVER_NAME=<CP_SERVER_NAME>" \
+     -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=<TELEMETRY_ENDPOINT>:443" \
+     -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME=<TELEMETRY_SERVER_NAME>" \
+     -e "KONG_CLUSTER_CERT=<CLUSTER_CERT>" \
+     -e "KONG_CLUSTER_CERT_KEY=<CLUSTER_CERT_KEY>" \
+     -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system" \
+     -e "KONG_KONNECT_MODE=on" \
+     -e "KONG_PROXY_LISTEN=0.0.0.0:8443 ssl" \
+     --add-host=<THUNDER_HOST>:host-gateway \
+     -p 8443:8443 \
+     kong/kong-gateway:3.9
+   ```
+
+4. Wait until the data plane shows as **Connected** in the Konnect **Gateway Manager**.
+
+:::important
+`<THUNDER_HOST>` must be a hostname the Kong data plane container can resolve to your <ProductName /> instance — not `localhost`, which from inside the container points to Kong itself. The same hostname must appear in the discovery document's `issuer`, the access token's `iss` claim, and the plugin's `issuer` value.
+:::
+
+#### Create a Service and Route
+
+1. In **Gateway Manager**, open your control plane and go to **Services** → **Add Service**.
+2. Enter a name (for example, `bookings`) and set the **URL** to your upstream bookings API (for example, `https://<BOOKINGS_API>`).
+3. Open the new service, go to **Routes** → **Add Route**, and add a route with the path `/bookings`.
+
+#### Add JWT Authentication
+
+Attach the plugin to the route so it validates every incoming token.
+
+1. Open the `/bookings` route and go to **Plugins** → **Add Plugin**.
+2. Select **OpenID Connect**.
+3. Configure these parameters:
+
+   | Parameter | Value |
+   |-----------|-------|
+   | `issuer` | `https://<THUNDER_HOST>:8090/.well-known/openid-configuration` |
+   | `client_id` | `<CLIENT_ID>` |
+   | `client_secret` | `<CLIENT_SECRET>` |
+   | `client_auth` | `client_secret_post` |
+   | `auth_methods` | `bearer` |
+   | `bearer_token_param_type` | `header` |
+
+4. Save the plugin.
+
+With `issuer` set, the plugin fetches <ProductName />'s JWKS from the discovery document and verifies each token's signature, issuer, and expiry by default. Restricting `auth_methods` to `bearer` makes the plugin validate the incoming access token only, without initiating a login flow. Setting `bearer_token_param_type` to `header` makes the plugin read the token from the `Authorization: Bearer <token>` header used in the examples below.
+
+### Try It Out
+
+**Request without a token — expect `401 Unauthorized`:**
+
+```bash
+curl -k -i "https://127.0.0.1:8443/bookings"
+```
+
+**Request with a valid <ProductName /> token — expect `200 OK`:**
+
+```bash
+export ACCESS_TOKEN="<ACCESS_TOKEN>"
+curl -k -i "https://127.0.0.1:8443/bookings" \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+A successful request returns an HTTP `200` response forwarded from the upstream. If the token is missing, invalid, or expired, Kong returns `401 Unauthorized`.
+
+## Scope-Based Authorization
+
+JWT authentication confirms that a token is valid and was issued by <ProductName />. It does not control what the token holder is allowed to do. With the configuration from the previous section, Kong accepts any valid <ProductName /> token regardless of the application or its assigned permissions.
+
+Scope-based authorization adds a second layer of control. <ProductName /> embeds scopes in tokens based on the roles assigned to an application. Kong then checks those scopes on every request and rejects tokens that do not carry the required permissions. To enforce that tokens carry specific permission scopes, configure the OpenID Connect plugin's `scopes_required` parameter.
+
+The steps below build on the JWT authentication configuration from the previous section. You will define a Resource Server, a Resource, and actions in <ProductName /> to model your API permissions. Then bundle them into a role, assign the role to your application, and update the Kong plugin configuration to enforce scope validation.
+
+### Configure <ProductName />
+
+#### Create a Resource Server
+
+A Resource Server represents your API in <ProductName />. It groups all resources and actions under a single handle, which prefixes every permission (scope) the API exposes.
+
+1. In the Console, navigate to **Resource Servers** → **Add resource server**.
+2. For the type, select **API**.
+3. Enter a **Resource Server Name** (for example, `Bookings API`) and a **Handle** (`bookingsapi`). The handle prefixes every permission and cannot be changed after creation.
+4. For the **Permission Delimiter**, select `:`.
+5. Select the **Organization** the resource server belongs to, then create it.
+
+#### Add Resources and Actions
+
+A Resource represents an entity within the API (such as the `/bookings` route), and Actions define the operations allowed on it. Each action produces a scope in the format `<resource-server-handle>:<resource-handle>:<action-handle>`.
+
+1. Open the resource server you just created and go to the **Resources & Actions** tab.
+2. Click **Add Resource** and enter a **Name** (for example, `Bookings`) and a **Handle** (`bookings`).
+3. Under that resource, click **Add Action** and enter a **Name** (for example, `Read Bookings`) and a **Handle** (`read`).
+4. Add a second action with a **Name** (for example, `Write Bookings`) and a **Handle** (`write`).
+
+This produces the permissions `bookingsapi:bookings:read` and `bookingsapi:bookings:write`, which <ProductName /> includes in tokens issued to applications that hold a role granting them.
+
+#### Create a Role
+
+Roles bundle one or more permissions together. Assigning a role to an application controls which scopes appear in its tokens.
+
+1. Navigate to **Roles** → **Add Role**.
+2. Enter a **Role Name** (for example, `Bookings manager`).
+3. Select the **Organization Unit** the role belongs to, then create it.
+4. Open the new role and note its **ID** (`<ROLE_ID>`) from the role details.
+
+#### Add Permissions to the Role
+
+Adding permissions to a role is done through the API. First obtain an admin access token with the `client_credentials` grant and the `system` scope, using your administrator client credentials:
+
+```bash
+curl -k -X POST "https://<THUNDER_HOST>:8090/oauth2/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=<ADMIN_CLIENT_ID>&client_secret=<ADMIN_CLIENT_SECRET>&scope=system"
+```
+
+Then send a `PUT` to `/roles/{id}` with the full permission set. Use the resource server **ID** (`<RESOURCE_SERVER_ID>`) from the resource server details in the Console and the role's organization unit **ID** (`<OU_ID>`):
+
+```bash
+curl -k -X PUT "https://<THUNDER_HOST>:8090/roles/<ROLE_ID>" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <ADMIN_TOKEN>" \
+  -d '{
+    "name": "Bookings manager",
+    "ouId": "<OU_ID>",
+    "permissions": [
+      {
+        "resourceServerId": "<RESOURCE_SERVER_ID>",
+        "permissions": ["bookingsapi:bookings:read", "bookingsapi:bookings:write"]
+      }
+    ]
+  }'
+```
+
+:::warning
+`PUT /roles/{id}` replaces the role's entire permission set — it does not append. Always send the complete list of permissions the role should have, including any it already has. Any permission omitted from the request is removed from the role.
+:::
+
+`name`, `ouId`, and `permissions` are required on update, so include them even when only the permissions change.
+
+#### Assign the Role to the Application
+
+Assign the role to the application you created in the previous section. <ProductName /> includes the role's scopes in every token issued for that application.
+
+1. Open the role and go to the **Assignments** tab.
+2. Under **Apps**, assign the application you created earlier (`kong-api-client`).
+
+### Configure Kong Konnect
+
+Update the OpenID Connect plugin on your `/bookings` route to require the generated scope:
+
+1. Open the route's **OpenID Connect** plugin configuration.
+2. Set the following parameter:
+
+   | Parameter | Value |
+   |-----------|-------|
+   | `scopes_required` | `bookingsapi:bookings:read` |
+
+3. Save the plugin.
+
+The plugin reads scopes from the `scope` claim (the default `scopes_claim`) and rejects any token missing `bookingsapi:bookings:read` with `403 Forbidden`, before the request reaches your upstream.
+
+:::tip
+To restrict which application's tokens are accepted, also set `audience_required` to the **Client ID** of the application. <ProductName /> sets each token's `aud` claim to the issuing application's Client ID, which the plugin reads from the default `audience_claim` (`aud`).
+:::
+
+### Try It Out
+
+#### Obtain an Access Token with the Required Scope
+
+Request a token for the application that has the role assigned:
+
+```bash
+curl --location 'https://<THUNDER_HOST>:8090/oauth2/token' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'grant_type=client_credentials' \
+  --data-urlencode 'scope=bookingsapi:bookings:read' \
+  --data-urlencode 'client_id=<CLIENT_ID>' \
+  --data-urlencode 'client_secret=<CLIENT_SECRET>'
+```
+
+The response confirms the scope is present:
+
+```json
+{
+  "access_token": "<ACCESS_TOKEN>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "bookingsapi:bookings:read"
+}
+```
+
+#### Call the Protected API
+
+**With a token that has the required scope — the request is forwarded to the upstream:**
+
+```bash
+export ACCESS_TOKEN="<ACCESS_TOKEN>"
+curl -k -i "https://127.0.0.1:8443/bookings" \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+Kong verifies the token carries the `bookingsapi:bookings:read` scope and forwards the request to your upstream bookings API.
+
+**With a token missing the required scope — expect `403 Forbidden`:**
+
+```bash
+curl -k -i "https://127.0.0.1:8443/bookings" \
+  -H "Authorization: Bearer <TOKEN_WITHOUT_REQUIRED_SCOPE>"
+```
+
+Kong inspects the token, finds the `bookingsapi:bookings:read` scope absent, and returns `403 Forbidden`.
+
+## Plugin Parameter Reference
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `issuer` | `https://<THUNDER_HOST>:8090/.well-known/openid-configuration` | <ProductName />'s discovery endpoint. The plugin fetches the JWKS from here and verifies each token's signature, issuer, and expiry. |
+| `client_id` | `<CLIENT_ID>` | Client ID of the <ProductName /> Backend Service application. |
+| `client_secret` | `<CLIENT_SECRET>` | Client secret of the <ProductName /> Backend Service application. |
+| `client_auth` | `client_secret_post` | Sends plugin client credentials in the request body when the plugin calls <ProductName /> endpoints. |
+| `auth_methods` | `bearer` | Restricts the plugin to validating the incoming bearer access token, without starting a login flow. |
+| `bearer_token_param_type` | `header` | Reads the bearer token from the `Authorization` header. |
+| `scopes_required` | `bookingsapi:bookings:read` | Scopes the token must carry. Missing scopes are rejected with `403`. Omit to accept any valid token. |
+| `scopes_claim` | `scope` | The token claim the plugin reads scopes from. <ProductName /> emits resource scopes in the `scope` claim. |
+| `audience_required` | `<CLIENT_ID>` | Optional. Audiences the token must carry. <ProductName /> sets `aud` to the issuing application's Client ID. |
+| `audience_claim` | `aud` | The token claim the plugin reads the audience from. |
+
+## Next Steps
+
+- [Applications](/docs/next/guides/guides/applications) — Configure grant types and token settings for your application.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -394,6 +394,7 @@ const sidebars: SidebarsConfig = {
             {type: 'doc', id: 'use-cases/sts/krakend', label: 'Protect APIs on KrakenD'},
             {type: 'doc', id: 'use-cases/sts/envoy', label: 'Protect APIs on Envoy'},
             {type: 'doc', id: 'use-cases/sts/azure-apim', label: 'Protect APIs on Azure API Management'},
+            {type: 'doc', id: 'use-cases/sts/kong', label: 'Protect APIs on Kong Konnect'},
           ],
         },
       ],


### PR DESCRIPTION
## Purpose

Adds a Security Token Service (STS) integration guide for **Kong Konnect**, mirroring the existing KrakenD guide. It shows how to use Thunder as the STS for Kong Konnect using the **OpenID Connect** plugin (bearer-only): native JWKS discovery, signature/issuer/expiry verification, and scope-based authorization via `scopes_required`.

## What's included

- `docs/content/use-cases/sts/kong.mdx` — the guide (Thunder app + token, Konnect control plane/data plane, OpenID Connect plugin, scope-based authorization).
- `docs/sidebars.ts` — sidebar entry under **Secure Token Service (STS)**.
- `.vale/styles/config/vocabularies/vocab/accept.txt` — `Kong`, `Konnect`, `ngrok`, `httpbin` terms.

## Verification

The **Thunder-side** flow was verified live against Thunder 0.34.0: application + `client_credentials` token, resource server/resource/action, role assigned to the application (assignee type `app`), and a scoped `client_credentials` token carrying the `scope` claim (`headers:read`), with `aud` set to the client ID.

> Note: The **Kong Konnect** configuration steps were written from Kong's official OpenID Connect plugin reference and have not yet been run end-to-end against a live Konnect data plane.

## References

- KrakenD STS guide: https://github.com/thunder-id/thunderid/pull/3248
- Kong OpenID Connect plugin: https://developer.konghq.com/plugins/openid-connect/

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Secure Token Service (STS) guide for protecting upstream APIs on Kong Konnect, covering Kong’s OpenID Connect setup, local JWT validation, and optional scope-based authorization.
* **Chores**
  * Updated editorial vocabulary to accept additional terms (“Kong”, “[Kk]onnect”, “ngrok”, “httpbin”).
  * Extended the Secure Token Service (STS) sidebar with a link to the new Kong Konnect protection guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->