### PR TITLE
Propagate correlation ID to outbound HTTP requests

### DIFF
--- a/backend/cmd/server/config/default.json
+++ b/backend/cmd/server/config/default.json
@@ -238,6 +238,7 @@
     "rest": {
       "base_url": "",
       "timeout": 10,
+      "correlation_id_header": "X-Correlation-ID",
       "security": {
         "api_key": ""
       }

--- a/backend/internal/authnprovider/provider/init.go
+++ b/backend/internal/authnprovider/provider/init.go
@@ -29,6 +29,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/entity"
 	"github.com/thunder-id/thunderid/internal/openid4vp"
 	"github.com/thunder-id/thunderid/internal/system/config"
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	systemhttp "github.com/thunder-id/thunderid/internal/system/http"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -70,6 +71,7 @@ func initializeRestAuthnProvider() AuthnProviderInterface {
 	baseURL := authnProviderConfig.Rest.BaseURL
 	apiKey := authnProviderConfig.Rest.Security.APIKey
 	timeout := time.Duration(authnProviderConfig.Rest.Timeout) * time.Second
+	correlationIDHeader := authnProviderConfig.Rest.CorrelationIDHeader
 	if baseURL == "" {
 		// Provider initialization runs during application startup, outside any request.
 		log.GetLogger().Fatal(context.Background(), "AuthnProvider Rest BaseURL is required but found empty")
@@ -77,6 +79,9 @@ func initializeRestAuthnProvider() AuthnProviderInterface {
 	if timeout == 0 {
 		timeout = 10 * time.Second
 	}
+	if correlationIDHeader == "" {
+		correlationIDHeader = serverconst.CorrelationIDHeaderName
+	}
 	httpClient := systemhttp.NewHTTPClientWithTimeout(timeout)
-	return newRestAuthnProvider(baseURL, apiKey, httpClient)
+	return newRestAuthnProvider(baseURL, apiKey, correlationIDHeader, httpClient)
 }

--- a/backend/internal/authnprovider/provider/rest_authn_provider.go
+++ b/backend/internal/authnprovider/provider/rest_authn_provider.go
@@ -29,16 +29,18 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	systemhttp "github.com/thunder-id/thunderid/internal/system/http"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
 
 // restAuthnProvider is an authentication provider that communicates with an external service via REST.
 type restAuthnProvider struct {
-	baseURL    string
-	apiKey     string
-	httpClient systemhttp.HTTPClientInterface
-	logger     *log.Logger
+	baseURL             string
+	apiKey              string
+	correlationIDHeader string
+	httpClient          systemhttp.HTTPClientInterface
+	logger              *log.Logger
 }
 
 // AuthenticateRequest is the request body for the authentication endpoint.
@@ -62,12 +64,14 @@ type apiErrorResponse struct {
 }
 
 // newRestAuthnProvider creates a new REST authentication provider.
-func newRestAuthnProvider(baseURL, apiKey string, httpClient systemhttp.HTTPClientInterface) AuthnProviderInterface {
+func newRestAuthnProvider(baseURL, apiKey, correlationIDHeader string,
+	httpClient systemhttp.HTTPClientInterface) AuthnProviderInterface {
 	return &restAuthnProvider{
-		baseURL:    baseURL,
-		apiKey:     apiKey,
-		httpClient: httpClient,
-		logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, "RestAuthnProvider")),
+		baseURL:             baseURL,
+		apiKey:              apiKey,
+		correlationIDHeader: correlationIDHeader,
+		httpClient:          httpClient,
+		logger:              log.GetLogger().With(log.String(log.LoggerKeyComponentName, "RestAuthnProvider")),
 	}
 }
 
@@ -183,6 +187,7 @@ func (p *restAuthnProvider) doRequest(ctx context.Context, url string, body io.R
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(p.correlationIDHeader, sysContext.GetTraceID(ctx))
 	if p.apiKey != "" {
 		req.Header.Set("API-KEY", p.apiKey)
 	}

--- a/backend/internal/authnprovider/provider/rest_authn_provider_test.go
+++ b/backend/internal/authnprovider/provider/rest_authn_provider_test.go
@@ -32,6 +32,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
+	"github.com/thunder-id/thunderid/internal/system/config"
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/tests/mocks/httpmock"
 )
 
@@ -49,6 +52,34 @@ func (suite *RestAuthnProviderTestSuite) setupMockClient() *httpmock.HTTPClientI
 		return http.DefaultClient.Do(req)
 	})
 	return client
