### PR TITLE
Improve Magiclink efficiency by stopping JWT decoding twice

### DIFF
--- a/backend/internal/authn/magiclink/constants.go
+++ b/backend/internal/authn/magiclink/constants.go
@@ -24,4 +24,16 @@ const (
 
 	// tokenAudience is the audience claim for magic link tokens.
 	tokenAudience = "magiclink-svc"
+
+	// ClaimMagicLinkUsedJti is the authenticated claim key for the used magic link JTI.
+	ClaimMagicLinkUsedJti = "magicLinkUsedJti"
+
+	// CredentialKeyUsedJti is the credential map key for the magic link used JTI.
+	CredentialKeyUsedJti = "usedJti"
+
+	// CredentialKeyToken is the credential map key for the magic link token.
+	CredentialKeyToken = "token"
+
+	// CredentialKeySubjectAttribute is the credential map key for the magic link subject attribute.
+	CredentialKeySubjectAttribute = "subjectAttribute"
 )

--- a/backend/internal/authn/magiclink/service.go
+++ b/backend/internal/authn/magiclink/service.go
@@ -30,7 +30,6 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/log"
-	"github.com/thunder-id/thunderid/internal/system/utils"
 )
 
 // MagicLinkAuthnServiceInterface defines the interface for magic link authentication operations.
@@ -43,8 +42,8 @@ type MagicLinkAuthnServiceInterface interface {
 		additionalClaims map[string]interface{},
 		magicLinkURL string,
 	) (string, *tidcommon.ServiceError)
-	Authenticate(ctx context.Context, token string,
-		subjectAttribute string) (*common.AuthnResult, *tidcommon.ServiceError)
+	Authenticate(ctx context.Context, token string, nonce string,
+		usedJTI string, subjectAttribute string) (*common.AuthnResult, *tidcommon.ServiceError)
 }
 
 // magicLinkAuthnService is the default implementation of MagicLinkAuthnServiceInterface.
@@ -115,7 +114,8 @@ func (s *magicLinkAuthnService) GenerateMagicLink(ctx context.Context,
 // A missing local user is NOT an error — the result carries VerifiedIdentifiers instead,
 // allowing callers to handle registration flows.
 func (s *magicLinkAuthnService) Authenticate(ctx context.Context,
-	token string, subjectAttribute string) (*common.AuthnResult, *tidcommon.ServiceError) {
+	token string, nonce string, usedJTI string,
+	subjectAttribute string) (*common.AuthnResult, *tidcommon.ServiceError) {
 	s.logger.Debug(ctx, "Authenticating with magic link token")
 
 	token = strings.TrimSpace(token)
@@ -127,9 +127,32 @@ func (s *magicLinkAuthnService) Authenticate(ctx context.Context,
 		return nil, svcErr
 	}
 
-	subject, svcErr := s.extractSubject(ctx, token)
-	if svcErr != nil {
-		return nil, svcErr
+	payload, decodeErr := jwt.DecodeJWTPayload(token)
+	if decodeErr != nil {
+		s.logger.Debug(ctx, "Failed to decode magic link token payload", log.Error(decodeErr))
+		return nil, &ErrorInvalidToken
+	}
+
+	tokenNonce, ok := payload["nonce"].(string)
+	if !ok || tokenNonce == "" || (nonce != "" && tokenNonce != nonce) {
+		s.logger.Debug(ctx, "Magic link token nonce claim missing, invalid, or mismatched")
+		return nil, &ErrorInvalidToken
+	}
+
+	jtiClaim, ok := payload["jti"].(string)
+	if !ok || jtiClaim == "" {
+		s.logger.Debug(ctx, "Magic link token jti claim missing or invalid")
+		return nil, &ErrorInvalidToken
+	}
+	if usedJTI != "" && usedJTI == jtiClaim {
+		s.logger.Debug(ctx, "Magic link token has already been used", log.String("jti", jtiClaim))
+		return nil, &ErrorInvalidToken
+	}
+
+	subject, ok := payload["sub"].(string)
+	if !ok || subject == "" {
+		s.logger.Debug(ctx, "Subject claim not found or invalid")
+		return nil, &ErrorMalformedTokenClaims
 	}
 
 	subjectAttribute = strings.TrimSpace(subjectAttribute)
@@ -142,8 +165,11 @@ func (s *magicLinkAuthnService) Authenticate(ctx context.Context,
 		log.MaskedString("subject", subject))
 
 	return &common.AuthnResult{
-		Token:               map[string]interface{}{subjectAttribute: subject},
-		AuthenticatedClaims: map[string]interface{}{subjectAttribute: subject},
+		Token: map[string]interface{}{subjectAttribute: subject},
+		AuthenticatedClaims: map[string]interface{}{
+			subjectAttribute:      subject,
+			ClaimMagicLinkUsedJti: jtiClaim,
+		},
 	}, nil
 }
 
@@ -159,24 +185,6 @@ func (s *magicLinkAuthnService) verifyToken(ctx context.Context, token string) *
 		return &ErrorInvalidToken
 	}
 	return nil
-}
-
-// extractSubject retrieves the subject claim from the JWT token payload and returns it as a string.
-// along with any service errors encountered during decoding or extraction.
-func (s *magicLinkAuthnService) extractSubject(ctx context.Context, token string) (string, *tidcommon.ServiceError) {
-	payload, decodeErr := jwt.DecodeJWTPayload(token)
-	if decodeErr != nil {
-		s.logger.Debug(ctx, "Failed to decode magic link token payload", log.Error(decodeErr))
-		return "", &ErrorInvalidToken
-	}
-
-	subject := utils.ConvertInterfaceValueToString(payload["sub"])
-	if subject == "" {
-		s.logger.Debug(ctx, "Subject claim not found or invalid")
-		return "", &ErrorMalformedTokenClaims
-	}
-
-	return subject, nil
 }
 
 // buildMagicLinkURL constructs a magic link URL by appending query parameters to a base URL or default configuration.

