### PR TITLE
Add integrations catalog endpoint

### DIFF
--- a/api/integrations.yaml
+++ b/api/integrations.yaml
@@ -1,0 +1,198 @@
+openapi: 3.0.3
+
+info:
+  title: Integrations API
+  description: >-
+    Read-only catalog of integrations (identity providers, notification senders, ...)
+    that ThunderID can connect to. The console renders the integrations catalog and
+    connector configuration forms from this metadata, and a future marketplace can
+    register additional connectors into it.
+  version: "1.0"
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://{host}:{port}
+    variables:
+      host:
+        default: "localhost"
+      port:
+        default: "8090"
+
+tags:
+  - name: Integrations
+    description: Discover the integrations available to connect and their configuration shape.
+
+security:
+  - OAuth2: [system]
+
+paths:
+  /integrations:
+    get:
+      tags:
+        - Integrations
+      summary: List available integrations
+      description: >-
+        Returns every connector ThunderID can integrate with, grouped by category, along
+        with the configuration fields each connector accepts.
+      responses:
+        "200":
+          description: The connector catalog
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogResponse'
+              example:
+                connectors:
+                  - type: "GOOGLE"
+                    displayName: "Google"
+                    category: "SOCIAL_LOGIN"
+                    hostedCredentials: false
+                    fields:
+                      - name: "client_id"
+                        required: true
+                      - name: "client_secret"
+                        required: true
+                        secret: true
+                      - name: "redirect_uri"
+                        required: true
+                  - type: "twilio"
+                    displayName: "Twilio"
+                    category: "SMS"
+                    hostedCredentials: false
+                    fields:
+                      - name: "account_sid"
+                        required: true
+                      - name: "auth_token"
+                        required: true
+                        secret: true
+                      - name: "sender_id"
+                        required: true
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "CATALOG-5000"
+                message:
+                  key: "error.catalog.internal_error"
+                  defaultValue: "An unexpected error occurred"
+
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://localhost:8090/oauth2/authorize
+          tokenUrl: https://localhost:8090/oauth2/token
+          scopes:
+            system: Access to system management APIs
+        clientCredentials:
+          tokenUrl: https://localhost:8090/oauth2/token
+          scopes:
+            system: Access to system management APIs
+
+  schemas:
+    CatalogResponse:
+      type: object
+      required:
+        - connectors
+      properties:
+        connectors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Connector'
+
+    Connector:
+      type: object
+      required:
+        - type
+        - displayName
+        - category
+        - hostedCredentials
+        - fields
+      properties:
+        type:
+          type: string
+          description: Stable connector type identifier.
+          example: "GOOGLE"
+        displayName:
+          type: string
+          description: Default human-readable name (the console may localize it).
+          example: "Google"
+        category:
+          type: string
+          description: Category used to group the connector in the catalog.
+          enum: [SOCIAL_LOGIN, ENTERPRISE, SMS]
+          example: "SOCIAL_LOGIN"
+        hostedCredentials:
+          type: boolean
+          description: >-
+            Whether ThunderID ships default test credentials for this connector
+            (hosted/cloud deployments). False for self-hosted.
+          example: false
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectorField'
+
+    ConnectorField:
+      type: object
+      required:
+        - name
+        - required
+      properties:
+        name:
+          type: string
+          description: Property key as stored on the connector instance.
+          example: "client_secret"
+        required:
+          type: boolean
+          description: Whether the property must be provided for the connector to work.
+          example: true
+        secret:
+          type: boolean
+          description: Whether the value is sensitive (masked on read, write-only on write).
+          example: true
+        readOnly:
+          type: boolean
+          description: Whether the value is managed by ThunderID and cannot be edited.
+          example: false
+        default:
+          type: string
+          description: Value pre-filled when the connector is configured.
+          example: "https://accounts.google.com/o/oauth2/v2/auth"
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: "Error code. Codes follow the CATALOG-XXXX convention."
+          example: "CATALOG-5000"
+        message:
+          $ref: '#/components/schemas/I18nMessage'
+        description:
+          $ref: '#/components/schemas/I18nMessage'
+
+    I18nMessage:
+      type: object
+      required:
+        - key
+        - defaultValue
+      properties:
+        key:
+          type: string
+          description: Translation key for the message.
+          example: "error.catalog.internal_error"
+        defaultValue:
+          type: string
+          description: Default message text when no translation is available.
+          example: "An unexpected error occurred"

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -60,6 +60,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/group"
 	"github.com/thunder-id/thunderid/internal/idp"
 	"github.com/thunder-id/thunderid/internal/inboundclient"
