### PR TITLE
Fix stale in-memory graph cache issue in multi-node deployments

### DIFF
--- a/backend/internal/flow/core/FlowFactoryInterface_mock_test.go
+++ b/backend/internal/flow/core/FlowFactoryInterface_mock_test.go
@@ -232,16 +232,16 @@ func (_c *FlowFactoryInterfaceMock_CreateExecutor_Call) RunAndReturn(run func(na
 }
 
 // CreateGraph provides a mock function for the type FlowFactoryInterfaceMock
-func (_mock *FlowFactoryInterfaceMock) CreateGraph(id string, _type common.FlowType) GraphInterface {
-	ret := _mock.Called(id, _type)
+func (_mock *FlowFactoryInterfaceMock) CreateGraph(id string, _type common.FlowType, version int) GraphInterface {
+	ret := _mock.Called(id, _type, version)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateGraph")
 	}
 
 	var r0 GraphInterface
-	if returnFunc, ok := ret.Get(0).(func(string, common.FlowType) GraphInterface); ok {
-		r0 = returnFunc(id, _type)
+	if returnFunc, ok := ret.Get(0).(func(string, common.FlowType, int) GraphInterface); ok {
+		r0 = returnFunc(id, _type, version)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(GraphInterface)
@@ -258,11 +258,12 @@ type FlowFactoryInterfaceMock_CreateGraph_Call struct {
 // CreateGraph is a helper method to define mock.On call
 //   - id string
 //   - _type common.FlowType
-func (_e *FlowFactoryInterfaceMock_Expecter) CreateGraph(id interface{}, _type interface{}) *FlowFactoryInterfaceMock_CreateGraph_Call {
-	return &FlowFactoryInterfaceMock_CreateGraph_Call{Call: _e.mock.On("CreateGraph", id, _type)}
+//   - version int
+func (_e *FlowFactoryInterfaceMock_Expecter) CreateGraph(id interface{}, _type interface{}, version interface{}) *FlowFactoryInterfaceMock_CreateGraph_Call {
+	return &FlowFactoryInterfaceMock_CreateGraph_Call{Call: _e.mock.On("CreateGraph", id, _type, version)}
 }
 
-func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) Run(run func(id string, _type common.FlowType)) *FlowFactoryInterfaceMock_CreateGraph_Call {
+func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) Run(run func(id string, _type common.FlowType, version int)) *FlowFactoryInterfaceMock_CreateGraph_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -272,9 +273,14 @@ func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) Run(run func(id string, _ty
 		if args[1] != nil {
 			arg1 = args[1].(common.FlowType)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -285,7 +291,7 @@ func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) Return(graphInterface Graph
 	return _c
 }
 
-func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) RunAndReturn(run func(id string, _type common.FlowType) GraphInterface) *FlowFactoryInterfaceMock_CreateGraph_Call {
+func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) RunAndReturn(run func(id string, _type common.FlowType, version int) GraphInterface) *FlowFactoryInterfaceMock_CreateGraph_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/core/GraphInterface_mock_test.go
+++ b/backend/internal/flow/core/GraphInterface_mock_test.go
@@ -690,6 +690,50 @@ func (_c *GraphInterfaceMock_GetType_Call) RunAndReturn(run func() common.FlowTy
 	return _c
 }
 
+// GetVersion provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) GetVersion() int {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetVersion")
+	}
+
+	var r0 int
+	if returnFunc, ok := ret.Get(0).(func() int); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	return r0
+}
+
+// GraphInterfaceMock_GetVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetVersion'
+type GraphInterfaceMock_GetVersion_Call struct {
+	*mock.Call
+}
+
+// GetVersion is a helper method to define mock.On call
+func (_e *GraphInterfaceMock_Expecter) GetVersion() *GraphInterfaceMock_GetVersion_Call {
+	return &GraphInterfaceMock_GetVersion_Call{Call: _e.mock.On("GetVersion")}
+}
+
+func (_c *GraphInterfaceMock_GetVersion_Call) Run(run func()) *GraphInterfaceMock_GetVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetVersion_Call) Return(n int) *GraphInterfaceMock_GetVersion_Call {
+	_c.Call.Return(n)
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetVersion_Call) RunAndReturn(run func() int) *GraphInterfaceMock_GetVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // HasSegments provides a mock function for the type GraphInterfaceMock
 func (_mock *GraphInterfaceMock) HasSegments() bool {
 	ret := _mock.Called()
@@ -999,6 +1043,46 @@ func (_c *GraphInterfaceMock_SetStartNode_Call) Return(err error) *GraphInterfac
 
 func (_c *GraphInterfaceMock_SetStartNode_Call) RunAndReturn(run func(startNodeID string) error) *GraphInterfaceMock_SetStartNode_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// SetVersion provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) SetVersion(version int) {
+	_mock.Called(version)
+	return
+}
+
+// GraphInterfaceMock_SetVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetVersion'
+type GraphInterfaceMock_SetVersion_Call struct {
+	*mock.Call
+}
+
+// SetVersion is a helper method to define mock.On call
+//   - version int
+func (_e *GraphInterfaceMock_Expecter) SetVersion(version interface{}) *GraphInterfaceMock_SetVersion_Call {
+	return &GraphInterfaceMock_SetVersion_Call{Call: _e.mock.On("SetVersion", version)}
+}
+
+func (_c *GraphInterfaceMock_SetVersion_Call) Run(run func(version int)) *GraphInterfaceMock_SetVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_SetVersion_Call) Return() *GraphInterfaceMock_SetVersion_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *GraphInterfaceMock_SetVersion_Call) RunAndReturn(run func(version int)) *GraphInterfaceMock_SetVersion_Call {
+	_c.Run(run)
 	return _c
 }
 

