### PR TITLE
Add Envoy Integration

### DIFF
--- a/docs/content/use-cases/sts/envoy.mdx
+++ b/docs/content/use-cases/sts/envoy.mdx
@@ -1,0 +1,260 @@
+---
+title: Protect APIs on Envoy with {{ProductName}}
+description: Configure Envoy to validate JWTs issued by {{ProductName}} before forwarding requests to upstream APIs.
+sidebar_position: 2
+---
+
+# Protect APIs on Envoy with <ProductName />
+
+This guide walks you through configuring [Envoy](https://www.envoyproxy.io/) to protect upstream APIs using JSON Web Tokens (JWTs) issued by <ProductName />. Envoy fetches public keys from the <ProductName /> JWKS endpoint and validates tokens on incoming requests before forwarding traffic to the upstream service.
+
+## Prerequisites
+
+Before you begin, ensure you have the following:
+
+- A running <ProductName /> installation. Follow [Get <ProductName />](../../../guides/getting-started/get-thunderid) for download, setup, and start commands.
+- The latest stable [Envoy](https://www.envoyproxy.io/docs/envoy/latest/start/install) version installed.
+- A backend REST API service running and accessible, for example `http://localhost:8081`.
+- `curl` available in your terminal.
+
+Verify your Envoy version:
+
+```bash
+envoy --version
+```
+
+## JWT Authentication
+
+JWT authentication is the foundation of API security with Envoy and <ProductName />. In this section, you register an application in <ProductName /> to obtain credentials, configure Envoy to validate tokens using the <ProductName /> JWKS endpoint, and verify that unauthenticated requests are rejected.
+
+### Configure <ProductName />
+
+#### Create an Application
+
+1. Sign in to the <ProductName /> Console at `https://<THUNDER_HOST>:<THUNDER_PORT>/console`.
+2. Navigate to **Applications** -> **New Application**.
+3. Enter an **Application Name**.
+4. Select **Backend Service** as the application type.
+5. Click **Create Application**.
+6. Note the **Client ID** and **Client Secret** from the application details page.
+
+#### Obtain an Access Token
+
+Use the client credentials grant to request an access token. The examples use HTTP Basic authentication for the client credentials:
+
+```bash
+curl -kL -X POST 'https://<THUNDER_HOST>:8090/oauth2/token' \
+  --user '<CLIENT_ID>:<CLIENT_SECRET>' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'grant_type=client_credentials'
+```
+
+Save the returned `access_token`. You will use it in the **Try It Out** section.
+
+### Configure Envoy
+
+#### Create an API
+
+Create an Envoy configuration file. See the [Envoy configuration overview](https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/overview) for a full reference.
+
+The listener defines the port Envoy exposes to clients. The route configuration defines the paths Envoy exposes. The cluster configuration defines the upstream service.
+
+This example exposes Envoy on port `8080` and forwards requests for `/resources` to an upstream API on `http://localhost:8081`.
+
+<CodeBlock lang="yaml">
+{`static_resources:
+  listeners:
+    - name: local_listener
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: resources_api_gateway
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: resources_api
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/resources"
+                          route:
+                            cluster: upstream_api
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+    - name: upstream_api
+      connect_timeout: 1s
+      type: STATIC
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: upstream_api
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8081`}
+</CodeBlock>
+
+Start Envoy to verify the API is reachable before adding authentication:
+
+<CodeBlock lang="bash">
+{`envoy --mode validate -c envoy.yaml
+envoy -c envoy.yaml`}
+</CodeBlock>
+
+Envoy starts on port `8080`. Verify the endpoint responds:
+
+```bash
+curl -i --location 'http://localhost:8080/resources' \
+  --header 'Content-Type: application/json'
+```
+
+Expected response:
+
+```text
+HTTP/1.1 200 OK
+```
+
+#### Add JWT Authentication
+
+Envoy validates JWTs using the [`jwt_authn`](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/jwt_authn_filter) HTTP filter. Envoy fetches public keys from the <ProductName /> JWKS endpoint and uses the keys to verify the signature on incoming tokens.
+
+Add the `jwt_authn` filter before the router filter:
+
+<CodeBlock lang="yaml">
+{`http_filters:
+  - name: envoy.filters.http.jwt_authn
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+      providers:
+        thunderid:
+          issuer: "https://localhost:8090"
+          remote_jwks:
+            http_uri:
+              uri: "https://127.0.0.1:8090/oauth2/jwks"
+              cluster: thunderid
+              timeout: 5s
+            cache_duration: 300s
+          from_headers:
+            - name: authorization
+              value_prefix: "Bearer "
+      rules:
+        - match:
+            prefix: "/resources"
+          requires:
+            provider_name: thunderid
+        - match:
+            prefix: "/"
+          requires:
+            allow_missing: {}
+  - name: envoy.filters.http.router
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router`}
+</CodeBlock>
+
+Add a cluster for the <ProductName /> JWKS endpoint:
+
+<CodeBlock lang="yaml">
+{`clusters:
+  - name: thunderid
+    connect_timeout: 1s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: thunderid
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 8090
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        sni: localhost
+        common_tls_context:
+          tls_params:
+            tls_minimum_protocol_version: TLSv1_3
+            tls_maximum_protocol_version: TLSv1_3
+          validation_context:
+            trust_chain_verification: ACCEPT_UNTRUSTED`}
+</CodeBlock>
+
+:::warning Local development only
+`trust_chain_verification: ACCEPT_UNTRUSTED` skips certificate chain verification for local development with self-signed certificates. Remove this setting in production and configure Envoy with a certificate authority trusted by your deployment.
+:::
+
+**Configuration reference** -- see the full list of options in the [JWT authentication filter docs](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/jwt_authn_filter):
+
+| Field | Value | Description |
+|---|---|---|
+| `issuer` | `https://<THUNDER_HOST>:<THUNDER_PORT>` | Token issuer expected by Envoy |
+| `remote_jwks.http_uri.uri` | `https://<THUNDER_HOST>:<THUNDER_PORT>/oauth2/jwks` | <ProductName /> JWKS endpoint for fetching public keys |
+| `cache_duration` | `300s` | Caches JWKS keys to avoid fetching them on every request |
+| `from_headers` | `Authorization: Bearer` | Reads the JWT from the `Authorization` header |
+| `trust_chain_verification` | `ACCEPT_UNTRUSTED` | Skips TLS certificate chain verification. Use only in local development. |
+
+Restart Envoy to apply the changes:
+
+<CodeBlock lang="bash">
+{`pkill -f "envoy -c envoy.yaml"
+envoy --mode validate -c envoy.yaml
+envoy -c envoy.yaml`}
+</CodeBlock>
+
+### Try It Out
+
+**Request without a token — expect `401 Unauthorized`:**
+
+```bash
+curl -i --location 'http://localhost:8080/resources' \
+  --header 'Content-Type: application/json'
+```
+
+Expected response:
+
+```text
+HTTP/1.1 401 Unauthorized
+
+Jwt is missing
+```
+
+**Request with a valid <ProductName /> token — expect `200 OK`:**
+
+```bash
+curl -i --location 'http://localhost:8080/resources' \
+  --header 'Authorization: Bearer <ACCESS_TOKEN>' \
+  --header 'Content-Type: application/json'
+```
+
+Expected response:
+
+```json
+{
+  "resources": [
+    {
+      "id": "101",
+      "name": "Resource One",
+      "status": "active"
+    },
+    {
+      "id": "102",
+      "name": "Resource Two",
+      "status": "pending"
+    }
+  ]
+}
+```

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -384,7 +384,10 @@ const sidebars: SidebarsConfig = {
           label: 'Secure Token Service (STS)',
           collapsible: true,
           collapsed: true,
-          items: [{type: 'doc', id: 'use-cases/sts/krakend', label: 'Protect APIs on KrakenD'}],
+          items: [
+            {type: 'doc', id: 'use-cases/sts/krakend', label: 'Protect APIs on KrakenD'},
+            {type: 'doc', id: 'use-cases/sts/envoy', label: 'Protect APIs on Envoy'},
+          ],
         },
       ],
     },


### PR DESCRIPTION
### Purpose
This PR adds a new STS documentation guide for protecting APIs on Envoy with ThunderID-issued JWTs.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Protect APIs on Envoy” use-case guide for validating JWTs with Envoy, including setup prerequisites, client-credentials token retrieval, and a complete `envoy.yaml` example.
  * Included provider/JWKS configuration and routing rules to require JWTs on `/resources`.
  * Added Envoy validate/restart commands and “Try It Out” curl examples with expected outcomes for missing tokens (`401 Unauthorized`) and valid requests (`200 OK`).
  * Updated the STS documentation sidebar to include the new Envoy guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->