### PR TITLE
Resolve favicon by OS color scheme and Vite base URL

### DIFF
--- a/frontend/apps/console/src/components/Head.tsx
+++ b/frontend/apps/console/src/components/Head.tsx
@@ -18,27 +18,37 @@
 
 import {Helmet} from '@thunderid/components';
 import {useConfig} from '@thunderid/contexts';
-import {useColorScheme} from '@wso2/oxygen-ui';
+
+/**
+ * Resolves a configured favicon path against the Vite base URL so it loads
+ * correctly when the console is served under a sub-path such as `/console`.
+ * Already-resolved values (absolute, protocol-relative or root-relative URLs,
+ * and `data:` URIs) are returned untouched.
+ */
+function resolveFaviconHref(path: string): string {
+  if (/^([a-z]+:|\/)/i.test(path)) {
+    return path;
+  }
+  return `${import.meta.env.BASE_URL.replace(/\/$/, '')}/${path}`;
+}
 
 /**
  * Manages document head metadata, specifically the favicon, with support for
- * separate light and dark mode variants.
+ * separate light and dark variants.
  *
- * The resolved favicon switches automatically based on the active OxygenUI color scheme,
- * correctly handling the `"system"` mode by falling back to the OS-resolved value.
- *
- * Must be rendered inside an `OxygenUIThemeProvider` so that `useColorScheme`
- * reads from the correct context.
+ * Both variants are registered with a `prefers-color-scheme` media query so the
+ * browser picks the matching favicon based on the operating system / browser
+ * color scheme. This is independent of the in-app color scheme toggle — the tab
+ * icon tracks the OS theme, switching live when the OS theme changes.
  */
 export default function Head() {
   const {config} = useConfig();
-  const {mode, systemMode} = useColorScheme();
-  const resolvedMode = mode === 'system' ? systemMode : mode;
-  const resolvedFavicon = resolvedMode === 'dark' ? config.brand.favicon.dark : config.brand.favicon.light;
+  const {favicon} = config.brand;
 
   return (
     <Helmet>
-      <link rel="icon" href={resolvedFavicon} />
+      <link rel="icon" href={resolveFaviconHref(favicon.light)} media="(prefers-color-scheme: light)" />
+      <link rel="icon" href={resolveFaviconHref(favicon.dark)} media="(prefers-color-scheme: dark)" />
     </Helmet>
   );
 }

--- a/frontend/apps/console/src/components/__tests__/Head.test.tsx
+++ b/frontend/apps/console/src/components/__tests__/Head.test.tsx
@@ -26,11 +26,6 @@ vi.mock('@thunderid/contexts', () => ({
   useConfig: mockUseConfig,
 }));
 
-const mockUseColorScheme = vi.hoisted(() => vi.fn());
-vi.mock('@wso2/oxygen-ui', () => ({
-  useColorScheme: mockUseColorScheme,
-}));
-
 vi.mock('@thunderid/components', () => ({
   Helmet: ({children = undefined}: {children?: ReactNode}) => children,
 }));
@@ -39,6 +34,11 @@ const defaultFavicon = {
   light: 'assets/images/favicon.ico',
   dark: 'assets/images/favicon-inverted.ico',
 };
