### PR TITLE
Add skills for resolving npm vulnerabilities

### DIFF
--- a/.agent/skills/fix-npm-vulnerability/SKILL.md
+++ b/.agent/skills/fix-npm-vulnerability/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: fix-npm-vulnerability
+description: Fix a pnpm/npm security advisory in a pnpm monorepo. First attempts to update the head dependency; falls back to a pnpm override with a tracking GitHub issue. Use when pnpm audit or Dependabot surfaces a vulnerability.
+allowed-tools: Bash(*) Read(*) Edit(*) WebSearch(*)
+---
+
+# Fix npm Vulnerability
+
+You are resolving a security advisory in a pnpm monorepo.
+
+## Step 0 — Gather the advisory details
+
+Ask the user for one or both of:
+
+> **What vulnerability do you want to fix?**
+> Provide a CVE ID (e.g. `CVE-2026-44705`), GHSA slug (e.g. `GHSA-w7jw-789q-3m8p`), or vulnerable package name.
+> Optionally paste the `pnpm audit` output line for it.
+
+Wait for the answer before proceeding.
+
+---
+
+## Step 1 — Locate the workspace root
+
+Find the directory containing `pnpm-workspace.yaml`, starting from the current directory and walking up:
+
+```bash
+dir=$(pwd); while [ "$dir" != "/" ]; do [ -f "$dir/pnpm-workspace.yaml" ] && echo "$dir" && break; dir=$(dirname "$dir"); done
+```
+
+If nothing is found, ask the user to navigate to the monorepo root first.
+
+All subsequent commands run from this root.
+
+---
+
+## Step 2 — Get the full audit picture
+
+```bash
+pnpm audit --json 2>/dev/null | jq '.advisories // .vulnerabilities // .' 2>/dev/null | head -400
+```
+
+Identify for each advisory matching the user's input:
+- **`vulnerablePackage`** — the transitive package that contains the flaw
+- **`patchedVersions`** — the version range that fixes it (e.g. `>=4.0.6`)
+- **`via`** — the dependency chain showing which head (direct workspace) dep pulls it in
+- **`advisoryId`** — CVE or GHSA identifier
+- **`severity`** — high / critical
+
+---
+
+## Step 3 — Traverse the dependency chain
+
+Use `pnpm why` to confirm the full chain from the workspace to the vulnerable package:
+
+```bash
+pnpm why <vulnerable-package> 2>&1 | head -60
+```
+
+This shows every head dep that transitively depends on it. Record:
+- The **head package(s)** (direct workspace deps) pulling in the vulnerable version
+- The **current version** of those head packages
+
+---
+
+## Step 4 — Check if updating the head dep resolves the issue
+
+For each head package, inspect what version of the vulnerable package its latest release ships:
+
+```bash
+# Latest available version of the head dep
+npm info <head-package> version
+
+# Its full dependency tree for the vulnerable package
+npm info <head-package>@latest dependencies --json 2>/dev/null | jq '.<vulnerable-package> // "not direct"'
+
+# If it's deeper, check peer dependencies too
+npm info <head-package>@latest peerDependencies --json
+```
+
+For transitive chains deeper than one level, check the registry manifest:
+
+```bash
+npm pack <head-package>@latest --dry-run --json 2>/dev/null | head -50
+```
+
+**Decision:**
+
+**A. If the latest `<head-package>` ships `<vulnerable-package>` at a version satisfying `<patchedVersions>`:**
+→ The update resolves the issue. Continue to Step 5a.
+
+**B. If the latest `<head-package>` still ships the vulnerable version** (fix not yet released upstream):
+→ An override is required. Continue to Step 5b.
+
+---
+
+## Step 5a — Update the head dependency
+
+Check whether this is a **major version bump**:
+
+```bash
+current=$(node -p "require('./node_modules/<head-package>/package.json').version" 2>/dev/null)
+latest=$(npm info <head-package> version)
+echo "current=$current latest=$latest"
+```
+
+**If it IS a major bump**, before touching any files, generate testing guidance (Step 6) and show it to the user. Ask:
+
+> This is a major version upgrade for `<head-package>` (`<current>` → `<latest>`).
+> I've listed the affected workspaces and test commands above.
+> Shall I proceed with the upgrade?
+
+Wait for confirmation.
+
+Update the dep:
+
+```bash
+pnpm update <head-package>@latest
+```
+
+Verify the vulnerable package is now at the patched version:
+
+```bash
+pnpm why <vulnerable-package> 2>&1 | grep -E "version|<vulnerable-package>"
+pnpm audit --audit-level=high 2>&1 | grep -c "high\|critical" && echo "ISSUES REMAIN" || echo "CLEAN"
+```
+
+If clean, skip Steps 5b, 7, and 8. Report the upgrade (and testing checklist if it was a major bump).
+
+---
+
+## Step 5b — Add the pnpm override
+
+**First create the GitHub issue (Step 7)** so you have the URL to embed in the comment.
+
+Then open `pnpm-workspace.yaml` and add under `overrides:`:
+
+```yaml
+  # JUSTIFICATION: Fixes <CVE/GHSA-slug> — <one-line description of the flaw>.
+  # Added <YYYY-MM-DD>. Remove once <head-dep> ships a release containing <vulnerable-package>@<patchedVersions>.
+  # Tracking: <github-issue-url>
+  <vulnerable-package>: '<patchedVersion>'
+```
+
+Use scoped syntax when the vulnerability is only reachable through one specific head dep:
+
+```yaml
+  <head-package>><vulnerable-package>: '<patchedVersion>'
+```
+
+Match the comment and formatting style of existing entries in the file.
+
+Run:
+
+```bash
+pnpm install
+pnpm audit --audit-level=high 2>&1 | grep -c "high\|critical" && echo "ISSUES REMAIN" || echo "CLEAN"
+```
+
+---
+
+## Step 6 — Testing guidance (major version bumps only)
+
+When the head dep crosses a major version, output a checklist **before** applying the change.
+
+**Affected workspaces** — every workspace that depends on `<head-package>`:
+
+```bash
+grep -rl '"<head-package>"' --include='package.json' . | grep -v node_modules
+```
+
+**Changelog / breaking changes** — fetch release notes:
+
+```bash
+npm info <head-package>@latest 2>/dev/null | grep -A5 "homepage\|repository"
+```
+
+Then `WebSearch` for `"<head-package> v<major> migration guide"` or its changelog.
+
+**Test commands to run after the upgrade:**
+- For each affected workspace: `pnpm --filter <workspace> test`
+- If the workspace has a dev server: `pnpm --filter <workspace> dev` — note which URLs or UI flows exercise this package
+- Run the full audit: `pnpm audit --audit-level=high`
+
+Present this as a numbered checklist the developer can follow manually after the PR lands.
+
+---
+
+## Step 7 — Create the tracking GitHub issue (override path only)
+
+Detect the remote:
+
+```bash
+git remote get-url origin 2>/dev/null
+```
+
+```bash
+gh issue create \
+  --title "[Dependency Management 🔒] Remove Pnpm Override for <vulnerable-package> Once <head-dep> Ships the Fix" \
+  --label "security,maintenance" \
+  --body "$(cat <<'EOF'
+## Tracking Override Added on <YYYY-MM-DD>
+
+| Field | Value |
+|---|---|
+| Advisory | <CVE/GHSA-slug> |
+| Vulnerable package | `<vulnerable-package>` |
+| Fix requires | `<vulnerable-package>@<patchedVersions>` |
+| Blocked by | `<head-dep>` — fix not yet released upstream |
+| Override location | `pnpm-workspace.yaml` |
+
+## How to Remove
+
+Once `<head-dep>` publishes a release that includes `<vulnerable-package>@<patchedVersions>`:
+
+1. Delete the override line from `pnpm-workspace.yaml`
+2. Run `pnpm install`
+3. Run `pnpm audit --audit-level=high` to confirm it is clean
+EOF
+)"
+```
+
+Capture the returned issue URL. Use it in the `# Tracking:` comment in Step 5b.
+
+> If `security` or `maintenance` labels don't exist in the repo, omit `--label` rather than failing.
+
+---
+
+## Step 8 — Final report
+
+**If upgraded:**
+- Package upgraded and the fix confirmed clean
+- Testing checklist (if major bump)
+
+**If overridden:**
+- Exact lines added to `pnpm-workspace.yaml`
+- GitHub issue URL
+- When to revisit: "Once `<head-dep>` releases with `<vulnerable-package>@<patchedVersions>`, delete the override line and run `pnpm install && pnpm audit --audit-level=high`"

