### PR TITLE
Fix Resource Server identifier update error from Console

### DIFF
--- a/frontend/packages/configure-resource-servers/src/components/resource-server-detail/AdvancedTab.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-server-detail/AdvancedTab.tsx
@@ -41,7 +41,15 @@ export default function AdvancedTab({resourceServer, onRefresh}: AdvancedTabProp
 
   const handleIdentifierSave = (): void => {
     updateRs.mutate(
-      {id: resourceServer.id, data: {identifier: identifier || null}},
+      {
+        id: resourceServer.id,
+        data: {
+          name: resourceServer.name,
+          description: resourceServer.description ?? null,
+          identifier: identifier || null,
+          ouId: resourceServer.ouId,
+        },
+      },
       {
         onSuccess: () => {
           showToast(t('resourceServers:edit.advanced.identifier.saved', 'Identifier saved.'), 'success');

--- a/frontend/packages/configure-resource-servers/src/components/resource-server-detail/__tests__/AdvancedTab.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-server-detail/__tests__/AdvancedTab.test.tsx
@@ -47,6 +47,7 @@ vi.mock('../../../api/useUpdateResourceServer', () => ({
 const mockResourceServer: ResourceServer = {
   id: 'rs-1',
   name: 'Test API',
+  description: 'Existing API description',
   handle: 'test-api',
   identifier: 'https://api.example.com',
   ouId: 'ou-1',
@@ -95,7 +96,15 @@ describe('AdvancedTab', () => {
     fireEvent.click(screen.getByRole('button', {name: /Save/i}));
 
     expect(mockUpdateMutate).toHaveBeenCalledWith(
-      {id: 'rs-1', data: {identifier: 'https://new-api.example.com'}},
+      {
+        id: 'rs-1',
+        data: {
+          name: 'Test API',
+          description: 'Existing API description',
+          identifier: 'https://new-api.example.com',
+          ouId: 'ou-1',
+        },
+      },
       expect.any(Object),
     );
   });

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/ResourceDetailPanel.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/ResourceDetailPanel.tsx
@@ -93,7 +93,10 @@ function DetailForm({selectedNode, resourceServer, onRefresh}: DetailFormProps):
   const handleSave = (): void => {
     if (selectedNode.type === 'server') {
       updateRs.mutate(
-        {id: resourceServer.id, data: {name, description: description || null, identifier: identifier || null}},
+        {
+          id: resourceServer.id,
+          data: {name, description: description || null, identifier: identifier || null, ouId: resourceServer.ouId},
+        },
         {
           onSuccess: () => {
             showToast(t('resourceServers:detail.saved', 'Changes saved.'), 'success');

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/ResourceDetailPanel.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/ResourceDetailPanel.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {renderWithProviders, screen} from '@thunderid/test-utils';
+import {fireEvent, renderWithProviders, screen, waitFor} from '@thunderid/test-utils';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import type {ResourceServer} from '../../../models/resource-server';
 import ResourceDetailPanel from '../ResourceDetailPanel';
@@ -39,8 +39,10 @@ vi.mock('@thunderid/logger/react', () => ({
   useLogger: () => ({error: vi.fn(), info: vi.fn(), debug: vi.fn()}),
 }));
 
+const mockUpdateResourceServerMutate = vi.fn();
+
 vi.mock('../../../api/useUpdateResourceServer', () => ({
-  default: () => ({mutate: vi.fn(), isPending: false}),
+  default: () => ({mutate: mockUpdateResourceServerMutate, isPending: false}),
 }));
 
 vi.mock('../../../api/useUpdateResource', () => ({
@@ -147,6 +149,41 @@ describe('ResourceDetailPanel', () => {
     );
 
     expect(screen.getByDisplayValue('https://api.example.com')).toBeInTheDocument();
+  });
+
+  it('includes the resource server ouId when saving a server identifier change', async () => {
+    const selectedNode: SelectedNode = {
+      type: 'server',
+      id: 'rs-1',
+      data: mockResourceServer,
+    };
+
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={selectedNode} resourceServer={mockResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByDisplayValue('https://api.example.com'), {
+      target: {value: 'https://new-api.example.com'},
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /Save/i})).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', {name: /Save/i}));
+
+    expect(mockUpdateResourceServerMutate).toHaveBeenCalledWith(
+      {
+        id: 'rs-1',
+        data: {
+          name: 'Dark Dodos Smash',
+          description: null,
+          identifier: 'https://new-api.example.com',
+          ouId: 'ou-1',
+        },
+      },
+      expect.any(Object),
+    );
   });
 
   it('renders the delimiter chip when a server node is selected', () => {

--- a/frontend/packages/configure-resource-servers/src/models/resource-server.ts
+++ b/frontend/packages/configure-resource-servers/src/models/resource-server.ts
@@ -84,9 +84,10 @@ export interface CreateResourceServerRequest {
 }
 
 export interface UpdateResourceServerRequest {
-  name?: string;
+  name: string;
   description?: string | null;
   identifier?: string | null;
+  ouId: string;
 }
 
 export interface CreateResourceRequest {

--- a/frontend/packages/configure-resource-servers/src/pages/ResourceServerEditPage.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/ResourceServerEditPage.tsx
@@ -119,6 +119,7 @@ export default function ResourceServerEditPage(): JSX.Element {
                 ? editedFields.description
                 : null
               : (resourceServer.description ?? null),
+          ouId: resourceServer.ouId,
         },
       },
       {


### PR DESCRIPTION
### Purpose
Fixes a Console bug where saving a Resource Server identifier from Advanced Settings failed with a missing `ouId` validation error.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Updated the Console Resource Server update payloads to include the existing `ouId` whenever a Resource Server is saved. Also tightened the update request type and added focused test coverage for the identifier save path.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/3487

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Saving resource server details now preserves more of the existing server information, including organization/unit and description values.
  * Updates from the edit screen and detail panels now send the full set of server fields, reducing the chance of overwriting data when changing the identifier.
  * Improved save handling for resource server edits so changes are applied more reliably across different edit views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->