+}
+
+func (suite *RestAuthnProviderTestSuite) initRuntime(rest config.RestConfig) {
+	cfg := &config.Config{
+		AuthnProvider: config.AuthnProviderConfig{Type: "rest", Rest: rest},
+	}
+	config.ResetServerRuntime()
+	suite.Require().NoError(config.InitializeServerRuntime("/tmp/test", cfg))
+	suite.T().Cleanup(config.ResetServerRuntime)
+}
+
+func (suite *RestAuthnProviderTestSuite) TestInitializeRestAuthnProvider_DefaultCorrelationHeader() {
+	suite.initRuntime(config.RestConfig{BaseURL: "https://authn.example.com"})
+
+	provider := initializeRestAuthnProvider().(*restAuthnProvider)
+
+	suite.Equal(serverconst.CorrelationIDHeaderName, provider.correlationIDHeader)
+}
+
+func (suite *RestAuthnProviderTestSuite) TestInitializeRestAuthnProvider_ConfiguredCorrelationHeader() {
+	suite.initRuntime(config.RestConfig{
+		BaseURL:             "https://authn.example.com",
+		CorrelationIDHeader: "X-Trace-Token",
+	})
+
+	provider := initializeRestAuthnProvider().(*restAuthnProvider)
+
+	suite.Equal("X-Trace-Token", provider.correlationIDHeader)
 }
 
 func (suite *RestAuthnProviderTestSuite) TestAuthenticate_Success() {
@@ -75,7 +106,7 @@ func (suite *RestAuthnProviderTestSuite) TestAuthenticate_Success() {
 	}))
 	defer ts.Close()
 
-	provider := newRestAuthnProvider(ts.URL, "apikey123", suite.setupMockClient())
+	provider := newRestAuthnProvider(ts.URL, "apikey123", "X-Correlation-ID", suite.setupMockClient())
 	identifiers := map[string]interface{}{"username": "user"}
 	credentials := map[string]interface{}{"password": "pass"}
 
@@ -85,6 +116,46 @@ func (suite *RestAuthnProviderTestSuite) TestAuthenticate_Success() {
 	suite.NotNil(result.EntityReference)
 	suite.Equal("user123", result.EntityReference.EntityID)
 	suite.Equal("customer", result.EntityReference.EntityType)
+}
+
+func (suite *RestAuthnProviderTestSuite) TestAuthenticate_PropagatesCorrelationID() {
+	var gotCorrelationID string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCorrelationID = r.Header.Get("X-Correlation-ID")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(providers.AuthnResult{})
+	}))
+	defer ts.Close()
+
+	provider := newRestAuthnProvider(ts.URL, "", "X-Correlation-ID", suite.setupMockClient())
+	ctx := sysContext.WithTraceID(context.Background(), "trace-xyz")
+
+	_, err := provider.Authenticate(ctx, map[string]interface{}{"username": "user"},
+		map[string]interface{}{"password": "pass"}, nil)
+
+	suite.Nil(err)
+	suite.Equal("trace-xyz", gotCorrelationID)
+}
+
+func (suite *RestAuthnProviderTestSuite) TestAuthenticate_PropagatesConfiguredCorrelationIDHeader() {
+	var defaultHeader, customHeader string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defaultHeader = r.Header.Get("X-Correlation-ID")
+		customHeader = r.Header.Get("X-Trace-Token")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(providers.AuthnResult{})
+	}))
+	defer ts.Close()
+
+	provider := newRestAuthnProvider(ts.URL, "", "X-Trace-Token", suite.setupMockClient())
+	ctx := sysContext.WithTraceID(context.Background(), "trace-xyz")
+
+	_, err := provider.Authenticate(ctx, map[string]interface{}{"username": "user"},
+		map[string]interface{}{"password": "pass"}, nil)
+
+	suite.Nil(err)
+	suite.Equal("trace-xyz", customHeader)
+	suite.Empty(defaultHeader)
 }
 
 func (suite *RestAuthnProviderTestSuite) TestAuthenticate_Failure() {
@@ -97,7 +168,7 @@ func (suite *RestAuthnProviderTestSuite) TestAuthenticate_Failure() {
 	}))
 	defer ts.Close()
 
