### PR TITLE
Add usage service registry and flow usages support

### DIFF
--- a/api/design.yaml
+++ b/api/design.yaml
@@ -303,7 +303,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ThemeUsagesResponse'
+                $ref: '#/components/schemas/ResourceUsagesResponse'
               example:
                 totalResults: 3
                 count: 3
@@ -900,9 +900,9 @@ components:
           items:
             $ref: '#/components/schemas/ThemeListItem'
 
-    ThemeUsage:
+    ResourceUsage:
       type: object
-      description: A single resource that references the theme.
+      description: A single resource that references the target resource.
       required:
         - resourceType
         - id
@@ -926,13 +926,13 @@ components:
         behaviorOnDelete:
           type: string
           description: |
-            What happens to this resource when the theme is deleted.
-            - `fallback`: the reference is kept and resolved to the system default theme at read time.
+            What happens to this resource when the target resource is deleted.
+            - `fallback`: the reference is kept and resolved to the system default at read time.
             - `cascade`: the resource is permanently deleted.
           enum: [fallback, cascade]
           example: fallback
 
-    ThemeUsagesSummary:
+    ResourceUsagesSummary:
       type: object
       nullable: true
       description: |
@@ -944,14 +944,17 @@ components:
         application: 2
         agent: 1
 
-    ThemeUsagesResponse:
+    ResourceUsagesResponse:
       type: object
+      description: |
+        Resources that reference a target resource, aggregated across all resource types.
+        Drives pre-delete confirmation dialogs; informational only.
       properties:
         totalResults:
           type: integer
           nullable: true
           description: |
-            Total number of resources that reference this theme.
+            Total number of resources that reference the target resource.
             Null when usage data is unavailable; 0 means confirmed empty.
           example: 3
         count:
@@ -959,11 +962,11 @@ components:
           description: Number of results returned.
           example: 3
         summary:
-          $ref: '#/components/schemas/ThemeUsagesSummary'
+          $ref: '#/components/schemas/ResourceUsagesSummary'
         usages:
           type: array
           items:
-            $ref: '#/components/schemas/ThemeUsage'
+            $ref: '#/components/schemas/ResourceUsage'
 
     LayoutRequest:
       type: object

--- a/api/flow-management.yaml
+++ b/api/flow-management.yaml
@@ -379,6 +379,75 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /flows/{flowId}/usages:
+    get:
+      tags:
+        - Flow Management
+      summary: Get flow usages
+      description: |
+        Returns the resources that reference this flow (through its authentication,
+        registration, or recovery flow slots), aggregated across all resource types.
+        This endpoint is informational only — it drives the pre-delete confirmation
+        dialog in the UI and does not gate deletion on the server.
+
+        When usage data is unavailable (e.g. the server has not fully initialised),
+        `totalResults` and `summary` are `null` rather than `0`/empty.
+        Consumers must treat `null` as "unknown" and `0` as "confirmed empty".
+      operationId: getFlowUsages
+      parameters:
+        - name: flowId
+          in: path
+          required: true
+          description: Unique identifier of the flow
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resources that reference this flow
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceUsagesResponse'
+              example:
+                totalResults: 2
+                count: 2
+                summary:
+                  application: 1
+                  agent: 1
+                usages:
+                  - resourceType: application
+                    id: "a1b2c3d4-0000-0000-0000-000000000001"
+                    displayName: "Customer Portal"
+                    behaviorOnDelete: fallback
+                  - resourceType: agent
+                    id: "a1b2c3d4-0000-0000-0000-000000000002"
+                    displayName: "Support Agent"
+                    behaviorOnDelete: fallback
+        '404':
+          description: Flow not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "FLM-1003"
+                message:
+                  key: "error.flowmgtservice.flow_not_found"
+                  defaultValue: "Flow not found"
+                description:
+                  key: "error.flowmgtservice.flow_not_found_description"
+                  defaultValue: "The flow with the specified ID does not exist"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /flows/{flowId}/versions/{version}:
     get:
       tags:
@@ -546,6 +615,74 @@ components:
               defaultValue: "You do not have sufficient permissions to access this resource"
 
   schemas:
+    ResourceUsage:
+      type: object
+      description: A single resource that references the target resource.
+      required:
+        - resourceType
+        - id
+        - displayName
+        - behaviorOnDelete
+      properties:
+        resourceType:
+          type: string
+          description: Type of the referencing resource.
+          enum: [application, agent]
+          example: application
+        id:
+          type: string
+          format: uuid
+          description: Identifier of the referencing resource.
+          example: "a1b2c3d4-0000-0000-0000-000000000001"
+        displayName:
+          type: string
+          description: Human-readable name of the referencing resource.
+          example: "Customer Portal"
+        behaviorOnDelete:
+          type: string
+          description: |
+            What happens to this resource when the target resource is deleted.
+            - `fallback`: the reference is kept and resolved to the system default at read time.
+            - `cascade`: the resource is permanently deleted.
+          enum: [fallback, cascade]
+          example: fallback
+
+    ResourceUsagesSummary:
+      type: object
+      nullable: true
+      description: |
+        Per-resource-type count of usages, keyed by resource type
+        (e.g. `application`, `agent`). Null when the counts could not be determined.
+      additionalProperties:
+        type: integer
+      example:
+        application: 1
+        agent: 1
+
+    ResourceUsagesResponse:
+      type: object
+      description: |
+        Resources that reference a target resource, aggregated across all resource types.
+        Drives pre-delete confirmation dialogs; informational only.
+      properties:
+        totalResults:
+          type: integer
+          nullable: true
+          description: |
+            Total number of resources that reference the target resource.
+            Null when usage data is unavailable; 0 means confirmed empty.
+          example: 2
+        count:
+          type: integer
+          description: Number of results returned.
+          example: 2
+        summary:
+          $ref: '#/components/schemas/ResourceUsagesSummary'
+        usages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceUsage'
+
     FlowListResponse:
       type: object
       properties:

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -381,8 +381,9 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	}
 	exporters = append(exporters, agentExporter)
 
-	// Wire the dependency registry into the theme service (two-phase init to avoid cyclic imports).
-	registerDependencyRegistry(themeMgtService, applicationService, agentService)
+	// Wire the dependency registry into the theme and flow services (two-phase init to avoid
+	// cyclic imports).
+	registerDependencyRegistry(themeMgtService, flowMgtService, applicationService, agentService)
 
 	// Initialize design resolve service for theme and layout resolution
 	designResolveService := resolve.Initialize(mux, themeMgtService, layoutMgtService, applicationService)
@@ -446,11 +447,15 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 }
 
 // registerDependencyRegistry builds the dependency registry from the given providers and wires
-// it into the theme management service.
+// it into the theme and flow management services.
 func registerDependencyRegistry(
-	themeMgtService thememgt.ThemeMgtServiceInterface, providers ...resourcedependency.Provider,
+	themeMgtService thememgt.ThemeMgtServiceInterface,
+	flowMgtService flowmgt.FlowMgtServiceInterface,
+	providers ...resourcedependency.Provider,
 ) {
-	themeMgtService.SetDependencyRegistry(resourcedependency.Initialize(providers...))
+	registry := resourcedependency.Initialize(providers...)
+	themeMgtService.SetDependencyRegistry(registry)
+	flowMgtService.SetDependencyRegistry(registry)
 }
 
 // unregisterServices unregisters all services that require cleanup during shutdown.

--- a/backend/internal/agent/service.go
+++ b/backend/internal/agent/service.go
@@ -392,25 +392,16 @@ func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *tidcomm
 }
 
 // GetResourceDependencies returns the agents that reference the resource identified by
