### PR TITLE
Add configurable audience resolution mode (explicit vs implicit)

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
@@ -615,6 +615,12 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ImplicitRSD
 	// identifier rather than the clientID fallback.
 	const rsIdentifier = "https://rs01.example.com"
 
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		OAuth: config.OAuthConfig{AudienceResolution: "implicit"},
+	})
+	suite.T().Cleanup(config.ResetServerRuntime)
+
 	mockTokenBuilder := tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 	mockAuthzService := authzmock.NewAuthorizationServiceInterfaceMock(suite.T())
 	mockResourceService := resourcemock.NewResourceServiceInterfaceMock(suite.T())
@@ -676,6 +682,12 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ImplicitRSD
 	// When the granted scope maps to two registered RSes, both identifiers appear in aud (sorted).
 	const rsIdentifier1 = "https://rs01.example.com"
 	const rsIdentifier2 = "https://rs02.example.com"
+
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		OAuth: config.OAuthConfig{AudienceResolution: "implicit"},
+	})
+	suite.T().Cleanup(config.ResetServerRuntime)
 
 	mockTokenBuilder := tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 	mockAuthzService := authzmock.NewAuthorizationServiceInterfaceMock(suite.T())

--- a/backend/internal/oauth/oauth2/resourceindicators/resourceindicators.go
+++ b/backend/internal/oauth/oauth2/resourceindicators/resourceindicators.go
@@ -28,6 +28,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
 	"github.com/thunder-id/thunderid/internal/resource"
+	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 )
 
