### PR TITLE
Restrict direct flow initiation guard to authentication flows

### DIFF
--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -178,7 +178,7 @@ func (s *flowExecService) loadNewContext(ctx context.Context, appID, flowTypeStr
 		return nil, err
 	}
 
-	if svcErr := s.checkDirectFlowInitiationAllowed(ctx, appID, logger); svcErr != nil {
+	if svcErr := s.checkDirectFlowInitiationAllowed(ctx, appID, flowType, logger); svcErr != nil {
 		return nil, svcErr
 	}
 
@@ -192,10 +192,15 @@ func (s *flowExecService) loadNewContext(ctx context.Context, appID, flowTypeStr
 }
 
 // checkDirectFlowInitiationAllowed returns an error if the application's grant type does not
-// permit direct HTTP flow initiation. Applications configured with the authorization_code grant
-// type must have their flows initiated by the OAuth component, not via a direct HTTP call.
+// permit direct HTTP initiation of an authentication flow. Applications configured with the
+// authorization_code grant type must have their authentication flows initiated by the OAuth
+// component, not via a direct HTTP call. Other flow types (registration, recovery, user
+// onboarding) are not subject to this restriction.
 func (s *flowExecService) checkDirectFlowInitiationAllowed(ctx context.Context, appID string,
-	logger *log.Logger) *serviceerror.ServiceError {
+	flowType common.FlowType, logger *log.Logger) *serviceerror.ServiceError {
+	if flowType != common.FlowTypeAuthentication {
+		return nil
+	}
 	if appID == "" {
 		return nil
 	}

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -2290,7 +2290,16 @@ func (s *ServiceTestSuite) TestCheckDirectFlowInitiationAllowed_ClientNotFound()
 		cfg:           testFlowExecCfg,
 	}
 
-	svcErr := service.checkDirectFlowInitiationAllowed(context.Background(), "app-notfound", log.GetLogger())
+	svcErr := service.checkDirectFlowInitiationAllowed(context.Background(), "app-notfound",
+		common.FlowTypeAuthentication, log.GetLogger())
+	s.Nil(svcErr)
+}
+
+func (s *ServiceTestSuite) TestCheckDirectFlowInitiationAllowed_NonAuthFlowAllowed() {
+	service := &flowExecService{cfg: testFlowExecCfg}
+
+	svcErr := service.checkDirectFlowInitiationAllowed(context.Background(), "test-app",
+		common.FlowTypeRegistration, log.GetLogger())
 	s.Nil(svcErr)
 }
 


### PR DESCRIPTION
### Purpose

#3289 added a guard that blocks `authorization_code` applications from initiating flows directly via `POST /flow/execute`, forcing them through `GET /oauth2/authorize`. However, the guard was applied to **all** flow types, which unintentionally broke direct initiation of registration, recovery, and user onboarding flows for `authorization_code` applications.

Only **authentication** flows need this restriction — those are the flows the OAuth component must drive to produce an authorization code. Registration, recovery, and user onboarding flows return assertions or simply complete; they do not depend on the OAuth authorization context and should remain directly initiable regardless of grant type.

This PR scopes the guard to `AUTHENTICATION` flows only.

### Approach

`checkDirectFlowInitiationAllowed` now takes the resolved `flowType` and returns early (allowing initiation) for any flow type other than `AUTHENTICATION`. The grant-type lookup and `authorization_code` check only run for authentication flows.

- For `AUTHENTICATION` flows on `authorization_code` apps: still returns `403` (`FES-1011`), unchanged.
- For `REGISTRATION`, `RECOVERY`, and `USER_ONBOARDING` flows: always permitted to initiate directly, regardless of grant type. The grant-type lookup is skipped entirely.
- Continuation requests (with an `executionId`) remain unaffected — they never reach this guard.

Added a unit test (`TestCheckDirectFlowInitiationAllowed_NonAuthFlowAllowed`) verifying a registration flow is permitted without consulting the grant type, alongside the existing test that confirms authentication flows are still blocked.

### Related Issues
- Refs #3289

### Related PRs
- #3289

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided.
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes.
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined direct flow initiation security controls to apply only to authentication flows, while permitting other flow types such as registration to be initiated directly via HTTP, improving operational flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->