### PR TITLE
Bump react-router-dom to 7.15.1 to fix CSRF advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2309,8 +2309,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(react@19.2.3)
       react-router-dom:
-        specifier: 7.15.0
-        version: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 7.15.1
+        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: 9.27.0
@@ -13748,8 +13748,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router-dom@7.15.0:
-    resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
+  react-router-dom@7.15.1:
+    resolution: {integrity: sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -13765,16 +13765,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
-
-  react-router@7.15.0:
-    resolution: {integrity: sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
 
   react-router@7.15.1:
     resolution: {integrity: sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==}
@@ -29823,11 +29813,11 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-router: 6.30.4(react@19.2.3)
 
-  react-router-dom@7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router-dom@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      react-router: 7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-router: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   react-router@5.3.4(react@19.2.3):
     dependencies:
@@ -29846,14 +29836,6 @@ snapshots:
     dependencies:
       '@remix-run/router': 1.23.3
       react: 19.2.3
-
-  react-router@7.15.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.3
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
-      react-dom: 19.2.3(react@19.2.3)
 
   react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/samples/apps/react-vanilla-sample/package.json
+++ b/samples/apps/react-vanilla-sample/package.json
@@ -18,7 +18,7 @@
     "@mui/system": "7.1.0",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-router-dom": "7.15.0"
+    "react-router-dom": "7.15.1"
   },
   "devDependencies": {
     "@eslint/js": "9.27.0",


### PR DESCRIPTION
### Purpose

Resolves a [Dependabot security alert](https://github.com/asgardeo/thunder/security/dependabot) by bumping a vulnerable transitive dependency.

- **Alert https://github.com/thunder-id/thunderid/security/dependabot/364 — `react-router` CSRF** ([GHSA-84g9-w2xq-vcv6](https://github.com/advisories/GHSA-84g9-w2xq-vcv6), low): Potential CSRF via `PUT`/`PATCH`/`DELETE` document requests. Affects `react-router` `>= 7.12.0, < 7.15.1`.

The alert originated from `samples/apps/react-vanilla-sample`, which pinned `react-router-dom` to `7.15.0` — pulling the vulnerable `react-router@7.15.0`. Bumping to `7.15.1` pulls the patched `react-router@7.15.1`, matching the version already pinned in the workspace pnpm catalog.

### Approach

- Changed `react-router-dom` from `7.15.0` to `7.15.1` in `samples/apps/react-vanilla-sample/package.json`.
- Regenerated `pnpm-lock.yaml` (`pnpm install --lockfile-only`); the vulnerable `react-router@7.15.0` / `react-router-dom@7.15.0` entries are removed and only the patched `7.15.1` remains.

This is a patch-level bump within the same minor, so no API changes are involved.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. (Lockfile regenerated; confirmed vulnerable `react-router@7.15.0` no longer resolves.)
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `react-router-dom` dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->