--- a/.agent/skills/fix-npm-vulnerability/SKILL.md
+++ b/.agent/skills/fix-npm-vulnerability/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: fix-npm-vulnerability
+description: Fix a pnpm/npm security advisory in a pnpm monorepo. First attempts to update the head dependency; falls back to a pnpm override with a tracking GitHub issue. Use when pnpm audit or Dependabot surfaces a vulnerability.
+allowed-tools: Bash(*) Read(*) Edit(*) WebSearch(*)
+---
+
+# Fix npm Vulnerability
+
+You are resolving a security advisory in a pnpm monorepo.
+
+## Step 0 — Gather the advisory details
+
+Ask the user for one or both of:
+
+> **What vulnerability do you want to fix?**
+> Provide a CVE ID (e.g. `CVE-2026-44705`), GHSA slug (e.g. `GHSA-w7jw-789q-3m8p`), or vulnerable package name.
+> Optionally paste the `pnpm audit` output line for it.
+
+Wait for the answer before proceeding.
+
+---
+
+## Step 1 — Locate the workspace root
+
+Find the directory containing `pnpm-workspace.yaml`, starting from the current directory and walking up:
+
+```bash
+dir=$(pwd); while [ "$dir" != "/" ]; do [ -f "$dir/pnpm-workspace.yaml" ] && echo "$dir" && break; dir=$(dirname "$dir"); done
+```
+
+If nothing is found, ask the user to navigate to the monorepo root first.
+
+All subsequent commands run from this root.
+
+---
+
+## Step 2 — Get the full audit picture
+
+```bash
+pnpm audit --json 2>/dev/null | jq '.advisories // .vulnerabilities // .' 2>/dev/null | head -400
+```
+
+Identify for each advisory matching the user's input:
+- **`vulnerablePackage`** — the transitive package that contains the flaw
+- **`patchedVersions`** — the version range that fixes it (e.g. `>=4.0.6`)
+- **`via`** — the dependency chain showing which head (direct workspace) dep pulls it in
+- **`advisoryId`** — CVE or GHSA identifier
+- **`severity`** — high / critical
+
+---
+
+## Step 3 — Traverse the dependency chain
+
+Use `pnpm why` to confirm the full chain from the workspace to the vulnerable package:
+
+```bash
+pnpm why <vulnerable-package> 2>&1 | head -60
+```
+
+This shows every head dep that transitively depends on it. Record:
+- The **head package(s)** (direct workspace deps) pulling in the vulnerable version
+- The **current version** of those head packages
+
+---
+
+## Step 4 — Check if updating the head dep resolves the issue
+
+For each head package, inspect what version of the vulnerable package its latest release ships:
+
+```bash
+# Latest available version of the head dep
+npm info <head-package> version
+
+# Its full dependency tree for the vulnerable package
+npm info <head-package>@latest dependencies --json 2>/dev/null | jq '.<vulnerable-package> // "not direct"'
+
+# If it's deeper, check peer dependencies too
+npm info <head-package>@latest peerDependencies --json
+```
+
+For transitive chains deeper than one level, check the registry manifest:
+
+```bash
+npm pack <head-package>@latest --dry-run --json 2>/dev/null | head -50
+```
+
+**Decision:**
+
+**A. If the latest `<head-package>` ships `<vulnerable-package>` at a version satisfying `<patchedVersions>`:**
+→ The update resolves the issue. Continue to Step 5a.
+
+**B. If the latest `<head-package>` still ships the vulnerable version** (fix not yet released upstream):
+→ An override is required. Continue to Step 5b.
+
+---
+
+## Step 5a — Update the head dependency
+
+Check whether this is a **major version bump**:
+
+```bash
+current=$(node -p "require('./node_modules/<head-package>/package.json').version" 2>/dev/null)
+latest=$(npm info <head-package> version)
+echo "current=$current latest=$latest"
+```
+
+**If it IS a major bump**, before touching any files, generate testing guidance (Step 6) and show it to the user. Ask:
+
+> This is a major version upgrade for `<head-package>` (`<current>` → `<latest>`).
+> I've listed the affected workspaces and test commands above.
+> Shall I proceed with the upgrade?
+
+Wait for confirmation.
+
+Update the dep:
+
+```bash
+pnpm update <head-package>@latest
+```
+
+Verify the vulnerable package is now at the patched version:
+
+```bash
+pnpm why <vulnerable-package> 2>&1 | grep -E "version|<vulnerable-package>"
+pnpm audit --audit-level=high 2>&1 | grep -c "high\|critical" && echo "ISSUES REMAIN" || echo "CLEAN"
+```
+
+If clean, skip Steps 5b, 7, and 8. Report the upgrade (and testing checklist if it was a major bump).
+
+---
+
+## Step 5b — Add the pnpm override
+
+**First create the GitHub issue (Step 7)** so you have the URL to embed in the comment.
+
+Then open `pnpm-workspace.yaml` and add under `overrides:`:
+
+```yaml
+  # JUSTIFICATION: Fixes <CVE/GHSA-slug> — <one-line description of the flaw>.
+  # Added <YYYY-MM-DD>. Remove once <head-dep> ships a release containing <vulnerable-package>@<patchedVersions>.
+  # Tracking: <github-issue-url>
+  <vulnerable-package>: '<patchedVersion>'
+```
+
+Use scoped syntax when the vulnerability is only reachable through one specific head dep:
+
+```yaml
+  <head-package>><vulnerable-package>: '<patchedVersion>'
+```
+
+Match the comment and formatting style of existing entries in the file.
+
+The override needs `pnpm install` to take effect in the lockfile — that regenerates resolutions
+for the whole tree, not just the pinned package, so it can pull in unrelated drift (a transitive
+dep bumping a patch version elsewhere). Ask before running it:
+
+> I've added the override to `pnpm-workspace.yaml`. Running `pnpm install` now will regenerate
+> `pnpm-lock.yaml` to match — that can also shift unrelated transitive versions. Shall I proceed?
+
+Wait for confirmation, then run:
+
+```bash
+pnpm install
+pnpm audit --audit-level=high 2>&1 | grep -c "high\|critical" && echo "ISSUES REMAIN" || echo "CLEAN"
+```
+
+Make sure `pnpm-lock.yaml` ends up staged/committed together with the `pnpm-workspace.yaml` edit —
+don't leave the lockfile change uncommitted for a later, unrelated commit to pick up.
+
+---
+
+## Step 6 — Testing guidance (major version bumps only)
+
+When the head dep crosses a major version, output a checklist **before** applying the change.
+
+**Affected workspaces** — every workspace that depends on `<head-package>`:
+
+```bash
+grep -rl '"<head-package>"' --include='package.json' . | grep -v node_modules
+```
+
+**Changelog / breaking changes** — fetch release notes:
+
+```bash
+npm info <head-package>@latest 2>/dev/null | grep -A5 "homepage\|repository"
+```
+
+Then `WebSearch` for `"<head-package> v<major> migration guide"` or its changelog.
+
+**Test commands to run after the upgrade:**
+- For each affected workspace: `pnpm --filter <workspace> test`
+- If the workspace has a dev server: `pnpm --filter <workspace> dev` — note which URLs or UI flows exercise this package
+- Run the full audit: `pnpm audit --audit-level=high`
+
+Present this as a numbered checklist the developer can follow manually after the PR lands.
+
+---
+
+## Step 7 — Create the tracking GitHub issue (override path only)
+
+Detect the remote:
+
+```bash
+git remote get-url origin 2>/dev/null
+```
+
+```bash
+gh issue create \
+  --title "[Dependency Management 🔒] Remove Pnpm Override for <vulnerable-package> Once <head-dep> Ships the Fix" \
+  --label "security,maintenance" \
+  --body "$(cat <<'EOF'
+## Tracking Override Added on <YYYY-MM-DD>
+
+| Field | Value |
+|---|---|
+| Advisory | <CVE/GHSA-slug> |
+| Vulnerable package | `<vulnerable-package>` |
+| Fix requires | `<vulnerable-package>@<patchedVersions>` |
+| Blocked by | `<head-dep>` — fix not yet released upstream |
+| Override location | `pnpm-workspace.yaml` |
+
+## How to Remove
+
+Once `<head-dep>` publishes a release that includes `<vulnerable-package>@<patchedVersions>`:
+
+1. Delete the override line from `pnpm-workspace.yaml`
+2. Run `pnpm install`
+3. Run `pnpm audit --audit-level=high` to confirm it is clean
+EOF
+)"
+```
+
+Capture the returned issue URL. Use it in the `# Tracking:` comment in Step 5b.
+
+> If `security` or `maintenance` labels don't exist in the repo, omit `--label` rather than failing.
+
+---
+
+## Step 8 — Final report
+
+**If upgraded:**
+- Package upgraded and the fix confirmed clean
+- Testing checklist (if major bump)
+
+**If overridden:**
+- Exact lines added to `pnpm-workspace.yaml`
+- GitHub issue URL
+- When to revisit: "Once `<head-dep>` releases with `<vulnerable-package>@<patchedVersions>`, delete the override line and run `pnpm install && pnpm audit --audit-level=high`"

