### PR TITLE
Fix DocSearch sidepanel not visible in production build

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -4370,3 +4370,12 @@ a.connect-card {
   fill: var(--ifm-color-emphasis-500);
 }
 
+
+/* Fix DocSearch sidepanel not appearing in production build.
+   The default transform is overridden by a conflicting style — !important ensures
+   the panel becomes visible when opened. */
+.DocSearch-Sidepanel-Container.floating.is-open,
+.DocSearch-Sidepanel-Container.inline.is-open {
+  opacity: 1;
+  transform: none !important;
+}


### PR DESCRIPTION
### Purpose
$subject

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the documentation search experience by keeping the DocSearch side panel fully visible when opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->