### PR TITLE
Hide Guide tab when no guide exists for selected template variant

### DIFF
--- a/frontend/apps/console/src/features/applications/components/edit-application/integration-guides/TechnologyGuide.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/integration-guides/TechnologyGuide.tsx
@@ -25,9 +25,8 @@ import {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Prism as SyntaxHighlighter} from 'react-syntax-highlighter';
 import {vscDarkPlus} from 'react-syntax-highlighter/dist/esm/styles/prism';
-import TemplateConstants from '../../../constants/template-constants';
-import {ApplicationCreateFlowSignInApproach} from '../../../models/application-create-flow';
 import type {IntegrationGuides, IntegrationStep} from '../../../models/application-templates';
+import {getIntegrationGuideVariantKey} from '../../../utils/getIntegrationGuidesForTemplate';
 import GradientBorderButton from '../../GradientBorderButton';
 
 /**
@@ -92,14 +91,10 @@ export default function TechnologyGuide({
     return null;
   }
 
-  // Get the guide key based on template ID - check if it contains embedded suffix
-  // Templates with -embedded suffix (e.g., react-embedded) → use 'embedded' guide
-  // Templates without -embedded suffix (e.g., react) → use 'inbuilt' guide
-  const isEmbedded = templateId?.includes(TemplateConstants.EMBEDDED_SUFFIX) ?? false;
-  const guideKey = isEmbedded
-    ? ApplicationCreateFlowSignInApproach.EMBEDDED
-    : ApplicationCreateFlowSignInApproach.INBUILT;
-  const selectedGuide = guides[guideKey];
+  // Select the guide for the variant determined by the template ID.
+  // Templates with the -embedded suffix (e.g., react-embedded) use the EMBEDDED guide;
+  // all others use the INBUILT guide.
+  const selectedGuide = guides[getIntegrationGuideVariantKey(templateId)];
 
   if (!selectedGuide) {
     return null;

--- a/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
@@ -46,7 +46,7 @@ import IntegrationGuides from '../components/edit-application/integration-guides
 import EditTokenSettings from '../components/edit-application/token-settings/EditTokenSettings';
 import type {Application} from '../models/application';
 import type {OAuth2Config} from '../models/oauth';
-import getIntegrationGuidesForTemplate from '../utils/getIntegrationGuidesForTemplate';
+import {getIntegrationGuideForTemplate} from '../utils/getIntegrationGuidesForTemplate';
 import getTemplateFieldConstraints from '../utils/getTemplateFieldConstraints';
 import getTemplateMetadata from '../utils/getTemplateMetadata';
 
@@ -110,7 +110,7 @@ export default function ApplicationEditPage() {
   );
 
   const hasIntegrationGuides = useMemo(
-    () => application && getIntegrationGuidesForTemplate(application.template) !== null,
+    () => Boolean(application && getIntegrationGuideForTemplate(application.template)),
     [application],
   );
 

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
@@ -23,7 +23,7 @@ import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import useGetApplication from '../../api/useGetApplication';
 import useUpdateApplication from '../../api/useUpdateApplication';
 import type {Application} from '../../models/application';
-import getIntegrationGuidesForTemplate from '../../utils/getIntegrationGuidesForTemplate';
+import {getIntegrationGuideForTemplate} from '../../utils/getIntegrationGuidesForTemplate';
 import getTemplateMetadata from '../../utils/getTemplateMetadata';
 import ApplicationEditPage from '../ApplicationEditPage';
 
@@ -78,6 +78,7 @@ vi.mock('../../utils/getTemplateMetadata', () => ({
 
 vi.mock('../../utils/getIntegrationGuidesForTemplate', () => ({
   default: vi.fn(),
+  getIntegrationGuideForTemplate: vi.fn(),
 }));
 
 // Mock child components
@@ -216,7 +217,7 @@ vi.mock('@thunderid/components', async () => {
 const mockUseGetApplication = useGetApplication as ReturnType<typeof vi.fn>;
 const mockUseUpdateApplication = useUpdateApplication as ReturnType<typeof vi.fn>;
 const mockGetTemplateMetadata = getTemplateMetadata as ReturnType<typeof vi.fn>;
-const mockGetIntegrationGuidesForTemplate = getIntegrationGuidesForTemplate as ReturnType<typeof vi.fn>;
+const mockGetIntegrationGuidesForTemplate = getIntegrationGuideForTemplate as ReturnType<typeof vi.fn>;
 
 describe('ApplicationEditPage', () => {
   const mockApplication: Application = {

--- a/frontend/apps/console/src/features/applications/utils/__tests__/getIntegrationGuidesForTemplate.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/getIntegrationGuidesForTemplate.test.ts
@@ -19,7 +19,10 @@
 import {describe, expect, it, vi} from 'vitest';
 import type {IntegrationGuides} from '../../models/application-templates';
 
-import getIntegrationGuidesForTemplate from '../getIntegrationGuidesForTemplate';
+import getIntegrationGuidesForTemplate, {
+  getIntegrationGuideForTemplate,
+  getIntegrationGuideVariantKey,
+} from '../getIntegrationGuidesForTemplate';
 
 // Mock the config files - must be defined before any imports that use them
 vi.mock('../../config/TechnologyBasedApplicationTemplateMetadata', () => ({
@@ -28,7 +31,7 @@ vi.mock('../../config/TechnologyBasedApplicationTemplateMetadata', () => ({
       template: {
         id: 'express',
         integrationGuides: {
-          inbuilt: {
+          INBUILT: {
             llm_prompt: {
               id: 'express-llm',
               title: 'AI-Assisted Integration',
@@ -57,7 +60,7 @@ vi.mock('../../config/TechnologyBasedApplicationTemplateMetadata', () => ({
       template: {
         id: 'react',
         integrationGuides: {
-          inbuilt: {
+          INBUILT: {
             llm_prompt: {
               id: 'react-llm',
               title: 'AI-Assisted Integration',
@@ -79,6 +82,23 @@ vi.mock('../../config/TechnologyBasedApplicationTemplateMetadata', () => ({
               },
             ],
           },
+          EMBEDDED: {
+            llm_prompt: {
+              id: 'react-embedded-llm',
+              title: 'AI-Assisted Integration',
+              description: 'React embedded integration guide',
+              type: 'llm' as const,
+              icon: 'react',
+              content: 'Embedded LLM prompt content',
+            },
+            manual_steps: [
+              {
+                step: 1,
+                title: 'Embedded Step 1',
+                description: 'First embedded step description',
+              },
+            ],
+          },
         },
       },
     },
@@ -86,7 +106,7 @@ vi.mock('../../config/TechnologyBasedApplicationTemplateMetadata', () => ({
       template: {
         id: 'nextjs',
         integrationGuides: {
-          inbuilt: {
+          INBUILT: {
             llm_prompt: {
               id: 'nextjs-llm',
               title: 'AI-Assisted Integration',
@@ -125,7 +145,7 @@ vi.mock('../../config/PlatformBasedApplicationTemplateMetadata', () => ({
       template: {
         id: 'browser',
         integrationGuides: {
-          inbuilt: {
+          INBUILT: {
             llm_prompt: {
               id: 'browser-llm',
               title: 'AI-Assisted Integration',
@@ -167,7 +187,7 @@ vi.mock('../normalizeTemplateId', () => ({
 
 // Test data - define after mocks
 const mockReactGuides: IntegrationGuides = {
-  inbuilt: {
+  INBUILT: {
     llm_prompt: {
       id: 'react-llm',
       title: 'AI-Assisted Integration',
@@ -189,10 +209,27 @@ const mockReactGuides: IntegrationGuides = {
       },
     ],
   },
+  EMBEDDED: {
+    llm_prompt: {
+      id: 'react-embedded-llm',
+      title: 'AI-Assisted Integration',
+      description: 'React embedded integration guide',
+      type: 'llm' as const,
+      icon: 'react',
+      content: 'Embedded LLM prompt content',
+    },
+    manual_steps: [
+      {
+        step: 1,
+        title: 'Embedded Step 1',
+        description: 'First embedded step description',
+      },
+    ],
+  },
 };
 
 const mockExpressGuides: IntegrationGuides = {
-  inbuilt: {
+  INBUILT: {
     llm_prompt: {
       id: 'express-llm',
       title: 'AI-Assisted Integration',
@@ -217,7 +254,7 @@ const mockExpressGuides: IntegrationGuides = {
 };
 
 const mockNextjsGuides: IntegrationGuides = {
-  inbuilt: {
+  INBUILT: {
     llm_prompt: {
       id: 'nextjs-llm',
       title: 'AI-Assisted Integration',
@@ -242,7 +279,7 @@ const mockNextjsGuides: IntegrationGuides = {
 };
 
 const mockBrowserGuides: IntegrationGuides = {
-  inbuilt: {
+  INBUILT: {
     llm_prompt: {
       id: 'browser-llm',
       title: 'AI-Assisted Integration',
@@ -339,5 +376,50 @@ describe('getIntegrationGuidesForTemplate', () => {
 
       expect(result).toBeNull();
     });
+  });
+});
+
+describe('getIntegrationGuideVariantKey', () => {
+  it('should resolve INBUILT for a template without the embedded suffix', () => {
+    expect(getIntegrationGuideVariantKey('react')).toBe('INBUILT');
+  });
+
+  it('should resolve EMBEDDED for a template with the embedded suffix', () => {
+    expect(getIntegrationGuideVariantKey('react-embedded')).toBe('EMBEDDED');
+  });
+
+  it('should resolve INBUILT for undefined and null template IDs', () => {
+    expect(getIntegrationGuideVariantKey(undefined)).toBe('INBUILT');
+    expect(getIntegrationGuideVariantKey(null)).toBe('INBUILT');
+  });
+});
+
+describe('getIntegrationGuideForTemplate', () => {
+  it('should return the INBUILT guide for the react template', () => {
+    expect(getIntegrationGuideForTemplate('react')).toEqual(mockReactGuides.INBUILT);
+  });
+
+  it('should return the EMBEDDED guide for the react-embedded template', () => {
+    expect(getIntegrationGuideForTemplate('react-embedded')).toEqual(mockReactGuides.EMBEDDED);
+  });
+
+  it('should return the INBUILT guide for the express template', () => {
+    expect(getIntegrationGuideForTemplate('express')).toEqual(mockExpressGuides.INBUILT);
+  });
+
+  it('should return null for express-embedded since no EMBEDDED variant exists', () => {
+    expect(getIntegrationGuideForTemplate('express-embedded')).toBeNull();
+  });
+
+  it('should return null for a template without any integration guides', () => {
+    expect(getIntegrationGuideForTemplate('angular')).toBeNull();
+  });
+
+  it('should return null for undefined template ID', () => {
+    expect(getIntegrationGuideForTemplate(undefined)).toBeNull();
+  });
+
+  it('should return null for a non-existent template ID', () => {
+    expect(getIntegrationGuideForTemplate('non-existent-template')).toBeNull();
   });
 });

--- a/frontend/apps/console/src/features/applications/utils/getIntegrationGuidesForTemplate.ts
+++ b/frontend/apps/console/src/features/applications/utils/getIntegrationGuidesForTemplate.ts
@@ -19,6 +19,8 @@
 import normalizeTemplateId from './normalizeTemplateId';
 import PlatformBasedApplicationTemplateMetadata from '../config/PlatformBasedApplicationTemplateMetadata';
 import TechnologyBasedApplicationTemplateMetadata from '../config/TechnologyBasedApplicationTemplateMetadata';
+import TemplateConstants from '../constants/template-constants';
+import {ApplicationCreateFlowSignInApproach} from '../models/application-create-flow';
 import type {IntegrationGuides} from '../models/application-templates';
 
 /**
@@ -53,4 +55,39 @@ export default function getIntegrationGuidesForTemplate(templateId: string | und
   }
 
   return null;
+}
+
+/**
+ * Resolves the integration guide variant key for a template ID.
+ *
+ * Templates with the '-embedded' suffix (e.g., 'react-embedded') use the EMBEDDED
+ * variant; all others use the INBUILT variant.
+ *
+ * @param templateId - The template ID (e.g., 'react', 'react-embedded')
+ * @returns The guide variant key (EMBEDDED or INBUILT)
+ */
+export function getIntegrationGuideVariantKey(templateId: string | undefined | null): string {
+  const isEmbedded = templateId?.includes(TemplateConstants.EMBEDDED_SUFFIX) ?? false;
+
+  return isEmbedded ? ApplicationCreateFlowSignInApproach.EMBEDDED : ApplicationCreateFlowSignInApproach.INBUILT;
+}
+
+/**
+ * Gets the integration guide for the variant selected by a template ID.
+ *
+ * Unlike {@link getIntegrationGuidesForTemplate}, which returns the full guides object,
+ * this returns only the guide for the selected variant (EMBEDDED or INBUILT), or null
+ * when that variant has no content. Use this to decide whether a guide can be rendered.
+ *
+ * @param templateId - The template ID (e.g., 'react', 'react-embedded', 'express-embedded')
+ * @returns The guide for the selected variant, or null if not found
+ */
+export function getIntegrationGuideForTemplate(templateId: string | undefined): IntegrationGuides[string] | null {
+  const guides = getIntegrationGuidesForTemplate(templateId);
+
+  if (!guides) {
+    return null;
+  }
+
+  return guides[getIntegrationGuideVariantKey(templateId)] ?? null;
 }