-	provider := newRestAuthnProvider(ts.URL, "", suite.setupMockClient())
+	provider := newRestAuthnProvider(ts.URL, "", "X-Correlation-ID", suite.setupMockClient())
 	result, err := provider.Authenticate(context.Background(), nil, nil, nil)
 
 	suite.Nil(result)
@@ -122,7 +193,7 @@ func (suite *RestAuthnProviderTestSuite) TestGetEntityReference_Success() {
 	}))
 	defer ts.Close()
 
-	provider := newRestAuthnProvider(ts.URL, "apikey123", suite.setupMockClient())
+	provider := newRestAuthnProvider(ts.URL, "apikey123", "X-Correlation-ID", suite.setupMockClient())
 	result, err := provider.GetEntityReference(context.Background(), "ref-token-123")
 
 	suite.Nil(err)
@@ -143,7 +214,7 @@ func (suite *RestAuthnProviderTestSuite) TestGetEntityReference_Failure() {
 	}))
 	defer ts.Close()
 
-	provider := newRestAuthnProvider(ts.URL, "", suite.setupMockClient())
+	provider := newRestAuthnProvider(ts.URL, "", "X-Correlation-ID", suite.setupMockClient())
 	result, err := provider.GetEntityReference(context.Background(), "invalid-token")
 
 	suite.Nil(result)
@@ -173,7 +244,7 @@ func (suite *RestAuthnProviderTestSuite) TestGetAttributes_Success() {
 	}))
 	defer ts.Close()
 
-	provider := newRestAuthnProvider(ts.URL, "apikey123", suite.setupMockClient())
+	provider := newRestAuthnProvider(ts.URL, "apikey123", "X-Correlation-ID", suite.setupMockClient())
 	reqAttrs := &providers.RequestedAttributes{
 		Attributes: map[string]*providers.AttributeMetadataRequest{
 			"email": nil,
@@ -195,7 +266,7 @@ func (suite *RestAuthnProviderTestSuite) TestGetAttributes_InvalidToken() {
 	}))
 	defer ts.Close()
 
-	provider := newRestAuthnProvider(ts.URL, "", suite.setupMockClient())
+	provider := newRestAuthnProvider(ts.URL, "", "X-Correlation-ID", suite.setupMockClient())
 	result, err := provider.GetAttributes(context.Background(), "invalid", nil, nil)
 
 	suite.Nil(result)
@@ -211,7 +282,7 @@ func (suite *RestAuthnProviderTestSuite) TestSystemError_Decoding() {
 	}))
 	defer ts.Close()
 
-	provider := newRestAuthnProvider(ts.URL, "", suite.setupMockClient())
+	provider := newRestAuthnProvider(ts.URL, "", "X-Correlation-ID", suite.setupMockClient())
 	result, err := provider.Authenticate(context.Background(), nil, nil, nil)
 
 	suite.Nil(result)

--- a/backend/internal/consent/default_client.go
+++ b/backend/internal/consent/default_client.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/config"
 	sysconst "github.com/thunder-id/thunderid/internal/system/constants"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	httpservice "github.com/thunder-id/thunderid/internal/system/http"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
