### PR TITLE
Add CIBA poll mode support to the JavaScript SDK

### DIFF
--- a/sdks/javascript/src/ThunderIDJavaScriptClient.ts
+++ b/sdks/javascript/src/ThunderIDJavaScriptClient.ts
@@ -24,9 +24,11 @@ import PKCEConstants from './constants/PKCEConstants';
 import {DefaultCacheStore} from './DefaultCacheStore';
 import {DefaultCrypto} from './DefaultCrypto';
 import {ThunderIDAuthException} from './errors/exception';
+import ThunderIDAPIError from './errors/ThunderIDAPIError';
 import {IsomorphicCrypto} from './IsomorphicCrypto';
 import {AgentConfig} from './models/agent';
 import {AuthCodeResponse} from './models/auth-code-response';
+import type {CIBAInitiateOptions, CIBAInitiateResponse, CIBAPollOptions} from './models/ciba';
 import {ThunderIDClient} from './models/client';
 import {AuthClientConfig, Config, SignInOptions, SignOutOptions, SignUpOptions} from './models/config';
 import {Crypto} from './models/crypto';
@@ -784,6 +786,247 @@ class ThunderIDJavaScriptClient<T = Config> implements ThunderIDClient<T> {
     this.authHelper.clearSession(userId);
 
     return response;
+  }
+
+  public async initiateCIBA(options: CIBAInitiateOptions): Promise<CIBAInitiateResponse> {
+    if (
+      !(await this.storageManager.getTemporaryDataParameter(
+        OIDCDiscoveryConstants.Storage.StorageKeys.OPENID_PROVIDER_CONFIG_INITIATED,
+      ))
+    ) {
+      await this.loadOpenIDProviderConfiguration(false);
+    }
+
+    const backchannelEndpoint: string | undefined =
+      (await this.oidcProviderMetaDataProvider()).backchannel_authentication_endpoint;
+
+    if (!backchannelEndpoint || backchannelEndpoint.trim().length === 0) {
+      throw new ThunderIDAPIError(
+        'No backchannel_authentication_endpoint was found in the OIDC provider metadata.',
+        'JS-AUTH_CORE-CIBA1-NF01',
+        'javascript',
+      );
+    }
+
+    const hintCount = [options.loginHint, options.loginHintToken, options.idTokenHint].filter(Boolean).length;
+
+    if (hintCount === 0) {
+      throw new ThunderIDAPIError(
+        'Provide one of loginHint, loginHintToken, or idTokenHint.',
+        'JS-AUTH_CORE-CIBA1-IV01',
+        'javascript',
+        undefined,
+        undefined,
+        'CIBA initiation requires exactly one hint',
+      );
+    }
+
+    if (hintCount > 1) {
+      throw new ThunderIDAPIError(
+        'Only one of loginHint, loginHintToken, or idTokenHint may be set.',
+        'JS-AUTH_CORE-CIBA1-IV02',
+        'javascript',
+        undefined,
+        undefined,
+        'CIBA initiation received multiple hints',
+      );
+    }
+
+    const configData = await this.configProvider();
+    const hasSecret = Boolean(configData.clientSecret && configData.clientSecret.trim().length > 0);
+    const tokenEndpointAuthMethod = configData.tokenRequest?.authMethod ?? 'client_secret_basic';
+
+    const body = new URLSearchParams();
+
+    body.set('client_id', configData.clientId ?? '');
+
+    if (hasSecret && tokenEndpointAuthMethod === 'client_secret_post') {
+      body.set('client_secret', configData.clientSecret!);
+    }
+
+    const scopeStr = processOpenIDScopes(configData.scopes);
+    if (scopeStr) body.set('scope', scopeStr);
+    if (options.loginHint) body.set('login_hint', options.loginHint);
+    if (options.loginHintToken) body.set('login_hint_token', options.loginHintToken);
+    if (options.idTokenHint) body.set('id_token_hint', options.idTokenHint);
+    if (options.bindingMessage) body.set('binding_message', options.bindingMessage);
+    if (options.acrValues) body.set('acr_values', options.acrValues);
+    if (options.requestedExpiry !== undefined) body.set('requested_expiry', String(options.requestedExpiry));
+
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+
+    if (hasSecret && tokenEndpointAuthMethod === 'client_secret_basic') {
+      const credential = `${encodeURIComponent(configData.clientId!)}:${encodeURIComponent(configData.clientSecret!)}`;
+      headers['Authorization'] = `Basic ${base64Encode(credential)}`;
+    }
+
+    let response: Response;
+
+    try {
+      response = await fetch(backchannelEndpoint, {
+        body,
+        credentials: configData.sendCookiesInRequests ? 'include' : 'same-origin',
+        headers,
+        method: 'POST',
+      });
+    } catch (error: any) {
+      throw new ThunderIDAPIError(
+        error ?? 'The request to the backchannel authentication endpoint failed.',
+        'JS-AUTH_CORE-CIBA1-NE02',
+        'javascript',
+        undefined,
+        undefined,
+        'CIBA backchannel authentication request failed',
+      );
+    }
+
+    const rawBody = await response.text().catch(() => '');
+    let parsedBody: unknown;
+    try {
+      parsedBody = JSON.parse(rawBody);
+    } catch {
+      parsedBody = rawBody;
+    }
+
+    if (!response.ok) {
+      throw new ThunderIDAPIError(
+        parsedBody as string,
+        'JS-AUTH_CORE-CIBA1-HE03',
+        'javascript',
+        response.status,
+        response.statusText,
+        'CIBA backchannel authentication request failed',
+      );
+    }
+
+    const payload = parsedBody as {auth_req_id?: string; expires_in?: number; interval?: number};
+
+    if (!payload.auth_req_id) {
+      throw new ThunderIDAPIError(
+        'The server response did not include an auth_req_id.',
+        'JS-AUTH_CORE-CIBA1-PR04',
+        'javascript',
+      );
+    }
+
+    return {
+      authReqId: payload.auth_req_id,
+      expiresIn: payload.expires_in ?? 120,
+      interval: payload.interval ?? 5,
+    };
+  }
+
+  public async pollCIBA(authReqId: string, interval: number, options?: CIBAPollOptions): Promise<TokenResponse> {
+    const tokenEndpoint: string | undefined = (await this.oidcProviderMetaDataProvider()).token_endpoint;
+    const configData = await this.configProvider();
+
+    if (!tokenEndpoint || tokenEndpoint.trim().length === 0) {
+      throw new ThunderIDAPIError(
+        'No token endpoint was found in the OIDC provider metadata.',
+        'JS-AUTH_CORE-CIBA2-NF01',
+        'javascript',
+      );
+    }
+
+    const hasSecret = Boolean(configData.clientSecret && configData.clientSecret.trim().length > 0);
+    const tokenEndpointAuthMethod = configData.tokenRequest?.authMethod ?? 'client_secret_basic';
+
+    const buildBody = (): URLSearchParams => {
+      const body = new URLSearchParams();
+      body.set('grant_type', 'urn:openid:params:grant-type:ciba');
+      body.set('auth_req_id', authReqId);
+      body.set('client_id', configData.clientId ?? '');
+      if (hasSecret && tokenEndpointAuthMethod === 'client_secret_post') {
+        body.set('client_secret', configData.clientSecret!);
+      }
+      return body;
+    };
+
+    const buildHeaders = (): Record<string, string> => {
+      const headers: Record<string, string> = {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      };
+      if (hasSecret && tokenEndpointAuthMethod === 'client_secret_basic') {
+        const credential = `${encodeURIComponent(configData.clientId!)}:${encodeURIComponent(configData.clientSecret!)}`;
+        headers['Authorization'] = `Basic ${base64Encode(credential)}`;
+      }
+      return headers;
+    };
+
+    let currentInterval = interval;
+
+    while (true) {
+      if (options?.signal?.aborted) {
+        throw new ThunderIDAPIError('CIBA polling was cancelled.', 'JS-AUTH_CORE-CIBA2-AB05', 'javascript');
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, currentInterval * 1000);
+        options?.signal?.addEventListener('abort', () => {
+          clearTimeout(timer);
+          reject(new ThunderIDAPIError('CIBA polling was cancelled.', 'JS-AUTH_CORE-CIBA2-AB05', 'javascript'));
+        }, {once: true});
+      });
+
+      let pollResponse: Response;
+
+      try {
+        pollResponse = await fetch(tokenEndpoint, {
+          body: buildBody(),
+          credentials: configData.sendCookiesInRequests ? 'include' : 'same-origin',
+          headers: buildHeaders(),
+          method: 'POST',
+          signal: options?.signal,
+        });
+      } catch (error: any) {
+        if (error?.name === 'AbortError') {
+          throw new ThunderIDAPIError('CIBA polling was cancelled.', 'JS-AUTH_CORE-CIBA2-AB05', 'javascript');
+        }
+        throw new ThunderIDAPIError(
+          error ?? 'The polling request to the token endpoint failed.',
+          'JS-AUTH_CORE-CIBA2-NE02',
+          'javascript',
+          undefined,
+          undefined,
+          'CIBA token polling request failed',
+        );
+      }
+
+      if (pollResponse.ok) {
+        return this.authHelper.handleTokenResponse(pollResponse) as Promise<TokenResponse>;
+      }
+
+      const rawPollBody = await pollResponse.text().catch(() => '');
+      let errorPayload: {error?: string; error_description?: string};
+      try {
+        errorPayload = JSON.parse(rawPollBody);
+      } catch {
+        errorPayload = {};
+      }
+      const errorCode = errorPayload.error;
+
+      if (errorCode === 'authorization_pending') {
+        continue;
+      }
+
+      if (errorCode === 'slow_down') {
+        currentInterval += 5;
+        continue;
+      }
+
+      throw new ThunderIDAPIError(
+        JSON.stringify(errorPayload),
+        'JS-AUTH_CORE-CIBA2-HE03',
+        'javascript',
+        pollResponse.status,
+        pollResponse.statusText,
+        `CIBA polling terminated: ${errorCode}`,
+      );
+    }
   }
 
   protected async getPKCECode(state: string, userId?: string): Promise<string> {

--- a/sdks/javascript/src/__tests__/ThunderIDJavaScriptClient.test.ts
+++ b/sdks/javascript/src/__tests__/ThunderIDJavaScriptClient.test.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {describe, expect, it, vi, beforeEach} from 'vitest';
+import {describe, expect, it, vi, beforeEach, afterEach} from 'vitest';
 import ThunderIDJavaScriptClient from '../ThunderIDJavaScriptClient';
 import type {Storage} from '../models/store';
 
@@ -26,9 +26,12 @@ vi.mock('../IsomorphicCrypto', () => ({
   },
 }));
 
