### PR TITLE
Add Maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,42 @@
+# ThunderID Maintainers
+
+The people who maintain ThunderID. Maintainers review designs, review code, shape the roadmap, ship releases, and keep the community healthy. Decisions are made by consensus among maintainers.
+
+## Core Maintainers
+
+Core Maintainers have write/merge access across the entire repository and are responsible for stewardship of the project’s long-term roadmap and architectural consistency. Core Maintainers are expected to remain active, participate in design discussions, and provide timely reviews.
+
+In addition to these responsibilities, the Core Maintainers collectively serve as the project’s Security Team, handling security-related issues, coordinating responsible disclosures, and ensuring that patches and advisories are managed appropriately.
+
+| Name | GitHub ID | Affiliation |
+| ----- | ----- | ----- |
+| Darshana Gunawardana | [@darshanasbg](https://github.com/darshanasbg) | WSO2 |
+| Ishara Karunarathne | [@isharak](https://github.com/isharak) | WSO2 |
+| Omindu Rathnaweera | [@omindu](https://github.com/omindu) | WSO2 |
+| Senthalan Kanagalingam | [@senthalan](https://github.com/senthalan) | WSO2 |
+
+## Area Maintainers
+
+These Maintainers are responsible for a specific area of the codebase. Their approval is needed to merge changes in their area, and they're expected to weigh in on design discussions that touch it.
+
+| Name | GitHub ID | Affiliation |
+| ----- | ----- | ----- |
+| Anusha Sunkada  | [@anushasunkada](https://github.com/anushasunkada)  | MOSIP  |
+| Brion Silva  | [@brionmario](https://github.com/brionmario)  | WSO2  |
+| Charith Rajitha  | [@rajithacharith](https://github.com/rajithacharith)  | WSO2  |
+| Jerad Rutnam  | [@jeradrutnam](https://github.com/jeradrutnam)  | WSO2  |
+| Omal Wijegunawardana  | [@DonOmalVindula](https://github.com/DonOmalVindula)  | WSO2  |
+| Piumini Ranasinghe  | [@KaveeshaPiumini](https://github.com/KaveeshaPiumini)  | WSO2  |
+| Sahan Dilshan  | [@sahandilshan](https://github.com/sahandilshan)  | WSO2  |
+| Thamindu Jayawickrama  | [@ThaminduDilshan](https://github.com/ThaminduDilshan)  | WSO2  |
+| Thivaharan Kalyanasundaram  | [@thiva-k](https://github.com/thiva-k)  | WSO2  |
+| Thumula Perera  | [@ThumulaPerera](https://github.com/ThumulaPerera)  | WSO2  |
+
+## Docs Maintainers
+
+Docs Maintainers own the project documentation and public website.
+
+| Name | GitHub ID | Affiliation |
+| ----- | ----- | ----- |
+| Himesh Siriwardana | [@himeshsiriwardana](https://github.com/himeshsiriwardana) | WSO2 |
+| Sagara Gunathunga | [@sagara-gunathunga](https://github.com/sagara-gunathunga) | WSO2 |


### PR DESCRIPTION
### Purpose

$subject by adding MAINTAINERS.md listing core/area/docs maintainers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added maintainer documentation outlining the governance structure and responsibilities of core maintainers (including security stewardship), area maintainers (for domain-specific approvals), and documentation maintainers (for documentation oversight), along with associated team member details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->