### PR TITLE
Add missing seq-diagram CSS styles for sequence diagram components

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -4242,3 +4242,78 @@ a.connect-card {
   .dp-next-grid   { grid-template-columns: 1fr; }
 }
 
+/* ── Sequence Diagrams ── */
+
+.seq-diagram {
+  margin: 1.5rem 0;
+  overflow-x: auto;
+}
+
+.seq-actor {
+  fill: color-mix(in srgb, var(--ifm-color-primary) 10%, transparent);
+  stroke: var(--ifm-color-primary);
+  stroke-width: 1.5;
+}
+
+.seq-actor-label {
+  fill: var(--ifm-font-color-base);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.seq-lifeline {
+  stroke: var(--ifm-color-emphasis-300);
+  stroke-width: 1;
+  stroke-dasharray: 5 4;
+}
+
+.seq-message {
+  stroke: var(--ifm-color-emphasis-600);
+  stroke-width: 1.5;
+  fill: none;
+}
+
+.seq-arrowhead {
+  fill: var(--ifm-color-emphasis-600);
+}
+
+.seq-message-label {
+  fill: var(--ifm-font-color-base);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.seq-message-sublabel {
+  fill: var(--ifm-color-emphasis-600);
+  font-size: 11px;
+}
+
+.seq-note-bg {
+  fill: color-mix(in srgb, var(--ifm-color-primary) 8%, transparent);
+  stroke: color-mix(in srgb, var(--ifm-color-primary) 30%, transparent);
+  stroke-width: 1;
+}
+
+.seq-note {
+  fill: var(--ifm-font-color-base);
+  font-size: 11px;
+}
+
+[data-theme='dark'] .seq-actor {
+  fill: color-mix(in srgb, var(--ifm-color-primary) 18%, transparent);
+}
+
+[data-theme='dark'] .seq-lifeline {
+  stroke: var(--ifm-color-emphasis-400);
+}
+
+[data-theme='dark'] .seq-message,
+[data-theme='dark'] .seq-arrowhead {
+  stroke: var(--ifm-color-emphasis-500);
+  fill: var(--ifm-color-emphasis-500);
+}
+
+[data-theme='dark'] .seq-message-sublabel {
+  fill: var(--ifm-color-emphasis-500);
+}
+


### PR DESCRIPTION
### Purpose
Sequence diagrams on all OAuth/OIDC protocol pages and the authentication integration models page were rendering without any styling — no actor boxes, lifelines, arrows, or labels — because the seq-* CSS classes used by the SequenceDiagram component were never added to custom.css.

### Approach
Added the missing seq-* CSS rules to custom.css with light and dark theme support. This single change fixes all 11 affected pages.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3330

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced styling for sequence diagrams in the documentation, including actors, lifelines, message arrows, labels, and note callouts.
  * Added dark mode overrides to keep diagram colors and contrast consistent and readable across themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->