### PR TITLE
verified_claims support in claims parameter of authorization request

### DIFF
--- a/backend/internal/oauth/oauth2/authz/auth_req_store_test.go
+++ b/backend/internal/oauth/oauth2/authz/auth_req_store_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
+	oauth2utils "github.com/thunder-id/thunderid/internal/oauth/oauth2/utils"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 
@@ -771,4 +772,56 @@ func (suite *AuthorizationRequestStoreTestSuite) testGetRequestWithInvalidScopes
 
 	suite.mockdbProvider.AssertExpectations(suite.T())
 	suite.mockDBClient.AssertExpectations(suite.T())
+}
+
+// TestRoundTrip_VerifiedClaims verifies that a claims request carrying userinfo.verified_claims
+// survives serialization to the store JSON and reconstruction faithfully.
+func (suite *AuthorizationRequestStoreTestSuite) TestRoundTrip_VerifiedClaims() {
+	claimsParam := `{
+		"userinfo": {
+			"email": {"essential": true},
+			"verified_claims": {
+				"verification": {"trust_framework": {"value": "eidas"}, "evidence": [{"type": "document"}]},
+				"claims": {"given_name": null, "address": {"essential": true}}
+			}
+		}
+	}`
+	claimsRequest, err := oauth2utils.ParseClaimsRequest(claimsParam)
+	suite.Require().NoError(err)
+
+	original := authRequestContext{
+		OAuthParameters: model.OAuthParameters{
+			ClientID:       "test-client-id",
+			ResponseType:   "code",
+			StandardScopes: []string{"openid"},
+			ClaimsRequest:  claimsRequest,
+		},
+	}
+
+	// Serialize as the store would when persisting.
+	jsonDataBytes, err := suite.store.getJSONDataBytes(original)
+	suite.Require().NoError(err)
+
+	// Reconstruct as the store would when reading back from the database.
+	row := map[string]interface{}{
+		dbColumnRequestData: string(jsonDataBytes),
+	}
+	reconstructed, err := suite.store.buildAuthRequestContextFromResultRow(row)
+	suite.Require().NoError(err)
+
+	reloaded := reconstructed.OAuthParameters.ClaimsRequest
+	suite.Require().NotNil(reloaded)
+
+	// verified_claims is reconstructed as a single normalized entry (unmodeled members dropped).
+	suite.Require().Len(reloaded.VerifiedUserInfo, 1)
+	verifiedEntry := reloaded.VerifiedUserInfo[0]
+	assert.Equal(suite.T(), "eidas", verifiedEntry.Verification.TrustFramework.Value)
+	assert.Len(suite.T(), verifiedEntry.Claims, 2)
+	assert.True(suite.T(), verifiedEntry.Claims["address"].Essential)
+
+	// Normal claims are preserved and resolvable.
+	normalClaims := reloaded.UserInfo
+	assert.Len(suite.T(), normalClaims, 1)
+	assert.NotNil(suite.T(), normalClaims["email"])
+	assert.True(suite.T(), normalClaims["email"].Essential)
 }

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -783,8 +783,8 @@ func appendAttributesFromClaimsParameter(claimsRequest *oauth2model.ClaimsReques
 		}
 	}
 
