### PR TITLE
Reconcile custom sign-in flow selection with method toggles in app creation

### DIFF
--- a/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureSignInOptions.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureSignInOptions.test.tsx
@@ -17,9 +17,11 @@
  */
 
 import userEvent from '@testing-library/user-event';
-import {render, screen} from '@thunderid/test-utils';
+import {render, screen, within} from '@thunderid/test-utils';
+import type {JSX} from 'react';
 import {describe, it, expect, beforeEach, vi} from 'vitest';
 import ApplicationCreateProvider from '../../../contexts/ApplicationCreate/ApplicationCreateProvider';
+import useApplicationCreateContext from '../../../hooks/useApplicationCreateContext';
 import ConfigureSignInOptions, {
   type ConfigureSignInOptionsProps,
 } from '../configure-signin-options/ConfigureSignInOptions';
@@ -907,6 +909,117 @@ describe('ConfigureSignInOptions', () => {
       expect(
         screen.getByText('You can always change these settings later in the application settings.'),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('Custom flow selection (issue #2959)', () => {
+    const customFlow = {
+      id: 'custom-flow-id',
+      handle: 'custom-passwordless',
+      name: 'Custom Passwordless',
+      flowType: 'AUTHENTICATION',
+      activeVersion: 1,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+
+    const WiredHarness = ({onReadyChange = undefined}: {onReadyChange?: (isReady: boolean) => void}): JSX.Element => {
+      const {integrations, toggleIntegration, selectedAuthFlow} = useApplicationCreateContext();
+      return (
+        <>
+          <span data-testid="selected-flow-id">{selectedAuthFlow?.id ?? ''}</span>
+          <ConfigureSignInOptions
+            integrations={integrations}
+            onIntegrationToggle={toggleIntegration}
+            onReadyChange={onReadyChange}
+          />
+        </>
+      );
+    };
+
+    const renderWired = (onReadyChange?: (isReady: boolean) => void) =>
+      render(
+        <ApplicationCreateProvider>
+          <WiredHarness onReadyChange={onReadyChange} />
+        </ApplicationCreateProvider>,
+      );
+
+    const usernamePasswordSwitch = (): HTMLElement => {
+      const item = screen.getByText('Username & Password').closest('li');
+      if (!item) {
+        throw new Error('Username & Password list item not found');
+      }
+      return within(item).getByRole('switch');
+    };
+
+    beforeEach(() => {
+      vi.mocked(useIdentityProviders).mockReturnValue({
+        data: mockIdentityProviders,
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof useIdentityProviders>);
+
+      vi.mocked(useGetFlows).mockReturnValue({
+        data: {
+          totalResults: 1,
+          startIndex: 1,
+          count: 1,
+          flows: [customFlow],
+          links: [],
+        },
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+        isFetching: false,
+        isStale: false,
+        isPending: false,
+        error: null,
+        status: 'success',
+        fetchStatus: 'idle',
+      } as unknown as ReturnType<typeof useGetFlows>);
+    });
+
+    it('unselects all integration toggles when a custom flow is selected', async () => {
+      const user = userEvent.setup();
+      renderWired();
+
+      expect(usernamePasswordSwitch()).toBeChecked();
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(await screen.findByText('Custom Passwordless'));
+
+      expect(usernamePasswordSwitch()).not.toBeChecked();
+      expect(screen.getByTestId('selected-flow-id')).toHaveTextContent('custom-flow-id');
+    });
+
+    it('keeps the step ready (Continue enabled) with all toggles off once a flow is selected', async () => {
+      const user = userEvent.setup();
+      const onReadyChange = vi.fn();
+      renderWired(onReadyChange);
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(await screen.findByText('Custom Passwordless'));
+
+      expect(usernamePasswordSwitch()).not.toBeChecked();
+      expect(onReadyChange).toHaveBeenLastCalledWith(true);
+    });
+
+    it('clears the selected flow and returns to toggle-driven mode when a method is re-enabled', async () => {
+      const user = userEvent.setup();
+      const onReadyChange = vi.fn();
+      renderWired(onReadyChange);
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(await screen.findByText('Custom Passwordless'));
+      expect(usernamePasswordSwitch()).not.toBeChecked();
+      expect(screen.getByTestId('selected-flow-id')).toHaveTextContent('custom-flow-id');
+
+      await user.click(screen.getByText('Username & Password'));
+
+      expect(usernamePasswordSwitch()).toBeChecked();
+      expect(screen.getByTestId('selected-flow-id')).toHaveTextContent('');
+      expect(screen.getByRole('combobox')).toHaveValue('');
+      expect(onReadyChange).toHaveBeenLastCalledWith(true);
     });
   });
 });

--- a/frontend/apps/console/src/features/applications/components/create-application/configure-signin-options/ConfigureSignInOptions.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/configure-signin-options/ConfigureSignInOptions.tsx
@@ -130,7 +130,7 @@ export default function ConfigureSignInOptions({
 }: ConfigureSignInOptionsProps): JSX.Element {
   const {t} = useTranslation();
   const theme = useTheme();
-  const {selectedAuthFlow, setSelectedAuthFlow} = useApplicationCreateContext();
+  const {selectedAuthFlow, setSelectedAuthFlow, setIntegrations} = useApplicationCreateContext();
 
   const {data, isLoading, error} = useIdentityProviders();
   const {
@@ -257,6 +257,10 @@ export default function ConfigureSignInOptions({
       availableFlows?.find((flow: BasicFlowDefinition) => flow.id === flowId) ?? null;
 
     setSelectedAuthFlow(selectedFlow);
+
+    if (selectedFlow) {
+      setIntegrations({});
+    }
   };
 
   const handleClearFlowSelection = (): void => {

--- a/frontend/apps/console/src/features/applications/components/create-application/configure-signin-options/FlowsListView.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/configure-signin-options/FlowsListView.tsx
@@ -88,7 +88,7 @@ export default function FlowsListView({
             disabled={disabled}
             options={selectableFlows}
             getOptionLabel={(option) => option.name}
-            value={selectableFlows.find((flow) => flow.id === selectedAuthFlow?.id)}
+            value={selectableFlows.find((flow) => flow.id === selectedAuthFlow?.id) ?? null}
             onChange={(_, newValue) => {
               if (newValue?.id) {
                 onFlowSelect(newValue.id);

--- a/frontend/apps/console/src/features/applications/components/create-application/configure-signin-options/__tests__/ConfigureSignInOptions.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/configure-signin-options/__tests__/ConfigureSignInOptions.test.tsx
@@ -70,11 +70,13 @@ vi.mock('@/features/flows/api/useGetFlows', () => ({
 
 // Mock useApplicationCreateContext - need to mock the correct path used by the component
 const mockSetSelectedAuthFlow = vi.fn();
+const mockSetIntegrations = vi.fn();
 const mockSelectedAuthFlow: BasicFlowDefinition | null = null;
 vi.mock('@/features/applications/hooks/useApplicationCreateContext', () => ({
   default: () => ({
     selectedAuthFlow: mockSelectedAuthFlow,
     setSelectedAuthFlow: mockSetSelectedAuthFlow,
+    setIntegrations: mockSetIntegrations,
   }),
 }));
 

--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -26,8 +26,10 @@ import {useState, useCallback, useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useLocation, useNavigate} from 'react-router';
 import useCreateFlow from '../../flows/api/useCreateFlow';
+import useGetFlowById from '../../flows/api/useGetFlowById';
 import type {BasicFlowDefinition} from '../../flows/models/responses';
 import generateFlowGraph from '../../flows/utils/generateFlowGraph';
+import getFlowEntryComponents from '../../flows/utils/getFlowEntryComponents';
 import useIdentityProviders from '../../integrations/api/useIdentityProviders';
 import {AuthenticatorTypes} from '../../integrations/models/authenticators';
 import {IdentityProviderTypes} from '../../integrations/models/identity-provider';
@@ -117,6 +119,24 @@ export default function ApplicationCreatePage(): JSX.Element {
   const createFlow = useCreateFlow();
   const {data: idpData} = useIdentityProviders();
 
+  const hasEnabledIntegrations = useMemo((): boolean => Object.values(integrations).some(Boolean), [integrations]);
+
+  const previewFlowId: string | undefined =
+    !hasEnabledIntegrations && selectedAuthFlow ? selectedAuthFlow.id : undefined;
+  const {data: previewFlow, isLoading: isPreviewFlowLoading} = useGetFlowById(previewFlowId, Boolean(previewFlowId));
+
+  const previewMock = useMemo(() => {
+    if (hasEnabledIntegrations || !selectedAuthFlow) {
+      return buildPreviewMock(integrations, idpData ?? [], {
+        application: {
+          logoUrl: appLogo!,
+        },
+      });
+    }
+
+    return getFlowEntryComponents(previewFlow) ?? [];
+  }, [hasEnabledIntegrations, selectedAuthFlow, integrations, idpData, appLogo, previewFlow]);
+
   const [stepReady, setStepReady] = useState<Record<ApplicationCreateFlowStep, boolean>>({
     STACK: true,
     NAME: false,
@@ -171,7 +191,6 @@ export default function ApplicationCreatePage(): JSX.Element {
 
   const handleIntegrationToggle = (integrationId: string): void => {
     toggleIntegration(integrationId);
-    setSelectedAuthFlow(null);
   };
 
   const handleCreateApplication = (skipOAuthConfig = false, overrideFlowId?: string): void => {
@@ -651,15 +670,13 @@ export default function ApplicationCreatePage(): JSX.Element {
           currentStep !== ApplicationCreateFlowStep.ORGANIZATION_UNIT &&
           currentStep !== ApplicationCreateFlowStep.COMPLETE && (
             <Box sx={{flex: '0 0 50%', display: 'flex', flexDirection: 'column', p: 5}}>
-              <GatePreview
-                theme={selectedTheme}
-                mock={buildPreviewMock(integrations, idpData ?? [], {
-                  application: {
-                    logoUrl: appLogo!,
-                  },
-                })}
-                displayName={appName ?? undefined}
-              />
+              {isPreviewFlowLoading ? (
+                <Box sx={{display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1}}>
+                  <CircularProgress />
+                </Box>
+              ) : (
+                <GatePreview theme={selectedTheme} mock={previewMock} displayName={appName ?? undefined} />
+              )}
             </Box>
           )}
       </Box>

--- a/frontend/apps/console/src/features/flows/utils/__tests__/getFlowEntryComponents.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/getFlowEntryComponents.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {FlowNodeType} from '../../models/flows';
+import type {FlowDefinitionResponse, FlowNode} from '../../models/responses';
+import getFlowEntryComponents from '../getFlowEntryComponents';
+
+describe('getFlowEntryComponents', () => {
+  const createFlow = (nodes: FlowNode[]): FlowDefinitionResponse => ({
+    id: 'flow-1',
+    name: 'Test Flow',
+    handle: 'test-flow',
+    flowType: 'AUTHENTICATION',
+    activeVersion: 1,
+    nodes,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  });
+
+  const promptComponents = [{id: 'username', type: 'TEXT_INPUT'}];
+
+  it('returns the components of the PROMPT node reached from START via onSuccess', () => {
+    const flow = createFlow([
+      {id: 'start', type: FlowNodeType.START, onSuccess: 'prompt'},
+      {id: 'prompt', type: FlowNodeType.PROMPT, meta: {components: promptComponents}},
+    ]);
+
+    expect(getFlowEntryComponents(flow)).toEqual(promptComponents);
+  });
+
+  it('walks through TASK_EXECUTION nodes to reach the first PROMPT', () => {
+    const flow = createFlow([
+      {id: 'start', type: FlowNodeType.START, onSuccess: 'task'},
+      {id: 'task', type: FlowNodeType.TASK_EXECUTION, onSuccess: 'prompt'},
+      {id: 'prompt', type: FlowNodeType.PROMPT, meta: {components: promptComponents}},
+    ]);
+
+    expect(getFlowEntryComponents(flow)).toEqual(promptComponents);
+  });
+
+  it('falls back to the first PROMPT node with components when START is not connected', () => {
+    const flow = createFlow([
+      {id: 'start', type: FlowNodeType.START},
+      {id: 'prompt', type: FlowNodeType.PROMPT, meta: {components: promptComponents}},
+    ]);
+
+    expect(getFlowEntryComponents(flow)).toEqual(promptComponents);
+  });
+
+  it('skips PROMPT nodes without components when traversing', () => {
+    const second = [{id: 'password', type: 'PASSWORD_INPUT'}];
+    const flow = createFlow([
+      {id: 'start', type: FlowNodeType.START, onSuccess: 'empty-prompt'},
+      {id: 'empty-prompt', type: FlowNodeType.PROMPT, meta: {components: []}, onSuccess: 'prompt'},
+      {id: 'prompt', type: FlowNodeType.PROMPT, meta: {components: second}},
+    ]);
+
+    expect(getFlowEntryComponents(flow)).toEqual(second);
+  });
+
+  it('returns null when the flow has no PROMPT node with components', () => {
+    const flow = createFlow([
+      {id: 'start', type: FlowNodeType.START, onSuccess: 'end'},
+      {id: 'end', type: FlowNodeType.END},
+    ]);
+
+    expect(getFlowEntryComponents(flow)).toBeNull();
+  });
+
+  it('does not loop forever on a cyclic graph', () => {
+    const flow = createFlow([
+      {id: 'start', type: FlowNodeType.START, onSuccess: 'a'},
+      {id: 'a', type: FlowNodeType.TASK_EXECUTION, onSuccess: 'b'},
+      {id: 'b', type: FlowNodeType.TASK_EXECUTION, onSuccess: 'a'},
+    ]);
+
+    expect(getFlowEntryComponents(flow)).toBeNull();
+  });
+
+  it('returns null for an undefined flow', () => {
+    expect(getFlowEntryComponents(undefined)).toBeNull();
+  });
+
+  it('returns null for a flow with no nodes', () => {
+    expect(getFlowEntryComponents(createFlow([]))).toBeNull();
+  });
+});

--- a/frontend/apps/console/src/features/flows/utils/getFlowEntryComponents.ts
+++ b/frontend/apps/console/src/features/flows/utils/getFlowEntryComponents.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {EmbeddedFlowComponent} from '@thunderid/react';
+import {FlowNodeType} from '../models/flows';
+import type {FlowDefinitionResponse} from '../models/responses';
+
+/**
+ * Extracts the UI components of a flow's first sign-in screen.
+ *
+ * Walks the flow graph from the START node, following `onSuccess` through
+ * non-prompt nodes (e.g. TASK_EXECUTION), until it reaches the first PROMPT node
+ * that has renderable components. The returned components are in the same shape
+ * consumed by the embedded flow renderer, so they can be passed directly to
+ * {@link GatePreview}'s `mock` prop.
+ *
+ * @param flow - The full flow definition, or undefined while loading
+ * @returns The first PROMPT screen's components, or null if the flow has no
+ *   renderable prompt screen
+ *
+ * @public
+ */
+export default function getFlowEntryComponents(
+  flow: FlowDefinitionResponse | undefined,
+): EmbeddedFlowComponent[] | null {
+  if (!flow?.nodes?.length) {
+    return null;
+  }
+
+  const start = flow.nodes.find((node) => node.type === FlowNodeType.START);
+  const visited = new Set<string>();
+  let currentId: string | undefined = start?.onSuccess;
+
+  while (currentId && !visited.has(currentId)) {
+    visited.add(currentId);
+    const node = flow.nodes.find((candidate) => candidate.id === currentId);
+    if (!node) {
+      break;
+    }
+    if (node.type === FlowNodeType.PROMPT && node.meta?.components?.length) {
+      return node.meta.components as EmbeddedFlowComponent[];
+    }
+    currentId = node.onSuccess;
+  }
+
+  const anyPrompt = flow.nodes.find((node) => node.type === FlowNodeType.PROMPT && node.meta?.components?.length);
+
+  return (anyPrompt?.meta?.components as EmbeddedFlowComponent[]) ?? null;
+}


### PR DESCRIPTION
## Purpose

In the **Sign In Options** step of application creation, selecting a custom flow did not behave as expected: the individual method toggles (e.g. Username & Password) stayed enabled, the preview did not update to reflect the selected flow, and manually turning the toggle off disabled the Continue button. This change makes the toggles and the selected flow a single, reconciled selection.

## Behaviour
[<img width="1680" height="1050" alt="Screenshot 2026-06-23 at 09 44 07" src="https://github.com/user-attachments/assets/7310c5ee-0498-46ca-8890-34d1bda2006c" />](https://drive.google.com/file/d/1MqGc5DeBycFd8Gs6fH6Aev-JbSdVEDOi/view?usp=sharing)

## Related Issue

- https://github.com/thunder-id/thunderid/issues/2959

## Implementation

- `ConfigureSignInOptions`: selecting a custom flow now clears the individual method toggles, so the chosen flow is the sole sign-in configuration. With toggles off and a flow selected, the step stays ready (Continue enabled).
- `ApplicationCreatePage`: the toggle handler no longer clears the selected flow on its own (the component already recomputes the match, giving a single source of truth). The preview now renders the effective selection — the integrations-based mock in toggle mode, and the selected flow's first screen otherwise.
- `getFlowEntryComponents` (new util): walks a flow graph from the START node through to the first prompt screen and returns its components for the preview. The selected flow's definition is fetched via `useGetFlowById` only when a flow drives the preview.
- `FlowsListView`: the flow selector is now always controlled, so it clears correctly when the selection is reset.
- Tests: added coverage for the new util and for the custom-flow selection interactions (toggles clearing, step readiness, and returning to toggle-driven mode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Selecting a pre-configured authentication flow now resets integration toggle selections.
  * Fixed authentication flow selection autocomplete to correctly handle “no matching flow” by clearing the displayed value.
* **New Features**
  * Authentication flow preview now supports a preview based on the selected flow when integrations are disabled, and shows a loading state while fetching.
* **Tests**
  * Added/expanded tests for custom flow selection, readiness behavior, and integration toggle interactions.
  * Added tests for extracting entry-screen components from flow definitions (including cycle/edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->