--- a/.agent/skills/prune-npm-overrides/SKILL.md
+++ b/.agent/skills/prune-npm-overrides/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: prune-npm-overrides
+description: Audit the pnpm overrides a repo already carries, remove the ones upstream has since fixed, and require a justification comment on every one that stays. The counterpart to fix-npm-vulnerability. Use when asked to check, clean up, or prune the overrides, or when an override's tracking issue comes up for review.
+allowed-tools: Bash(*) Read(*) Edit(*) WebSearch(*)
+---
+
+# Prune npm Overrides
+
+`fix-npm-vulnerability` adds an override when no upstream fix exists yet. This skill is the other half: it goes back through the overrides already in the tree and retires the ones that are no longer doing anything.
+
+An override is a workaround, not a fix. It pins a transitive package past what a head dependency asks for, and it keeps doing that long after the head dependency ships a release with a patched range. Left unaudited, `overrides:` only grows, and every stale entry constrains unrelated upgrades.
+
+Each entry ends the run in exactly one of three states:
+
+| Outcome | Condition | Action |
+|---|---|---|
+| Remove | Tree already resolves to a patched version without the pin, or `pnpm why` reports nothing at all | Delete the entry, close its tracking issue |
+| Replace | The package is a direct workspace dependency | Bump it (or its catalog entry) and delete the override |
+| Keep | Still resolves to an affected version and no head dependency release fixes it | Keep the entry, ensure it carries a full justification comment |
+
+---
+
+## Step 1 - Locate the workspace root
+
+```bash
+dir=$(pwd); while [ "$dir" != "/" ]; do [ -f "$dir/pnpm-workspace.yaml" ] && echo "$dir" && break; dir=$(dirname "$dir"); done
+```
+
+All subsequent commands run from this root.
+
+---
+
+## Step 2 - Inventory every override declaration
+
+Overrides hide in more places than the root file:
+
+```bash
+# Root workspace overrides (the ones pnpm actually honors)
+grep -n -A200 '^overrides:' pnpm-workspace.yaml
+
+# Per-package blocks: ignored by pnpm at install time, but honored by npm
+grep -rn --include=package.json -E '"(overrides|resolutions)"' . | grep -v node_modules
+```
+
+A per-package `overrides` block in a workspace member is either dead weight or a sign that the package is also installed standalone with `npm` (samples are the usual case). Determine which before touching it, and do not delete one just because pnpm ignores it.
+
+Build a table before changing anything, one row per entry:
+
+| Override | Pinned to | Declared in | Justification present? |
+|---|---|---|---|
+
+Entries with no `# JUSTIFICATION:` comment are the priority. Nobody recorded why they exist, so they are the most likely to be stale and the most dangerous to guess at.
+
+---
+
+## Step 3 - Find out who actually pulls each one in
+
+```bash
+pnpm why <vulnerable-package> -r --depth 6 2>&1 | head -60
+```
+
+Three questions per entry:
+
+- **Is it in the tree at all?** No output means the override is dead. Delete it, no further checking needed.
+- **Is it a direct workspace dependency?** Then the override was the wrong mechanism. Bump the dependency or its `catalog:` entry and delete the override.
+- **Which head dependency's range is the binding constraint?** That is the package that has to move before the pin becomes unnecessary, and it is what the justification comment must name.
+
+---
+
+## Step 4 - Verify staleness empirically
+
+A pinned version number tells you nothing about what the tree would resolve to on its own. Test it.
+
+Copy the manifest aside first. **Never `git stash`**, not even transiently: this working tree routinely carries a large amount of unrelated in progress work.
+
+```bash
+cp pnpm-workspace.yaml /tmp/pnpm-workspace.yaml.bak
+```
+
+Comment out every entry you suspect is stale in one pass, then re-resolve without installing:
+
+```bash
+pnpm install --lockfile-only
+pnpm why <vulnerable-package> -r --depth 6 2>&1 | head -40
+```
+
+Compare what the tree now resolves to against the patched range from the advisory:
+
+- **Resolves to a patched version on its own** - upstream caught up. Drop the entry permanently.
+- **Still resolves to an affected version** - restore it and go to Step 5. Before you do, check whether a newer head dependency release would fix it, since bumping that is the real fix:
+
+```bash
+npm info <head-package> version
+npm info <head-package>@latest dependencies --json 2>/dev/null | jq '.["<vulnerable-package>"] // "not direct"'
+```
+
+If a head dependency bump removes the need for the pin, prefer that and hand the major-version cases to `fix-npm-vulnerability` Step 6 for the testing checklist.
+
+Restore from the backup if you need to start over:
+
+```bash
+cp /tmp/pnpm-workspace.yaml.bak pnpm-workspace.yaml
+```
+
+---
+
+## Step 5 - Every surviving entry carries a full justification
+
+Backfill the same comment shape `fix-npm-vulnerability` writes, so the next audit can check the condition mechanically rather than re-deriving it:
+
+```yaml
+  # JUSTIFICATION: Fixes <CVE/GHSA-slug>: <one line on the flaw>.
+  # Added <YYYY-MM-DD>. Remove once <head-dep> ships a release containing <vulnerable-package>@<patchedVersions>.
+  # Tracking: <github-issue-url>
+  <vulnerable-package>: '<patchedVersion>'
+```
+
+A justification is incomplete unless it answers all four: which advisory, how the package enters the tree, what blocks the real fix, and the concrete condition for deletion. For a backfilled entry whose original advisory cannot be determined, say so explicitly in the comment rather than inventing one, and `WebSearch` the package and version range to recover the advisory ID where possible.
+
+While you are in the entry, tighten it to the narrowest form that still covers the flaw, so it expires on its own:
+
+- `<head-package>><vulnerable-package>` scopes the pin to one dependency path instead of the whole workspace.
+- `<package>@<affected range>: '<patched>'` applies only to versions that are actually affected and becomes a no-op once nothing resolves into that range. The existing `vite@>=8.0.0 <=8.0.15` and `minimatch@<3.1.4` entries are the pattern to follow.
+
+A bare `<package>: <version>` is the weakest form: it pins every consumer, including ones that were never affected. Prefer a scoped or range-qualified entry whenever the affected range can be determined.
+
+JSON manifests cannot carry comments. For a sample app's `package.json` block that has to stay, record the rationale in the PR body and the tracking issue instead of inventing a JSON key for it.
+
+Keep the file's existing grouping and do not reorder unrelated lines.
+
+---
+
+## Step 6 - Close out the tracking issues
+
+Each override added through `fix-npm-vulnerability` has a tracking issue. For every entry removed in this run, close its issue with the reason:
+
+```bash
+gh issue list --search "Remove Pnpm Override" --state open --limit 50
+gh issue close <number> --comment "Removed in <PR/commit>: <head-dep>@<version> now resolves <vulnerable-package>@<version>, so the override is no longer needed."
+```
+
+For entries that stay, leave the issue open and make sure the override comment still points at it.
+
+---
+
+## Step 7 - Verify
+
+Entries were removed or narrowed in `pnpm-workspace.yaml`. `pnpm install` needs to run to regenerate
+`pnpm-lock.yaml` and confirm the tree still resolves clean — but it re-resolves the whole workspace,
+not just the touched entries, so it can shift unrelated transitive versions too. Ask before running it:
+
+> The overrides file is updated. Running `pnpm install` now will regenerate `pnpm-lock.yaml` and let
+> me verify nothing regressed — it can also shift unrelated transitive versions in the process. Shall
+> I proceed?
+
+Wait for confirmation, then run:
+
+```bash
+pnpm install
+pnpm audit --audit-level=high
+git diff --stat pnpm-lock.yaml
+```
+
+The lockfile diff tells you which workspaces actually moved. Build and lint those, because a removed override that shifts a build tool across a major version fails at build time, not install time.
+
+Make sure `pnpm-lock.yaml` ends up staged/committed together with the `pnpm-workspace.yaml` edit —
+don't leave the lockfile change uncommitted for a later, unrelated commit to pick up.
+
+Report honestly: if `pnpm audit` still reports findings you deliberately left unpinned, name them and say why, rather than adding a pin to quiet the output.
+
+---
+
+## Step 8 - Final report
+
+Output the table with the outcome and reason per entry:
+
+| Override | Outcome | Reason |
+|---|---|---|
+| `flatted` | Removed | `nx` now depends on a patched range; tree resolves clean without the pin |
+| `postcss` | Kept | Packed through `next@15.5.18`; needs next 16. Justification backfilled |
+| `axios` | Replaced | Direct workspace dependency; bumped in the catalog instead |
+
+Then state the count removed, kept, and replaced, and list the tracking issues closed.
+
+---
+
+## Cadence
+
+An override added to close an advisory is usually removable within a release or two of the head dependency. Run this audit on a schedule, not only during vulnerability sweeps, otherwise the overrides block becomes a set of undocumented version pins that nobody can safely delete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Clone the SDK repository only if you are developing or debugging the SDK itself,
 
 - [Console Navigator](.agent/skills/console/SKILL.md) — Browse and interact with the Console UI using `playwright-cli`. Use when asked to navigate the console, test UI changes, or create/edit resources through the browser.
 - [Database](.agent/skills/db/SKILL.md) — Database schema design principles and query conventions. Use for any database-related work.
