### PR TITLE
Fix deployment.yaml path in release Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ ARG CERT_FILE
 ARG KEY_FILE
 
 # Modify the hostname in the deployment configuration
-RUN sed -i 's/hostname: "localhost"/hostname: "0.0.0.0"/' backend/cmd/server/repository/conf/deployment.yaml && \
-    sed -i '/hostname: "0.0.0.0"/a\  public_url: "https://localhost:8090"' backend/cmd/server/repository/conf/deployment.yaml
+RUN sed -i 's/hostname: "localhost"/hostname: "0.0.0.0"/' backend/cmd/server/deployment.yaml && \
+    sed -i '/hostname: "0.0.0.0"/a\  public_url: "https://localhost:8090"' backend/cmd/server/deployment.yaml
 
 # Handle shared certificates - use provided certificates or generate new ones
 RUN if [ -n "$CERT_FILE" ] && [ -n "$KEY_FILE" ] && [ -f "$CERT_FILE" ] && [ -f "$KEY_FILE" ]; then \


### PR DESCRIPTION
### Purpose
Fixes the release workflow's **Build and Push Multi-Arch Docker Image** step, which fails with:

```
sed: backend/cmd/server/repository/conf/deployment.yaml: No such file or directory
```

The distribution reorg in `3aeb474b4` moved `deployment.yaml` from `backend/cmd/server/repository/conf/` to `backend/cmd/server/`, but the `Dockerfile` `sed` commands still referenced the old path, breaking the multi-arch image build.

### Approach
Updated the two `sed` paths in the `Dockerfile` to point at the new `backend/cmd/server/deployment.yaml` location. No other references to the old server path remain (the `consent/repository/conf/` paths belong to the separate consent server and are unchanged).

### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3300

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