--- a/backend/internal/authn/magiclink/service_test.go
+++ b/backend/internal/authn/magiclink/service_test.go
@@ -21,7 +21,7 @@ package magiclink
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
+	"encoding/json"
 	"net/url"
 	"sync"
 	"testing"
@@ -45,27 +45,31 @@ const (
 	testIssuedAt    = int64(1609459200)
 )
 
-// testValidJWT is a valid JWT with recipient and user_id in the standard subclaim.
-// nolint:gosec // G101: test data, not a real secret
-var testValidJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-	"eyJyZWNpcGllbnQiOiJ0ZXN0QGV4YW1wbGUuY29tIiwic3ViIjoidXNlci0xMjMifQ." +
-	"test-signature"
-
-var testMissingSubJWT = "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9." +
-	"eyJyZWNpcGllbnQiOiAidGVzdEBleGFtcGxlLmNvbSJ9." +
-	"test-signature"
-
 var (
 	testUserID   = "user-123"
 	runtimeMutex sync.Mutex
 )
 
-func createMagicLinkJWTWithSubject(subject string) string {
+func createMagicLinkJWTWithClaims(subject, executionID, jti string) string {
+	payloadMap := make(map[string]interface{})
+	if subject != "" {
+		payloadMap["sub"] = subject
+	}
+	if executionID != "" {
+		payloadMap["nonce"] = executionID
+	}
+	if jti != "" {
+		payloadMap["jti"] = jti
+	}
+	return createMagicLinkJWTWithRawPayload(payloadMap)
+}
+
+func createMagicLinkJWTWithRawPayload(payloadMap map[string]interface{}) string {
 	header := `{"alg":"HS256","typ":"JWT"}`
-	payload := fmt.Sprintf(`{"sub":%q}`, subject)
+	payloadBytes, _ := json.Marshal(payloadMap)
 
 	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(header))
-	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadBytes)
 
 	return headerB64 + "." + payloadB64 + ".test-signature"
 }
@@ -172,7 +176,7 @@ func (suite *MagicLinkServiceTestSuite) TestGenerateMagicLinkJWTGenerationError(
 }
 
 func (suite *MagicLinkServiceTestSuite) TestAuthenticateEmptyToken() {
-	result, err := suite.service.Authenticate(context.Background(), "", "")
+	result, err := suite.service.Authenticate(context.Background(), "", "", "", "")
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidToken.Code, err.Code)
@@ -184,7 +188,7 @@ func (suite *MagicLinkServiceTestSuite) TestAuthenticateExpiredToken() {
 	}
 	suite.mockJWTService.On("VerifyJWT", mock.Anything, testToken, tokenAudience, mock.Anything).Return(expiredErr)
 
-	result, err := suite.service.Authenticate(context.Background(), testToken, "")
+	result, err := suite.service.Authenticate(context.Background(), testToken, testExecutionID, "", "")
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorExpiredToken.Code, err.Code)
@@ -196,20 +200,22 @@ func (suite *MagicLinkServiceTestSuite) TestAuthenticateInvalidToken() {
 			Code: "JWT_INVALID",
 		})
 
-	result, err := suite.service.Authenticate(context.Background(), testToken, "")
+	result, err := suite.service.Authenticate(context.Background(), testToken, testExecutionID, "", "")
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidToken.Code, err.Code)
 }
 
 func (suite *MagicLinkServiceTestSuite) TestAuthenticateSuccess() {
-	suite.mockJWTService.On("VerifyJWT", mock.Anything, testValidJWT, tokenAudience, mock.Anything).Return(nil)
+	testJWT := createMagicLinkJWTWithClaims(testUserID, testExecutionID, "jti-123")
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testJWT, tokenAudience, mock.Anything).Return(nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testValidJWT, "")
+	result, err := suite.service.Authenticate(context.Background(), testJWT, testExecutionID, "", "")
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(testUserID, result.Token[common.UserAttributeUserID])
 	suite.Equal(testUserID, result.AuthenticatedClaims[common.UserAttributeUserID])
+	suite.Equal("jti-123", result.AuthenticatedClaims[ClaimMagicLinkUsedJti])
 }
 
 func (suite *MagicLinkServiceTestSuite) TestAuthenticateSuccessWithSubjectAttribute() {
@@ -217,28 +223,78 @@ func (suite *MagicLinkServiceTestSuite) TestAuthenticateSuccessWithSubjectAttrib
 		workEmailAttr  = "workemail"
 		workEmailValue = "johnwork@company.lk"
 	)