+	"github.com/thunder-id/thunderid/internal/integration"
 	"github.com/thunder-id/thunderid/internal/notification"
 	"github.com/thunder-id/thunderid/internal/oauth"
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
@@ -231,6 +232,10 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		logger.Fatal(ctx, "Failed to initialize NotificationService", log.Error(err))
 	}
 	exporters = append(exporters, notificationExporter)
+
+	// Register the read-only integrations catalog aggregated from the domain packages.
+	integrations := append(idp.Integrations(), notification.Integrations()...)
+	integration.Initialize(mux, integrations)
 
 	// Initialize passkey service
 	passkeyService := passkey.Initialize(entityService)

--- a/backend/internal/idp/catalog.go
+++ b/backend/internal/idp/catalog.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package idp
+
+import "github.com/thunder-id/thunderid/internal/integration"
+
+// idpIntegrationInfo holds the catalog presentation details for an IDP type.
+type idpIntegrationInfo struct {
+	displayName string
+	category    string
+}
+
+// idpIntegrationInfos maps each supported IDP type to its catalog presentation details.
+var idpIntegrationInfos = map[IDPType]idpIntegrationInfo{
+	IDPTypeGoogle: {displayName: "Google", category: integration.CategorySocialLogin},
+	IDPTypeGitHub: {displayName: "GitHub", category: integration.CategorySocialLogin},
+	IDPTypeOAuth:  {displayName: "OAuth 2.0", category: integration.CategoryEnterprise},
+	IDPTypeOIDC:   {displayName: "OpenID Connect", category: integration.CategoryEnterprise},
+}
+
+// Integrations returns the integration catalog descriptors for all supported
+// identity provider types, derived from their property configurations.
+func Integrations() []integration.Descriptor {
+	descriptors := make([]integration.Descriptor, 0, len(supportedIDPTypes))
+
+	for _, idpType := range supportedIDPTypes {
+		info := idpIntegrationInfos[idpType]
+		propConfig := idpPropertyConfigs[idpType]
+
+		fields := make([]integration.Field, 0,
+			len(propConfig.Required)+len(propConfig.Optional))
+		fields = appendIntegrationFields(fields, propConfig.Required, true, propConfig.Defaults)
+		fields = appendIntegrationFields(fields, propConfig.Optional, false, propConfig.Defaults)
+
+		descriptors = append(descriptors, integration.Descriptor{
+			Type:              string(idpType),
+			DisplayName:       info.displayName,
+			Category:          info.category,
+			HostedCredentials: false,
+			Fields:            fields,
+		})
+	}
+
+	return descriptors
+}
+
+// appendIntegrationFields converts property names into integration fields, marking
+// secrets and applying any default values.
+func appendIntegrationFields(fields []integration.Field, names []string,
+	required bool, defaults map[string]string) []integration.Field {
+	for _, name := range names {
+		fields = append(fields, integration.Field{
+			Name:     name,
+			Required: required,
+			Secret:   name == PropClientSecret,
+			Default:  defaults[name],
+		})
+	}
+	return fields
+}

