### PR TITLE
Skip single-choice Sign-In Approach step for redirect-only (SPA) applications

### DIFF
--- a/docs/content/guides/guides/applications/manage-applications.mdx
+++ b/docs/content/guides/guides/applications/manage-applications.mdx
@@ -68,7 +68,7 @@ Select the sign-in methods users will use to authenticate with this application 
 - **Embedded sign-in/sign-up components in your app** — the sign-in experience renders inside your application using <ProductName />'s UI components or APIs. No redirect occurs.
 
 :::note
-**Browser App** applications (SPAs) support only the **Redirect** approach. Because they run entirely in the browser as public clients, they cannot drive embedded (app-native) flow execution securely, so the embedded option is not offered for them. Other application types, such as **Mobile App** and **Full-stack App**, continue to support the embedded approach.
+**Browser App** applications (SPAs) support only the **Redirect** approach. Because they run entirely in the browser as public clients, they cannot drive embedded (app-native) flow execution securely. The **Sign-In Approach** selection is therefore not shown for them — the application uses redirect-based sign-in automatically — and this step is skipped entirely when there are fewer than two user types to choose from. Other application types, such as **Mobile App** and **Full-stack App**, continue to support the embedded approach.
 :::
 
 **User Access** controls which user types can register with this application. Select one or more of the allowed user types (for example, **Customer** or **Person**).