+const mockHandleTokenResponse = vi.fn();
+
 vi.mock('../utils/AuthenticationHelper', () => ({
   default: class MockAuthenticationHelper {
     constructor(_storage: unknown, _crypto: unknown) {}
+    handleTokenResponse = mockHandleTokenResponse;
   },
 }));
 
@@ -52,12 +55,46 @@ async function getStoredConfig(client: ThunderIDJavaScriptClient): Promise<Recor
   return (client as any).storageManager.getConfigData();
 }
 
+const BASE_CONFIG = {baseUrl: 'https://example.com', clientId: 'test-client', clientSecret: 'test-secret'} as any;
+
+const OIDC_META = {
+  backchannel_authentication_endpoint: 'https://example.com/oauth2/bc-authorize',
+  token_endpoint: 'https://example.com/oauth2/token',
+};
+
+async function initClientWithOIDC(store: MemoryStore): Promise<ThunderIDJavaScriptClient> {
+  const client = new ThunderIDJavaScriptClient(store, {} as any);
+  await client.initialize(BASE_CONFIG);
+  const sm = (client as any).storageManager;
+  await sm.setOIDCProviderMetaData(OIDC_META);
+  await sm.setTemporaryDataParameter('op_config_initiated', true);
+  return client;
+}
+
+function mockFetchOnce(body: unknown, ok = true, status = 200): void {
+  const serialized = typeof body === 'string' ? body : JSON.stringify(body);
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValueOnce({
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(serialized),
+      ok,
+      status,
+      statusText: ok ? 'OK' : 'Bad Request',
+    }),
+  );
+}
+
 describe('ThunderIDJavaScriptClient', () => {
   let store: MemoryStore;
 
   beforeEach(() => {
     vi.clearAllMocks();
     store = new MemoryStore();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   describe('initialize()', () => {
@@ -121,6 +158,285 @@ describe('ThunderIDJavaScriptClient', () => {
 
       expect(config['applicationId']).toBe('app-123');
       expect(config['scope']).toContain('openid');
+    });
+  });
+
+  describe('initiateCIBA()', () => {
+    it('should throw when backchannel_authentication_endpoint is absent from OIDC metadata', async () => {
+      const client = new ThunderIDJavaScriptClient(store, {} as any);
+      await client.initialize(BASE_CONFIG);
+      const sm = (client as any).storageManager;
+      await sm.setOIDCProviderMetaData({token_endpoint: 'https://example.com/oauth2/token'});
+      await sm.setTemporaryDataParameter('op_config_initiated', true);
+
+      await expect(client.initiateCIBA({loginHint: 'user@example.com'})).rejects.toMatchObject({
+        code: 'JS-AUTH_CORE-CIBA1-NF01',
+      });
+    });
+
+    it('should throw when no hint is provided', async () => {
+      const client = await initClientWithOIDC(store);
+
+      await expect(client.initiateCIBA({})).rejects.toMatchObject({
+        code: 'JS-AUTH_CORE-CIBA1-IV01',
+      });
+    });
+
+    it('should throw when multiple hints are provided', async () => {
+      const client = await initClientWithOIDC(store);
+
+      await expect(
+        client.initiateCIBA({loginHint: 'user@example.com', idTokenHint: 'id-token'}),
+      ).rejects.toMatchObject({code: 'JS-AUTH_CORE-CIBA1-IV02'});
+    });
+
+    it('should throw when the server returns a non-ok response', async () => {
+      const client = await initClientWithOIDC(store);
+      mockFetchOnce({error: 'invalid_request'}, false, 400);
+
+      await expect(client.initiateCIBA({loginHint: 'user@example.com'})).rejects.toMatchObject({
+        code: 'JS-AUTH_CORE-CIBA1-HE03',
+        statusCode: 400,
+      });
+    });
+
+    it('should throw when the server response is missing auth_req_id', async () => {
+      const client = await initClientWithOIDC(store);
+      mockFetchOnce({expires_in: 120, interval: 5});
+
+      await expect(client.initiateCIBA({loginHint: 'user@example.com'})).rejects.toMatchObject({
+        code: 'JS-AUTH_CORE-CIBA1-PR04',
+      });
+    });
+
+    it('should return authReqId, interval, and expiresIn on success', async () => {
+      const client = await initClientWithOIDC(store);
+      mockFetchOnce({auth_req_id: 'req-123', expires_in: 300, interval: 5});
+
+      const result = await client.initiateCIBA({loginHint: 'user@example.com'});
+
+      expect(result).toEqual({authReqId: 'req-123', expiresIn: 300, interval: 5});
+    });
+
+    it('should default interval to 5 and expiresIn to 120 when server omits them', async () => {
+      const client = await initClientWithOIDC(store);
+      mockFetchOnce({auth_req_id: 'req-456'});
+
+      const result = await client.initiateCIBA({loginHint: 'user@example.com'});
+
+      expect(result.interval).toBe(5);
+      expect(result.expiresIn).toBe(120);
+    });
+
+    it('should send Authorization: Basic header when using client_secret_basic', async () => {
+      const client = await initClientWithOIDC(store);
+      const fetchMock = vi.fn().mockResolvedValueOnce({
+        json: () => Promise.resolve({auth_req_id: 'req-789', expires_in: 120, interval: 5}),
+        text: () => Promise.resolve(JSON.stringify({auth_req_id: 'req-789', expires_in: 120, interval: 5})),
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await client.initiateCIBA({bindingMessage: 'Approve login', loginHint: 'user@example.com'});
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['Authorization']).toMatch(/^Basic /);
+      const body: URLSearchParams = init.body;
+      expect(body.has('client_secret')).toBe(false);
+    });
+
+    it('should send client_secret in body and no Authorization header when using client_secret_post', async () => {
+      const client = new ThunderIDJavaScriptClient(store, {} as any);
+      await client.initialize({...BASE_CONFIG, tokenRequest: {authMethod: 'client_secret_post'}} as any);
+      const sm = (client as any).storageManager;
+      await sm.setOIDCProviderMetaData(OIDC_META);
+      await sm.setTemporaryDataParameter('op_config_initiated', true);
+
+      const fetchMock = vi.fn().mockResolvedValueOnce({
+        json: () => Promise.resolve({auth_req_id: 'req-post', expires_in: 120, interval: 5}),
+        text: () => Promise.resolve(JSON.stringify({auth_req_id: 'req-post', expires_in: 120, interval: 5})),
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await client.initiateCIBA({loginHint: 'user@example.com'});
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['Authorization']).toBeUndefined();
+      const body: URLSearchParams = init.body;
+      expect(body.get('client_secret')).toBe('test-secret');
+    });
+  });
+
+  describe('pollCIBA()', () => {
+    it('should throw when token_endpoint is absent from OIDC metadata', async () => {
+      const client = new ThunderIDJavaScriptClient(store, {} as any);
+      await client.initialize(BASE_CONFIG);
+      const sm = (client as any).storageManager;
+      await sm.setOIDCProviderMetaData({
+        backchannel_authentication_endpoint: 'https://example.com/oauth2/bc-authorize',
+      });
+      await sm.setTemporaryDataParameter('op_config_initiated', true);
+
+      await expect(client.pollCIBA('req-123', 5)).rejects.toMatchObject({
+        code: 'JS-AUTH_CORE-CIBA2-NF01',
+      });
+    });
+
+    it('should resolve with TokenResponse when the server approves on the first poll', async () => {
+      const client = await initClientWithOIDC(store);
+      const tokenResponse = {access_token: 'tok', expires_in: 3600};
+      mockHandleTokenResponse.mockResolvedValueOnce(tokenResponse);
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValueOnce({
+          json: () => Promise.resolve(tokenResponse),
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+        }),
+      );
+
+      const result = await client.pollCIBA('req-123', 0);
+
+      expect(result).toBe(tokenResponse);
+      expect(mockHandleTokenResponse).toHaveBeenCalledOnce();
+    });
+
+    it('should retry on authorization_pending and resolve on subsequent approval', async () => {
+      const client = await initClientWithOIDC(store);
+      const tokenResponse = {access_token: 'tok', expires_in: 3600};
+      mockHandleTokenResponse.mockResolvedValueOnce(tokenResponse);
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          json: () => Promise.resolve({error: 'authorization_pending'}),
+          text: () => Promise.resolve(JSON.stringify({error: 'authorization_pending'})),
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+        })
+        .mockResolvedValueOnce({
+          json: () => Promise.resolve(tokenResponse),
+          text: () => Promise.resolve(JSON.stringify(tokenResponse)),
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+        });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await client.pollCIBA('req-123', 0);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result).toBe(tokenResponse);
+    });
+
+    it('should increase interval by 5 on slow_down and continue polling', async () => {
+      const client = await initClientWithOIDC(store);
+      const tokenResponse = {access_token: 'tok', expires_in: 3600};
+      mockHandleTokenResponse.mockResolvedValueOnce(tokenResponse);
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          json: () => Promise.resolve({error: 'slow_down'}),
+          text: () => Promise.resolve(JSON.stringify({error: 'slow_down'})),
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+        })
+        .mockResolvedValueOnce({
+          json: () => Promise.resolve(tokenResponse),
+          text: () => Promise.resolve(JSON.stringify(tokenResponse)),
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+        });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const delays: number[] = [];
+      vi.stubGlobal(
+        'setTimeout',
+        (fn: () => void, ms: number) => {
+          delays.push(ms);
+          fn();
+          return 0;
+        },
+      );
+
+      await client.pollCIBA('req-123', 2);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(delays[0]).toBe(2000);
+      expect(delays[1]).toBe(7000);
+    });
+
+    it('should throw on expired_token', async () => {
+      const client = await initClientWithOIDC(store);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValueOnce({
+          json: () => Promise.resolve({error: 'expired_token'}),
+          text: () => Promise.resolve(JSON.stringify({error: 'expired_token'})),
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+        }),
+      );
+
+      await expect(client.pollCIBA('req-123', 0)).rejects.toMatchObject({
+        code: 'JS-AUTH_CORE-CIBA2-HE03',
+      });
+    });
+
+    it('should throw on access_denied', async () => {
+      const client = await initClientWithOIDC(store);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValueOnce({
+          json: () => Promise.resolve({error: 'access_denied'}),
+          text: () => Promise.resolve(JSON.stringify({error: 'access_denied'})),
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+        }),
+      );
+
+      await expect(client.pollCIBA('req-123', 0)).rejects.toMatchObject({
+        code: 'JS-AUTH_CORE-CIBA2-HE03',
+      });
+    });
+
+    it('should throw immediately when AbortSignal is already aborted', async () => {
+      const client = await initClientWithOIDC(store);
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(client.pollCIBA('req-123', 0, {signal: controller.signal})).rejects.toMatchObject({
+        code: 'JS-AUTH_CORE-CIBA2-AB05',
+      });
+    });
+
+    it('should abort mid-sleep and reject without waiting for the full interval', async () => {
+      const client = await initClientWithOIDC(store);
+      const controller = new AbortController();
+
+      // Abort after a short delay while pollCIBA is sleeping before its first poll
+      const abortTimer = globalThis.setTimeout(() => controller.abort(), 10);
+
+      try {
+        await expect(
+          client.pollCIBA('req-123', 60, {signal: controller.signal}),
+        ).rejects.toMatchObject({code: 'JS-AUTH_CORE-CIBA2-AB05'});
+      } finally {
+        globalThis.clearTimeout(abortTimer);
+      }
     });
   });
 });

