### PR TITLE
added promp=consent support in authorize

### DIFF
--- a/api/oauth2.yaml
+++ b/api/oauth2.yaml
@@ -124,6 +124,15 @@ paths:
           schema:
             type: string
           description: JSON-encoded claims request (OIDC Core §5.5).
+        - name: prompt
+          in: query
+          required: false
+          schema:
+            type: string
+          description: >
+            Space-separated list of prompts (OIDC Core §3.1.2.1). Supported values:
+            `login` forces re-authentication; `consent` forces re-consent for all required
+            attributes regardless of existing consent records.
       responses:
         "302":
           description: Redirect to the login page or the client redirect_uri on error.
@@ -614,6 +623,12 @@ components:
           type: string
         claims:
           type: string
+        prompt:
+          type: string
+          description: >
+            Space-separated list of prompts (OIDC Core §3.1.2.1). Supported values:
+            `login` forces re-authentication; `consent` forces re-consent for all required
+            attributes regardless of existing consent records.
 
     PARResponse:
       type: object

--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -42,10 +42,11 @@ type ConsentEnforcerServiceInterface interface {
 	// ResolveConsent checks whether the user has provided required consents for the given
 	// application, attribute set, and authorized permission set. Returns nil if all required
 	// consents are active; otherwise returns ConsentPromptData describing which purposes /
-	// elements still need user consent.
+	// elements still need user consent. When forceReprompt is true, consent is re-prompted for
+	// all required claims regardless of existing active consent.
 	ResolveConsent(ctx context.Context, ouID, appID, appName, userID string,
 		essentialAttributes, optionalAttributes, authorizedPermissions []string,
-		availableAttributes *authnprovidercm.AttributesResponse,
+		availableAttributes *authnprovidercm.AttributesResponse, forceReprompt bool,
 		runtimeMetadata map[string]string) (
 		*ConsentPromptData, *serviceerror.ServiceError)
 
@@ -77,7 +78,8 @@ func newConsentEnforcerService(consentSvc consent.ConsentServiceInterface,
 // ResolveConsent implements ConsentEnforcerServiceInterface.ResolveConsent.
 func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID, appName, userID string,
 	essentialAttributes, optionalAttributes, authorizedPermissions []string,
-	availableAttributes *authnprovidercm.AttributesResponse, runtimeMetadata map[string]string) (
+	availableAttributes *authnprovidercm.AttributesResponse, forceReprompt bool,
+	runtimeMetadata map[string]string) (
 	*ConsentPromptData, *serviceerror.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID))
 	logger.Debug(ctx, "Resolving consent for user")
@@ -107,25 +109,28 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 		return nil, nil
 	}
 