+- [Fix npm Vulnerability](.agent/skills/fix-npm-vulnerability/SKILL.md) — Resolve a pnpm/npm security advisory. Use when `pnpm audit` or Dependabot surfaces a security advisory. Tries to update the head dependency first; falls back to a scoped override with a tracking GitHub issue.
 
 ## Contributing Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ Load only the guidance the task needs:
 | Documentation | [docs/AGENTS.md](docs/AGENTS.md) |
 | Database schema, queries, or stores | [.agent/skills/db/SKILL.md](.agent/skills/db/SKILL.md) |
 | Browser automation / Console UI verification | [.agent/skills/console/SKILL.md](.agent/skills/console/SKILL.md) |
+| Resolving a pnpm/npm security advisory | [.agent/skills/fix-npm-vulnerability/SKILL.md](.agent/skills/fix-npm-vulnerability/SKILL.md) |
+| Auditing or pruning existing pnpm overrides | [.agent/skills/prune-npm-overrides/SKILL.md](.agent/skills/prune-npm-overrides/SKILL.md) |
 
 The `.agent/skills/` entries above are internal guidance for **developing** ThunderID. Consumer-facing setup and framework-integration skills (`setup-thunderid`, `integrate-*`) live in the separate ThunderID Skills repository (installable via `/plugin marketplace add thunder-id/skills`) and are not used when working in this repo.
 