-	testWorkEmailJWT := createMagicLinkJWTWithSubject(workEmailValue)
+	testWorkEmailJWT := createMagicLinkJWTWithClaims(workEmailValue, testExecutionID, "jti-work")
 	suite.mockJWTService.On("VerifyJWT", mock.Anything, testWorkEmailJWT, tokenAudience, mock.Anything).Return(nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testWorkEmailJWT, workEmailAttr)
+	result, err := suite.service.Authenticate(
+		context.Background(), testWorkEmailJWT, testExecutionID, "", workEmailAttr)
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(workEmailValue, result.Token[workEmailAttr])
 	suite.Equal(workEmailValue, result.AuthenticatedClaims[workEmailAttr])
+	suite.Equal("jti-work", result.AuthenticatedClaims[ClaimMagicLinkUsedJti])
+}
+
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateExecutionIDMismatch() {
+	testJWT := createMagicLinkJWTWithClaims(testUserID, "wrong-exec-id", "jti-123")
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testJWT, tokenAudience, mock.Anything).Return(nil)
+
+	result, err := suite.service.Authenticate(context.Background(), testJWT, testExecutionID, "", "")
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(ErrorInvalidToken.Code, err.Code)
+}
+
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateAlreadyUsedJTI() {
+	testJWT := createMagicLinkJWTWithClaims(testUserID, testExecutionID, "jti-used")
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, testJWT, tokenAudience, mock.Anything).Return(nil)
+
+	result, err := suite.service.Authenticate(context.Background(), testJWT, testExecutionID, "jti-used", "")
+	suite.Nil(result)
+	suite.NotNil(err)
+	suite.Equal(ErrorInvalidToken.Code, err.Code)
 }
 
 func (suite *MagicLinkServiceTestSuite) TestAuthenticateMissingSubjectClaim() {
+	testMissingSubJWT := createMagicLinkJWTWithClaims("", testExecutionID, "jti-nosub")
 	suite.mockJWTService.On("VerifyJWT", mock.Anything, testMissingSubJWT, tokenAudience, mock.Anything).Return(nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testMissingSubJWT, "")
+	result, err := suite.service.Authenticate(context.Background(), testMissingSubJWT, testExecutionID, "", "")
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorMalformedTokenClaims.Code, err.Code)
 }
 
-func (suite *MagicLinkServiceTestSuite) TestAuthenticateWhitespaceOnlyToken() {
-	result, err := suite.service.Authenticate(context.Background(), "   ", "")
-	suite.Nil(result)
+func (suite *MagicLinkServiceTestSuite) TestAuthenticateNonStringClaims() {
+	ctx := context.Background()
+
+	// Non-string sub claim (number)
+	tokenNonStringSub := createMagicLinkJWTWithRawPayload(map[string]interface{}{
+		"sub": 12345, "nonce": testExecutionID, "jti": "jti-1",
+	})
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, tokenNonStringSub, tokenAudience, mock.Anything).Return(nil)
+	res, err := suite.service.Authenticate(ctx, tokenNonStringSub, testExecutionID, "", "")
+	suite.Nil(res)
+	suite.NotNil(err)
+	suite.Equal(ErrorMalformedTokenClaims.Code, err.Code)
+
+	// Non-string nonce claim (boolean)
+	tokenNonStringNonce := createMagicLinkJWTWithRawPayload(map[string]interface{}{
+		"sub": testUserID, "nonce": true, "jti": "jti-2",
+	})
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, tokenNonStringNonce, tokenAudience, mock.Anything).Return(nil)
+	res, err = suite.service.Authenticate(ctx, tokenNonStringNonce, testExecutionID, "", "")
+	suite.Nil(res)
+	suite.NotNil(err)
+	suite.Equal(ErrorInvalidToken.Code, err.Code)
+
+	// Non-string jti claim (number)
+	tokenNonStringJTI := createMagicLinkJWTWithRawPayload(map[string]interface{}{
+		"sub": testUserID, "nonce": testExecutionID, "jti": 999,
+	})
+	suite.mockJWTService.On("VerifyJWT", mock.Anything, tokenNonStringJTI, tokenAudience, mock.Anything).Return(nil)
+	res, err = suite.service.Authenticate(ctx, tokenNonStringJTI, testExecutionID, "", "")
+	suite.Nil(res)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidToken.Code, err.Code)
 }

--- a/backend/internal/authnprovider/defaultprovider/default_authn_provider.go
+++ b/backend/internal/authnprovider/defaultprovider/default_authn_provider.go
@@ -402,14 +402,16 @@ func (p *defaultAuthnProvider) authenticateWithMagicLink(
 		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
 			"Invalid magic link payload", "The provided magic link credential is invalid")
 	}
-	token, ok := mlCredential["token"].(string)
+	token, ok := mlCredential[magiclink.CredentialKeyToken].(string)
 	if !ok || token == "" {
 		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
 			"Invalid magic link payload", "token is required")
 	}
-	subjectAttribute, _ := mlCredential["subjectAttribute"].(string)
+	nonce, _ := mlCredential["nonce"].(string)
+	usedJTI, _ := mlCredential[magiclink.CredentialKeyUsedJti].(string)
+	subjectAttribute, _ := mlCredential[magiclink.CredentialKeySubjectAttribute].(string)
 