-	// Search for existing consent records for this user and application
-	filter := &consent.ConsentSearchFilter{
-		GroupIDs:        []string{appID},
-		UserIDs:         []string{userID},
-		ConsentStatuses: []consent.ConsentStatus{consent.ConsentStatusActive},
-	}
-	existingConsents, svcErr := s.consentService.SearchConsents(ctx, ouID, filter)
-	if svcErr != nil {
-		if svcErr.Type == serviceerror.ClientErrorType {
-			logger.Debug(ctx, "Client error from consent service when searching consents",
-				log.Any("error", svcErr))
-			return nil, &ErrorConsentSearchFailed
+	// Build the set of elements that already have active consent. When forceReprompt is set, existing
+	// consent is ignored so every required claim is prompted again; the lookup is skipped entirely.
+	var consentedElements map[string]bool
+	if !forceReprompt {
+		// Search for existing consent records for this user and application
+		filter := &consent.ConsentSearchFilter{
+			GroupIDs:        []string{appID},
+			UserIDs:         []string{userID},
+			ConsentStatuses: []consent.ConsentStatus{consent.ConsentStatusActive},
 		}
-		logger.Error(ctx, "Failed to search existing consents", log.Any("error", svcErr))
-		return nil, &serviceerror.InternalServerError
+		existingConsents, searchErr := s.consentService.SearchConsents(ctx, ouID, filter)
+		if searchErr != nil {
+			if searchErr.Type == serviceerror.ClientErrorType {
+				logger.Debug(ctx, "Client error from consent service when searching consents",
+					log.Any("error", searchErr))
+				return nil, &ErrorConsentSearchFailed
+			}
+			logger.Error(ctx, "Failed to search existing consents", log.Any("error", searchErr))
+			return nil, &serviceerror.InternalServerError
+		}
+		consentedElements = buildConsentedElementSet(existingConsents)
 	}
-
-	// Build a set of elements that already have active consent
-	consentedElements := buildConsentedElementSet(existingConsents)
 
 	// Build a set of attributes present in the user's profile for profile filtering
 	userAttributeSet := buildUserAttributeSet(availableAttributes)

--- a/backend/internal/authn/consent/service_test.go
+++ b/backend/internal/authn/consent/service_test.go
@@ -80,7 +80,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_ConsentDisabled() {
 	s.mockConsentSvc.On("IsEnabled").Return(false)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, nil, nil, nil, nil)
+		[]string{"email"}, nil, nil, nil, false, nil)
 
 	s.Nil(result)
 	s.Nil(svcErr)
@@ -97,7 +97,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_ListPurposesClientE
 		Return(nil, clientErr)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, nil, nil, nil, nil)
+		[]string{"email"}, nil, nil, nil, false, nil)
 
 	s.Nil(result)
 	s.NotNil(svcErr)
@@ -115,7 +115,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_ListPurposesServerE
 		Return(nil, serverErr)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, nil, nil, nil, nil)
+		[]string{"email"}, nil, nil, nil, false, nil)
 
 	s.Nil(result)
 	s.NotNil(svcErr)
@@ -128,7 +128,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_NoPurposesConfigure
 		Return([]consent.ConsentPurpose{}, nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, nil, nil, nil, nil)
+		[]string{"email"}, nil, nil, nil, false, nil)
 
 	s.Nil(result)
 	s.Nil(svcErr)
@@ -157,7 +157,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_SearchConsentsClien
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return(nil, clientErr)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, nil, nil, nil, nil)
+		[]string{"email"}, nil, nil, nil, false, nil)
 
 	s.Nil(result)
 	s.NotNil(svcErr)
@@ -187,7 +187,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_SearchConsentsServe
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return(nil, serverErr)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, nil, nil, nil, nil)
+		[]string{"email"}, nil, nil, nil, false, nil)
 
 	s.Nil(result)
 	s.NotNil(svcErr)
@@ -227,10 +227,42 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_AllConsentsActive()
 		mock.AnythingOfType("*consent.ConsentSearchFilter")).Return(existingConsents, nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, nil, nil, nil, nil)
+		[]string{"email"}, nil, nil, nil, false, nil)
 
 	s.Nil(result)
 	s.Nil(svcErr)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_ForceRepromptIgnoresExistingConsent() {
+	purposes := []consent.ConsentPurpose{
+		{
+			ID:        "purpose-1",
+			Namespace: consent.NamespaceAttribute,
+			Name:      "app:app1:attrs",
+			Elements: []consent.PurposeElement{
+				{Name: "email", IsMandatory: true},
+			},
+		},
+	}
+
+	s.mockConsentSvc.On("IsEnabled").Return(true)
+	s.mockConsentSvc.On("ListConsentPurposes", mock.Anything, "ou1", "app1").
+		Return(purposes, nil)
+	s.mockJWTSvc.On("GenerateJWT", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
+
+	// forceReprompt is honored: existing active consent is ignored, the element is prompted again,
+	// and SearchConsents is never called.
+	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
+		[]string{"email"}, nil, nil, nil, true, nil)
+
+	s.Nil(svcErr)
+	s.NotNil(result)
+	s.Len(result.Purposes, 1)
+	s.Equal("app:app1:attrs", result.Purposes[0].PurposeName)
+	s.Equal([]PromptElement{{Name: "email"}}, result.Purposes[0].Essential)
+	s.NotEmpty(result.SessionToken)
+	s.mockConsentSvc.AssertNotCalled(s.T(), "SearchConsents", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_PromptNeeded() {
@@ -256,7 +288,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_PromptNeeded() {
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, []string{"phone"}, nil, nil, nil)
+		[]string{"email"}, []string{"phone"}, nil, nil, false, nil)
 
 	s.Nil(svcErr)
 	s.NotNil(result)
@@ -291,7 +323,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_RequiredAttributesF
 
 	// Only request "email" — "phone" and "address" should be filtered out
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, nil, nil, nil, nil)
+		[]string{"email"}, nil, nil, nil, false, nil)
 
 	s.Nil(svcErr)
 	s.NotNil(result)