### PR DESCRIPTION
### Purpose
When `pnpm audit` or Dependabot surfaces a security advisory in this monorepo, there is no documented procedure for resolving it. The result is inconsistent fixes: sometimes a head dependency is bumped, sometimes a `pnpm-workspace.yaml` override is dropped in without a justification comment or any record of when it can be removed, so stale overrides accumulate and silently pin packages long after upstream has shipped a real fix.

This PR adds a `fix-npm-vulnerability` agent skill that codifies the procedure we already follow by hand, and registers it in the `AGENTS.md` "Where to Look Next" table so an agent picks it up when the task is resolving a pnpm/npm advisory.

No product code is touched. The change is limited to internal agent guidance.

### Approach
The skill is a single `SKILL.md` under `.agent/skills/fix-npm-vulnerability/`, following the same layout and frontmatter convention as the existing `db` and `console` skills.

Key decisions:

- **Upgrade first, override second.** The skill walks the dependency chain with `pnpm why`, checks whether the latest release of the head dependency already ships a patched version of the vulnerable transitive package, and only falls back to a `pnpm-workspace.yaml` override when the fix genuinely is not available upstream yet. This keeps overrides as the exception rather than the default.
- **Every override is tracked.** On the override path, the skill creates a GitHub issue first, then embeds that issue URL in a `# Tracking:` comment alongside the advisory ID, the date, and the exact condition for removal. That way an override always carries the information needed to retire it, and there is a searchable issue rather than a comment nobody revisits.
- **Major bumps ask before acting.** If resolving the advisory requires crossing a major version on a head dependency, the skill enumerates the affected workspaces, gathers the migration notes, produces a test checklist, and stops for confirmation before changing any files. Security fixes should not turn into an unreviewed breaking upgrade.
- **Scoped overrides where possible.** The skill prefers the `<head-package>><vulnerable-package>` form when a vulnerability is only reachable through one head dependency, to avoid pinning the package globally across the workspace.
- **Graceful degradation.** Steps that depend on optional repo state (for example the `security` and `maintenance` labels existing) are written to fall back rather than fail.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/5263

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for resolving pnpm/npm security advisories.
  * Added guidance for auditing and pruning existing pnpm overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
