### PR TITLE
[Docs] Remove static favicon override so theme-aware favicons apply

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -63,7 +63,6 @@ const siteUrl = process.env.DOCUSAURUS_URL || productConfig.documentation.deploy
 const config: Config = {
   title: productConfig.project.name,
   tagline: productConfig.project.description,
-  favicon: 'assets/images/favicon-inverted.ico',
 
   noIndex: false,
 


### PR DESCRIPTION
## Purpose
The documentation site's browser-tab logo did not adapt to the browser/OS color scheme. The colored logo was hard to see on dark tabs and the inverted (white) logo was washed out on light tabs.

## Related Issue
- N/A

## Implementation
Removed the `favicon` field from `docs/docusaurus.config.ts`. That field injected an additional `<link rel="icon">` with no `media` attribute, which always took precedence over the existing theme-aware favicon links in `headTags`. As a result, whichever single icon it pointed at won in both light and dark modes.

The config already defines `prefers-color-scheme`-aware favicons in `headTags` (`logo-mini.svg` for light, `logo-mini-inverted.svg` for dark). With the conflicting field removed, the browser now picks the correct favicon for each theme.

## Behaviour
### Dark
<img width="371" height="148" alt="Screenshot 2026-06-18 at 9 21 34 AM" src="https://github.com/user-attachments/assets/e49479ef-cc9a-4ece-8d33-b15f412596ba" />

### Light
<img width="368" height="154" alt="Screenshot 2026-06-18 at 9 21 45 AM" src="https://github.com/user-attachments/assets/44d8d1dd-fcbd-432e-b76e-dad490b460ec" />
