### PR TITLE
Validate logo URL input in the resource logo dialog

### DIFF
--- a/frontend/packages/components/src/lab/components/EmojiPicker/EmojiPicker.tsx
+++ b/frontend/packages/components/src/lab/components/EmojiPicker/EmojiPicker.tsx
@@ -29,7 +29,7 @@ import {
   Hash,
   Flag,
 } from '@wso2/oxygen-ui-icons-react';
-import {useState, useCallback, useMemo, useRef, useEffect, type ComponentType, type JSX} from 'react';
+import {useState, useCallback, useMemo, useRef, useEffect, memo, type ComponentType, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import EMOJI_DATA from './emojis.json';
 
@@ -142,7 +142,7 @@ export interface EmojiPickerProps {
  *
  * @public
  */
-export default function EmojiPicker({value = '', onChange}: EmojiPickerProps): JSX.Element {
+function EmojiPicker({value = '', onChange}: EmojiPickerProps): JSX.Element {
   const {t} = useTranslation('elements');
   const [search, setSearch] = useState<string>('');
   const allCategories: EmojiCategory[] = getSupportedCategories();
@@ -361,3 +361,5 @@ export default function EmojiPicker({value = '', onChange}: EmojiPickerProps): J
     </Stack>
   );
 }
+
+export default memo(EmojiPicker);

--- a/frontend/packages/components/src/lab/components/ResourceAvatar.tsx
+++ b/frontend/packages/components/src/lab/components/ResourceAvatar.tsx
@@ -22,12 +22,9 @@ import {Edit} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback} from 'react';
 import type {ReactNode, JSX, KeyboardEvent} from 'react';
 import ResourceLogoDialog from './ResourceLogoDialog';
+import isValidLogoUri from '../utils/isValidLogoUri';
 
 const EMOJI_SCHEME = 'emoji:';
-
-function isUrl(value: string): boolean {
-  return value.startsWith('http://') || value.startsWith('https://');
-}
 
 function resolveDisplayValue(value: string): string {
   return value.startsWith(EMOJI_SCHEME) ? value.slice(EMOJI_SCHEME.length) : value;
@@ -126,7 +123,7 @@ export default function ResourceAvatar({
 
   const hasValue = Boolean(value);
   const displayValue: string = hasValue ? resolveDisplayValue(value!) : '';
-  const isUrlValue: boolean = Boolean(displayValue) && isUrl(displayValue);
+  const isUrlValue: boolean = Boolean(displayValue) && isValidLogoUri(displayValue);
   const imgError: boolean = imgErrorUrl === displayValue && Boolean(displayValue);
 
   const resolvedFallbackIcon: ReactNode =

--- a/frontend/packages/components/src/lab/components/ResourceLogoDialog.tsx
+++ b/frontend/packages/components/src/lab/components/ResourceLogoDialog.tsx
@@ -34,11 +34,12 @@ import {X} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import EmojiPicker from './EmojiPicker/EmojiPicker';
+import isValidLogoUri from '../utils/isValidLogoUri';
 
 const EMOJI_SCHEME = 'emoji:';
 
-function isUrl(value: string): boolean {
-  return value.startsWith('http://') || value.startsWith('https://');
+function isUrlValue(value: string): boolean {
+  return !value.startsWith(EMOJI_SCHEME) && isValidLogoUri(value);
 }
 
 /**
@@ -81,10 +82,10 @@ export default function ResourceLogoDialog({
 }: ResourceLogoDialogProps): JSX.Element {
   const {t} = useTranslation('elements');
   const [pendingEmoji, setPendingEmoji] = useState<string>(() => {
-    if (!open || isUrl(value)) return '';
+    if (!open || isUrlValue(value)) return '';
     return value.startsWith(EMOJI_SCHEME) ? value.slice(EMOJI_SCHEME.length) : value;
   });
-  const [pendingUrl, setPendingUrl] = useState<string>(() => (open && isUrl(value) ? value : ''));
+  const [pendingUrl, setPendingUrl] = useState<string>(() => (open && isUrlValue(value) ? value : ''));
   const [prevOpen, setPrevOpen] = useState<boolean>(open);
   const [prevValue, setPrevValue] = useState<string>(value);
 
@@ -92,7 +93,7 @@ export default function ResourceLogoDialog({
     setPrevOpen(open);
     setPrevValue(value);
     if (open) {
-      if (isUrl(value)) {
+      if (isUrlValue(value)) {
         setPendingUrl(value);
         setPendingEmoji('');
       } else {
@@ -113,8 +114,12 @@ export default function ResourceLogoDialog({
     if (url) setPendingEmoji('');
   }, []);
 
+  const isUrlValid: boolean = isValidLogoUri(pendingUrl);
+  const urlHasError: boolean = Boolean(pendingUrl) && !isUrlValid;
+
   const handleSelect = useCallback((): void => {
     if (pendingUrl) {
+      if (!isValidLogoUri(pendingUrl)) return;
       onSelect(pendingUrl);
     } else if (pendingEmoji) {
       onSelect(EMOJI_SCHEME + pendingEmoji);
@@ -122,7 +127,7 @@ export default function ResourceLogoDialog({
     onClose();
   }, [pendingUrl, pendingEmoji, onSelect, onClose]);
 
-  const canSelect = Boolean(pendingUrl || pendingEmoji);
+  const canSelect = Boolean((pendingUrl && isUrlValid) || pendingEmoji);
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
@@ -151,12 +156,18 @@ export default function ResourceLogoDialog({
               <TextField
                 fullWidth
                 size="small"
+                error={urlHasError}
                 placeholder={t('resource_logo_dialog.url_section.placeholder', 'https://example.com/logo.png')}
                 value={pendingUrl}
                 onChange={(e) => handleUrlChange(e.target.value)}
               />
-              <FormHelperText>
-                {t('resource_logo_dialog.url_section.helper_text', 'Enter a direct URL to a custom logo image')}
+              <FormHelperText error={urlHasError}>
+                {urlHasError
+                  ? t(
+                      'resource_logo_dialog.url_section.error_text',
+                      'Enter a valid image URL (e.g. https://example.com/logo.png)',
+                    )
+                  : t('resource_logo_dialog.url_section.helper_text', 'Enter a direct URL to a custom logo image')}
               </FormHelperText>
             </Box>
           </Stack>

--- a/frontend/packages/components/src/lab/components/__tests__/ResourceLogoDialog.test.tsx
+++ b/frontend/packages/components/src/lab/components/__tests__/ResourceLogoDialog.test.tsx
@@ -230,6 +230,49 @@ describe('ResourceLogoDialog', () => {
     });
   });
 
+  describe('User interaction — URL validation', () => {
+    it('should keep the Select button disabled when the entered URL is invalid', () => {
+      render(<ResourceLogoDialog {...defaultProps} value="" />);
+
+      const urlInput = screen.getByPlaceholderText(/https:\/\/example\.com\/logo\.png/i);
+      fireEvent.change(urlInput, {target: {value: 'not a url'}});
+
+      expect(screen.getByRole('button', {name: /^select$/i})).toBeDisabled();
+    });
+
+    it('should show an inline error message when the entered URL is invalid', () => {
+      render(<ResourceLogoDialog {...defaultProps} value="" />);
+
+      const urlInput = screen.getByPlaceholderText(/https:\/\/example\.com\/logo\.png/i);
+      fireEvent.change(urlInput, {target: {value: 'javascript:alert(1)'}});
+
+      expect(screen.getByText(/enter a valid image url/i)).toBeInTheDocument();
+    });
+
+    it('should not call onSelect when Select is clicked with an invalid URL', () => {
+      const onSelect = vi.fn();
+      render(<ResourceLogoDialog {...defaultProps} onSelect={onSelect} value="" />);
+
+      const urlInput = screen.getByPlaceholderText(/https:\/\/example\.com\/logo\.png/i);
+      fireEvent.change(urlInput, {target: {value: 'example.com/logo.png'}});
+      fireEvent.click(screen.getByRole('button', {name: /^select$/i}));
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('should accept an absolute path as a valid logo URL', () => {
+      const onSelect = vi.fn();
+      render(<ResourceLogoDialog {...defaultProps} onSelect={onSelect} value="" />);
+
+      const urlInput = screen.getByPlaceholderText(/https:\/\/example\.com\/logo\.png/i);
+      fireEvent.change(urlInput, {target: {value: '/assets/logo.png'}});
+
+      expect(screen.getByRole('button', {name: /^select$/i})).not.toBeDisabled();
+      fireEvent.click(screen.getByRole('button', {name: /^select$/i}));
+      expect(onSelect).toHaveBeenCalledWith('/assets/logo.png');
+    });
+  });
+
   describe('Initial state — plain emoji value without prefix', () => {
     it('should pre-populate emoji state when value is a raw emoji character without emoji: prefix', () => {
       render(<ResourceLogoDialog {...defaultProps} value="🎉" />);

--- a/frontend/packages/components/src/lab/utils/__tests__/isValidLogoUri.test.ts
+++ b/frontend/packages/components/src/lab/utils/__tests__/isValidLogoUri.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it} from 'vitest';
+import isValidLogoUri from '../isValidLogoUri';
+
+describe('isValidLogoUri', () => {
+  // Mirrors the backend `IsValidLogoURI` allowlist (http_util.go).
+  it.each([
+    ['', false],
+    ['https://example.com/logo.png', true],
+    ['http://example.com/logo.png', true],
+    ['data:image/png;base64,abc123', true],
+    ['blob:https://example.com/uuid', true],
+    ['emoji:smile', true],
+    ['/images/logo.png', true],
+    ['./logo.png', false],
+    ['logo.png', false],
+    ['://invalid', false],
+    ['javascript:alert(1)', false],
+    ['file:///etc/passwd', false],
+    ['ftp://example.com/logo.png', false],
+    ['http:///no-host', false],
+    ['https:///no-host', false],
+    ['http://example.com:8080/logo.png', true],
+    ['http://user@example.com/logo.png', true],
+    ['http://example.com:99999/logo.png', true],
+    ['http://example.com:abc', false],
+    ['http://exa mple.com', false],
+  ])('returns %s -> %s', (uri, expected) => {
+    expect(isValidLogoUri(uri)).toBe(expected);
+  });
+});

--- a/frontend/packages/components/src/lab/utils/isValidLogoUri.ts
+++ b/frontend/packages/components/src/lab/utils/isValidLogoUri.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const SCHEME_PATTERN = /^([a-zA-Z][a-zA-Z0-9+.-]*):/;
+const HTTP_AUTHORITY_PATTERN = /^https?:\/\/([^/?#]*)/i;
+// A non-empty host (bracketed IPv6 or any run of non-space, non-colon chars)
+// followed by an optional, purely numeric port — mirroring Go's url.Parse.
+const HTTP_HOST_PORT_PATTERN = /^(\[[^\]]+\]|[^\s:]+)(:\d*)?$/;
+
+/**
+ * Checks whether a value is valid for use as a resource logo URI.
+ *
+ * Mirrors the backend `IsValidLogoURI` allowlist so the client never commits a
+ * value the server will reject:
+ * - `http`/`https` are accepted only with a non-empty host and, if present, a
+ *   numeric port (so malformed authorities like `http://host:abc` are rejected
+ *   client-side instead of failing on the server).
+ * - `data`, `blob` and `emoji` schemes are always accepted.
+ * - A value with no scheme is accepted only when it is an absolute path
+ *   (starts with `/`).
+ * - Every other scheme (e.g. `javascript`, `file`, `ftp`) is rejected.
+ *
+ * @param value - The candidate logo URI.
+ * @returns `true` when the value is an acceptable logo URI.
+ *
+ * @public
+ */
+export default function isValidLogoUri(value: string): boolean {
+  if (!value) return false;
+
+  const schemeMatch = SCHEME_PATTERN.exec(value);
+
+  if (!schemeMatch) {
+    return value.startsWith('/');
+  }
+
+  switch (schemeMatch[1].toLowerCase()) {
+    case 'http':
+    case 'https': {
+      const authorityMatch = HTTP_AUTHORITY_PATTERN.exec(value);
+      if (!authorityMatch) return false;
+      const authority: string = authorityMatch[1].split('@').pop() ?? '';
+      return HTTP_HOST_PORT_PATTERN.test(authority);
+    }
+    case 'data':
+    case 'blob':
+    case 'emoji':
+      return true;
+    default:
+      return false;
+  }
+}

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -2443,6 +2443,7 @@ const translations = {
     'resource_logo_dialog.url_section.label': 'Use a custom image URL',
     'resource_logo_dialog.url_section.placeholder': 'https://example.com/logo.png',
     'resource_logo_dialog.url_section.helper_text': 'Enter a direct URL to a custom logo image',
+    'resource_logo_dialog.url_section.error_text': 'Enter a valid image URL (e.g. https://example.com/logo.png)',
     'resource_logo_dialog.actions.cancel': 'Cancel',
     'resource_logo_dialog.actions.select': 'Select',
   },


### PR DESCRIPTION
## Purpose
Custom logo URLs entered through the resource logo dialog (used in both the application create design step and the application edit header) were not checked at the point of input. Any non-empty string could be confirmed, and the only check happened on the backend at create/update time, so the failure was only reported after the user committed the change. The frontend's own URL check was also inconsistent with the backend's accepted set, and typing in the URL field felt laggy.

## Behaviour
<img width="1680" height="770" alt="Screenshot 2026-06-23 at 11 57 38" src="https://github.com/user-attachments/assets/e2695ef1-54ba-4966-8047-03107d26932d" />


## Related Issue
- Fixes https://github.com/thunder-id/thunderid/issues/2926

## Implementation
- Added `isValidLogoUri` (`frontend/packages/components/src/lab/utils/isValidLogoUri.ts`), a single shared helper that mirrors the backend `IsValidLogoURI` allowlist: `http`/`https` require a non-empty host, `data`/`blob`/`emoji` are accepted, no-scheme values must be absolute paths, and all other schemes are rejected.
- `ResourceLogoDialog` now validates the URL field with this helper: invalid input shows an inline error and disables the select action, and the emoji-vs-URL routing uses the same predicate so relative and `data:` URLs route to the URL field instead of the emoji branch.
- `ResourceAvatar` renders an image for any valid non-emoji URI (http/https/data/blob/relative), not just `http(s)`.
- Memoized `EmojiPicker` so typing in the URL field no longer re-renders the full emoji grid, removing the input lag.
- Added the `resource_logo_dialog.url_section.error_text` translation key.
- Added tests for the new helper (mirroring the backend test matrix) and new URL validation cases in the dialog tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for custom logo URLs in the Resource logo dialog, including clearer inline error feedback and a dedicated invalid-URL message.
  * The Select action is now blocked until the entered value is valid, while valid absolute paths and additional URI formats (such as data/blob/emoji and approved http/https forms) are accepted.
  * Resource avatar rendering now follows the same validation rules for logo URL vs non-URL values.
* **Tests**
  * Added client-side and interaction test coverage for logo URI validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->