+
+const withBase = (path: string): string => `${import.meta.env.BASE_URL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+
+const iconFor = (scheme: 'light' | 'dark'): Element | null =>
+  document.head.querySelector(`link[rel="icon"][media="(prefers-color-scheme: ${scheme})"]`);
 
 describe('Head', () => {
   beforeEach(() => {
@@ -51,40 +51,37 @@ describe('Head', () => {
     document.head.querySelectorAll('link[rel="icon"]').forEach((el) => el.remove());
   });
 
-  it('renders a single favicon link tag', () => {
-    mockUseColorScheme.mockReturnValue({mode: 'light', systemMode: 'light'});
+  it('renders a light and a dark favicon link, each scoped to a prefers-color-scheme media query', () => {
     render(<Head />);
-    expect(document.head.querySelectorAll('link[rel="icon"]')).toHaveLength(1);
+    expect(document.head.querySelectorAll('link[rel="icon"]')).toHaveLength(2);
+    expect(iconFor('light')).not.toBeNull();
+    expect(iconFor('dark')).not.toBeNull();
   });
 
-  it('renders the light favicon when mode is "light"', () => {
-    mockUseColorScheme.mockReturnValue({mode: 'light', systemMode: 'light'});
+  it('maps the light favicon to the light color scheme and the dark favicon to the dark color scheme', () => {
     render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', defaultFavicon.light);
+    expect(iconFor('light')).toHaveAttribute('href', withBase(defaultFavicon.light));
+    expect(iconFor('dark')).toHaveAttribute('href', withBase(defaultFavicon.dark));
   });
 
-  it('renders the dark favicon when mode is "dark"', () => {
-    mockUseColorScheme.mockReturnValue({mode: 'dark', systemMode: 'dark'});
+  it('prefixes the base URL to relative favicon paths', () => {
     render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', defaultFavicon.dark);
+    const href = iconFor('light')?.getAttribute('href');
+    expect(href).toBe(withBase(defaultFavicon.light));
+    expect(href?.startsWith(import.meta.env.BASE_URL)).toBe(true);
   });
 
-  it('renders the light favicon when mode is "system" and systemMode is "light"', () => {
-    mockUseColorScheme.mockReturnValue({mode: 'system', systemMode: 'light'});
+  it('uses absolute favicon URLs as-is without prefixing the base URL', () => {
+    mockUseConfig.mockReturnValue({
+      config: {
+        brand: {
+          favicon: {light: 'https://cdn.example.com/light.ico', dark: 'https://cdn.example.com/dark.ico'},
+        },
+      },
+    });
     render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', defaultFavicon.light);
-  });
-
-  it('renders the dark favicon when mode is "system" and systemMode is "dark"', () => {
-    mockUseColorScheme.mockReturnValue({mode: 'system', systemMode: 'dark'});
-    render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', defaultFavicon.dark);
-  });
-
-  it('falls back to the light favicon when mode is neither "dark" nor "system"', () => {
-    mockUseColorScheme.mockReturnValue({mode: undefined, systemMode: undefined});
-    render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', defaultFavicon.light);
+    expect(iconFor('light')).toHaveAttribute('href', 'https://cdn.example.com/light.ico');
+    expect(iconFor('dark')).toHaveAttribute('href', 'https://cdn.example.com/dark.ico');
   });
 
   it('reflects custom favicon paths from config', () => {
@@ -95,8 +92,8 @@ describe('Head', () => {
         },
       },
     });
-    mockUseColorScheme.mockReturnValue({mode: 'dark', systemMode: 'dark'});
     render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', 'custom/dark.ico');
+    expect(iconFor('light')).toHaveAttribute('href', withBase('custom/light.ico'));
+    expect(iconFor('dark')).toHaveAttribute('href', withBase('custom/dark.ico'));
   });
 });

--- a/frontend/apps/gate/src/components/Head.tsx
+++ b/frontend/apps/gate/src/components/Head.tsx
@@ -18,27 +18,37 @@
 
 import {Helmet} from '@thunderid/components';
 import {useConfig} from '@thunderid/contexts';
-import {useColorScheme} from '@wso2/oxygen-ui';
+
+/**
+ * Resolves a configured favicon path against the Vite base URL so it loads
+ * correctly when the gate is served under a sub-path such as `/gate`.
+ * Already-resolved values (absolute, protocol-relative or root-relative URLs,
+ * and `data:` URIs) are returned untouched.
+ */
+function resolveFaviconHref(path: string): string {
+  if (/^([a-z]+:|\/)/i.test(path)) {
+    return path;
+  }
+  return `${import.meta.env.BASE_URL.replace(/\/$/, '')}/${path}`;
+}
 
 /**
  * Manages document head metadata, specifically the favicon, with support for
- * separate light and dark mode variants.
+ * separate light and dark variants.
  *
- * The resolved favicon switches automatically based on the active OxygenUI color scheme,
- * correctly handling the `"system"` mode by falling back to the OS-resolved value.
- *
- * Must be rendered inside an `OxygenUIThemeProvider` so that `useColorScheme`
- * reads from the correct context.
+ * Both variants are registered with a `prefers-color-scheme` media query so the
+ * browser picks the matching favicon based on the operating system / browser
+ * color scheme. This is independent of the in-app color scheme toggle — the tab
+ * icon tracks the OS theme, switching live when the OS theme changes.
  */
 export default function Head() {
   const {config} = useConfig();
-  const {mode, systemMode} = useColorScheme();
-  const resolvedMode = mode === 'system' ? systemMode : mode;
-  const resolvedFavicon = resolvedMode === 'dark' ? config.brand.favicon.dark : config.brand.favicon.light;
+  const {favicon} = config.brand;
 
   return (
     <Helmet>
-      <link rel="icon" href={resolvedFavicon} />
+      <link rel="icon" href={resolveFaviconHref(favicon.light)} media="(prefers-color-scheme: light)" />
+      <link rel="icon" href={resolveFaviconHref(favicon.dark)} media="(prefers-color-scheme: dark)" />
     </Helmet>
   );
 }

--- a/frontend/apps/gate/src/components/__tests__/Head.test.tsx
+++ b/frontend/apps/gate/src/components/__tests__/Head.test.tsx
@@ -26,11 +26,6 @@ vi.mock('@thunderid/contexts', () => ({
   useConfig: mockUseConfig,
 }));
 
-const mockUseColorScheme = vi.hoisted(() => vi.fn());
-vi.mock('@wso2/oxygen-ui', () => ({
-  useColorScheme: mockUseColorScheme,
-}));
-
 vi.mock('@thunderid/components', () => ({
   Helmet: ({children = undefined}: {children?: ReactNode}) => children,
 }));
@@ -39,6 +34,11 @@ const defaultFavicon = {
   light: 'assets/images/favicon.ico',
   dark: 'assets/images/favicon-inverted.ico',
 };
+
+const withBase = (path: string): string => `${import.meta.env.BASE_URL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+
+const iconFor = (scheme: 'light' | 'dark'): Element | null =>
+  document.head.querySelector(`link[rel="icon"][media="(prefers-color-scheme: ${scheme})"]`);
 
 describe('Head', () => {
   beforeEach(() => {
@@ -51,40 +51,37 @@ describe('Head', () => {
     document.head.querySelectorAll('link[rel="icon"]').forEach((el) => el.remove());
   });
 
-  it('renders a single favicon link tag', () => {
-    mockUseColorScheme.mockReturnValue({mode: 'light', systemMode: 'light'});
+  it('renders a light and a dark favicon link, each scoped to a prefers-color-scheme media query', () => {
     render(<Head />);
-    expect(document.head.querySelectorAll('link[rel="icon"]')).toHaveLength(1);
+    expect(document.head.querySelectorAll('link[rel="icon"]')).toHaveLength(2);
+    expect(iconFor('light')).not.toBeNull();
+    expect(iconFor('dark')).not.toBeNull();
   });
 
-  it('renders the light favicon when mode is "light"', () => {
-    mockUseColorScheme.mockReturnValue({mode: 'light', systemMode: 'light'});
+  it('maps the light favicon to the light color scheme and the dark favicon to the dark color scheme', () => {
     render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', defaultFavicon.light);
+    expect(iconFor('light')).toHaveAttribute('href', withBase(defaultFavicon.light));
+    expect(iconFor('dark')).toHaveAttribute('href', withBase(defaultFavicon.dark));
   });
 
-  it('renders the dark favicon when mode is "dark"', () => {
-    mockUseColorScheme.mockReturnValue({mode: 'dark', systemMode: 'dark'});
+  it('prefixes the base URL to relative favicon paths', () => {
     render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', defaultFavicon.dark);
+    const href = iconFor('light')?.getAttribute('href');
+    expect(href).toBe(withBase(defaultFavicon.light));
+    expect(href?.startsWith(import.meta.env.BASE_URL)).toBe(true);
   });
 
-  it('renders the light favicon when mode is "system" and systemMode is "light"', () => {
-    mockUseColorScheme.mockReturnValue({mode: 'system', systemMode: 'light'});
+  it('uses absolute favicon URLs as-is without prefixing the base URL', () => {
+    mockUseConfig.mockReturnValue({
+      config: {
+        brand: {
+          favicon: {light: 'https://cdn.example.com/light.ico', dark: 'https://cdn.example.com/dark.ico'},
+        },
+      },
+    });
     render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', defaultFavicon.light);
-  });
-
-  it('renders the dark favicon when mode is "system" and systemMode is "dark"', () => {
-    mockUseColorScheme.mockReturnValue({mode: 'system', systemMode: 'dark'});
-    render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', defaultFavicon.dark);
-  });
-
-  it('falls back to the light favicon when mode is neither "dark" nor "system"', () => {
-    mockUseColorScheme.mockReturnValue({mode: undefined, systemMode: undefined});
-    render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', defaultFavicon.light);
+    expect(iconFor('light')).toHaveAttribute('href', 'https://cdn.example.com/light.ico');
+    expect(iconFor('dark')).toHaveAttribute('href', 'https://cdn.example.com/dark.ico');
   });
 
   it('reflects custom favicon paths from config', () => {
@@ -95,8 +92,8 @@ describe('Head', () => {
         },
       },
     });
-    mockUseColorScheme.mockReturnValue({mode: 'dark', systemMode: 'dark'});
     render(<Head />);
-    expect(document.head.querySelector('link[rel="icon"]')).toHaveAttribute('href', 'custom/dark.ico');
+    expect(iconFor('light')).toHaveAttribute('href', withBase('custom/light.ico'));
+    expect(iconFor('dark')).toHaveAttribute('href', withBase('custom/dark.ico'));
   });
 });


### PR DESCRIPTION
## Purpose
The `Head` component in the console and gate apps resolved the favicon in JavaScript from the in-app OxygenUI color scheme, coupling the tab icon to the in-app theme toggle instead of the OS / browser color scheme. It also emitted favicon paths verbatim, so relative paths failed to load when the app is served under a sub-path such as `/console` or `/gate`.

## Related Issue
- https://github.com/thunder-id/thunderid/issues/3410

## Behaviour
### Gate
<img width="562" height="110" alt="Screenshot 2026-06-19 at 16 41 44" src="https://github.com/user-attachments/assets/08696a8a-9882-43a4-9aa2-22f1441a894a" />

### Console
<img width="596" height="103" alt="Screenshot 2026-06-19 at 16 41 58" src="https://github.com/user-attachments/assets/f1af1ec8-f14a-4399-8ca2-e20907297c21" />

## Implementation
- Replaced the JS color-scheme resolution (`useColorScheme`) with two `<link rel="icon">` tags scoped to `prefers-color-scheme: light` and `prefers-color-scheme: dark`, so the browser selects the matching favicon from the OS theme and switches live when it changes.
- Added `resolveFaviconHref`, which prefixes relative favicon paths with the Vite base URL while leaving already-resolved values (absolute, protocol-relative, root-relative, and `data:` URIs) untouched.
- Applied the same change to both `frontend/apps/console/src/components/Head.tsx` and `frontend/apps/gate/src/components/Head.tsx`.
- Updated the `Head` tests in both apps to assert the two media-scoped links, the base-URL prefixing for relative paths, and that absolute URLs pass through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Favicons now automatically switch between light and dark variants based on your system theme preference (browser `prefers-color-scheme`).

* **Bug Fixes**
  * Favicon URLs are now resolved correctly when the app is deployed under a configured base path (relative paths are base-prefixed; absolute/protocol/data URLs remain unchanged).
  * Updated and expanded favicon behavior coverage in tests for both light and dark variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->