### PR DESCRIPTION
## Purpose
The Guide tab displayed but rendered empty for applications created with the embedded flows option on technology templates (Express, Next.js, etc.). The `hasIntegrationGuides` check only verified that a guides object existed, not whether the specific variant (EMBEDDED vs INBUILT) had content. Most technology templates only define INBUILT guides, so for an `-embedded` template ID the lookup found no content and the tab rendered empty.

## Related Issue
- https://github.com/thunder-id/thunderid/issues/3469

## Implementation
- Added `getIntegrationGuideVariantKey` to resolve the variant key (EMBEDDED or INBUILT) from a template ID based on the `-embedded` suffix.
- Added `getIntegrationGuideForTemplate`, which returns the guide for the selected variant or `null` when that variant has no content.
- `ApplicationEditPage.tsx` now uses `getIntegrationGuideForTemplate` for the `hasIntegrationGuides` check, so the Guide tab is hidden when the selected variant has no guide content.
- `TechnologyGuide.tsx` now uses the shared `getIntegrationGuideVariantKey` helper instead of duplicating the variant-selection logic.
- Updated and extended unit tests to cover the new helpers, including the embedded-variant and missing-variant cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved integration guide selection to correctly choose the appropriate guide variant based on the template’s embedded/inbuilt form.
* **Bug Fixes**
  * Adjusted the Application Edit page logic so the Overview tab availability reflects the resolved integration guide content more reliably.
* **Tests**
  * Expanded unit tests to cover embedded vs non-embedded variant resolution and guide selection, including cases where the embedded variant is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->