--- a/backend/internal/idp/catalog_test.go
+++ b/backend/internal/idp/catalog_test.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package idp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thunder-id/thunderid/internal/integration"
+)
+
+func findIntegration(descriptors []integration.Descriptor,
+	idpType IDPType) *integration.Descriptor {
+	for i := range descriptors {
+		if descriptors[i].Type == string(idpType) {
+			return &descriptors[i]
+		}
+	}
+	return nil
+}
+
+func fieldByName(d *integration.Descriptor, name string) *integration.Field {
+	for i := range d.Fields {
+		if d.Fields[i].Name == name {
+			return &d.Fields[i]
+		}
+	}
+	return nil
+}
+
+func TestIntegrationsCoversAllSupportedTypes(t *testing.T) {
+	descriptors := Integrations()
+
+	assert.Len(t, descriptors, len(supportedIDPTypes))
+	for _, idpType := range supportedIDPTypes {
+		assert.NotNil(t, findIntegration(descriptors, idpType), "missing integration for %s", idpType)
+	}
+}
+
+func TestIntegrationsPresentation(t *testing.T) {
+	descriptors := Integrations()
+
+	google := findIntegration(descriptors, IDPTypeGoogle)
+	assert.NotNil(t, google)
+	assert.Equal(t, "Google", google.DisplayName)
+	assert.Equal(t, integration.CategorySocialLogin, google.Category)
+	assert.False(t, google.HostedCredentials)
+
+	oidc := findIntegration(descriptors, IDPTypeOIDC)
+	assert.NotNil(t, oidc)
+	assert.Equal(t, integration.CategoryEnterprise, oidc.Category)
+}
+
+func TestIntegrationsFieldMetadata(t *testing.T) {
+	descriptors := Integrations()
+	google := findIntegration(descriptors, IDPTypeGoogle)
+	assert.NotNil(t, google)
+
+	clientID := fieldByName(google, PropClientID)
+	assert.NotNil(t, clientID)
+	assert.True(t, clientID.Required)
+	assert.False(t, clientID.Secret)
+
+	clientSecret := fieldByName(google, PropClientSecret)
+	assert.NotNil(t, clientSecret)
+	assert.True(t, clientSecret.Required)
+	assert.True(t, clientSecret.Secret)
+
+	// Optional properties carry their configured defaults.
+	authEndpoint := fieldByName(google, PropAuthorizationEndpoint)
+	assert.NotNil(t, authEndpoint)
+	assert.False(t, authEndpoint.Required)
+	assert.Equal(t, googleAuthorizationEndpoint, authEndpoint.Default)
+}

--- a/backend/internal/integration/handler.go
+++ b/backend/internal/integration/handler.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package integration
+
+import (
+	"net/http"
+
+	"github.com/thunder-id/thunderid/internal/system/log"
+	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
+)
+
+// handler handles integration catalog HTTP requests.
+type handler struct {
+	service ServiceInterface
+}
+
+// newHandler creates a new integration handler.
+func newHandler(service ServiceInterface) *handler {
+	return &handler{service: service}
+}
+
+// HandleIntegrationsRequest handles GET /integrations requests.
+func (h *handler) HandleIntegrationsRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IntegrationHandler"))
+
+	integrations := h.service.GetIntegrations(ctx)
+
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, integrations)
+	logger.Debug(ctx, "Integrations catalog response sent successfully")
+}

--- a/backend/internal/integration/init.go
+++ b/backend/internal/integration/init.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package integration
+
+import (
+	"net/http"
+
+	"github.com/thunder-id/thunderid/internal/system/middleware"
+)
+
+// Initialize initializes the integration catalog service and registers its routes.
+// The integrations slice is the aggregated catalog contributed by the domain packages.
+func Initialize(mux *http.ServeMux, integrations []Descriptor) ServiceInterface {
+	svc := newService(integrations)
+	h := newHandler(svc)
+	registerRoutes(mux, h)
+	return svc
+}
+
+// registerRoutes registers the routes for integration catalog operations.
+func registerRoutes(mux *http.ServeMux, h *handler) {
+	opts := middleware.CORSOptions{
+		AllowedMethods:   []string{"GET"},
+		AllowedHeaders:   middleware.DefaultAllowedHeaders,
+		AllowCredentials: true,
+		MaxAge:           600,
+	}
+	mux.HandleFunc(middleware.WithCORS("GET /integrations", h.HandleIntegrationsRequest, opts))
+	mux.HandleFunc(middleware.WithCORS("OPTIONS /integrations",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}, opts))
+}