-	// Append user info attributes
-	if claimsRequest.UserInfo != nil && userInfoAllowedSet != nil {
+	// Append user info attributes (verified_claims is held separately in VerifiedUserInfo)
+	if userInfoAllowedSet != nil {
 		for name, value := range claimsRequest.UserInfo {
 			if userInfoAllowedSet[name] {
 				if value != nil && value.Essential {
@@ -860,12 +860,10 @@ func validateSubClaimConstraint(claimsRequest *oauth2model.ClaimsRequest, actual
 		}
 	}
 
-	// Check userinfo sub claim constraint.
-	if claimsRequest.UserInfo != nil {
-		if subReq, exists := claimsRequest.UserInfo["sub"]; exists && subReq != nil {
-			if !subReq.MatchesValue(actualSubject) {
-				return errors.New("sub claim in userinfo does not match requested value")
-			}
+	// Check userinfo sub claim constraint (verified_claims is held separately in VerifiedUserInfo).
+	if subReq, exists := claimsRequest.UserInfo["sub"]; exists && subReq != nil {
+		if !subReq.MatchesValue(actualSubject) {
+			return errors.New("sub claim in userinfo does not match requested value")
 		}
 	}
 

--- a/backend/internal/oauth/oauth2/model/parameter.go
+++ b/backend/internal/oauth/oauth2/model/parameter.go
@@ -18,7 +18,14 @@
 
 package model
 
-import "github.com/thunder-id/thunderid/internal/system/utils"
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/thunder-id/thunderid/internal/system/utils"
+)
 
 // OAuthParameters represents the parameters required for OAuth2 authorization.
 type OAuthParameters struct {
@@ -39,10 +46,26 @@ type OAuthParameters struct {
 	DPoPJkt             string
 }
 
+// VerifiedClaimsMember is the OIDC Identity Assurance member name that may appear in the
+// userinfo and id_token sections of the claims request. Its request form is the nested IDA
+// structure (verification + claims) rather than the {essential, value, values} shape, so each
+// section's verified_claims is held separately in VerifiedUserInfo and VerifiedIDToken and
+// excluded from all normal-claim processing.
+const VerifiedClaimsMember = "verified_claims"
+
+// jsonNull is the JSON wire representation of a null value.
+const jsonNull = "null"
+
 // ClaimsRequest represents the OIDC claims request parameter structure.
+// UserInfo and IDToken carry only normal claims; each section's verified_claims IDA structure is
+// held separately in VerifiedUserInfo and VerifiedIDToken, normalized to an array of typed
+// VerifiedClaimsRequest entries. On the wire verified_claims remains nested under its
+// userinfo/id_token object, handled by the custom MarshalJSON/UnmarshalJSON.
 type ClaimsRequest struct {
-	UserInfo map[string]*IndividualClaimRequest `json:"userinfo,omitempty"`
-	IDToken  map[string]*IndividualClaimRequest `json:"id_token,omitempty"`
+	UserInfo         map[string]*IndividualClaimRequest `json:"-"`
+	VerifiedUserInfo []*VerifiedClaimsRequest           `json:"-"`
+	IDToken          map[string]*IndividualClaimRequest `json:"-"`
+	VerifiedIDToken  []*VerifiedClaimsRequest           `json:"-"`
 }
 
 // IndividualClaimRequest represents a request for an individual claim.
@@ -52,9 +75,315 @@ type IndividualClaimRequest struct {
 	Values    []interface{} `json:"values,omitempty"`
 }
 
+// VerifiedClaimsRequest is one normalized OIDC Identity Assurance verified_claims request entry.
+// Only the verification and claims members are modeled; other IDA members are dropped on decode.
+type VerifiedClaimsRequest struct {
+	Verification *VerificationRequest               `json:"verification"`
+	Claims       map[string]*IndividualClaimRequest `json:"claims"`
+}
+
+// VerificationRequest is the verification element of a verified_claims request. TrustFramework is
+// required and is a constrainable element (JSON null, decoded to a nil request meaning "any
+// framework", or an object honoring the value/values grammar); Time is the optional constraint.
+type VerificationRequest struct {
+	TrustFramework *TrustFrameworkRequest   `json:"trust_framework"`
+	Time           *VerificationTimeRequest `json:"time,omitempty"`
+}
+
+// TrustFrameworkRequest is the constrainable trust_framework element of a verification request.
+// Value and Values are mutually exclusive string constraints per the OIDC constraint grammar.
+type TrustFrameworkRequest struct {
+	Value     string   `json:"value,omitempty"`
+	Values    []string `json:"values,omitempty"`
+	Essential bool     `json:"essential,omitempty"`
+}
+
+// Validate checks the trust_framework constraint grammar: value and values are mutually exclusive,
+// and a present values array must be non-empty.
+func (tf *TrustFrameworkRequest) Validate() error {
+	if tf.Value != "" && len(tf.Values) > 0 {
+		return errors.New("has both 'value' and 'values' specified (mutually exclusive per OIDC spec)")
+	}
+	if tf.Values != nil && len(tf.Values) == 0 {
+		return errors.New("has empty 'values' array (must contain at least one value)")
+	}
+	return nil
+}
+
+// VerificationTimeRequest is the optional time constraint of a verification element. MaxAge is the
+// maximum age of the verification in seconds (a non-negative integer) when present.
+type VerificationTimeRequest struct {
+	MaxAge *int64 `json:"max_age,omitempty"`
+}
+
+// UnmarshalJSON decodes a single verified_claims entry, requiring a verification element and a
+// non-empty claims object. Each claims entry follows the normal-claim constraint grammar.
+func (vcr *VerifiedClaimsRequest) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Verification *VerificationRequest       `json:"verification"`
+		Claims       map[string]json.RawMessage `json:"claims"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if raw.Verification == nil {
+		return errors.New("'verified_claims' is missing the required 'verification' member")
+	}
+	if raw.Claims == nil {
+		return errors.New("'verified_claims' is missing the required 'claims' member")
+	}
+	if len(raw.Claims) == 0 {
+		return errors.New("'verified_claims.claims' must request at least one claim")
+	}
+
+	vcr.Verification = raw.Verification
+	vcr.Claims = make(map[string]*IndividualClaimRequest, len(raw.Claims))
+	for name, value := range raw.Claims {
+		if string(value) == jsonNull {
+			vcr.Claims[name] = nil
+			continue
+		}
+		claimReq, err := DecodeIndividualClaimRequest(value)
+		if err != nil {
+			return fmt.Errorf("claim '%s' in verified_claims.claims is malformed: %w", name, err)
+		}
+		if err := claimReq.Validate(); err != nil {
+			return fmt.Errorf("claim '%s' in verified_claims.claims %w", name, err)
+		}
+		vcr.Claims[name] = claimReq
+	}
+	return nil
+}
+
+// decodeTrustFramework decodes the trust_framework constrainable element per OIDC Identity
+// Assurance: JSON null yields a nil request (no constraint), an object is decoded and checked
+// against the value/values grammar, and any other shape (a bare scalar, an array) is rejected.
+func decodeTrustFramework(raw json.RawMessage) (*TrustFrameworkRequest, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if string(trimmed) == jsonNull {
+		return nil, nil
+	}
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, errors.New("must be null or an object")
+	}
+	var tf TrustFrameworkRequest
+	if err := json.Unmarshal(trimmed, &tf); err != nil {
+		return nil, fmt.Errorf("is malformed: %w", err)
+	}
+	if err := tf.Validate(); err != nil {
+		return nil, err
+	}
+	return &tf, nil
+}
+
+// UnmarshalJSON decodes a verification element, enforcing the presence of trust_framework and
+// validating the optional time constraint.
+func (vr *VerificationRequest) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		TrustFramework json.RawMessage `json:"trust_framework"`
+		Time           json.RawMessage `json:"time"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if raw.TrustFramework == nil {
+		return errors.New(
+			"'verified_claims.verification' is missing the required 'trust_framework' member")
+	}
+	trustFramework, err := decodeTrustFramework(raw.TrustFramework)
+	if err != nil {
+		return fmt.Errorf("'verified_claims.verification.trust_framework' %w", err)
+	}
+	vr.TrustFramework = trustFramework
+
+	if raw.Time == nil || string(raw.Time) == jsonNull {
+		return nil
+	}
+
+	var timeObj struct {
+		MaxAge json.RawMessage `json:"max_age"`
+	}
+	if err := json.Unmarshal(raw.Time, &timeObj); err != nil {
+		return errors.New("'verified_claims.verification.time' must be an object")
+	}
+	vr.Time = &VerificationTimeRequest{}
+	if timeObj.MaxAge == nil {
+		return nil
+	}
+
+	var maxAgeNum json.Number
+	if err := json.Unmarshal(timeObj.MaxAge, &maxAgeNum); err != nil {
+		return errors.New(
+			"'verified_claims.verification.time.max_age' must be a non-negative integer")
+	}
+	maxAge, err := maxAgeNum.Int64()
+	if err != nil || maxAge < 0 {
+		return fmt.Errorf(
+			"'verified_claims.verification.time.max_age' must be a non-negative integer, got %s",
+			string(timeObj.MaxAge))
+	}
+	vr.Time.MaxAge = &maxAge
+	return nil
+}
+
+// decodeVerifiedClaims normalizes the verified_claims member, which may be a single object or an
+// array of objects on the wire, into an array of typed entries.
+func decodeVerifiedClaims(raw json.RawMessage) ([]*VerifiedClaimsRequest, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, errors.New("'verified_claims' must be an object or an array of objects")
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var entries []*VerifiedClaimsRequest
+		if err := json.Unmarshal(trimmed, &entries); err != nil {
+			return nil, err
+		}
+		if len(entries) == 0 {
+			return nil, errors.New("'verified_claims' array must contain at least one entry")
+		}
+		for _, entry := range entries {
+			if entry == nil {
+				return nil, errors.New("'verified_claims' array must not contain null entries")
+			}
+		}
+		return entries, nil
+	case '{':
+		var entry VerifiedClaimsRequest
+		if err := json.Unmarshal(trimmed, &entry); err != nil {
+			return nil, err
+		}
+		return []*VerifiedClaimsRequest{&entry}, nil
+	default:
+		return nil, errors.New("'verified_claims' must be an object or an array of objects")
+	}
+}
+
+// decodeClaimsSection splits one section (userinfo or id_token) of the claims request into its
+// normal claims, each decoded as *IndividualClaimRequest, and the verified_claims member held
+// separately. An absent or empty section yields a nil normal map and nil verified entries.
+func decodeClaimsSection(section string, raw map[string]json.RawMessage) (
+	map[string]*IndividualClaimRequest, []*VerifiedClaimsRequest, error) {
+	if len(raw) == 0 {
+		return nil, nil, nil
+	}
+
+	normal := make(map[string]*IndividualClaimRequest, len(raw))
+	var verified []*VerifiedClaimsRequest
+	for name, value := range raw {
+		if name == VerifiedClaimsMember {
+			entries, err := decodeVerifiedClaims(value)
+			if err != nil {
+				return nil, nil, err
+			}
+			verified = entries
+			continue
+		}
+		if string(value) == jsonNull {
+			normal[name] = nil
+			continue
+		}
+		claimReq, err := DecodeIndividualClaimRequest(value)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s claim %q is malformed: %w", section, name, err)
+		}
+		normal[name] = claimReq
+	}
+	return normal, verified, nil
+}
+
+// UnmarshalJSON decodes a ClaimsRequest, splitting each of the userinfo and id_token objects into
+// normal claims (each decoded as *IndividualClaimRequest) and the verified_claims member (held
+// separately in VerifiedUserInfo / VerifiedIDToken). This applies on every decode path:
+// ParseClaimsRequest as well as the Redis-backed request/code/PAR stores that restore the struct
+// with a plain json.Unmarshal.
+func (cr *ClaimsRequest) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		UserInfo map[string]json.RawMessage `json:"userinfo"`
+		IDToken  map[string]json.RawMessage `json:"id_token"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	userInfo, verifiedUserInfo, err := decodeClaimsSection("userinfo", raw.UserInfo)
+	if err != nil {
+		return err
+	}
+	idToken, verifiedIDToken, err := decodeClaimsSection("id_token", raw.IDToken)
+	if err != nil {
+		return err
+	}
+
+	cr.UserInfo = userInfo
+	cr.VerifiedUserInfo = verifiedUserInfo
+	cr.IDToken = idToken
+	cr.VerifiedIDToken = verifiedIDToken
+	return nil
+}
+
+// marshalClaimsSection rebuilds one section's wire object from its normal claims and verified_claims
+// member, re-nesting verified_claims under the section. Returns nil when the section has nothing.
+func marshalClaimsSection(normal map[string]*IndividualClaimRequest,
+	verified []*VerifiedClaimsRequest) map[string]any {
+	if len(normal) == 0 && len(verified) == 0 {
+		return nil
+	}
+
+	section := make(map[string]any, len(normal)+1)
+	for name, claim := range normal {
+		section[name] = claim
+	}
+	if len(verified) > 0 {
+		section[VerifiedClaimsMember] = verified
+	}
+	return section
+}
+
+// MarshalJSON encodes a ClaimsRequest back into the OIDC wire shape, re-nesting each section's
+// verified_claims under its userinfo/id_token object so the serialized form round-trips through
+// the stores and the access-token claims_request claim unchanged.
+func (cr *ClaimsRequest) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, 2)
+
+	if userInfo := marshalClaimsSection(cr.UserInfo, cr.VerifiedUserInfo); userInfo != nil {
+		out["userinfo"] = userInfo
+	}
+	if idToken := marshalClaimsSection(cr.IDToken, cr.VerifiedIDToken); idToken != nil {
+		out["id_token"] = idToken
+	}
+
+	return json.Marshal(out)
+}
+
+// DecodeIndividualClaimRequest decodes a raw claim request value into an *IndividualClaimRequest.
+// A nil value ("email": null) means "requested, no constraint" and yields a nil request.
+func DecodeIndividualClaimRequest(raw any) (*IndividualClaimRequest, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	if icr, ok := raw.(*IndividualClaimRequest); ok {
+		return icr, nil
+	}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var icr IndividualClaimRequest
+	if err := json.Unmarshal(data, &icr); err != nil {
+		return nil, err
+	}
+	return &icr, nil
+}
+
 // IsEmpty returns true if the ClaimsRequest has no claims requested.
 func (cr *ClaimsRequest) IsEmpty() bool {
-	return cr == nil || (len(cr.UserInfo) == 0 && len(cr.IDToken) == 0)
+	return cr == nil || (len(cr.UserInfo) == 0 && len(cr.VerifiedUserInfo) == 0 &&
+		len(cr.IDToken) == 0 && len(cr.VerifiedIDToken) == 0)
 }
 
 // MatchesValue checks if the given value matches the requested value or values.
@@ -82,4 +411,23 @@ func (icr *IndividualClaimRequest) MatchesValue(value interface{}) bool {
 	}
 
 	return false
+}
+
+// Validate checks an individual claim request against the OIDC constraint grammar: value and
+// values are mutually exclusive, and a present values array must be non-empty. A nil request
+// (requested without constraint) is always valid.
+func (icr *IndividualClaimRequest) Validate() error {
+	if icr == nil {
+		return nil
+	}
+
+	if icr.Value != nil && len(icr.Values) > 0 {
+		return errors.New("has both 'value' and 'values' specified (mutually exclusive per OIDC spec)")
+	}
+
+	if icr.Values != nil && len(icr.Values) == 0 {
+		return errors.New("has empty 'values' array (must contain at least one value)")
+	}
+
+	return nil
 }

--- a/backend/internal/oauth/oauth2/model/parameter_test.go
+++ b/backend/internal/oauth/oauth2/model/parameter_test.go
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ClaimsRequestTestSuite struct {
+	suite.Suite
+}
+
+func TestClaimsRequestSuite(t *testing.T) {
+	suite.Run(t, new(ClaimsRequestTestSuite))
+}
+
+// TestUnmarshalJSON_NormalizesUserInfo verifies that a plain json.Unmarshal (the path used by
+// the Redis-backed request/code/PAR stores) splits the userinfo object into typed normal
+// claims in UserInfo and the opaque verified_claims member in VerifiedUserInfo.
+func (suite *ClaimsRequestTestSuite) TestUnmarshalJSON_NormalizesUserInfo() {
+	raw := `{
+		"userinfo": {
+			"email": {"essential": true},
+			"name": null,
+			"sub": {"value": "alice"},
+			"verified_claims": {
+				"verification": {"trust_framework": {"value": "eidas"}},
+				"claims": {"given_name": null}
+			}
+		},
+		"id_token": {
+			"auth_time": {"essential": true}
+		}
+	}`
+
+	var cr ClaimsRequest
+	err := json.Unmarshal([]byte(raw), &cr)
+	assert.NoError(suite.T(), err)
+
+	normal := cr.UserInfo
+	assert.Len(suite.T(), normal, 3)
+
+	assert.NotNil(suite.T(), normal["email"])
+	assert.True(suite.T(), normal["email"].Essential)
+
+	// "name": null is a requested-without-constraint claim.
+	val, present := normal["name"]
+	assert.True(suite.T(), present)
+	assert.Nil(suite.T(), val)
+
+	// sub value constraint must survive the plain-unmarshal path (security: it gates auth).
+	assert.NotNil(suite.T(), normal["sub"])
+	assert.True(suite.T(), normal["sub"].MatchesValue("alice"))
+	assert.False(suite.T(), normal["sub"].MatchesValue("bob"))
+
+	// verified_claims is held separately and retained opaquely.
+	assert.NotContains(suite.T(), normal, VerifiedClaimsMember)
+	assert.NotEmpty(suite.T(), cr.VerifiedUserInfo)
+
+	// id_token stays typed.
+	assert.True(suite.T(), cr.IDToken["auth_time"].Essential)
+}
+
+// TestMarshalUnmarshal_RoundTrip mirrors the Redis store flow: marshal a normalized request,
+// then unmarshal it back, and confirm the normal claims survive.
+func (suite *ClaimsRequestTestSuite) TestMarshalUnmarshal_RoundTrip() {
+	original := ClaimsRequest{
+		UserInfo: map[string]*IndividualClaimRequest{
+			"email": {Essential: true},
+			"sub":   {Value: "alice"},
+		},
+		VerifiedUserInfo: []*VerifiedClaimsRequest{{
+			Verification: &VerificationRequest{TrustFramework: &TrustFrameworkRequest{Value: "eidas"}},
+			Claims:       map[string]*IndividualClaimRequest{"given_name": nil},
+		}},
+	}
+
+	data, err := json.Marshal(&original)
+	assert.NoError(suite.T(), err)
+
+	var reloaded ClaimsRequest
+	err = json.Unmarshal(data, &reloaded)
+	assert.NoError(suite.T(), err)
+
+	normal := reloaded.UserInfo
+	assert.Len(suite.T(), normal, 2)
+	assert.True(suite.T(), normal["email"].Essential)
+	assert.True(suite.T(), normal["sub"].MatchesValue("alice"))
+	assert.NotEmpty(suite.T(), reloaded.VerifiedUserInfo)
+}
+
+func (suite *ClaimsRequestTestSuite) TestUnmarshalJSON_MalformedUserInfoClaim() {
+	raw := `{"userinfo": {"email": "not-an-object"}}`
+
+	var cr ClaimsRequest
+	err := json.Unmarshal([]byte(raw), &cr)
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "email")
+}
+
+// TestUnmarshalJSON_NormalizesIDToken verifies that a plain json.Unmarshal splits the id_token
+// object into typed normal claims in IDToken and the opaque verified_claims member in
+// VerifiedIDToken, mirroring the userinfo handling.
+func (suite *ClaimsRequestTestSuite) TestUnmarshalJSON_NormalizesIDToken() {
+	raw := `{
+		"id_token": {
+			"auth_time": {"essential": true},
+			"acr": null,
+			"verified_claims": {
+				"verification": {"trust_framework": {"value": "eidas"}},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	var cr ClaimsRequest
+	err := json.Unmarshal([]byte(raw), &cr)
+	assert.NoError(suite.T(), err)
+
+	normal := cr.IDToken
+	assert.Len(suite.T(), normal, 2)
+
+	assert.NotNil(suite.T(), normal["auth_time"])
+	assert.True(suite.T(), normal["auth_time"].Essential)
+
+	// "acr": null is a requested-without-constraint claim.
+	val, present := normal["acr"]
+	assert.True(suite.T(), present)
+	assert.Nil(suite.T(), val)
+
+	// verified_claims is held separately and retained opaquely.
+	assert.NotContains(suite.T(), normal, VerifiedClaimsMember)
+	assert.NotEmpty(suite.T(), cr.VerifiedIDToken)
+}
+
+// TestMarshalUnmarshal_RoundTripIDToken confirms the id_token verified_claims survives the
+// marshal/unmarshal round trip used by the Redis stores.
+func (suite *ClaimsRequestTestSuite) TestMarshalUnmarshal_RoundTripIDToken() {
+	original := ClaimsRequest{
+		IDToken: map[string]*IndividualClaimRequest{
+			"auth_time": {Essential: true},
+		},
+		VerifiedIDToken: []*VerifiedClaimsRequest{{
+			Verification: &VerificationRequest{TrustFramework: &TrustFrameworkRequest{Value: "eidas"}},
+			Claims:       map[string]*IndividualClaimRequest{"given_name": nil},
+		}},
+	}
+
+	data, err := json.Marshal(&original)
+	assert.NoError(suite.T(), err)
+
+	var reloaded ClaimsRequest
+	err = json.Unmarshal(data, &reloaded)
+	assert.NoError(suite.T(), err)
+
+	normal := reloaded.IDToken
+	assert.Len(suite.T(), normal, 1)
+	assert.True(suite.T(), normal["auth_time"].Essential)
+	assert.NotContains(suite.T(), normal, VerifiedClaimsMember)
+	assert.NotEmpty(suite.T(), reloaded.VerifiedIDToken)
+}
+
+func (suite *ClaimsRequestTestSuite) TestUnmarshalJSON_MalformedIDTokenClaim() {
+	raw := `{"id_token": {"auth_time": "not-an-object"}}`
+
+	var cr ClaimsRequest
+	err := json.Unmarshal([]byte(raw), &cr)
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "auth_time")
+}

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -157,11 +157,10 @@ func (tb *tokenBuilder) buildAccessTokenClaims(
 		claims["act"] = actClaim
 	}
 
-	// Include only userinfo claims request for UserInfo endpoint support
-	if ctx.ClaimsRequest != nil && ctx.ClaimsRequest.UserInfo != nil {
-		userinfoClaims := &oauth2model.ClaimsRequest{
-			UserInfo: ctx.ClaimsRequest.UserInfo,
-		}
+	// Include only normal userinfo claims for UserInfo endpoint support.
+	// verified_claims is never resolved or returned, so it is excluded from the access token.
+	if ctx.ClaimsRequest != nil && len(ctx.ClaimsRequest.UserInfo) > 0 {
+		userinfoClaims := &oauth2model.ClaimsRequest{UserInfo: ctx.ClaimsRequest.UserInfo}
 		serialized, err := oauth2utils.SerializeClaimsRequest(userinfoClaims)
 		if err != nil {
 			return nil, fmt.Errorf("failed to serialize userinfo claims request: %w", err)

--- a/backend/internal/oauth/oauth2/utils/oauthutils.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils.go
@@ -173,13 +173,15 @@ func ParseClaimsRequest(claimsParam string) (*model.ClaimsRequest, error) {
 	return &claimsRequest, nil
 }
 
-// validateClaimsRequest validates a ClaimsRequest against OIDC spec constraints.
+// validateClaimsRequest validates a ClaimsRequest against OIDC spec constraints. Normal claims
+// and verified_claims are already normalized and structurally validated by
+// ClaimsRequest.UnmarshalJSON; here only the normal-claim constraint grammar is enforced.
 func validateClaimsRequest(cr *model.ClaimsRequest) error {
 	if cr == nil {
 		return nil
 	}
 
-	// Validate userinfo claims
+	// Validate normal userinfo claims
 	for claimName, claimReq := range cr.UserInfo {
 		if err := validateIndividualClaimRequest("userinfo", claimName, claimReq); err != nil {
 			return err
@@ -198,26 +200,9 @@ func validateClaimsRequest(cr *model.ClaimsRequest) error {
 
 // validateIndividualClaimRequest validates constraints for an individual claim request.
 func validateIndividualClaimRequest(location, claimName string, icr *model.IndividualClaimRequest) error {
-	if icr == nil {
-		return nil
+	if err := icr.Validate(); err != nil {
+		return fmt.Errorf("invalid claims parameter: claim '%s' in %s %w", claimName, location, err)
 	}
-
-	// value and values are mutually exclusive
-	if icr.Value != nil && len(icr.Values) > 0 {
-		return fmt.Errorf(
-			"invalid claims parameter: claim '%s' in %s has both 'value' and 'values' specified "+
-				"(mutually exclusive per OIDC spec)",
-			claimName, location)
-	}
-
-	// values array must contain at least one value
-	if icr.Values != nil && len(icr.Values) == 0 {
-		return fmt.Errorf(
-			"invalid claims parameter: claim '%s' in %s has empty 'values' array "+
-				"(must contain at least one value)",
-			claimName, location)
-	}
-
 	return nil
 }
 

--- a/backend/internal/oauth/oauth2/utils/oauthutils_test.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils_test.go
@@ -1032,6 +1032,622 @@ func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_NullClaimRequest() {
 	assert.Nil(suite.T(), claimsRequest.UserInfo["name"])
 }
 
+// verified_claims (OIDC Identity Assurance) tests
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_ObjectValid() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": null},
+				"claims": {"given_name": null, "family_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), claimsRequest)
+	// verified_claims is retained in the parsed request...
+	assert.NotEmpty(suite.T(), claimsRequest.VerifiedUserInfo)
+	// ...but excluded from normal-claim resolution.
+	assert.Empty(suite.T(), claimsRequest.UserInfo)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_ArrayValid() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": [
+				{"verification": {"trust_framework": {"value": "eidas"}}, "claims": {"given_name": null}},
+				{"verification": {"trust_framework": {"value": "de_aml"}}, "claims": {"birthdate": null}}
+			]
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), claimsRequest)
+	assert.NotEmpty(suite.T(), claimsRequest.VerifiedUserInfo)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_AlongsideNormalClaims() {
+	jsonStr := `{
+		"userinfo": {
+			"email": {"essential": true},
+			"verified_claims": {
+				"verification": {"trust_framework": null},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), claimsRequest)
+	// Normal claims are still decoded and resolvable.
+	normalClaims := claimsRequest.UserInfo
+	assert.Len(suite.T(), normalClaims, 1)
+	assert.NotNil(suite.T(), normalClaims["email"])
+	assert.True(suite.T(), normalClaims["email"].Essential)
+	// verified_claims is excluded from the normal-claim view.
+	assert.NotContains(suite.T(), normalClaims, model.VerifiedClaimsMember)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_MissingVerification() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {"claims": {"given_name": null}}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "verification")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_MissingTrustFramework() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {"verification": {}, "claims": {"given_name": null}}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "trust_framework")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_TrustFrameworkValuesValid() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": {"values": ["eidas", "de_aml"]}},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), claimsRequest)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_TrustFrameworkNotObject() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": "eidas"},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "trust_framework")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_TrustFrameworkValueAndValues() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": {"value": "eidas", "values": ["eidas", "de_aml"]}},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "trust_framework")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_MissingClaims() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {"verification": {"trust_framework": null}}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "claims")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_EmptyArray() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": []
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_NotAnObject() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": "not-an-object"
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_ArrayEntryInvalid() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": [
+				{"verification": {"trust_framework": null}, "claims": {"given_name": null}},
+				{"claims": {"birthdate": null}}
+			]
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "verification")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_ArrayNullEntry() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": [
+				{"verification": {"trust_framework": null}, "claims": {"given_name": null}},
+				null
+			]
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "null entries")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_ClaimEntryConstraintAllowed() {
+	// purpose and other IDA-specific members are ignored, not rejected.
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": null},
+				"claims": {
+					"given_name": null,
+					"email": {"essential": true, "purpose": "to contact you"}
+				}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), claimsRequest)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_ClaimEntryNotObject() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": null},
+				"claims": {"given_name": "not-an-object"}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "verified_claims.claims")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_ClaimEntryValueAndValues() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": null},
+				"claims": {
+					"given_name": {"value": "Alice", "values": ["Alice", "Bob"]}
+				}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "verified_claims.claims")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_TimeMaxAgeValid() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {
+					"trust_framework": null,
+					"time": {"max_age": 63113852}
+				},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), claimsRequest)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_TimeNull() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": null, "time": null},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), claimsRequest)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_TimeNotObject() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": null, "time": "yesterday"},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "verified_claims.verification.time")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_MaxAgeNegative() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": null, "time": {"max_age": -5}},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "max_age")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_MaxAgeNotInteger() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": null, "time": {"max_age": "soon"}},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "max_age")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_VerifiedClaims_MaxAgeFractional() {
+	jsonStr := `{
+		"userinfo": {
+			"verified_claims": {
+				"verification": {"trust_framework": null, "time": {"max_age": 3.9}},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "max_age")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestSerializeClaimsRequest_RoundTrip_VerifiedClaims() {
+	jsonStr := `{
+		"userinfo": {
+			"email": {"essential": true},
+			"verified_claims": {
+				"verification": {"trust_framework": {"value": "eidas"}, "evidence": [{"type": "document"}]},
+				"claims": {"given_name": null, "address": {"essential": true}}
+			}
+		}
+	}`
+
+	original, err := ParseClaimsRequest(jsonStr)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), original)
+
+	// Round-trip through serialization and re-parse (the store persistence path).
+	serialized, err := SerializeClaimsRequest(original)
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), serialized)
+
+	reloaded, err := ParseClaimsRequest(serialized)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), reloaded)
+
+	// verified_claims survives as a single normalized entry; unmodeled IDA members (evidence) are
+	// dropped while the modeled fields are reconstructed.
+	suite.Require().Len(reloaded.VerifiedUserInfo, 1)
+	entry := reloaded.VerifiedUserInfo[0]
+	assert.Equal(suite.T(), "eidas", entry.Verification.TrustFramework.Value)
+	assert.Len(suite.T(), entry.Claims, 2)
+	givenName, hasGivenName := entry.Claims["given_name"]
+	assert.True(suite.T(), hasGivenName)
+	assert.Nil(suite.T(), givenName)
+	assert.True(suite.T(), entry.Claims["address"].Essential)
+}
+
+// verified_claims in the id_token section (OIDC Identity Assurance) tests
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_IDTokenVerifiedClaims_ObjectValid() {
+	jsonStr := `{
+		"id_token": {
+			"verified_claims": {
+				"verification": {"trust_framework": null},
+				"claims": {"given_name": null, "family_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), claimsRequest)
+	// verified_claims is retained in the parsed request...
+	assert.NotEmpty(suite.T(), claimsRequest.VerifiedIDToken)
+	// ...but excluded from normal-claim resolution.
+	assert.Empty(suite.T(), claimsRequest.IDToken)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_IDTokenVerifiedClaims_ArrayValid() {
+	jsonStr := `{
+		"id_token": {
+			"verified_claims": [
+				{"verification": {"trust_framework": {"value": "eidas"}}, "claims": {"given_name": null}},
+				{"verification": {"trust_framework": {"value": "de_aml"}}, "claims": {"birthdate": null}}
+			]
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), claimsRequest)
+	assert.NotEmpty(suite.T(), claimsRequest.VerifiedIDToken)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_IDTokenVerifiedClaims_AlongsideNormalClaims() {
+	jsonStr := `{
+		"id_token": {
+			"auth_time": {"essential": true},
+			"verified_claims": {
+				"verification": {"trust_framework": null},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), claimsRequest)
+	// Normal claims are still decoded and resolvable.
+	normalClaims := claimsRequest.IDToken
+	assert.Len(suite.T(), normalClaims, 1)
+	assert.NotNil(suite.T(), normalClaims["auth_time"])
+	assert.True(suite.T(), normalClaims["auth_time"].Essential)
+	// verified_claims is excluded from the normal-claim view.
+	assert.NotContains(suite.T(), normalClaims, model.VerifiedClaimsMember)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_IDTokenVerifiedClaims_MissingVerification() {
+	jsonStr := `{
+		"id_token": {
+			"verified_claims": {"claims": {"given_name": null}}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "verification")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_IDTokenVerifiedClaims_MissingTrustFramework() {
+	jsonStr := `{
+		"id_token": {
+			"verified_claims": {"verification": {}, "claims": {"given_name": null}}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "trust_framework")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_IDTokenVerifiedClaims_MissingClaims() {
+	jsonStr := `{
+		"id_token": {
+			"verified_claims": {"verification": {"trust_framework": null}}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "claims")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_IDTokenVerifiedClaims_EmptyArray() {
+	jsonStr := `{
+		"id_token": {
+			"verified_claims": []
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_IDTokenVerifiedClaims_NotAnObject() {
+	jsonStr := `{
+		"id_token": {
+			"verified_claims": "not-an-object"
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_IDTokenVerifiedClaims_ClaimEntryValueAndValues() {
+	jsonStr := `{
+		"id_token": {
+			"verified_claims": {
+				"verification": {"trust_framework": null},
+				"claims": {
+					"given_name": {"value": "Alice", "values": ["Alice", "Bob"]}
+				}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "verified_claims.claims")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_IDTokenVerifiedClaims_MaxAgeNegative() {
+	jsonStr := `{
+		"id_token": {
+			"verified_claims": {
+				"verification": {"trust_framework": null, "time": {"max_age": -5}},
+				"claims": {"given_name": null}
+			}
+		}
+	}`
+
+	claimsRequest, err := ParseClaimsRequest(jsonStr)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), claimsRequest)
+	assert.Contains(suite.T(), err.Error(), "max_age")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestSerializeClaimsRequest_RoundTrip_IDTokenVerifiedClaims() {
+	jsonStr := `{
+		"id_token": {
+			"auth_time": {"essential": true},
+			"verified_claims": {
+				"verification": {"trust_framework": {"value": "eidas"}, "evidence": [{"type": "document"}]},
+				"claims": {"given_name": null, "address": {"essential": true}}
+			}
+		}
+	}`
+
+	original, err := ParseClaimsRequest(jsonStr)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), original)
+
+	// Round-trip through serialization and re-parse (the store persistence path).
+	serialized, err := SerializeClaimsRequest(original)
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), serialized)
+
+	reloaded, err := ParseClaimsRequest(serialized)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), reloaded)
+
+	// The normal id_token claim survives the round trip.
+	assert.True(suite.T(), reloaded.IDToken["auth_time"].Essential)
+
+	// verified_claims survives as a single normalized entry; unmodeled IDA members (evidence) are
+	// dropped while the modeled fields are reconstructed.
+	suite.Require().Len(reloaded.VerifiedIDToken, 1)
+	entry := reloaded.VerifiedIDToken[0]
+	assert.Equal(suite.T(), "eidas", entry.Verification.TrustFramework.Value)
+	assert.Len(suite.T(), entry.Claims, 2)
+	givenName, hasGivenName := entry.Claims["given_name"]
+	assert.True(suite.T(), hasGivenName)
+	assert.Nil(suite.T(), givenName)
+	assert.True(suite.T(), entry.Claims["address"].Essential)
+}
+
 // buildTestAssertion builds a minimal (unsigned) JWT string from the given payload map.
 // The signature segment is a placeholder; DecodeFlowAssertionClaims only base64-decodes the payload.
 func buildTestAssertion(payload map[string]interface{}) string {


### PR DESCRIPTION
### Purpose
Support verified_claims in the claims.userinfo parameter in authorize endpoint

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- #3315 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OIDC Identity Assurance `verified_claims` in both userinfo and ID token requests, including trust framework, evidence/claim constraints, and time constraints.
* **Bug Fixes**
  * Improved `verified_claims` handling so they’re validated and preserved separately from normal claim resolution, and ensured access-token claim inclusion excludes `verified_claims`.
* **Tests**
  * Added extensive parsing, validation, marshal/unmarshal, and serialize/round-trip persistence tests for `verified_claims` (including object and array forms) and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->