### PR TITLE
Show validation error instead of silently blocking delimiter in handle field

### DIFF
--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/AddNodeDialog.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/AddNodeDialog.tsx
@@ -135,6 +135,7 @@ export default function AddNodeDialog({
   };
 
   const isPending = createResource.isPending || createAction.isPending;
+  const handleContainsDelimiter = handle.includes(delimiter);
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
@@ -165,14 +166,22 @@ export default function AddNodeDialog({
               onChange={(e) => {
                 setHandleEdited(true);
                 const sanitized = e.target.value.toLowerCase().replace(/[^a-z0-9._\-:/]/g, '');
-                setHandle(sanitized.replace(new RegExp(`\\${delimiter}`, 'g'), ''));
+                setHandle(sanitized);
               }}
               fullWidth
               size="small"
-              helperText={t(
-                'resourceServers:tree.fields.handleHint',
-                'Lowercase, alphanumeric and . _ - : / — cannot be changed after creation.',
-              )}
+              error={handleContainsDelimiter}
+              helperText={
+                handleContainsDelimiter
+                  ? t(
+                      'resourceServers:tree.fields.handleDelimiterError',
+                      `Handle cannot contain the delimiter character "${delimiter}".`,
+                    )
+                  : t(
+                      'resourceServers:tree.fields.handleHint',
+                      'Lowercase, alphanumeric and . _ - : / — cannot be changed after creation.',
+                    )
+              }
             />
           </FormControl>
           <FormControl fullWidth>
@@ -208,7 +217,11 @@ export default function AddNodeDialog({
         <Button variant="outlined" onClick={handleClose} disabled={isPending}>
           {t('common:cancel', 'Cancel')}
         </Button>
-        <Button variant="contained" onClick={handleSubmit} disabled={isPending || !name.trim() || !handle.trim()}>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={isPending || !name.trim() || !handle.trim() || handleContainsDelimiter}
+        >
           {isPending ? t('common:adding', 'Adding…') : t('common:add', 'Add')}
         </Button>
       </DialogActions>

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/AddNodeDialog.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/AddNodeDialog.test.tsx
@@ -143,4 +143,22 @@ describe('AddNodeDialog', () => {
 
     expect(screen.queryByText('Add Resource')).not.toBeInTheDocument();
   });
+
+  it('shows an error and disables the Add button when the handle contains the delimiter character', async () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} delimiter="/" />);
+
+    const textboxes = screen.getAllByRole('textbox');
+    const handleInput = textboxes[1];
+
+    fireEvent.change(handleInput, {target: {value: 'foo/bar'}});
+
+    await waitFor(() => {
+      expect(handleInput).toHaveValue('foo/bar');
+    });
+
+    expect(screen.getByText('Handle cannot contain the delimiter character "/".')).toBeInTheDocument();
+
+    const addButton = screen.getByRole('button', {name: /^add$/i});
+    expect(addButton).toBeDisabled();
+  });
 });


### PR DESCRIPTION
## Purpose

Fixes #3371

## Description

When creating a resource or sub-resource, the Handle field silently stripped the delimiter character (e.g., `:` for a colon-delimited resource server). The key appeared non-functional — no error, no feedback.

This PR changes the behavior to:
- **Allow** the delimiter character to be typed into the Handle field
- **Show an inline validation error** when the handle contains the delimiter character
- **Disable the Add button** while the validation error is active

## Approach

- Removed the silent `RegExp` strip of the delimiter from the Handle `onChange` handler
- Added a derived `handleContainsDelimiter` boolean
- Conditionally render `error` state and error `helperText` on the Handle `TextField`
- Extended the Add button's `disabled` condition

## Testing

- Added a test that verifies the delimiter character is preserved in the input, the error message is displayed, and the Add button is disabled
- All existing tests continue to pass (145/145)

## Checklist

- [x] Manual verification: colon typed into handle field is no longer stripped; error shown
- [x] `pnpm format:check` — PASS
- [x] `pnpm typecheck` — PASS
- [x] `pnpm test` — PASS (145/145)
- [x] `pnpm lint` — PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent delimiter characters from being used in handle values, providing clear error messaging when detected.
  * Disabled the submit button when a delimiter is present in the handle input.

* **Tests**
  * Added test coverage for delimiter validation in handle fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->