-// (resourceType, id). It implements the resourcedependency.Provider interface.
+// (resourceType, id). It implements the resourcedependency.Provider interface. The
+// inbound-client store resolves which reference types are tracked, so no per-type handling is
+// needed here. The number of referencing entities is bounded by MaxCompositeStoreRecords
+// (the inbound-client store limit).
 func (s *agentService) GetResourceDependencies(
 	ctx context.Context, resourceType, id string) ([]resourcedependency.ResourceDependency, error) {
-	switch resourceType {
-	case resourcedependency.ResourceTypeTheme:
-		return s.getAgentsByThemeID(ctx, id)
-	default:
-		return []resourcedependency.ResourceDependency{}, nil
-	}
-}
-
-// getAgentsByThemeID returns agents referencing the given theme. The number of referencing
-// entities is bounded by MaxCompositeStoreRecords (the inbound-client store limit).
-func (s *agentService) getAgentsByThemeID(
-	ctx context.Context, themeID string) ([]resourcedependency.ResourceDependency, error) {
-	ids, _, err := s.inboundClientService.GetEntityIDsByThemeID(
-		ctx, themeID, serverconst.MaxCompositeStoreRecords, 0)
+	ids, _, err := s.inboundClientService.GetEntityIDsByReference(
+		ctx, resourceType, id, serverconst.MaxCompositeStoreRecords, 0)
 	if err != nil {
-		s.logger.Error(ctx, "Failed to get entity IDs by theme ID", log.Error(err))
+		s.logger.Error(ctx, "Failed to get entity IDs by reference", log.Error(err))
 		return nil, err
 	}
 	if len(ids) == 0 {

--- a/backend/internal/agent/service_test.go
+++ b/backend/internal/agent/service_test.go
@@ -2103,7 +2103,9 @@ func (suite *AgentServiceTestSuite) TestUpdateAgent_ExplicitOUIDChanged_Validate
 // --- GetResourceDependencies tests ---
 
 func (suite *AgentServiceTestSuite) TestGetResourceDependencies_UnknownResourceType() {
-	svc, _, _, _ := suite.setupService()
+	svc, _, mockInbound, _ := suite.setupService()
+	mockInbound.On("GetEntityIDsByReference", mock.Anything, "unknown", "id-1",
+		serverconst.MaxCompositeStoreRecords, 0).Return([]string{}, 0, nil)
 
 	result, err := svc.GetResourceDependencies(context.Background(), "unknown", "id-1")
 	assert.NoError(suite.T(), err)
@@ -2112,7 +2114,8 @@ func (suite *AgentServiceTestSuite) TestGetResourceDependencies_UnknownResourceT
 
 func (suite *AgentServiceTestSuite) TestGetResourceDependencies_InboundClientError() {
 	svc, _, mockInbound, _ := suite.setupService()
-	mockInbound.On("GetEntityIDsByThemeID", mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+	mockInbound.On("GetEntityIDsByReference", mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1",
+		serverconst.MaxCompositeStoreRecords, 0).
 		Return(nil, 0, errors.New("store error"))
 
 	result, err := svc.GetResourceDependencies(context.Background(), resourcedependency.ResourceTypeTheme, "theme-1")
@@ -2122,7 +2125,8 @@ func (suite *AgentServiceTestSuite) TestGetResourceDependencies_InboundClientErr
 
 func (suite *AgentServiceTestSuite) TestGetResourceDependencies_EmptyIDs() {
 	svc, _, mockInbound, _ := suite.setupService()
-	mockInbound.On("GetEntityIDsByThemeID", mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+	mockInbound.On("GetEntityIDsByReference", mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1",
+		serverconst.MaxCompositeStoreRecords, 0).
 		Return([]string{}, 0, nil)
 
 	result, err := svc.GetResourceDependencies(context.Background(), resourcedependency.ResourceTypeTheme, "theme-1")
@@ -2132,7 +2136,8 @@ func (suite *AgentServiceTestSuite) TestGetResourceDependencies_EmptyIDs() {
 
 func (suite *AgentServiceTestSuite) TestGetResourceDependencies_Success() {
 	svc, mockEntity, mockInbound, _ := suite.setupService()
-	mockInbound.On("GetEntityIDsByThemeID", mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+	mockInbound.On("GetEntityIDsByReference", mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1",
+		serverconst.MaxCompositeStoreRecords, 0).
 		Return([]string{"agent-1"}, 1, nil)
 
 	sysAttrs, _ := json.Marshal(map[string]interface{}{"name": "Agent One"})
@@ -2152,7 +2157,8 @@ func (suite *AgentServiceTestSuite) TestGetResourceDependencies_Success() {
 // Applications share the inbound-client store; the agent provider must skip non-agent entities.
 func (suite *AgentServiceTestSuite) TestGetResourceDependencies_FiltersOutNonAgentEntities() {
 	svc, mockEntity, mockInbound, _ := suite.setupService()
-	mockInbound.On("GetEntityIDsByThemeID", mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+	mockInbound.On("GetEntityIDsByReference", mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1",
+		serverconst.MaxCompositeStoreRecords, 0).
 		Return([]string{"agent-1", "app-1"}, 2, nil)
 
 	sysAttrs, _ := json.Marshal(map[string]interface{}{"name": "Agent One"})

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -543,25 +543,16 @@ func (as *applicationService) DeleteApplication(ctx context.Context, appID strin
 }
 
 // GetResourceDependencies returns the applications that reference the resource identified
-// by (resourceType, id). It implements the resourcedependency.Provider interface.
+// by (resourceType, id). It implements the resourcedependency.Provider interface. The
+// inbound-client store resolves which reference types are tracked, so no per-type handling is
+// needed here. The number of referencing entities is bounded by MaxCompositeStoreRecords
+// (the inbound-client store limit).
 func (as *applicationService) GetResourceDependencies(
 	ctx context.Context, resourceType, id string) ([]resourcedependency.ResourceDependency, error) {
-	switch resourceType {
-	case resourcedependency.ResourceTypeTheme:
-		return as.getApplicationsByThemeID(ctx, id)
-	default:
-		return []resourcedependency.ResourceDependency{}, nil
-	}
-}
-
-// getApplicationsByThemeID returns applications referencing the given theme. The number of
-// referencing entities is bounded by MaxCompositeStoreRecords (the inbound-client store limit).
-func (as *applicationService) getApplicationsByThemeID(
-	ctx context.Context, themeID string) ([]resourcedependency.ResourceDependency, error) {
-	ids, _, err := as.inboundClientService.GetEntityIDsByThemeID(
-		ctx, themeID, serverconst.MaxCompositeStoreRecords, 0)
+	ids, _, err := as.inboundClientService.GetEntityIDsByReference(
+		ctx, resourceType, id, serverconst.MaxCompositeStoreRecords, 0)
 	if err != nil {
-		as.logger.Error(ctx, "Failed to get entity IDs by theme ID", log.Error(err))
+		as.logger.Error(ctx, "Failed to get entity IDs by reference", log.Error(err))
 		return nil, err
 	}
 	if len(ids) == 0 {

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -3325,7 +3325,11 @@ func (suite *ServiceTestSuite) TestValidateApplicationFields_FlowHandleResolutio
 // --- GetResourceDependencies tests ---
 
 func (suite *ServiceTestSuite) TestGetResourceDependencies_UnknownResourceType() {
-	service, _ := suite.setupTestService()
+	service, mockStore := suite.setupTestService()
+	mockStore.EXPECT().
+		GetEntityIDsByReference(
+			mock.Anything, "unknown", "id-1", serverconst.MaxCompositeStoreRecords, 0).
+		Return([]string{}, 0, nil)
 
 	result, err := service.GetResourceDependencies(context.Background(), "unknown", "id-1")
 	assert.NoError(suite.T(), err)
@@ -3335,7 +3339,8 @@ func (suite *ServiceTestSuite) TestGetResourceDependencies_UnknownResourceType()
 func (suite *ServiceTestSuite) TestGetResourceDependencies_InboundClientError() {
 	service, mockStore := suite.setupTestService()
 	mockStore.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
 		Return(nil, 0, errors.New("store error"))
 
 	result, err := service.GetResourceDependencies(
@@ -3347,7 +3352,8 @@ func (suite *ServiceTestSuite) TestGetResourceDependencies_InboundClientError() 
 func (suite *ServiceTestSuite) TestGetResourceDependencies_EmptyIDs() {
 	service, mockStore := suite.setupTestService()
 	mockStore.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
 		Return([]string{}, 0, nil)
 
 	result, err := service.GetResourceDependencies(
@@ -3359,7 +3365,8 @@ func (suite *ServiceTestSuite) TestGetResourceDependencies_EmptyIDs() {
 func (suite *ServiceTestSuite) TestGetResourceDependencies_EntityProviderError() {
 	service, mockStore := suite.setupTestService()
 	mockStore.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
 		Return([]string{"app-1"}, 1, nil)
 
 	ep := resetEntityProviderMethod(service, "GetEntitiesByIDs")
@@ -3375,7 +3382,8 @@ func (suite *ServiceTestSuite) TestGetResourceDependencies_EntityProviderError()
 func (suite *ServiceTestSuite) TestGetResourceDependencies_Success() {
 	service, mockStore := suite.setupTestService()
 	mockStore.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
 		Return([]string{"app-1", "app-2"}, 2, nil)
 
 	sysAttrs1, _ := json.Marshal(map[string]interface{}{"name": "Portal App"})
@@ -3402,7 +3410,8 @@ func (suite *ServiceTestSuite) TestGetResourceDependencies_Success() {
 func (suite *ServiceTestSuite) TestGetResourceDependencies_FiltersOutNonAppEntities() {
 	service, mockStore := suite.setupTestService()
 	mockStore.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
 		Return([]string{"app-1", "agent-1"}, 2, nil)
 
 	sysAttrs, _ := json.Marshal(map[string]interface{}{"name": "Portal App"})
@@ -3422,7 +3431,8 @@ func (suite *ServiceTestSuite) TestGetResourceDependencies_FiltersOutNonAppEntit
 func (suite *ServiceTestSuite) TestGetResourceDependencies_NoSystemAttributes() {
 	service, mockStore := suite.setupTestService()
 	mockStore.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
 		Return([]string{"app-1"}, 1, nil)
 
 	ep := resetEntityProviderMethod(service, "GetEntitiesByIDs")
@@ -3441,7 +3451,8 @@ func (suite *ServiceTestSuite) TestGetResourceDependencies_NoSystemAttributes() 
 func (suite *ServiceTestSuite) TestGetResourceDependencies_SystemAttributesWithoutName() {
 	service, mockStore := suite.setupTestService()
 	mockStore.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", serverconst.MaxCompositeStoreRecords, 0).
 		Return([]string{"app-1"}, 1, nil)
 
 	sysAttrs, _ := json.Marshal(map[string]interface{}{"description": "some desc"})

--- a/backend/internal/flow/mgt/FlowMgtServiceInterface_mock_test.go
+++ b/backend/internal/flow/mgt/FlowMgtServiceInterface_mock_test.go
@@ -9,6 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/flow/core"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -311,6 +312,76 @@ func (_c *FlowMgtServiceInterfaceMock_GetFlowByHandle_Call) Return(completeFlowD
 }
 
 func (_c *FlowMgtServiceInterfaceMock_GetFlowByHandle_Call) RunAndReturn(run func(ctx context.Context, handle string, flowType providers.FlowType) (*providers.CompleteFlowDefinition, *common.ServiceError)) *FlowMgtServiceInterfaceMock_GetFlowByHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetFlowUsages provides a mock function for the type FlowMgtServiceInterfaceMock
+func (_mock *FlowMgtServiceInterfaceMock) GetFlowUsages(ctx context.Context, flowID string) (*resourcedependency.DependenciesResponse, *common.ServiceError) {
+	ret := _mock.Called(ctx, flowID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFlowUsages")
+	}
+
+	var r0 *resourcedependency.DependenciesResponse
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*resourcedependency.DependenciesResponse, *common.ServiceError)); ok {
+		return returnFunc(ctx, flowID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *resourcedependency.DependenciesResponse); ok {
+		r0 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcedependency.DependenciesResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// FlowMgtServiceInterfaceMock_GetFlowUsages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFlowUsages'
+type FlowMgtServiceInterfaceMock_GetFlowUsages_Call struct {
+	*mock.Call
+}
+
+// GetFlowUsages is a helper method to define mock.On call
+//   - ctx context.Context
+//   - flowID string
+func (_e *FlowMgtServiceInterfaceMock_Expecter) GetFlowUsages(ctx interface{}, flowID interface{}) *FlowMgtServiceInterfaceMock_GetFlowUsages_Call {
+	return &FlowMgtServiceInterfaceMock_GetFlowUsages_Call{Call: _e.mock.On("GetFlowUsages", ctx, flowID)}
+}
+
+func (_c *FlowMgtServiceInterfaceMock_GetFlowUsages_Call) Run(run func(ctx context.Context, flowID string)) *FlowMgtServiceInterfaceMock_GetFlowUsages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *FlowMgtServiceInterfaceMock_GetFlowUsages_Call) Return(dependenciesResponse *resourcedependency.DependenciesResponse, serviceError *common.ServiceError) *FlowMgtServiceInterfaceMock_GetFlowUsages_Call {
+	_c.Call.Return(dependenciesResponse, serviceError)
+	return _c
+}
+
+func (_c *FlowMgtServiceInterfaceMock_GetFlowUsages_Call) RunAndReturn(run func(ctx context.Context, flowID string) (*resourcedependency.DependenciesResponse, *common.ServiceError)) *FlowMgtServiceInterfaceMock_GetFlowUsages_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -760,6 +831,46 @@ func (_c *FlowMgtServiceInterfaceMock_RestoreFlowVersion_Call) Return(completeFl
 
 func (_c *FlowMgtServiceInterfaceMock_RestoreFlowVersion_Call) RunAndReturn(run func(ctx context.Context, flowID string, version int) (*providers.CompleteFlowDefinition, *common.ServiceError)) *FlowMgtServiceInterfaceMock_RestoreFlowVersion_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// SetDependencyRegistry provides a mock function for the type FlowMgtServiceInterfaceMock
+func (_mock *FlowMgtServiceInterfaceMock) SetDependencyRegistry(r resourcedependency.Registry) {
+	_mock.Called(r)
+	return
+}
+
+// FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDependencyRegistry'
+type FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call struct {
+	*mock.Call
+}
+
+// SetDependencyRegistry is a helper method to define mock.On call
+//   - r resourcedependency.Registry
+func (_e *FlowMgtServiceInterfaceMock_Expecter) SetDependencyRegistry(r interface{}) *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call {
+	return &FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call{Call: _e.mock.On("SetDependencyRegistry", r)}
+}
+
+func (_c *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call) Run(run func(r resourcedependency.Registry)) *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 resourcedependency.Registry
+		if args[0] != nil {
+			arg0 = args[0].(resourcedependency.Registry)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call) Return() *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run func(r resourcedependency.Registry)) *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Run(run)
 	return _c
 }
 

--- a/backend/internal/flow/mgt/handler.go
+++ b/backend/internal/flow/mgt/handler.go
@@ -127,6 +127,25 @@ func (h *flowMgtHandler) getFlow(w http.ResponseWriter, r *http.Request) {
 	h.logger.Debug(ctx, "Flow retrieved successfully", log.String(logKeyFlowID, flowID))
 }
 
+// getFlowUsages handles GET requests to retrieve the resources that reference a flow.
+func (h *flowMgtHandler) getFlowUsages(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	flowID := r.PathValue(pathParamFlowID)
+	if flowID == "" {
+		handleError(ctx, w, &ErrorMissingFlowID)
+		return
+	}
+
+	result, svcErr := h.service.GetFlowUsages(ctx, flowID)
+	if svcErr != nil {
+		handleError(ctx, w, svcErr)
+		return
+	}
+
+	utils.WriteSuccessResponse(ctx, w, http.StatusOK, result)
+	h.logger.Debug(ctx, "Flow usages retrieved successfully", log.String(logKeyFlowID, flowID))
+}
+
 // updateFlow handles PUT requests to update an existing flow definition.
 func (h *flowMgtHandler) updateFlow(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/backend/internal/flow/mgt/handler_test.go
+++ b/backend/internal/flow/mgt/handler_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
@@ -248,6 +249,57 @@ func (s *FlowMgtHandlerTestSuite) TestGetFlow_NotFound() {
 	w := httptest.NewRecorder()
 
 	s.handler.getFlow(w, req)
+
+	s.Equal(http.StatusNotFound, w.Code)
+}
+
+// Test getFlowUsages
+
+func (s *FlowMgtHandlerTestSuite) TestGetFlowUsages_Success() {
+	total := 1
+	s.mockService.EXPECT().GetFlowUsages(mock.Anything, testFlowIDHandler).Return(
+		&resourcedependency.DependenciesResponse{
+			TotalResults: &total,
+			Count:        1,
+			Summary:      map[string]int{resourcedependency.ResourceTypeApplication: 1},
+			Usages: []resourcedependency.ResourceDependency{
+				{ResourceType: resourcedependency.ResourceTypeApplication, ID: "app-1",
+					DisplayName: "App One", BehaviorOnDelete: resourcedependency.BehaviorFallback},
+			},
+		}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/flows/"+testFlowIDHandler+"/usages", nil)
+	req.SetPathValue(pathParamFlowID, testFlowIDHandler)
+	w := httptest.NewRecorder()
+
+	s.handler.getFlowUsages(w, req)
+
+	s.Equal(http.StatusOK, w.Code)
+	var response resourcedependency.DependenciesResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	s.NoError(err)
+	s.Equal(1, *response.TotalResults)
+	s.Len(response.Usages, 1)
+	s.Equal(resourcedependency.ResourceTypeApplication, response.Usages[0].ResourceType)
+}
+
+func (s *FlowMgtHandlerTestSuite) TestGetFlowUsages_MissingFlowID() {
+	req := httptest.NewRequest(http.MethodGet, "/flows//usages", nil)
+	w := httptest.NewRecorder()
+
+	s.handler.getFlowUsages(w, req)
+
+	s.Equal(http.StatusBadRequest, w.Code)
+}
+
+func (s *FlowMgtHandlerTestSuite) TestGetFlowUsages_NotFound() {
+	s.mockService.EXPECT().GetFlowUsages(mock.Anything, testFlowIDHandler).Return(nil, &ErrorFlowNotFound)
+
+	req := httptest.NewRequest(http.MethodGet, "/flows/"+testFlowIDHandler+"/usages", nil)
+	req.SetPathValue(pathParamFlowID, testFlowIDHandler)
+	w := httptest.NewRecorder()
+
+	s.handler.getFlowUsages(w, req)
 
 	s.Equal(http.StatusNotFound, w.Code)
 }

--- a/backend/internal/flow/mgt/init.go
+++ b/backend/internal/flow/mgt/init.go
@@ -198,6 +198,12 @@ func registerRoutes(mux *http.ServeMux, handler *flowMgtHandler) {
 			w.WriteHeader(http.StatusNoContent)
 		}, opts3),
 	)
+	mux.HandleFunc(middleware.WithCORS("GET /flows/{flowId}/usages", handler.getFlowUsages, opts3))
+	mux.HandleFunc(middleware.WithCORS("OPTIONS /flows/{flowId}/usages",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}, opts3),
+	)
 	mux.HandleFunc(middleware.WithCORS("GET /flows/{flowId}/versions/{version}", handler.getFlowVersion, opts3))
 	mux.HandleFunc(middleware.WithCORS("OPTIONS /flows/{flowId}/versions/{version}",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/flow/mgt/service.go
+++ b/backend/internal/flow/mgt/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/flow/interceptor"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )
@@ -73,6 +74,9 @@ type FlowMgtServiceInterface interface {
 		*providers.CompleteFlowDefinition, *tidcommon.ServiceError)
 	GetGraph(ctx context.Context, flowID string) (core.GraphInterface, *tidcommon.ServiceError)
 	IsValidFlow(ctx context.Context, flowID string, flowType providers.FlowType) (bool, *tidcommon.ServiceError)
+	SetDependencyRegistry(r resourcedependency.Registry)
+	GetFlowUsages(ctx context.Context, flowID string) (
+		*resourcedependency.DependenciesResponse, *tidcommon.ServiceError)
 }
 
 // flowMgtService is the default implementation of the FlowMgtServiceInterface.
@@ -84,6 +88,7 @@ type flowMgtService struct {
 	interceptorRegistry interceptor.InterceptorRegistryInterface
 	compositeStore      *compositeFlowStore
 	transactioner       transaction.Transactioner
+	dependencyRegistry  resourcedependency.Registry
 	logger              *log.Logger
 }
 
@@ -224,6 +229,47 @@ func (s *flowMgtService) GetFlow(ctx context.Context, flowID string) (
 	}
 
 	return flow, nil
+}
+
+// SetDependencyRegistry injects the dependency registry. Called by servicemanager after the
+// provider services are initialized to avoid a cyclic import.
+func (s *flowMgtService) SetDependencyRegistry(r resourcedependency.Registry) {
+	s.dependencyRegistry = r
+}
+
+// GetFlowUsages returns the resources that reference this flow.
+func (s *flowMgtService) GetFlowUsages(
+	ctx context.Context, flowID string) (*resourcedependency.DependenciesResponse, *tidcommon.ServiceError) {
+	if flowID == "" {
+		return nil, &ErrorMissingFlowID
+	}
+
+	if _, err := s.store.GetFlowByID(ctx, flowID); err != nil {
+		if errors.Is(err, errFlowNotFound) {
+			return nil, &ErrorFlowNotFound
+		}
+		s.logger.Error(ctx, "Failed to get flow", log.String(logKeyFlowID, flowID), log.Error(err))
+		return nil, &tidcommon.InternalServerError
+	}
+
+	if s.dependencyRegistry == nil {
+		s.logger.Warn(ctx, "Dependency registry not set; returning unknown usages",
+			log.String(logKeyFlowID, flowID))
+		return &resourcedependency.DependenciesResponse{
+			TotalResults: nil,
+			Count:        0,
+			Summary:      nil,
+			Usages:       []resourcedependency.ResourceDependency{},
+		}, nil
+	}
+
+	result, err := s.dependencyRegistry.GetDependencies(ctx, resourcedependency.ResourceTypeFlow, flowID)
+	if err != nil {
+		s.logger.Error(ctx, "Failed to get flow usages", log.String(logKeyFlowID, flowID), log.Error(err))
+		return nil, &tidcommon.InternalServerError
+	}
+
+	return result, nil
 }
 
 // GetFlowByHandle retrieves a flow definition by its handle and type.

--- a/backend/internal/flow/mgt/service_test.go
+++ b/backend/internal/flow/mgt/service_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/flow/interceptor"
 	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/executormock"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/interceptormock"
@@ -59,6 +60,21 @@ type stubTransactioner struct{}
 
 func (s *stubTransactioner) Transact(ctx context.Context, txFunc func(context.Context) error) error {
 	return txFunc(ctx)
+}
+
+// stubDependencyRegistry is a stub implementation of resourcedependency.Registry for testing.
+// The real registry never returns an error from GetDependencies, so a stub is required to
+// exercise the error branch of GetFlowUsages.
+type stubDependencyRegistry struct {
+	resp *resourcedependency.DependenciesResponse
+	err  error
+}
+
+func (r *stubDependencyRegistry) RegisterProvider(resourcedependency.Provider) {}
+
+func (r *stubDependencyRegistry) GetDependencies(
+	context.Context, string, string) (*resourcedependency.DependenciesResponse, error) {
+	return r.resp, r.err
 }
 
 func (s *FlowMgtServiceTestSuite) SetupTest() {
@@ -856,7 +872,77 @@ func (s *FlowMgtServiceTestSuite) TestGetFlow_StoreError() {
 	s.Equal(&tidcommon.InternalServerError, err)
 }
 
-// GetFlowByHandle tests
+// GetFlowUsages tests
+
+func (s *FlowMgtServiceTestSuite) TestGetFlowUsages_EmptyID() {
+	result, err := s.service.GetFlowUsages(context.Background(), "")
+
+	s.Nil(result)
+	s.Equal(&ErrorMissingFlowID, err)
+}
+
+func (s *FlowMgtServiceTestSuite) TestGetFlowUsages_NotFound() {
+	s.mockStore.EXPECT().GetFlowByID(mock.Anything, testFlowIDService).Return(nil, errFlowNotFound)
+
+	result, err := s.service.GetFlowUsages(context.Background(), testFlowIDService)
+
+	s.Nil(result)
+	s.Equal(&ErrorFlowNotFound, err)
+}
+
+func (s *FlowMgtServiceTestSuite) TestGetFlowUsages_StoreError() {
+	s.mockStore.EXPECT().GetFlowByID(mock.Anything, testFlowIDService).Return(nil, errors.New("db error"))
+
+	result, err := s.service.GetFlowUsages(context.Background(), testFlowIDService)
+
+	s.Nil(result)
+	s.Equal(&tidcommon.InternalServerError, err)
+}
+
+func (s *FlowMgtServiceTestSuite) TestGetFlowUsages_NoRegistrySet() {
+	s.mockStore.EXPECT().GetFlowByID(mock.Anything, testFlowIDService).
+		Return(&providers.CompleteFlowDefinition{ID: testFlowIDService}, nil)
+
+	result, err := s.service.GetFlowUsages(context.Background(), testFlowIDService)
+
+	s.Nil(err)
+	s.NotNil(result)
+	s.Nil(result.TotalResults)
+	s.Nil(result.Summary)
+	s.Empty(result.Usages)
+}
+
+func (s *FlowMgtServiceTestSuite) TestGetFlowUsages_RegistryError() {
+	s.mockStore.EXPECT().GetFlowByID(mock.Anything, testFlowIDService).
+		Return(&providers.CompleteFlowDefinition{ID: testFlowIDService}, nil)
+	s.service.SetDependencyRegistry(&stubDependencyRegistry{err: errors.New("registry error")})
+
+	result, err := s.service.GetFlowUsages(context.Background(), testFlowIDService)
+
+	s.Nil(result)
+	s.Equal(&tidcommon.InternalServerError, err)
+}
+
+func (s *FlowMgtServiceTestSuite) TestGetFlowUsages_Success() {
+	s.mockStore.EXPECT().GetFlowByID(mock.Anything, testFlowIDService).
+		Return(&providers.CompleteFlowDefinition{ID: testFlowIDService}, nil)
+	total := 1
+	expected := &resourcedependency.DependenciesResponse{
+		TotalResults: &total,
+		Count:        1,
+		Summary:      map[string]int{resourcedependency.ResourceTypeApplication: 1},
+		Usages: []resourcedependency.ResourceDependency{
+			{ResourceType: resourcedependency.ResourceTypeApplication, ID: "app-1",
+				DisplayName: "App One", BehaviorOnDelete: resourcedependency.BehaviorFallback},
+		},
+	}
+	s.service.SetDependencyRegistry(&stubDependencyRegistry{resp: expected})
+
+	result, err := s.service.GetFlowUsages(context.Background(), testFlowIDService)
+
+	s.Nil(err)
+	s.Equal(expected, result)
+}
 
 func (s *FlowMgtServiceTestSuite) TestGetFlowByHandle_Success() {
 	expectedFlow := &providers.CompleteFlowDefinition{

--- a/backend/internal/inboundclient/InboundClientServiceInterface_mock_test.go
+++ b/backend/internal/inboundclient/InboundClientServiceInterface_mock_test.go
@@ -248,55 +248,56 @@ func (_c *InboundClientServiceInterfaceMock_GetCertificate_Call) RunAndReturn(ru
 	return _c
 }
 
-// GetEntityIDsByThemeID provides a mock function for the type InboundClientServiceInterfaceMock
-func (_mock *InboundClientServiceInterfaceMock) GetEntityIDsByThemeID(ctx context.Context, themeID string, limit int, offset int) ([]string, int, error) {
-	ret := _mock.Called(ctx, themeID, limit, offset)
+// GetEntityIDsByReference provides a mock function for the type InboundClientServiceInterfaceMock
+func (_mock *InboundClientServiceInterfaceMock) GetEntityIDsByReference(ctx context.Context, refType string, refID string, limit int, offset int) ([]string, int, error) {
+	ret := _mock.Called(ctx, refType, refID, limit, offset)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetEntityIDsByThemeID")
+		panic("no return value specified for GetEntityIDsByReference")
 	}
 
 	var r0 []string
 	var r1 int
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]string, int, error)); ok {
-		return returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, int, int) ([]string, int, error)); ok {
+		return returnFunc(ctx, refType, refID, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []string); ok {
-		r0 = returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, int, int) []string); ok {
+		r0 = returnFunc(ctx, refType, refID, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) int); ok {
-		r1 = returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, int, int) int); ok {
+		r1 = returnFunc(ctx, refType, refID, limit, offset)
 	} else {
 		r1 = ret.Get(1).(int)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, string, int, int) error); ok {
-		r2 = returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string, int, int) error); ok {
+		r2 = returnFunc(ctx, refType, refID, limit, offset)
 	} else {
 		r2 = ret.Error(2)
 	}
 	return r0, r1, r2
 }
 
-// InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityIDsByThemeID'
-type InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call struct {
+// InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityIDsByReference'
+type InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call struct {
 	*mock.Call
 }
 
-// GetEntityIDsByThemeID is a helper method to define mock.On call
+// GetEntityIDsByReference is a helper method to define mock.On call
 //   - ctx context.Context
-//   - themeID string
+//   - refType string
+//   - refID string
 //   - limit int
 //   - offset int
-func (_e *InboundClientServiceInterfaceMock_Expecter) GetEntityIDsByThemeID(ctx interface{}, themeID interface{}, limit interface{}, offset interface{}) *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call {
-	return &InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call{Call: _e.mock.On("GetEntityIDsByThemeID", ctx, themeID, limit, offset)}
+func (_e *InboundClientServiceInterfaceMock_Expecter) GetEntityIDsByReference(ctx interface{}, refType interface{}, refID interface{}, limit interface{}, offset interface{}) *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call {
+	return &InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call{Call: _e.mock.On("GetEntityIDsByReference", ctx, refType, refID, limit, offset)}
 }
 
-func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call) Run(run func(ctx context.Context, themeID string, limit int, offset int)) *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call {
+func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call) Run(run func(ctx context.Context, refType string, refID string, limit int, offset int)) *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -306,30 +307,35 @@ func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call) Run(run 
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 int
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(int)
+			arg2 = args[2].(string)
 		}
 		var arg3 int
 		if args[3] != nil {
 			arg3 = args[3].(int)
+		}
+		var arg4 int
+		if args[4] != nil {
+			arg4 = args[4].(int)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
 }
 
-func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call) Return(strings []string, n int, err error) *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call {
+func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call) Return(strings []string, n int, err error) *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call {
 	_c.Call.Return(strings, n, err)
 	return _c
 }
 
-func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call) RunAndReturn(run func(ctx context.Context, themeID string, limit int, offset int) ([]string, int, error)) *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call {
+func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call) RunAndReturn(run func(ctx context.Context, refType string, refID string, limit int, offset int) ([]string, int, error)) *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/inboundclient/cache_backed_store.go
+++ b/backend/internal/inboundclient/cache_backed_store.go
@@ -147,9 +147,9 @@ func (c *cachedBackStore) IsDeclarative(ctx context.Context, entityID string) bo
 	return c.inner.IsDeclarative(ctx, entityID)
 }
 
-func (c *cachedBackStore) GetEntityIDsByThemeID(
-	ctx context.Context, themeID string, limit, offset int) ([]string, int, error) {
-	return c.inner.GetEntityIDsByThemeID(ctx, themeID, limit, offset)
+func (c *cachedBackStore) GetEntityIDsByReference(
+	ctx context.Context, refType, refID string, limit, offset int) ([]string, int, error) {
+	return c.inner.GetEntityIDsByReference(ctx, refType, refID, limit, offset)
 }
 
 // --- Cache helpers ---

--- a/backend/internal/inboundclient/composite_store.go
+++ b/backend/internal/inboundclient/composite_store.go
@@ -71,16 +71,17 @@ func (c *compositeStore) GetInboundClientList(ctx context.Context, limit int) ([
 	return clients, nil
 }
 
-func (c *compositeStore) GetEntityIDsByThemeID(
-	ctx context.Context, themeID string, limit, offset int) ([]string, int, error) {
-	dbIDs, _, err := c.dbStore.GetEntityIDsByThemeID(ctx, themeID, serverconst.MaxCompositeStoreRecords, 0)
+func (c *compositeStore) GetEntityIDsByReference(
+	ctx context.Context, refType, refID string, limit, offset int) ([]string, int, error) {
+	dbIDs, _, err := c.dbStore.GetEntityIDsByReference(ctx, refType, refID, serverconst.MaxCompositeStoreRecords, 0)
 	if err != nil {
 		return nil, 0, err
 	}
 	if len(dbIDs) == serverconst.MaxCompositeStoreRecords {
 		return nil, 0, ErrCompositeResultLimitExceeded
 	}
-	fileIDs, _, err := c.fileStore.GetEntityIDsByThemeID(ctx, themeID, serverconst.MaxCompositeStoreRecords, 0)
+	fileIDs, _, err := c.fileStore.GetEntityIDsByReference(
+		ctx, refType, refID, serverconst.MaxCompositeStoreRecords, 0)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/backend/internal/inboundclient/composite_store_test.go
+++ b/backend/internal/inboundclient/composite_store_test.go
@@ -28,6 +28,7 @@ import (
 
 	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
 	sysconfig "github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
@@ -269,10 +270,12 @@ func (suite *CompositeStoreTestSuite) TestMergeAndDeduplicate_SetsReadOnly() {
 func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_OnlyDB() {
 	ctx := context.Background()
 	suite.dbMock.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return([]string{"db-1", "db-2"}, 2, nil)
 
-	ids, total, err := suite.composite.GetEntityIDsByThemeID(ctx, "theme-1", 10, 0)
+	ids, total, err := suite.composite.GetEntityIDsByReference(
+		ctx, resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 	suite.NoError(err)
 	suite.Equal(2, total)
 	suite.ElementsMatch([]string{"db-1", "db-2"}, ids)
@@ -284,10 +287,12 @@ func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_MergesDBAndFile(
 		inboundmodel.InboundClient{ID: "file-1", ThemeID: "theme-1"}))
 
 	suite.dbMock.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return([]string{"db-1"}, 1, nil)
 
-	ids, total, err := suite.composite.GetEntityIDsByThemeID(ctx, "theme-1", 10, 0)
+	ids, total, err := suite.composite.GetEntityIDsByReference(
+		ctx, resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 	suite.NoError(err)
 	suite.Equal(2, total)
 	suite.ElementsMatch([]string{"db-1", "file-1"}, ids)
@@ -299,10 +304,12 @@ func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_DeduplicatesOver
 		inboundmodel.InboundClient{ID: "shared", ThemeID: "theme-1"}))
 
 	suite.dbMock.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return([]string{"shared", "db-only"}, 2, nil)
 
-	ids, total, err := suite.composite.GetEntityIDsByThemeID(ctx, "theme-1", 10, 0)
+	ids, total, err := suite.composite.GetEntityIDsByReference(
+		ctx, resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 	suite.NoError(err)
 	suite.Equal(2, total)
 	suite.ElementsMatch([]string{"shared", "db-only"}, ids)
@@ -311,20 +318,24 @@ func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_DeduplicatesOver
 func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_DBError() {
 	ctx := context.Background()
 	suite.dbMock.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return(nil, 0, errors.New("db error"))
 
-	_, _, err := suite.composite.GetEntityIDsByThemeID(ctx, "theme-1", 10, 0)
+	_, _, err := suite.composite.GetEntityIDsByReference(
+		ctx, resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 	suite.Error(err)
 }
 
 func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_Pagination() {
 	ctx := context.Background()
 	suite.dbMock.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return([]string{"db-1", "db-2", "db-3"}, 3, nil)
 
-	ids, total, err := suite.composite.GetEntityIDsByThemeID(ctx, "theme-1", 2, 1)
+	ids, total, err := suite.composite.GetEntityIDsByReference(
+		ctx, resourcedependency.ResourceTypeTheme, "theme-1", 2, 1)
 	suite.NoError(err)
 	suite.Equal(3, total)
 	suite.Len(ids, 2)
@@ -333,10 +344,12 @@ func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_Pagination() {
 func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_OffsetBeyondTotal() {
 	ctx := context.Background()
 	suite.dbMock.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return([]string{"db-1"}, 1, nil)
 
-	ids, total, err := suite.composite.GetEntityIDsByThemeID(ctx, "theme-1", 10, 5)
+	ids, total, err := suite.composite.GetEntityIDsByReference(
+		ctx, resourcedependency.ResourceTypeTheme, "theme-1", 10, 5)
 	suite.NoError(err)
 	suite.Equal(1, total)
 	suite.Empty(ids)
@@ -350,10 +363,12 @@ func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_DBHitsCap() {
 		capIDs[i] = "db-id"
 	}
 	suite.dbMock.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return(capIDs, 1000, nil)
 
-	ids, total, err := suite.composite.GetEntityIDsByThemeID(ctx, "theme-1", 10, 0)
+	ids, total, err := suite.composite.GetEntityIDsByReference(
+		ctx, resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 	suite.ErrorIs(err, ErrCompositeResultLimitExceeded)
 	suite.Nil(ids)
 	suite.Equal(0, total)
@@ -372,13 +387,16 @@ func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_FileStoreError()
 	composite2 := &compositeStore{dbStore: dbMock2, fileStore: fileMock}
 
 	dbMock2.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return([]string{"db-1"}, 1, nil)
 	fileMock.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return(nil, 0, errors.New("file store error"))
 
-	ids, total, err := composite2.GetEntityIDsByThemeID(ctx, "theme-1", 10, 0)
+	ids, total, err := composite2.GetEntityIDsByReference(
+		ctx, resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 	suite.Error(err)
 	suite.Nil(ids)
 	suite.Equal(0, total)
@@ -395,13 +413,16 @@ func (suite *CompositeStoreTestSuite) TestGetEntityIDsByThemeID_FileHitsCap() {
 	composite2 := &compositeStore{dbStore: dbMock2, fileStore: fileMock}
 
 	dbMock2.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return([]string{"db-1"}, 1, nil)
 	fileMock.EXPECT().
-		GetEntityIDsByThemeID(mock.Anything, "theme-1", mock.AnythingOfType("int"), 0).
+		GetEntityIDsByReference(
+			mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", mock.AnythingOfType("int"), 0).
 		Return(capIDs, 1000, nil)
 
-	ids, total, err := composite2.GetEntityIDsByThemeID(ctx, "theme-1", 10, 0)
+	ids, total, err := composite2.GetEntityIDsByReference(
+		ctx, resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 	suite.ErrorIs(err, ErrCompositeResultLimitExceeded)
 	suite.Nil(ids)
 	suite.Equal(0, total)

--- a/backend/internal/inboundclient/file_based_store.go
+++ b/backend/internal/inboundclient/file_based_store.go
@@ -182,8 +182,8 @@ func (f *fileBasedStore) IsDeclarative(_ context.Context, entityID string) bool 
 	return err == nil
 }
 
-func (f *fileBasedStore) GetEntityIDsByThemeID(
-	_ context.Context, themeID string, limit, offset int) ([]string, int, error) {
+func (f *fileBasedStore) GetEntityIDsByReference(
+	_ context.Context, refType, refID string, limit, offset int) ([]string, int, error) {
 	list, err := f.GenericFileBasedStore.List()
 	if err != nil {
 		return nil, 0, err
@@ -191,7 +191,7 @@ func (f *fileBasedStore) GetEntityIDsByThemeID(
 
 	matched := make([]string, 0)
 	for _, item := range list {
-		if c, ok := item.Data.(*inboundmodel.InboundClient); ok && c.ThemeID == themeID {
+		if c, ok := item.Data.(*inboundmodel.InboundClient); ok && clientReferences(c, refType, refID) {
 			matched = append(matched, c.ID)
 		}
 	}

--- a/backend/internal/inboundclient/file_based_store_test.go
+++ b/backend/internal/inboundclient/file_based_store_test.go
@@ -28,6 +28,7 @@ import (
 	sysconfig "github.com/thunder-id/thunderid/internal/system/config"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/declarative_resource/entity"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
@@ -324,7 +325,7 @@ func (suite *FileBasedStoreTestSuite) TestGetEntityIDsByThemeID_Empty() {
 	store := newFileBasedStoreForTest()
 	ctx := context.Background()
 
-	ids, total, err := store.GetEntityIDsByThemeID(ctx, "theme-1", 10, 0)
+	ids, total, err := store.GetEntityIDsByReference(ctx, resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 	suite.NoError(err)
 	suite.Equal(0, total)
 	suite.Empty(ids)
@@ -338,10 +339,37 @@ func (suite *FileBasedStoreTestSuite) TestGetEntityIDsByThemeID_MatchesOnThemeID
 	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-2", ThemeID: "theme-b"}))
 	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-3", ThemeID: "theme-a"}))
 
-	ids, total, err := store.GetEntityIDsByThemeID(ctx, "theme-a", 10, 0)
+	ids, total, err := store.GetEntityIDsByReference(ctx, resourcedependency.ResourceTypeTheme, "theme-a", 10, 0)
 	suite.NoError(err)
 	suite.Equal(2, total)
 	suite.ElementsMatch([]string{"app-1", "app-3"}, ids)
+}
+
+func (suite *FileBasedStoreTestSuite) TestGetEntityIDsByReference_MatchesFlowAcrossSlots() {
+	store := newFileBasedStoreForTest()
+	ctx := context.Background()
+
+	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-1", AuthFlowID: "flow-x"}))
+	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-2", RegistrationFlowID: "flow-x"}))
+	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-3", RecoveryFlowID: "flow-x"}))
+	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-4", AuthFlowID: "flow-y"}))
+
+	ids, total, err := store.GetEntityIDsByReference(ctx, resourcedependency.ResourceTypeFlow, "flow-x", 10, 0)
+	suite.NoError(err)
+	suite.Equal(3, total)
+	suite.ElementsMatch([]string{"app-1", "app-2", "app-3"}, ids)
+}
+
+func (suite *FileBasedStoreTestSuite) TestGetEntityIDsByReference_UnknownTypeReturnsEmpty() {
+	store := newFileBasedStoreForTest()
+	ctx := context.Background()
+
+	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-1", ThemeID: "theme-a"}))
+
+	ids, total, err := store.GetEntityIDsByReference(ctx, "unknown", "theme-a", 10, 0)
+	suite.NoError(err)
+	suite.Equal(0, total)
+	suite.Empty(ids)
 }
 
 func (suite *FileBasedStoreTestSuite) TestGetEntityIDsByThemeID_Pagination() {
@@ -352,7 +380,7 @@ func (suite *FileBasedStoreTestSuite) TestGetEntityIDsByThemeID_Pagination() {
 	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-2", ThemeID: "theme-a"}))
 	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-3", ThemeID: "theme-a"}))
 
-	ids, total, err := store.GetEntityIDsByThemeID(ctx, "theme-a", 2, 1)
+	ids, total, err := store.GetEntityIDsByReference(ctx, resourcedependency.ResourceTypeTheme, "theme-a", 2, 1)
 	suite.NoError(err)
 	suite.Equal(3, total)
 	suite.Len(ids, 2)
@@ -364,7 +392,7 @@ func (suite *FileBasedStoreTestSuite) TestGetEntityIDsByThemeID_OffsetBeyondTota
 
 	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-1", ThemeID: "theme-a"}))
 
-	ids, total, err := store.GetEntityIDsByThemeID(ctx, "theme-a", 10, 5)
+	ids, total, err := store.GetEntityIDsByReference(ctx, resourcedependency.ResourceTypeTheme, "theme-a", 10, 5)
 	suite.NoError(err)
 	suite.Equal(1, total)
 	suite.Empty(ids)
@@ -376,8 +404,35 @@ func (suite *FileBasedStoreTestSuite) TestGetEntityIDsByThemeID_ZeroLimit() {
 
 	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-1", ThemeID: "theme-a"}))
 
-	ids, total, err := store.GetEntityIDsByThemeID(ctx, "theme-a", 0, 0)
+	ids, total, err := store.GetEntityIDsByReference(ctx, resourcedependency.ResourceTypeTheme, "theme-a", 0, 0)
 	suite.NoError(err)
 	suite.Equal(1, total)
+	suite.Empty(ids)
+}
+
+func (suite *FileBasedStoreTestSuite) TestGetEntityIDsByFlowID_MatchesAnyFlowSlot() {
+	store := newFileBasedStoreForTest()
+	ctx := context.Background()
+
+	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-1", AuthFlowID: "flow-x"}))
+	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-2", RegistrationFlowID: "flow-x"}))
+	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-3", RecoveryFlowID: "flow-x"}))
+	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-4", AuthFlowID: "flow-y"}))
+
+	ids, total, err := store.GetEntityIDsByReference(ctx, resourcedependency.ResourceTypeFlow, "flow-x", 10, 0)
+	suite.NoError(err)
+	suite.Equal(3, total)
+	suite.ElementsMatch([]string{"app-1", "app-2", "app-3"}, ids)
+}
+
+func (suite *FileBasedStoreTestSuite) TestGetEntityIDsByReference_UnknownType() {
+	store := newFileBasedStoreForTest()
+	ctx := context.Background()
+
+	suite.NoError(store.CreateInboundClient(ctx, inboundmodel.InboundClient{ID: "app-1", ThemeID: "theme-a"}))
+
+	ids, total, err := store.GetEntityIDsByReference(ctx, "layout", "layout-1", 10, 0)
+	suite.NoError(err)
+	suite.Equal(0, total)
 	suite.Empty(ids)
 }

--- a/backend/internal/inboundclient/inboundClientStoreInterface_mock_test.go
+++ b/backend/internal/inboundclient/inboundClientStoreInterface_mock_test.go
@@ -272,55 +272,56 @@ func (_c *inboundClientStoreInterfaceMock_DeleteOAuthProfile_Call) RunAndReturn(
 	return _c
 }
 
-// GetEntityIDsByThemeID provides a mock function for the type inboundClientStoreInterfaceMock
-func (_mock *inboundClientStoreInterfaceMock) GetEntityIDsByThemeID(ctx context.Context, themeID string, limit int, offset int) ([]string, int, error) {
-	ret := _mock.Called(ctx, themeID, limit, offset)
+// GetEntityIDsByReference provides a mock function for the type inboundClientStoreInterfaceMock
+func (_mock *inboundClientStoreInterfaceMock) GetEntityIDsByReference(ctx context.Context, refType string, refID string, limit int, offset int) ([]string, int, error) {
+	ret := _mock.Called(ctx, refType, refID, limit, offset)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetEntityIDsByThemeID")
+		panic("no return value specified for GetEntityIDsByReference")
 	}
 
 	var r0 []string
 	var r1 int
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]string, int, error)); ok {
-		return returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, int, int) ([]string, int, error)); ok {
+		return returnFunc(ctx, refType, refID, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []string); ok {
-		r0 = returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, int, int) []string); ok {
+		r0 = returnFunc(ctx, refType, refID, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) int); ok {
-		r1 = returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, int, int) int); ok {
+		r1 = returnFunc(ctx, refType, refID, limit, offset)
 	} else {
 		r1 = ret.Get(1).(int)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, string, int, int) error); ok {
-		r2 = returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string, int, int) error); ok {
+		r2 = returnFunc(ctx, refType, refID, limit, offset)
 	} else {
 		r2 = ret.Error(2)
 	}
 	return r0, r1, r2
 }
 
-// inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityIDsByThemeID'
-type inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call struct {
+// inboundClientStoreInterfaceMock_GetEntityIDsByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityIDsByReference'
+type inboundClientStoreInterfaceMock_GetEntityIDsByReference_Call struct {
 	*mock.Call
 }
 
-// GetEntityIDsByThemeID is a helper method to define mock.On call
+// GetEntityIDsByReference is a helper method to define mock.On call
 //   - ctx context.Context
-//   - themeID string
+//   - refType string
+//   - refID string
 //   - limit int
 //   - offset int
-func (_e *inboundClientStoreInterfaceMock_Expecter) GetEntityIDsByThemeID(ctx interface{}, themeID interface{}, limit interface{}, offset interface{}) *inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call {
-	return &inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call{Call: _e.mock.On("GetEntityIDsByThemeID", ctx, themeID, limit, offset)}
+func (_e *inboundClientStoreInterfaceMock_Expecter) GetEntityIDsByReference(ctx interface{}, refType interface{}, refID interface{}, limit interface{}, offset interface{}) *inboundClientStoreInterfaceMock_GetEntityIDsByReference_Call {
+	return &inboundClientStoreInterfaceMock_GetEntityIDsByReference_Call{Call: _e.mock.On("GetEntityIDsByReference", ctx, refType, refID, limit, offset)}
 }
 
-func (_c *inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call) Run(run func(ctx context.Context, themeID string, limit int, offset int)) *inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call {
+func (_c *inboundClientStoreInterfaceMock_GetEntityIDsByReference_Call) Run(run func(ctx context.Context, refType string, refID string, limit int, offset int)) *inboundClientStoreInterfaceMock_GetEntityIDsByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -330,30 +331,35 @@ func (_c *inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call) Run(run fu
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 int
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(int)
+			arg2 = args[2].(string)
 		}
 		var arg3 int
 		if args[3] != nil {
 			arg3 = args[3].(int)
+		}
+		var arg4 int
+		if args[4] != nil {
+			arg4 = args[4].(int)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
 }
 
-func (_c *inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call) Return(strings []string, n int, err error) *inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call {
+func (_c *inboundClientStoreInterfaceMock_GetEntityIDsByReference_Call) Return(strings []string, n int, err error) *inboundClientStoreInterfaceMock_GetEntityIDsByReference_Call {
 	_c.Call.Return(strings, n, err)
 	return _c
 }
 
-func (_c *inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call) RunAndReturn(run func(ctx context.Context, themeID string, limit int, offset int) ([]string, int, error)) *inboundClientStoreInterfaceMock_GetEntityIDsByThemeID_Call {
+func (_c *inboundClientStoreInterfaceMock_GetEntityIDsByReference_Call) RunAndReturn(run func(ctx context.Context, refType string, refID string, limit int, offset int) ([]string, int, error)) *inboundClientStoreInterfaceMock_GetEntityIDsByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -57,8 +57,9 @@ type InboundClientServiceInterface interface {
 	GetInboundClientByEntityID(ctx context.Context, entityID string) (*inboundmodel.InboundClient, error)
 	// GetInboundClientList returns all inbound clients.
 	GetInboundClientList(ctx context.Context) ([]inboundmodel.InboundClient, error)
-	// GetEntityIDsByThemeID returns paginated entity IDs of inbound clients referencing the given theme.
-	GetEntityIDsByThemeID(ctx context.Context, themeID string, limit, offset int) ([]string, int, error)
+	// GetEntityIDsByReference returns paginated entity IDs of inbound clients referencing the resource
+	// identified by (refType, refID). Unknown reference types resolve to no usages.
+	GetEntityIDsByReference(ctx context.Context, refType, refID string, limit, offset int) ([]string, int, error)
 	// UpdateInboundClient validates and persists updates to an inbound client, certificates, and OAuth config.
 	UpdateInboundClient(ctx context.Context, client *inboundmodel.InboundClient,
 		oauthProfile *providers.OAuthProfile, hasClientSecret bool, oauthClientID string, entityName string) error
@@ -191,16 +192,17 @@ func (s *inboundClientService) GetInboundClientList(ctx context.Context) ([]inbo
 	return s.store.GetInboundClientList(ctx, serverconst.MaxCompositeStoreRecords)
 }
 
-// GetEntityIDsByThemeID returns paginated entity IDs of inbound clients referencing the given theme.
-func (s *inboundClientService) GetEntityIDsByThemeID(
-	ctx context.Context, themeID string, limit, offset int) ([]string, int, error) {
+// GetEntityIDsByReference returns paginated entity IDs of inbound clients referencing the resource
+// identified by (refType, refID).
+func (s *inboundClientService) GetEntityIDsByReference(
+	ctx context.Context, refType, refID string, limit, offset int) ([]string, int, error) {
 	if limit < 0 {
 		return nil, 0, fmt.Errorf("invalid limit: must be non-negative, got %d", limit)
 	}
 	if offset < 0 {
 		return nil, 0, fmt.Errorf("invalid offset: must be non-negative, got %d", offset)
 	}
-	return s.store.GetEntityIDsByThemeID(ctx, themeID, limit, offset)
+	return s.store.GetEntityIDsByReference(ctx, refType, refID, limit, offset)
 }
 
 // UpdateInboundClient validates and persists updates to an inbound client, certificates, and OAuth config.

--- a/backend/internal/inboundclient/service_test.go
+++ b/backend/internal/inboundclient/service_test.go
@@ -38,6 +38,7 @@ import (
 	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
 	sysconfig "github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
 	"github.com/thunder-id/thunderid/tests/mocks/certmock"
 	"github.com/thunder-id/thunderid/tests/mocks/consentmock"
@@ -2347,33 +2348,37 @@ func (suite *InboundClientServiceTestSuite) TestSyncConsentOnUpdate_UpdatesWhenA
 
 func (suite *InboundClientServiceTestSuite) TestGetEntityIDsByThemeID_NegativeLimit() {
 	svc := newServiceForTest(newInboundClientStoreInterfaceMock(suite.T()))
-	_, _, err := svc.GetEntityIDsByThemeID(context.Background(), "theme-1", -1, 0)
+	_, _, err := svc.GetEntityIDsByReference(
+		context.Background(), resourcedependency.ResourceTypeTheme, "theme-1", -1, 0)
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "limit")
 }
 
 func (suite *InboundClientServiceTestSuite) TestGetEntityIDsByThemeID_NegativeOffset() {
 	svc := newServiceForTest(newInboundClientStoreInterfaceMock(suite.T()))
-	_, _, err := svc.GetEntityIDsByThemeID(context.Background(), "theme-1", 10, -1)
+	_, _, err := svc.GetEntityIDsByReference(
+		context.Background(), resourcedependency.ResourceTypeTheme, "theme-1", 10, -1)
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "offset")
 }
 
 func (suite *InboundClientServiceTestSuite) TestGetEntityIDsByThemeID_StoreError() {
 	store := newInboundClientStoreInterfaceMock(suite.T())
-	store.EXPECT().GetEntityIDsByThemeID(mock.Anything, "theme-1", 10, 0).
+	store.EXPECT().GetEntityIDsByReference(mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", 10, 0).
 		Return(nil, 0, errors.New("db error"))
 	svc := newServiceForTest(store)
-	_, _, err := svc.GetEntityIDsByThemeID(context.Background(), "theme-1", 10, 0)
+	_, _, err := svc.GetEntityIDsByReference(
+		context.Background(), resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 	assert.Error(suite.T(), err)
 }
 
 func (suite *InboundClientServiceTestSuite) TestGetEntityIDsByThemeID_Success() {
 	store := newInboundClientStoreInterfaceMock(suite.T())
-	store.EXPECT().GetEntityIDsByThemeID(mock.Anything, "theme-1", 10, 0).
+	store.EXPECT().GetEntityIDsByReference(mock.Anything, resourcedependency.ResourceTypeTheme, "theme-1", 10, 0).
 		Return([]string{"app-1", "app-2"}, 2, nil)
 	svc := newServiceForTest(store)
-	ids, total, err := svc.GetEntityIDsByThemeID(context.Background(), "theme-1", 10, 0)
+	ids, total, err := svc.GetEntityIDsByReference(
+		context.Background(), resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 2, total)
 	assert.Equal(suite.T(), []string{"app-1", "app-2"}, ids)

--- a/backend/internal/inboundclient/store.go
+++ b/backend/internal/inboundclient/store.go
@@ -25,8 +25,10 @@ import (
 
 	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
 	"github.com/thunder-id/thunderid/internal/system/config"
+	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -51,7 +53,7 @@ type inboundClientStoreInterface interface {
 	GetInboundClientByEntityID(ctx context.Context, entityID string) (*providers.InboundClient, error)
 	GetOAuthProfileByEntityID(ctx context.Context, entityID string) (*providers.OAuthProfile, error)
 	GetInboundClientList(ctx context.Context, limit int) ([]providers.InboundClient, error)
-	GetEntityIDsByThemeID(ctx context.Context, themeID string, limit, offset int) ([]string, int, error)
+	GetEntityIDsByReference(ctx context.Context, refType, refID string, limit, offset int) ([]string, int, error)
 	GetTotalInboundClientCount(ctx context.Context) (int, error)
 	UpdateInboundClient(ctx context.Context, client providers.InboundClient) error
 	UpdateOAuthProfile(ctx context.Context, entityID string, oauthProfile *providers.OAuthProfile) error
@@ -238,14 +240,22 @@ func (st *store) GetInboundClientList(ctx context.Context, limit int) ([]provide
 	return clients, nil
 }
 
-// GetEntityIDsByThemeID retrieves paginated entity IDs for inbound clients using a specific theme.
-func (st *store) GetEntityIDsByThemeID(ctx context.Context, themeID string, limit, offset int) ([]string, int, error) {
+// GetEntityIDsByReference retrieves paginated entity IDs for inbound clients referencing the resource
+// identified by (refType, refID). Unknown reference types resolve to no usages, since an inbound client
+// cannot reference a resource type it has no column for.
+func (st *store) GetEntityIDsByReference(
+	ctx context.Context, refType, refID string, limit, offset int) ([]string, int, error) {
+	countQuery, listQuery, filterArgs, ok := referenceQueries(refType, refID, st.deploymentID)
+	if !ok {
+		return []string{}, 0, nil
+	}
+
 	dbClient, err := st.dbProvider.GetConfigDBClient()
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	countResults, err := dbClient.QueryContext(ctx, queryGetEntityIDsByThemeIDCount, themeID, st.deploymentID)
+	countResults, err := dbClient.QueryContext(ctx, countQuery, filterArgs...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to execute count query: %w", err)
 	}
@@ -256,7 +266,7 @@ func (st *store) GetEntityIDsByThemeID(ctx context.Context, themeID string, limi
 		}
 	}
 
-	results, err := dbClient.QueryContext(ctx, queryGetEntityIDsByThemeID, themeID, st.deploymentID, limit, offset)
+	results, err := dbClient.QueryContext(ctx, listQuery, append(filterArgs, limit, offset)...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -270,6 +280,36 @@ func (st *store) GetEntityIDsByThemeID(ctx context.Context, themeID string, limi
 		ids = append(ids, id)
 	}
 	return ids, total, nil
+}
+
+// referenceQueries maps a reference resource type to its count/list queries and the leading filter
+// arguments (the reference ID repeated per column slot, followed by the deployment ID). The boolean
+// is false when the reference type is not tracked by the inbound-client store.
+func referenceQueries(refType, refID, deploymentID string) (
+	dbmodel.DBQuery, dbmodel.DBQuery, []interface{}, bool) {
+	switch refType {
+	case resourcedependency.ResourceTypeTheme:
+		return queryGetEntityIDsByThemeIDCount, queryGetEntityIDsByThemeID,
+			[]interface{}{refID, deploymentID}, true
+	case resourcedependency.ResourceTypeFlow:
+		return queryGetEntityIDsByFlowIDCount, queryGetEntityIDsByFlowID,
+			[]interface{}{refID, refID, refID, deploymentID}, true
+	default:
+		return dbmodel.DBQuery{}, dbmodel.DBQuery{}, nil, false
+	}
+}
+
+// clientReferences reports whether the inbound client references the resource identified by
+// (refType, refID). It mirrors referenceQueries for the in-memory (file-based) store.
+func clientReferences(c *inboundmodel.InboundClient, refType, refID string) bool {
+	switch refType {
+	case resourcedependency.ResourceTypeTheme:
+		return c.ThemeID == refID
+	case resourcedependency.ResourceTypeFlow:
+		return c.AuthFlowID == refID || c.RegistrationFlowID == refID || c.RecoveryFlowID == refID
+	default:
+		return false
+	}
 }
 
 // GetTotalInboundClientCount retrieves the total count of inbound clients.

--- a/backend/internal/inboundclient/store_constants.go
+++ b/backend/internal/inboundclient/store_constants.go
@@ -102,4 +102,20 @@ var (
 		ID:    "ASQ-INBC_MGT-14",
 		Query: `SELECT COUNT(*) as total FROM "INBOUND_CLIENT" WHERE THEME_ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
+
+	// queryGetEntityIDsByFlowID retrieves paginated entity IDs for inbound clients referencing a specific
+	// flow through any of the authentication, registration, or recovery flow slots.
+	queryGetEntityIDsByFlowID = dbmodel.DBQuery{
+		ID: "ASQ-INBC_MGT-15",
+		Query: `SELECT ENTITY_ID FROM "INBOUND_CLIENT" WHERE ` +
+			`(AUTH_FLOW_ID = $1 OR REGISTRATION_FLOW_ID = $2 OR RECOVERY_FLOW_ID = $3) AND DEPLOYMENT_ID = $4 ` +
+			`ORDER BY ENTITY_ID ASC LIMIT $5 OFFSET $6`,
+	}
+
+	// queryGetEntityIDsByFlowIDCount retrieves the total count of inbound clients referencing a specific flow.
+	queryGetEntityIDsByFlowIDCount = dbmodel.DBQuery{
+		ID: "ASQ-INBC_MGT-16",
+		Query: `SELECT COUNT(*) as total FROM "INBOUND_CLIENT" WHERE ` +
+			`(AUTH_FLOW_ID = $1 OR REGISTRATION_FLOW_ID = $2 OR RECOVERY_FLOW_ID = $3) AND DEPLOYMENT_ID = $4`,
+	}
 )

--- a/backend/internal/inboundclient/store_test.go
+++ b/backend/internal/inboundclient/store_test.go
@@ -30,6 +30,7 @@ import (
 	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
 )
@@ -723,7 +724,8 @@ func (suite *InboundClientStoreTestSuite) TestGetEntityIDsByThemeID() {
 		suite.mockDBProvider.On("GetConfigDBClient").
 			Return((*providermock.DBClientInterfaceMock)(nil), errors.New("db unavailable")).Once()
 
-		ids, total, err := suite.store.GetEntityIDsByThemeID(context.Background(), "theme-1", 10, 0)
+		ids, total, err := suite.store.GetEntityIDsByReference(
+			context.Background(), resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 		suite.Error(err)
 		suite.Nil(ids)
 		suite.Equal(0, total)
@@ -734,7 +736,8 @@ func (suite *InboundClientStoreTestSuite) TestGetEntityIDsByThemeID() {
 		suite.mockDBClient.On("QueryContext", mock.Anything, queryGetEntityIDsByThemeIDCount,
 			"theme-1", testServerID).Return(nil, errors.New("count query failed")).Once()
 
-		ids, total, err := suite.store.GetEntityIDsByThemeID(context.Background(), "theme-1", 10, 0)
+		ids, total, err := suite.store.GetEntityIDsByReference(
+			context.Background(), resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 		suite.Error(err)
 		suite.Nil(ids)
 		suite.Equal(0, total)
@@ -749,7 +752,8 @@ func (suite *InboundClientStoreTestSuite) TestGetEntityIDsByThemeID() {
 			"theme-1", testServerID, 10, 0).
 			Return(nil, errors.New("list query failed")).Once()
 
-		ids, total, err := suite.store.GetEntityIDsByThemeID(context.Background(), "theme-1", 10, 0)
+		ids, total, err := suite.store.GetEntityIDsByReference(
+			context.Background(), resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 		suite.Error(err)
 		suite.Nil(ids)
 		suite.Equal(0, total)
@@ -764,7 +768,8 @@ func (suite *InboundClientStoreTestSuite) TestGetEntityIDsByThemeID() {
 			"theme-1", testServerID, 10, 0).
 			Return([]map[string]interface{}{{"entity_id": 12345}}, nil).Once()
 
-		ids, total, err := suite.store.GetEntityIDsByThemeID(context.Background(), "theme-1", 10, 0)
+		ids, total, err := suite.store.GetEntityIDsByReference(
+			context.Background(), resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 		suite.Error(err)
 		suite.Nil(ids)
 		suite.Equal(0, total)
@@ -782,7 +787,8 @@ func (suite *InboundClientStoreTestSuite) TestGetEntityIDsByThemeID() {
 				{"entity_id": "app-2"},
 			}, nil).Once()
 
-		ids, total, err := suite.store.GetEntityIDsByThemeID(context.Background(), "theme-1", 10, 0)
+		ids, total, err := suite.store.GetEntityIDsByReference(
+			context.Background(), resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 		suite.NoError(err)
 		suite.Equal(2, total)
 		suite.Equal([]string{"app-1", "app-2"}, ids)
@@ -797,9 +803,40 @@ func (suite *InboundClientStoreTestSuite) TestGetEntityIDsByThemeID() {
 			"theme-1", testServerID, 10, 0).
 			Return([]map[string]interface{}{}, nil).Once()
 
-		ids, total, err := suite.store.GetEntityIDsByThemeID(context.Background(), "theme-1", 10, 0)
+		ids, total, err := suite.store.GetEntityIDsByReference(
+			context.Background(), resourcedependency.ResourceTypeTheme, "theme-1", 10, 0)
 		suite.NoError(err)
 		suite.Equal(0, total)
 		suite.Empty(ids)
 	})
+}
+
+func (suite *InboundClientStoreTestSuite) TestGetEntityIDsByReference_Flow() {
+	suite.Run("uses flow queries and repeats the id across slots", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil).Once()
+		suite.mockDBClient.On("QueryContext", mock.Anything, queryGetEntityIDsByFlowIDCount,
+			"flow-1", "flow-1", "flow-1", testServerID).
+			Return([]map[string]interface{}{{"total": int64(2)}}, nil).Once()
+		suite.mockDBClient.On("QueryContext", mock.Anything, queryGetEntityIDsByFlowID,
+			"flow-1", "flow-1", "flow-1", testServerID, 10, 0).
+			Return([]map[string]interface{}{
+				{"entity_id": "app-1"},
+				{"entity_id": "app-2"},
+			}, nil).Once()
+
+		ids, total, err := suite.store.GetEntityIDsByReference(
+			context.Background(), resourcedependency.ResourceTypeFlow, "flow-1", 10, 0)
+		suite.NoError(err)
+		suite.Equal(2, total)
+		suite.Equal([]string{"app-1", "app-2"}, ids)
+	})
+}
+
+func (suite *InboundClientStoreTestSuite) TestGetEntityIDsByReference_UnknownTypeSkipsDB() {
+	ids, total, err := suite.store.GetEntityIDsByReference(
+		context.Background(), "layout", "layout-1", 10, 0)
+	suite.NoError(err)
+	suite.Equal(0, total)
+	suite.Empty(ids)
+	suite.mockDBProvider.AssertNotCalled(suite.T(), "GetConfigDBClient")
 }

--- a/backend/internal/system/resourcedependency/registry.go
+++ b/backend/internal/system/resourcedependency/registry.go
@@ -36,6 +36,7 @@ const BehaviorFallback = "fallback"
 // Resource type identifiers shared across dependency providers and consumers.
 const (
 	ResourceTypeTheme       = "theme"
+	ResourceTypeFlow        = "flow"
 	ResourceTypeApplication = "application"
 	ResourceTypeAgent       = "agent"
 )
@@ -94,8 +95,14 @@ func newRegistry() Registry {
 	}
 }
 
-// RegisterProvider adds a provider to the registry.
+// RegisterProvider adds a provider to the registry. A nil provider — e.g. a service that
+// failed to initialize and was wired in regardless — is ignored so it cannot panic a later
+// usage lookup.
 func (r *registry) RegisterProvider(p Provider) {
+	if p == nil {
+		r.logger.Warn(context.Background(), "Ignoring nil usage provider registration")
+		return
+	}
 	r.providers = append(r.providers, p)
 }
 

--- a/backend/internal/system/resourcedependency/registry_test.go
+++ b/backend/internal/system/resourcedependency/registry_test.go
@@ -72,6 +72,21 @@ func TestGetDependenciesProviderErrorReturnsUnknown(t *testing.T) {
 	assert.Empty(t, resp.Usages)
 }
 
+func TestRegisterProviderIgnoresNil(t *testing.T) {
+	reg := newRegistry()
+	reg.RegisterProvider(nil)
+	reg.RegisterProvider(&stubProvider{usages: []ResourceDependency{
+		{ResourceType: "application", ID: "a1", DisplayName: "App 1", BehaviorOnDelete: BehaviorFallback},
+	}})
+
+	resp, err := reg.GetDependencies(context.Background(), "theme", "t1")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp.TotalResults)
+	assert.Equal(t, 1, *resp.TotalResults)
+	assert.Len(t, resp.Usages, 1)
+}
+
 func TestGetDependenciesNoProvidersReturnsEmpty(t *testing.T) {
 	reg := newRegistry()
 

--- a/backend/tests/mocks/flow/flowmgtmock/FlowMgtServiceInterface_mock.go
+++ b/backend/tests/mocks/flow/flowmgtmock/FlowMgtServiceInterface_mock.go
@@ -10,6 +10,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/flow/core"
 	"github.com/thunder-id/thunderid/internal/flow/mgt"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -312,6 +313,76 @@ func (_c *FlowMgtServiceInterfaceMock_GetFlowByHandle_Call) Return(completeFlowD
 }
 
 func (_c *FlowMgtServiceInterfaceMock_GetFlowByHandle_Call) RunAndReturn(run func(ctx context.Context, handle string, flowType providers.FlowType) (*providers.CompleteFlowDefinition, *common.ServiceError)) *FlowMgtServiceInterfaceMock_GetFlowByHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetFlowUsages provides a mock function for the type FlowMgtServiceInterfaceMock
+func (_mock *FlowMgtServiceInterfaceMock) GetFlowUsages(ctx context.Context, flowID string) (*resourcedependency.DependenciesResponse, *common.ServiceError) {
+	ret := _mock.Called(ctx, flowID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFlowUsages")
+	}
+
+	var r0 *resourcedependency.DependenciesResponse
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*resourcedependency.DependenciesResponse, *common.ServiceError)); ok {
+		return returnFunc(ctx, flowID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *resourcedependency.DependenciesResponse); ok {
+		r0 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcedependency.DependenciesResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, flowID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// FlowMgtServiceInterfaceMock_GetFlowUsages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFlowUsages'
+type FlowMgtServiceInterfaceMock_GetFlowUsages_Call struct {
+	*mock.Call
+}
+
+// GetFlowUsages is a helper method to define mock.On call
+//   - ctx context.Context
+//   - flowID string
+func (_e *FlowMgtServiceInterfaceMock_Expecter) GetFlowUsages(ctx interface{}, flowID interface{}) *FlowMgtServiceInterfaceMock_GetFlowUsages_Call {
+	return &FlowMgtServiceInterfaceMock_GetFlowUsages_Call{Call: _e.mock.On("GetFlowUsages", ctx, flowID)}
+}
+
+func (_c *FlowMgtServiceInterfaceMock_GetFlowUsages_Call) Run(run func(ctx context.Context, flowID string)) *FlowMgtServiceInterfaceMock_GetFlowUsages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *FlowMgtServiceInterfaceMock_GetFlowUsages_Call) Return(dependenciesResponse *resourcedependency.DependenciesResponse, serviceError *common.ServiceError) *FlowMgtServiceInterfaceMock_GetFlowUsages_Call {
+	_c.Call.Return(dependenciesResponse, serviceError)
+	return _c
+}
+
+func (_c *FlowMgtServiceInterfaceMock_GetFlowUsages_Call) RunAndReturn(run func(ctx context.Context, flowID string) (*resourcedependency.DependenciesResponse, *common.ServiceError)) *FlowMgtServiceInterfaceMock_GetFlowUsages_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -761,6 +832,46 @@ func (_c *FlowMgtServiceInterfaceMock_RestoreFlowVersion_Call) Return(completeFl
 
 func (_c *FlowMgtServiceInterfaceMock_RestoreFlowVersion_Call) RunAndReturn(run func(ctx context.Context, flowID string, version int) (*providers.CompleteFlowDefinition, *common.ServiceError)) *FlowMgtServiceInterfaceMock_RestoreFlowVersion_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// SetDependencyRegistry provides a mock function for the type FlowMgtServiceInterfaceMock
+func (_mock *FlowMgtServiceInterfaceMock) SetDependencyRegistry(r resourcedependency.Registry) {
+	_mock.Called(r)
+	return
+}
+
+// FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDependencyRegistry'
+type FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call struct {
+	*mock.Call
+}
+
+// SetDependencyRegistry is a helper method to define mock.On call
+//   - r resourcedependency.Registry
+func (_e *FlowMgtServiceInterfaceMock_Expecter) SetDependencyRegistry(r interface{}) *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call {
+	return &FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call{Call: _e.mock.On("SetDependencyRegistry", r)}
+}
+
+func (_c *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call) Run(run func(r resourcedependency.Registry)) *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 resourcedependency.Registry
+		if args[0] != nil {
+			arg0 = args[0].(resourcedependency.Registry)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call) Return() *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run func(r resourcedependency.Registry)) *FlowMgtServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Run(run)
 	return _c
 }
 

--- a/backend/tests/mocks/inboundclientmock/InboundClientServiceInterface_mock.go
+++ b/backend/tests/mocks/inboundclientmock/InboundClientServiceInterface_mock.go
@@ -249,55 +249,56 @@ func (_c *InboundClientServiceInterfaceMock_GetCertificate_Call) RunAndReturn(ru
 	return _c
 }
 
-// GetEntityIDsByThemeID provides a mock function for the type InboundClientServiceInterfaceMock
-func (_mock *InboundClientServiceInterfaceMock) GetEntityIDsByThemeID(ctx context.Context, themeID string, limit int, offset int) ([]string, int, error) {
-	ret := _mock.Called(ctx, themeID, limit, offset)
+// GetEntityIDsByReference provides a mock function for the type InboundClientServiceInterfaceMock
+func (_mock *InboundClientServiceInterfaceMock) GetEntityIDsByReference(ctx context.Context, refType string, refID string, limit int, offset int) ([]string, int, error) {
+	ret := _mock.Called(ctx, refType, refID, limit, offset)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetEntityIDsByThemeID")
+		panic("no return value specified for GetEntityIDsByReference")
 	}
 
 	var r0 []string
 	var r1 int
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) ([]string, int, error)); ok {
-		return returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, int, int) ([]string, int, error)); ok {
+		return returnFunc(ctx, refType, refID, limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, int) []string); ok {
-		r0 = returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, int, int) []string); ok {
+		r0 = returnFunc(ctx, refType, refID, limit, offset)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, int) int); ok {
-		r1 = returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, int, int) int); ok {
+		r1 = returnFunc(ctx, refType, refID, limit, offset)
 	} else {
 		r1 = ret.Get(1).(int)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, string, int, int) error); ok {
-		r2 = returnFunc(ctx, themeID, limit, offset)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string, int, int) error); ok {
+		r2 = returnFunc(ctx, refType, refID, limit, offset)
 	} else {
 		r2 = ret.Error(2)
 	}
 	return r0, r1, r2
 }
 
-// InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityIDsByThemeID'
-type InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call struct {
+// InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityIDsByReference'
+type InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call struct {
 	*mock.Call
 }
 
-// GetEntityIDsByThemeID is a helper method to define mock.On call
+// GetEntityIDsByReference is a helper method to define mock.On call
 //   - ctx context.Context
-//   - themeID string
+//   - refType string
+//   - refID string
 //   - limit int
 //   - offset int
-func (_e *InboundClientServiceInterfaceMock_Expecter) GetEntityIDsByThemeID(ctx interface{}, themeID interface{}, limit interface{}, offset interface{}) *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call {
-	return &InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call{Call: _e.mock.On("GetEntityIDsByThemeID", ctx, themeID, limit, offset)}
+func (_e *InboundClientServiceInterfaceMock_Expecter) GetEntityIDsByReference(ctx interface{}, refType interface{}, refID interface{}, limit interface{}, offset interface{}) *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call {
+	return &InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call{Call: _e.mock.On("GetEntityIDsByReference", ctx, refType, refID, limit, offset)}
 }
 
-func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call) Run(run func(ctx context.Context, themeID string, limit int, offset int)) *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call {
+func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call) Run(run func(ctx context.Context, refType string, refID string, limit int, offset int)) *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -307,30 +308,35 @@ func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call) Run(run 
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 int
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(int)
+			arg2 = args[2].(string)
 		}
 		var arg3 int
 		if args[3] != nil {
 			arg3 = args[3].(int)
+		}
+		var arg4 int
+		if args[4] != nil {
+			arg4 = args[4].(int)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
 }
 
-func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call) Return(strings []string, n int, err error) *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call {
+func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call) Return(strings []string, n int, err error) *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call {
 	_c.Call.Return(strings, n, err)
 	return _c
 }
 
-func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call) RunAndReturn(run func(ctx context.Context, themeID string, limit int, offset int) ([]string, int, error)) *InboundClientServiceInterfaceMock_GetEntityIDsByThemeID_Call {
+func (_c *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call) RunAndReturn(run func(ctx context.Context, refType string, refID string, limit int, offset int) ([]string, int, error)) *InboundClientServiceInterfaceMock_GetEntityIDsByReference_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/frontend/apps/console/src/features/flows/api/useGetFlowUsages.ts
+++ b/frontend/apps/console/src/features/flows/api/useGetFlowUsages.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import {useConfig} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import FlowQueryKeys from '../constants/flow-query-keys';
+import type {FlowUsagesResponse} from '../models/responses';
+
+/**
+ * Custom hook to fetch resources that reference a flow.
+ * Used to populate the pre-delete confirmation dialog.
+ *
+ * @param flowId - The unique identifier of the flow
+ * @param enabled - Whether the query should run (default true)
+ * @returns TanStack Query result with flow usages data
+ */
+export default function useGetFlowUsages(flowId: string | null, enabled = true): UseQueryResult<FlowUsagesResponse> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+
+  return useQuery<FlowUsagesResponse>({
+    queryKey: [FlowQueryKeys.FLOW_USAGES, flowId],
+    queryFn: async (): Promise<FlowUsagesResponse> => {
+      const serverUrl: string = getServerUrl();
+
+      const response: {data: FlowUsagesResponse} = await http.request({
+        url: `${serverUrl}/flows/${encodeURIComponent(flowId!)}/usages`,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      return response.data;
+    },
+    enabled: Boolean(flowId) && enabled,
+  });
+}

--- a/frontend/apps/console/src/features/flows/components/FlowDeleteDialog.tsx
+++ b/frontend/apps/console/src/features/flows/components/FlowDeleteDialog.tsx
@@ -16,10 +16,26 @@
  * under the License.
  */
 
-import {Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Alert} from '@wso2/oxygen-ui';
+import {
+  Alert,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+} from '@wso2/oxygen-ui';
 import {useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import useDeleteFlow from '../api/useDeleteFlow';
+import useGetFlowUsages from '../api/useGetFlowUsages';
+
+const MAX_VISIBLE_USAGES = 5;
 
 export interface FlowDeleteDialogProps {
   /**
@@ -53,6 +69,12 @@ export default function FlowDeleteDialog({
   const deleteFlow = useDeleteFlow();
   const [error, setError] = useState<string | null>(null);
 
+  const {data: usagesData, isLoading: isLoadingUsages} = useGetFlowUsages(flowId, open);
+
+  const usagesKnown = usagesData !== undefined && usagesData.totalResults !== null;
+  const visibleUsages = usagesData?.usages.slice(0, MAX_VISIBLE_USAGES) ?? [];
+  const hiddenCount = (usagesData?.totalResults ?? 0) - visibleUsages.length;
+
   const handleCancel = (): void => {
     if (deleteFlow.isPending) return;
     setError(null);
@@ -79,9 +101,45 @@ export default function FlowDeleteDialog({
       <DialogTitle>{t('flows:delete.title')}</DialogTitle>
       <DialogContent>
         <DialogContentText sx={{mb: 2}}>{t('flows:delete.message')}</DialogContentText>
-        <Alert severity="warning" sx={{mb: 2}}>
-          {t('flows:delete.disclaimer')}
-        </Alert>
+
+        {isLoadingUsages ? (
+          <Alert severity="info" icon={<CircularProgress size={16} />} sx={{mb: 2}}>
+            {t('flows:delete.usages.loading')}
+          </Alert>
+        ) : !usagesKnown ? (
+          <Alert severity="warning" sx={{mb: 2}}>
+            {t('flows:delete.disclaimer')}
+          </Alert>
+        ) : (usagesData?.totalResults ?? 0) > 0 ? (
+          <Alert severity="warning" sx={{mb: 2}}>
+            <Typography variant="body2" sx={{mb: 1}}>
+              {t('flows:delete.usages.title')}
+            </Typography>
+            <List dense disablePadding>
+              {visibleUsages.map((usage) => (
+                <ListItem key={usage.id} disableGutters sx={{py: 0}}>
+                  <ListItemText primary={<Typography variant="body2">{usage.displayName}</Typography>} />
+                </ListItem>
+              ))}
+              {hiddenCount > 0 && (
+                <ListItem disableGutters sx={{py: 0}}>
+                  <ListItemText
+                    primary={
+                      <Typography variant="body2" color="text.secondary">
+                        {t('flows:delete.usages.more', {count: hiddenCount})}
+                      </Typography>
+                    }
+                  />
+                </ListItem>
+              )}
+            </List>
+          </Alert>
+        ) : (
+          <Alert severity="info" sx={{mb: 2}}>
+            {t('flows:delete.usages.none')}
+          </Alert>
+        )}
+
         {error && (
           <Alert severity="error" sx={{mt: 2}}>
             {error}
@@ -92,7 +150,12 @@ export default function FlowDeleteDialog({
         <Button onClick={handleCancel} disabled={deleteFlow.isPending}>
           {t('common:actions.cancel')}
         </Button>
-        <Button onClick={handleConfirm} color="error" variant="contained" disabled={deleteFlow.isPending}>
+        <Button
+          onClick={handleConfirm}
+          color="error"
+          variant="contained"
+          disabled={deleteFlow.isPending || !flowId || isLoadingUsages}
+        >
           {deleteFlow.isPending ? t('common:status.deleting') : t('common:actions.delete')}
         </Button>
       </DialogActions>

--- a/frontend/apps/console/src/features/flows/components/__tests__/FlowDeleteDialog.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/__tests__/FlowDeleteDialog.test.tsx
@@ -49,6 +49,14 @@ vi.mock('../../api/useDeleteFlow', () => ({
   default: () => mockDeleteFlow,
 }));
 
+// Mock useGetFlowUsages hook
+vi.mock('../../api/useGetFlowUsages', () => ({
+  default: () => ({
+    data: undefined,
+    isLoading: false,
+  }),
+}));
+
 describe('FlowDeleteDialog', () => {
   const mockOnClose = vi.fn();
   const mockOnSuccess = vi.fn();

--- a/frontend/apps/console/src/features/flows/constants/flow-query-keys.ts
+++ b/frontend/apps/console/src/features/flows/constants/flow-query-keys.ts
@@ -48,6 +48,10 @@ const FlowQueryKeys = {
    * Key for a single flow query
    */
   FLOW: 'flow',
+  /**
+   * Key for a flow usages query
+   */
+  FLOW_USAGES: 'flow-usages',
 } as const;
 
 export default FlowQueryKeys;

--- a/frontend/apps/console/src/features/flows/models/responses.ts
+++ b/frontend/apps/console/src/features/flows/models/responses.ts
@@ -347,3 +347,30 @@ export interface FlowDefinitionResponse {
    */
   isReadOnly?: boolean;
 }
+
+/**
+ * A single resource that references a flow.
+ */
+export interface FlowUsage {
+  resourceType: string;
+  id: string;
+  displayName: string;
+  behaviorOnDelete: 'fallback' | 'cascade';
+}
+
+/**
+ * Per-resource-type count of usages, keyed by resource type
+ * (e.g. `application`, `agent`). Null when the counts could not be determined.
+ */
+export type FlowUsagesSummary = Record<string, number> | null;
+
+/**
+ * Response for the flow usages endpoint.
+ * totalResults is null when usage data is unavailable; 0 means confirmed empty.
+ */
+export interface FlowUsagesResponse {
+  totalResults: number | null;
+  count: number;
+  summary: FlowUsagesSummary;
+  usages: FlowUsage[];
+}

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -2492,6 +2492,10 @@ const translations = {
     'delete.message': 'Are you sure you want to delete this flow? This action cannot be undone.',
     'delete.disclaimer': 'Warning: All associated configurations will be permanently removed.',
     'delete.error': 'Failed to delete flow. Please try again.',
+    'delete.usages.loading': 'Checking affected resources…',
+    'delete.usages.none': 'No applications or agents are currently using this flow.',
+    'delete.usages.title': 'The following resources will revert to the default flow:',
+    'delete.usages.more': '+{{count}} more',
 
     // Create flow wizard
     'create.steps.type': 'Flow Type',


### PR DESCRIPTION
### Purpose

Generalises the resource-usage lookup introduced for themes into a reusable **usage service registry**, and adds a flow usages endpoint + pre-delete confirmation UI on top of it.

Previously, "what references this theme?" was wired ad-hoc: `thememgt` defined an `ApplicationUsageReader` interface, `servicemanager` built a bespoke adapter, and only applications were considered (agents — which share the inbound-client store — were miscounted as applications). Every new "X references Y" relationship would have needed another reader interface, adapter, and `SetXxx` call.

This PR replaces that with a registry any resource-owning service can query, and uses it to answer flow usages (`GET /flows/{flowId}/usages`).

Key changes:
- New `internal/system/usage` package: `Registry` + `Provider` (`GetResourceUsages(ctx, resourceType, id)`) + aggregated `UsagesResponse` (per-type `summary` map; `totalResults`/`summary` are `null` when unavailable = "unknown").
- `application` and `agent` are registered as providers and now filter by entity `Category`, fixing the agents-counted-as-applications bug.
- Generalised inbound-client lookup `GetEntityIDsByReference(refType, refID, …)` (replaces `GetEntityIDsByThemeID`), keyed by reference type — adding a new referenced type no longer requires editing existing providers.
- Theme migrated from `ApplicationUsageReader` to the registry; new flow usages endpoint, handler, route, and service method.
- Console: `useGetFlowUsages` hook + `FlowDeleteDialog` now lists affected applications/agents before deletion (mirrors the theme delete dialog).
- Registry is hardened against nil/uninitialised providers; consumers degrade to "unknown" if the registry was never injected.

### Approach

- **Registry over point-to-point wiring.** A service that owns a resource asks the registry which other resources reference `(resourceType, id)`; the registry fans out to all registered providers and concatenates results. Providers are blind to each other.
- **Reference mapping lives in the inbound-client store**, not in each provider. `GetEntityIDsByReference` maps `theme → THEME_ID` and `flow → (AUTH_FLOW_ID | REGISTRATION_FLOW_ID | RECOVERY_FLOW_ID)`. Unknown reference types resolve to empty, so providers stay generic (no per-type `switch`).
- **Aggregated, non-paginated response.** The endpoint is informational (drives the pre-delete dialog), so the registry returns one aggregated array with a per-`resourceType` count map; each provider is bounded by `MaxCompositeStoreRecords`.
- **Graceful degradation.** Nil provider registrations are ignored; a missing registry yields an "unknown" response rather than an error or panic.

### Related Issues
- N/A

### Related PRs
- Stacked on #3208 (theme usages endpoint). This branch targets `main`, so until #3208 merges this PR's diff also includes the theme-usages commit; that commit drops out once #3208 lands.

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a flow usages view to flow deletion dialogs, listing referencing resources and showing a “+ more” counter when results exceed the display limit.
  * Introduced a new API endpoint to fetch aggregated usages for a specific flow.

* **Bug Fixes**
  * Improved delete confirmation behavior by disabling the action while usage data is loading or totals are unavailable.

* **Documentation**
  * Updated API response schemas to align usage models with the new “target resource” terminology and the flow usages payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->