### PR TITLE
Preserve skip-changelog label on force-push and manual apply

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,7 +8,13 @@ reviews:
   auto_apply_labels: true
   labeling_instructions:
     - label: skip-changelog
-      instructions: "All changed files are under docs/"
+      instructions: |
+        Apply this label when ALL changed files in the PR are under the `docs/` directory.
+        On force-push or re-review, re-apply this label if the condition is still met.
+        Remove this label only if ALL of the following are true:
+          1. Non-docs files are present in the PR.
+          2. The label was previously applied automatically by CodeRabbit (not added manually by a developer).
+        Never remove this label if it was manually added by a developer, regardless of what files are changed.
 
   path_instructions:
     - path: "**/*.go"


### PR DESCRIPTION
## Summary

- Updated CodeRabbit labeling instructions to explicitly preserve the `skip-changelog` label when it was already applied (either by a previous automated review or manually by a maintainer)
- Instructs CodeRabbit to re-apply the label on force-push if the docs-only condition is still met
- Prevents CodeRabbit from stripping manually-added `skip-changelog` labels during re-reviews

Fixes the two regressions observed in:
- [#3235](https://github.com/thunder-id/thunderid/pull/3235) — label removed after force-push on a docs-only PR
- [#3329](https://github.com/thunder-id/thunderid/pull/3329) — manually-added `skip-changelog` label removed by CodeRabbit

## Test plan

- [ ] Open a docs-only PR, verify `skip-changelog` is applied
- [ ] Force-push to that PR, verify the label is preserved
- [ ] Manually add `skip-changelog` to a non-docs PR, verify CodeRabbit does not remove it on next review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated changelog label configuration to improve automatic application criteria (only when all changes are within `docs/`), including safer handling for re-reviews and force-pushes, while ensuring manually-applied `skip-changelog` labels are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->