@@ -327,7 +359,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_UserProfileFilter()
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		nil, nil, nil, availableAttributes, nil)
+		nil, nil, nil, availableAttributes, false, nil)
 
 	s.Nil(svcErr)
 	s.NotNil(result)
@@ -371,7 +403,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_PartialConsentsExis
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("test-session-token", int64(0), nil)
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, []string{"phone"}, nil, nil, nil)
+		[]string{"email"}, []string{"phone"}, nil, nil, false, nil)
 
 	s.Nil(svcErr)
 	s.NotNil(result)
@@ -433,7 +465,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestResolveConsent_CreateConsentSessio
 		})
 
 	result, svcErr := s.service.ResolveConsent(context.Background(), "ou1", "app1", "App 1", "user1",
-		[]string{"email"}, nil, nil, nil, nil)
+		[]string{"email"}, nil, nil, nil, false, nil)
 
 	s.Nil(result)
 	s.NotNil(svcErr)

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -208,6 +208,9 @@ const (
 	RuntimeKeyConsentedAttributes = "consented_attributes"
 	// RuntimeKeyConsentSessionToken holds the signed JWT session token for consent validation.
 	RuntimeKeyConsentSessionToken = "consent_session_token"
+	// RuntimeKeyForceConsentReprompt indicates that consent must be re-prompted for all required
+	// claims, set when the authorization request includes prompt=consent.
+	RuntimeKeyForceConsentReprompt = "force_consent_reprompt"
 	// RuntimeKeyStoredInviteToken holds the generated invite token stored during the invite send phase.
 	RuntimeKeyStoredInviteToken = "storedInviteToken"
 	// RuntimeKeyUserAttributesCacheTTLSeconds indicates the TTL of the user attributes cache.

--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -151,12 +151,13 @@ func (e *consentExecutor) checkConsent(ctx *core.NodeContext, execResp *common.E
 	authorizedPermissions := strings.Fields(ctx.RuntimeData["authorized_permissions"])
 	availableAttributes := e.buildAugmentedAvailableAttributes(availableAttrResp, entityRef)
 	appName := ctx.Application.Name
+	forceReprompt := ctx.RuntimeData[common.RuntimeKeyForceConsentReprompt] == "true"
 
 	// Resolve consent to determine if any required consents are missing and need to be prompted
 	promptData, svcErr := e.consentEnforcer.ResolveConsent(
 		ctx.Context, ouID, appID, appName, entityRef.EntityID,
 		essentialAttributes, optionalAttributes, authorizedPermissions,
-		availableAttributes, buildRuntimeMetadata(ctx))
+		availableAttributes, forceReprompt, buildRuntimeMetadata(ctx))
 	if svcErr != nil {
 		if svcErr.Type == serviceerror.ClientErrorType {
 			logger.Debug(ctx.Context, "Client error while resolving user consent", log.Any("error", svcErr))

--- a/backend/internal/flow/executor/consent_executor_test.go
+++ b/backend/internal/flow/executor/consent_executor_test.go
@@ -197,13 +197,54 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_AllConsentsActive() 
 
 	// ResolveConsent returns nil = all consents active
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
-		[]string{}, []string{"email", "phone"}, mock.Anything, mock.Anything, mock.Anything).
+		[]string{}, []string{"email", "phone"}, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_ForceRepromptFromRuntimeData() {
+	ctx := buildConsentNodeContext()
+	ctx.RuntimeData[common.RuntimeKeyForceConsentReprompt] = "true"
+	suite.setupDefaultAuthnProviderMocks()
+
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*common.ExecutorResponse"), mock.Anything).Return(true)
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(false)
+
+	// forceReprompt must be true when the force-consent-reprompt runtime key is set
+	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, true, mock.Anything).
+		Return(nil, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_ForceRepromptDefaultsFalse() {
+	ctx := buildConsentNodeContext()
+	suite.setupDefaultAuthnProviderMocks()
+
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*common.ExecutorResponse"), mock.Anything).Return(true)
+	suite.executor.ExecutorInterface.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(false)
+
+	// forceReprompt must be false when the runtime key is absent
+	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, mock.Anything).
+		Return(nil, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.ExecComplete, resp.Status)
 }
 
@@ -219,7 +260,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_RequiredAttributesFr
 
 	// ResolveConsent should receive attributes from RuntimeData, not from Application config
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
-		[]string{}, []string{"email", "name"}, mock.Anything, mock.Anything, mock.Anything).
+		[]string{}, []string{"email", "name"}, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -240,7 +281,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_RequiredEssentialAnd
 		On("HasRequiredInputs", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(false)
 
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
-		[]string{"email"}, []string{"name"}, mock.Anything, mock.Anything, mock.Anything).
+		[]string{"email"}, []string{"name"}, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -261,7 +302,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_NilAssertionConfig()
 
 	// Attributes should be nil when no RuntimeData and no Assertion config
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
-		[]string{}, []string{}, mock.Anything, mock.Anything, mock.Anything).
+		[]string{}, []string{}, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -285,7 +326,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_ExplicitEmptyRuntime
 
 	// Expect empty slices — NOT the Application.Assertion.UserAttributes (["email","phone"])
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
-		[]string{}, []string{}, mock.Anything, mock.Anything, mock.Anything).
+		[]string{}, []string{}, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -304,7 +345,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_ResolveConsent_Clien
 		On("HasRequiredInputs", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(false)
 
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, &serviceerror.ServiceError{
 			Type: serviceerror.ClientErrorType,
 			ErrorDescription: i18ncore.I18nMessage{
@@ -330,7 +371,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_ResolveConsent_Serve
 		On("HasRequiredInputs", ctx, mock.AnythingOfType("*common.ExecutorResponse")).Return(false)
 
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, &serviceerror.ServiceError{
 			Type: serviceerror.ServerErrorType,
 		})
@@ -363,7 +404,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_PromptRequired_NoTim
 	}
 
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(promptData, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -404,7 +445,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_PromptRequired_Store
 	}
 
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, "default", "app-123", "", "user-123",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(promptData, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -431,7 +472,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_PromptRequired_WithT
 	}
 
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(promptData, nil)
 
 	beforeExec := time.Now().UnixMilli()
@@ -475,7 +516,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_EmptyTimeout() {
 	}
 
 	suite.mockConsentEnforcer.On("ResolveConsent", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(promptData, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -1008,7 +1049,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_AugmentedAttributes_
 			}
 			groupsMeta, hasGroups := aa.Attributes["groups"]
 			return hasGroups && groupsMeta != nil
-		}), mock.Anything).
+		}), mock.Anything, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -1043,7 +1084,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_AugmentedAttributes_
 			_, hasOUName := aa.Attributes["ouName"]
 			_, hasOUHandle := aa.Attributes["ouHandle"]
 			return hasOUID && hasOUName && hasOUHandle
