### PR TITLE
Document direct flow initiation restriction for authorization_code apps

### DIFF
--- a/docs/content/guides/guides/applications/application-settings.mdx
+++ b/docs/content/guides/guides/applications/application-settings.mdx
@@ -113,7 +113,7 @@ This section applies to OAuth 2.0 / OIDC applications only.
 The **Advanced Settings** tab shows the OAuth 2.0 settings configured at creation.
 | Setting | Description |
 |---------|-------------|
-| **Grant Types** | The OAuth 2.0 flows this application can use. Supported values: `authorization_code`, `refresh_token`, `client_credentials`, `urn:ietf:params:oauth:grant-type:token-exchange`. |
+| **Grant Types** | The OAuth 2.0 flows this application can use. Supported values: `authorization_code`, `refresh_token`, `client_credentials`, `urn:ietf:params:oauth:grant-type:token-exchange`. Applications configured with `authorization_code` cannot initiate new flows directly via `POST /flow/execute`. They must begin authentication through the Authorization endpoint (`GET /oauth2/authorize`), which initiates the flow internally. |
 | **Response Types** | The response types the application can request (for example, `code`). |
 | **Token Endpoint Auth Method** | How the application authenticates at the token endpoint: `client_secret_basic` (default), `client_secret_post`, `private_key_jwt`, or `none` (public clients). |
 | **Public Client** | Whether this is a public client that cannot securely store a client secret. |

--- a/docs/content/guides/key-concepts/authentication/integration-models.mdx
+++ b/docs/content/guides/key-concepts/authentication/integration-models.mdx
@@ -50,6 +50,10 @@ The core principle is **shared responsibility**: <ProductName /> enforces authen
 ###  When to Use
 Choose this approach when your application must render its own authentication screens (no redirects to hosted pages) while <ProductName /> enforces authentication logic, MFA, and policies server-side. This model suits mobile apps, single-page applications, or any context where a redirect-based flow would disrupt the user experience.
 
+:::note[Grant Type Requirement]
+The Flow Execution API only accepts new flow initiation requests from applications that do **not** have the `authorization_code` grant type configured. Applications registered with `authorization_code` must initiate authentication through the [Authorization endpoint](/docs/next/apis/#tag/authorization) (`GET /oauth2/authorize`), which then drives the flow internally. Continuation requests that carry a valid `executionId` are always accepted regardless of grant type.
+:::
+
 ### Key Features
 
 - **Server-side flow execution:** Authentication logic, step ordering, and branching live in <ProductName />. Changes take effect immediately without redeploying your application.

--- a/docs/content/guides/key-concepts/authentication/passwordless/magiclink.mdx
+++ b/docs/content/guides/key-concepts/authentication/passwordless/magiclink.mdx
@@ -48,6 +48,10 @@ For more details, see [Redirect-Based Integration](../../integration-models#redi
 
 If you are building a custom authentication UI, you can implement Magic Links using the App-Native model by orchestrating the Flow Execution API.
 
+:::note
+Applications configured with the `authorization_code` grant type cannot start flows directly through `POST /flow/execute`. They must initiate authentication through the Authorization endpoint (`GET /oauth2/authorize`). See [Integration Models](../../integration-models#app-native).
+:::
+
 ### Starting the Flow
 
 1) **Start the flow** – send an initial flow request.

--- a/docs/content/guides/key-concepts/authentication/passwordless/passkeys.mdx
+++ b/docs/content/guides/key-concepts/authentication/passwordless/passkeys.mdx
@@ -171,6 +171,10 @@ On success, the API returns an authentication response compatible with other <Pr
 
 Passkeys also work through the flow engine (`POST /flow/execute`), which returns dynamic prompts and additional data.
 
+:::note
+Applications configured with the `authorization_code` grant type cannot start flows directly through `POST /flow/execute`. They must initiate authentication through the Authorization endpoint (`GET /oauth2/authorize`). See [Integration Models](../../integration-models#app-native).
+:::
+
 ### Authentication with Flow/Execute
 
 1) **Start the flow** – send an initial flow request.


### PR DESCRIPTION
### Purpose

Documents the breaking change introduced in #3289: applications configured with the `authorization_code` grant type cannot initiate new flows directly via `POST /flow/execute`. They must begin authentication through the Authorization endpoint (`GET /oauth2/authorize`), which drives the flow internally. Continuation requests carrying a valid `executionId` are unaffected regardless of grant type.

### Approach

Added a consistent note across every doc that shows a raw `POST /flow/execute` initiation or describes the App-Native model, so readers do not plug in an `authorization_code` application and hit a `403` (`FES-1011`):

- **`integration-models.mdx`** — Added a "Grant Type Requirement" note in the App-Native "When to Use" section, the canonical place where developers choose this model.
- **`application-settings.mdx`** — Extended the Grant Types row to explain the implication on the Flow Execution API.
- **`passwordless/magiclink.mdx`** — Added a note under "App-Native Integration" before the raw `POST /flow/execute` example.
- **`passwordless/passkeys.mdx`** — Added a note under "Use Passkeys with Flow/Execute" before the raw `POST /flow/execute` example.

Each note cross-references the App-Native section in [Integration Models](/docs/next/guides/key-concepts/authentication/integration-models#app-native).

#### Scope notes

- The b2c use-case tutorials (`configure-it-yourself`, `self-sign-up`, `account-recovery`, `onboard-internal-users`) reference `flowType` only inside flow-definition JSON posted to `/flows` (management API), never a `/flow/execute` initiation — no change needed.
- The JavaScript embedded SDK flow docs complete with an assertion (app-native model, non-`authorization_code` app), so direct initiation remains correct.
- `apis.mdx` renders the auto-generated OpenAPI reference; the new `403`/`FES-1011` response belongs in the OpenAPI spec, not in docs content.

### Related Issues
- Refs #3289

### Related PRs
- #3289

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided.
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided.
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes.
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.