### PR TITLE
Enable MCP server tryout on welcome screen

### DIFF
--- a/frontend/apps/console/src/features/welcome/components/CodeInline.tsx
+++ b/frontend/apps/console/src/features/welcome/components/CodeInline.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box} from '@wso2/oxygen-ui';
+import type {JSX, ReactNode} from 'react';
+
+// TODO: Move this to oxygen-ui and use.
+export default function CodeInline({children = null}: {children?: ReactNode}): JSX.Element {
+  return (
+    <Box
+      component="code"
+      sx={{
+        fontFamily: 'monospace',
+        fontSize: '0.85em',
+        color: 'primary.main',
+        bgcolor: 'action.selected',
+        borderRadius: 0.5,
+        px: 0.5,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/components/CredentialsBlock.tsx
+++ b/frontend/apps/console/src/features/welcome/components/CredentialsBlock.tsx
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, IconButton, Stack, Typography} from '@wso2/oxygen-ui';
+import {Check, Copy, Eye, EyeOff} from '@wso2/oxygen-ui-icons-react';
+import type {JSX} from 'react';
+import {useState} from 'react';
+
+interface CredentialRowProps {
+  field: 'username' | 'password';
+  value: string;
+  showPassword: boolean;
+  isCopied: boolean;
+  onToggleShow: () => void;
+  onCopy: () => void;
+}
+
+function CredentialRow({field, value, showPassword, isCopied, onToggleShow, onCopy}: CredentialRowProps): JSX.Element {
+  const isPassword = field === 'password';
+  return (
+    <Box
+      sx={{
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1.5,
+        px: 2,
+        py: 1,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+      }}
+    >
+      <Box sx={{flex: 1, minWidth: 0}}>
+        <Typography variant="caption" color="text.secondary" sx={{display: 'block', textTransform: 'capitalize'}}>
+          {field}
+        </Typography>
+        <Typography variant="body2" fontFamily="monospace">
+          {isPassword && !showPassword ? '••••••••' : value}
+        </Typography>
+      </Box>
+      {isPassword && (
+        <IconButton
+          size="small"
+          aria-label={showPassword ? 'Hide password' : 'Show password'}
+          onClick={onToggleShow}
+          sx={{color: 'text.secondary'}}
+        >
+          {showPassword ? <EyeOff size={14} /> : <Eye size={14} />}
+        </IconButton>
+      )}
+      <IconButton
+        size="small"
+        aria-label={`Copy ${field}`}
+        onClick={onCopy}
+        sx={{color: isCopied ? 'success.main' : 'text.secondary'}}
+      >
+        {isCopied ? <Check size={14} /> : <Copy size={14} />}
+      </IconButton>
+    </Box>
+  );
+}
+
+export interface CredentialsBlockProps {
+  username: string;
+  password: string;
+}
+
+export default function CredentialsBlock({username, password}: CredentialsBlockProps): JSX.Element {
+  const [showPassword, setShowPassword] = useState(false);
+  const [copiedField, setCopiedField] = useState<'username' | 'password' | null>(null);
+
+  const handleCopy = (field: 'username' | 'password', value: string): void => {
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 2000);
+    });
+  };
+
+  return (
+    <Stack spacing={1}>
+      <CredentialRow
+        field="username"
+        value={username}
+        showPassword={showPassword}
+        isCopied={copiedField === 'username'}
+        onToggleShow={() => setShowPassword((v) => !v)}
+        onCopy={() => handleCopy('username', username)}
+      />
+      <CredentialRow
+        field="password"
+        value={password}
+        showPassword={showPassword}
+        isCopied={copiedField === 'password'}
+        onToggleShow={() => setShowPassword((v) => !v)}
+        onCopy={() => handleCopy('password', password)}
+      />
+    </Stack>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/components/ExternalLink.tsx
+++ b/frontend/apps/console/src/features/welcome/components/ExternalLink.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Link} from '@wso2/oxygen-ui';
+import {ExternalLink as ExternalLinkIcon} from '@wso2/oxygen-ui-icons-react';
+import type {JSX, ReactNode} from 'react';
+
+// TODO: Move this to oxygen-ui and use.
+export default function ExternalLink({href, children = null}: {href: string; children?: ReactNode}): JSX.Element {
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{color: 'inherit', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 2}}
+    >
+      {children}
+      <ExternalLinkIcon size={12} style={{flexShrink: 0, opacity: 0.7}} />
+    </Link>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/components/FormFieldsBlock.tsx
+++ b/frontend/apps/console/src/features/welcome/components/FormFieldsBlock.tsx
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, IconButton, Typography} from '@wso2/oxygen-ui';
+import {Check, Copy, Eye, EyeOff} from '@wso2/oxygen-ui-icons-react';
+import type {JSX} from 'react';
+import {useState} from 'react';
+
+export interface FormField {
+  label: string;
+  value: string;
+  isPassword?: boolean;
+  highlight?: boolean;
+  readOnly?: boolean;
+}
+
+export default function FormFieldsBlock({fields}: {fields: FormField[]}): JSX.Element {
+  const [copiedLabel, setCopiedLabel] = useState<string | null>(null);
+  const [visiblePasswords, setVisiblePasswords] = useState<Set<string>>(new Set());
+
+  const handleCopy = (label: string, value: string): void => {
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopiedLabel(label);
+      setTimeout(() => setCopiedLabel(null), 2000);
+    });
+  };
+
+  const togglePasswordVisibility = (label: string): void => {
+    setVisiblePasswords((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden'}}>
+      {fields.map((f, i) => {
+        const isVisible = !f.isPassword || visiblePasswords.has(f.label);
+        return (
+          <Box
+            key={f.label}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 2,
+              px: 2,
+              py: f.highlight ? 1 : 0.75,
+              borderTop: i === 0 ? 'none' : '1px solid',
+              borderColor: 'divider',
+              bgcolor: f.highlight ? 'action.selected' : 'transparent',
+            }}
+          >
+            <Typography variant="caption" color="text.secondary" sx={{minWidth: 100, flexShrink: 0}}>
+              {f.label}
+            </Typography>
+            {f.highlight ? (
+              <Box
+                sx={{
+                  flex: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  px: 1.25,
+                  py: 0.5,
+                  borderRadius: 1,
+                  bgcolor: 'background.paper',
+                  border: '1px solid',
+                  borderColor: 'primary.light',
+                  minWidth: 0,
+                }}
+              >
+                <Typography
+                  variant="body2"
+                  fontFamily="monospace"
+                  color="primary.main"
+                  fontWeight={600}
+                  sx={{flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}
+                >
+                  {f.value}
+                </Typography>
+              </Box>
+            ) : (
+              <Typography variant="body2" fontFamily="monospace" sx={{flex: 1}}>
+                {isVisible ? f.value : '••••••••'}
+              </Typography>
+            )}
+            {!f.readOnly && (
+              <Box sx={{display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0}}>
+                {f.isPassword && (
+                  <IconButton
+                    size="small"
+                    aria-label={isVisible ? 'Hide password' : 'Show password'}
+                    onClick={() => togglePasswordVisibility(f.label)}
+                    sx={{color: 'text.secondary'}}
+                  >
+                    {isVisible ? <EyeOff size={13} /> : <Eye size={13} />}
+                  </IconButton>
+                )}
+                <IconButton
+                  size="small"
+                  aria-label={`Copy ${f.label}`}
+                  onClick={() => handleCopy(f.label, f.value)}
+                  sx={{
+                    color: copiedLabel === f.label ? 'success.main' : f.highlight ? 'primary.main' : 'text.secondary',
+                  }}
+                >
+                  {copiedLabel === f.label ? <Check size={13} /> : <Copy size={13} />}
+                </IconButton>
+              </Box>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/components/StepList.tsx
+++ b/frontend/apps/console/src/features/welcome/components/StepList.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, Stack, Typography} from '@wso2/oxygen-ui';
+import type {JSX, ReactNode} from 'react';
+
+export interface StepListProps {
+  steps: ReactNode[];
+  startFrom?: number;
+}
+
+export default function StepList({steps, startFrom = 1}: StepListProps): JSX.Element {
+  return (
+    <Stack spacing={1} component="ol" sx={{pl: 0, m: 0, listStyle: 'none'}}>
+      {steps.map((step, i) => (
+        <Stack
+          // eslint-disable-next-line react/no-array-index-key
+          key={i}
+          component="li"
+          direction="row"
+          spacing={1.5}
+          alignItems="flex-start"
+        >
+          <Box
+            sx={{
+              width: 20,
+              height: 20,
+              borderRadius: '50%',
+              bgcolor: 'action.selected',
+              color: 'text.secondary',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '0.7rem',
+              fontWeight: 700,
+              flexShrink: 0,
+              mt: 0.15,
+            }}
+          >
+            {startFrom + i}
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{flex: 1}}>
+            {step}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}

--- a/frontend/apps/console/src/features/welcome/components/__tests__/CodeInline.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/CodeInline.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen} from '@thunderid/test-utils';
+import {describe, expect, it} from 'vitest';
+import CodeInline from '../CodeInline';
+
+describe('CodeInline', () => {
+  it('renders children', () => {
+    render(<CodeInline>my-token</CodeInline>);
+    expect(screen.getByText('my-token')).toBeInTheDocument();
+  });
+
+  it('renders as a code element', () => {
+    const {container} = render(<CodeInline>value</CodeInline>);
+    expect(container.querySelector('code')).toBeInTheDocument();
+  });
+
+  it('renders without children', () => {
+    const {container} = render(<CodeInline />);
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/welcome/components/__tests__/CredentialsBlock.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/CredentialsBlock.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent} from '@thunderid/test-utils';
+import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    Check: () => <span data-testid="icon-check" />,
+    Copy: () => <span data-testid="icon-copy" />,
+    Eye: () => <span data-testid="icon-eye" />,
+    EyeOff: () => <span data-testid="icon-eye-off" />,
+  };
+});
+
+import CredentialsBlock from '../CredentialsBlock';
+
+describe('CredentialsBlock', () => {
+  it('renders the username', () => {
+    render(<CredentialsBlock username="john.doe" password="john.doe" />);
+    expect(screen.getByText('john.doe')).toBeInTheDocument();
+  });
+
+  it('masks the password by default', () => {
+    render(<CredentialsBlock username="john.doe" password="secret" />);
+    expect(screen.getByText('••••••••')).toBeInTheDocument();
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+  });
+
+  it('shows the password when the eye button is clicked', () => {
+    render(<CredentialsBlock username="john.doe" password="secret" />);
+    fireEvent.click(screen.getByRole('button', {name: /show password/i}));
+    expect(screen.getByText('secret')).toBeInTheDocument();
+  });
+
+  it('hides the password again when eye-off is clicked', () => {
+    render(<CredentialsBlock username="john.doe" password="secret" />);
+    fireEvent.click(screen.getByRole('button', {name: /show password/i}));
+    fireEvent.click(screen.getByRole('button', {name: /hide password/i}));
+    expect(screen.getByText('••••••••')).toBeInTheDocument();
+  });
+
+  describe('clipboard', () => {
+    let writeTextSpy: ReturnType<typeof vi.fn>;
+
+    beforeAll(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {writeText: vi.fn()},
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    beforeEach(() => {
+      writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('copies username on copy button click', () => {
+      render(<CredentialsBlock username="john.doe" password="secret" />);
+      fireEvent.click(screen.getByRole('button', {name: /copy username/i}));
+      expect(writeTextSpy).toHaveBeenCalledWith('john.doe');
+    });
+
+    it('copies password on copy button click', () => {
+      render(<CredentialsBlock username="john.doe" password="secret" />);
+      fireEvent.click(screen.getByRole('button', {name: /copy password/i}));
+      expect(writeTextSpy).toHaveBeenCalledWith('secret');
+    });
+  });
+});

--- a/frontend/apps/console/src/features/welcome/components/__tests__/ExternalLink.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/ExternalLink.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen} from '@thunderid/test-utils';
+import {describe, expect, it, vi} from 'vitest';
+import {MCP_INSPECTOR_URL} from '../../constants/sample-urls';
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    ExternalLink: () => <span data-testid="icon-external-link" />,
+  };
+});
+
+import ExternalLink from '../ExternalLink';
+
+describe('ExternalLink', () => {
+  it('renders an anchor with the given href', () => {
+    render(<ExternalLink href={MCP_INSPECTOR_URL}>Open Inspector</ExternalLink>);
+    const link = screen.getByRole('link', {name: /Open Inspector/});
+    expect(link).toHaveAttribute('href', 'http://localhost:6274');
+  });
+
+  it('opens in a new tab with noopener noreferrer', () => {
+    render(<ExternalLink href={MCP_INSPECTOR_URL}>Link</ExternalLink>);
+    const link = screen.getByRole('link', {name: /Link/});
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders the external link icon', () => {
+    render(<ExternalLink href={MCP_INSPECTOR_URL}>Link</ExternalLink>);
+    expect(screen.getByTestId('icon-external-link')).toBeInTheDocument();
+  });
+
+  it('renders children text', () => {
+    render(<ExternalLink href={MCP_INSPECTOR_URL}>Click here</ExternalLink>);
+    expect(screen.getByText('Click here')).toBeInTheDocument();
+  });
+
+  it('renders without children', () => {
+    render(<ExternalLink href={MCP_INSPECTOR_URL} />);
+    expect(screen.getByRole('link')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/welcome/components/__tests__/FormFieldsBlock.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/FormFieldsBlock.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent} from '@thunderid/test-utils';
+import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wso2/oxygen-ui-icons-react')>();
+  return {
+    ...actual,
+    Check: () => <span data-testid="icon-check" />,
+    Copy: () => <span data-testid="icon-copy" />,
+    Eye: () => <span data-testid="icon-eye" />,
+    EyeOff: () => <span data-testid="icon-eye-off" />,
+  };
+});
+
+import FormFieldsBlock from '../FormFieldsBlock';
+
+const basicFields = [
+  {label: 'URL', value: 'http://localhost:8787/mcp'},
+  {label: 'Client ID', value: 'MY-CLIENT'},
+];
+
+describe('FormFieldsBlock', () => {
+  it('renders each field label', () => {
+    render(<FormFieldsBlock fields={basicFields} />);
+    expect(screen.getByText('URL')).toBeInTheDocument();
+    expect(screen.getByText('Client ID')).toBeInTheDocument();
+  });
+
+  it('renders each field value', () => {
+    render(<FormFieldsBlock fields={basicFields} />);
+    expect(screen.getByText('http://localhost:8787/mcp')).toBeInTheDocument();
+    expect(screen.getByText('MY-CLIENT')).toBeInTheDocument();
+  });
+
+  it('does not render a copy button for readOnly fields', () => {
+    render(<FormFieldsBlock fields={[{label: 'Transport', value: 'Streamable HTTP', readOnly: true}]} />);
+    expect(screen.queryByRole('button', {name: /copy transport/i})).not.toBeInTheDocument();
+  });
+
+  it('renders a copy button for non-readOnly fields', () => {
+    render(<FormFieldsBlock fields={[{label: 'URL', value: 'http://localhost'}]} />);
+    expect(screen.getByRole('button', {name: /copy url/i})).toBeInTheDocument();
+  });
+
+  it('masks password fields by default', () => {
+    render(<FormFieldsBlock fields={[{label: 'Secret', value: 'mysecret', isPassword: true}]} />);
+    expect(screen.getByText('••••••••')).toBeInTheDocument();
+    expect(screen.queryByText('mysecret')).not.toBeInTheDocument();
+  });
+
+  it('shows password field value when eye button is clicked', () => {
+    render(<FormFieldsBlock fields={[{label: 'Secret', value: 'mysecret', isPassword: true}]} />);
+    fireEvent.click(screen.getByRole('button', {name: /show password/i}));
+    expect(screen.getByText('mysecret')).toBeInTheDocument();
+  });
+
+  describe('clipboard', () => {
+    let writeTextSpy: ReturnType<typeof vi.fn>;
+
+    beforeAll(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {writeText: vi.fn()},
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    beforeEach(() => {
+      writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('copies the field value on copy button click', () => {
+      render(<FormFieldsBlock fields={[{label: 'URL', value: 'http://localhost:8787/mcp'}]} />);
+      fireEvent.click(screen.getByRole('button', {name: /copy url/i}));
+      expect(writeTextSpy).toHaveBeenCalledWith('http://localhost:8787/mcp');
+    });
+  });
+});

--- a/frontend/apps/console/src/features/welcome/components/__tests__/StepList.test.tsx
+++ b/frontend/apps/console/src/features/welcome/components/__tests__/StepList.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen} from '@thunderid/test-utils';
+import {describe, expect, it} from 'vitest';
+import StepList from '../StepList';
+
+describe('StepList', () => {
+  it('renders each step', () => {
+    render(<StepList steps={['First step', 'Second step']} />);
+    expect(screen.getByText('First step')).toBeInTheDocument();
+    expect(screen.getByText('Second step')).toBeInTheDocument();
+  });
+
+  it('numbers steps starting from 1 by default', () => {
+    render(<StepList steps={['Step A', 'Step B']} />);
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('numbers steps from a custom startFrom value', () => {
+    render(<StepList steps={['Step A', 'Step B']} startFrom={3} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+  });
+
+  it('renders JSX node steps', () => {
+    render(
+      <StepList
+        steps={[
+          <span key="a" data-testid="jsx-step">
+            JSX content
+          </span>,
+        ]}
+      />,
+    );
+    expect(screen.getByTestId('jsx-step')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/welcome/constants/sample-urls.ts
+++ b/frontend/apps/console/src/features/welcome/constants/sample-urls.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const WAYFINDER_APP_URL = 'http://localhost:5173';
+export const WAYFINDER_MAIL_URL = 'http://localhost:8788';
+export const WAYFINDER_MCP_URL = 'http://localhost:8787/mcp';
+export const MCP_INSPECTOR_URL = 'http://localhost:6274';
+export const MCP_INSPECTOR_CALLBACK_URL = 'http://localhost:6274/oauth/callback';

--- a/frontend/apps/console/src/features/welcome/pages/TryoutSecuringAIAgentsPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/TryoutSecuringAIAgentsPage.tsx
@@ -18,171 +18,23 @@
 
 import {useConfig} from '@thunderid/contexts';
 import {Box, Button, Stack, Tab, Tabs, Typography, IconButton, LinearProgress, AppBreadcrumbs} from '@wso2/oxygen-ui';
-import {
-  BookOpen,
-  Bot,
-  CalendarCheck,
-  Check,
-  Copy,
-  ExternalLink,
-  Eye,
-  EyeOff,
-  Search,
-  Shield,
-  X,
-} from '@wso2/oxygen-ui-icons-react';
+import {BookOpen, Bot, CalendarCheck, Check, Copy, Search, Shield, X} from '@wso2/oxygen-ui-icons-react';
 import {motion} from 'framer-motion';
-import type {JSX, ReactNode} from 'react';
-import {useState} from 'react';
+import {type JSX, useState} from 'react';
 import {Trans, useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import AIAgentApiKeySetup from '../components/AIAgentApiKeySetup';
+import CodeInline from '../components/CodeInline';
+import CredentialsBlock from '../components/CredentialsBlock';
+import ExternalLink from '../components/ExternalLink';
+import StepList from '../components/StepList';
 import WayfinderSampleSetup from '../components/WayfinderSampleSetup';
+import {WAYFINDER_APP_URL} from '../constants/sample-urls';
 import useWelcomeClose from '../hooks/useWelcomeClose';
 
 const MotionBox = motion.create(Box);
 
 type ScenarioTab = 'protect' | 'browse' | 'book';
-
-interface CredentialRowProps {
-  field: 'username' | 'password';
-  value: string;
-  showPassword: boolean;
-  isCopied: boolean;
-  onToggleShow: () => void;
-  onCopy: () => void;
-}
-
-function CredentialRow({field, value, showPassword, isCopied, onToggleShow, onCopy}: CredentialRowProps): JSX.Element {
-  const isPassword = field === 'password';
-  return (
-    <Box
-      sx={{
-        border: '1px solid',
-        borderColor: 'divider',
-        borderRadius: 1.5,
-        px: 2,
-        py: 1,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 1,
-      }}
-    >
-      <Box sx={{flex: 1, minWidth: 0}}>
-        <Typography variant="caption" color="text.secondary" sx={{display: 'block', textTransform: 'capitalize'}}>
-          {field}
-        </Typography>
-        <Typography variant="body2" fontFamily="monospace">
-          {isPassword && !showPassword ? '••••••••' : value}
-        </Typography>
-      </Box>
-      {isPassword && (
-        <IconButton
-          size="small"
-          aria-label={showPassword ? 'Hide password' : 'Show password'}
-          onClick={onToggleShow}
-          sx={{color: 'text.secondary'}}
-        >
-          {showPassword ? <EyeOff size={14} /> : <Eye size={14} />}
-        </IconButton>
-      )}
-      <IconButton
-        size="small"
-        aria-label={`Copy ${field}`}
-        onClick={onCopy}
-        sx={{color: isCopied ? 'success.main' : 'text.secondary'}}
-      >
-        {isCopied ? <Check size={14} /> : <Copy size={14} />}
-      </IconButton>
-    </Box>
-  );
-}
-
-function CredentialsBlock({username, password}: {username: string; password: string}): JSX.Element {
-  const [showPassword, setShowPassword] = useState(false);
-  const [copiedField, setCopiedField] = useState<'username' | 'password' | null>(null);
-
-  const handleCopy = (field: 'username' | 'password', value: string): void => {
-    void navigator.clipboard.writeText(value).then(() => {
-      setCopiedField(field);
-      setTimeout(() => setCopiedField(null), 2000);
-    });
-  };
-
-  return (
-    <Stack spacing={1}>
-      <CredentialRow
-        field="username"
-        value={username}
-        showPassword={showPassword}
-        isCopied={copiedField === 'username'}
-        onToggleShow={() => setShowPassword((v) => !v)}
-        onCopy={() => handleCopy('username', username)}
-      />
-      <CredentialRow
-        field="password"
-        value={password}
-        showPassword={showPassword}
-        isCopied={copiedField === 'password'}
-        onToggleShow={() => setShowPassword((v) => !v)}
-        onCopy={() => handleCopy('password', password)}
-      />
-    </Stack>
-  );
-}
-
-function StepList({steps, startFrom = 1}: {steps: ReactNode[]; startFrom?: number}): JSX.Element {
-  return (
-    <Stack spacing={1} component="ol" sx={{pl: 0, m: 0, listStyle: 'none'}}>
-      {steps.map((step, i) => (
-        <Stack
-          // eslint-disable-next-line react/no-array-index-key
-          key={i}
-          component="li"
-          direction="row"
-          spacing={1.5}
-          alignItems="flex-start"
-        >
-          <Box
-            sx={{
-              width: 20,
-              height: 20,
-              borderRadius: '50%',
-              bgcolor: 'action.selected',
-              color: 'text.secondary',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '0.7rem',
-              fontWeight: 700,
-              flexShrink: 0,
-              mt: 0.15,
-            }}
-          >
-            {startFrom + i}
-          </Box>
-          <Typography variant="body2" color="text.secondary" sx={{flex: 1}}>
-            {step}
-          </Typography>
-        </Stack>
-      ))}
-    </Stack>
-  );
-}
-
-function AppLink({children = null}: {children?: ReactNode}): JSX.Element {
-  return (
-    <a
-      href="http://localhost:5173"
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{color: 'inherit', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 2}}
-    >
-      {children}
-      <ExternalLink size={12} style={{flexShrink: 0, opacity: 0.7}} />
-    </a>
-  );
-}
 
 function ChatPromptBlock({text}: {text: string}): JSX.Element {
   const [copied, setCopied] = useState(false);
@@ -220,35 +72,6 @@ function ChatPromptBlock({text}: {text: string}): JSX.Element {
         {copied ? <Check size={14} /> : <Copy size={14} />}
       </IconButton>
     </Box>
-  );
-}
-
-function tLink(i18nKey: string): JSX.Element {
-  return <Trans ns="common" i18nKey={i18nKey} components={{a: <AppLink />}} />;
-}
-
-function tCode(i18nKey: string): JSX.Element {
-  return (
-    <Trans
-      ns="common"
-      i18nKey={i18nKey}
-      components={{
-        code: (
-          <Box
-            component="code"
-            sx={{
-              px: 0.5,
-              py: 0.4,
-              borderRadius: 0.5,
-              bgcolor: 'action.selected',
-              fontFamily: 'monospace',
-              fontSize: '0.8em',
-              color: 'text.main',
-            }}
-          />
-        ),
-      }}
-    />
   );
 }
 
@@ -390,7 +213,16 @@ export default function TryoutSecuringAIAgentsPage(): JSX.Element {
                       <Typography variant="body2" color="text.secondary">
                         {t('common:welcome.aiAgentsTryout.scenarios.protect.description')}
                       </Typography>
-                      <StepList steps={[tLink('welcome.aiAgentsTryout.scenarios.protect.step1')]} />
+                      <StepList
+                        steps={[
+                          <Trans
+                            key="step1"
+                            ns="common"
+                            i18nKey="welcome.aiAgentsTryout.scenarios.protect.step1"
+                            components={{a: <ExternalLink href={WAYFINDER_APP_URL} />}}
+                          />,
+                        ]}
+                      />
                       <Stack spacing={1}>
                         <Typography
                           variant="caption"
@@ -398,14 +230,23 @@ export default function TryoutSecuringAIAgentsPage(): JSX.Element {
                           sx={{display: 'inline-flex', alignItems: 'center', gap: 0.5}}
                         >
                           <Check size={12} />
-                          {tCode('welcome.aiAgentsTryout.scenarios.protect.johnLabel')}
+                          <Trans
+                            ns="common"
+                            i18nKey="welcome.aiAgentsTryout.scenarios.protect.johnLabel"
+                            components={{code: <CodeInline />}}
+                          />
                         </Typography>
                         <CredentialsBlock username="john.doe" password="john.doe" />
                       </Stack>
                       <StepList
                         startFrom={2}
                         steps={[
-                          tCode('welcome.aiAgentsTryout.scenarios.protect.step2'),
+                          <Trans
+                            key="step2"
+                            ns="common"
+                            i18nKey="welcome.aiAgentsTryout.scenarios.protect.step2"
+                            components={{code: <CodeInline />}}
+                          />,
                           t('common:welcome.aiAgentsTryout.scenarios.protect.step3'),
                         ]}
                       />
@@ -416,7 +257,11 @@ export default function TryoutSecuringAIAgentsPage(): JSX.Element {
                           sx={{display: 'inline-flex', alignItems: 'center', gap: 0.5}}
                         >
                           <X size={12} />
-                          {tCode('welcome.aiAgentsTryout.scenarios.protect.janeLabel')}
+                          <Trans
+                            ns="common"
+                            i18nKey="welcome.aiAgentsTryout.scenarios.protect.janeLabel"
+                            components={{code: <CodeInline />}}
+                          />
                         </Typography>
                         <CredentialsBlock username="jane.smith" password="jane.smith" />
                       </Stack>
@@ -429,7 +274,16 @@ export default function TryoutSecuringAIAgentsPage(): JSX.Element {
                       <Typography variant="body2" color="text.secondary">
                         {t('common:welcome.aiAgentsTryout.scenarios.browse.description')}
                       </Typography>
-                      <StepList steps={[tLink('welcome.aiAgentsTryout.scenarios.browse.step1')]} />
+                      <StepList
+                        steps={[
+                          <Trans
+                            key="step1"
+                            ns="common"
+                            i18nKey="welcome.aiAgentsTryout.scenarios.browse.step1"
+                            components={{a: <ExternalLink href={WAYFINDER_APP_URL} />}}
+                          />,
+                        ]}
+                      />
                       <CredentialsBlock username="john.doe" password="john.doe" />
                       <StepList steps={[t('common:welcome.aiAgentsTryout.scenarios.browse.step2')]} startFrom={2} />
                       <ChatPromptBlock text="What flights are there from Colombo to Singapore?" />
@@ -437,7 +291,12 @@ export default function TryoutSecuringAIAgentsPage(): JSX.Element {
                         startFrom={3}
                         steps={[
                           t('common:welcome.aiAgentsTryout.scenarios.browse.step3'),
-                          tCode('welcome.aiAgentsTryout.scenarios.browse.step4'),
+                          <Trans
+                            key="step4"
+                            ns="common"
+                            i18nKey="welcome.aiAgentsTryout.scenarios.browse.step4"
+                            components={{code: <CodeInline />}}
+                          />,
                         ]}
                       />
                       <ChatPromptBlock text={t('common:welcome.aiAgentsTryout.scenarios.browse.step4Prompt')} />
@@ -449,14 +308,28 @@ export default function TryoutSecuringAIAgentsPage(): JSX.Element {
                       <Typography variant="body2" color="text.secondary">
                         {t('common:welcome.aiAgentsTryout.scenarios.book.description')}
                       </Typography>
-                      <StepList steps={[tLink('welcome.aiAgentsTryout.scenarios.book.step1')]} />
+                      <StepList
+                        steps={[
+                          <Trans
+                            key="step1"
+                            ns="common"
+                            i18nKey="welcome.aiAgentsTryout.scenarios.book.step1"
+                            components={{a: <ExternalLink href={WAYFINDER_APP_URL} />}}
+                          />,
+                        ]}
+                      />
                       <CredentialsBlock username="john.doe" password="john.doe" />
                       <StepList startFrom={2} steps={[t('common:welcome.aiAgentsTryout.scenarios.book.step2')]} />
                       <ChatPromptBlock text={t('common:welcome.aiAgentsTryout.scenarios.book.step2Prompt')} />
                       <StepList
                         startFrom={3}
                         steps={[
-                          tCode('common:welcome.aiAgentsTryout.scenarios.book.step3'),
+                          <Trans
+                            key="step3"
+                            ns="common"
+                            i18nKey="welcome.aiAgentsTryout.scenarios.book.step3"
+                            components={{code: <CodeInline />}}
+                          />,
                           t('common:welcome.aiAgentsTryout.scenarios.book.step4'),
                         ]}
                       />

--- a/frontend/apps/console/src/features/welcome/pages/TryoutSecuringApplicationPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/TryoutSecuringApplicationPage.tsx
@@ -33,13 +33,8 @@ import {
 } from '@wso2/oxygen-ui';
 import {
   AppWindow,
-  Check,
-  Copy,
-  ExternalLink,
   X,
   BookOpen,
-  Eye,
-  EyeOff,
   KeyRound,
   LogIn,
   Share2,
@@ -48,266 +43,21 @@ import {
   UserPlus,
 } from '@wso2/oxygen-ui-icons-react';
 import {motion} from 'framer-motion';
-import type {JSX, ReactNode} from 'react';
-import {useState} from 'react';
+import {useState, type JSX} from 'react';
 import {Trans, useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
+import CodeInline from '../components/CodeInline';
+import CredentialsBlock from '../components/CredentialsBlock';
+import ExternalLink from '../components/ExternalLink';
+import FormFieldsBlock from '../components/FormFieldsBlock';
+import StepList from '../components/StepList';
 import WayfinderSampleSetup from '../components/WayfinderSampleSetup';
+import {WAYFINDER_APP_URL, WAYFINDER_MAIL_URL} from '../constants/sample-urls';
 import useWelcomeClose from '../hooks/useWelcomeClose';
 
 const MotionBox = motion.create(Box);
 
-const WAYFINDER_SAMPLE_URL = 'http://localhost:5173';
-const WAYFINDER_MAIL_URL = 'http://localhost:8788';
-
 type ScenarioTab = 'login' | 'signup' | 'recovery' | 'onboard' | 'mfa' | 'social';
-
-interface CredentialRowProps {
-  field: 'username' | 'password';
-  value: string;
-  showPassword: boolean;
-  isCopied: boolean;
-  onToggleShow: () => void;
-  onCopy: () => void;
-}
-
-function CredentialRow({field, value, showPassword, isCopied, onToggleShow, onCopy}: CredentialRowProps): JSX.Element {
-  const isPassword = field === 'password';
-  return (
-    <Box
-      sx={{
-        border: '1px solid',
-        borderColor: 'divider',
-        borderRadius: 1.5,
-        px: 2,
-        py: 1,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 1,
-      }}
-    >
-      <Box sx={{flex: 1, minWidth: 0}}>
-        <Typography variant="caption" color="text.secondary" sx={{display: 'block', textTransform: 'capitalize'}}>
-          {field}
-        </Typography>
-        <Typography variant="body2" fontFamily="monospace">
-          {isPassword && !showPassword ? '••••••••' : value}
-        </Typography>
-      </Box>
-      {isPassword && (
-        <IconButton
-          size="small"
-          aria-label={showPassword ? 'Hide password' : 'Show password'}
-          onClick={onToggleShow}
-          sx={{color: 'text.secondary'}}
-        >
-          {showPassword ? <EyeOff size={14} /> : <Eye size={14} />}
-        </IconButton>
-      )}
-      <IconButton
-        size="small"
-        aria-label={`Copy ${field}`}
-        onClick={onCopy}
-        sx={{color: isCopied ? 'success.main' : 'text.secondary'}}
-      >
-        {isCopied ? <Check size={14} /> : <Copy size={14} />}
-      </IconButton>
-    </Box>
-  );
-}
-
-interface CredentialsBlockProps {
-  username: string;
-  password: string;
-}
-
-function CredentialsBlock({username, password}: CredentialsBlockProps): JSX.Element {
-  const [showPassword, setShowPassword] = useState(false);
-  const [copiedField, setCopiedField] = useState<'username' | 'password' | null>(null);
-
-  const handleCopy = (field: 'username' | 'password', value: string): void => {
-    void navigator.clipboard.writeText(value).then(() => {
-      setCopiedField(field);
-      setTimeout(() => setCopiedField(null), 2000);
-    });
-  };
-
-  return (
-    <Stack spacing={1}>
-      <CredentialRow
-        field="username"
-        value={username}
-        showPassword={showPassword}
-        isCopied={copiedField === 'username'}
-        onToggleShow={() => setShowPassword((v) => !v)}
-        onCopy={() => handleCopy('username', username)}
-      />
-      <CredentialRow
-        field="password"
-        value={password}
-        showPassword={showPassword}
-        isCopied={copiedField === 'password'}
-        onToggleShow={() => setShowPassword((v) => !v)}
-        onCopy={() => handleCopy('password', password)}
-      />
-    </Stack>
-  );
-}
-
-interface StepListProps {
-  steps: ReactNode[];
-  startFrom?: number;
-}
-
-function StepList({steps, startFrom = 1}: StepListProps): JSX.Element {
-  return (
-    <Stack spacing={1} component="ol" sx={{pl: 0, m: 0, listStyle: 'none'}}>
-      {steps.map((step, i) => (
-        <Stack
-          // eslint-disable-next-line react/no-array-index-key
-          key={i}
-          component="li"
-          direction="row"
-          spacing={1.5}
-          alignItems="flex-start"
-        >
-          <Box
-            sx={{
-              width: 20,
-              height: 20,
-              borderRadius: '50%',
-              bgcolor: 'action.selected',
-              color: 'text.secondary',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '0.7rem',
-              fontWeight: 700,
-              flexShrink: 0,
-              mt: 0.15,
-            }}
-          >
-            {startFrom + i}
-          </Box>
-          <Typography variant="body2" color="text.secondary" sx={{flex: 1}}>
-            {step}
-          </Typography>
-        </Stack>
-      ))}
-    </Stack>
-  );
-}
-
-function AppLink({children = null}: {children?: ReactNode}): JSX.Element {
-  return (
-    <a
-      href={WAYFINDER_SAMPLE_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{color: 'inherit', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 2}}
-    >
-      {children}
-      <ExternalLink size={12} style={{flexShrink: 0, opacity: 0.7}} />
-    </a>
-  );
-}
-
-function MailLink({children = null}: {children?: ReactNode}): JSX.Element {
-  return (
-    <a
-      href={WAYFINDER_MAIL_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{color: 'inherit', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 2}}
-    >
-      {children}
-      <ExternalLink size={12} style={{flexShrink: 0, opacity: 0.7}} />
-    </a>
-  );
-}
-
-function tLink(i18nKey: string, values?: Record<string, unknown>): JSX.Element {
-  return <Trans ns="common" i18nKey={i18nKey} values={values} components={{a: <AppLink />, mail: <MailLink />}} />;
-}
-
-interface FormField {
-  label: string;
-  value: string;
-  isPassword?: boolean;
-}
-
-function FormFieldsBlock({fields}: {fields: FormField[]}): JSX.Element {
-  const [copiedLabel, setCopiedLabel] = useState<string | null>(null);
-  const [visiblePasswords, setVisiblePasswords] = useState<Set<string>>(new Set());
-
-  const handleCopy = (label: string, value: string): void => {
-    void navigator.clipboard.writeText(value).then(() => {
-      setCopiedLabel(label);
-      setTimeout(() => setCopiedLabel(null), 2000);
-    });
-  };
-
-  const togglePasswordVisibility = (label: string): void => {
-    setVisiblePasswords((prev) => {
-      const next = new Set(prev);
-      if (next.has(label)) {
-        next.delete(label);
-      } else {
-        next.add(label);
-      }
-      return next;
-    });
-  };
-
-  return (
-    <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden'}}>
-      {fields.map((f, i) => {
-        const isVisible = !f.isPassword || visiblePasswords.has(f.label);
-        return (
-          <Box
-            key={f.label}
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2,
-              px: 2,
-              py: 0.75,
-              borderTop: i === 0 ? 'none' : '1px solid',
-              borderColor: 'divider',
-            }}
-          >
-            <Typography variant="caption" color="text.secondary" sx={{minWidth: 96, flexShrink: 0}}>
-              {f.label}
-            </Typography>
-            <Typography variant="body2" fontFamily="monospace" sx={{flex: 1}}>
-              {isVisible ? f.value : '••••••••'}
-            </Typography>
-            <Box sx={{display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0}}>
-              {f.isPassword && (
-                <IconButton
-                  size="small"
-                  aria-label={isVisible ? 'Hide password' : 'Show password'}
-                  onClick={() => togglePasswordVisibility(f.label)}
-                  sx={{color: 'text.secondary'}}
-                >
-                  {isVisible ? <EyeOff size={13} /> : <Eye size={13} />}
-                </IconButton>
-              )}
-              <IconButton
-                size="small"
-                aria-label={`Copy ${f.label}`}
-                onClick={() => handleCopy(f.label, f.value)}
-                sx={{color: copiedLabel === f.label ? 'success.main' : 'text.secondary'}}
-              >
-                {copiedLabel === f.label ? <Check size={13} /> : <Copy size={13} />}
-              </IconButton>
-            </Box>
-          </Box>
-        );
-      })}
-    </Box>
-  );
-}
 
 export default function TryoutSecuringConsumerApp(): JSX.Element {
   const {t} = useTranslation(['common']);
@@ -488,7 +238,15 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
                     </Typography>
                     <StepList
                       steps={[
-                        tLink('welcome.applicationTryout.scenarios.login.step1'),
+                        <Trans
+                          key="step1"
+                          ns="common"
+                          i18nKey="welcome.applicationTryout.scenarios.login.step1"
+                          components={{
+                            a: <ExternalLink href={WAYFINDER_APP_URL} />,
+                            mail: <ExternalLink href={WAYFINDER_MAIL_URL} />,
+                          }}
+                        />,
                         t('common:welcome.applicationTryout.scenarios.login.step2'),
                       ]}
                     />
@@ -519,7 +277,15 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
                     </Typography>
                     <StepList
                       steps={[
-                        tLink('welcome.applicationTryout.scenarios.signup.step1'),
+                        <Trans
+                          key="step1"
+                          ns="common"
+                          i18nKey="welcome.applicationTryout.scenarios.signup.step1"
+                          components={{
+                            a: <ExternalLink href={WAYFINDER_APP_URL} />,
+                            mail: <ExternalLink href={WAYFINDER_MAIL_URL} />,
+                          }}
+                        />,
                         t('common:welcome.applicationTryout.scenarios.signup.step2', {productName}),
                         t('common:welcome.applicationTryout.scenarios.signup.step3'),
                       ]}
@@ -572,10 +338,32 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
                     </Typography>
                     <StepList
                       steps={[
-                        tLink('welcome.applicationTryout.scenarios.recovery.step1'),
+                        <Trans
+                          key="step1"
+                          ns="common"
+                          i18nKey="welcome.applicationTryout.scenarios.recovery.step1"
+                          components={{
+                            a: <ExternalLink href={WAYFINDER_APP_URL} />,
+                            mail: <ExternalLink href={WAYFINDER_MAIL_URL} />,
+                          }}
+                        />,
                         t('common:welcome.applicationTryout.scenarios.recovery.step2', {productName}),
-                        t('common:welcome.applicationTryout.scenarios.recovery.step3'),
-                        tLink('welcome.applicationTryout.scenarios.recovery.step4', {productName}),
+                        <Trans
+                          key="step3"
+                          ns="common"
+                          i18nKey="welcome.applicationTryout.scenarios.recovery.step3"
+                          components={{code: <CodeInline />}}
+                        />,
+                        <Trans
+                          key="step4"
+                          ns="common"
+                          i18nKey="welcome.applicationTryout.scenarios.recovery.step4"
+                          values={{productName}}
+                          components={{
+                            a: <ExternalLink href={WAYFINDER_APP_URL} />,
+                            mail: <ExternalLink href={WAYFINDER_MAIL_URL} />,
+                          }}
+                        />,
                         t('common:welcome.applicationTryout.scenarios.recovery.step5'),
                         t('common:welcome.applicationTryout.scenarios.recovery.step6'),
                       ]}
@@ -597,7 +385,15 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
                         t('common:welcome.applicationTryout.scenarios.onboard.step2'),
                         t('common:welcome.applicationTryout.scenarios.onboard.step3'),
                         t('common:welcome.applicationTryout.scenarios.onboard.step4'),
-                        tLink('welcome.applicationTryout.scenarios.onboard.step5'),
+                        <Trans
+                          key="step5"
+                          ns="common"
+                          i18nKey="welcome.applicationTryout.scenarios.onboard.step5"
+                          components={{
+                            a: <ExternalLink href={WAYFINDER_APP_URL} />,
+                            mail: <ExternalLink href={WAYFINDER_MAIL_URL} />,
+                          }}
+                        />,
                         t('common:welcome.applicationTryout.scenarios.onboard.step6'),
                         t('common:welcome.applicationTryout.scenarios.onboard.step7'),
                       ]}

--- a/frontend/apps/console/src/features/welcome/pages/TryoutSecuringMCPPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/TryoutSecuringMCPPage.tsx
@@ -17,208 +17,23 @@
  */
 
 import {useConfig} from '@thunderid/contexts';
-import {Box, Button, Stack, Tab, Tabs, Typography, IconButton, LinearProgress, AppBreadcrumbs} from '@wso2/oxygen-ui';
-import {
-  BookOpen,
-  Check,
-  Copy,
-  ExternalLink,
-  Link2,
-  Play,
-  ShieldCheck,
-  Terminal,
-  MCP,
-  X,
-} from '@wso2/oxygen-ui-icons-react';
+import {Box, Button, Divider, Stack, Typography, IconButton, LinearProgress, AppBreadcrumbs} from '@wso2/oxygen-ui';
+import {BookOpen, Terminal, MCP, X} from '@wso2/oxygen-ui-icons-react';
 import {motion} from 'framer-motion';
-import type {JSX, ReactNode} from 'react';
-import {useState} from 'react';
+import type {JSX} from 'react';
 import {Trans, useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
+import CodeInline from '../components/CodeInline';
+import CredentialsBlock from '../components/CredentialsBlock';
+import ExternalLink from '../components/ExternalLink';
+import FormFieldsBlock from '../components/FormFieldsBlock';
+import StepList from '../components/StepList';
 import TerminalBlock from '../components/TerminalBlock';
 import WayfinderSampleSetup from '../components/WayfinderSampleSetup';
+import {MCP_INSPECTOR_CALLBACK_URL, MCP_INSPECTOR_URL, WAYFINDER_MCP_URL} from '../constants/sample-urls';
 import useWelcomeClose from '../hooks/useWelcomeClose';
 
 const MotionBox = motion.create(Box);
-
-type ScenarioTab = 'connect' | 'permissions';
-
-interface FormField {
-  label: string;
-  value: string;
-}
-
-function FormFieldsBlock({fields}: {fields: FormField[]}): JSX.Element {
-  const [copiedLabel, setCopiedLabel] = useState<string | null>(null);
-
-  const handleCopy = (label: string, value: string): void => {
-    void navigator.clipboard.writeText(value).then(() => {
-      setCopiedLabel(label);
-      setTimeout(() => setCopiedLabel(null), 2000);
-    });
-  };
-
-  return (
-    <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden'}}>
-      {fields.map((f, i) => (
-        <Box
-          key={f.label}
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2,
-            px: 2,
-            py: 0.75,
-            borderTop: i === 0 ? 'none' : '1px solid',
-            borderColor: 'divider',
-          }}
-        >
-          <Typography variant="caption" color="text.secondary" sx={{minWidth: 100, flexShrink: 0}}>
-            {f.label}
-          </Typography>
-          <Typography variant="body2" fontFamily="monospace" sx={{flex: 1}}>
-            {f.value}
-          </Typography>
-          <IconButton
-            size="small"
-            aria-label={`Copy ${f.label}`}
-            onClick={() => handleCopy(f.label, f.value)}
-            sx={{color: copiedLabel === f.label ? 'success.main' : 'text.secondary', flexShrink: 0}}
-          >
-            {copiedLabel === f.label ? <Check size={13} /> : <Copy size={13} />}
-          </IconButton>
-        </Box>
-      ))}
-    </Box>
-  );
-}
-
-function StepList({steps, startFrom = 1}: {steps: ReactNode[]; startFrom?: number}): JSX.Element {
-  return (
-    <Stack spacing={1} component="ol" sx={{pl: 0, m: 0, listStyle: 'none'}}>
-      {steps.map((step, i) => (
-        <Stack
-          // eslint-disable-next-line react/no-array-index-key
-          key={i}
-          component="li"
-          direction="row"
-          spacing={1.5}
-          alignItems="flex-start"
-        >
-          <Box
-            sx={{
-              width: 20,
-              height: 20,
-              borderRadius: '50%',
-              bgcolor: 'action.selected',
-              color: 'text.secondary',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '0.7rem',
-              fontWeight: 700,
-              flexShrink: 0,
-              mt: 0.15,
-            }}
-          >
-            {startFrom + i}
-          </Box>
-          <Typography variant="body2" color="text.secondary" sx={{flex: 1}}>
-            {step}
-          </Typography>
-        </Stack>
-      ))}
-    </Stack>
-  );
-}
-
-function ExternalAppLink({href, children = null}: {href: string; children?: ReactNode}): JSX.Element {
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{color: 'inherit', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 2}}
-    >
-      {children}
-      <ExternalLink size={12} style={{flexShrink: 0, opacity: 0.7}} />
-    </a>
-  );
-}
-
-function tLink(i18nKey: string, href: string): JSX.Element {
-  return <Trans ns="common" i18nKey={i18nKey} components={{a: <ExternalAppLink href={href} />}} />;
-}
-
-function tCode(i18nKey: string): JSX.Element {
-  return (
-    <Trans
-      ns="common"
-      i18nKey={i18nKey}
-      components={{
-        code: (
-          <Box
-            component="code"
-            sx={{
-              fontFamily: 'monospace',
-              fontSize: '0.85em',
-              color: 'primary.main',
-              bgcolor: 'action.selected',
-              borderRadius: 0.5,
-              px: 0.5,
-            }}
-          />
-        ),
-      }}
-    />
-  );
-}
-
-function CodeBlock({code}: {code: string}): JSX.Element {
-  const [copied, setCopied] = useState(false);
-  const handleCopy = (): void => {
-    void navigator.clipboard.writeText(code).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  };
-  return (
-    <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden'}}>
-      <Box
-        sx={{
-          bgcolor: 'action.selected',
-          px: 1.5,
-          py: 0.5,
-          display: 'flex',
-          justifyContent: 'flex-end',
-          borderBottom: '1px solid',
-          borderColor: 'divider',
-        }}
-      >
-        <IconButton
-          size="small"
-          aria-label="Copy snippet"
-          onClick={handleCopy}
-          sx={{color: copied ? 'success.main' : 'text.secondary'}}
-        >
-          {copied ? <Check size={13} /> : <Copy size={13} />}
-        </IconButton>
-      </Box>
-      <Box sx={{bgcolor: 'grey.900', px: 2, py: 1.5}}>
-        {code.split('\n').map((line) => (
-          <Typography
-            key={line.toLowerCase().split(' ').join('-')}
-            variant="body2"
-            fontFamily="monospace"
-            sx={{color: 'grey.300', whiteSpace: 'pre'}}
-          >
-            {line}
-          </Typography>
-        ))}
-      </Box>
-    </Box>
-  );
-}
 
 export default function TryoutSecuringMCPPage(): JSX.Element {
   const {t} = useTranslation(['common']);
@@ -227,34 +42,6 @@ export default function TryoutSecuringMCPPage(): JSX.Element {
   const handleClose = useWelcomeClose();
   const productName = config.brand.product_name;
   const docsBaseUrl = (config.brand.documentation?.baseUrl ?? '').replace(/\/$/, '');
-
-  const [scenarioTab, setScenarioTab] = useState<ScenarioTab>('connect');
-
-  const corsSnippet = `cors:\n  allowed_origins:\n    # ...existing entries...\n    - "http://localhost:6274"`;
-
-  const tabDefs: {value: ScenarioTab; label: string; icon: JSX.Element}[] = [
-    {value: 'connect', label: t('common:welcome.mcpTryout.scenarios.tabs.connect'), icon: <Link2 size={15} />},
-    {
-      value: 'permissions',
-      label: t('common:welcome.mcpTryout.scenarios.tabs.permissions'),
-      icon: <ShieldCheck size={15} />,
-    },
-  ];
-
-  const setupSteps = [
-    {
-      number: 4,
-      icon: <Terminal size={28} />,
-      title: t('common:welcome.mcpTryout.steps.installInspector.title'),
-      description: t('common:welcome.mcpTryout.steps.installInspector.description'),
-    },
-    {
-      number: 5,
-      icon: <Play size={28} />,
-      title: t('common:welcome.mcpTryout.steps.allowCors.title'),
-      description: t('common:welcome.mcpTryout.steps.allowCors.description', {productName}),
-    },
-  ];
 
   return (
     <Box sx={{minHeight: '100vh', display: 'flex', flexDirection: 'column'}}>
@@ -338,163 +125,134 @@ export default function TryoutSecuringMCPPage(): JSX.Element {
 
             <WayfinderSampleSetup />
 
-            {/* MCP-specific setup steps */}
-            <Stack spacing={3} sx={{mt: 3}}>
-              {setupSteps.map((step, index) => (
-                <MotionBox
-                  key={step.number}
-                  initial={{opacity: 0, x: -10}}
-                  animate={{opacity: 1, x: 0}}
-                  transition={{duration: 0.3, delay: 0.2 + index * 0.1}}
+            {/* Step 4 — Launch MCP Inspector */}
+            <MotionBox
+              initial={{opacity: 0, x: -10}}
+              animate={{opacity: 1, x: 0}}
+              transition={{duration: 0.3, delay: 0.2}}
+              sx={{mt: 3}}
+            >
+              <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden'}}>
+                <Box
+                  sx={{
+                    p: 2.5,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 2,
+                    bgcolor: 'action.selected',
+                    borderBottom: '1px solid',
+                    borderColor: 'divider',
+                  }}
                 >
                   <Box
                     sx={{
-                      display: 'flex',
-                      gap: 3,
-                      p: 3,
-                      border: '1px solid',
-                      borderColor: 'divider',
+                      width: 40,
+                      height: 40,
                       borderRadius: 2,
-                      alignItems: 'flex-start',
+                      bgcolor: 'background.paper',
+                      color: 'text.secondary',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0,
                     }}
                   >
-                    <Box
-                      sx={{
-                        width: 36,
-                        height: 36,
-                        borderRadius: '50%',
-                        bgcolor: 'action.selected',
-                        color: 'text.primary',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontWeight: 700,
-                        fontSize: '0.875rem',
-                        flexShrink: 0,
-                        mt: 0.25,
-                      }}
-                    >
-                      {step.number}
-                    </Box>
-                    <Box sx={{flex: 1}}>
-                      <Box
-                        sx={{
-                          width: 48,
-                          height: 48,
-                          borderRadius: 2,
-                          bgcolor: 'action.selected',
-                          color: 'text.secondary',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          mb: 1.5,
-                        }}
-                      >
-                        {step.icon}
-                      </Box>
-                      <Typography variant="subtitle1" fontWeight={600} sx={{mb: 0.5}}>
-                        {step.title}
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary" sx={{mb: step.number === 1 ? 1.5 : 0}}>
-                        {step.description}
-                      </Typography>
-
-                      {step.number === 4 && <TerminalBlock command="npx @modelcontextprotocol/inspector" />}
-
-                      {step.number === 5 && <CodeBlock code={corsSnippet} />}
-                    </Box>
+                    <Terminal size={22} />
                   </Box>
-                </MotionBox>
-              ))}
-            </Stack>
+                  <Typography variant="subtitle2" fontWeight={600}>
+                    {t('common:welcome.mcpTryout.steps.installInspector.title')}
+                  </Typography>
+                </Box>
+                <Divider />
+                <Box sx={{p: 2.5}}>
+                  <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>
+                    {t('common:welcome.mcpTryout.steps.installInspector.description')}
+                  </Typography>
+                  <TerminalBlock command="npx @modelcontextprotocol/inspector" />
+                </Box>
+              </Box>
+            </MotionBox>
 
             {/* Try use cases */}
             <MotionBox
               initial={{opacity: 0, y: 10}}
               animate={{opacity: 1, y: 0}}
               transition={{duration: 0.4, delay: 0.5}}
-              sx={{mt: 4}}
+              sx={{mt: 5}}
             >
               <Typography variant="h3" sx={{fontSize: '1.25rem', fontWeight: 600, mb: 2}}>
                 {t('common:welcome.mcpTryout.scenarios.title')}
               </Typography>
 
-              <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden'}}>
-                <Tabs
-                  value={scenarioTab}
-                  onChange={(_e, v: ScenarioTab) => setScenarioTab(v)}
-                  variant="scrollable"
-                  scrollButtons="auto"
-                  sx={{
-                    borderBottom: '1px solid',
-                    borderColor: 'divider',
-                    bgcolor: 'action.selected',
-                    minHeight: 44,
-                    '& .MuiTab-root': {minHeight: 44, fontSize: '0.8rem', gap: 0.75},
-                  }}
-                >
-                  {tabDefs.map((tab) => (
-                    <Tab key={tab.value} value={tab.value} label={tab.label} icon={tab.icon} iconPosition="start" />
-                  ))}
-                </Tabs>
-
-                <Box sx={{p: 3}}>
-                  {scenarioTab === 'connect' && (
-                    <Stack spacing={2}>
-                      <Typography variant="body2" color="text.secondary">
-                        {t('common:welcome.mcpTryout.scenarios.connect.description', {productName})}
-                      </Typography>
-                      <StepList
-                        steps={[
-                          tLink('welcome.mcpTryout.scenarios.connect.step1', 'http://localhost:6274'),
-                          t('common:welcome.mcpTryout.scenarios.connect.step2'),
-                          t('common:welcome.mcpTryout.scenarios.connect.step3'),
-                          t('common:welcome.mcpTryout.scenarios.connect.step4', {productName}),
-                          t('common:welcome.mcpTryout.scenarios.connect.step5'),
-                        ]}
-                      />
-                      <Typography variant="caption" color="text.secondary">
-                        {t('common:welcome.mcpTryout.scenarios.connect.connectionLabel')}
-                      </Typography>
-                      <FormFieldsBlock
-                        fields={[
-                          {
-                            label: t('common:welcome.mcpTryout.scenarios.connect.fields.transport'),
-                            value: 'Streamable HTTP',
-                          },
-                          {
-                            label: t('common:welcome.mcpTryout.scenarios.connect.fields.serverUrl'),
-                            value: 'http://localhost:8787/mcp',
-                          },
-                          {
-                            label: t('common:welcome.mcpTryout.scenarios.connect.fields.clientId'),
-                            value: 'EXTERNAL-MCP-CLIENT',
-                          },
-                          {
-                            label: t('common:welcome.mcpTryout.scenarios.connect.fields.clientSecret'),
-                            value: '(leave blank)',
-                          },
-                        ]}
-                      />
-                    </Stack>
-                  )}
-
-                  {scenarioTab === 'permissions' && (
-                    <Stack spacing={2}>
-                      <Typography variant="body2" color="text.secondary">
-                        {t('common:welcome.mcpTryout.scenarios.permissions.description', {productName})}
-                      </Typography>
-                      <StepList
-                        steps={[
-                          tCode('common:welcome.mcpTryout.scenarios.permissions.step1'),
-                          tCode('common:welcome.mcpTryout.scenarios.permissions.step2'),
-                          t('common:welcome.mcpTryout.scenarios.permissions.step3'),
-                          t('common:welcome.mcpTryout.scenarios.permissions.step4'),
-                        ]}
-                      />
-                    </Stack>
-                  )}
-                </Box>
+              <Box sx={{border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 3}}>
+                <Stack spacing={2}>
+                  <Typography variant="body2" color="text.secondary">
+                    {t('common:welcome.mcpTryout.scenarios.connect.description', {productName})}
+                  </Typography>
+                  <StepList
+                    steps={[
+                      <Trans
+                        key="step1"
+                        ns="common"
+                        i18nKey="welcome.mcpTryout.scenarios.connect.step1"
+                        components={{a: <ExternalLink href={MCP_INSPECTOR_URL} />}}
+                      />,
+                      t('common:welcome.mcpTryout.scenarios.connect.step2'),
+                    ]}
+                  />
+                  <FormFieldsBlock
+                    fields={[
+                      {
+                        label: t('common:welcome.mcpTryout.scenarios.connect.fields.transport'),
+                        value: 'Streamable HTTP',
+                        readOnly: true,
+                      },
+                      {
+                        label: t('common:welcome.mcpTryout.scenarios.connect.fields.serverUrl'),
+                        value: WAYFINDER_MCP_URL,
+                      },
+                      {
+                        label: t('common:welcome.mcpTryout.scenarios.connect.fields.connectionType'),
+                        value: 'Direct',
+                        readOnly: true,
+                      },
+                    ]}
+                  />
+                  <StepList startFrom={3} steps={[t('common:welcome.mcpTryout.scenarios.connect.step3')]} />
+                  <FormFieldsBlock
+                    fields={[
+                      {
+                        label: t('common:welcome.mcpTryout.scenarios.connect.fields.clientId'),
+                        value: 'EXTERNAL-MCP-CLIENT',
+                      },
+                      {
+                        label: t('common:welcome.mcpTryout.scenarios.connect.fields.clientSecret'),
+                        value: '(leave blank)',
+                        readOnly: true,
+                      },
+                      {
+                        label: t('common:welcome.mcpTryout.scenarios.connect.fields.redirectUrl'),
+                        value: MCP_INSPECTOR_CALLBACK_URL,
+                      },
+                    ]}
+                  />
+                  <StepList
+                    startFrom={4}
+                    steps={[t('common:welcome.mcpTryout.scenarios.connect.step4', {productName})]}
+                  />
+                  <CredentialsBlock username="john.doe" password="john.doe" />
+                  <StepList
+                    startFrom={5}
+                    steps={[
+                      <Trans
+                        key="step5"
+                        ns="common"
+                        i18nKey="welcome.mcpTryout.scenarios.connect.step5"
+                        components={{code: <CodeInline />}}
+                      />,
+                    ]}
+                  />
+                </Stack>
               </Box>
             </MotionBox>
 

--- a/frontend/apps/console/src/features/welcome/pages/WelcomePage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/WelcomePage.tsx
@@ -98,9 +98,10 @@ export default function WelcomePage(): JSX.Element {
       icon: <MCP size={18} />,
       label: t('common:welcome.tryoutProduct.mcp'),
       description: t('common:welcome.tryoutProduct.mcpDesc'),
-      action: () =>
-        window.open(`${docsBaseUrl}/use-cases/ai-agents/mcp-authorization/try-it-out`, '_blank', 'noopener,noreferrer'),
-      endIcon: <ExternalLink size={14} />,
+      action: () => {
+        sessionStorage.setItem(getWelcomeDismissedStorageKey(productName), 'true');
+        void navigate('/welcome/tryout/mcp');
+      },
     },
   ];
 
@@ -417,7 +418,7 @@ export default function WelcomePage(): JSX.Element {
                         transition: 'opacity 0.2s',
                       }}
                     >
-                      {item.endIcon ?? <ChevronRight size={14} />}
+                      <ChevronRight size={14} />
                     </Box>
                   </Box>
                 ))}

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringApplicationPage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringApplicationPage.test.tsx
@@ -18,6 +18,7 @@
 
 import {render, screen, userEvent, fireEvent} from '@thunderid/test-utils';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {WAYFINDER_APP_URL, WAYFINDER_MAIL_URL} from '../../constants/sample-urls';
 
 const mockNavigate = vi.fn();
 const mockSessionStorageSetItem = vi.fn();
@@ -251,8 +252,8 @@ describe('TryoutSecuringApplicationPage', () => {
 
     expect(screen.getByText('common:welcome.applicationTryout.scenarios.recovery.description')).toBeInTheDocument();
     const hrefs = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
-    expect(hrefs).toContain('http://localhost:5173');
-    expect(hrefs).toContain('http://localhost:8788');
+    expect(hrefs).toContain(WAYFINDER_APP_URL);
+    expect(hrefs).toContain(WAYFINDER_MAIL_URL);
   });
 
   it('shows onboard scenario with a mail-inbox link when onboard tab is clicked', async () => {
@@ -265,7 +266,7 @@ describe('TryoutSecuringApplicationPage', () => {
       screen.getByText('common:welcome.applicationTryout.scenarios.onboard.description:ThunderID'),
     ).toBeInTheDocument();
     const hrefs = screen.getAllByRole('link').map((a) => a.getAttribute('href'));
-    expect(hrefs).toContain('http://localhost:8788');
+    expect(hrefs).toContain(WAYFINDER_MAIL_URL);
   });
 
   describe('credential interactions', () => {

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringMCPPage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringMCPPage.test.tsx
@@ -18,6 +18,7 @@
 
 import {render, screen, userEvent, fireEvent} from '@thunderid/test-utils';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {WAYFINDER_MCP_URL} from '../../constants/sample-urls';
 
 const mockNavigate = vi.fn();
 const mockSessionStorageSetItem = vi.fn();
@@ -160,10 +161,9 @@ describe('TryoutSecuringMCPPage', () => {
     expect(screen.getByTestId('wayfinder-sample-setup')).toBeInTheDocument();
   });
 
-  it('renders scenario tabs', () => {
+  it('renders connect scenario content', () => {
     render(<TryoutSecuringMCPPage />);
-    expect(screen.getByText('common:welcome.mcpTryout.scenarios.tabs.connect')).toBeInTheDocument();
-    expect(screen.getByText('common:welcome.mcpTryout.scenarios.tabs.permissions')).toBeInTheDocument();
+    expect(screen.getByText(/common:welcome\.mcpTryout\.scenarios\.connect\.description/)).toBeInTheDocument();
   });
 
   it('navigates to /home and sets session storage on close', async () => {
@@ -207,15 +207,6 @@ describe('TryoutSecuringMCPPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/welcome');
   });
 
-  it('shows permissions scenario when permissions tab is clicked', async () => {
-    const user = userEvent.setup();
-    render(<TryoutSecuringMCPPage />);
-
-    await user.click(screen.getByText('common:welcome.mcpTryout.scenarios.tabs.permissions'));
-
-    expect(screen.getByText(/common:welcome\.mcpTryout\.scenarios\.permissions\.description/)).toBeInTheDocument();
-  });
-
   describe('clipboard interactions', () => {
     let writeTextSpy: ReturnType<typeof vi.fn>;
 
@@ -235,33 +226,21 @@ describe('TryoutSecuringMCPPage', () => {
       vi.restoreAllMocks();
     });
 
-    it('renders terminal block and tabs with user interaction', async () => {
-      const user = userEvent.setup();
+    it('renders terminal block and connect scenario content', () => {
       render(<TryoutSecuringMCPPage />);
       expect(screen.getByTestId('terminal-block')).toBeInTheDocument();
-      await user.click(screen.getByText('common:welcome.mcpTryout.scenarios.tabs.connect'));
       expect(screen.getByText(/common:welcome\.mcpTryout\.scenarios\.connect\.description/)).toBeInTheDocument();
     });
 
-    it('copies a form field in the connect tab', async () => {
-      const user = userEvent.setup();
+    it('copies a form field in the connect tab', () => {
       render(<TryoutSecuringMCPPage />);
 
       const copyButtons = screen.getAllByRole('button', {
         name: /^Copy common:welcome\.mcpTryout\.scenarios\.connect\.fields\./,
       });
-      await user.click(copyButtons[0]);
+      fireEvent.click(copyButtons[0]);
 
-      expect(writeTextSpy).toHaveBeenCalledWith('Streamable HTTP');
-    });
-
-    it('copies the CORS snippet via CodeBlock', async () => {
-      const user = userEvent.setup();
-      render(<TryoutSecuringMCPPage />);
-
-      await user.click(screen.getByRole('button', {name: 'Copy snippet'}));
-
-      expect(writeTextSpy).toHaveBeenCalledWith(expect.stringContaining('allowed_origins'));
+      expect(writeTextSpy).toHaveBeenCalledWith(WAYFINDER_MCP_URL);
     });
   });
 });

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/WelcomePage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/WelcomePage.test.tsx
@@ -208,19 +208,14 @@ describe('WelcomePage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/welcome/tryout/ai-agents');
   });
 
-  it('opens MCP docs URL on mcp item click', async () => {
-    const mockOpen = vi.fn();
-    vi.stubGlobal('open', mockOpen);
+  it('navigates to MCP tryout page on mcp item click', async () => {
     const user = userEvent.setup();
     render(<WelcomePage />);
 
     await user.click(screen.getByText('common:welcome.tryoutProduct.mcp'));
 
-    expect(mockOpen).toHaveBeenCalledWith(
-      'https://docs.example.com/use-cases/ai-agents/mcp-authorization/try-it-out',
-      '_blank',
-      'noopener,noreferrer',
-    );
+    expect(mockSessionStorageSetItem).toHaveBeenCalledWith('thunderid:welcome:dismissed', 'true');
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome/tryout/mcp');
   });
 
   it('triggers new project action on start card Enter keypress', () => {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -303,7 +303,7 @@ const translations = {
       'Walk through the password recovery flow - John forgets his password and resets it via email.',
     'welcome.applicationTryout.scenarios.recovery.step1': 'Open <a>http://localhost:5173</a> and click Sign in.',
     'welcome.applicationTryout.scenarios.recovery.step2': 'On the {{productName}} sign-in page, click Forgot password?',
-    'welcome.applicationTryout.scenarios.recovery.step3': 'Enter john.doe as the username and submit.',
+    'welcome.applicationTryout.scenarios.recovery.step3': 'Enter <code>john.doe</code> as the username and submit.',
     'welcome.applicationTryout.scenarios.recovery.step4':
       "{{productName}} sends a recovery email to John's registered address. Open it from the inbox at <mail>http://localhost:8788</mail>.",
     'welcome.applicationTryout.scenarios.recovery.step5': 'Click the reset link in the email and set a new password.',
@@ -408,14 +408,14 @@ const translations = {
     'welcome.mcpTryout.steps.verifyApp.description':
       'In the {{productName}} Console, open Applications and confirm EXTERNAL-MCP-CLIENT is listed.',
     'welcome.mcpTryout.steps.verifyApp.action': 'Open Applications',
-    'welcome.mcpTryout.steps.installInspector.title': 'Install MCP Inspector',
+    'welcome.mcpTryout.steps.installInspector.title': 'Launch MCP Inspector',
     'welcome.mcpTryout.steps.installInspector.description':
-      'Launch MCP Inspector locally — a browser-based reference UI for MCP servers with built-in OAuth support.',
+      'Launch MCP Inspector locally — a browser-based reference UI for MCP servers with built-in OAuth support. Open a new terminal in the sample app directory and run:',
     'welcome.mcpTryout.steps.allowCors.title': 'Allow Inspector in CORS',
     'welcome.mcpTryout.steps.allowCors.description':
       "Add Inspector's origin to {{productName}}'s CORS allow-list in repository/conf/deployment.yaml, then restart {{productName}}.",
 
-    'welcome.mcpTryout.scenarios.title': 'Try the following user journeys',
+    'welcome.mcpTryout.scenarios.title': 'Try out the following test scenarios',
     'welcome.mcpTryout.scenarios.tabs.connect': 'Connect & Sign In',
     'welcome.mcpTryout.scenarios.tabs.permissions': 'Test Permissions',
 
@@ -423,22 +423,24 @@ const translations = {
       'Point MCP Inspector at the Wayfinder MCP server, authenticate through {{productName}}, and grant booking permissions at the consent screen.',
     'welcome.mcpTryout.scenarios.connect.step1':
       'Open <a>http://localhost:6274</a> in your browser (Inspector should already be running from the setup step above).',
-    'welcome.mcpTryout.scenarios.connect.step2':
-      'Set Transport to Streamable HTTP and Server URL to http://localhost:8787/mcp.',
-    'welcome.mcpTryout.scenarios.connect.step3':
-      'Enable OAuth. Set Client ID to EXTERNAL-MCP-CLIENT and leave Client Secret blank (public client).',
+    'welcome.mcpTryout.scenarios.connect.step2': 'Fill in the form with the details below.',
+    'welcome.mcpTryout.scenarios.connect.step3': 'Expand "Authentication" and fill in the details below.',
     'welcome.mcpTryout.scenarios.connect.step4':
-      'Click Connect. You are redirected to {{productName}} — sign in as john.doe / john.doe.',
+      'Click Connect. You are redirected to {{productName}} Sign in page — Sign in as John.',
     'welcome.mcpTryout.scenarios.connect.step5':
       'At the consent screen select the booking permissions to grant (<code>booking:read</code>, <code>booking:create</code>, <code>booking:cancel</code>) and confirm.',
     'welcome.mcpTryout.scenarios.connect.connectionLabel': 'Connection details',
-    'welcome.mcpTryout.scenarios.connect.fields.transport': 'Transport',
-    'welcome.mcpTryout.scenarios.connect.fields.serverUrl': 'Server URL',
+    'welcome.mcpTryout.scenarios.connect.fields.transport': 'Transport Type',
+    'welcome.mcpTryout.scenarios.connect.fields.serverUrl': 'URL',
+    'welcome.mcpTryout.scenarios.connect.fields.connectionType': 'Connection Type',
     'welcome.mcpTryout.scenarios.connect.fields.clientId': 'Client ID',
     'welcome.mcpTryout.scenarios.connect.fields.clientSecret': 'Client Secret',
+    'welcome.mcpTryout.scenarios.connect.fields.redirectUrl': 'Redirect URL',
 
     'welcome.mcpTryout.scenarios.permissions.description':
       'Call MCP tools and observe how {{productName}} enforces the scopes you granted at consent. Reconnect with different permissions to see the difference.',
+    'welcome.mcpTryout.scenarios.permissions.step0':
+      'At the consent screen select the booking permissions to grant (<code>booking:read</code>, <code>booking:create</code>, <code>booking:cancel</code>) and confirm.',
     'welcome.mcpTryout.scenarios.permissions.step1':
       'In the Tools tab, call create_booking. Set type=flight, itemId=flight-cmb-sin-01, travelers=1. The call succeeds if you granted <code>booking:create</code>.',
     'welcome.mcpTryout.scenarios.permissions.step2':


### PR DESCRIPTION
### Purpose
This pull request introduces several new reusable UI components to the `frontend/apps/console/src/features/welcome/components` directory and enable MCP server tryout on welcome screen, each with comprehensive unit tests. These components are designed to display credentials, form fields, inline code, external application links, and step lists, and include features such as password masking, copy-to-clipboard functionality, and accessibility improvements. The changes enhance the modularity and reusability of the codebase for handling common UI patterns in the welcome feature.

**New UI Components:**

- **Credential and Form Field Display:**
  - Added `CredentialsBlock`, a component for displaying username and password fields with password masking, show/hide toggle, and copy-to-clipboard functionality.
  - Added `FormFieldsBlock`, a flexible component for displaying a list of labeled fields (including password and read-only support), with optional highlighting and copy-to-clipboard features.

- **Utility and Presentation Components:**
  - Added `CodeInline`, a component for rendering inline code snippets with consistent styling.
  - Added `ExternalAppLink`, a component for rendering external hyperlinks with an icon, opening in a new tab with proper security attributes.
  - Added `StepList`, a component for rendering a numbered list of steps, each with custom content.

**Testing Enhancements:**

- **Comprehensive Unit Tests:**
  - Added unit tests for `CredentialsBlock`, covering password masking, show/hide toggling, and clipboard copy actions.
  - Added unit tests for `FormFieldsBlock`, testing field rendering, password visibility, copy functionality, and read-only behavior.
  - Added unit tests for `CodeInline` to verify rendering and correct element usage.
  - Added unit tests for `ExternalAppLink` to ensure correct link behavior, icon rendering, and accessibility.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Credentials display now includes copy-to-clipboard functionality with visual feedback
  * Password fields support visibility toggle control
  * Added numbered step-list interface for multi-step guidance
  * Inline code formatting component for better content readability

* **UI Updates**
  * MCP onboarding workflow streamlined and simplified
  * MCP tryout now uses internal navigation
  * Updated translations for account recovery and MCP scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->