@@ -183,8 +184,10 @@ func UnionScopes(rsValidScopes map[string][]string) []string {
 // ComposeAudiences builds the aud claim from the resolved Resource Servers. When resolvedRSes is
 // non-nil (explicit resource parameter), all resolved RS identifiers are included. When
 // resolvedRSes is nil and granted scopes are present, contributors are discovered via the resource
-// service (implicit audience). If no RS contributes, clientID is returned as the sole fallback
-// audience. If clientID is also empty, an empty slice is returned.
+// service only if audienceResolution is "implicit". In "explicit" mode (default, including empty
+// string), the implicit scope-to-RS reverse-lookup is skipped entirely. If no RS contributes,
+// clientID is returned as the sole fallback audience. If clientID is also empty, an empty slice
+// is returned.
 func ComposeAudiences(
 	ctx context.Context,
 	resourceService resource.ResourceServiceInterface,
@@ -192,10 +195,12 @@ func ComposeAudiences(
 	resolvedRSes []*resource.ResourceServer,
 	grantedScopes []string,
 ) ([]string, *model.ErrorResponse) {
+	audienceResolution := config.GetServerRuntime().Config.OAuth.AudienceResolution
+
 	var rsIdentifiers []string
 	if resolvedRSes != nil {
 		rsIdentifiers = ContributingAudiences(resolvedRSes)
-	} else if len(grantedScopes) > 0 {
+	} else if audienceResolution == "implicit" && len(grantedScopes) > 0 {
 		implicit, svcErr := resourceService.FindResourceServersByPermissions(ctx, grantedScopes)
 		if svcErr != nil {
 			return nil, &model.ErrorResponse{

--- a/backend/internal/oauth/oauth2/resourceindicators/resourceindicators_test.go
+++ b/backend/internal/oauth/oauth2/resourceindicators/resourceindicators_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/resource"
+	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/error/serviceerror"
 	"github.com/thunder-id/thunderid/tests/mocks/resourcemock"
 )
@@ -42,7 +43,20 @@ func TestResourceIndicatorsTestSuite(t *testing.T) {
 }
 
 func (suite *ResourceIndicatorsTestSuite) SetupTest() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{})
 	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+}
+
+func (suite *ResourceIndicatorsTestSuite) TearDownTest() {
+	config.ResetServerRuntime()
+}
+
+func (suite *ResourceIndicatorsTestSuite) initConfigWithAudienceResolution(mode string) {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("", &config.Config{
+		OAuth: config.OAuthConfig{AudienceResolution: mode},
+	})
 }
 
 // ValidateResourceURIs tests
@@ -123,10 +137,11 @@ func (suite *ResourceIndicatorsTestSuite) TestResolveResourceServers_StoreFailur
 	assert.Equal(suite.T(), "Failed to resolve resource server", err.ErrorDescription)
 }
 
-// ComposeAudiences §4 fallback-only clientID tests
+// ComposeAudiences §4 fallback-only clientID tests (implicit mode preserves original behavior)
 
 func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_RSContributes_NoClientID() {
 	// When at least one RS contributes, clientID must NOT appear in aud.
+	suite.initConfigWithAudienceResolution("implicit")
 	rs := &resource.ResourceServer{ID: "rs01", Identifier: "https://rs01.example.com"}
 	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
 		"client123", []*resource.ResourceServer{rs}, []string{"read"})
@@ -137,6 +152,7 @@ func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_RSContributes_NoC
 
 func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_NoRS_FallbackToClientID() {
 	// When no RS contributes (explicit empty resolvedRSes), aud falls back to clientID.
+	suite.initConfigWithAudienceResolution("implicit")
 	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
 		"client123", []*resource.ResourceServer{}, []string{})
 
@@ -146,6 +162,7 @@ func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_NoRS_FallbackToCl
 
 func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_NilResolvedRSes_NoScopes_FallbackToClientID() {
 	// resolvedRSes==nil, no scopes → implicit discovery skipped → fallback to clientID.
+	suite.initConfigWithAudienceResolution("implicit")
 	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
 		Return([]resource.ResourceServer{}, nil).Maybe()
 
@@ -158,6 +175,7 @@ func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_NilResolvedRSes_N
 
 func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_ImplicitDiscovery_RSFound() {
 	// resolvedRSes==nil with scopes → implicit discovery returns RS → aud contains RS only, no clientID.
+	suite.initConfigWithAudienceResolution("implicit")
 	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, []string{"read"}).
 		Return([]resource.ResourceServer{
 			{ID: "rs01", Identifier: "https://rs01.example.com"},
@@ -172,6 +190,7 @@ func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_ImplicitDiscovery
 
 func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_ImplicitDiscovery_NoRSFound_FallbackToClientID() {
 	// resolvedRSes==nil with scopes → implicit discovery returns nothing → fallback to clientID.
+	suite.initConfigWithAudienceResolution("implicit")
 	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, []string{"openid"}).
 		Return([]resource.ResourceServer{}, nil)
 
@@ -204,6 +223,7 @@ func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_MultipleRS_Dedupe
 
 func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_ImplicitDiscovery_ServiceError() {
 	// FindResourceServersByPermissions failure returns server error.
+	suite.initConfigWithAudienceResolution("implicit")
 	svcErr := &serviceerror.ServiceError{Code: "internal_error"}
 	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, []string{"read"}).
 		Return(nil, svcErr)
@@ -214,6 +234,53 @@ func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_ImplicitDiscovery
 	assert.Nil(suite.T(), auds)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+}
+
+// ComposeAudiences — explicit mode tests
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_Explicit_WithResolvedRSes() {
+	// Explicit mode with resolvedRSes should still use RS identifiers (same as implicit).
+	suite.initConfigWithAudienceResolution("explicit")
+	rs := &resource.ResourceServer{ID: "rs01", Identifier: "https://rs01.example.com"}
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", []*resource.ResourceServer{rs}, []string{"read"})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"https://rs01.example.com"}, auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_Explicit_NoRSes_ScopesPresent_FallbackToClientID() {
+	// Explicit mode with no resolvedRSes but scopes present should NOT do reverse-lookup,
+	// should fall back to clientID.
+	suite.initConfigWithAudienceResolution("explicit")
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", nil, []string{"read", "write"})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"client123"}, auds)
+	suite.mockResourceService.AssertNotCalled(suite.T(), "FindResourceServersByPermissions",
+		mock.Anything, mock.Anything)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_Explicit_NoRSes_NoScopes_FallbackToClientID() {
+	// Explicit mode with no resolvedRSes and no scopes should fall back to clientID.
+	suite.initConfigWithAudienceResolution("explicit")
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", nil, []string{})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"client123"}, auds)
+}
+
+func (suite *ResourceIndicatorsTestSuite) TestComposeAudiences_EmptyString_BehavesLikeExplicit() {
+	// Empty string (default) should behave like "explicit" — no reverse-lookup.
+	auds, err := ComposeAudiences(context.Background(), suite.mockResourceService,
+		"client123", nil, []string{"read"})
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"client123"}, auds)
+	suite.mockResourceService.AssertNotCalled(suite.T(), "FindResourceServersByPermissions",
+		mock.Anything, mock.Anything)
 }
 
 // ContributingAudiences tests

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -282,7 +282,8 @@ type OAuthConfig struct {
 	CIBA              CIBAConfig              `yaml:"ciba" json:"ciba"`
 	// AllowWildcardRedirectURI enables wildcard pattern matching for redirect URIs.
 	// When false (default), only exact redirect URI matching is performed.
-	AllowWildcardRedirectURI bool `yaml:"allow_wildcard_redirect_uri" json:"allow_wildcard_redirect_uri"`
+	AllowWildcardRedirectURI bool   `yaml:"allow_wildcard_redirect_uri" json:"allow_wildcard_redirect_uri"`
+	AudienceResolution       string `yaml:"audience_resolution" json:"audience_resolution"`
 }
 
 // NotificationConfig holds the notification configuration details.

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -328,6 +328,7 @@ OAuth 2.0 and OpenID Connect settings.
 | `oauth.authorization_code.validity_period` | `600` | Authorization code validity period in seconds (10 minutes) |
 | `oauth.dcr.insecure` | `false` | If `true`, allows insecure dynamic client registration (development only) |
 | `oauth.allow_wildcard_redirect_uri` | `false` | If `true`, allows wildcard patterns in registered redirect URIs: `*` and `**` in the path component, and `*` in the host component (label-internal, alphanumeric only). When `false`, only exact redirect URI matching is performed and registering a wildcard URI returns a `400 Bad Request` error. |
+| `oauth.audience_resolution` | `explicit` | Controls how the access token `aud` claim is populated when the client does not send a `resource` parameter ([RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707)). **`explicit`** (default): `aud` is set only from the `resource` parameter; without it, `aud` defaults to the client ID. **`implicit`**: scopes are reverse-mapped to registered resource servers and their identifiers are included in `aud` (convenience mode, not recommended for security-sensitive deployments). |
 
 :::note
 Enabling `oauth.allow_wildcard_redirect_uri` affects all applications in the deployment. See [Use Wildcard Redirect URIs](/docs/next/guides/guides/applications/application-settings#use-wildcard-redirect-uris) for pattern syntax and matching rules.

--- a/docs/content/guides/guides/resource-indicators.mdx
+++ b/docs/content/guides/guides/resource-indicators.mdx
@@ -22,7 +22,16 @@ This feature implements [RFC 8707 — Resource Indicators for OAuth 2.0](https:/
 
 ## How Resource Indicators Work
 
-Without resource indicators, an access token's audience defaults to the client ID. The token carries all scopes the client requested and was authorized for. Resource servers must trust the client to present the correct token to the correct service.
+Without resource indicators, an access token's audience defaults to the client ID (in the default `explicit` mode). The token carries all scopes the client requested and was authorized for. Resource servers must trust the client to present the correct token to the correct service.
+
+:::info Audience Resolution Modes
+<ProductName /> supports two audience resolution modes via the `oauth.audience_resolution` deployment setting:
+
+- **`explicit`** (default): The `aud` claim is populated solely from the `resource` parameter. Without it, `aud` defaults to the client ID. This follows RFC 8707 where the client declares its target audience.
+- **`implicit`**: When no `resource` parameter is provided, <ProductName /> reverse-maps the granted scopes to registered resource servers and includes their identifiers in `aud`. This is a convenience mode and is not recommended for security-sensitive deployments.
+
+See [Configuration — OAuth](/docs/next/guides/getting-started/configuration#oauth-configuration) for details.
+:::
 
 With resource indicators, the client declares the target resource server by passing its identifier in the `resource` parameter. <ProductName /> then:
 

--- a/docs/content/guides/key-concepts/tokens.mdx
+++ b/docs/content/guides/key-concepts/tokens.mdx
@@ -22,10 +22,11 @@ Access tokens are JWTs that a client presents to a resource server to access pro
 
 ### Audience Claim Behavior
 
-The `aud` claim varies based on whether the client used [resource indicators](/docs/next/guides/guides/resource-indicators):
+The `aud` claim varies based on whether the client used [resource indicators](/docs/next/guides/guides/resource-indicators) and the deployment's `oauth.audience_resolution` mode:
 
-- **With `resource` parameter:** The `aud` claim contains the identifier(s) of the targeted resource server(s).
-- **Without `resource` parameter:** <ProductName /> discovers which registered resource servers own the granted scopes and includes their identifiers. If no resource server matches, the `aud` defaults to the client ID.
+- **With `resource` parameter:** The `aud` claim contains the identifier(s) of the targeted resource server(s). This behavior is the same in both modes.
+- **Without `resource` parameter (explicit mode, default):** The `aud` claim defaults to the client ID. No implicit discovery is performed. This follows [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) where the client declares its target audience.
+- **Without `resource` parameter (implicit mode):** <ProductName /> discovers which registered resource servers own the granted scopes and includes their identifiers. If no resource server matches, the `aud` defaults to the client ID. Enable this mode by setting `oauth.audience_resolution: "implicit"` in `deployment.yaml`.
 - **Single audience:** Serialized as a JSON string (for example, `"aud": "https://api.example.com/booking"`).
 - **Multiple audiences:** Serialized as a JSON array (for example, `"aud": ["https://api.example.com/booking", "https://api.example.com/payments"]`).
 


### PR DESCRIPTION
## Summary

- Add `oauth.audience_resolution` deployment config (`explicit` default, `implicit` opt-in) to control how `ComposeAudiences()` populates the access token `aud` claim when the client omits the `resource` parameter (RFC 8707)
- In `explicit` mode (default): `aud` comes solely from the `resource` parameter; no `resource` → falls back to client ID
- In `implicit` mode: preserves the existing reverse-lookup behavior where scopes are mapped to resource server identifiers
- Update documentation (configuration reference, tokens concept page, resource indicators guide)

Closes #3393

## Test plan

- [ ] Verify `explicit` mode (default): token issued without `resource` param has `aud` = client ID, not reverse-mapped RS identifiers
- [ ] Verify `explicit` mode with `resource` param: `aud` = RS identifier (unchanged behavior)
- [ ] Verify `implicit` mode (`oauth.audience_resolution: "implicit"` in deployment.yaml): token issued without `resource` param has `aud` = reverse-mapped RS identifiers (legacy behavior)
- [ ] Verify `implicit` mode with `resource` param: `aud` = RS identifier (unchanged behavior)
- [ ] Run existing unit tests pass with both modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `oauth.audience_resolution` configuration option to control how the access token `aud` claim is populated when no `resource` parameter is provided.
  * Supports `explicit` mode (default, RFC 8707 compliant) and `implicit` mode (enables reverse-lookup from granted scopes).

* **Documentation**
  * Updated OAuth configuration and token behavior guides to explain audience resolution modes and security implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->