### PR TITLE
Add current node inputs to interceptor context

### DIFF
--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -91,6 +91,7 @@ type InterceptorContext struct {
 	NodeType            common.NodeType
 	ExecutionPolicy     *ExecutionPolicy
 	AllowSegmentRestart bool
+	CurrentNodeInputs   []common.Input
 	ForwardedData       map[string]interface{}
 	AdditionalData      map[string]string
 

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -307,6 +307,7 @@ func (fe *flowEngine) runInterceptors(
 		UserInputs:           maps.Clone(ctx.UserInputs),
 		ForwardedData:        maps.Clone(ctx.ForwardedData),
 		AdditionalData:       maps.Clone(ctx.AdditionalData),
+		CurrentNodeInputs:    getNodeInputs(currentNode),
 		ResolvedInterceptors: ctx.Graph.GetInterceptors(mode),
 		SharedData:           ctx.InterceptorSharedData,
 	}

--- a/backend/internal/flow/flowexec/interceptor_runner.go
+++ b/backend/internal/flow/flowexec/interceptor_runner.go
@@ -185,6 +185,7 @@ func (s *interceptorRunner) executeInterceptor(
 		NodeType:            execCtx.NodeType,
 		ExecutionPolicy:     execCtx.ExecutionPolicy,
 		AllowSegmentRestart: execCtx.AllowSegmentRestart,
+		CurrentNodeInputs:   execCtx.CurrentNodeInputs,
 		ForwardedData:       execCtx.ForwardedData,
 		AdditionalData:      execCtx.AdditionalData,
 		SharedData:          execCtx.SharedData,

--- a/backend/internal/flow/flowexec/interceptor_runner_test.go
+++ b/backend/internal/flow/flowexec/interceptor_runner_test.go
@@ -371,6 +371,69 @@ func (s *InterceptorRunnerTestSuite) TestRunInterceptors_DefaultInterceptorCanno
 	assert.True(s.T(), executed, "default interceptor must not be bypassed by node skipInterceptors")
 }
 
+func (s *InterceptorRunnerTestSuite) TestRunInterceptors_CurrentNodeInputsPassedToInterceptor() {
+	expectedInputs := []common.Input{
+		{Identifier: "email", Type: "string", Required: true},
+		{Identifier: "password", Type: common.InputTypePassword, Required: true},
+	}
+
+	var receivedInputs []common.Input
+	icMock := newTestInterceptorMock(s.T(), "InputIC", false, 100)
+	icMock.On("Execute", mock.Anything).
+		Run(func(args mock.Arguments) {
+			ctx := args.Get(0).(*core.InterceptorContext)
+			receivedInputs = ctx.CurrentNodeInputs
+		}).
+		Return(&common.InterceptorResponse{Status: common.InterceptorStatusComplete}, nil)
+
+	s.registry.On("GetInterceptor", "InputIC").Return(icMock, nil)
+
+	execCtx := &InterceptorRunnerContext{
+		Ctx: context.Background(),
+		ResolvedInterceptors: []core.InterceptorUnitInterface{
+			newTestInterceptorUnitMock(s.T(), "InputIC", common.InterceptorModePreNode,
+				common.InterceptorScopeAll, nil),
+		},
+		CurrentNodeInputs: expectedInputs,
+		SharedData:        map[string]string{},
+	}
+
+	_, svcErr := s.service.runInterceptors(common.InterceptorModePreRequest, execCtx)
+
+	assert.Nil(s.T(), svcErr)
+	assert.Equal(s.T(), expectedInputs, receivedInputs)
+}
+
+func (s *InterceptorRunnerTestSuite) TestRunInterceptors_NilCurrentNodeInputsPassedAsNil() {
+	var receivedInputs []common.Input
+	called := false
+	icMock := newTestInterceptorMock(s.T(), "NilInputIC", false, 100)
+	icMock.On("Execute", mock.Anything).
+		Run(func(args mock.Arguments) {
+			called = true
+			ctx := args.Get(0).(*core.InterceptorContext)
+			receivedInputs = ctx.CurrentNodeInputs
+		}).
+		Return(&common.InterceptorResponse{Status: common.InterceptorStatusComplete}, nil)
+
+	s.registry.On("GetInterceptor", "NilInputIC").Return(icMock, nil)
+
+	execCtx := &InterceptorRunnerContext{
+		Ctx: context.Background(),
+		ResolvedInterceptors: []core.InterceptorUnitInterface{
+			newTestInterceptorUnitMock(s.T(), "NilInputIC", common.InterceptorModePreRequest,
+				common.InterceptorScope(""), nil),
+		},
+		SharedData: map[string]string{},
+	}
+
+	_, svcErr := s.service.runInterceptors(common.InterceptorModePreRequest, execCtx)
+
+	assert.Nil(s.T(), svcErr)
+	assert.True(s.T(), called)
+	assert.Nil(s.T(), receivedInputs)
+}
+
 // --- Test helpers ---
 
 func newTestInterceptorMock(t interface {

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -92,6 +92,7 @@ type InterceptorRunnerContext struct {
 	UserInputs           map[string]string
 	ForwardedData        map[string]interface{}
 	AdditionalData       map[string]string
+	CurrentNodeInputs    []common.Input
 	ResolvedInterceptors []core.InterceptorUnitInterface
 	SharedData           map[string]string
 }


### PR DESCRIPTION
### Purpose
This PR add inputs of the current node to `InterceptorRunnerContext` and `Interceptor Context` to support input validation interceptor onboarding.

<!--
---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3122

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3123

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interceptors can now read the inputs for the currently executing node via the interceptor execution context.
  * The engine now propagates current node inputs into interceptor context during interceptor runs.

* **Tests**
  * Added coverage to confirm interceptors receive the expected inputs.
  * Added coverage for the case where current node inputs are unset (verifies they are passed as `nil`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->