-	result, authErr := p.magicLinkService.Authenticate(ctx, token, subjectAttribute)
+	result, authErr := p.magicLinkService.Authenticate(ctx, token, nonce, usedJTI, subjectAttribute)
 	if authErr != nil {
 		if authErr.Type == tidcommon.ClientErrorType {
 			return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,

--- a/backend/internal/authnprovider/defaultprovider/default_authn_provider_test.go
+++ b/backend/internal/authnprovider/defaultprovider/default_authn_provider_test.go
@@ -908,7 +908,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_MagicLink_Authentic
 		},
 	}
 
-	mockML.On("Authenticate", mock.Anything, "expired-token", "").
+	mockML.On("Authenticate", mock.Anything, "expired-token", "", "", "").
 		Return(nil, &tidcommon.ServiceError{
 			Type:             tidcommon.ClientErrorType,
 			Code:             "AUTHN-ML-1002",
@@ -933,7 +933,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_MagicLink_ServerErr
 		},
 	}
 
-	mockML.On("Authenticate", mock.Anything, "valid-token", "").
+	mockML.On("Authenticate", mock.Anything, "valid-token", "", "", "").
 		Return(nil, &tidcommon.ServiceError{
 			Type:             tidcommon.ServerErrorType,
 			Code:             "INTERNAL",
@@ -1001,7 +1001,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_TokenizedAuth_Entit
 	setupMagicLink := func() (authnprovider.AuthnProviderInterface, map[string]interface{}, map[string]interface{}) {
 		mockML := magiclinkmock.NewMagicLinkAuthnServiceInterfaceMock(suite.T())
 		token := map[string]interface{}{"email": "test@example.com"}
-		mockML.On("Authenticate", mock.Anything, "valid-jwt-token", "").
+		mockML.On("Authenticate", mock.Anything, "valid-jwt-token", "", "", "").
 			Return(&authncommon.AuthnResult{
 				Token:               token,
 				AuthenticatedClaims: map[string]interface{}{"email": "test@example.com"},
@@ -1070,7 +1070,7 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_TokenizedAuth_Ident
 	setupMagicLink := func() (authnprovider.AuthnProviderInterface, map[string]interface{}, map[string]interface{}) {
 		mockML := magiclinkmock.NewMagicLinkAuthnServiceInterfaceMock(suite.T())
 		token := map[string]interface{}{"email": "test@example.com"}
-		mockML.On("Authenticate", mock.Anything, "valid-jwt-token", "email").
+		mockML.On("Authenticate", mock.Anything, "valid-jwt-token", "", "", "email").
 			Return(&authncommon.AuthnResult{
 				Token:               token,
 				AuthenticatedClaims: map[string]interface{}{"email": "test@example.com"},

--- a/backend/internal/flow/executor/magic_link_executor.go
+++ b/backend/internal/flow/executor/magic_link_executor.go
@@ -31,7 +31,6 @@ import (
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
-	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )
@@ -198,7 +197,7 @@ func (m *magicLinkExecutor) InitiateMagicLink(ctx *providers.NodeContext,
 		subject = userID
 	}
 
-	claims := map[string]interface{}{"executionId": ctx.ExecutionID}
+	claims := map[string]interface{}{"nonce": ctx.ExecutionID}
 
 	expirySeconds := m.getTokenExpiry(ctx)
 	magicLinkURL := m.getMagicLinkURL(ctx)
@@ -330,8 +329,10 @@ func (m *magicLinkExecutor) executeVerify(ctx *providers.NodeContext) (*provider
 
 	creds := map[string]interface{}{
 		"magiclink": map[string]interface{}{
-			"token":            token,
-			"subjectAttribute": subjectAttribute,
+			magiclink.CredentialKeyToken:            token,
+			"nonce":                                ctx.ExecutionID,
+			magiclink.CredentialKeyUsedJti:          ctx.RuntimeData[common.RuntimeKeyMagicLinkUsedJti],
+			magiclink.CredentialKeySubjectAttribute: subjectAttribute,
 		},
 	}
 
@@ -350,46 +351,9 @@ func (m *magicLinkExecutor) executeVerify(ctx *providers.NodeContext) (*provider
 		execResp.RuntimeData[key] = utils.ConvertInterfaceValueToString(value)
 	}
 
-	tokenJTI, execErr := m.validateFlowClaims(ctx, token, logger)
-	if execErr != nil {
-		execResp.Status = providers.ExecFailure
-		execResp.Error = execErr
-		return execResp, nil
-	}
-	execResp.RuntimeData[common.RuntimeKeyMagicLinkUsedJti] = tokenJTI
-
 	execResp.Status = providers.ExecComplete
 	logger.Debug(ctx.Context, "Magic link verify completed successfully")
 	return execResp, nil
-}
-
-// validateFlowClaims checks executionId and JTI claims in the magic link JWT token.
-// These are flow-specific concerns and not part of the auth provider contract.
-func (m *magicLinkExecutor) validateFlowClaims(ctx *providers.NodeContext,
-	token string, logger *log.Logger) (string, *tidcommon.ServiceError) {
-	payload, decodeErr := jwt.DecodeJWTPayload(token)
-	if decodeErr != nil {
-		logger.Debug(ctx.Context, "Failed to decode magic link token", log.Error(decodeErr))
-		return "", &ErrInvalidMagicLinkToken
-	}
-
-	executionIDClaim := utils.ConvertInterfaceValueToString(payload["executionId"])
-	if executionIDClaim == "" || executionIDClaim != ctx.ExecutionID {
-		logger.Debug(ctx.Context, "Magic link token executionId mismatch")
-		return "", &ErrInvalidMagicLinkToken
-	}
-
-	jtiClaim := utils.ConvertInterfaceValueToString(payload["jti"])
-	if jtiClaim == "" {
-		return "", &ErrInvalidMagicLinkToken
-	}
-	if usedJti, exists := ctx.RuntimeData[common.RuntimeKeyMagicLinkUsedJti]; exists && usedJti == jtiClaim {
-		logger.Debug(ctx.Context, "Magic link token has already been used", log.String("jti", jtiClaim))
-		return "", &ErrInvalidMagicLinkToken
-	}
-
-	logger.Debug(ctx.Context, "Magic link token validated successfully")
-	return jtiClaim, nil
 }
 
 // resolveDestinationAttribute infers the destination attribute from the first configured node input.

--- a/backend/internal/flow/executor/magic_link_executor_test.go
+++ b/backend/internal/flow/executor/magic_link_executor_test.go
@@ -35,7 +35,6 @@ import (
 	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/flow/common"
-	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/magiclinkmock"
 	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
 	"github.com/thunder-id/thunderid/tests/mocks/entityprovidermock"
@@ -61,10 +60,10 @@ func newMagicLinkAuthenticatedUser() providers.AuthUser {
 	return authUser
 }
 
-// createTestJWTWithClaims creates a test JWT string with the given executionId and jti
-func createTestJWTWithClaims(executionID, jti string) string {
+// createTestJWTWithClaims creates a test JWT string with the default executionId and given jti
+func createTestJWTWithClaims(jti string) string {
 	header := magicLinkTestJWTHeader
-	payload := fmt.Sprintf(`{"sub":"user-123","executionId":%q,"jti":%q,"exp":9999999999}`, executionID, jti)
+	payload := fmt.Sprintf(`{"sub":"user-123","nonce":%q,"jti":%q,"exp":9999999999}`, magicLinkTestExecutionID, jti)
 
 	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(header))
 	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
@@ -75,7 +74,7 @@ func createTestJWTWithClaims(executionID, jti string) string {
 func createRegistrationMagicLinkJWT(executionID, jti, subject string) string {
 	header := magicLinkTestJWTHeader
 	payload := fmt.Sprintf(
-		`{"sub":%q,"email":%q,"registration":true,"executionId":%q,"jti":%q,"exp":9999999999}`,
+		`{"sub":%q,"email":%q,"registration":true,"nonce":%q,"jti":%q,"exp":9999999999}`,
 		subject, subject, executionID, jti)
 
 	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(header))
@@ -193,7 +192,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_Success_Authen
 			"applicationId": magicLinkTestAppID,
 			"type":          "AUTHENTICATION",
 		},
-		map[string]interface{}{"executionId": magicLinkTestExecutionID}, "").Return(
+		map[string]interface{}{"nonce": magicLinkTestExecutionID}, "").Return(
 		"https://example.com/verify?id=flow-123&token=jwt-token-123", nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -235,7 +234,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_Success_Regist
 			"applicationId": magicLinkTestAppID,
 			"type":          "REGISTRATION"},
 		map[string]interface{}{
-			"executionId": magicLinkTestExecutionID,
+			"nonce": magicLinkTestExecutionID,
 		}, "").Return(
 		"https://example.com/verify?id=flow-123&token=jwt-token-123", nil)
 
@@ -281,7 +280,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_Success_Regist
 			"applicationId": magicLinkTestAppID,
 			"type":          "REGISTRATION"},
 		map[string]interface{}{
-			"executionId": magicLinkTestExecutionID,
+			"nonce": magicLinkTestExecutionID,
 		}, "").Return(
 		"https://example.com/verify?id=flow-123&token=jwt-token-123", nil)
 
@@ -355,7 +354,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_Success_WithCu
 			"applicationId": magicLinkTestAppID,
 			"type":          "AUTHENTICATION",
 		},
-		map[string]interface{}{"executionId": magicLinkTestExecutionID}, "").Return(
+		map[string]interface{}{"nonce": magicLinkTestExecutionID}, "").Return(
 		"https://example.com/verify?id=flow-123&token=jwt-token-123", nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -397,7 +396,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_Success_WithCu
 			"applicationId": magicLinkTestAppID,
 			"type":          "AUTHENTICATION",
 		},
-		map[string]interface{}{"executionId": magicLinkTestExecutionID},
+		map[string]interface{}{"nonce": magicLinkTestExecutionID},
 		magicLinkTestMagicLinkURL).Return(magicLinkTestMagicLinkURL+"?id=flow-123&token=jwt-token-123", nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -431,7 +430,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_Failure_Genera
 			"applicationId": magicLinkTestAppID,
 			"type":          "AUTHENTICATION",
 		},
-		map[string]interface{}{"executionId": magicLinkTestExecutionID}, "").Return(
+		map[string]interface{}{"nonce": magicLinkTestExecutionID}, "").Return(
 		"", &tidcommon.ServiceError{Code: tidcommon.InternalServerError.Code})
 
 	resp, err := suite.executor.Execute(ctx)
@@ -472,7 +471,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_Failure_Client
 			"applicationId": magicLinkTestAppID,
 			"type":          "AUTHENTICATION",
 		},
-		map[string]interface{}{"executionId": magicLinkTestExecutionID}, "").
+		map[string]interface{}{"nonce": magicLinkTestExecutionID}, "").
 		Return("", clientErr)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -542,7 +541,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_Success_WithAu
 			"applicationId": magicLinkTestAppID,
 			"type":          "AUTHENTICATION",
 		},
