### PR TITLE
Fail docs build on broken markdown links

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -82,6 +82,9 @@ const config: Config = {
   onBrokenLinks: 'throw',
 
   markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
     // Replace {{ProductName}} placeholders in frontmatter values at build time.
     // This applies globally to all content (docs, pages, etc.).
     // See: https://docusaurus.io/docs/api/docusaurus-config#markdown


### PR DESCRIPTION
### Purpose
Make broken Markdown-style links (`[text](../path/to/file.mdx)`) fail the documentation build, the same way broken site-path links already do via `onBrokenLinks: 'throw'`.

Currently `onBrokenMarkdownLinks` is unset, so it falls back to the Docusaurus default of `warn`. This means that when a doc file is moved or renamed, any relative `.md`/`.mdx` references to it from other (possibly unchanged) pages only produce a build warning instead of failing CI — letting broken links slip into the published docs. The `build-docs` job runs a full site build, so it already detects these links; it just wasn't treating them as errors.

### Approach
Set `onBrokenMarkdownLinks: 'throw'` in `docs/docusaurus.config.ts`, alongside the existing `onBrokenLinks: 'throw'`. This promotes broken relative Markdown links from warnings to build failures, closing the gap for the small number of `.mdx`-style references in the content.

Verified by running a full `make build_docs` with the change applied — the build succeeds with no broken Markdown links surfaced, confirming there are no pre-existing violations and the existing content stays green. (Broken-anchor warnings are governed by the separate `onBrokenAnchors` setting and are intentionally left unchanged.)

### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/3419

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced documentation build validation to fail fast on broken Markdown links, improving overall doc quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->