### PR TITLE
Fix integration test coverage path duplication on Windows

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1020,12 +1020,15 @@ function Test-Integration {
     Push-Location $SCRIPT_DIR
     try {
         # Set up coverage directory for integration tests
-        $coverage_dir = Join-Path (Get-Location) "$OUTPUT_DIR\.test\integration"
+        $coverage_dir = [System.IO.Path]::GetFullPath((Join-Path $SCRIPT_DIR "target\out\.test\integration"))
+        if (Test-Path $coverage_dir) {
+            Remove-Item -Path $coverage_dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
         New-Item -Path $coverage_dir -ItemType Directory -Force | Out-Null
-        
+
         # Export coverage directory for the server binary to use
         $env:GOCOVERDIR = $coverage_dir
-        
+
         Write-Host "Coverage data will be collected in: $coverage_dir"
         if ($extra_args.Count -gt 0) {
             & go run -C ./tests/integration ./main.go @extra_args
@@ -1033,27 +1036,31 @@ function Test-Integration {
             & go run -C ./tests/integration ./main.go
         }
         $test_exit_code = $LASTEXITCODE
-        
+
         # Process coverage data if tests passed or failed
         if ((Test-Path $coverage_dir) -and ((Get-ChildItem $coverage_dir -ErrorAction SilentlyContinue).Count -gt 0)) {
             Write-Host "================================================================"
             Write-Host "Processing integration test coverage..."
-            
-            # Convert binary coverage data to text format
+
+            # Formulate robust absolute target paths to keep Windows volume prefixes intact
+            $output_file = [System.IO.Path]::GetFullPath((Join-Path $SCRIPT_DIR "target\coverage_integration.out"))
+            $output_html = [System.IO.Path]::GetFullPath((Join-Path $SCRIPT_DIR "target\coverage_integration.html"))
+
+            # Convert binary coverage data to text format cleanly
             Push-Location $BACKEND_BASE_DIR
             try {
-                & go tool covdata textfmt -i="$coverage_dir" -o="../$TARGET_DIR/coverage_integration.out"
-                Write-Host "Integration test coverage report generated in: $TARGET_DIR/coverage_integration.out"
-                
+                & go tool covdata textfmt -i="$coverage_dir" -o="$output_file"
+                Write-Host "Integration test coverage report generated in: $output_file"
+
                 # Generate HTML coverage report
-                & go tool cover -html="../$TARGET_DIR/coverage_integration.out" -o="../$TARGET_DIR/coverage_integration.html"
-                Write-Host "Integration test coverage HTML report generated in: $TARGET_DIR/coverage_integration.html"
-                
+                & go tool cover -html="$output_file" -o="$output_html"
+                Write-Host "Integration test coverage HTML report generated in: $output_html"
+
                 # Display coverage summary
                 Write-Host ""
                 Write-Host "================================================================"
                 Write-Host "Coverage Summary:"
-                & go tool cover -func="../$TARGET_DIR/coverage_integration.out" | Select-Object -Last 1
+                & go tool cover -func="$output_file" | Select-Object -Last 1
                 Write-Host "================================================================"
                 Write-Host ""
             }


### PR DESCRIPTION
### Purpose
Fix a path duplication bug in the `Test-Integration` function in `build.ps1` that prevents integration test coverage collection from starting on Windows. When `$OUTPUT_DIR` (an absolute path) is passed as the second argument to `Join-Path`, PowerShell concatenates rather than replaces, producing a doubled volume prefix causing the process to fail immediately when trying to create or access the coverage directory.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Replace the affected `Join-Path` expressions with `[System.IO.Path]::GetFullPath()` anchored from `$SCRIPT_DIR` with relative path suffixes. 


### Related Issues
- #3360 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the integration test coverage generation flow to use a consistent absolute output directory under the build output, with cleanup of any previous results.
  * Improved robustness of coverage report generation and ensured correct absolute paths for generated text and HTML coverage reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->