-		map[string]interface{}{"executionId": magicLinkTestExecutionID}, "").Return(
+		map[string]interface{}{"nonce": magicLinkTestExecutionID}, "").Return(
 		"https://example.com/verify?id=flow-123&token=jwt-token-123", nil)
 
 	resp, err := suite.executor.Execute(ctx)
@@ -558,7 +557,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_Success_WithAu
 // Test Verify Mode
 
 func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Success() {
-	testToken := createTestJWTWithClaims(magicLinkTestExecutionID, "jti-success")
+	testToken := createTestJWTWithClaims("jti-success")
 
 	ctx := &providers.NodeContext{
 		Context:      context.Background(),
@@ -576,7 +575,9 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Success() {
 	authenticatedAuthUser := newMagicLinkAuthenticatedUser()
 	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return(
-		authenticatedAuthUser, providers.AuthenticatedClaims{}, (*tidcommon.ServiceError)(nil))
+		authenticatedAuthUser, providers.AuthenticatedClaims{
+			common.RuntimeKeyMagicLinkUsedJti: "jti-success",
+		}, (*tidcommon.ServiceError)(nil))
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -606,7 +607,9 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Success_Registra
 
 	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return(
-		providers.AuthUser{}, providers.AuthenticatedClaims{}, (*tidcommon.ServiceError)(nil))
+		providers.AuthUser{}, providers.AuthenticatedClaims{
+			common.RuntimeKeyMagicLinkUsedJti: "jti-registration",
+		}, (*tidcommon.ServiceError)(nil))
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -635,7 +638,9 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Success_Registra
 
 	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return(
-		providers.AuthUser{}, providers.AuthenticatedClaims{}, (*tidcommon.ServiceError)(nil))
+		providers.AuthUser{}, providers.AuthenticatedClaims{
+			common.RuntimeKeyMagicLinkUsedJti: "jti-registration",
+		}, (*tidcommon.ServiceError)(nil))
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -719,7 +724,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Failure_TokenNot
 }
 
 func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Failure_InvalidToken() {
-	testToken := createTestJWTWithClaims(magicLinkTestExecutionID, "jti-invalid")
+	testToken := createTestJWTWithClaims("jti-invalid")
 
 	ctx := &providers.NodeContext{
 		Context:      context.Background(),
@@ -751,7 +756,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Failure_InvalidT
 }
 
 func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Failure_ReplayAttack() {
-	testToken := createTestJWTWithClaims(magicLinkTestExecutionID, "jti-replay")
+	testToken := createTestJWTWithClaims("jti-replay")
 
 	ctx := &providers.NodeContext{
 		Context:      context.Background(),
@@ -768,18 +773,27 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Failure_ReplayAt
 
 	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return(
-		providers.AuthUser{}, providers.AuthenticatedClaims{}, (*tidcommon.ServiceError)(nil))
+		providers.AuthUser{}, (providers.AuthenticatedClaims)(nil),
+		&tidcommon.ServiceError{
+			Type: tidcommon.ClientErrorType,
+			Code: authnprovidermgr.ErrorAuthenticationFailed.Code,
+			ErrorDescription: tidcommon.I18nMessage{
+				DefaultValue: ErrInvalidMagicLinkToken.ErrorDescription.DefaultValue,
+			},
+		})
 
 	resp, err := suite.executor.Execute(ctx)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
-	assert.Equal(suite.T(), ErrInvalidMagicLinkToken.Error.DefaultValue, resp.Error.Error.DefaultValue)
+	assert.Equal(suite.T(), ErrInvalidMagicLinkToken.ErrorDescription.DefaultValue,
+		resp.Error.ErrorDescription.DefaultValue)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
 func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Success_ReplacesStoredJTI() {
-	testToken := createTestJWTWithClaims(magicLinkTestExecutionID, "jti-new")
+	testToken := createTestJWTWithClaims("jti-new")
 
 	ctx := &providers.NodeContext{
 		Context:      context.Background(),
@@ -798,7 +812,9 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Success_Replaces
 	authenticatedAuthUser := newMagicLinkAuthenticatedUser()
 	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).Return(
-		authenticatedAuthUser, providers.AuthenticatedClaims{}, (*tidcommon.ServiceError)(nil))
+		authenticatedAuthUser, providers.AuthenticatedClaims{
+			common.RuntimeKeyMagicLinkUsedJti: "jti-new",
+		}, (*tidcommon.ServiceError)(nil))
 
 	resp, err := suite.executor.Execute(ctx)
 
@@ -810,7 +826,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Success_Replaces
 }
 
 func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Failure_AuthenticateUserServerError() {
-	testToken := createTestJWTWithClaims(magicLinkTestExecutionID, "jti-server-error")
+	testToken := createTestJWTWithClaims("jti-server-error")
 
 	ctx := &providers.NodeContext{
 		Context:      context.Background(),
@@ -1095,7 +1111,7 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_RegistrationFl
 			"type":          "REGISTRATION",
 		},
 		map[string]interface{}{
-			"executionId": magicLinkTestExecutionID,
+			"nonce": magicLinkTestExecutionID,
 		}, "").Return(
 		"https://example.com/verify?id=flow-123&token=jwt-token-123", nil)
 
@@ -1106,52 +1122,6 @@ func (suite *MagicLinkExecutorTestSuite) TestExecute_GenerateMode_RegistrationFl
 	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
 	suite.mockEntityProvider.AssertExpectations(suite.T())
 	suite.mockMagicLinkService.AssertExpectations(suite.T())
-}
-
-func (suite *MagicLinkExecutorTestSuite) TestValidateFlowClaims_FlowIdMismatch() {
-	token := createTestJWTWithClaims("wrong-flow-id", "test-jti-123")
-	ctx := &providers.NodeContext{
-		Context:     context.Background(),
-		ExecutionID: magicLinkTestExecutionID,
-		RuntimeData: make(map[string]string),
-	}
-
-	logger := log.GetLogger()
-	tokenJTI, failure := suite.executor.validateFlowClaims(ctx, token, logger)
-
-	suite.Empty(tokenJTI)
-	suite.Equal(ErrInvalidMagicLinkToken.Error.DefaultValue, failure.Error.DefaultValue)
-}
-
-func (suite *MagicLinkExecutorTestSuite) TestValidateFlowClaims_ReplayAttack() {
-	token := createTestJWTWithClaims(magicLinkTestExecutionID, "test-jti-123")
-	ctx := &providers.NodeContext{
-		Context:     context.Background(),
-		ExecutionID: magicLinkTestExecutionID,
-		RuntimeData: map[string]string{common.RuntimeKeyMagicLinkUsedJti: "test-jti-123"},
-	}
-
-	logger := log.GetLogger()
-	tokenJTI, failure := suite.executor.validateFlowClaims(ctx, token, logger)
-
-	suite.Empty(tokenJTI)
-	suite.Equal(ErrInvalidMagicLinkToken.Error.DefaultValue, failure.Error.DefaultValue)
-}
-
-func (suite *MagicLinkExecutorTestSuite) TestValidateFlowClaims_NewTokenReturnsJTI() {
-	newToken := createTestJWTWithClaims(magicLinkTestExecutionID, "new-jti-456")
-	ctx := &providers.NodeContext{
-		Context:     context.Background(),
-		ExecutionID: magicLinkTestExecutionID,
-		RuntimeData: map[string]string{common.RuntimeKeyMagicLinkUsedJti: "old-jti-123"},
-	}
-
-	logger := log.GetLogger()
-	tokenJTI, failure := suite.executor.validateFlowClaims(ctx, newToken, logger)
-
-	suite.Equal("new-jti-456", tokenJTI)
-	suite.Nil(failure)
-	suite.Equal("old-jti-123", ctx.RuntimeData[common.RuntimeKeyMagicLinkUsedJti])
 }
 
 func (suite *MagicLinkExecutorTestSuite) TestCreateRegistrationMagicLinkJWT_Helper() {
@@ -1166,54 +1136,42 @@ func (suite *MagicLinkExecutorTestSuite) TestCreateRegistrationMagicLinkJWT_Help
 	suite.Contains(token, ".", "Generated token should contain JWT separators")
 }
 