--- a/backend/internal/integration/integration_test.go
+++ b/backend/internal/integration/integration_test.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package integration provides tests for the integrations catalog endpoint.
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type IntegrationTestSuite struct {
+	suite.Suite
+	integrations []Descriptor
+	service      ServiceInterface
+	handler      *handler
+}
+
+func TestIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(IntegrationTestSuite))
+}
+
+func (suite *IntegrationTestSuite) SetupTest() {
+	suite.integrations = []Descriptor{
+		{
+			Type:        "GOOGLE",
+			DisplayName: "Google",
+			Category:    CategorySocialLogin,
+			Fields: []Field{
+				{Name: "client_id", Required: true},
+				{Name: "client_secret", Required: true, Secret: true},
+			},
+		},
+		{
+			Type:        "twilio",
+			DisplayName: "Twilio",
+			Category:    CategorySMS,
+			Fields:      []Field{{Name: "account_sid", Required: true}},
+		},
+	}
+	suite.service = newService(suite.integrations)
+	suite.handler = newHandler(suite.service)
+}
+
+func (suite *IntegrationTestSuite) TestGetIntegrationsReturnsAll() {
+	catalog := suite.service.GetIntegrations(context.Background())
+
+	assert.Len(suite.T(), catalog.Integrations, 2)
+	assert.Equal(suite.T(), "GOOGLE", catalog.Integrations[0].Type)
+	assert.Equal(suite.T(), CategorySMS, catalog.Integrations[1].Category)
+}
+
+func (suite *IntegrationTestSuite) TestHandleIntegrationsRequest() {
+	req := httptest.NewRequest(http.MethodGet, "/integrations", nil)
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleIntegrationsRequest(w, req)
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	assert.Equal(suite.T(), "application/json", w.Header().Get("Content-Type"))
+
+	var catalog ListResponse
+	err := json.NewDecoder(w.Body).Decode(&catalog)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), catalog.Integrations, 2)
+
+	google := catalog.Integrations[0]
+	assert.Equal(suite.T(), "Google", google.DisplayName)
+	assert.Equal(suite.T(), CategorySocialLogin, google.Category)
+	assert.True(suite.T(), google.Fields[1].Secret)
+}
+
+func (suite *IntegrationTestSuite) TestHandleIntegrationsRequestEmpty() {
+	svc := newService(nil)
+	h := newHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/integrations", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleIntegrationsRequest(w, req)
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var catalog ListResponse
+	err := json.NewDecoder(w.Body).Decode(&catalog)
+	assert.NoError(suite.T(), err)
+	assert.Empty(suite.T(), catalog.Integrations)
+}

