### PR TITLE
Refactoring exporter structs to unexported

### DIFF
--- a/backend/internal/system/export/registry.go
+++ b/backend/internal/system/export/registry.go
@@ -21,29 +21,29 @@ package export
 import declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 
 // ResourceExporterRegistry holds all registered resource exporters.
-type ResourceExporterRegistry struct {
+type resourceExporterRegistry struct {
 	exporters map[string]declarativeresource.ResourceExporter
 }
 
 // NewResourceExporterRegistry creates a new registry for resource exporters.
-func newResourceExporterRegistry() *ResourceExporterRegistry {
-	return &ResourceExporterRegistry{
+func newResourceExporterRegistry() *resourceExporterRegistry {
+	return &resourceExporterRegistry{
 		exporters: make(map[string]declarativeresource.ResourceExporter),
 	}
 }
 
 // Register adds a new resource exporter to the registry.
-func (r *ResourceExporterRegistry) Register(exporter declarativeresource.ResourceExporter) {
+func (r *resourceExporterRegistry) Register(exporter declarativeresource.ResourceExporter) {
 	r.exporters[exporter.GetResourceType()] = exporter
 }
 
 // Get retrieves a resource exporter by type.
-func (r *ResourceExporterRegistry) Get(resourceType string) (declarativeresource.ResourceExporter, bool) {
+func (r *resourceExporterRegistry) Get(resourceType string) (declarativeresource.ResourceExporter, bool) {
 	exporter, exists := r.exporters[resourceType]
 	return exporter, exists
 }
 
 // GetAll returns all registered exporters.
-func (r *ResourceExporterRegistry) GetAll() map[string]declarativeresource.ResourceExporter {
+func (r *resourceExporterRegistry) GetAll() map[string]declarativeresource.ResourceExporter {
 	return r.exporters
 }

--- a/backend/internal/system/export/registry_test.go
+++ b/backend/internal/system/export/registry_test.go
@@ -32,7 +32,7 @@ import (
 
 type RegistryTestSuite struct {
 	suite.Suite
-	registry *ResourceExporterRegistry
+	registry *resourceExporterRegistry
 }
 
 func TestRegistryTestSuite(t *testing.T) {

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -73,7 +73,7 @@ type ExportServiceInterface interface {
 // exportService implements the ExportServiceInterface.
 type exportService struct {
 	parameterizer parameterizerInterface
-	registry      *ResourceExporterRegistry
+	registry      *resourceExporterRegistry
 }
 
 // newExportService creates a new instance of exportService.


### PR DESCRIPTION
### Purpose
Refactor remaining struct in packages to be unexported, as they are internal implementation details that do not need to be accessible outside the package.
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Renamed ResourceExporterRegistry to resourceExporterRegistry in registry.go, as that is the only exported struct remain and updated all references within the export package (service.go, registry_test.go).

### Related Issues
- #1569 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the internal resource exporter registry to use a non-public implementation while preserving existing registration and lookup behavior.
* **Tests**
  * Adjusted the registry test suite and related service wiring to match the updated internal registry type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->