-func (suite *MagicLinkExecutorTestSuite) TestValidateFlowClaims_DecodeFailure() {
-	// Pass a completely malformed token string
-	// nolint:gosec // G101: Test data for negative case, not a real credential
-	token := "not.a.valid.jwt.format"
+func (suite *MagicLinkExecutorTestSuite) TestExecute_VerifyMode_Failure_InvalidTokenFormat() {
+	// nolint:gosec // test data for negative test case
+	testToken := "invalid.jwt.format"
 
 	ctx := &providers.NodeContext{
-		Context:     context.Background(),
-		ExecutionID: magicLinkTestExecutionID,
+		Context:      context.Background(),
+		ExecutionID:  magicLinkTestExecutionID,
+		FlowType:     providers.FlowTypeAuthentication,
+		ExecutorMode: ExecutorModeVerify,
+		UserInputs: map[string]string{
+			userInputMagicLinkToken: testToken,
+		},
 		RuntimeData: make(map[string]string),
 	}
 
-	logger := log.GetLogger()
-	tokenJTI, failure := suite.executor.validateFlowClaims(ctx, token, logger)
+	suite.mockAuthnProvider.On("AuthenticateUser", ctx.Context, mock.Anything,
+		mock.MatchedBy(func(creds map[string]interface{}) bool {
+			ml, ok := creds["magiclink"].(map[string]interface{})
+			return ok && ml["token"] == testToken && ml["nonce"] == ctx.ExecutionID &&
+				ml["usedJti"] == ctx.RuntimeData[common.RuntimeKeyMagicLinkUsedJti]
+		}), mock.Anything, mock.Anything, mock.Anything).Return(
+		providers.AuthUser{}, (providers.AuthenticatedClaims)(nil),
+		&tidcommon.ServiceError{
+			Type: tidcommon.ClientErrorType,
+			Code: authnprovidermgr.ErrorAuthenticationFailed.Code,
+			ErrorDescription: tidcommon.I18nMessage{
+				DefaultValue: ErrInvalidMagicLinkToken.ErrorDescription.DefaultValue,
+			},
+		})
 
-	suite.Empty(tokenJTI)
-	suite.Equal(ErrInvalidMagicLinkToken.Error.DefaultValue, failure.Error.DefaultValue)
-}
+	resp, err := suite.executor.Execute(ctx)
 
-func (suite *MagicLinkExecutorTestSuite) TestValidateFlowClaims_MissingJTI() {
-	header := magicLinkTestJWTHeader
-	payload := fmt.Sprintf(`{"sub":"user-123","executionId":%q,"exp":9999999999}`, magicLinkTestExecutionID)
-
-	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(header))
-	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
-	token := headerB64 + "." + payloadB64 + ".test-signature"
-
-	ctx := &providers.NodeContext{
-		Context:     context.Background(),
-		ExecutionID: magicLinkTestExecutionID,
-		RuntimeData: make(map[string]string),
-	}
-
-	logger := log.GetLogger()
-	tokenJTI, failure := suite.executor.validateFlowClaims(ctx, token, logger)
-
-	suite.Empty(tokenJTI)
-	suite.Equal(ErrInvalidMagicLinkToken.Error.DefaultValue, failure.Error.DefaultValue)
-}
-
-func (suite *MagicLinkExecutorTestSuite) TestGetExecutionPolicy() {
-	policyVerify := suite.executor.GetExecutionPolicy(ExecutorModeVerify)
-	suite.NotNil(policyVerify)
-	suite.True(policyVerify.SkipChallengeValidation)
-	suite.False(policyVerify.AllowSegmentRestart)
-
-	policyGenerate := suite.executor.GetExecutionPolicy(ExecutorModeGenerate)
-	suite.Nil(policyGenerate)
-
-	policyUnknown := suite.executor.GetExecutionPolicy("unknown")
-	suite.Nil(policyUnknown)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), ErrInvalidMagicLinkToken.ErrorDescription.DefaultValue,
+		resp.Error.ErrorDescription.DefaultValue)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }

