### PR TITLE
Refactor server-key cryptography 

### DIFF
--- a/backend/internal/openid4vci/credential_test.go
+++ b/backend/internal/openid4vci/credential_test.go
@@ -398,9 +398,9 @@ func newTestSigner(t *testing.T) *issuerSigner {
 		t.Fatalf("generate key: %v", err)
 	}
 	provider := cryptomock.NewRuntimeCryptoProviderMock(t)
-	provider.EXPECT().Sign(mock.Anything, mock.Anything, cryptolib.ECDSASHA256, mock.Anything).
+	provider.EXPECT().Sign(mock.Anything, mock.Anything, "ES256", mock.Anything).
 		RunAndReturn(func(
-			_ context.Context, _ kmprovider.KeyRef, _ cryptolib.SignAlgorithm, content []byte,
+			_ context.Context, _ kmprovider.KeyRef, _ string, content []byte,
 		) ([]byte, error) {
 			digest := sha256.Sum256(content)
 			return ecdsa.SignASN1(rand.Reader, key, digest[:])

--- a/backend/internal/openid4vci/signer.go
+++ b/backend/internal/openid4vci/signer.go
@@ -101,7 +101,7 @@ func (s *issuerSigner) header(typ string) map[string]interface{} {
 // sign signs the JWS signing input and returns the signature in JWS wire form
 // (P1363 r||s for ECDSA), suitable for sdjwt.Issue.
 func (s *issuerSigner) sign(ctx context.Context, signingInput string) ([]byte, error) {
-	derSig, err := s.cryptoProvider.Sign(ctx, s.keyRef, s.signAlg, []byte(signingInput))
+	derSig, err := s.cryptoProvider.Sign(ctx, s.keyRef, s.jwsAlg, []byte(signingInput))
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign credential: %w", err)
 	}

--- a/backend/internal/openid4vci/signer_test.go
+++ b/backend/internal/openid4vci/signer_test.go
@@ -140,14 +140,14 @@ func (s *SignerTestSuite) TestNewIssuerSignerCertChain() {
 func (s *SignerTestSuite) TestSign() {
 	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	provider := cryptomock.NewRuntimeCryptoProviderMock(s.T())
-	provider.EXPECT().Sign(mock.Anything, mock.Anything, cryptolib.ECDSASHA256, mock.Anything).
+	provider.EXPECT().Sign(mock.Anything, mock.Anything, "ES256", mock.Anything).
 		RunAndReturn(func(
-			_ context.Context, _ kmprovider.KeyRef, _ cryptolib.SignAlgorithm, content []byte,
+			_ context.Context, _ kmprovider.KeyRef, _ string, content []byte,
 		) ([]byte, error) {
 			digest := sha256.Sum256(content)
 			return ecdsa.SignASN1(rand.Reader, key, digest[:])
 		})
-	signer := &issuerSigner{cryptoProvider: provider, signAlg: cryptolib.ECDSASHA256}
+	signer := &issuerSigner{cryptoProvider: provider, signAlg: cryptolib.ECDSASHA256, jwsAlg: "ES256"}
 
 	sig, err := signer.sign(context.Background(), "input")
 	s.Require().NoError(err)

--- a/backend/internal/openid4vp/signer.go
+++ b/backend/internal/openid4vp/signer.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/jose/jws"
 	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 )
@@ -38,7 +37,6 @@ const requestObjectType = "oauth-authz-req+jwt"
 type cryptoProviderSigner struct {
 	cryptoProvider kmprovider.RuntimeCryptoProvider
 	keyRef         kmprovider.KeyRef
-	signAlg        cryptolib.SignAlgorithm
 	jwsAlg         string
 	x5c            []string
 }
@@ -59,8 +57,7 @@ func newRequestSigner(
 	}
 	key := keys[0]
 
-	signAlg, err := jws.MapAlgorithmToSignAlg(jws.Algorithm(key.Algorithm))
-	if err != nil {
+	if _, err := jws.MapAlgorithmToSignAlg(jws.Algorithm(key.Algorithm)); err != nil {
 		return nil, fmt.Errorf("%w: unsupported signing algorithm for key %q", ErrPolicy, keyID)
 	}
 	if len(key.CertificateDER) == 0 {
@@ -78,7 +75,6 @@ func newRequestSigner(
 	return &cryptoProviderSigner{
 		cryptoProvider: cryptoProvider,
 		keyRef:         kmprovider.KeyRef{KeyID: keyID},
-		signAlg:        signAlg,
 		jwsAlg:         string(key.Algorithm),
 		x5c:            x5c,
 	}, nil
@@ -106,28 +102,28 @@ func (s *cryptoProviderSigner) signRequestObject(ctx context.Context, claims map
 
 	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
 		base64.RawURLEncoding.EncodeToString(payloadJSON)
-	derSig, err := s.cryptoProvider.Sign(ctx, s.keyRef, s.signAlg, []byte(signingInput))
+	derSig, err := s.cryptoProvider.Sign(ctx, s.keyRef, s.jwsAlg, []byte(signingInput))
 	if err != nil {
 		return "", fmt.Errorf("failed to sign request object: %w", err)
 	}
-	jwsSig := ecdsaDERToJWS(derSig, s.signAlg)
+	jwsSig := ecdsaDERToJWS(derSig, s.jwsAlg)
 	return signingInput + "." + base64.RawURLEncoding.EncodeToString(jwsSig), nil
 }
 
 // ecdsaDERToJWS converts a DER-encoded ASN.1 ECDSA signature to the raw r||s
 // fixed-size format required by JWS (RFC 7518 §3.4).
-func ecdsaDERToJWS(derSig []byte, alg cryptolib.SignAlgorithm) []byte {
+func ecdsaDERToJWS(derSig []byte, alg string) []byte {
 	var sig struct{ R, S *big.Int }
 	if _, err := asn1.Unmarshal(derSig, &sig); err != nil {
 		return derSig // not DER (e.g. Ed25519): return as-is
 	}
 	var coordLen int
-	switch alg {
-	case cryptolib.ECDSASHA256:
+	switch jws.Algorithm(alg) {
+	case jws.ES256:
 		coordLen = 32
-	case cryptolib.ECDSASHA384:
+	case jws.ES384:
 		coordLen = 48
-	case cryptolib.ECDSASHA512:
+	case jws.ES512:
 		coordLen = 66
 	default:
 		return derSig

--- a/backend/internal/openid4vp/signer_test.go
+++ b/backend/internal/openid4vp/signer_test.go
@@ -54,7 +54,7 @@ func newSignerMock(
 	m.EXPECT().GetPublicKeys(mock.Anything, mock.Anything).Return([]kmprovider.PublicKeyInfo{info}, nil).Maybe()
 	m.EXPECT().Sign(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		RunAndReturn(func(
-			_ context.Context, _ kmprovider.KeyRef, _ cryptolib.SignAlgorithm, content []byte,
+			_ context.Context, _ kmprovider.KeyRef, _ string, content []byte,
 		) ([]byte, error) {
 			return cryptolib.Generate(content, cryptolib.ECDSASHA256, key)
 		}).Maybe()
@@ -107,6 +107,33 @@ func (suite *OpenID4VPSignerTestSuite) TestRequestSignerSignsVerifiableJAR() {
 	r := new(big.Int).SetBytes(sig[:32])
 	s := new(big.Int).SetBytes(sig[32:])
 	suite.True(ecdsa.Verify(&key.PublicKey, hashed[:], r, s))
+}
+
+func (suite *OpenID4VPSignerTestSuite) TestEcdsaDERToJWS() {
+	digest := sha256.Sum256([]byte("signing input"))
+
+	tests := []struct {
+		name    string
+		curve   elliptic.Curve
+		alg     string
+		wantLen int
+	}{
+		{"ES256", elliptic.P256(), "ES256", 64},
+		{"ES384", elliptic.P384(), "ES384", 96},
+		{"ES512", elliptic.P521(), "ES512", 132},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			key, err := ecdsa.GenerateKey(tt.curve, rand.Reader)
+			suite.Require().NoError(err)
+			der, err := ecdsa.SignASN1(rand.Reader, key, digest[:])
+			suite.Require().NoError(err)
+
+			raw := ecdsaDERToJWS(der, tt.alg)
+			suite.Len(raw, tt.wantLen)
+		})
+	}
 }
 
 func (suite *OpenID4VPSignerTestSuite) TestNewRequestSignerErrors() {

--- a/backend/internal/system/cryptolib/sign.go
+++ b/backend/internal/system/cryptolib/sign.go
@@ -39,6 +39,29 @@ var (
 	ErrInvalidSignature     = errors.New("signature verification failed")
 )
 
+// SignAlgorithmFor maps a JWA algorithm identifier to its corresponding SignAlgorithm.
+// Returns ErrUnsupportedAlgorithm for unknown or non-signature algorithms.
+func SignAlgorithmFor(alg Algorithm) (SignAlgorithm, error) {
+	switch alg {
+	case AlgorithmRS256:
+		return RSASHA256, nil
+	case AlgorithmRS512:
+		return RSASHA512, nil
+	case AlgorithmPS256:
+		return RSAPSSSHA256, nil
+	case AlgorithmES256:
+		return ECDSASHA256, nil
+	case AlgorithmES384:
+		return ECDSASHA384, nil
+	case AlgorithmES512:
+		return ECDSASHA512, nil
+	case AlgorithmEdDSA:
+		return ED25519, nil
+	default:
+		return "", ErrUnsupportedAlgorithm
+	}
+}
+
 // Generate hashes data according to alg and returns the digital signature using privateKey.
 func Generate(data []byte, alg SignAlgorithm, privateKey crypto.PrivateKey) ([]byte, error) {
 	hashed, hashFunc := hashData(data, alg)

--- a/backend/internal/system/jose/jws/utils.go
+++ b/backend/internal/system/jose/jws/utils.go
@@ -62,24 +62,11 @@ func DecodeHeader(token string) (map[string]interface{}, error) {
 
 // MapAlgorithmToSignAlg maps JWS alg header values to internal SignAlgorithm.
 func MapAlgorithmToSignAlg(jwsAlg Algorithm) (cryptolib.SignAlgorithm, error) {
-	switch jwsAlg {
-	case RS256:
-		return cryptolib.RSASHA256, nil
-	case RS512:
-		return cryptolib.RSASHA512, nil
-	case PS256:
-		return cryptolib.RSAPSSSHA256, nil
-	case ES256:
-		return cryptolib.ECDSASHA256, nil
-	case ES384:
-		return cryptolib.ECDSASHA384, nil
-	case ES512:
-		return cryptolib.ECDSASHA512, nil
-	case EdDSA:
-		return cryptolib.ED25519, nil
-	default:
+	signAlg, err := cryptolib.SignAlgorithmFor(cryptolib.Algorithm(jwsAlg))
+	if err != nil {
 		return "", fmt.Errorf("unsupported JWS alg: %s", jwsAlg)
 	}
+	return signAlg, nil
 }
 
 // JWKToPublicKey converts a JWK map to a crypto.PublicKey supporting RSA, EC, and Ed25519.

--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -65,7 +65,6 @@ type jwksCacheEntry struct {
 type jwtService struct {
 	cryptoProvider kmprovider.RuntimeCryptoProvider
 	keyRef         kmprovider.KeyRef
-	signAlg        cryptolib.SignAlgorithm
 	jwsAlg         jws.Algorithm
 	kid            string
 	logger         *log.Logger
@@ -90,15 +89,13 @@ func newJWTService(
 	}
 	key := keys[0]
 
-	signAlg, err := jws.MapAlgorithmToSignAlg(jws.Algorithm(key.Algorithm))
-	if err != nil {
+	if _, err := jws.MapAlgorithmToSignAlg(jws.Algorithm(key.Algorithm)); err != nil {
 		return nil, errors.New("unsupported algorithm for key id: " + preferredKid)
 	}
 
 	return &jwtService{
 		cryptoProvider: cryptoProvider,
 		keyRef:         keyRef,
-		signAlg:        signAlg,
 		jwsAlg:         jws.Algorithm(key.Algorithm),
 		kid:            key.Thumbprint,
 		logger:         logger,
@@ -118,8 +115,7 @@ func (js *jwtService) GenerateJWT(
 ) (string, int64, *serviceerror.ServiceError) {
 	jwsAlg := js.jwsAlg
 	if alg != "" {
-		mapped, err := jws.MapAlgorithmToSignAlg(jws.Algorithm(alg))
-		if err != nil || mapped != js.signAlg {
+		if alg != string(js.jwsAlg) {
 			return "", 0, &ErrorUnsupportedJWSAlgorithm
 		}
 		jwsAlg = jws.Algorithm(alg)
@@ -208,7 +204,7 @@ func (js *jwtService) GenerateJWT(
 
 	// Create the signing input and sign it with the crypto provider.
 	signingInput := headerBase64 + "." + payloadBase64
-	signature, err := js.cryptoProvider.Sign(ctx, js.keyRef, js.signAlg, []byte(signingInput))
+	signature, err := js.cryptoProvider.Sign(ctx, js.keyRef, string(jwsAlg), []byte(signingInput))
 	if err != nil {
 		js.logger.Error(ctx, "Failed to sign JWT: "+err.Error())
 		return "", 0, &serviceerror.InternalServerError
@@ -295,15 +291,14 @@ func (js *jwtService) VerifyJWTSignature(ctx context.Context, jwtToken string) *
 	}
 	kid, _ := header["kid"].(string)
 	algStr, _ := header["alg"].(string)
-	signAlg, err := jws.MapAlgorithmToSignAlg(jws.Algorithm(algStr))
-	if err != nil {
-		return &ErrorUnsupportedJWSAlgorithm
-	}
 
-	// Verify the signature through the provider (resolves kid to key internally).
-	if err = js.cryptoProvider.Verify(ctx, kid, signAlg, []byte(signingInput), signature); err != nil {
+	// Verify the signature through the provider (resolves kid to key and validates alg internally).
+	if err = js.cryptoProvider.Verify(ctx, kid, algStr, []byte(signingInput), signature); err != nil {
 		if errors.Is(err, kmprovider.ErrKeyNotFound) {
 			return &ErrorNoMatchingJWKFound
+		}
+		if errors.Is(err, kmprovider.ErrUnsupportedAlgorithm) {
+			return &ErrorUnsupportedJWSAlgorithm
 		}
 		return &ErrorInvalidTokenSignature
 	}

--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -300,25 +300,11 @@ func (js *jwtService) VerifyJWTSignature(ctx context.Context, jwtToken string) *
 		return &ErrorUnsupportedJWSAlgorithm
 	}
 
-	// Retrieve all public keys from the provider and match by thumbprint
-	keys, providerErr := js.cryptoProvider.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
-	if providerErr != nil {
-		js.logger.Error(ctx, "Failed to retrieve public keys for JWT verification: "+providerErr.Error())
-		return &serviceerror.InternalServerError
-	}
-	var matchedKey *kmprovider.PublicKeyInfo
-	for i := range keys {
-		if keys[i].Thumbprint == kid {
-			matchedKey = &keys[i]
-			break
+	// Verify the signature through the provider (resolves kid to key internally).
+	if err = js.cryptoProvider.Verify(ctx, kid, signAlg, []byte(signingInput), signature); err != nil {
+		if errors.Is(err, kmprovider.ErrKeyNotFound) {
+			return &ErrorNoMatchingJWKFound
 		}
-	}
-	if matchedKey == nil {
-		return &ErrorNoMatchingJWKFound
-	}
-
-	// Verify the signature using the matched public key
-	if err = cryptolib.Verify([]byte(signingInput), signature, signAlg, matchedKey.PublicKey); err != nil {
 		return &ErrorInvalidTokenSignature
 	}
 	return nil

--- a/backend/internal/system/jose/jwt/service_test.go
+++ b/backend/internal/system/jose/jwt/service_test.go
@@ -149,6 +149,16 @@ func (suite *JWTServiceTestSuite) SetupTest() {
 				Thumbprint: "test-kid",
 			},
 		}, nil).Maybe()
+	cryptoMock.EXPECT().
+		Verify(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(
+			_ context.Context, kid string, alg cryptolib.SignAlgorithm, content []byte, sig []byte,
+		) error {
+			if kid == "test-kid" {
+				return cryptolib.Verify(content, sig, alg, &suite.testPrivateKey.PublicKey)
+			}
+			return fmt.Errorf("%w: kid=%s", kmprovider.ErrKeyNotFound, kid)
+		}).Maybe()
 
 	suite.jwtService = &jwtService{
 		cryptoProvider: cryptoMock,
@@ -1418,8 +1428,8 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 			setupSvc: func() *jwtService {
 				cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
 				cryptoMock.EXPECT().
-					GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
-					Return([]kmprovider.PublicKeyInfo{}, nil)
+					Verify(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(fmt.Errorf("%w: kid=unknown", kmprovider.ErrKeyNotFound))
 				return &jwtService{
 					cryptoProvider: cryptoMock,
 					signAlg:        cryptolib.RSASHA256,
@@ -2002,13 +2012,12 @@ func (suite *JWTServiceTestSuite) TestInitWithECDSAKeys() {
 					return cryptolib.Generate(content, sa, ecKey)
 				}).Maybe()
 			cryptoMock.EXPECT().
-				GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
-				Return([]kmprovider.PublicKeyInfo{{
-					KeyID:      "test-kid",
-					Algorithm:  alg,
-					PublicKey:  &ecKey.PublicKey,
-					Thumbprint: "test-kid",
-				}}, nil).Maybe()
+				Verify(mock.Anything, "test-kid", tc.expectedSignAlg, mock.Anything, mock.Anything).
+				RunAndReturn(func(
+					_ context.Context, _ string, sa cryptolib.SignAlgorithm, content []byte, sig []byte,
+				) error {
+					return cryptolib.Verify(content, sig, sa, &ecKey.PublicKey)
+				}).Maybe()
 
 			service, err := Initialize(cryptoMock)
 
@@ -2056,13 +2065,12 @@ func (suite *JWTServiceTestSuite) TestInitWithEd25519Key() {
 			return cryptolib.Generate(content, sa, priv)
 		}).Maybe()
 	cryptoMock.EXPECT().
-		GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{}).
-		Return([]kmprovider.PublicKeyInfo{{
-			KeyID:      "test-kid",
-			Algorithm:  cryptolib.AlgorithmEdDSA,
-			PublicKey:  priv.Public(),
-			Thumbprint: "test-kid",
-		}}, nil).Maybe()
+		Verify(mock.Anything, "test-kid", cryptolib.ED25519, mock.Anything, mock.Anything).
+		RunAndReturn(func(
+			_ context.Context, _ string, sa cryptolib.SignAlgorithm, content []byte, sig []byte,
+		) error {
+			return cryptolib.Verify(content, sig, sa, priv.Public())
+		}).Maybe()
 
 	service, err := Initialize(cryptoMock)
 	assert.NoError(suite.T(), err)

--- a/backend/internal/system/jose/jwt/service_test.go
+++ b/backend/internal/system/jose/jwt/service_test.go
@@ -133,9 +133,9 @@ func (suite *JWTServiceTestSuite) SetupTest() {
 
 	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
 	cryptoMock.EXPECT().
-		Sign(mock.Anything, kmprovider.KeyRef{KeyID: "test-kid"}, cryptolib.RSASHA256, mock.Anything).
+		Sign(mock.Anything, kmprovider.KeyRef{KeyID: "test-kid"}, string(jws.RS256), mock.Anything).
 		RunAndReturn(func(
-			_ context.Context, _ kmprovider.KeyRef, _ cryptolib.SignAlgorithm, content []byte,
+			_ context.Context, _ kmprovider.KeyRef, _ string, content []byte,
 		) ([]byte, error) {
 			return cryptolib.Generate(content, cryptolib.RSASHA256, suite.testPrivateKey)
 		}).Maybe()
@@ -152,18 +152,21 @@ func (suite *JWTServiceTestSuite) SetupTest() {
 	cryptoMock.EXPECT().
 		Verify(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		RunAndReturn(func(
-			_ context.Context, kid string, alg cryptolib.SignAlgorithm, content []byte, sig []byte,
+			_ context.Context, kid string, alg string, content []byte, sig []byte,
 		) error {
-			if kid == "test-kid" {
-				return cryptolib.Verify(content, sig, alg, &suite.testPrivateKey.PublicKey)
+			if kid != "test-kid" {
+				return fmt.Errorf("%w: kid=%s", kmprovider.ErrKeyNotFound, kid)
 			}
-			return fmt.Errorf("%w: kid=%s", kmprovider.ErrKeyNotFound, kid)
+			signAlg, err := cryptolib.SignAlgorithmFor(cryptolib.Algorithm(alg))
+			if err != nil {
+				return fmt.Errorf("%w: %q", kmprovider.ErrUnsupportedAlgorithm, alg)
+			}
+			return cryptolib.Verify(content, sig, signAlg, &suite.testPrivateKey.PublicKey)
 		}).Maybe()
 
 	suite.jwtService = &jwtService{
 		cryptoProvider: cryptoMock,
 		keyRef:         kmprovider.KeyRef{KeyID: "test-kid"},
-		signAlg:        cryptolib.RSASHA256,
 		jwsAlg:         jws.RS256,
 		kid:            "test-kid",
 		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
@@ -1432,7 +1435,6 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignature() {
 					Return(fmt.Errorf("%w: kid=unknown", kmprovider.ErrKeyNotFound))
 				return &jwtService{
 					cryptoProvider: cryptoMock,
-					signAlg:        cryptolib.RSASHA256,
 					jwsAlg:         jws.RS256,
 					kid:            "test-kid",
 					logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
@@ -1509,6 +1511,50 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKey() {
 			}
 		})
 	}
+}
+
+func (suite *JWTServiceTestSuite) TestGenerateJWTUnsupportedAlgOverride() {
+	for _, alg := range []string{"ES256", "invalid"} {
+		suite.T().Run(alg, func(t *testing.T) {
+			_, _, err := suite.jwtService.GenerateJWT(context.Background(),
+				"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, alg)
+			require.NotNil(t, err)
+			assert.Equal(t, ErrorUnsupportedJWSAlgorithm.Code, err.Code)
+		})
+	}
+}
+
+func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureUnsupportedAlgFromProvider() {
+	token, _, genErr := suite.jwtService.GenerateJWT(context.Background(),
+		"test-subject", testIssuer, 3600, map[string]interface{}{"aud": testAudience}, TokenTypeJWT, "")
+	assert.Nil(suite.T(), genErr)
+
+	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
+	cryptoMock.EXPECT().
+		Verify(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(fmt.Errorf("%w: %q", kmprovider.ErrUnsupportedAlgorithm, "none"))
+	jwtSvc := &jwtService{
+		cryptoProvider: cryptoMock,
+		jwsAlg:         jws.RS256,
+		kid:            "test-kid",
+		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
+	}
+
+	err := jwtSvc.VerifyJWTSignature(context.Background(), token)
+	require.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), ErrorUnsupportedJWSAlgorithm.Code, err.Code)
+}
+
+func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKeyUnsupportedAlg() {
+	token := suite.createJWTWithCustomHeader(map[string]interface{}{
+		"alg": "none",
+		"typ": "JWT",
+		"kid": "test-kid",
+	})
+
+	err := suite.jwtService.VerifyJWTSignatureWithPublicKey(token, &suite.testPrivateKey.PublicKey)
+	require.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), ErrorUnsupportedJWSAlgorithm.Code, err.Code)
 }
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKS() {
@@ -2005,18 +2051,18 @@ func (suite *JWTServiceTestSuite) TestInitWithECDSAKeys() {
 					Thumbprint: "test-kid",
 				}}, nil)
 			cryptoMock.EXPECT().
-				Sign(mock.Anything, kmprovider.KeyRef{KeyID: "test-kid"}, tc.expectedSignAlg, mock.Anything).
+				Sign(mock.Anything, kmprovider.KeyRef{KeyID: "test-kid"}, string(tc.expectedAlg), mock.Anything).
 				RunAndReturn(func(
-					_ context.Context, _ kmprovider.KeyRef, sa cryptolib.SignAlgorithm, content []byte,
+					_ context.Context, _ kmprovider.KeyRef, _ string, content []byte,
 				) ([]byte, error) {
-					return cryptolib.Generate(content, sa, ecKey)
+					return cryptolib.Generate(content, tc.expectedSignAlg, ecKey)
 				}).Maybe()
 			cryptoMock.EXPECT().
-				Verify(mock.Anything, "test-kid", tc.expectedSignAlg, mock.Anything, mock.Anything).
+				Verify(mock.Anything, "test-kid", string(tc.expectedAlg), mock.Anything, mock.Anything).
 				RunAndReturn(func(
-					_ context.Context, _ string, sa cryptolib.SignAlgorithm, content []byte, sig []byte,
+					_ context.Context, _ string, _ string, content []byte, sig []byte,
 				) error {
-					return cryptolib.Verify(content, sig, sa, &ecKey.PublicKey)
+					return cryptolib.Verify(content, sig, tc.expectedSignAlg, &ecKey.PublicKey)
 				}).Maybe()
 
 			service, err := Initialize(cryptoMock)
@@ -2026,7 +2072,6 @@ func (suite *JWTServiceTestSuite) TestInitWithECDSAKeys() {
 
 			jwtSvc, ok := service.(*jwtService)
 			assert.True(t, ok)
-			assert.Equal(t, tc.expectedSignAlg, jwtSvc.signAlg)
 			assert.Equal(t, tc.expectedAlg, jwtSvc.jwsAlg)
 
 			token, _, svcErr := service.GenerateJWT(context.Background(),
@@ -2058,18 +2103,18 @@ func (suite *JWTServiceTestSuite) TestInitWithEd25519Key() {
 			Thumbprint: "test-kid",
 		}}, nil)
 	cryptoMock.EXPECT().
-		Sign(mock.Anything, kmprovider.KeyRef{KeyID: "test-kid"}, cryptolib.ED25519, mock.Anything).
+		Sign(mock.Anything, kmprovider.KeyRef{KeyID: "test-kid"}, string(jws.EdDSA), mock.Anything).
 		RunAndReturn(func(
-			_ context.Context, _ kmprovider.KeyRef, sa cryptolib.SignAlgorithm, content []byte,
+			_ context.Context, _ kmprovider.KeyRef, _ string, content []byte,
 		) ([]byte, error) {
-			return cryptolib.Generate(content, sa, priv)
+			return cryptolib.Generate(content, cryptolib.ED25519, priv)
 		}).Maybe()
 	cryptoMock.EXPECT().
-		Verify(mock.Anything, "test-kid", cryptolib.ED25519, mock.Anything, mock.Anything).
+		Verify(mock.Anything, "test-kid", string(jws.EdDSA), mock.Anything, mock.Anything).
 		RunAndReturn(func(
-			_ context.Context, _ string, sa cryptolib.SignAlgorithm, content []byte, sig []byte,
+			_ context.Context, _ string, _ string, content []byte, sig []byte,
 		) error {
-			return cryptolib.Verify(content, sig, sa, priv.Public())
+			return cryptolib.Verify(content, sig, cryptolib.ED25519, priv.Public())
 		}).Maybe()
 
 	service, err := Initialize(cryptoMock)
@@ -2078,7 +2123,6 @@ func (suite *JWTServiceTestSuite) TestInitWithEd25519Key() {
 
 	jwtSvc, ok := service.(*jwtService)
 	assert.True(suite.T(), ok)
-	assert.Equal(suite.T(), cryptolib.ED25519, jwtSvc.signAlg)
 	assert.Equal(suite.T(), jws.EdDSA, jwtSvc.jwsAlg)
 
 	token, _, svcErr := service.GenerateJWT(context.Background(),
@@ -2114,7 +2158,6 @@ func (suite *JWTServiceTestSuite) TestInitWithECPrivateKeyFormat() {
 
 	jwtSvc, ok := service.(*jwtService)
 	assert.True(suite.T(), ok)
-	assert.Equal(suite.T(), cryptolib.ECDSASHA256, jwtSvc.signAlg)
 	assert.Equal(suite.T(), jws.ES256, jwtSvc.jwsAlg)
 }
 
@@ -2312,16 +2355,15 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithPublicKeyAlgorithmDe
 			priv, pub, signAlg, jwsAlg := tc.setupKey()
 			cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(t)
 			keyRef := kmprovider.KeyRef{KeyID: "test-sign-key"}
-			cryptoMock.EXPECT().Sign(mock.Anything, keyRef, signAlg, mock.Anything).
+			cryptoMock.EXPECT().Sign(mock.Anything, keyRef, string(jwsAlg), mock.Anything).
 				RunAndReturn(func(
-					_ context.Context, _ kmprovider.KeyRef, _ cryptolib.SignAlgorithm, content []byte,
+					_ context.Context, _ kmprovider.KeyRef, _ string, content []byte,
 				) ([]byte, error) {
 					return cryptolib.Generate(content, signAlg, priv)
 				}).Maybe()
 			jwtService := &jwtService{
 				cryptoProvider: cryptoMock,
 				keyRef:         keyRef,
-				signAlg:        signAlg,
 				jwsAlg:         jwsAlg,
 			}
 

--- a/backend/internal/system/kmprovider/common/error_constants.go
+++ b/backend/internal/system/kmprovider/common/error_constants.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package common
+
+import "errors"
+
+// ErrKeyNotFound indicates that no key managed by the provider matches the
+// requested identifier.
+var ErrKeyNotFound = errors.New("kmprovider: no key found matching the requested identifier")

--- a/backend/internal/system/kmprovider/common/error_constants.go
+++ b/backend/internal/system/kmprovider/common/error_constants.go
@@ -23,3 +23,7 @@ import "errors"
 // ErrKeyNotFound indicates that no key managed by the provider matches the
 // requested identifier.
 var ErrKeyNotFound = errors.New("kmprovider: no key found matching the requested identifier")
+
+// ErrUnsupportedAlgorithm indicates the requested signature algorithm is not
+// supported by the provider or is incompatible with the resolved key.
+var ErrUnsupportedAlgorithm = errors.New("kmprovider: unsupported signature algorithm")

--- a/backend/internal/system/kmprovider/common/interface.go
+++ b/backend/internal/system/kmprovider/common/interface.go
@@ -41,8 +41,8 @@ type RuntimeCryptoProvider interface {
 		ctx context.Context, keyRef *KeyRef, params cryptolib.AlgorithmParams, content []byte,
 	) ([]byte, *cryptolib.CryptoDetails, error)
 	Decrypt(ctx context.Context, keyRef *KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, error)
-	Sign(ctx context.Context, keyRef KeyRef, algorithm cryptolib.SignAlgorithm, content []byte) ([]byte, error)
-	Verify(ctx context.Context, kid string, algorithm cryptolib.SignAlgorithm, content, signature []byte) error
+	Sign(ctx context.Context, keyRef KeyRef, alg string, content []byte) ([]byte, error)
+	Verify(ctx context.Context, kid string, alg string, content, signature []byte) error
 	GetPublicKeys(ctx context.Context, filter PublicKeyFilter) ([]PublicKeyInfo, error)
 	GetTLSMaterial(ctx context.Context) (*TLSMaterial, error)
 }

--- a/backend/internal/system/kmprovider/common/interface.go
+++ b/backend/internal/system/kmprovider/common/interface.go
@@ -35,13 +35,14 @@ type ConfigCryptoProvider interface {
 }
 
 // RuntimeCryptoProvider provides asymmetric cryptographic operations including
-// encryption, decryption, signing, and key discovery.
+// encryption, decryption, signing, verification, and key discovery.
 type RuntimeCryptoProvider interface {
 	Encrypt(
 		ctx context.Context, keyRef *KeyRef, params cryptolib.AlgorithmParams, content []byte,
 	) ([]byte, *cryptolib.CryptoDetails, error)
 	Decrypt(ctx context.Context, keyRef *KeyRef, params cryptolib.AlgorithmParams, content []byte) ([]byte, error)
 	Sign(ctx context.Context, keyRef KeyRef, algorithm cryptolib.SignAlgorithm, content []byte) ([]byte, error)
+	Verify(ctx context.Context, kid string, algorithm cryptolib.SignAlgorithm, content, signature []byte) error
 	GetPublicKeys(ctx context.Context, filter PublicKeyFilter) ([]PublicKeyInfo, error)
 	GetTLSMaterial(ctx context.Context) (*TLSMaterial, error)
 }

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
@@ -119,17 +119,21 @@ func (s *runtimeCryptoService) Decrypt(
 }
 
 func (s *runtimeCryptoService) Sign(
-	ctx context.Context, keyRef kmprovider.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte,
+	ctx context.Context, keyRef kmprovider.KeyRef, alg string, content []byte,
 ) ([]byte, error) {
 	if s.pkiService == nil {
 		return nil, errors.New("PKI service not initialized")
+	}
+	signAlg, err := cryptolib.SignAlgorithmFor(cryptolib.Algorithm(alg))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %q", kmprovider.ErrUnsupportedAlgorithm, alg)
 	}
 	privKey, svcErr := s.pkiService.GetPrivateKey(ctx, keyRef.KeyID)
 	if svcErr != nil {
 		return nil, fmt.Errorf("key not found for id %s: [%s] %s",
 			keyRef.KeyID, svcErr.Code, svcErr.Error.DefaultValue)
 	}
-	return cryptolib.Generate(content, algorithm, privKey)
+	return cryptolib.Generate(content, signAlg, privKey)
 }
 
 func (s *runtimeCryptoService) GetPublicKeys(
@@ -193,10 +197,14 @@ func (s *runtimeCryptoService) GetPublicKeys(
 }
 
 func (s *runtimeCryptoService) Verify(
-	ctx context.Context, kid string, algorithm cryptolib.SignAlgorithm, content []byte, signature []byte,
+	ctx context.Context, kid string, alg string, content []byte, signature []byte,
 ) error {
 	if s.pkiService == nil {
 		return errors.New("PKI service not initialized")
+	}
+	signAlg, err := cryptolib.SignAlgorithmFor(cryptolib.Algorithm(alg))
+	if err != nil {
+		return fmt.Errorf("%w: %q", kmprovider.ErrUnsupportedAlgorithm, alg)
 	}
 	keys, err := s.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
 	if err != nil {
@@ -204,7 +212,7 @@ func (s *runtimeCryptoService) Verify(
 	}
 	for _, key := range keys {
 		if key.Thumbprint == kid {
-			return cryptolib.Verify(content, signature, algorithm, key.PublicKey)
+			return cryptolib.Verify(content, signature, signAlg, key.PublicKey)
 		}
 	}
 	return fmt.Errorf("%w: kid=%s", kmprovider.ErrKeyNotFound, kid)

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
@@ -192,6 +192,24 @@ func (s *runtimeCryptoService) GetPublicKeys(
 	return keys, nil
 }
 
+func (s *runtimeCryptoService) Verify(
+	ctx context.Context, kid string, algorithm cryptolib.SignAlgorithm, content []byte, signature []byte,
+) error {
+	if s.pkiService == nil {
+		return errors.New("PKI service not initialized")
+	}
+	keys, err := s.GetPublicKeys(ctx, kmprovider.PublicKeyFilter{})
+	if err != nil {
+		return fmt.Errorf("failed to retrieve public keys: %w", err)
+	}
+	for _, key := range keys {
+		if key.Thumbprint == kid {
+			return cryptolib.Verify(content, signature, algorithm, key.PublicKey)
+		}
+	}
+	return fmt.Errorf("%w: kid=%s", kmprovider.ErrKeyNotFound, kid)
+}
+
 func (s *runtimeCryptoService) GetTLSMaterial(
 	ctx context.Context,
 ) (*kmprovider.TLSMaterial, error) {

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider_test.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider_test.go
@@ -648,6 +648,105 @@ func TestGetPublicKeys_FilterByAlgorithm(t *testing.T) {
 	assert.Equal(t, "ec-key", keys[0].KeyID)
 }
 
+// Sign
+
+func TestSign_NilPKIService(t *testing.T) {
+	svc := &runtimeCryptoService{pkiService: nil}
+	_, err := svc.Sign(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, "ES256", []byte("data"))
+	assert.EqualError(t, err, "PKI service not initialized")
+}
+
+func TestSign_UnsupportedAlgorithm(t *testing.T) {
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	_, err := svc.Sign(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, "none", []byte("data"))
+	assert.ErrorIs(t, err, kmprovider.ErrUnsupportedAlgorithm)
+}
+
+func TestSign_KeyNotFound(t *testing.T) {
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetPrivateKey(mock.Anything, testKeyID).Return(nil, newTestSvcErr())
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	_, err := svc.Sign(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, "ES256", []byte("data"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), testKeyID)
+}
+
+func TestSign_Success(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetPrivateKey(mock.Anything, testKeyID).Return(ecKey, nil)
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	sig, err := svc.Sign(context.Background(), kmprovider.KeyRef{KeyID: testKeyID}, "ES256", []byte("data"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, sig)
+}
+
+// Verify
+
+func TestVerify_NilPKIService(t *testing.T) {
+	svc := &runtimeCryptoService{pkiService: nil}
+	err := svc.Verify(context.Background(), "kid-1", "ES256", []byte("data"), []byte("sig"))
+	assert.EqualError(t, err, "PKI service not initialized")
+}
+
+func TestVerify_UnsupportedAlgorithm(t *testing.T) {
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	err := svc.Verify(context.Background(), "kid-1", "none", []byte("data"), []byte("sig"))
+	assert.ErrorIs(t, err, kmprovider.ErrUnsupportedAlgorithm)
+}
+
+func TestVerify_GetPublicKeysError(t *testing.T) {
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetAllX509Certificates(mock.Anything).Return(nil, &serviceerror.InternalServerError)
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	err := svc.Verify(context.Background(), "kid-1", "ES256", []byte("data"), []byte("sig"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve public keys")
+}
+
+func TestVerify_Success(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	content := []byte("signing input")
+	sig, err := cryptolib.Generate(content, cryptolib.ECDSASHA256, ecKey)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetAllX509Certificates(mock.Anything).Return(
+		map[string]*x509.Certificate{"key1": {Raw: []byte("der"), PublicKey: &ecKey.PublicKey}}, nil,
+	)
+	pki.EXPECT().GetCertThumbprint("key1").Return("kid-1")
+	pki.EXPECT().GetCertificateChain("key1").Return(nil)
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	err = svc.Verify(context.Background(), "kid-1", "ES256", content, sig)
+	assert.NoError(t, err)
+}
+
+func TestVerify_KeyNotFound(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	pki := pkimock.NewPKIServiceInterfaceMock(t)
+	pki.EXPECT().GetAllX509Certificates(mock.Anything).Return(
+		map[string]*x509.Certificate{"key1": {Raw: []byte("der"), PublicKey: &ecKey.PublicKey}}, nil,
+	)
+	pki.EXPECT().GetCertThumbprint("key1").Return("kid-1")
+	pki.EXPECT().GetCertificateChain("key1").Return(nil)
+
+	svc := &runtimeCryptoService{pkiService: pki, logger: newTestLogger()}
+	err = svc.Verify(context.Background(), "other-kid", "ES256", []byte("data"), []byte("sig"))
+	assert.ErrorIs(t, err, kmprovider.ErrKeyNotFound)
+}
+
 // GetTLSMaterial
 
 func TestGetTLSMaterial_NilPKIService(t *testing.T) {

--- a/backend/tests/mocks/crypto/cryptomock/RuntimeCryptoProvider_mock.go
+++ b/backend/tests/mocks/crypto/cryptomock/RuntimeCryptoProvider_mock.go
@@ -416,3 +416,78 @@ func (_c *RuntimeCryptoProviderMock_Sign_Call) RunAndReturn(run func(ctx context
 	_c.Call.Return(run)
 	return _c
 }
+
+// Verify provides a mock function for the type RuntimeCryptoProviderMock
+func (_mock *RuntimeCryptoProviderMock) Verify(ctx context.Context, kid string, algorithm cryptolib.SignAlgorithm, content []byte, signature []byte) error {
+	ret := _mock.Called(ctx, kid, algorithm, content, signature)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Verify")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, cryptolib.SignAlgorithm, []byte, []byte) error); ok {
+		r0 = returnFunc(ctx, kid, algorithm, content, signature)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// RuntimeCryptoProviderMock_Verify_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Verify'
+type RuntimeCryptoProviderMock_Verify_Call struct {
+	*mock.Call
+}
+
+// Verify is a helper method to define mock.On call
+//   - ctx context.Context
+//   - kid string
+//   - algorithm cryptolib.SignAlgorithm
+//   - content []byte
+//   - signature []byte
+func (_e *RuntimeCryptoProviderMock_Expecter) Verify(ctx interface{}, kid interface{}, algorithm interface{}, content interface{}, signature interface{}) *RuntimeCryptoProviderMock_Verify_Call {
+	return &RuntimeCryptoProviderMock_Verify_Call{Call: _e.mock.On("Verify", ctx, kid, algorithm, content, signature)}
+}
+
+func (_c *RuntimeCryptoProviderMock_Verify_Call) Run(run func(ctx context.Context, kid string, algorithm cryptolib.SignAlgorithm, content []byte, signature []byte)) *RuntimeCryptoProviderMock_Verify_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 cryptolib.SignAlgorithm
+		if args[2] != nil {
+			arg2 = args[2].(cryptolib.SignAlgorithm)
+		}
+		var arg3 []byte
+		if args[3] != nil {
+			arg3 = args[3].([]byte)
+		}
+		var arg4 []byte
+		if args[4] != nil {
+			arg4 = args[4].([]byte)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *RuntimeCryptoProviderMock_Verify_Call) Return(err error) *RuntimeCryptoProviderMock_Verify_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *RuntimeCryptoProviderMock_Verify_Call) RunAndReturn(run func(ctx context.Context, kid string, algorithm cryptolib.SignAlgorithm, content []byte, signature []byte) error) *RuntimeCryptoProviderMock_Verify_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/backend/tests/mocks/crypto/cryptomock/RuntimeCryptoProvider_mock.go
+++ b/backend/tests/mocks/crypto/cryptomock/RuntimeCryptoProvider_mock.go
@@ -338,8 +338,8 @@ func (_c *RuntimeCryptoProviderMock_GetTLSMaterial_Call) RunAndReturn(run func(c
 }
 
 // Sign provides a mock function for the type RuntimeCryptoProviderMock
-func (_mock *RuntimeCryptoProviderMock) Sign(ctx context.Context, keyRef common.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte) ([]byte, error) {
-	ret := _mock.Called(ctx, keyRef, algorithm, content)
+func (_mock *RuntimeCryptoProviderMock) Sign(ctx context.Context, keyRef common.KeyRef, alg string, content []byte) ([]byte, error) {
+	ret := _mock.Called(ctx, keyRef, alg, content)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Sign")
@@ -347,18 +347,18 @@ func (_mock *RuntimeCryptoProviderMock) Sign(ctx context.Context, keyRef common.
 
 	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, common.KeyRef, cryptolib.SignAlgorithm, []byte) ([]byte, error)); ok {
-		return returnFunc(ctx, keyRef, algorithm, content)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.KeyRef, string, []byte) ([]byte, error)); ok {
+		return returnFunc(ctx, keyRef, alg, content)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, common.KeyRef, cryptolib.SignAlgorithm, []byte) []byte); ok {
-		r0 = returnFunc(ctx, keyRef, algorithm, content)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.KeyRef, string, []byte) []byte); ok {
+		r0 = returnFunc(ctx, keyRef, alg, content)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, common.KeyRef, cryptolib.SignAlgorithm, []byte) error); ok {
-		r1 = returnFunc(ctx, keyRef, algorithm, content)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.KeyRef, string, []byte) error); ok {
+		r1 = returnFunc(ctx, keyRef, alg, content)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -373,13 +373,13 @@ type RuntimeCryptoProviderMock_Sign_Call struct {
 // Sign is a helper method to define mock.On call
 //   - ctx context.Context
 //   - keyRef common.KeyRef
-//   - algorithm cryptolib.SignAlgorithm
+//   - alg string
 //   - content []byte
-func (_e *RuntimeCryptoProviderMock_Expecter) Sign(ctx interface{}, keyRef interface{}, algorithm interface{}, content interface{}) *RuntimeCryptoProviderMock_Sign_Call {
-	return &RuntimeCryptoProviderMock_Sign_Call{Call: _e.mock.On("Sign", ctx, keyRef, algorithm, content)}
+func (_e *RuntimeCryptoProviderMock_Expecter) Sign(ctx interface{}, keyRef interface{}, alg interface{}, content interface{}) *RuntimeCryptoProviderMock_Sign_Call {
+	return &RuntimeCryptoProviderMock_Sign_Call{Call: _e.mock.On("Sign", ctx, keyRef, alg, content)}
 }
 
-func (_c *RuntimeCryptoProviderMock_Sign_Call) Run(run func(ctx context.Context, keyRef common.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte)) *RuntimeCryptoProviderMock_Sign_Call {
+func (_c *RuntimeCryptoProviderMock_Sign_Call) Run(run func(ctx context.Context, keyRef common.KeyRef, alg string, content []byte)) *RuntimeCryptoProviderMock_Sign_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -389,9 +389,9 @@ func (_c *RuntimeCryptoProviderMock_Sign_Call) Run(run func(ctx context.Context,
 		if args[1] != nil {
 			arg1 = args[1].(common.KeyRef)
 		}
-		var arg2 cryptolib.SignAlgorithm
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(cryptolib.SignAlgorithm)
+			arg2 = args[2].(string)
 		}
 		var arg3 []byte
 		if args[3] != nil {
@@ -412,22 +412,22 @@ func (_c *RuntimeCryptoProviderMock_Sign_Call) Return(bytes []byte, err error) *
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_Sign_Call) RunAndReturn(run func(ctx context.Context, keyRef common.KeyRef, algorithm cryptolib.SignAlgorithm, content []byte) ([]byte, error)) *RuntimeCryptoProviderMock_Sign_Call {
+func (_c *RuntimeCryptoProviderMock_Sign_Call) RunAndReturn(run func(ctx context.Context, keyRef common.KeyRef, alg string, content []byte) ([]byte, error)) *RuntimeCryptoProviderMock_Sign_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Verify provides a mock function for the type RuntimeCryptoProviderMock
-func (_mock *RuntimeCryptoProviderMock) Verify(ctx context.Context, kid string, algorithm cryptolib.SignAlgorithm, content []byte, signature []byte) error {
-	ret := _mock.Called(ctx, kid, algorithm, content, signature)
+func (_mock *RuntimeCryptoProviderMock) Verify(ctx context.Context, kid string, alg string, content []byte, signature []byte) error {
+	ret := _mock.Called(ctx, kid, alg, content, signature)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Verify")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, cryptolib.SignAlgorithm, []byte, []byte) error); ok {
-		r0 = returnFunc(ctx, kid, algorithm, content, signature)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, []byte, []byte) error); ok {
+		r0 = returnFunc(ctx, kid, alg, content, signature)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -442,14 +442,14 @@ type RuntimeCryptoProviderMock_Verify_Call struct {
 // Verify is a helper method to define mock.On call
 //   - ctx context.Context
 //   - kid string
-//   - algorithm cryptolib.SignAlgorithm
+//   - alg string
 //   - content []byte
 //   - signature []byte
-func (_e *RuntimeCryptoProviderMock_Expecter) Verify(ctx interface{}, kid interface{}, algorithm interface{}, content interface{}, signature interface{}) *RuntimeCryptoProviderMock_Verify_Call {
-	return &RuntimeCryptoProviderMock_Verify_Call{Call: _e.mock.On("Verify", ctx, kid, algorithm, content, signature)}
+func (_e *RuntimeCryptoProviderMock_Expecter) Verify(ctx interface{}, kid interface{}, alg interface{}, content interface{}, signature interface{}) *RuntimeCryptoProviderMock_Verify_Call {
+	return &RuntimeCryptoProviderMock_Verify_Call{Call: _e.mock.On("Verify", ctx, kid, alg, content, signature)}
 }
 
-func (_c *RuntimeCryptoProviderMock_Verify_Call) Run(run func(ctx context.Context, kid string, algorithm cryptolib.SignAlgorithm, content []byte, signature []byte)) *RuntimeCryptoProviderMock_Verify_Call {
+func (_c *RuntimeCryptoProviderMock_Verify_Call) Run(run func(ctx context.Context, kid string, alg string, content []byte, signature []byte)) *RuntimeCryptoProviderMock_Verify_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -459,9 +459,9 @@ func (_c *RuntimeCryptoProviderMock_Verify_Call) Run(run func(ctx context.Contex
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 cryptolib.SignAlgorithm
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(cryptolib.SignAlgorithm)
+			arg2 = args[2].(string)
 		}
 		var arg3 []byte
 		if args[3] != nil {
@@ -487,7 +487,7 @@ func (_c *RuntimeCryptoProviderMock_Verify_Call) Return(err error) *RuntimeCrypt
 	return _c
 }
 
-func (_c *RuntimeCryptoProviderMock_Verify_Call) RunAndReturn(run func(ctx context.Context, kid string, algorithm cryptolib.SignAlgorithm, content []byte, signature []byte) error) *RuntimeCryptoProviderMock_Verify_Call {
+func (_c *RuntimeCryptoProviderMock_Verify_Call) RunAndReturn(run func(ctx context.Context, kid string, alg string, content []byte, signature []byte) error) *RuntimeCryptoProviderMock_Verify_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
---
Decouple the JWT service (and openid4vp signer) from the `cryptolib` library so that the key-manager provider owns key resolution, signature verification, and algorithm validation. Allowing an alternate provider  instead of consumers being hardwired to `defaultkm`'s in-process crypto.


**Verify JWT signing via `RuntimeCryptoProvider`**
JWT signature verification now goes through the provider (which resolves the token's `kid` to a key internally) rather than the JWT service pulling every public key and calling `cryptolib.Verify` itself with an extracted key.

**Move crypto algorithm-type validation to the provider**
the provider  boundary now speaks RFC 7518 JWA algorithm identifiers (`"RS256"`) instead of `cryptolib.SignAlgorithm`, and the provider maps + validates the algorithm internally. As a result the `cryptolib.SignAlgorithm` field is removed from the JWT service struct.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
**1. Verification via RuntimeCryptoProvider** 
- Added `Verify(ctx, kid, alg, content, signature)` to the `RuntimeCryptoProvider` interfacem implemented in `defaultkm/runtime_crypto_provider.go` (resolves `kid` to key, and then verifies). 
- Introduced a `kmprovider.ErrKeyNotFound`, `VerifyJWTSignature` maps it to `ErrorNoMatchingJWKFound`, so the JWT service no longer interprets keys itself. 
- `cryptolib.Verify` is retained only in `VerifyJWTSignatureWithPublicKey`, which verifies against a caller-supplied public key.

**2. Moving the algorithm identifier to the `deafultkm` and removing `crytolib.SignAlogrithm` from the `jwtService` stucture** 
- Added `cryptolib.SignAlgorithmFor(Algorithm) (SignAlgorithm, error)`, co-located with both types; `jws.MapAlgorithmToSignAlg` now delegates to it (single source of truth). 
- Changed `Sign`/`Verify` to take `alg string` (the JWA name) instead of `cryptolib.SignAlgorithm`. `defaultkm` maps the string internally and validates it: unsupported algorithm is wrapped `kmprovider.ErrUnsupportedAlgorithm`, and key-type incompatibility surfaces from `cryptolib` (`ErrInvalidPrivateKey` / `ErrInvalidPublicKey`). 
- Removed `signAlg cryptolib.SignAlgorithm` from the JWT service struct. The `alg` override check becomes a JWA string compare; the verify path maps `kmprovider.ErrUnsupportedAlgorithm` to `ErrorUnsupportedJWSAlgorithm`.
- Applied the same cleanup to the OpenID4VP request-object signer (dropped its `cryptolib.SignAlgorithm` field; `ecdsaDERToJWS` keys off the JWA alg).


__The internal `RuntimeCryptoProvider` Go interface signature changed (`Sign` now takes `alg string`, and `Verify` is new).__

### Related Issues
<!--  - https://github.com/thunder-id/thunderid/issues/3391 -->

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime signature verification support and streamlined JWT/request-object signature verification around the JWS `alg` header.
* **Bug Fixes**
  * Standardized signing/verification algorithm handling to use the JWS `alg` value end-to-end.
  * Improved unsupported-algorithm and missing-key error behavior across providers.
  * Corrected ECDSA DER → JWS formatting to ensure expected raw signature lengths.
* **Tests**
  * Added/updated coverage for ECDSA DER-to-JWS conversion plus runtime signing/verification, including unsupported-algorithm and key-not-found scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->