-		}), mock.Anything).
+		}), mock.Anything, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -1072,7 +1113,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_AugmentedAttributes_
 		mock.Anything,
 		mock.MatchedBy(func(aa *authnprovidercm.AttributesResponse) bool {
 			return aa != nil && func() bool { _, ok := aa.Attributes["userType"]; return ok }()
-		}), mock.Anything).
+		}), mock.Anything, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -1103,7 +1144,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_AugmentedAttributes_
 		mock.Anything,
 		mock.MatchedBy(func(aa *authnprovidercm.AttributesResponse) bool {
 			return aa == nil
-		}), mock.Anything).
+		}), mock.Anything, mock.Anything).
 		Return(nil, nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -1542,7 +1583,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_BasicAuth_NilAvailableAttribu
 			_, hasEmail := aa.Attributes["email"]
 			_, hasGroups := aa.Attributes["groups"]
 			return hasGivenName && hasEmail && hasGroups
-		}), mock.Anything).
+		}), mock.Anything, mock.Anything).
 		Return(promptData, nil)
 
 	resp, err := suite.executor.Execute(ctx)

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
@@ -135,12 +135,7 @@ func ValidatePromptParameter(prompt string) (string, string) {
 			"User authentication is required"
 	}
 
-	// The server does not support consent or account selection prompts as of now.
-	if slices.Contains(values, constants.PromptConsent) {
-		return constants.ErrorConsentRequired,
-			"Consent is not supported"
-	}
-
+	// The server does not support account selection prompts as of now.
 	if slices.Contains(values, constants.PromptSelectAccount) {
 		return constants.ErrorAccountSelectionRequired,
 			"Account selection is not supported"

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
@@ -215,13 +215,24 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PromptNoneCombined() {
 	assert.Contains(suite.T(), errMsg, "must not be combined")
 }
 
-func (suite *AuthzValidationTestSuite) TestValidateParams_PromptConsent() {
+func (suite *AuthzValidationTestSuite) TestValidateParams_PromptConsent_Success() {
 	params := suite.validParams()
 	params[constants.RequestParamPrompt] = "consent"
 
-	errCode, _ := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
+	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
-	assert.Equal(suite.T(), constants.ErrorConsentRequired, errCode)
+	assert.Empty(suite.T(), errCode)
+	assert.Empty(suite.T(), errMsg)
+}
+
+func (suite *AuthzValidationTestSuite) TestValidateParams_PromptLoginConsent_Success() {
+	params := suite.validParams()
+	params[constants.RequestParamPrompt] = "login consent"
+
+	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
+
+	assert.Empty(suite.T(), errCode)
+	assert.Empty(suite.T(), errMsg)
 }
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_PromptSelectAccount() {
@@ -316,7 +327,7 @@ func (suite *AuthzValidationTestSuite) TestValidatePromptParameter_None_LoginReq
 
 func (suite *AuthzValidationTestSuite) TestValidatePromptParameter_Consent() {
 	errCode, _ := ValidatePromptParameter("consent")
-	assert.Equal(suite.T(), constants.ErrorConsentRequired, errCode)
+	assert.Empty(suite.T(), errCode)
 }
 
 func (suite *AuthzValidationTestSuite) TestValidatePromptParameter_SelectAccount() {
@@ -342,7 +353,7 @@ func (suite *AuthzValidationTestSuite) TestValidatePromptParameter_NoneWithOther
 
 func (suite *AuthzValidationTestSuite) TestValidatePromptParameter_LoginConsent() {
 	errCode, _ := ValidatePromptParameter("login consent")
-	assert.Equal(suite.T(), constants.ErrorConsentRequired, errCode)
+	assert.Empty(suite.T(), errCode)
 }
 
 type ACRValuesTestSuite struct {

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -226,6 +226,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 	nonce := msg.RequestQueryParams[oauth2const.RequestParamNonce]
 	acrValues := msg.RequestQueryParams[oauth2const.RequestParamAcrValues]
 	dpopJkt := msg.RequestQueryParams[oauth2const.RequestParamDPoPJkt]
+	prompt := msg.RequestQueryParams[oauth2const.RequestParamPrompt]
 
 	// Parse the claims parameter if present.
 	var claimsRequest *oauth2model.ClaimsRequest
@@ -290,6 +291,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 		Nonce:               nonce,
 		AcrValues:           acrValues,
 		DPoPJkt:             dpopJkt,
+		Prompt:              prompt,
 	}
 
 	// Set the redirect URI if not provided in the request. Invalid cases are already handled at this point.
@@ -347,6 +349,9 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 	}
 	if effectiveAcrValues != "" {
 		runtimeData[flowcm.RuntimeKeyRequestedAuthClasses] = effectiveAcrValues
+	}
+	if slices.Contains(strings.Fields(oauthParams.Prompt), oauth2const.PromptConsent) {
+		runtimeData[flowcm.RuntimeKeyForceConsentReprompt] = "true"
 	}
 	flowInitCtx := &flowexec.FlowInitContext{
 		ApplicationID: app.ID,

--- a/backend/internal/oauth/oauth2/authz/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/validator_test.go
@@ -597,7 +597,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 	assert.Empty(suite.T(), errorMessage)
 }
 
-func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptConsent_ConsentRequired() {
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptConsent_Success() {
 	msg := &OAuthMessage{
 		RequestQueryParams: map[string]string{
 			constants.RequestParamClientID:     "test-client-id",
@@ -610,9 +610,9 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(context.Background(),
 		msg, suite.oauthApp)
 
-	assert.True(suite.T(), sendErrorToApp)
-	assert.Equal(suite.T(), constants.ErrorConsentRequired, errorCode)
-	assert.Equal(suite.T(), "Consent is not supported", errorMessage)
+	assert.False(suite.T(), sendErrorToApp)
+	assert.Empty(suite.T(), errorCode)
+	assert.Empty(suite.T(), errorMessage)
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptNoneCombined_InvalidRequest() {
@@ -669,7 +669,7 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 	assert.Equal(suite.T(), "Account selection is not supported", errorMessage)
 }
 
-func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptLoginConsent_ConsentRequired() {
+func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptLoginConsent_Success() {
 	msg := &OAuthMessage{
 		RequestQueryParams: map[string]string{
 			constants.RequestParamClientID:     "test-client-id",
@@ -682,9 +682,9 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 	sendErrorToApp, errorCode, errorMessage := suite.validator.validateInitialAuthorizationRequest(context.Background(),
 		msg, suite.oauthApp)
 
-	assert.True(suite.T(), sendErrorToApp)
-	assert.Equal(suite.T(), constants.ErrorConsentRequired, errorCode)
-	assert.Equal(suite.T(), "Consent is not supported", errorMessage)
+	assert.False(suite.T(), sendErrorToApp)
+	assert.Empty(suite.T(), errorCode)
+	assert.Empty(suite.T(), errorMessage)
 }
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptEmpty_InvalidRequest() {

--- a/backend/internal/oauth/oauth2/model/parameter.go
+++ b/backend/internal/oauth/oauth2/model/parameter.go
@@ -37,6 +37,7 @@ type OAuthParameters struct {
 	Nonce               string
 	AcrValues           string
 	DPoPJkt             string
+	Prompt              string
 }
 
 // ClaimsRequest represents the OIDC claims request parameter structure.

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -140,6 +140,7 @@ func (s *parService) HandlePushedAuthorizationRequest(
 		Nonce:               params[oauth2const.RequestParamNonce],
 		AcrValues:           params[oauth2const.RequestParamAcrValues],
 		DPoPJkt:             resolveDPoPJkt(params[oauth2const.RequestParamDPoPJkt], dpopHeaderJkt),
+		Prompt:              params[oauth2const.RequestParamPrompt],
 	}
 
 	parRequest := pushedAuthorizationRequest{

--- a/backend/tests/mocks/authn/consentenforcermock/ConsentEnforcerServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/consentenforcermock/ConsentEnforcerServiceInterface_mock.go
@@ -148,8 +148,8 @@ func (_c *ConsentEnforcerServiceInterfaceMock_RecordConsent_Call) RunAndReturn(r
 }
 
 // ResolveConsent provides a mock function for the type ConsentEnforcerServiceInterfaceMock
-func (_mock *ConsentEnforcerServiceInterfaceMock) ResolveConsent(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *common.AttributesResponse, runtimeMetadata map[string]string) (*consent.ConsentPromptData, *serviceerror.ServiceError) {
-	ret := _mock.Called(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, runtimeMetadata)
+func (_mock *ConsentEnforcerServiceInterfaceMock) ResolveConsent(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *common.AttributesResponse, forceReprompt bool, runtimeMetadata map[string]string) (*consent.ConsentPromptData, *serviceerror.ServiceError) {
+	ret := _mock.Called(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, forceReprompt, runtimeMetadata)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ResolveConsent")
@@ -157,18 +157,18 @@ func (_mock *ConsentEnforcerServiceInterfaceMock) ResolveConsent(ctx context.Con
 
 	var r0 *consent.ConsentPromptData
 	var r1 *serviceerror.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, []string, []string, []string, *common.AttributesResponse, map[string]string) (*consent.ConsentPromptData, *serviceerror.ServiceError)); ok {
-		return returnFunc(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, runtimeMetadata)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, []string, []string, []string, *common.AttributesResponse, bool, map[string]string) (*consent.ConsentPromptData, *serviceerror.ServiceError)); ok {
+		return returnFunc(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, forceReprompt, runtimeMetadata)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, []string, []string, []string, *common.AttributesResponse, map[string]string) *consent.ConsentPromptData); ok {
-		r0 = returnFunc(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, runtimeMetadata)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, []string, []string, []string, *common.AttributesResponse, bool, map[string]string) *consent.ConsentPromptData); ok {
+		r0 = returnFunc(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, forceReprompt, runtimeMetadata)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*consent.ConsentPromptData)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string, []string, []string, []string, *common.AttributesResponse, map[string]string) *serviceerror.ServiceError); ok {
-		r1 = returnFunc(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, runtimeMetadata)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string, []string, []string, []string, *common.AttributesResponse, bool, map[string]string) *serviceerror.ServiceError); ok {
+		r1 = returnFunc(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, forceReprompt, runtimeMetadata)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*serviceerror.ServiceError)
@@ -192,12 +192,13 @@ type ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call struct {
 //   - optionalAttributes []string
 //   - authorizedPermissions []string
 //   - availableAttributes *common.AttributesResponse
+//   - forceReprompt bool
 //   - runtimeMetadata map[string]string
-func (_e *ConsentEnforcerServiceInterfaceMock_Expecter) ResolveConsent(ctx interface{}, ouID interface{}, appID interface{}, appName interface{}, userID interface{}, essentialAttributes interface{}, optionalAttributes interface{}, authorizedPermissions interface{}, availableAttributes interface{}, runtimeMetadata interface{}) *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call {
-	return &ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call{Call: _e.mock.On("ResolveConsent", ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, runtimeMetadata)}
+func (_e *ConsentEnforcerServiceInterfaceMock_Expecter) ResolveConsent(ctx interface{}, ouID interface{}, appID interface{}, appName interface{}, userID interface{}, essentialAttributes interface{}, optionalAttributes interface{}, authorizedPermissions interface{}, availableAttributes interface{}, forceReprompt interface{}, runtimeMetadata interface{}) *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call {
+	return &ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call{Call: _e.mock.On("ResolveConsent", ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, forceReprompt, runtimeMetadata)}
 }
 
-func (_c *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call) Run(run func(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *common.AttributesResponse, runtimeMetadata map[string]string)) *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call {
+func (_c *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call) Run(run func(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *common.AttributesResponse, forceReprompt bool, runtimeMetadata map[string]string)) *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -235,9 +236,13 @@ func (_c *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call) Run(run func(
 		if args[8] != nil {
 			arg8 = args[8].(*common.AttributesResponse)
 		}
-		var arg9 map[string]string
+		var arg9 bool
 		if args[9] != nil {
-			arg9 = args[9].(map[string]string)
+			arg9 = args[9].(bool)
+		}
+		var arg10 map[string]string
+		if args[10] != nil {
+			arg10 = args[10].(map[string]string)
 		}
 		run(
 			arg0,
@@ -250,6 +255,7 @@ func (_c *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call) Run(run func(
 			arg7,
 			arg8,
 			arg9,
+			arg10,
 		)
 	})
 	return _c
@@ -260,7 +266,7 @@ func (_c *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call) Return(consen
 	return _c
 }
 
-func (_c *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call) RunAndReturn(run func(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *common.AttributesResponse, runtimeMetadata map[string]string) (*consent.ConsentPromptData, *serviceerror.ServiceError)) *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call {
+func (_c *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call) RunAndReturn(run func(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *common.AttributesResponse, forceReprompt bool, runtimeMetadata map[string]string) (*consent.ConsentPromptData, *serviceerror.ServiceError)) *ConsentEnforcerServiceInterfaceMock_ResolveConsent_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/content/guides/guides/protocols/oauth-oidc/openid-connect.mdx
+++ b/docs/content/guides/guides/protocols/oauth-oidc/openid-connect.mdx
@@ -54,7 +54,7 @@ These parameters on the authorization request control *how* the user authenticat
 | Parameter | Purpose | Notes |
 |---|---|---|
 | `nonce` | Replay protection for the ID Token | Max 64 characters. Required for clients that accept the ID Token. |
-| `prompt` | Control re-authentication | Only `login` is currently honored — see below |
+| `prompt` | Control re-authentication | Only `login` and `consent` is currently honored — see below |
 | `acr_values` | Request a specific authentication context | <ProductName /> selects an authentication flow that satisfies the requested ACR |
 | `claims` | Request specific claims claim-by-claim | See [Claims & Scopes](../claims-and-scopes) |
 
@@ -64,7 +64,7 @@ These parameters on the authorization request control *how* the user authenticat
 |---|---|
 | `login` | Forces the user to authenticate. **Supported.** |
 | `none` | Returns `login_required`. <ProductName /> does not yet maintain server-side sessions, so silent re-authentication is not available. |
-| `consent` | Returns `consent_required` — prompt-driven consent is not currently supported. |
+| `consent` | Forces the user to re-grant consent for all required attributes, even if consent was previously granted. |
 | `select_account` | Returns `account_selection_required` — account selection is not currently supported. |
 
 ## Try It in <ProductName />


### PR DESCRIPTION
### Purpose
Support to accept prompt=consent in the authorize endpoint call in the oidc flow.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Accept the prompt parameter with value 'consent' and have a key in runtime data to know to reprompt user for consent for all claims. The consent executor passes the forceReprompt boolean argument to consentEnforce if the key is present in runtimedata.

### Related Issues
- #3036 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `prompt=consent` (and `prompt=login consent`) in OAuth2/OIDC authorization requests, forcing re-consent for required attributes even when active consent exists.
  * Works for both standard authorization requests and pushed authorization requests.
* **Bug Fixes**
  * Updated prompt validation to treat consent-driven prompts as valid instead of returning a consent-required error.
* **Documentation**
  * Updated the OpenAPI spec and OpenID Connect guides to document `prompt` behavior and supported values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->