--- a/backend/internal/integration/models.go
+++ b/backend/internal/integration/models.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package integration serves the read-only catalog of integrations (identity
+// providers, notification senders, ...) that ThunderID can connect to. Domain
+// packages describe their available integrations as Descriptor values; this package
+// aggregates and exposes them so the console can render the integrations catalog and
+// configuration forms from metadata rather than hardcoded UI.
+package integration
+
+// Integration categories used to group integrations in the catalog.
+const (
+	CategorySocialLogin = "SOCIAL_LOGIN"
+	CategoryEnterprise  = "ENTERPRISE"
+	CategorySMS         = "SMS"
+)
+
+// Field describes a single configurable property of an integration.
+type Field struct {
+	// Name is the property key as stored on the integration instance (e.g. "client_id").
+	Name string `json:"name"`
+	// Required indicates the property must be provided for the integration to work.
+	Required bool `json:"required"`
+	// Secret indicates the value is sensitive: masked on read, write-only on write.
+	Secret bool `json:"secret,omitempty"`
+	// ReadOnly indicates the value is managed by ThunderID and cannot be edited.
+	ReadOnly bool `json:"readOnly,omitempty"`
+	// Default is the value pre-filled when the integration is configured.
+	Default string `json:"default,omitempty"`
+}
+
+// Descriptor describes an available integration and its configuration shape.
+type Descriptor struct {
+	// Type is the stable integration type identifier (e.g. "GOOGLE", "twilio").
+	Type string `json:"type"`
+	// DisplayName is the default human-readable name (the console may localize it).
+	DisplayName string `json:"displayName"`
+	// Category groups the integration in the catalog (see Category* constants).
+	Category string `json:"category"`
+	// HostedCredentials reports whether ThunderID ships default test credentials for
+	// this integration (hosted/cloud deployments). False for self-hosted.
+	HostedCredentials bool `json:"hostedCredentials"`
+	// Fields lists the configurable properties of the integration.
+	Fields []Field `json:"fields"`
+}
+
+// ListResponse is the payload returned by GET /integrations.
+type ListResponse struct {
+	Integrations []Descriptor `json:"integrations"`
+}

--- a/backend/internal/integration/service.go
+++ b/backend/internal/integration/service.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package integration
+
+import "context"
+
+// ServiceInterface exposes the integration catalog.
+type ServiceInterface interface {
+	GetIntegrations(ctx context.Context) ListResponse
+}
+
+// service serves a static set of integration descriptors.
+type service struct {
+	integrations []Descriptor
+}
+
+// newService creates an integration service over the given descriptors.
+func newService(integrations []Descriptor) ServiceInterface {
+	return &service{integrations: integrations}
+}
+
+// GetIntegrations returns the full integration catalog.
+func (s *service) GetIntegrations(_ context.Context) ListResponse {
+	return ListResponse{Integrations: s.integrations}
+}

--- a/backend/internal/notification/catalog.go
+++ b/backend/internal/notification/catalog.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package notification
+
+import (
+	"github.com/thunder-id/thunderid/internal/integration"
+	"github.com/thunder-id/thunderid/internal/notification/common"
+)
+
+// Integrations returns the integration catalog descriptors for all supported
+// message notification providers.
+func Integrations() []integration.Descriptor {
+	return []integration.Descriptor{
+		{
+			Type:              string(common.MessageProviderTypeTwilio),
+			DisplayName:       "Twilio",
+			Category:          integration.CategorySMS,
+			HostedCredentials: false,
+			Fields: []integration.Field{
+				{Name: common.TwilioPropKeyAccountSID, Required: true},
+				{Name: common.TwilioPropKeyAuthToken, Required: true, Secret: true},
+				{Name: common.TwilioPropKeySenderID, Required: true},
+			},
+		},
+		{
+			Type:              string(common.MessageProviderTypeVonage),
+			DisplayName:       "Vonage",
+			Category:          integration.CategorySMS,
+			HostedCredentials: false,
+			Fields: []integration.Field{
+				{Name: common.VonagePropKeyAPIKey, Required: true},
+				{Name: common.VonagePropKeyAPISecret, Required: true, Secret: true},
+				{Name: common.VonagePropKeySenderID, Required: true},
+			},
+		},
+		{
+			Type:              string(common.MessageProviderTypeCustom),
+			DisplayName:       "Custom Gateway",
+			Category:          integration.CategorySMS,
+			HostedCredentials: false,
+			Fields: []integration.Field{
+				{Name: common.CustomPropKeyURL, Required: true},
+				{Name: common.CustomPropKeyHTTPMethod, Required: true},
+				{Name: common.CustomPropKeyHTTPHeaders, Required: false},
+				{Name: common.CustomPropKeyContentType, Required: false},
+			},
+		},
+	}
+}

--- a/backend/internal/notification/catalog_test.go
+++ b/backend/internal/notification/catalog_test.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package notification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thunder-id/thunderid/internal/integration"
+	"github.com/thunder-id/thunderid/internal/notification/common"
+)
+
+func findIntegration(descriptors []integration.Descriptor,
+	connectorType string) *integration.Descriptor {
+	for i := range descriptors {
+		if descriptors[i].Type == connectorType {
+			return &descriptors[i]
+		}
+	}
+	return nil
+}
+
+func fieldByName(d *integration.Descriptor, name string) *integration.Field {
+	for i := range d.Fields {
+		if d.Fields[i].Name == name {
+			return &d.Fields[i]
+		}
+	}
+	return nil
+}
+
+func TestIntegrationsCoversAllProviders(t *testing.T) {
+	descriptors := Integrations()
+
+	assert.Len(t, descriptors, 3)
+	for _, provider := range []common.MessageProviderType{
+		common.MessageProviderTypeTwilio,
+		common.MessageProviderTypeVonage,
+		common.MessageProviderTypeCustom,
+	} {
+		d := findIntegration(descriptors, string(provider))
+		assert.NotNil(t, d, "missing integration for %s", provider)
+		assert.Equal(t, integration.CategorySMS, d.Category)
+		assert.False(t, d.HostedCredentials)
+	}
+}
+
+func TestIntegrationsSecretFields(t *testing.T) {
+	descriptors := Integrations()
+
+	twilio := findIntegration(descriptors, string(common.MessageProviderTypeTwilio))
+	assert.NotNil(t, twilio)
+	authToken := fieldByName(twilio, common.TwilioPropKeyAuthToken)
+	assert.NotNil(t, authToken)
+	assert.True(t, authToken.Required)
+	assert.True(t, authToken.Secret)
+	accountSID := fieldByName(twilio, common.TwilioPropKeyAccountSID)
+	assert.NotNil(t, accountSID)
+	assert.False(t, accountSID.Secret)
+
+	vonage := findIntegration(descriptors, string(common.MessageProviderTypeVonage))
+	assert.NotNil(t, vonage)
+	apiSecret := fieldByName(vonage, common.VonagePropKeyAPISecret)
+	assert.NotNil(t, apiSecret)
+	assert.True(t, apiSecret.Secret)
+}
+
+func TestIntegrationsCustomOptionalFields(t *testing.T) {
+	descriptors := Integrations()
+
+	custom := findIntegration(descriptors, string(common.MessageProviderTypeCustom))
+	assert.NotNil(t, custom)
+
+	url := fieldByName(custom, common.CustomPropKeyURL)
+	assert.NotNil(t, url)
+	assert.True(t, url.Required)
+
+	headers := fieldByName(custom, common.CustomPropKeyHTTPHeaders)
+	assert.NotNil(t, headers)
+	assert.False(t, headers.Required)
+}