--- a/frontend/apps/console/src/features/applications/components/create-application/ConfigureExperience.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/ConfigureExperience.tsx
@@ -19,6 +19,7 @@
 import type {UserTypeListItem} from '@thunderid/configure-user-types';
 import {useConfig} from '@thunderid/contexts';
 import {
+  Alert,
   Box,
   Typography,
   Stack,
@@ -189,65 +190,81 @@ export default function ConfigureExperience({
         </Typography>
       </Stack>
 
-      <Stack direction="column" spacing={2} sx={{mt: 2}}>
-        <Stack direction="column" spacing={1}>
-          <Typography variant="h6">{t('applications:onboarding.configure.experience.approach.title')}</Typography>
-          <Typography variant="body2" color="text.disabled" gutterBottom>
-            {t('applications:onboarding.configure.experience.approach.subtitle')}
-          </Typography>
-        </Stack>
-        <RadioGroup value={selectedApproach} onChange={handleApproachChange}>
-          <Stack direction="column" spacing={2}>
-            {/* Hosted Pages Option */}
-            <Card variant="outlined" onClick={() => onApproachChange(ApplicationCreateFlowSignInApproach.INBUILT)}>
-              <CardActionArea
-                sx={{
-                  height: '100%',
-                  cursor: 'pointer',
-                  border: 1,
-                  borderColor:
-                    selectedApproach === ApplicationCreateFlowSignInApproach.INBUILT ? 'primary.main' : 'divider',
-                  transition: 'all 0.2s ease-in-out',
-                  '&:hover': {
-                    borderColor: 'primary.main',
-                    bgcolor:
-                      selectedApproach === ApplicationCreateFlowSignInApproach.INBUILT
-                        ? 'action.selected'
-                        : 'action.hover',
-                  },
-                }}
-              >
-                <CardContent>
-                  <Stack direction="row" spacing={2} alignItems="flex-start">
-                    <FormControlLabel
-                      value={ApplicationCreateFlowSignInApproach.INBUILT}
-                      control={<Radio />}
-                      label=""
-                      sx={{m: 0}}
-                      onClick={(e) => e.stopPropagation()}
-                    />
-                    <Box sx={{flex: 1}}>
-                      <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1}}>
-                        <ExternalLink size={20} />
-                        <Typography variant="h6">
-                          {t('applications:onboarding.configure.approach.inbuilt.title', {
+      {/*
+        Only offer the approach selection when the embedded option is available. For redirect-only
+        templates (public-client SPAs) there is no choice to make, so the single-option radio is
+        replaced by a non-blocking hint that the application uses redirect-based sign-in.
+      */}
+      {!allowEmbeddedApproach ? (
+        <Alert
+          severity="info"
+          icon={<ExternalLink size={20} />}
+          sx={{mt: 2}}
+          data-testid="application-experience-redirect-hint"
+        >
+          {t('applications:onboarding.configure.experience.approach.redirectOnlyHint', {
+            product: productName,
+          })}
+        </Alert>
+      ) : (
+        <Stack direction="column" spacing={2} sx={{mt: 2}}>
+          <Stack direction="column" spacing={1}>
+            <Typography variant="h6">{t('applications:onboarding.configure.experience.approach.title')}</Typography>
+            <Typography variant="body2" color="text.disabled" gutterBottom>
+              {t('applications:onboarding.configure.experience.approach.subtitle')}
+            </Typography>
+          </Stack>
+          <RadioGroup value={selectedApproach} onChange={handleApproachChange}>
+            <Stack direction="column" spacing={2}>
+              {/* Hosted Pages Option */}
+              <Card variant="outlined" onClick={() => onApproachChange(ApplicationCreateFlowSignInApproach.INBUILT)}>
+                <CardActionArea
+                  sx={{
+                    height: '100%',
+                    cursor: 'pointer',
+                    border: 1,
+                    borderColor:
+                      selectedApproach === ApplicationCreateFlowSignInApproach.INBUILT ? 'primary.main' : 'divider',
+                    transition: 'all 0.2s ease-in-out',
+                    '&:hover': {
+                      borderColor: 'primary.main',
+                      bgcolor:
+                        selectedApproach === ApplicationCreateFlowSignInApproach.INBUILT
+                          ? 'action.selected'
+                          : 'action.hover',
+                    },
+                  }}
+                >
+                  <CardContent>
+                    <Stack direction="row" spacing={2} alignItems="flex-start">
+                      <FormControlLabel
+                        value={ApplicationCreateFlowSignInApproach.INBUILT}
+                        control={<Radio />}
+                        label=""
+                        sx={{m: 0}}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                      <Box sx={{flex: 1}}>
+                        <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1}}>
+                          <ExternalLink size={20} />
+                          <Typography variant="h6">
+                            {t('applications:onboarding.configure.approach.inbuilt.title', {
+                              product: productName,
+                            })}
+                          </Typography>
+                        </Stack>
+                        <Typography variant="body2" color="text.secondary">
+                          {t('applications:onboarding.configure.approach.inbuilt.description', {
                             product: productName,
                           })}
                         </Typography>
-                      </Stack>
-                      <Typography variant="body2" color="text.secondary">
-                        {t('applications:onboarding.configure.approach.inbuilt.description', {
-                          product: productName,
-                        })}
-                      </Typography>
-                    </Box>
-                  </Stack>
-                </CardContent>
-              </CardActionArea>
-            </Card>
+                      </Box>
+                    </Stack>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
 
-            {/* Native/Custom UI Option - hidden for public-client SPAs which must use redirect-based flows */}
-            {allowEmbeddedApproach && (
+              {/* Native/Custom UI Option */}
               <Card variant="outlined" onClick={() => onApproachChange(ApplicationCreateFlowSignInApproach.EMBEDDED)}>
                 <CardActionArea
                   sx={{
@@ -294,10 +311,10 @@ export default function ConfigureExperience({
                   </CardContent>
                 </CardActionArea>
               </Card>
-            )}
-          </Stack>
-        </RadioGroup>
-      </Stack>
+            </Stack>
+          </RadioGroup>
+        </Stack>
+      )}
 
       {/* User Type Selection - Only show if there are 2 or more user types */}
       {showUserTypes && onUserTypesChange && (

--- a/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureExperience.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureExperience.test.tsx
@@ -81,7 +81,7 @@ describe('ConfigureExperience', () => {
       expect(embeddedRadio).toBeChecked();
     });
 
-    it('should hide the embedded approach when allowEmbeddedApproach is false', () => {
+    it('should replace the approach selection with a redirect-only hint when allowEmbeddedApproach is false', () => {
       render(
         <ConfigureExperience
           selectedApproach={ApplicationCreateFlowSignInApproach.INBUILT}
@@ -90,9 +90,12 @@ describe('ConfigureExperience', () => {
         />,
       );
 
-      expect(screen.getByText('applications:onboarding.configure.approach.inbuilt.title')).toBeInTheDocument();
+      expect(
+        screen.getByText('applications:onboarding.configure.experience.approach.redirectOnlyHint'),
+      ).toBeInTheDocument();
+      expect(screen.queryByText('applications:onboarding.configure.approach.inbuilt.title')).not.toBeInTheDocument();
       expect(screen.queryByText('applications:onboarding.configure.approach.native.title')).not.toBeInTheDocument();
-      expect(screen.getAllByRole('radio')).toHaveLength(1);
+      expect(screen.queryAllByRole('radio')).toHaveLength(0);
     });
 
     it('should reset to INBUILT when embedded is selected but not allowed', () => {

--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -193,17 +193,30 @@ export default function ApplicationCreatePage(): JSX.Element {
     );
   }, [selectedTemplateConfig, integrations, signInApproach, selectedAuthFlow]);
 
+  // The Sign-In Experience step is only worth showing when it offers a real choice: either the
+  // sign-in approach (available only when the embedded option is allowed) or a user-type selection
+  // (shown only when there are 2+ user types). For redirect-only templates (public-client SPAs)
+  // with fewer than two user types there is nothing to configure, so the step is skipped entirely.
+  const showExperienceStep = useMemo((): boolean => {
+    if (!isBrowserSpaTemplate) return true;
+    // Until user types resolve, keep the step visible so user-type selection is never skipped
+    // prematurely; only collapse it once we know there are fewer than two types to choose from.
+    const userTypes = userTypesData?.types;
+    return !userTypes || userTypes.length >= 2;
+  }, [isBrowserSpaTemplate, userTypesData]);
+
   const visibleSteps = useMemo((): ApplicationCreateFlowStep[] => {
     return creationFlow.steps.filter((step) => {
       if (step === ApplicationCreateFlowStep.ORGANIZATION_UNIT) return hasMultipleOUs;
       if (step === ApplicationCreateFlowStep.CONFIGURE) return needsConfigure;
+      if (step === ApplicationCreateFlowStep.EXPERIENCE) return showExperienceStep;
       // COMPLETE step is dynamic — only shown when an app with a client secret is created.
       // It's filtered out of visibleSteps here and is only set explicitly via setCurrentStep
       // when the creation succeeds with a client secret.
       if (step === ApplicationCreateFlowStep.COMPLETE) return false;
       return true;
     });
-  }, [creationFlow, hasMultipleOUs, needsConfigure]);
+  }, [creationFlow, hasMultipleOUs, needsConfigure, showExperienceStep]);
 
   const handleClose = (): void => {
     void navigate(isWelcomeFlow ? '/home' : '/applications');

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -29,6 +29,12 @@ const mockCreateApplication = vi.fn();
 const mockNavigate = vi.fn();
 let mockPathname = '/';
 
+const MOCK_DEFAULT_USER_TYPES = [
+  {name: 'customer', displayName: 'Customer'},
+  {name: 'employee', displayName: 'Employee'},
+];
+let mockUserTypes: {name: string; displayName: string}[] | undefined = MOCK_DEFAULT_USER_TYPES;
+
 // Mock logger
 vi.mock('@thunderid/logger/react', () => ({
   useLogger: () => ({
@@ -74,10 +80,7 @@ vi.mock('../../api/useCreateApplication', () => ({
 vi.mock('@thunderid/configure-user-types', () => ({
   useGetUserTypes: () => ({
     data: {
-      types: [
-        {name: 'customer', displayName: 'Customer'},
-        {name: 'employee', displayName: 'Employee'},
-      ],
+      types: mockUserTypes,
     },
     isLoading: false,
     error: null,
@@ -425,6 +428,7 @@ describe('ApplicationCreatePage', () => {
 
     window.history.replaceState({}, '', '/');
     mockPathname = '/';
+    mockUserTypes = MOCK_DEFAULT_USER_TYPES;
 
     vi.clearAllMocks();
     mockNavigate.mockResolvedValue(undefined);
@@ -931,6 +935,58 @@ describe('ApplicationCreatePage', () => {
       await goToExperienceStep();
 
       expect(screen.getByTestId('allow-embedded-approach')).toHaveTextContent('false');
+    });
+
+    it('should skip the Sign-In Experience step for browser SPAs with a single user type', async () => {
+      mockUserTypes = [{name: 'customer', displayName: 'Customer'}];
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-browser-platform'));
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
+      });
+      // OPTIONS → CONFIGURE (EXPERIENCE step is skipped, nothing to configure there)
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('application-configure-experience')).not.toBeInTheDocument();
+    });
+
+    it('should keep the Sign-In Experience step for browser SPAs while user types are unresolved', async () => {
+      // Simulate the user types query not having resolved yet — the step must not be skipped early.
+      mockUserTypes = undefined;
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-browser-platform'));
+
+      // STACK → NAME
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await user.type(screen.getByTestId('app-name-input'), 'My App');
+      // NAME → DESIGN
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      // DESIGN → OPTIONS
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
+      });
+      // OPTIONS → EXPERIENCE (still shown because the user type count is unknown)
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-experience')).toBeInTheDocument();
+      });
     });
   });
 

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1685,6 +1685,8 @@ const translations = {
     'onboarding.configure.approach.native.title': 'Embedded sign-in/sign-up components in your app',
     'onboarding.configure.approach.native.description':
       'Users will sign in or sign up through your app using the UI components or APIs provided by {{product}}. You can customize and brand the flows using the designer or through code.',
+    'onboarding.configure.experience.approach.redirectOnlyHint':
+      'This application uses redirect-based sign-in. Users are redirected to the hosted sign-in and sign-up pages provided by {{product}}, which you can customize using the Flow Designer.',
     'onboarding.configure.stack.title': 'Choose a template',
     'onboarding.configure.stack.subtitle': 'Select the template that best matches your application.',
     'onboarding.configure.stack.categoriesLabel': 'Categories',

--- a/tests/e2e/pages/applications/applications.page.ts
+++ b/tests/e2e/pages/applications/applications.page.ts
@@ -50,6 +50,7 @@ export class ApplicationsPage extends BasePage {
   readonly configureDetailsStep: Locator;
   readonly inbuiltExperienceCard: Locator;
   readonly embeddedExperienceCard: Locator;
+  readonly redirectOnlyExperienceHint: Locator;
   readonly showClientSecretStep: Locator;
   readonly clientSecretValue: Locator;
   readonly clientSecretContinue: Locator;
@@ -99,6 +100,7 @@ export class ApplicationsPage extends BasePage {
     this.configureDetailsStep = page.locator('[data-testid="application-configure-details"]');
     this.inbuiltExperienceCard = page.locator('div:has(input[value="INBUILT"])');
     this.embeddedExperienceCard = page.locator('div:has(input[value="EMBEDDED"])');
+    this.redirectOnlyExperienceHint = page.locator('[data-testid="application-experience-redirect-hint"]');
     this.showClientSecretStep = page.locator('[data-testid="application-show-client-secret"]');
     this.clientSecretValue = page.locator('[data-testid="application-client-secret-value"]');
     this.clientSecretContinue = page.locator('[data-testid="application-client-secret-continue"]');

--- a/tests/e2e/tests/applications/application-onboarding.spec.ts
+++ b/tests/e2e/tests/applications/application-onboarding.spec.ts
@@ -200,12 +200,13 @@ test.describe("Application Onboarding", () => {
         await applicationsPage.clickNext();
       });
 
-      await test.step("Step 6: Verify only the redirect-based option is offered", async () => {
+      await test.step("Step 6: Verify the approach selection is replaced by a redirect-only hint", async () => {
         await applicationsPage.waitForStep("application-configure-experience");
-        await expect(applicationsPage.inbuiltExperienceCard.first()).toBeVisible();
+        await expect(applicationsPage.redirectOnlyExperienceHint).toBeVisible();
+        await expect(applicationsPage.inbuiltExperienceCard).toHaveCount(0);
         await expect(applicationsPage.embeddedExperienceCard).toHaveCount(0);
-        console.log("EMBEDDED experience hidden for SPA — correct");
-        await applicationsPage.screenshot("tc004-spa-embedded-hidden");
+        console.log("Approach selection replaced by redirect-only hint for SPA — correct");
+        await applicationsPage.screenshot("tc004-spa-redirect-only-hint");
       });
     });
 


### PR DESCRIPTION
### Purpose

After [#3389](https://github.com/thunder-id/thunderid/pull/3389) blocked SPA creation with native (embedded) flow execution, the embedded sign-in option is hidden for browser-based SPA (public-client) templates. As a result, the **Sign-In Approach** selection in the application creation wizard collapsed to a single radio option — UX overkill, since a lone radio reads as a decision point with no decision to make.

This PR removes that single-choice friction while still making the redirect-based behavior clear.

Fixes #3533

### Approach

- **Drop the single-choice radio** ([`ConfigureExperience.tsx`](frontend/apps/console/src/features/applications/components/create-application/ConfigureExperience.tsx)): when the embedded approach is unavailable, the approach selection is replaced by a non-blocking info hint stating the application uses redirect-based hosted sign-in (customizable via the Flow Designer).
- **Skip the step when it has no choice** ([`ApplicationCreatePage.tsx`](frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx)): the `EXPERIENCE` step is now shown only when it offers a real choice — the embedded approach is allowed **or** there are 2+ user types to select. For redirect-only templates with fewer than two user types, the step is skipped entirely. Application creation still defaults to the redirect-based (INBUILT) approach with the correct OAuth config.
- **Docs** ([`manage-applications.mdx`](docs/content/guides/guides/applications/manage-applications.mdx)): refreshed the SPA note to reflect that the approach selection is no longer shown for SPAs and the step is skipped when there is nothing else to configure.
- **i18n**: added the `redirectOnlyHint` string.

A Flows-tab hint was considered as a third surface but skipped: reliably detecting "redirect-only" post-creation conflates browser SPAs with mobile public clients (which support embedded), and the wizard hint + docs already inform at the moments that matter.

### Related Issues
- Fixes #3533
- Refs #3389

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser app setup now displays a redirect-only sign-in informational hint when embedded sign-in isn’t available, removing the approach selection UI.
  * The app creation wizard can skip the Sign-In Experience step for browser SPAs when there aren’t enough user types to choose.

* **Bug Fixes**
  * Improved step visibility logic so users proceed directly to the next step in redirect-only scenarios.

* **Documentation**
  * Updated the “Configure the Sign-In Experience” guidance for browser app (SPA) applications to reflect redirect-only behavior.

* **Tests**
  * Updated unit and end-to-end tests to match the new redirect-only UI and step-skipping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->