--- a/backend/tests/mocks/authn/magiclinkmock/MagicLinkAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/magiclinkmock/MagicLinkAuthnServiceInterface_mock.go
@@ -40,8 +40,8 @@ func (_m *MagicLinkAuthnServiceInterfaceMock) EXPECT() *MagicLinkAuthnServiceInt
 }
 
 // Authenticate provides a mock function for the type MagicLinkAuthnServiceInterfaceMock
-func (_mock *MagicLinkAuthnServiceInterfaceMock) Authenticate(ctx context.Context, token string, subjectAttribute string) (*common.AuthnResult, *common0.ServiceError) {
-	ret := _mock.Called(ctx, token, subjectAttribute)
+func (_mock *MagicLinkAuthnServiceInterfaceMock) Authenticate(ctx context.Context, token string, nonce string, usedJTI string, subjectAttribute string) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, token, nonce, usedJTI, subjectAttribute)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Authenticate")
@@ -49,18 +49,18 @@ func (_mock *MagicLinkAuthnServiceInterfaceMock) Authenticate(ctx context.Contex
 
 	var r0 *common.AuthnResult
 	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.AuthnResult, *common0.ServiceError)); ok {
-		return returnFunc(ctx, token, subjectAttribute)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, token, nonce, usedJTI, subjectAttribute)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.AuthnResult); ok {
-		r0 = returnFunc(ctx, token, subjectAttribute)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, token, nonce, usedJTI, subjectAttribute)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthnResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *common0.ServiceError); ok {
-		r1 = returnFunc(ctx, token, subjectAttribute)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, token, nonce, usedJTI, subjectAttribute)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common0.ServiceError)
@@ -77,12 +77,14 @@ type MagicLinkAuthnServiceInterfaceMock_Authenticate_Call struct {
 // Authenticate is a helper method to define mock.On call
 //   - ctx context.Context
 //   - token string
+//   - nonce string
+//   - usedJTI string
 //   - subjectAttribute string
-func (_e *MagicLinkAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, token interface{}, subjectAttribute interface{}) *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call {
-	return &MagicLinkAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, token, subjectAttribute)}
+func (_e *MagicLinkAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, token interface{}, nonce interface{}, usedJTI interface{}, subjectAttribute interface{}) *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call {
+	return &MagicLinkAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, token, nonce, usedJTI, subjectAttribute)}
 }
 
-func (_c *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, token string, subjectAttribute string)) *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, token string, nonce string, usedJTI string, subjectAttribute string)) *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -96,10 +98,20 @@ func (_c *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -110,7 +122,7 @@ func (_c *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call) Return(authnResu
 	return _c
 }
 
-func (_c *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, token string, subjectAttribute string) (*common.AuthnResult, *common0.ServiceError)) *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, token string, nonce string, usedJTI string, subjectAttribute string) (*common.AuthnResult, *common0.ServiceError)) *MagicLinkAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Fixes https://github.com/thunder-id/thunderid/issues/2592

### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
Improve Magiclink efficiency by stopping JWT decoding twice
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2592


### Related PRs
- https://github.com/thunder-id/thunderid/pull/1879

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened magic-link authentication validation by enforcing execution nonce and token JTI rules, including replay/reuse detection.
  - Updated handling of malformed or missing claims to return consistent “invalid token” style errors.
  - Improved authenticated-claims propagation so downstream flow steps reliably receive the magic-link “used JTI” value.
- **Tests**
  - Refreshed magic-link JWT test coverage and helpers to align with the updated nonce/JTI claim behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->