### PR TITLE
Return specific error for attribute conflicts during user provisioning

### DIFF
--- a/backend/internal/flow/executor/error_constants.go
+++ b/backend/internal/flow/executor/error_constants.go
@@ -1145,6 +1145,20 @@ var (
 			DefaultValue: "The OpenID4VP presentation verification failed",
 		},
 	}
+
+	// ErrProvisioningAttributeConflict is returned when user provisioning fails due to an attribute conflict.
+	ErrProvisioningAttributeConflict = serviceerror.ServiceError{
+		Type: serviceerror.ClientErrorType,
+		Code: "FET-1081",
+		Error: core.I18nMessage{
+			Key:          "flows.executor.errors.provisioning_attribute_conflict",
+			DefaultValue: "A user with the provided attributes already exists",
+		},
+		ErrorDescription: core.I18nMessage{
+			Key:          "flows.executor.errors.provisioning_attribute_conflict_desc",
+			DefaultValue: "User provisioning failed because one or more unique attribute values are already taken",
+		},
+	}
 )
 
 // errAttributeNotUniqueFor returns a ServiceError for a specific attribute that is not unique.

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -175,9 +175,8 @@ func (p *provisioningExecutor) Execute(ctx *core.NodeContext) (*common.ExecutorR
 	}
 	createdEntity, err := p.createUserInStore(ctx, userAttributes)
 	if err != nil {
-		logger.Error(ctx.Context, "Failed to create user in the store", log.Error(err))
 		execResp.Status = common.ExecFailure
-		execResp.Error = &ErrProvisioningFailed
+		execResp.Error = p.handleCreateUserError(ctx, err, logger)
 		return execResp, nil
 	}
 	if createdEntity == nil || createdEntity.ID == "" {
@@ -637,7 +636,6 @@ func (p *provisioningExecutor) createUserInStore(nodeCtx *core.NodeContext,
 		Type:     userType,
 	}
 
-	// Convert the user attributes to JSON.
 	attributesJSON, err := json.Marshal(userAttributes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal user attributes: %w", err)
@@ -646,7 +644,7 @@ func (p *provisioningExecutor) createUserInStore(nodeCtx *core.NodeContext,
 
 	retEntity, svcErr := p.entityProvider.CreateEntity(&newEntity, nil)
 	if svcErr != nil {
-		return nil, fmt.Errorf("failed to create user in the store: %s", svcErr.Message)
+		return nil, svcErr
 	}
 	if retEntity != nil && retEntity.ID != "" {
 		logger.Debug(nodeCtx.Context, "User account created successfully",
@@ -654,6 +652,25 @@ func (p *provisioningExecutor) createUserInStore(nodeCtx *core.NodeContext,
 	}
 
 	return retEntity, nil
+}
+
+// handleCreateUserError maps an entity provider error during user creation to the appropriate ServiceError.
+func (p *provisioningExecutor) handleCreateUserError(
+	ctx *core.NodeContext,
+	err error,
+	logger *log.Logger,
+) *serviceerror.ServiceError {
+	var epErr *entityprovider.EntityProviderError
+	if errors.As(err, &epErr) {
+		if epErr.Code == entityprovider.ErrorCodeAttributeConflict {
+			return &ErrProvisioningAttributeConflict
+		}
+		logger.Error(ctx.Context, "Failed to create user in the store",
+			log.String("errorCode", string(epErr.Code)), log.String("message", epErr.Message))
+		return &ErrProvisioningFailed
+	}
+	logger.Error(ctx.Context, "Failed to create user in the store", log.Error(err))
+	return &ErrProvisioningFailed
 }
 
 // getTargetEntityRef retrieves the target entity reference (user type and OU ID) for provisioning.

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -298,6 +298,37 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFails() {
 	suite.mockEntityProvider.AssertExpectations(suite.T())
 }
 
+func (suite *ProvisioningExecutorTestSuite) TestExecute_CreateUserFails_AttributeConflict() {
+	suite.expectSchemaForProvisioning()
+	ctx := &core.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    common.FlowTypeRegistration,
+		UserInputs: map[string]string{
+			"username": "existinguser",
+		},
+		RuntimeData: map[string]string{
+			ouIDKey:     testOUID,
+			userTypeKey: testUserType,
+		},
+		NodeInputs: []common.Input{{Identifier: "username", Type: "string", Required: true}},
+	}
+
+	suite.mockEntityProvider.On("IdentifyEntity", mock.Anything).Return(nil,
+		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeEntityNotFound, "", ""))
+	suite.mockEntityProvider.On("CreateEntity", mock.Anything, mock.Anything).
+		Return(nil, entityprovider.NewEntityProviderError(
+			entityprovider.ErrorCodeAttributeConflict, "Attribute conflict", ""))
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), ErrProvisioningAttributeConflict.Code, resp.Error.Code)
+	assert.Equal(suite.T(), ErrProvisioningAttributeConflict.Error.DefaultValue, resp.Error.Error.DefaultValue)
+	suite.mockEntityProvider.AssertExpectations(suite.T())
+}
+
 func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AttributesFromAuthUser() {
 	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, true, false).
 		Return([]model.AttributeInfo{}, nil).Once()

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -1100,6 +1100,8 @@ var defaultMessages = map[string]string{
 	"flows.executor.errors.prerequisites_failed_desc": "The prerequisites for this operation have not been met",
 	"flows.executor.errors.provisioning_assignment_failed": "Failed to assign groups and roles",
 	"flows.executor.errors.provisioning_assignment_failed_desc": "An error occurred while assigning groups and roles to the provisioned user",
+	"flows.executor.errors.provisioning_attribute_conflict": "A user with the provided attributes already exists",
+	"flows.executor.errors.provisioning_attribute_conflict_desc": "User provisioning failed because one or more unique attribute values are already taken",
 	"flows.executor.errors.provisioning_failed": "User provisioning failed",
 	"flows.executor.errors.provisioning_failed_desc": "An error occurred while provisioning the user",
 	"flows.executor.errors.provisioning_user_attrs_missing": "No user attributes provided for provisioning",


### PR DESCRIPTION
### Purpose

When a user registers with a username (or other unique attribute) that already exists, the `ProvisioningExecutor` returns a generic `FET-1022` ("User provisioning failed") instead of a specific error. This PR makes the executor distinguish attribute conflicts from other provisioning failures, returning a new `FET-1081` error with the message "A user with the provided attributes already exists."

### Approach

- Changed `createUserInStore` to return the typed `*EntityProviderError` instead of converting it to a plain `error` string, preserving the error code.
- In `Execute`, after `createUserInStore` fails, check `svcErr.Code` for `ErrorCodeAttributeConflict` (EP-0004) and return the new `ErrProvisioningAttributeConflict` (FET-1081). All other failures still return `ErrProvisioningFailed` (FET-1022).
- Added the new error constant and i18n keys.

### Related Issues
- Fixes #3313

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user provisioning failure handling by detecting unique-attribute collisions and returning a dedicated attribute-conflict error.
  * Updated error propagation to preserve provider error details.
  * Added internationalized default messaging for attribute-conflict provisioning failures (error text and description).

* **Tests**
  * Added a unit test covering the attribute-conflict scenario to verify the correct error code and default message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->