--- a/backend/internal/flow/core/factory.go
+++ b/backend/internal/flow/core/factory.go
@@ -30,7 +30,7 @@ import (
 type FlowFactoryInterface interface {
 	CreateNode(id, _type string, properties map[string]interface{}, isStartNode, isFinalNode bool) (
 		NodeInterface, error)
-	CreateGraph(id string, _type common.FlowType) GraphInterface
+	CreateGraph(id string, _type common.FlowType, version int) GraphInterface
 	CreateExecutor(name string, executorType common.ExecutorType,
 		defaultInputs, prerequisites []common.Input) ExecutorInterface
 	CreateInterceptor(name string, isDefault bool, priority int) InterceptorInterface
@@ -74,19 +74,23 @@ func (f *flowFactory) CreateNode(id, _type string, properties map[string]interfa
 }
 
 // CreateGraph creates a new graph with the given ID and type
-func (f *flowFactory) CreateGraph(id string, _type common.FlowType) GraphInterface {
+func (f *flowFactory) CreateGraph(id string, _type common.FlowType, version int) GraphInterface {
 	if id == "" {
 		id = sysutils.GenerateUUID()
 	}
 	if _type == "" {
 		_type = common.FlowTypeAuthentication
 	}
+	if version <= 0 {
+		version = 1
+	}
 
 	return &graph{
-		id:    id,
-		_type: _type,
-		nodes: make(map[string]NodeInterface),
-		edges: make(map[string][]string),
+		id:      id,
+		_type:   _type,
+		version: version,
+		nodes:   make(map[string]NodeInterface),
+		edges:   make(map[string][]string),
 	}
 }
 

--- a/backend/internal/flow/core/factory_test.go
+++ b/backend/internal/flow/core/factory_test.go
@@ -156,7 +156,7 @@ func (s *FlowFactoryTestSuite) TestCreateGraph() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			graph := s.factory.CreateGraph(tt.graphID, tt.flowType)
+			graph := s.factory.CreateGraph(tt.graphID, tt.flowType, 1)
 
 			s.NotNil(graph)
 			if tt.expectUUID {

--- a/backend/internal/flow/core/graph.go
+++ b/backend/internal/flow/core/graph.go
@@ -48,6 +48,8 @@ type GraphInterface interface {
 	GetSegmentByStartNode(nodeID string) *Segment
 	GetInterceptors(mode common.InterceptorMode) []InterceptorUnitInterface
 	SetInterceptors(resolved map[common.InterceptorMode][]InterceptorUnitInterface)
+	GetVersion() int
+	SetVersion(version int)
 }
 
 // graph implements the GraphInterface for the flow execution
@@ -59,6 +61,7 @@ type graph struct {
 	startNodeID  string
 	segments     []Segment
 	interceptors map[common.InterceptorMode][]InterceptorUnitInterface
+	version      int
 }
 
 // GetID returns the unique ID of the graph
@@ -245,6 +248,16 @@ func (g *graph) GetInterceptors(mode common.InterceptorMode) []InterceptorUnitIn
 // SetInterceptors stores pre-resolved interceptor units grouped by mode.
 func (g *graph) SetInterceptors(resolved map[common.InterceptorMode][]InterceptorUnitInterface) {
 	g.interceptors = resolved
+}
+
+// GetVersion returns the flow definition version this graph was built from.
+func (g *graph) GetVersion() int {
+	return g.version
+}
+
+// SetVersion sets the flow definition version this graph was built from.
+func (g *graph) SetVersion(version int) {
+	g.version = version
 }
 
 // ToJSON converts the graph to a JSON string representation

--- a/backend/internal/flow/core/graph_cache_test.go
+++ b/backend/internal/flow/core/graph_cache_test.go
@@ -54,7 +54,7 @@ func (s *GraphCacheTestSuite) SetupTest() {
 func (s *GraphCacheTestSuite) TestGetSuccess() {
 	flowID := testFlowID
 	ctx := context.Background()
-	g := s.factory.CreateGraph(flowID, common.FlowTypeAuthentication)
+	g := s.factory.CreateGraph(flowID, common.FlowTypeAuthentication, 1)
 	concreteGraph := g.(*graph)
 
 	s.mockCache.EXPECT().Get(ctx, cache.CacheKey{Key: flowID}).Return(concreteGraph, true)
@@ -100,7 +100,7 @@ func (s *GraphCacheTestSuite) TestGetNilGraph() {
 func (s *GraphCacheTestSuite) TestSetSuccess() {
 	flowID := testFlowID
 	ctx := context.Background()
-	g := s.factory.CreateGraph(flowID, common.FlowTypeAuthentication)
+	g := s.factory.CreateGraph(flowID, common.FlowTypeAuthentication, 1)
 
 	s.mockCache.EXPECT().Set(ctx, cache.CacheKey{Key: flowID}, g.(*graph)).Return(nil)
 
@@ -112,7 +112,7 @@ func (s *GraphCacheTestSuite) TestSetSuccess() {
 func (s *GraphCacheTestSuite) TestSetCacheError() {
 	flowID := testFlowID
 	ctx := context.Background()
-	g := s.factory.CreateGraph(flowID, common.FlowTypeAuthentication)
+	g := s.factory.CreateGraph(flowID, common.FlowTypeAuthentication, 1)
 	cacheErr := errors.New("cache error")
 
 	s.mockCache.EXPECT().Set(ctx, cache.CacheKey{Key: flowID}, g.(*graph)).Return(cacheErr)
@@ -124,7 +124,7 @@ func (s *GraphCacheTestSuite) TestSetCacheError() {
 }
 
 func (s *GraphCacheTestSuite) TestSetEmptyFlowID() {
-	g := s.factory.CreateGraph(testFlowID, common.FlowTypeAuthentication)
+	g := s.factory.CreateGraph(testFlowID, common.FlowTypeAuthentication, 1)
 
 	err := s.cache.Set(context.Background(), "", g)
 

--- a/backend/internal/flow/core/graph_test.go
+++ b/backend/internal/flow/core/graph_test.go
@@ -38,7 +38,7 @@ func TestGraphTestSuite(t *testing.T) {
 
 func (s *GraphTestSuite) SetupTest() {
 	s.factory = newFlowFactory()
-	s.graph = s.factory.CreateGraph("test-graph", common.FlowTypeAuthentication)
+	s.graph = s.factory.CreateGraph("test-graph", common.FlowTypeAuthentication, 1)
 }
 
 func (s *GraphTestSuite) TestGetID() {
@@ -46,8 +46,17 @@ func (s *GraphTestSuite) TestGetID() {
 }
 
 func (s *GraphTestSuite) TestGetType() {
-	graph := s.factory.CreateGraph("test-graph", common.FlowTypeRegistration)
+	graph := s.factory.CreateGraph("test-graph", common.FlowTypeRegistration, 1)
 	s.Equal(common.FlowTypeRegistration, graph.GetType())
+}
+
+func (s *GraphTestSuite) TestGetVersion() {
+	s.Equal(1, s.graph.GetVersion())
+}
+
+func (s *GraphTestSuite) TestSetAndGetVersion() {
+	s.graph.SetVersion(5)
+	s.Equal(5, s.graph.GetVersion())
 }
 
 func (s *GraphTestSuite) TestAddNodeSuccess() {

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -164,7 +164,7 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication, 1)
 
 	// Mock inbound client + entity for the flow's owning entity (shared across test cases).
 	mockClient := &inboundmodel.InboundClient{
@@ -277,7 +277,7 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 					testUserOnboardingFlowHandle, common.FlowTypeUserOnboarding).Return(mockFlow, nil)
 
 				// Mock GetGraph call which is made during initContext
-				inviteGraph := flowFactory.CreateGraph("onboarding-flow-123", common.FlowTypeUserOnboarding)
+				inviteGraph := flowFactory.CreateGraph("onboarding-flow-123", common.FlowTypeUserOnboarding, 1)
 				mockFlowProvider.EXPECT().GetGraph(mock.Anything, "onboarding-flow-123").Return(inviteGraph, nil)
 
 				mockStore.EXPECT().StoreFlowContext(mock.MatchedBy(func(ctx context.Context) bool {
@@ -387,7 +387,7 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 					(*entityprovider.EntityProviderError)(nil))
 
 				// Mock flow management service to return valid graph
-				testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+				testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication, 1)
 				mockFlowProvider.EXPECT().GetGraph(mock.Anything, "auth-graph-1").Return(testGraph, nil)
 
 				// Mock store to return error
@@ -494,7 +494,7 @@ func TestEncryptedPayloadStoredBeforeWrite(t *testing.T) {
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication, 1)
 
 	mockStore := newFlowStoreInterfaceMock(t)
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
@@ -539,7 +539,7 @@ func TestDecryptCalledForEncryptedStoredContext(t *testing.T) {
 	// Verifies that when GetFlowContext returns an encrypted context (has "alg" field),
 	// Decrypt is called and the engine receives the properly restored EngineContext.
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication, 1)
 
 	engineCtx := EngineContext{
 		ExecutionID:       existingExecutionID,
@@ -649,7 +649,7 @@ func TestEncryptedContext_SensitiveFieldsHidden(t *testing.T) {
 			})
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication, 1)
 
 	sensitiveAppID := "app-sensitive-99999"
 	sensitiveUserID := "user-sensitive-88888"
@@ -751,7 +751,7 @@ func TestEncryptDecryptRoundTrip_AllFieldsPreserved(t *testing.T) {
 		})
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication, 1)
 
 	originalToken := "original-secret-token-value-xyz789"
 
@@ -841,7 +841,7 @@ func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 	// Tests that a plain-text stored context (decryption already handled by service before store)
 	// is loaded and used to continue flow execution without error.
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication, 1)
 
 	engineCtx := EngineContext{
 		ExecutionID: existingExecutionID,
@@ -902,7 +902,7 @@ func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 
 func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication, 1)
 
 	engineCtx := EngineContext{
 		ExecutionID: existingExecutionID,
@@ -965,7 +965,7 @@ func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
 
 func TestExecute_ExistingFlowWithDifferentChallengeTokens(t *testing.T) {
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication, 1)
 
 	tests := []struct {
 		name            string
@@ -1059,7 +1059,7 @@ func TestExecute_EngineError_InvalidChallengeToken_PreservesContext(t *testing.T
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication, 1)
 
 	engineCtx := EngineContext{
 		ExecutionID: existingExecutionID,
@@ -1125,7 +1125,7 @@ func TestExecute_EngineError_InvalidChallengeToken_PreservesContext(t *testing.T
 
 func TestExecute_EngineError_NonChallengeToken_RemovesContext(t *testing.T) {
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication, 1)
 
 	engineCtx := EngineContext{
 		ExecutionID: existingExecutionID,
@@ -1197,7 +1197,7 @@ func TestExecute_EngineError_NewFlow_ContextNeverRemoved(t *testing.T) {
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication, 1)
 
 	mockStore := newFlowStoreInterfaceMock(t)
 	mockFlowProvider := NewFlowProviderInterfaceMock(t)
@@ -1373,7 +1373,7 @@ func TestEncryptEngineContext_EncryptError(t *testing.T) {
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication, 1)
 
 	engineCtx := &EngineContext{
 		ExecutionID: "exec-id",
@@ -1436,7 +1436,7 @@ func TestInitiateAndExecute_CustomExpiryUsed(t *testing.T) {
 	defer config.ResetServerRuntime()
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-expiry", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-expiry", common.FlowTypeAuthentication, 1)
 
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
@@ -1488,7 +1488,7 @@ func TestInitiateAndExecute_ZeroExpiryUsesDefault(t *testing.T) {
 	defer config.ResetServerRuntime()
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-defexp", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-defexp", common.FlowTypeAuthentication, 1)
 
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
@@ -1548,7 +1548,7 @@ func TestInitiateAndExecute_InitialInputsAndRuntimeData(t *testing.T) {
 	defer config.ResetServerRuntime()
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-ia", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-ia", common.FlowTypeAuthentication, 1)
 
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
@@ -1604,7 +1604,7 @@ func TestInitiateAndExecute_FlowComplete_ContextNotStored(t *testing.T) {
 	defer config.ResetServerRuntime()
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-complete", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-complete", common.FlowTypeAuthentication, 1)
 
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
@@ -1652,7 +1652,7 @@ func TestInitiateAndExecute_EngineError(t *testing.T) {
 	defer config.ResetServerRuntime()
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-ee", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-ee", common.FlowTypeAuthentication, 1)
 
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
@@ -1698,7 +1698,7 @@ func TestInitiateAndExecute_StoreError_ReturnsError(t *testing.T) {
 	defer config.ResetServerRuntime()
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-se", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-se", common.FlowTypeAuthentication, 1)
 
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
@@ -1883,7 +1883,7 @@ func (s *ServiceTestSuite) TestExecute_NewFlow_IncompleteStoresContext() {
 	_ = config.InitializeServerRuntime("/tmp/test-new-flow", testConfig)
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-new", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-new", common.FlowTypeAuthentication, 1)
 
 	mockStore := newFlowStoreInterfaceMock(s.T())
 	mockFlowProvider := NewFlowProviderInterfaceMock(s.T())
@@ -1929,7 +1929,7 @@ func (s *ServiceTestSuite) TestExecute_ExistingFlow_CompleteRemovesContext() {
 	_ = config.InitializeServerRuntime("/tmp/test-existing-flow-complete", testConfig)
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("test-graph-id", common.FlowTypeAuthentication, 1)
 
 	engineCtx := EngineContext{
 		ExecutionID:       "existing-execution-id",
@@ -2142,7 +2142,7 @@ func (s *ServiceTestSuite) TestExecute_NewFlow_NonAuthCodeApp_Allowed() {
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication, 1)
 
 	mockStore := newFlowStoreInterfaceMock(t)
 	mockFlowProvider := NewFlowProviderInterfaceMock(t)
@@ -2210,7 +2210,7 @@ func (s *ServiceTestSuite) TestExecute_NewFlow_OAuthProfileNil_Allowed() {
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication, 1)
 
 	mockStore := newFlowStoreInterfaceMock(t)
 	mockFlowProvider := NewFlowProviderInterfaceMock(t)
@@ -2251,7 +2251,7 @@ func (s *ServiceTestSuite) TestExecute_ContinuationFlow_AuthCodeApp_NotBlocked()
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
 
 	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
-	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication)
+	testGraph := flowFactory.CreateGraph("auth-graph-1", common.FlowTypeAuthentication, 1)
 
 	mockStore := newFlowStoreInterfaceMock(t)
 	mockFlowProvider := NewFlowProviderInterfaceMock(t)

--- a/backend/internal/flow/mgt/graph_builder.go
+++ b/backend/internal/flow/mgt/graph_builder.go
@@ -75,10 +75,20 @@ func (b *graphBuilder) GetGraph(ctx context.Context, flow *CompleteFlowDefinitio
 	}
 
 	logger := b.logger.With(log.String("flowID", flow.ID))
-	// Check cache first
+	// Check cache first, with version-based staleness detection.
+	// The flow definition (with ActiveVersion) comes from the Redis-backed store,
+	// so all nodes see the latest version even though the graph cache is local.
 	if cachedGraph, ok := b.graphCache.Get(ctx, flow.ID); ok {
-		logger.Debug(ctx, "Graph retrieved from cache")
-		return cachedGraph, nil
+		if cachedGraph.GetVersion() == flow.ActiveVersion {
+			logger.Debug(ctx, "Graph retrieved from cache")
+			return cachedGraph, nil
+		}
+		logger.Debug(ctx, "Cached graph version mismatch, rebuilding",
+			log.Int("cachedVersion", cachedGraph.GetVersion()),
+			log.Int("activeVersion", flow.ActiveVersion))
+		if err := b.graphCache.Invalidate(ctx, flow.ID); err != nil {
+			logger.Error(ctx, "Failed to invalidate stale graph from cache", log.Error(err))
+		}
 	}
 
 	graph, err := b.buildGraph(ctx, flow)
@@ -119,7 +129,7 @@ func (b *graphBuilder) buildGraph(ctx context.Context, flow *CompleteFlowDefinit
 	}
 
 	// Create a graph
-	graph := b.flowFactory.CreateGraph(flow.ID, flow.FlowType)
+	graph := b.flowFactory.CreateGraph(flow.ID, flow.FlowType, flow.ActiveVersion)
 
 	// Process all nodes and build the graph structure
 	edges := make(map[string][]string)

--- a/backend/internal/flow/mgt/graph_builder_subset_registry_test.go
+++ b/backend/internal/flow/mgt/graph_builder_subset_registry_test.go
@@ -86,10 +86,11 @@ func (s *GraphBuilderSubsetRegistryTestSuite) TestBuildGraph_SubsetRegistryRejec
 	}
 
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{
 				ID:       "task",
@@ -102,7 +103,7 @@ func (s *GraphBuilderSubsetRegistryTestSuite) TestBuildGraph_SubsetRegistryRejec
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
 	mockTaskNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
 
-	mockFlowFactory.EXPECT().CreateGraph("flow-1", common.FlowTypeAuthentication).Return(mockGraph)
+	mockFlowFactory.EXPECT().CreateGraph("flow-1", common.FlowTypeAuthentication, 1).Return(mockGraph)
 	mockFlowFactory.EXPECT().CreateNode(
 		"task", "TASK_EXECUTION", map[string]interface{}(nil), false, true).Return(mockTaskNode, nil)
 	mockTaskNode.EXPECT().SetInputs([]common.Input{})

--- a/backend/internal/flow/mgt/graph_builder_test.go
+++ b/backend/internal/flow/mgt/graph_builder_test.go
@@ -81,11 +81,12 @@ func (s *GraphBuilderTestSuite) TestGetGraph_NilFlow() {
 
 func (s *GraphBuilderTestSuite) TestGetGraph_EmptyNodes() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
-		Nodes:    []NodeDefinition{},
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
+		Nodes:         []NodeDefinition{},
 	}
 
 	graph, err := s.builder.GetGraph(context.Background(), flow)
@@ -98,16 +99,18 @@ func (s *GraphBuilderTestSuite) TestGetGraph_EmptyNodes() {
 
 func (s *GraphBuilderTestSuite) TestGetGraph_CacheHit() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START"},
 		},
 	}
 
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.EXPECT().GetVersion().Return(1)
 	s.mockGraphCache.EXPECT().Get(mock.Anything, "flow-1").Return(mockGraph, true)
 
 	graph, err := s.builder.GetGraph(context.Background(), flow)
@@ -119,10 +122,11 @@ func (s *GraphBuilderTestSuite) TestGetGraph_CacheHit() {
 
 func (s *GraphBuilderTestSuite) TestGetGraph_BuildAndCache() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "end"},
 			{ID: "end", Type: "END"},
@@ -135,7 +139,7 @@ func (s *GraphBuilderTestSuite) TestGetGraph_BuildAndCache() {
 
 	s.mockGraphCache.EXPECT().Get(mock.Anything, "flow-1").Return(nil, false)
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(mockGraph)
+		"flow-1", common.FlowTypeAuthentication, 1).Return(mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, false).Return(
 		mockStartNode, nil)
@@ -166,12 +170,67 @@ func (s *GraphBuilderTestSuite) TestGetGraph_BuildAndCache() {
 	s.Equal(mockGraph, graph)
 }
 
+func (s *GraphBuilderTestSuite) TestGetGraph_CacheHitVersionMismatch() {
+	flow := &CompleteFlowDefinition{
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 3,
+		Nodes: []NodeDefinition{
+			{ID: "start", Type: "START", OnSuccess: "end"},
+			{ID: "end", Type: "END"},
+		},
+	}
+
+	staleGraph := coremock.NewGraphInterfaceMock(s.T())
+	staleGraph.EXPECT().GetVersion().Return(2)
+
+	newGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockStartNode := coremock.NewRepresentationNodeInterfaceMock(s.T())
+	mockEndNode := coremock.NewRepresentationNodeInterfaceMock(s.T())
+
+	s.mockGraphCache.EXPECT().Get(mock.Anything, "flow-1").Return(staleGraph, true)
+	s.mockGraphCache.EXPECT().Invalidate(mock.Anything, "flow-1").Return(nil)
+
+	s.mockFlowFactory.EXPECT().CreateGraph(
+		"flow-1", common.FlowTypeAuthentication, 3).Return(newGraph)
+	s.mockFlowFactory.EXPECT().CreateNode(
+		"start", "START", map[string]interface{}(nil), false, false).Return(
+		mockStartNode, nil)
+	s.mockFlowFactory.EXPECT().CreateNode(
+		"end", "END", map[string]interface{}(nil), false, true).Return(
+		mockEndNode, nil)
+
+	mockStartNode.EXPECT().SetOnSuccess("end")
+
+	newGraph.EXPECT().AddNode(mockStartNode).Return(nil)
+	newGraph.EXPECT().AddNode(mockEndNode).Return(nil)
+	newGraph.EXPECT().AddEdge("start", "end").Return(nil)
+	newGraph.EXPECT().GetNodes().Return(
+		map[string]core.NodeInterface{"start": mockStartNode, "end": mockEndNode})
+	mockStartNode.EXPECT().GetType().Return(common.NodeTypeStart)
+	mockEndNode.EXPECT().GetType().Return(common.NodeTypeEnd).Maybe()
+	mockStartNode.EXPECT().GetID().Return("start")
+	newGraph.EXPECT().SetStartNode("start").Return(nil)
+	newGraph.EXPECT().SetInterceptors(mock.Anything)
+
+	s.mockGraphCache.EXPECT().Set(mock.Anything, "flow-1", newGraph).Return(nil)
+
+	graph, err := s.builder.GetGraph(context.Background(), flow)
+
+	s.NotNil(graph)
+	s.Nil(err)
+	s.Equal(newGraph, graph)
+}
+
 func (s *GraphBuilderTestSuite) TestGetGraph_BuildFailure() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START"},
 		},
@@ -179,7 +238,7 @@ func (s *GraphBuilderTestSuite) TestGetGraph_BuildFailure() {
 
 	mockGraph := coremock.NewGraphInterfaceMock(s.T())
 	s.mockGraphCache.EXPECT().Get(mock.Anything, "flow-1").Return(nil, false)
-	s.mockFlowFactory.EXPECT().CreateGraph("flow-1", common.FlowTypeAuthentication).Return(
+	s.mockFlowFactory.EXPECT().CreateGraph("flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, true).Return(
@@ -195,10 +254,11 @@ func (s *GraphBuilderTestSuite) TestGetGraph_BuildFailure() {
 
 func (s *GraphBuilderTestSuite) TestGetGraph_CacheSetError() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START"},
 		},
@@ -209,7 +269,7 @@ func (s *GraphBuilderTestSuite) TestGetGraph_CacheSetError() {
 
 	s.mockGraphCache.EXPECT().Get(mock.Anything, "flow-1").Return(nil, false)
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, true).Return(
@@ -256,10 +316,11 @@ func (s *GraphBuilderTestSuite) TestInvalidateCache_Error() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_WithExecutor() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "task"},
 			{
@@ -275,7 +336,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithExecutor() {
 	mockTaskNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, false).Return(
@@ -308,10 +369,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithExecutor() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_ExecutorNotRegistered() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{
 				ID:       "task",
@@ -325,7 +387,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_ExecutorNotRegistered() {
 	mockTaskNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"task", "TASK_EXECUTION", map[string]interface{}(nil), false, true).Return(
@@ -343,10 +405,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_ExecutorNotRegistered() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_WithOnFailure() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "task"},
 			{
@@ -368,7 +431,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithOnFailure() {
 	mockEndNode := coremock.NewRepresentationNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, false).Return(
@@ -418,10 +481,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithOnFailure() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_OnFailureNotPromptNode() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{
 				ID:        "task",
@@ -436,7 +500,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_OnFailureNotPromptNode() {
 	mockTaskNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"task", "TASK_EXECUTION", map[string]interface{}(nil), false, false).Return(
@@ -454,10 +518,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_OnFailureNotPromptNode() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_OnFailureTargetNotFound() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{
 				ID:        "task",
@@ -471,7 +536,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_OnFailureTargetNotFound() {
 	mockTaskNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"task", "TASK_EXECUTION", map[string]interface{}(nil), false, false).Return(
@@ -488,10 +553,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_OnFailureTargetNotFound() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_WithInputs() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "task"},
 			{
@@ -512,7 +578,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithInputs() {
 	mockTaskNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, false).Return(
@@ -547,10 +613,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithInputs() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_WithActions() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "prompt"},
 			{
@@ -573,7 +640,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithActions() {
 	mockTask2Node := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, false).Return(
@@ -632,10 +699,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithActions() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_WithMeta() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "prompt"},
 			{
@@ -651,7 +719,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithMeta() {
 	mockPromptNode := coremock.NewPromptNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, false).Return(
@@ -685,10 +753,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithMeta() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_VariantExplicitlySet() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "chooser"},
 			{
@@ -704,7 +773,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_VariantExplicitlySet() {
 	mockPromptNode := coremock.NewPromptNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(mockGraph)
+		"flow-1", common.FlowTypeAuthentication, 1).Return(mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, false).Return(mockStartNode, nil)
 	s.mockFlowFactory.EXPECT().CreateNode(
@@ -732,10 +801,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_VariantExplicitlySet() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_WithCondition() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "task"},
 			{
@@ -757,7 +827,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithCondition() {
 	mockEndNode := coremock.NewRepresentationNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, false).Return(
@@ -800,10 +870,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithCondition() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_NoStartNode() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "task", Type: "TASK_EXECUTION"},
 			{ID: "end", Type: "END"},
@@ -815,7 +886,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_NoStartNode() {
 	mockEndNode := coremock.NewNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"task", "TASK_EXECUTION", map[string]interface{}(nil), false, true).Return(
@@ -840,10 +911,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_NoStartNode() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_AddNodeError() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START"},
 		},
@@ -853,7 +925,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_AddNodeError() {
 	mockStartNode := coremock.NewNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, true).Return(
@@ -870,10 +942,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_AddNodeError() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_AddEdgeError() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "end"},
 			{ID: "end", Type: "END"},
@@ -885,7 +958,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_AddEdgeError() {
 	mockEndNode := coremock.NewNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, false).Return(
@@ -907,10 +980,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_AddEdgeError() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_SetStartNodeError() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START"},
 		},
@@ -920,7 +994,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_SetStartNodeError() {
 	mockStartNode := coremock.NewNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, true).Return(
@@ -946,10 +1020,11 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithProperties() {
 	}
 
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "task", Properties: properties},
 			{ID: "task", Type: "TASK_EXECUTION"},
@@ -961,7 +1036,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithProperties() {
 	mockTaskNode := coremock.NewRepresentationNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", properties, false, false).Return(
@@ -1016,10 +1091,11 @@ func (s *GraphBuilderTestSuite) TestValidateExecutorName_Success() {
 
 func (s *GraphBuilderTestSuite) TestBuildGraph_WithExecutorMode() {
 	flow := &CompleteFlowDefinition{
-		ID:       "flow-1",
-		Handle:   "test-handle",
-		Name:     "Test Flow",
-		FlowType: common.FlowTypeAuthentication,
+		ID:            "flow-1",
+		Handle:        "test-handle",
+		Name:          "Test Flow",
+		FlowType:      common.FlowTypeAuthentication,
+		ActiveVersion: 1,
 		Nodes: []NodeDefinition{
 			{ID: "start", Type: "START", OnSuccess: "task"},
 			{
@@ -1035,7 +1111,7 @@ func (s *GraphBuilderTestSuite) TestBuildGraph_WithExecutorMode() {
 	mockTaskNode := coremock.NewExecutorBackedNodeInterfaceMock(s.T())
 
 	s.mockFlowFactory.EXPECT().CreateGraph(
-		"flow-1", common.FlowTypeAuthentication).Return(
+		"flow-1", common.FlowTypeAuthentication, 1).Return(
 		mockGraph)
 	s.mockFlowFactory.EXPECT().CreateNode(
 		"start", "START", map[string]interface{}(nil), false, false).Return(

--- a/backend/tests/mocks/flow/coremock/FlowFactoryInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/FlowFactoryInterface_mock.go
@@ -233,16 +233,16 @@ func (_c *FlowFactoryInterfaceMock_CreateExecutor_Call) RunAndReturn(run func(na
 }
 
 // CreateGraph provides a mock function for the type FlowFactoryInterfaceMock
-func (_mock *FlowFactoryInterfaceMock) CreateGraph(id string, _type common.FlowType) core.GraphInterface {
-	ret := _mock.Called(id, _type)
+func (_mock *FlowFactoryInterfaceMock) CreateGraph(id string, _type common.FlowType, version int) core.GraphInterface {
+	ret := _mock.Called(id, _type, version)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateGraph")
 	}
 
 	var r0 core.GraphInterface
-	if returnFunc, ok := ret.Get(0).(func(string, common.FlowType) core.GraphInterface); ok {
-		r0 = returnFunc(id, _type)
+	if returnFunc, ok := ret.Get(0).(func(string, common.FlowType, int) core.GraphInterface); ok {
+		r0 = returnFunc(id, _type, version)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(core.GraphInterface)
@@ -259,11 +259,12 @@ type FlowFactoryInterfaceMock_CreateGraph_Call struct {
 // CreateGraph is a helper method to define mock.On call
 //   - id string
 //   - _type common.FlowType
-func (_e *FlowFactoryInterfaceMock_Expecter) CreateGraph(id interface{}, _type interface{}) *FlowFactoryInterfaceMock_CreateGraph_Call {
-	return &FlowFactoryInterfaceMock_CreateGraph_Call{Call: _e.mock.On("CreateGraph", id, _type)}
+//   - version int
+func (_e *FlowFactoryInterfaceMock_Expecter) CreateGraph(id interface{}, _type interface{}, version interface{}) *FlowFactoryInterfaceMock_CreateGraph_Call {
+	return &FlowFactoryInterfaceMock_CreateGraph_Call{Call: _e.mock.On("CreateGraph", id, _type, version)}
 }
 
-func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) Run(run func(id string, _type common.FlowType)) *FlowFactoryInterfaceMock_CreateGraph_Call {
+func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) Run(run func(id string, _type common.FlowType, version int)) *FlowFactoryInterfaceMock_CreateGraph_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -273,9 +274,14 @@ func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) Run(run func(id string, _ty
 		if args[1] != nil {
 			arg1 = args[1].(common.FlowType)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -286,7 +292,7 @@ func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) Return(graphInterface core.
 	return _c
 }
 
-func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) RunAndReturn(run func(id string, _type common.FlowType) core.GraphInterface) *FlowFactoryInterfaceMock_CreateGraph_Call {
+func (_c *FlowFactoryInterfaceMock_CreateGraph_Call) RunAndReturn(run func(id string, _type common.FlowType, version int) core.GraphInterface) *FlowFactoryInterfaceMock_CreateGraph_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/coremock/GraphInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/GraphInterface_mock.go
@@ -691,6 +691,50 @@ func (_c *GraphInterfaceMock_GetType_Call) RunAndReturn(run func() common.FlowTy
 	return _c
 }
 
+// GetVersion provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) GetVersion() int {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetVersion")
+	}
+
+	var r0 int
+	if returnFunc, ok := ret.Get(0).(func() int); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	return r0
+}
+
+// GraphInterfaceMock_GetVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetVersion'
+type GraphInterfaceMock_GetVersion_Call struct {
+	*mock.Call
+}
+
+// GetVersion is a helper method to define mock.On call
+func (_e *GraphInterfaceMock_Expecter) GetVersion() *GraphInterfaceMock_GetVersion_Call {
+	return &GraphInterfaceMock_GetVersion_Call{Call: _e.mock.On("GetVersion")}
+}
+
+func (_c *GraphInterfaceMock_GetVersion_Call) Run(run func()) *GraphInterfaceMock_GetVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetVersion_Call) Return(n int) *GraphInterfaceMock_GetVersion_Call {
+	_c.Call.Return(n)
+	return _c
+}
+
+func (_c *GraphInterfaceMock_GetVersion_Call) RunAndReturn(run func() int) *GraphInterfaceMock_GetVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // HasSegments provides a mock function for the type GraphInterfaceMock
 func (_mock *GraphInterfaceMock) HasSegments() bool {
 	ret := _mock.Called()
@@ -1000,6 +1044,46 @@ func (_c *GraphInterfaceMock_SetStartNode_Call) Return(err error) *GraphInterfac
 
 func (_c *GraphInterfaceMock_SetStartNode_Call) RunAndReturn(run func(startNodeID string) error) *GraphInterfaceMock_SetStartNode_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// SetVersion provides a mock function for the type GraphInterfaceMock
+func (_mock *GraphInterfaceMock) SetVersion(version int) {
+	_mock.Called(version)
+	return
+}
+
+// GraphInterfaceMock_SetVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetVersion'
+type GraphInterfaceMock_SetVersion_Call struct {
+	*mock.Call
+}
+
+// SetVersion is a helper method to define mock.On call
+//   - version int
+func (_e *GraphInterfaceMock_Expecter) SetVersion(version interface{}) *GraphInterfaceMock_SetVersion_Call {
+	return &GraphInterfaceMock_SetVersion_Call{Call: _e.mock.On("SetVersion", version)}
+}
+
+func (_c *GraphInterfaceMock_SetVersion_Call) Run(run func(version int)) *GraphInterfaceMock_SetVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *GraphInterfaceMock_SetVersion_Call) Return() *GraphInterfaceMock_SetVersion_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *GraphInterfaceMock_SetVersion_Call) RunAndReturn(run func(version int)) *GraphInterfaceMock_SetVersion_Call {
+	_c.Run(run)
 	return _c
 }
 


### PR DESCRIPTION
### Purpose

- The compiled flow graph cache is hardcoded to in-memory. In a multi-node deployment, invalidating the cache on one node after a flow update has no effect on the other nodes — they continue serving the stale compiled graph until their process restarts or the entry naturally expires. 

<!--
---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

- Compiled graph objects cannot be serialized into the distributed (Redis) cache, so the graph cache is kept in-memory on each node. To detect staleness, the flow's `ActiveVersion` is stored in the compiled graph at build time. On retrieval, the cached graph's version is compared against the flow definition's current `ActiveVersion`. If there is a mismatch, the stale graph is invalidated and rebuilt.

#### Changes

**1. Added `version` field to the `graph` struct** (`backend/internal/flow/core/graph.go`)

```go
type graph struct {
    // ... existing fields
    version      int
}
```

With corresponding `GetVersion()` / `SetVersion()` methods on `GraphInterface`.

**2. Version stamped at build time** (`backend/internal/flow/mgt/graph_builder.go`)

```go
graph := b.flowFactory.CreateGraph(flow.ID, flow.FlowType)
graph.SetVersion(flow.ActiveVersion)
```

**3. Version-based staleness detection on cache retrieval** (`backend/internal/flow/mgt/graph_builder.go`)

```go
if cachedGraph, ok := b.graphCache.Get(ctx, flow.ID); ok {
    if cachedGraph.GetVersion() == flow.ActiveVersion {
        return cachedGraph, nil
    }
    // Version mismatch — invalidate and rebuild
    b.graphCache.Invalidate(ctx, flow.ID)
}
```


- The default global TTL is set to `3600s` = `1hr`. The same TTL has been used for graph cache as well.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3064
- https://github.com/thunder-id/thunderid/issues/1998

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added graph version tracking so cached graphs are only reused when they match the currently active version; otherwise the stale cache entry is discarded and the graph is rebuilt.

* **Tests**
  * Added unit tests for default version behavior plus set/get version updates.
  * Added coverage for cache hit vs version mismatch handling, including cache invalidation and rebuild behavior.
  * Updated existing test fixtures and mock expectations to include version-aware graph creation and retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->