### PR TITLE
Add scheduled documentation link check

### DIFF
--- a/.github/workflows/nightly-build-validation.yml
+++ b/.github/workflows/nightly-build-validation.yml
@@ -69,6 +69,8 @@ jobs:
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: 🔗 Check External Links
         id: lychee

--- a/.github/workflows/nightly-build-validation.yml
+++ b/.github/workflows/nightly-build-validation.yml
@@ -63,6 +63,62 @@ jobs:
             echo "Docs build artifacts verified successfully."
           fi
 
+  validate-docs-external-links:
+    name: 🔗 Validate Documentation External Links
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout Code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: 🔗 Check External Links
+        id: lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --accept 200,204,206,429
+            --exclude-loopback
+            --exclude-mail
+            './README.md'
+            './docs/content/**/*.md'
+            './docs/content/**/*.mdx'
+          fail: false
+          failIfEmpty: false
+          output: lychee-report.md
+
+      - name: 📝 Report Broken External Links
+        if: steps.lychee.outputs.exit_code != '0'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.existsSync('lychee-report.md')
+              ? fs.readFileSync('lychee-report.md', 'utf8')
+              : 'Lychee reported broken links, but no report file was generated.';
+            const title = '🔗 Documentation external link check failed';
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`,
+              per_page: 1
+            });
+            const body = `## Documentation external link check failed\n\nThe scheduled link check found broken external links in the documentation.\n\n**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n**Commit:** ${context.sha}\n\n### Lychee report\n\n${report}`;
+
+            if (search.data.total_count === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: search.data.items[0].number,
+                body
+              });
+            }
+
   validate-sample-packaging-linux:
     name: 📦 Validate Linux & Windows Sample Packaging
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-build-validation.yml
+++ b/.github/workflows/nightly-build-validation.yml
@@ -95,12 +95,17 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = fs.existsSync('lychee-report.md')
+            const rawReport = fs.existsSync('lychee-report.md')
               ? fs.readFileSync('lychee-report.md', 'utf8')
               : 'Lychee reported broken links, but no report file was generated.';
+            const maxReportLength = 60000;
+            const report = rawReport.length > maxReportLength
+              ? `${rawReport.slice(0, maxReportLength)}\n\n_Report truncated. See the workflow run for the full lychee output._`
+              : rawReport;
             const title = '🔗 Documentation external link check failed';
+            const label = 'nightly-build-failure';
             const search = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`,
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:${label} in:title "${title}"`,
               per_page: 1
             });
             const body = `## Documentation external link check failed\n\nThe scheduled link check found broken external links in the documentation.\n\n**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n**Commit:** ${context.sha}\n\n### Lychee report\n\n${report}`;
@@ -110,7 +115,8 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title,
-                body
+                body,
+                labels: [label]
               });
             } else {
               await github.rest.issues.createComment({


### PR DESCRIPTION
### Purpose
Adds scheduled validation for external documentation links so stale URLs in `README.md` and `docs/content` are detected automatically.

### Approach
Adds a nightly lychee-based link check to the existing nightly validation workflow. When broken links are found, the workflow opens a tracking issue or comments on the existing open tracking issue with the latest report.

### Related Issues
- Fixes #3488

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

### Verification
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `node --check /tmp/lychee-report-script.js`
- `python3 - <<'PY' ... workflow assertions ... PY`
- `git diff --check`