@@ -1108,6 +1109,7 @@ func (c *defaultClient) doRequest(ctx context.Context, method, url, ouID, groupI
 		if encodedBody != nil {
 			req.Header.Set(sysconst.ContentTypeHeaderName, sysconst.ContentTypeJSON)
 		}
+		req.Header.Set(sysconst.CorrelationIDHeaderName, sysContext.GetTraceID(reqCtx))
 		c.setCommonHeaders(req, ouID, groupID)
 
 		resp, err := c.httpClient.Do(req)

--- a/backend/internal/consent/default_client_test.go
+++ b/backend/internal/consent/default_client_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/tests/mocks/httpmock"
 )
 
@@ -133,6 +134,28 @@ func (s *DefaultClientTestSuite) TestCreateConsentElements_Success() {
 	s.Nil(svcErr)
 	s.Len(result, 1)
 	s.Equal("email", result[0].Name)
+}
+
+func (s *DefaultClientTestSuite) TestDoRequest_PropagatesCorrelationID() {
+	httpMock := httpmock.NewHTTPClientInterfaceMock(s.T())
+	c := newTestClient(s.T(), httpMock)
+
+	var gotCorrelationID string
+	respBody := elementsCreateResponseDTO{
+		Data: []elementResponseDTO{{ID: "e1", Name: "email", Type: "basic"}},
+	}
+	httpMock.EXPECT().Do(mock.AnythingOfType("*http.Request")).
+		RunAndReturn(func(req *http.Request) (*http.Response, error) {
+			gotCorrelationID = req.Header.Get("X-Correlation-ID")
+			return buildHTTPResponse(s.T(), http.StatusOK, respBody), nil
+		})
+
+	ctx := sysContext.WithTraceID(context.Background(), "trace-xyz")
+	inputs := []ConsentElementInput{{Name: "email", Namespace: providers.NamespaceAttribute}}
+	_, svcErr := c.createConsentElements(ctx, "ou1", inputs)
+
+	s.Nil(svcErr)
+	s.Equal("trace-xyz", gotCorrelationID)
 }
 
 func (s *DefaultClientTestSuite) TestCreateConsentElements_BadRequest() {

--- a/backend/internal/flow/executor/http_request_executor.go
+++ b/backend/internal/flow/executor/http_request_executor.go
@@ -37,6 +37,8 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/flow/core"
 	"github.com/thunder-id/thunderid/internal/ou"
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	httpservice "github.com/thunder-id/thunderid/internal/system/http"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
@@ -445,6 +447,11 @@ func (h *httpRequestExecutor) executeRequest(ctx *providers.NodeContext, config 
 	// Set headers
 	for key, value := range config.Headers {
 		req.Header.Set(key, value)
+	}
+
+	// Propagate the correlation ID unless the flow explicitly configured one.
+	if req.Header.Get(serverconst.CorrelationIDHeaderName) == "" {
+		req.Header.Set(serverconst.CorrelationIDHeaderName, sysContext.GetTraceID(ctx.Context))
 	}
 
 	// Set default Content-Type for requests with body

--- a/backend/internal/flow/executor/http_request_executor_test.go
+++ b/backend/internal/flow/executor/http_request_executor_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
 	"github.com/thunder-id/thunderid/tests/mocks/oumock"
@@ -394,6 +395,57 @@ func (suite *HTTPRequestExecutorTestSuite) TestExecute_SuccessfulPOSTRequest() {
 	// Verify headers
 	assert.Equal(suite.T(), "Bearer token123", receivedHeaders.Get("Authorization"))
 	assert.Equal(suite.T(), "custom123", receivedHeaders.Get("X-Custom-Header"))
+}
+
+func (suite *HTTPRequestExecutorTestSuite) TestExecute_PropagatesCorrelationID() {
+	var receivedHeaders http.Header
+	suite.mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+	}))
+
+	ctx := &providers.NodeContext{
+		Context:     sysContext.WithTraceID(context.Background(), "trace-xyz"),
+		ExecutionID: "test-flow",
+		NodeProperties: map[string]interface{}{
+			"url":    suite.mockServer.URL + "/api",
+			"method": "GET",
+		},
+		UserInputs:  make(map[string]string),
+		RuntimeData: make(map[string]string),
+	}
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "trace-xyz", receivedHeaders.Get("X-Correlation-ID"))
+}
+
+func (suite *HTTPRequestExecutorTestSuite) TestExecute_DoesNotOverrideConfiguredCorrelationID() {
+	var receivedHeaders http.Header
+	suite.mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+	}))
+
+	ctx := &providers.NodeContext{
+		Context:     sysContext.WithTraceID(context.Background(), "trace-xyz"),
+		ExecutionID: "test-flow",
+		NodeProperties: map[string]interface{}{
+			"url":     suite.mockServer.URL + "/api",
+			"method":  "GET",
+			"headers": `{"X-Correlation-ID": "explicit-id"}`,
+		},
+		UserInputs:  make(map[string]string),
+		RuntimeData: make(map[string]string),
+	}
+
+	_, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "explicit-id", receivedHeaders.Get("X-Correlation-ID"))
 }
 
 func (suite *HTTPRequestExecutorTestSuite) TestExecute_ResponseMapping() {

--- a/backend/internal/notification/client/vonage_client.go
+++ b/backend/internal/notification/client/vonage_client.go
@@ -27,6 +27,8 @@ import (
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/notification/common"
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	syshttp "github.com/thunder-id/thunderid/internal/system/http"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
@@ -126,6 +128,7 @@ func (v *VonageClient) sendSMS(ctx context.Context, data common.NotificationData
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set(serverconst.CorrelationIDHeaderName, sysContext.GetTraceID(ctx))
 	req.SetBasicAuth(v.apiKey, v.apiSecret)
 
 	resp, err := v.httpClient.Do(req)

--- a/backend/internal/notification/client/vonage_client_test.go
+++ b/backend/internal/notification/client/vonage_client_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/notification/common"
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
 	"github.com/thunder-id/thunderid/internal/system/config"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 )
 
 type VonageClientTestSuite struct {
@@ -121,6 +122,35 @@ func (suite *VonageClientTestSuite) TestSendSMS_Success() {
 	err := client.Send(context.Background(), common.ChannelTypeSMS, data)
 
 	suite.NoError(err)
+}
+
+func (suite *VonageClientTestSuite) TestSendSMS_PropagatesCorrelationID() {
+	sender := suite.getValidVonageSender()
+	client, _ := newVonageClient(context.Background(), sender)
+
+	var gotCorrelationID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCorrelationID = r.Header.Get("X-Correlation-ID")
+		w.WriteHeader(http.StatusAccepted)
+		if _, err := w.Write([]byte(`{"message_uuid":"abc123"}`)); err != nil {
+			suite.T().Errorf("Failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	vonageClient := client.(*VonageClient)
+	vonageClient.url = server.URL
+
+	data := common.NotificationData{
+		Recipient: "+15559876543",
+		Body:      "Test message",
+	}
+
+	ctx := sysContext.WithTraceID(context.Background(), "trace-xyz")
+	err := client.Send(ctx, common.ChannelTypeSMS, data)
+
+	suite.NoError(err)
+	suite.Equal("trace-xyz", gotCorrelationID)
 }
 
 func (suite *VonageClientTestSuite) TestSendSMS_Error() {

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -256,9 +256,10 @@ type EntityProviderConfig struct {
 
 // RestConfig holds the REST authentication provider configuration details.
 type RestConfig struct {
-	BaseURL  string             `yaml:"base_url" json:"base_url"`
-	Timeout  int                `yaml:"timeout"  json:"timeout"`
-	Security RestSecurityConfig `yaml:"security" json:"security"`
+	BaseURL             string             `yaml:"base_url" json:"base_url"`
+	Timeout             int                `yaml:"timeout" json:"timeout"`
+	CorrelationIDHeader string             `yaml:"correlation_id_header" json:"correlation_id_header"`
+	Security            RestSecurityConfig `yaml:"security" json:"security"`
 }
 
 // RestSecurityConfig holds the REST authentication provider security configuration details.

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -35,6 +35,10 @@ const AcceptHeaderName = "Accept"
 // ContentTypeHeaderName is the name of the content type header used in HTTP requests.
 const ContentTypeHeaderName = "Content-Type"
 
+// CorrelationIDHeaderName is the name of the correlation ID (trace ID) header used to propagate
+// the request's trace ID across service boundaries.
+const CorrelationIDHeaderName = "X-Correlation-ID"
+
 // TokenTypeBearer is the token type used in bearer authentication.
 const TokenTypeBearer = "Bearer"
 

--- a/backend/internal/system/middleware/correlationid.go
+++ b/backend/internal/system/middleware/correlationid.go
@@ -21,6 +21,7 @@ package middleware
 import (
 	"net/http"
 
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 )
 
@@ -50,7 +51,7 @@ func CorrelationIDMiddleware(next http.Handler) http.Handler {
 		r = r.WithContext(ctx)
 
 		// Add correlation ID to response headers so clients can track requests
-		w.Header().Set("X-Correlation-ID", correlationID)
+		w.Header().Set(serverconst.CorrelationIDHeaderName, correlationID)
 
 		// Continue with the next handler
 		next.ServeHTTP(w, r)

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -692,7 +692,21 @@ External authentication provider settings.
 | `authn_provider.type` | `default` | Provider type (`default` or `rest`) |
 | `authn_provider.rest.base_url` | `""` | Base URL for REST authentication provider |
 | `authn_provider.rest.timeout` | `10` | Request timeout in seconds |
+| `authn_provider.rest.correlation_id_header` | `X-Correlation-ID` | Header used to forward the request's correlation ID (trace ID) to the REST provider. Set a different name if the provider expects one. |
 | `authn_provider.rest.security.api_key` | `""` | API key for REST provider authentication |
+
+### Correlation ID Propagation
+
+Each request is assigned a correlation ID (trace ID), which the server generates when the client does not supply one. <ProductName /> forwards this ID on outbound HTTP calls so a request can be traced across services. The REST authentication provider, the consent service, the flow HTTP request executor, and the Vonage notification provider all set the `X-Correlation-ID` header when it is missing. For the REST authentication provider, the header name is configurable via `authn_provider.rest.correlation_id_header`.
+
+**Example** — forward the correlation ID under a custom header name:
+```yaml
+authn_provider:
+  type: rest
+  rest:
+    base_url: "https://my-authn-service"
+    correlation_id_header: "X-Trace-Token"
+```
 
 ## CORS Configuration
 


### PR DESCRIPTION
### Purpose

We already generate a correlation ID (trace ID) per request and attach it to every log line via the context-aware logging work (#2038). The problem is that the ID never left the process: any time Thunder made an *outbound* HTTP call, the correlation ID sitting in the context was dropped on the floor. So the moment a request crossed into an external service (a REST authn provider, the consent service, a flow's HTTP-request node, or an SMS provider), the trace was broken and you couldn't follow a single request end to end.

I actually confirmed this by hand before fixing it. With a REST authn provider pointed at a small listener that echoes back the headers it receives, a request sent in with `X-Correlation-ID: manual-test-123` showed up in our logs and in the response header, but the outbound call to the provider arrived with **no** correlation header at all.

This PR closes that gap. Every outbound HTTP client now forwards the request's correlation ID as the `X-Correlation-ID` header, so the trace continues across the service boundary.

This addresses the outbound-propagation part of #1484. See the note under *Approach* about why the user/entity provider side is intentionally not in here.

### Approach

The trace ID is already in `context.Context` by the time any handler runs (the `CorrelationIDMiddleware` puts it there on the way in). So the fix is simply to read it back out where we build an outbound request and set it as a header — no new plumbing on the request path, since the context was already threaded through.

Concretely:

- Added a single `CorrelationIDHeaderName = "X-Correlation-ID"` constant in `system/constants` and switched the middleware's response header over to it, so the inbound and outbound sides agree on one name.
- Each outbound request builder now sets that header from `sysContext.GetTraceID(ctx)`:
  - REST authn provider (`doRequest`) — this one spot covers `Authenticate`, `GetEntityReference` and `GetAttributes`, since they all go through it.
  - Consent client (`doRequest`).
  - Flow HTTP-request executor (`executeRequest`) — only when the flow hasn't already set a header of that name, so an explicit node-configured value still wins.
  - Vonage SMS client (`sendSMS`).
- The REST authn provider accepts an optional per-provider override, `authn_provider.rest.correlation_id_header`, which defaults to the constant when empty. This lets a downstream service that expects a different header name receive it. (We considered a server-wide setting but decided against it — only the pluggable authn provider needs the knob.)

`GetTraceID` generates a fresh UUID if the context somehow doesn't have one, so the header is always populated; in a normal request it's just the same ID that came in.

Here's how the ID flows after this change:

```mermaid
sequenceDiagram
    participant C as Client
    participant MW as CorrelationIDMiddleware
    participant Ctx as request context
    participant H as Handler / Service
    participant OUT as Outbound HTTP client
    participant EXT as External service

    C->>MW: request (maybe with X-Correlation-ID)
    MW->>Ctx: WithTraceID(extracted or generated)
    MW-->>C: response header X-Correlation-ID
    MW->>H: ServeHTTP (ctx carries trace ID)
    H->>OUT: call with ctx
    Note over OUT: GetTraceID(ctx) → set X-Correlation-ID
    OUT->>EXT: outbound request + X-Correlation-ID
    EXT-->>OUT: response
```

And the four outbound paths this touches, all reading from the same context:

```mermaid
flowchart LR
    Ctx["context.Context<br/>(trace ID)"]
    Ctx --> A["REST authn provider<br/>doRequest*"]
    Ctx --> B["Consent client<br/>doRequest"]
    Ctx --> D["Flow HTTP executor<br/>executeRequest**"]
    Ctx --> E["Vonage client<br/>sendSMS"]
    A --> X1["external authn service"]
    B --> X2["consent service"]
    D --> X3["flow-configured endpoint"]
    E --> X4["Vonage API"]
    classDef ext fill:#eee,stroke:#999;
    class X1,X2,X3,X4 ext;
```
<sub>* the REST authn provider can override the header name via `authn_provider.rest.correlation_id_header`.<br/>** the flow executor does not overwrite a correlation header the flow author set explicitly.</sub>

**Why the entity provider isn't here.** #1484 was originally written against the `UserProviderInterface` from #1420. That package was later replaced by the entity provider. As it stands today the entity provider has no REST implementation (only the in-process default and a disabled variant) and its interface methods don't take a `context.Context` at all, so there's nothing outbound to tag and no context to read from. Propagating the ID there is a separate follow-up that first needs `context.Context` threaded through `EntityProviderInterface` and a REST entity provider to exist. Calling it out here so this PR isn't mistaken for fully closing #1484.

### Related Issues
- Refs thunder-id/thunderid#1484
- Background: thunder-id/thunderid#2038 (correlation IDs in logs)

### Related PRs
- Builds on the context-aware logging work (#3141, #3238, #3254)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outbound REST authentication, consent, flow execution, and notification requests now propagate correlation/trace IDs via an HTTP header.
  * The correlation header name is configurable (defaults to `X-Correlation-ID`) and can be customized.
* **Bug Fixes**
  * Correlation ID middleware now uses the configured header name consistently for response headers.
  * If an outbound request already specifies a correlation header, it will not be overwritten.
* **Chores**
  * Expanded automated tests and documentation to cover correlation ID propagation end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
