### PR TITLE
Preserve sub claim during IDP attribute mapping

### DIFF
--- a/api/idp.yaml
+++ b/api/idp.yaml
@@ -90,9 +90,9 @@ paths:
                   isSecret: false
               attributeConfiguration:
                 userTypeResolution:
-                  default: "person"
+                  default: "Person"
                 userTypeAttributeMappings:
-                  - userType: "person"
+                  - userType: "Person"
                     attributes:
                       - externalAttribute: "given_name"
                         localAttribute: "firstName"
@@ -122,9 +122,9 @@ paths:
                     isSecret: false
                 attributeConfiguration:
                   userTypeResolution:
-                    default: "person"
+                    default: "Person"
                   userTypeAttributeMappings:
-                    - userType: "person"
+                    - userType: "Person"
                       attributes:
                         - externalAttribute: "given_name"
                           localAttribute: "firstName"
@@ -231,9 +231,9 @@ paths:
                     isSecret: false
                 attributeConfiguration:
                   userTypeResolution:
-                    default: "person"
+                    default: "Person"
                   userTypeAttributeMappings:
-                    - userType: "person"
+                    - userType: "Person"
                       attributes:
                         - externalAttribute: "given_name"
                           localAttribute: "firstName"
@@ -301,9 +301,9 @@ paths:
                   isSecret: true
               attributeConfiguration:
                 userTypeResolution:
-                  default: "person"
+                  default: "Person"
                 userTypeAttributeMappings:
-                  - userType: "person"
+                  - userType: "Person"
                     attributes:
                       - externalAttribute: "given_name"
                         localAttribute: "firstName"
@@ -330,9 +330,9 @@ paths:
                     isSecret: true
                 attributeConfiguration:
                   userTypeResolution:
-                    default: "person"
+                    default: "Person"
                   userTypeAttributeMappings:
-                    - userType: "person"
+                    - userType: "Person"
                       attributes:
                         - externalAttribute: "given_name"
                           localAttribute: "firstName"
@@ -598,7 +598,7 @@ components:
         default:
           type: string
           description: Default local user type for federated just-in-time provisioning.
-          example: "person"
+          example: "Person"
 
     UserTypeAttributeMapping:
       type: object
@@ -609,7 +609,7 @@ components:
         userType:
           type: string
           description: Local user type this profile applies to.
-          example: "person"
+          example: "Person"
         attributes:
           type: array
           description: External-to-local attribute mappings for this user type.