--- a/sdks/javascript/src/index.ts
+++ b/sdks/javascript/src/index.ts
@@ -58,6 +58,8 @@ export {default as ThunderIDAPIError} from './errors/ThunderIDAPIError';
 export {default as ThunderIDRuntimeError} from './errors/ThunderIDRuntimeError';
 export {ThunderIDAuthException} from './errors/exception';
 
+export type {CIBAInitiateOptions, CIBAInitiateResponse, CIBAErrorCode, CIBAPollOptions} from './models/ciba';
+
 export type {AllOrganizationsApiResponse} from './models/organization';
 export {Platform} from './models/platforms';
 export {

--- a/sdks/javascript/src/models/ciba.ts
+++ b/sdks/javascript/src/models/ciba.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Options for initiating a CIBA backchannel authentication request (CIBA Core 1.0 §7.1).
+ * Exactly one of loginHint, loginHintToken, or idTokenHint must be provided.
+ */
+export interface CIBAInitiateOptions {
+  /**
+   * A hint about the end-user to authenticate, typically an email address, phone number,
+   * or username. Sent as the login_hint parameter.
+   */
+  loginHint?: string;
+
+  /**
+   * An opaque token carrying hint data about the end-user, issued by a claims provider.
+   * Sent as the login_hint_token parameter.
+   */
+  loginHintToken?: string;
+
+  /**
+   * A previously issued ID Token that identifies the end-user.
+   * Sent as the id_token_hint parameter.
+   */
+  idTokenHint?: string;
+
+  /**
+   * A short human-readable string displayed on both the consumption device and the
+   * authentication device to bind the two interactions and help the user correlate them.
+   */
+  bindingMessage?: string;
+
+  /**
+   * Requested expiry in seconds for the auth_req_id. The authorization server may
+   * honour a shorter lifetime than requested.
+   */
+  requestedExpiry?: number;
+
+  /**
+   * Space-separated Authentication Context Class Reference values indicating the
+   * authentication context the authorization server is requested to use.
+   */
+  acrValues?: string;
+}
+
+/**
+ * Response returned by the backchannel authentication endpoint on a successful
+ * CIBA initiation (CIBA Core 1.0 §7.3).
+ */
+export interface CIBAInitiateResponse {
+  /**
+   * Unique identifier for the authentication request. Must be passed to pollCIBA()
+   * as the auth_req_id token endpoint parameter.
+   */
+  authReqId: string;
+
+  /**
+   * Minimum number of seconds the client must wait between polling attempts.
+   * Increases by 5 seconds on each slow_down error per CIBA Core 1.0 §7.3.
+   */
+  interval: number;
+
+  /**
+   * Lifetime in seconds of the auth_req_id. Polling must stop once this duration
+   * has elapsed without approval.
+   */
+  expiresIn: number;
+}
+
+/**
+ * Terminal and transient error codes returned by the token endpoint during
+ * CIBA polling (CIBA Core 1.0 §11).
+ *
+ * - `authorization_pending` — The user has not yet approved or denied the request.
+ * - `slow_down` — The client is polling too fast; increase the interval by 5 seconds.
+ * - `expired_token` — The auth_req_id has expired without user action.
+ * - `access_denied` — The user denied the authentication request.
+ */
+export type CIBAErrorCode = 'authorization_pending' | 'slow_down' | 'expired_token' | 'access_denied';
+
+/**
+ * Optional settings for pollCIBA().
+ */
+export interface CIBAPollOptions {
+  /**
+   * An AbortSignal that can be used to cancel polling. If the signal is aborted
+   * during a sleep window the wait is interrupted immediately and pollCIBA()
+   * rejects with a JS-AUTH_CORE-CIBA2-AB05 error.
+   */
+  signal?: AbortSignal;
+}

--- a/sdks/javascript/src/models/client.ts
+++ b/sdks/javascript/src/models/client.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import type {CIBAInitiateOptions, CIBAInitiateResponse, CIBAPollOptions} from './ciba';
 import {SignInOptions, SignOutOptions, SignUpOptions} from './config';
 import {
   EmbeddedFlowExecuteRequestConfig,
@@ -99,6 +100,22 @@ export interface ThunderIDClient<T> {
    * @returns User object containing user details.
    */
   getUser(options?: any): Promise<User>;
+
+  /**
+   * Initiates a CIBA backchannel authentication request (CIBA Core 1.0 §7.1).
+   * Exactly one of loginHint, loginHintToken, or idTokenHint must be set.
+   */
+  initiateCIBA(options: CIBAInitiateOptions): Promise<CIBAInitiateResponse>;
+
+  /**
+   * Polls the token endpoint until the user approves, denies, or the request expires.
+   * Applies the mandatory interval increase on slow_down (CIBA Core 1.0 §7.3).
+   * On approval, stores the token in the SDK session and resolves with a TokenResponse.
+   *
+   * @param authReqId - The auth_req_id from initiateCIBA.
+   * @param interval  - Initial polling interval in seconds from initiateCIBA.
+   */
+  pollCIBA(authReqId: string, interval: number, options?: CIBAPollOptions): Promise<TokenResponse>;
 
   /**
    * Fetches the user profile along with its schemas and a flattened version of the profile.

--- a/sdks/javascript/src/models/oidc-discovery.ts
+++ b/sdks/javascript/src/models/oidc-discovery.ts
@@ -400,6 +400,11 @@ export interface OIDCDiscoveryEndpointsApiResponse {
   revocation_endpoint?: string;
 
   /**
+   * CIBA backchannel authentication endpoint URL (CIBA Core 1.0 §4).
+   */
+  backchannel_authentication_endpoint?: string;
+
+  /**
    * OAuth 2.0 Token Endpoint URL.
    * Used to obtain tokens using various grant types.
    *


### PR DESCRIPTION
### Purpose

Adds CIBA (Client-Initiated Backchannel Authentication) poll mode support to the JavaScript SDK. Previously, applications using CIBA had to implement the full backchannel authentication and polling protocol themselves with raw fetch calls. This exposes `initiateCIBA()` and `pollCIBA()` as first-class methods on `ThunderIDJavaScriptClient`, covering the complete CIBA Core 1.0 flow.

### Approach

Two methods are added to `ThunderIDJavaScriptClient` and the `ThunderIDClient<T>` interface:

- `initiateCIBA(options)` — POSTs to the `backchannel_authentication_endpoint` discovered from OIDC provider metadata. Validates that exactly one hint (`loginHint`, `loginHintToken`, or `idTokenHint`) is provided, sends the configured scope, and returns `{ authReqId, interval, expiresIn }`.

- `pollCIBA(authReqId, interval, options?)` — Polls the token endpoint with `grant_type=urn:openid:params:grant-type:ciba`. Handles `authorization_pending` (continues), `slow_down` (permanently increases interval by 5 s per spec §7.3), and terminal states (`expired_token`, `access_denied`). Resolves with a `TokenResponse` on approval via the existing `handleTokenResponse()` path. Supports `AbortSignal` for cancellation.

#### Supporting Changes

- `backchannel_authentication_endpoint` added to `OIDCDiscoveryEndpointsApiResponse`
- New `models/ciba.ts` with `CIBAInitiateOptions`, `CIBAInitiateResponse`, `CIBAErrorCode`, and `CIBAPollOptions` types, all exported from the package index

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3222

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3171
- https://github.com/thunder-id/thunderid/pull/3286 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Client-Initiated Backchannel Authentication (CIBA) support to the JavaScript SDK, including initiating CIBA requests and polling for results.
  * Extended OIDC discovery to include the CIBA backchannel authentication endpoint URL.
  * Added typed CIBA option/response exports for easier integration, plus support for cancelling polling via abort signals.
* **Tests**
  * Expanded automated coverage for CIBA initiation and polling, including interval backoff and cancellation/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->