### PR TITLE
Block SPA creation with native flow execution

### DIFF
--- a/backend/internal/application/error_constants.go
+++ b/backend/internal/application/error_constants.go
@@ -501,4 +501,20 @@ var (
 			DefaultValue: "The provided recovery flow ID is invalid",
 		},
 	}
+	// ErrorNativeFlowNotAllowedForSPA is returned when a public client (SPA) is configured for
+	// native (embedded) flow execution instead of a redirect-based authorization_code flow.
+	ErrorNativeFlowNotAllowedForSPA = serviceerror.ServiceError{
+		Type: serviceerror.ClientErrorType,
+		Code: "APP-1037",
+		Error: core.I18nMessage{
+			Key:          "error.applicationservice.native_flow_not_allowed_for_spa",
+			DefaultValue: "Native flow execution is not allowed for single-page applications",
+		},
+		ErrorDescription: core.I18nMessage{
+			Key: "error.applicationservice.native_flow_not_allowed_for_spa_description",
+			DefaultValue: "Single-page applications (public clients) must use the authorization_code grant type " +
+				"with PKCE for redirect-based flows. Direct (native) flow execution is not supported for " +
+				"browser-based single-page applications.",
+		},
+	}
 )

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -1006,6 +1006,13 @@ func validateOAuthParamsForCreateAndUpdate(app *model.ApplicationDTO) (*inboundm
 	if len(oauthAppConfig.GrantTypes) == 0 {
 		oauthAppConfig.GrantTypes = []oauth2const.GrantType{oauth2const.GrantTypeAuthorizationCode}
 	}
+	// Browser-based SPAs (public clients) must use the redirect-based authorization_code flow.
+	// A public client without the authorization_code grant is configured for direct (native)
+	// flow execution, which is not permitted for single-page applications.
+	if oauthAppConfig.PublicClient &&
+		!slices.Contains(oauthAppConfig.GrantTypes, oauth2const.GrantTypeAuthorizationCode) {
+		return nil, &ErrorNativeFlowNotAllowedForSPA
+	}
 	if len(oauthAppConfig.ResponseTypes) == 0 {
 		if slices.Contains(oauthAppConfig.GrantTypes, oauth2const.GrantTypeAuthorizationCode) {
 			oauthAppConfig.ResponseTypes = []oauth2const.ResponseType{oauth2const.ResponseTypeCode}

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -1275,6 +1275,29 @@ func (suite *ServiceTestSuite) TestValidateOAuthParamsForCreateAndUpdate_PublicC
 	assert.True(suite.T(), result.OAuthConfig.PublicClient)
 }
 
+func (suite *ServiceTestSuite) TestValidateOAuthParamsForCreateAndUpdate_PublicClientNativeFlowRejected() {
+	app := &model.ApplicationDTO{
+		Name: "Test App",
+		OUID: testOUID,
+		InboundAuthConfig: []inboundmodel.InboundAuthConfigWithSecret{
+			{
+				Type: inboundmodel.OAuthInboundAuthType,
+				OAuthConfig: &inboundmodel.OAuthConfigWithSecret{
+					GrantTypes:              []oauth2const.GrantType{oauth2const.GrantTypeClientCredentials},
+					TokenEndpointAuthMethod: oauth2const.TokenEndpointAuthMethodNone,
+					PublicClient:            true,
+				},
+			},
+		},
+	}
+
+	result, svcErr := validateOAuthParamsForCreateAndUpdate(app)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), svcErr)
+	assert.Equal(suite.T(), ErrorNativeFlowNotAllowedForSPA.Code, svcErr.Code)
+}
+
 func (suite *ServiceTestSuite) TestValidateApplication_StoreErrorNonNotFound() {
 	service, _ := suite.setupTestService()
 

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -223,6 +223,8 @@ var defaultMessages = map[string]string{
 	"error.applicationservice.layout_not_found_description": "The specified layout configuration does not exist",
 	"error.applicationservice.multiple_oauth_configs": "Multiple OAuth inbound auth configs are not allowed",
 	"error.applicationservice.multiple_oauth_configs_description": "An application may have at most one inbound auth config per protocol",
+	"error.applicationservice.native_flow_not_allowed_for_spa": "Native flow execution is not allowed for single-page applications",
+	"error.applicationservice.native_flow_not_allowed_for_spa_description": "Single-page applications (public clients) must use the authorization_code grant type with PKCE for redirect-based flows. Direct (native) flow execution is not supported for browser-based single-page applications.",
 	"error.applicationservice.none_auth_method_cannot_have_cert_or_secret_description": "'none' authentication method cannot have a certificate or client secret",
 	"error.applicationservice.none_auth_method_requires_public_client_description": "'none' authentication method requires the client to be a public client",
 	"error.applicationservice.pkce_requires_authorization_code_description": "PKCE can only be enabled when the authorization_code grant type is selected",

--- a/docs/content/guides/guides/applications/manage-applications.mdx
+++ b/docs/content/guides/guides/applications/manage-applications.mdx
@@ -67,6 +67,10 @@ Select the sign-in methods users will use to authenticate with this application 
 - **Redirect to <ProductName /> sign-in/sign-up handling pages** (recommended) — users are redirected to <ProductName />-hosted sign-in pages. You can customize these pages with the Flow Designer and integrate with SDKs.
 - **Embedded sign-in/sign-up components in your app** — the sign-in experience renders inside your application using <ProductName />'s UI components or APIs. No redirect occurs.
 
+:::note
+**Browser App** applications (SPAs) support only the **Redirect** approach. Because they run entirely in the browser as public clients, they cannot drive embedded (app-native) flow execution securely, so the embedded option is not offered for them. Other application types, such as **Mobile App** and **Full-stack App**, continue to support the embedded approach.
+:::
+
 **User Access** controls which user types can register with this application. Select one or more of the allowed user types (for example, **Customer** or **Person**).
 Learn more about user types in [User Types](../../users/user-types).
 

--- a/docs/content/guides/key-concepts/authentication/integration-models.mdx
+++ b/docs/content/guides/key-concepts/authentication/integration-models.mdx
@@ -48,7 +48,11 @@ App-native authentication uses the Flow Execution API to drive authentication fr
 The core principle is **shared responsibility**: <ProductName /> enforces authentication logic and policies server-side, while your application controls the user experience. Authentication flow changes, such as adding MFA or conditional steps, take effect immediately on <ProductName /> without modifying or redeploying your application. 
 
 ###  When to Use
-Choose this approach when your application must render its own authentication screens (no redirects to hosted pages) while <ProductName /> enforces authentication logic, MFA, and policies server-side. This model suits mobile apps, single-page applications, or any context where a redirect-based flow would disrupt the user experience.
+Choose this approach when your application must render its own authentication screens (no redirects to hosted pages) while <ProductName /> enforces authentication logic, MFA, and policies server-side. This model suits native mobile and desktop apps, or confidential server-side applications, where the client can be trusted to drive the flow directly.
+
+:::warning
+App-native flow execution is **not supported for browser-based single-page applications (SPAs)** such as React, Angular, or Vue apps. SPAs are public clients that cannot be verified when calling the Flow Execution API directly, so they must use the [Redirect-Based](#redirect-based) model with the OAuth 2.0 Authorization Code grant and PKCE.
+:::
 
 ### Key Features
 

--- a/frontend/apps/console/src/features/applications/components/create-application/ConfigureExperience.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/ConfigureExperience.tsx
@@ -56,6 +56,13 @@ export interface ConfigureExperienceProps {
   onApproachChange: (approach: ApplicationCreateFlowSignInApproach) => void;
 
   /**
+   * Whether the embedded (native) sign-in approach is allowed. Browser-based SPAs
+   * (public clients) must use the redirect-based approach, so the embedded option is
+   * hidden for them. Defaults to true.
+   */
+  allowEmbeddedApproach?: boolean;
+
+  /**
    * Callback function to broadcast whether this step is ready to proceed
    */
   onReadyChange?: (isReady: boolean) => void;
@@ -119,6 +126,7 @@ export interface ConfigureExperienceProps {
 export default function ConfigureExperience({
   selectedApproach,
   onApproachChange,
+  allowEmbeddedApproach = true,
   onReadyChange = undefined,
   userTypes = [],
   selectedUserTypes = [],
@@ -151,6 +159,16 @@ export default function ConfigureExperience({
       onUserTypesChange([userTypes[0].name]);
     }
   }, [showUserTypes, userTypes, selectedUserTypes.length, onUserTypesChange]);
+
+  /**
+   * Reset to the redirect-based approach if the embedded approach is not allowed
+   * but is currently selected (e.g. after switching to a public-client SPA template).
+   */
+  useEffect((): void => {
+    if (!allowEmbeddedApproach && selectedApproach === ApplicationCreateFlowSignInApproach.EMBEDDED) {
+      onApproachChange(ApplicationCreateFlowSignInApproach.INBUILT);
+    }
+  }, [allowEmbeddedApproach, selectedApproach, onApproachChange]);
 
   const handleApproachChange = (event: ChangeEvent<HTMLInputElement>): void => {
     onApproachChange(event.target.value as ApplicationCreateFlowSignInApproach);
@@ -228,53 +246,55 @@ export default function ConfigureExperience({
               </CardActionArea>
             </Card>
 
-            {/* Native/Custom UI Option */}
-            <Card variant="outlined" onClick={() => onApproachChange(ApplicationCreateFlowSignInApproach.EMBEDDED)}>
-              <CardActionArea
-                sx={{
-                  height: '100%',
-                  cursor: 'pointer',
-                  border: 1,
-                  borderColor:
-                    selectedApproach === ApplicationCreateFlowSignInApproach.EMBEDDED ? 'primary.main' : 'divider',
-                  transition: 'all 0.2s ease-in-out',
-                  '&:hover': {
-                    borderColor: 'primary.main',
-                    bgcolor:
-                      selectedApproach === ApplicationCreateFlowSignInApproach.EMBEDDED
-                        ? 'action.selected'
-                        : 'action.hover',
-                  },
-                }}
-              >
-                <CardContent>
-                  <Stack direction="row" spacing={2} alignItems="flex-start">
-                    <FormControlLabel
-                      value={ApplicationCreateFlowSignInApproach.EMBEDDED}
-                      control={<Radio />}
-                      label=""
-                      sx={{m: 0}}
-                      onClick={(e) => e.stopPropagation()}
-                    />
-                    <Box sx={{flex: 1}}>
-                      <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1}}>
-                        <Code size={20} />
-                        <Typography variant="h6">
-                          {t('applications:onboarding.configure.approach.native.title', {
+            {/* Native/Custom UI Option - hidden for public-client SPAs which must use redirect-based flows */}
+            {allowEmbeddedApproach && (
+              <Card variant="outlined" onClick={() => onApproachChange(ApplicationCreateFlowSignInApproach.EMBEDDED)}>
+                <CardActionArea
+                  sx={{
+                    height: '100%',
+                    cursor: 'pointer',
+                    border: 1,
+                    borderColor:
+                      selectedApproach === ApplicationCreateFlowSignInApproach.EMBEDDED ? 'primary.main' : 'divider',
+                    transition: 'all 0.2s ease-in-out',
+                    '&:hover': {
+                      borderColor: 'primary.main',
+                      bgcolor:
+                        selectedApproach === ApplicationCreateFlowSignInApproach.EMBEDDED
+                          ? 'action.selected'
+                          : 'action.hover',
+                    },
+                  }}
+                >
+                  <CardContent>
+                    <Stack direction="row" spacing={2} alignItems="flex-start">
+                      <FormControlLabel
+                        value={ApplicationCreateFlowSignInApproach.EMBEDDED}
+                        control={<Radio />}
+                        label=""
+                        sx={{m: 0}}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                      <Box sx={{flex: 1}}>
+                        <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1}}>
+                          <Code size={20} />
+                          <Typography variant="h6">
+                            {t('applications:onboarding.configure.approach.native.title', {
+                              product: productName,
+                            })}
+                          </Typography>
+                        </Stack>
+                        <Typography variant="body2" color="text.secondary">
+                          {t('applications:onboarding.configure.approach.native.description', {
                             product: productName,
                           })}
                         </Typography>
-                      </Stack>
-                      <Typography variant="body2" color="text.secondary">
-                        {t('applications:onboarding.configure.approach.native.description', {
-                          product: productName,
-                        })}
-                      </Typography>
-                    </Box>
-                  </Stack>
-                </CardContent>
-              </CardActionArea>
-            </Card>
+                      </Box>
+                    </Stack>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            )}
           </Stack>
         </RadioGroup>
       </Stack>

--- a/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureExperience.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureExperience.test.tsx
@@ -80,6 +80,32 @@ describe('ConfigureExperience', () => {
       const embeddedRadio = screen.getAllByRole('radio')[1];
       expect(embeddedRadio).toBeChecked();
     });
+
+    it('should hide the embedded approach when allowEmbeddedApproach is false', () => {
+      render(
+        <ConfigureExperience
+          selectedApproach={ApplicationCreateFlowSignInApproach.INBUILT}
+          onApproachChange={mockOnApproachChange}
+          allowEmbeddedApproach={false}
+        />,
+      );
+
+      expect(screen.getByText('applications:onboarding.configure.approach.inbuilt.title')).toBeInTheDocument();
+      expect(screen.queryByText('applications:onboarding.configure.approach.native.title')).not.toBeInTheDocument();
+      expect(screen.getAllByRole('radio')).toHaveLength(1);
+    });
+
+    it('should reset to INBUILT when embedded is selected but not allowed', () => {
+      render(
+        <ConfigureExperience
+          selectedApproach={ApplicationCreateFlowSignInApproach.EMBEDDED}
+          onApproachChange={mockOnApproachChange}
+          allowEmbeddedApproach={false}
+        />,
+      );
+
+      expect(mockOnApproachChange).toHaveBeenCalledWith(ApplicationCreateFlowSignInApproach.INBUILT);
+    });
   });
 
   describe('User Interactions', () => {

--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -48,6 +48,7 @@ import {
   ApplicationCreateFlowSignInApproach,
   ApplicationCreateFlowStep,
 } from '../models/application-create-flow';
+import {PlatformApplicationTemplate} from '../models/application-templates';
 import type {OAuth2Config} from '../models/oauth';
 import type {CreateApplicationRequest} from '../models/requests';
 import getConfigurationTypeFromTemplate from '../utils/getConfigurationTypeFromTemplate';
@@ -137,6 +138,19 @@ export default function ApplicationCreatePage(): JSX.Element {
   );
 
   const creationFlow = useMemo(() => resolveCreationFlow(selectedTemplateConfig), [selectedTemplateConfig]);
+
+  // Browser-based SPAs are public clients that must use the redirect-based flow, so the
+  // embedded (native) sign-in approach is not offered for them. Native mobile apps are also
+  // public clients but legitimately use app-native flows, so they are excluded from this rule.
+  const isBrowserSpaTemplate = useMemo((): boolean => {
+    if (selectedPlatform === PlatformApplicationTemplate.MOBILE) {
+      return false;
+    }
+    const oauthConfig = selectedTemplateConfig?.defaults?.inboundAuthConfig?.find(
+      (config) => config.type === 'oauth2',
+    )?.config;
+    return oauthConfig?.publicClient === true;
+  }, [selectedTemplateConfig, selectedPlatform]);
 
   const needsConfigure = useMemo((): boolean => {
     const isPasskeyEnabled = !selectedAuthFlow && (integrations[AuthenticatorTypes.PASSKEY] ?? false);
@@ -437,6 +451,7 @@ export default function ApplicationCreatePage(): JSX.Element {
           <ConfigureExperience
             selectedApproach={signInApproach}
             onApproachChange={setSignInApproach}
+            allowEmbeddedApproach={!isBrowserSpaTemplate}
             onReadyChange={handleApproachStepReadyChange}
             userTypes={userTypesData?.types ?? []}
             selectedUserTypes={selectedUserTypes}

--- a/tests/e2e/pages/applications/applications.page.ts
+++ b/tests/e2e/pages/applications/applications.page.ts
@@ -48,6 +48,8 @@ export class ApplicationsPage extends BasePage {
   readonly configureExperienceStep: Locator;
   readonly configureStackStep: Locator;
   readonly configureDetailsStep: Locator;
+  readonly inbuiltExperienceCard: Locator;
+  readonly embeddedExperienceCard: Locator;
   readonly showClientSecretStep: Locator;
   readonly clientSecretValue: Locator;
   readonly clientSecretContinue: Locator;
@@ -95,6 +97,8 @@ export class ApplicationsPage extends BasePage {
     this.configureExperienceStep = page.locator('[data-testid="application-configure-experience"]');
     this.configureStackStep = page.locator('[data-testid="application-configure-stack"]');
     this.configureDetailsStep = page.locator('[data-testid="application-configure-details"]');
+    this.inbuiltExperienceCard = page.locator('div:has(input[value="INBUILT"])');
+    this.embeddedExperienceCard = page.locator('div:has(input[value="EMBEDDED"])');
     this.showClientSecretStep = page.locator('[data-testid="application-show-client-secret"]');
     this.clientSecretValue = page.locator('[data-testid="application-client-secret-value"]');
     this.clientSecretContinue = page.locator('[data-testid="application-client-secret-continue"]');
@@ -203,18 +207,21 @@ export class ApplicationsPage extends BasePage {
     await this.clickNext();
   }
 
-  /** Select the INBUILT experience option on the experience step (INBUILT is the default, only call if switching) */
-  async selectInbuiltExperience(): Promise<void> {
-    const inbuiltCard = this.page.locator('div:has(input[value="INBUILT"])').first();
-    await inbuiltCard.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
-    await inbuiltCard.click();
+  /** Select a stack/technology card on the stack step by its visible title (e.g. "React", "Next.js"). */
+  async selectStack(title: string): Promise<void> {
+    const card = this.configureStackStep
+      .locator('[role="button"]')
+      .filter({ has: this.page.getByText(title, { exact: true }) })
+      .first();
+    await card.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await card.click();
   }
 
-  /** Select the EMBEDDED experience option on the experience step */
-  async selectEmbeddedExperience(): Promise<void> {
-    const embeddedCard = this.page.locator('div:has(input[value="EMBEDDED"])').first();
-    await embeddedCard.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
-    await embeddedCard.click();
+  /** Select the INBUILT experience option on the experience step (INBUILT is the default, only call if switching) */
+  async selectInbuiltExperience(): Promise<void> {
+    const inbuiltCard = this.inbuiltExperienceCard.first();
+    await inbuiltCard.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await inbuiltCard.click();
   }
 
   /** Read the client secret value from the final wizard step */

--- a/tests/e2e/tests/applications/application-onboarding.spec.ts
+++ b/tests/e2e/tests/applications/application-onboarding.spec.ts
@@ -172,24 +172,23 @@ test.describe("Application Onboarding", () => {
       });
     });
 
-    /** TC004: EMBEDDED experience skips configure-details */
-    test("TC004: Create application - EMBEDDED experience skips configure-details", async ({ applicationsPage }) => {
-      const appData = TestDataFactory.createApplication({ name: `TestApp_EMBEDDED_${Date.now()}` });
-
+    /** TC004: SPA (public client) hides the EMBEDDED experience option */
+    test("TC004: Create application - SPA stack hides EMBEDDED experience", async ({ applicationsPage }) => {
       await test.step("Navigate and open wizard", async () => {
         await applicationsPage.goto();
         await applicationsPage.verifyPageLoaded();
         await applicationsPage.clickAddApplication();
       });
 
-      await test.step("Step 1: Skip stack and advance", async () => {
+      await test.step("Step 1: Select the React (SPA) stack and advance", async () => {
         await applicationsPage.waitForStep("application-configure-stack");
+        await applicationsPage.selectStack("React");
         await applicationsPage.clickNext();
       });
 
       await test.step("Step 2: Fill name and advance", async () => {
         await applicationsPage.waitForStep("application-configure-name");
-        await applicationsPage.fillAppName(appData.name);
+        await applicationsPage.fillAppName(`TestApp_SPA_${Date.now()}`);
         await applicationsPage.clickNext();
         await applicationsPage.handleOptionalOuStep();
       });
@@ -201,19 +200,12 @@ test.describe("Application Onboarding", () => {
         await applicationsPage.clickNext();
       });
 
-      await test.step("Step 6: Select EMBEDDED and verify configure-details is skipped", async () => {
+      await test.step("Step 6: Verify only the redirect-based option is offered", async () => {
         await applicationsPage.waitForStep("application-configure-experience");
-        console.log("Selecting EMBEDDED experience");
-        await applicationsPage.selectEmbeddedExperience();
-        await expect(applicationsPage.configureDetailsStep).not.toBeVisible();
-        await applicationsPage.clickNext();
-        await applicationsPage.screenshot("tc004-embedded-selected");
-        console.log("configure-details was never shown - correct EMBEDDED behaviour");
-        // EMBEDDED without passkey creates app directly and navigates to edit page
-        await applicationsPage.page.waitForURL(/\/console\/applications\/(?!create)[^/]+$/, { timeout: 30000 });
-        createdAppIds.push(applicationsPage.page.url().split("/").pop()!);
-        console.log("Navigated to edit page directly — EMBEDDED skips both configure-details and secret screen");
-        await applicationsPage.screenshot("tc004-details-skipped");
+        await expect(applicationsPage.inbuiltExperienceCard.first()).toBeVisible();
+        await expect(applicationsPage.embeddedExperienceCard).toHaveCount(0);
+        console.log("EMBEDDED experience hidden for SPA — correct");
+        await applicationsPage.screenshot("tc004-spa-embedded-hidden");
       });
     });
 


### PR DESCRIPTION
### Purpose
Enforce the architectural decision that browser-based single-page applications (SPAs) must use redirect-based flows. The platform rejects SPA applications created or updated with a configuration that enables embedded (native) flow execution, the console no longer offers the native sign-in approach when creating a browser SPA, and the documentation is updated to reflect the rule.

This is the application service-layer counterpart to the runtime HTTP guard added for direct flow initiation (#3215), ensuring the constraint cannot be bypassed via the management API, and aligns the console UX and docs with it.

### Approach
A browser SPA is represented at the backend as an OAuth **public client** (no client secret). Per the runtime guard, an application is eligible for direct (native) flow execution only when it does **not** carry the `authorization_code` grant — redirect-based apps use `authorization_code`.

**Backend**
- `validateOAuthParamsForCreateAndUpdate` (shared by create and update) rejects a public client whose grant types do not include `authorization_code`, since that configuration enables native flow execution for a browser SPA.
- New service error `ErrorNativeFlowNotAllowedForSPA` (`APP-1037`) with i18n defaults; the message guides developers toward `authorization_code` + PKCE.
- Native mobile apps are unaffected: they use `authorization_code` + PKCE (redirect with a deep link), and pure app-native mobile apps are created without an OAuth config, so neither path is blocked.

**Console**
- `ConfigureExperience` takes an `allowEmbeddedApproach` prop. When the selected template is a **browser SPA** (a public client that is not a Mobile app), only the redirect-based option is shown and any prior embedded selection resets to redirect.
- `ApplicationCreatePage` derives this from the selected template's default OAuth config (`publicClient === true`), explicitly excluding the Mobile platform so native mobile apps keep the embedded option.

**Docs**
- `integration-models.mdx`: the App-Native section no longer lists SPAs as a use case and adds a warning that app-native flow execution is not supported for browser SPAs.
- `manage-applications.mdx`: clarifies that Browser App (SPA) creation offers only the redirect approach.

Correctly-configured redirect-based SPAs (public client with `authorization_code`) are unaffected.

### Related Issues
- Fixes #3216

### Related PRs
- #3289 (runtime guard for direct flow initiation, #3215)

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests (e2e)
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
