### PR TITLE
Bump vulnerable npm dependencies to fix dependabot alerts #355, #364, #366, #367, #368

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,8 @@ overrides:
   lodash: 4.18.1
   protobufjs: 7.6.0
   js-yaml@>=4.0.0 <=4.1.1: 4.2.0
+  react-router@>=7.12.0 <7.15.1: 7.15.1
+  react-router-dom@>=7.12.0 <7.15.1: 7.15.1
   devalue: 5.8.1
   tmp: '>=0.2.7'
   js-cookie: 3.0.7
@@ -2181,8 +2183,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(react@19.2.3)
       react-router-dom:
-        specifier: 7.15.0
-        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 7.15.1
+        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: 9.27.0
@@ -13566,7 +13568,7 @@ packages:
     resolution: {integrity: sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==}
     peerDependencies:
       react: '>=15'
-      react-router: '>=5'
+      react-router: 7.15.1
 
   react-router-dom@5.3.4:
     resolution: {integrity: sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==}
@@ -13580,8 +13582,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router-dom@7.15.0:
-    resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
+  react-router-dom@7.15.1:
+    resolution: {integrity: sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -13597,16 +13599,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
-
-  react-router@7.15.0:
-    resolution: {integrity: sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
 
   react-router@7.15.1:
     resolution: {integrity: sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==}
@@ -29573,11 +29565,11 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-router: 6.30.4(react@19.2.3)
 
-  react-router-dom@7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router-dom@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      react-router: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-router: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   react-router@5.3.4(react@19.2.3):
     dependencies:
@@ -29596,14 +29588,6 @@ snapshots:
     dependencies:
       '@remix-run/router': 1.23.3
       react: 19.2.3
-
-  react-router@7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.3
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
-      react-dom: 19.2.3(react@19.2.3)
 
   react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -105,7 +105,8 @@ overrides:
   ajv-formats>ajv: 8.18.0
   flatted: 3.4.2
   vite: 'catalog:'
-  # JUSTIFICATION: Fixes GHSA-fx2h-pf6j-xcff — vite `server.fs.deny` bypass on Windows alternate paths.
+  # JUSTIFICATION: Fixes GHSA-fx2h-pf6j-xcff — vite `server.fs.deny` bypass on Windows alternate paths (#367).
+  # Also fixes GHSA-9cwx-2883-4wfx indirectly — vite < 8.0.16 carries launch-editor with NTLMv2 hash disclosure (#368).
   vite@>=8.0.0 <=8.0.15: '>=8.0.16'
   vue: 3.5.34
   defu: 6.1.5
@@ -126,7 +127,11 @@ overrides:
   brace-expansion@>=4.0.0 <5.0.5: 5.0.5
   lodash: 4.18.1
   protobufjs: 7.6.0
+  # JUSTIFICATION: Fixes GHSA-f9xv-q969-pqx4 — JS-YAML quadratic-complexity DoS via repeated merge key aliases (#355, #366).
   js-yaml@>=4.0.0 <=4.1.1: 4.2.0
+  # JUSTIFICATION: Fixes GHSA-cpf8-h7f6-7jqq — React Router CSRF via PUT/PATCH/DELETE document requests (#364).
+  react-router@>=7.12.0 <7.15.1: '7.15.1'
+  react-router-dom@>=7.12.0 <7.15.1: '7.15.1'
   # TODO: Remove once `nuxt` bumps `devalue` to 5.8.1 or later.
   devalue: 5.8.1
   # JUSTIFICATION: Fixes CVE-2026-44705 (GHSA-ph9p-34f9-6g65) — Path Traversal via unsanitized prefix/postfix in tmp,

--- a/samples/apps/react-vanilla-sample/package.json
+++ b/samples/apps/react-vanilla-sample/package.json
@@ -18,7 +18,7 @@
     "@mui/system": "7.1.0",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-router-dom": "7.15.0"
+    "react-router-dom": "7.15.1"
   },
   "devDependencies": {
     "@eslint/js": "9.27.0",


### PR DESCRIPTION
### Purpose
Fixes 5 open Dependabot security alerts by bumping vulnerable npm dependencies and adding workspace-level override guards.

| Alert | Package | Vulnerability | Fix |
|-------|---------|--------------|-----|
| [#367](https://github.com/thunder-id/thunderid/security/dependabot/367) | vite | GHSA-fx2h-pf6j-xcff — `server.fs.deny` bypass on Windows alternate paths | Already at 8.0.16 in catalog; override comment annotated |
| [#368](https://github.com/thunder-id/thunderid/security/dependabot/368) | vite / launch-editor | GHSA-9cwx-2883-4wfx — NTLMv2 hash disclosure via UNC path (transitive via vite) | Covered by vite 8.0.16 upgrade and existing launch-editor override |
| [#366](https://github.com/thunder-id/thunderid/security/dependabot/366) | js-yaml | GHSA-f9xv-q969-pqx4 — Quadratic-complexity DoS via repeated merge key aliases | Already overridden to 4.2.0; override comment annotated |
| [#355](https://github.com/thunder-id/thunderid/security/dependabot/355) | js-yaml | GHSA-f9xv-q969-pqx4 — same as above | Same override |
| [#364](https://github.com/thunder-id/thunderid/security/dependabot/364) | react-router | GHSA-cpf8-h7f6-7jqq — CSRF via PUT/PATCH/DELETE document requests | Bumped `react-router-dom` in `react-vanilla-sample` from 7.15.0 → 7.15.1; added workspace overrides for react-router/react-router-dom >=7.12.0 <7.15.1 |

### Approach
- `react-vanilla-sample` had a direct pin to `react-router-dom@7.15.0` (vulnerable range: >=7.12.0 <7.15.1), which was pulling in `react-router@7.15.0` as a peer dep. Bumped to 7.15.1.
- Added `react-router@>=7.12.0 <7.15.1` and `react-router-dom@>=7.12.0 <7.15.1` workspace overrides to prevent transitive resolution of vulnerable versions.
- The vite and js-yaml fixes were already present from the previous PR (#3339); this PR annotates those overrides with the relevant Dependabot alert numbers for traceability.
- Regenerated `pnpm-lock.yaml` — `react-router@7.15.0` is no longer present.

### Related Issues
- Fixes [Dependabot #355](https://github.com/thunder-id/thunderid/security/dependabot/355)
- Fixes [Dependabot #364](https://github.com/thunder-id/thunderid/security/dependabot/364)
- Fixes [Dependabot #366](https://github.com/thunder-id/thunderid/security/dependabot/366)
- Fixes [Dependabot #367](https://github.com/thunder-id/thunderid/security/dependabot/367)
- Fixes [Dependabot #368](https://github.com/thunder-id/thunderid/security/dependabot/368)

### Related PRs
- Follows #3339 (previous dependabot bump)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated React Router DOM to version **7.15.1** in the React vanilla sample to pick up the latest fixes.

* **Security / Maintenance**
  * Refreshed workspace-wide dependency overrides to ensure consistent, secure versions for **Vite**, **js-yaml**, and **React Router** packages across projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->