--- a/backend/internal/idp/store_test.go
+++ b/backend/internal/idp/store_test.go
@@ -777,10 +777,10 @@ func (s *IDPStoreTestSuite) TestSerializeAttributeConfiguration_Nil() {
 
 func (s *IDPStoreTestSuite) TestSerializeAttributeConfiguration_WithMapping() {
 	am := &AttributeConfiguration{
-		UserTypeResolution: &UserTypeResolution{Default: "person"},
+		UserTypeResolution: &UserTypeResolution{Default: "Person"},
 		UserTypeAttributeMappings: []UserTypeAttributeMapping{
 			{
-				UserType:   "person",
+				UserType:   "Person",
 				Attributes: []AttributeMapping{{ExternalAttribute: "given_name", LocalAttribute: "firstName"}},
 			},
 		},
@@ -788,8 +788,8 @@ func (s *IDPStoreTestSuite) TestSerializeAttributeConfiguration_WithMapping() {
 	result, err := serializeAttributeConfiguration(am)
 	s.NoError(err)
 	s.NotNil(result)
-	s.Contains(result.(string), `"userTypeResolution":{"default":"person"}`)
-	s.Contains(result.(string), `"userType":"person"`)
+	s.Contains(result.(string), `"userTypeResolution":{"default":"Person"}`)
+	s.Contains(result.(string), `"userType":"Person"`)
 	s.Contains(result.(string), `"externalAttribute":"given_name"`)
 	s.Contains(result.(string), `"localAttribute":"firstName"`)
 }
@@ -802,17 +802,17 @@ func (s *IDPStoreTestSuite) TestParseAttributeConfigurationFromRow_Missing() {
 
 func (s *IDPStoreTestSuite) TestParseAttributeConfigurationFromRow_StringValue() {
 	row := map[string]interface{}{
-		"attribute_configuration": `{"userTypeResolution":{"default":"person"},` +
-			`"userTypeAttributeMappings":[{"userType":"person","attributes":` +
+		"attribute_configuration": `{"userTypeResolution":{"default":"Person"},` +
+			`"userTypeAttributeMappings":[{"userType":"Person","attributes":` +
 			`[{"externalAttribute":"given_name","localAttribute":"firstName"}]}]}`,
 	}
 	result, err := parseAttributeConfigurationFromRow(row)
 	s.NoError(err)
 	s.Require().NotNil(result)
 	s.Require().NotNil(result.UserTypeResolution)
-	s.Equal("person", result.UserTypeResolution.Default)
+	s.Equal("Person", result.UserTypeResolution.Default)
 	s.Require().Len(result.UserTypeAttributeMappings, 1)
-	s.Equal("person", result.UserTypeAttributeMappings[0].UserType)
+	s.Equal("Person", result.UserTypeAttributeMappings[0].UserType)
 	s.Require().Len(result.UserTypeAttributeMappings[0].Attributes, 1)
 	s.Equal("given_name", result.UserTypeAttributeMappings[0].Attributes[0].ExternalAttribute)
 	s.Equal("firstName", result.UserTypeAttributeMappings[0].Attributes[0].LocalAttribute)

--- a/backend/internal/idp/utils.go
+++ b/backend/internal/idp/utils.go
@@ -31,6 +31,9 @@ import (
 	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
 
+// subClaim is the OIDC subject identifier claim, which is always preserved during attribute mapping.
+const subClaim = "sub"
+
 // GetPropertyValue returns the plain-text value for the named property from the slice,
 // or an empty string if the property is absent or its value cannot be retrieved.
 func GetPropertyValue(properties []cmodels.Property, name string) string {
@@ -74,9 +77,8 @@ func GetAttributeMappings(idp *IDPDTO) []AttributeMapping {
 	return nil
 }
 
-// ApplyAttributeMappings applies external→local attribute mappings to attrs, supporting dot-notation
-// source paths for nested claims. Unmapped attributes pass through; mapped values take precedence
-// on collision. Returns attrs unchanged when no mappings are configured.
+// ApplyAttributeMappings applies external→local attribute mappings. Unmapped attributes pass through;
+// mapped values take precedence on collision. Returns attrs unchanged when no mappings are configured.
 func ApplyAttributeMappings(attrs map[string]interface{}, mappings []AttributeMapping) map[string]interface{} {
 	if len(mappings) == 0 {
 		return attrs
@@ -84,6 +86,10 @@ func ApplyAttributeMappings(attrs map[string]interface{}, mappings []AttributeMa
 
 	mappedSources := make(map[string]bool, len(mappings))
 	for _, m := range mappings {
+		// sub is always preserved as-is; it must not be consumed by a mapping.
+		if m.ExternalAttribute == subClaim {
+			continue
+		}
 		mappedSources[m.ExternalAttribute] = true
 	}
 

--- a/backend/internal/idp/utils_test.go
+++ b/backend/internal/idp/utils_test.go
@@ -820,6 +820,34 @@ func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_DottedKeyMatchedLiterally
 	s.Equal("user@example.com", result["email"])
 }
 
+func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_SubPreservedWhenMappedToMultipleTargets() {
+	attrs := map[string]interface{}{"sub": "user-123"}
+	result := ApplyAttributeMappings(attrs, []AttributeMapping{
+		{ExternalAttribute: "sub", LocalAttribute: "username"},
+		{ExternalAttribute: "sub", LocalAttribute: "email"},
+	})
+	s.Equal("user-123", result["sub"])
+	s.Equal("user-123", result["username"])
+	s.Equal("user-123", result["email"])
+}
+
+func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_SubPreservedAlongsideOtherRenamedSources() {
+	attrs := map[string]interface{}{
+		"sub":        "user-123",
+		"given_name": "Jane",
+	}
+	result := ApplyAttributeMappings(attrs, []AttributeMapping{
+		{ExternalAttribute: "sub", LocalAttribute: "picture"},
+		{ExternalAttribute: "given_name", LocalAttribute: "firstName"},
+	})
+	s.Equal("user-123", result["sub"])
+	s.Equal("user-123", result["picture"])
+	s.Equal("Jane", result["firstName"])
+	// Non-sub sources are still consumed by the mapping.
+	_, present := result["given_name"]
+	s.False(present)
+}
+
 func (s *IDPUtilsTestSuite) TestGetAttributeMappings_NilIDP() {
 	s.Nil(GetAttributeMappings(nil))
 }

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -317,8 +317,9 @@ func (tv *tokenValidator) extractSubjectTokenClaims(
 	// Extract scopes
 	scopes := extractScopesFromClaims(claims, isAuthAssertion)
 
-	// Extract user attributes, applying any configured external-to-local claim mappings.
-	userAttributes := idp.ApplyAttributeMappings(ExtractUserAttributes(claims), attributeMappings)
+	// Apply attribute mappings against the full claim set first so reserved claims (e.g. sub) remain
+	// available as mapping sources, then drop the reserved claims that were not mapped to attributes.
+	userAttributes := ExtractUserAttributes(idp.ApplyAttributeMappings(claims, attributeMappings))
 
 	// Extract nested act claim if present
 	var nestedAct map[string]interface{}

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -239,6 +239,36 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Success_WithEmpty
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
+func (suite *TokenValidatorTestSuite) TestExtractSubjectTokenClaims_MapsReservedSubClaimToAttributes() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub":        "user123",
+		"iss":        "https://example.com",
+		"aud":        suite.getDefaultAudience(),
+		"exp":        float64(now + 3600),
+		"given_name": "Jane",
+	}
+	mappings := []idp.AttributeMapping{
+		{ExternalAttribute: "sub", LocalAttribute: "username"},
+		{ExternalAttribute: "sub", LocalAttribute: "email"},
+		{ExternalAttribute: "given_name", LocalAttribute: "firstName"},
+	}
+
+	result, err := suite.validator.extractSubjectTokenClaims(
+		"", "https://example.com", claims, suite.oauthApp, mappings)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), "user123", result.Sub)
+	// The sub value flows into every attribute it is mapped to.
+	assert.Equal(suite.T(), "user123", result.UserAttributes["username"])
+	assert.Equal(suite.T(), "user123", result.UserAttributes["email"])
+	assert.Equal(suite.T(), "Jane", result.UserAttributes["firstName"])
+	// Reserved claims are still filtered out of the attribute set.
+	assert.NotContains(suite.T(), result.UserAttributes, "sub")
+	assert.NotContains(suite.T(), result.UserAttributes, "given_name")
+}
+
 func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_InvalidJWTFormat() {
 	token := invalidJWTFormat
 

--- a/docs/content/guides/guides/identity-providers/add-oidc-provider.mdx
+++ b/docs/content/guides/guides/identity-providers/add-oidc-provider.mdx
@@ -97,11 +97,11 @@ External providers emit attributes under their own names, which may differ from 
   "properties": [ /* ... */ ],
   "attributeConfiguration": {
     "userTypeResolution": {
-      "default": "person"
+      "default": "Person"
     },
     "userTypeAttributeMappings": [
       {
-        "userType": "person",
+        "userType": "Person",
         "attributes": [
           { "externalAttribute": "given_name", "localAttribute": "firstName" },
           { "externalAttribute": "email.work", "localAttribute": "email" }


### PR DESCRIPTION
### Purpose

Fix IDP external→local attribute mapping so the OIDC `sub` claim is propagated correctly, and align the IDP API examples with the canonical default user type.

Two related mapping problems:

1. **Mapping layer (shared by token exchange and federated authentication):** `ApplyAttributeMappings` consumed any external attribute used as a mapping source, removing it from the resulting claims. For the reserved `sub` claim this meant it could be mapped to a target but was then dropped, so you could never keep `sub` as-is *and* map it.
2. **Token exchange subject-token path:** user attributes were extracted *before* mappings were applied (`ApplyAttributeMappings(ExtractUserAttributes(claims), ...)`). `ExtractUserAttributes` strips reserved JWT claims including `sub`, so by the time mappings ran `sub` was already gone — a `sub → picture` mapping produced nothing, while `org_name → picture` worked.

Additionally, the `api/idp.yaml` examples referenced the default user type as lowercase `"person"`, which does not match the `Person` user type created at bootstrap.

### Approach

- **`idp.ApplyAttributeMappings`** ([backend/internal/idp/utils.go](backend/internal/idp/utils.go)): never treat `sub` as a consumable mapping source. `sub` always passes through under its original key in addition to any attributes it is mapped to, so `sub → username` and `sub → email` yield `sub`, `username`, and `email` all carrying the subject value. Non-`sub` sources keep the existing rename-and-consume behavior.
- **`extractSubjectTokenClaims`** ([backend/internal/oauth/oauth2/tokenservice/validator.go](backend/internal/oauth/oauth2/tokenservice/validator.go)): apply mappings against the full claim set first, then filter reserved claims — `ExtractUserAttributes(idp.ApplyAttributeMappings(claims, attributeMappings))`. This makes reserved claims like `sub` available as mapping sources. The issued token's `sub` continues to come from the subject token's `sub` independently.
- **`api/idp.yaml`**: use `"Person"` instead of `"person"` in all attribute-configuration examples and schema field examples.

Self-issued tokens (which pass `nil` mappings) and the common case where `sub` is not mapped are unaffected.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OIDC `sub` handling during attribute mapping so the reserved subject claim is preserved and not overwritten when mappings include `sub`.

* **New Features**
  * Reserved identity claims (including `sub`) can now be used as sources for attribute mappings during token claim processing.

* **Documentation**
  * Updated identity provider attribute configuration examples to use capitalized user type values (`"Person"` instead of `"person"`).

* **Tests**
  * Added coverage for preserving `sub` and mapping reserved claims into target attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->