### PR DESCRIPTION
### Purpose

Adds a read-only **`GET /integrations`** endpoint that serves the catalog of integrations ThunderID can connect to, together with each integration's configuration field metadata. This is the foundation of the new console **Integrations** area (issue #1157): the console will render the integrations catalog and connector configuration forms from this metadata instead of hardcoded per-connector UI, and it is the seam a future marketplace can register connectors into without a console release.

This PR is backend-only (the first slice of the feature); the console grid page and configuration flow follow in subsequent PRs.

The endpoint aggregates the integrations contributed by the domain packages:

- **Identity providers** (`idp.Integrations()`): Google, GitHub → `SOCIAL_LOGIN`; OAuth, OIDC → `ENTERPRISE`. Fields are derived from the existing per-type property configs (required/optional, secret flag on `client_secret`, configured defaults).
- **Message notification senders** (`notification.Integrations()`): Twilio, Vonage, Custom → `SMS`, with their property fields (secret flag on `auth_token` / `api_secret`).

Example response:

```json
{
  "integrations": [
    {
      "type": "GOOGLE",
      "displayName": "Google",
      "category": "SOCIAL_LOGIN",
      "hostedCredentials": false,
      "fields": [
        { "name": "client_id", "required": true },
        { "name": "client_secret", "required": true, "secret": true },
        { "name": "redirect_uri", "required": true }
      ]
    }
  ]
}
```

### Approach

- New leaf package `internal/integration` owns the API DTO (`Descriptor`, `Field`, `ListResponse`), the service, the handler, and route registration (`GET /integrations`). It has no store, auth, or persistence — the catalog is static metadata.
- Metadata ownership stays in-domain: `idp` and `notification` each expose an exported `Integrations() []integration.Descriptor`, and `servicemanager` aggregates them and calls `integration.Initialize(mux, …)`. This avoids import cycles and keeps each domain the source of truth for its own connector shape.
- `hostedCredentials` is `false` for self-hosted; it is the seam for hosted/cloud deployments to later ship default test credentials. Field metadata includes a `readOnly` flag (unused in v1) for the same reason.
- The endpoint resolves to the root system permission by default (consistent with `/identity-providers`), so no changes to the permission map were required.
- OpenAPI spec added at `api/integrations.yaml`.

### Related Issues
- #1157

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Integrations API endpoint enabling discovery of available connectors, including identity providers and notification services. Returns connector metadata such as display name, category, configuration fields, and hosted credential availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->