### PR TITLE
Render MCP resource servers with an MCP-native Capabilities view

### DIFF
--- a/backend/internal/resource/service.go
+++ b/backend/internal/resource/service.go
@@ -230,12 +230,6 @@ func (rs *resourceService) CreateResourceServer(
 		resourceServer.Type = providers.ResourceServerTypeCustom
 	}
 
-	// MCP resource servers require a non-empty handle so server-level tools/resources derive a
-	// prefixed permission string and cannot collapse onto a bare action handle.
-	if resourceServer.Type == providers.ResourceServerTypeMCP && resourceServer.Handle == "" {
-		return nil, &ErrorInvalidRequestFormat
-	}
-
 	// Set default delimiter if not provided
 	if resourceServer.Delimiter == "" {
 		resourceServer.Delimiter = rs.defaultDelimiter
@@ -442,11 +436,6 @@ func (rs *resourceService) UpdateResourceServer(
 		resourceServer.Handle = existingResServer.Handle
 	} else if resourceServer.Handle != existingResServer.Handle {
 		return nil, &ErrorImmutableHandle
-	}
-
-	// MCP resource servers require a non-empty handle.
-	if resourceServer.Type == providers.ResourceServerTypeMCP && resourceServer.Handle == "" {
-		return nil, &ErrorInvalidRequestFormat
 	}
 
 	// Identifier: preserve existing if not provided; check uniqueness if changed

--- a/backend/internal/resource/service_test.go
+++ b/backend/internal/resource/service_test.go
@@ -738,35 +738,6 @@ func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_PreservesType() 
 	suite.mockStore.AssertExpectations(suite.T())
 }
 
-func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_MCPRejectsEmptyHandle() {
-	// Guards pre-existing handle-less MCP rows (legacy rows created before the handle
-	// requirement) per spec §8: updating such a row without supplying a handle must be
-	// rejected so an MCP RS can never end up with an empty handle.
-	rs := providers.ResourceServer{
-		Name: "updated-rs",
-		OUID: "ou-123",
-	}
-
-	existingRS := providers.ResourceServer{
-		ID:        "rs-123",
-		Name:      "old-name",
-		Handle:    "",
-		Type:      providers.ResourceServerTypeMCP,
-		OUID:      "ou-123",
-		Delimiter: ":",
-	}
-
-	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
-	suite.mockStore.On("GetResourceServer", mock.Anything, "rs-123").Return(existingRS, nil)
-
-	result, err := suite.service.UpdateResourceServer(context.Background(), "rs-123", rs)
-
-	suite.Nil(result)
-	suite.NotNil(err)
-	suite.Equal(ErrorInvalidRequestFormat.Code, err.Code)
-	suite.Equal(tidcommon.ClientErrorType, err.Type)
-}
-
 func (suite *ResourceServiceTestSuite) TestUpdateResourceServer_NotFound() {
 	rs := providers.ResourceServer{
 		Name: "test-rs",
@@ -3020,19 +2991,6 @@ func (suite *ResourceServiceTestSuite) TestUpdateAction_KindChangeRejected() {
 
 	result, err := suite.service.UpdateAction(context.Background(), "rs-mcp", &resID, "act-1",
 		providers.Action{Name: testUpdatedName, Kind: providers.ActionKindTool})
-
-	suite.Nil(result)
-	suite.NotNil(err)
-	suite.Equal(ErrorInvalidRequestFormat.Code, err.Code)
-}
-
-func (suite *ResourceServiceTestSuite) TestCreateResourceServer_MCP_RequiresHandle() {
-	suite.mockOU.On("GetOrganizationUnit", mock.Anything, "ou-123").
-		Return(providers.OrganizationUnit{ID: "ou-123"}, nil)
-	suite.mockStore.On("CheckResourceServerNameExists", mock.Anything, "x").Return(false, nil)
-
-	result, err := suite.service.CreateResourceServer(context.Background(),
-		providers.ResourceServer{Name: "x", OUID: "ou-123", Type: providers.ResourceServerTypeMCP, Handle: ""})
 
 	suite.Nil(result)
 	suite.NotNil(err)

--- a/frontend/packages/configure-resource-servers/src/components/create-resource-server/ConfigureName.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/create-resource-server/ConfigureName.tsx
@@ -21,14 +21,11 @@ import {Box, Chip, FormControl, FormLabel, Stack, TextField, Typography, useThem
 import {Lightbulb} from '@wso2/oxygen-ui-icons-react';
 import {useEffect, useMemo, type ChangeEvent, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
-import {deriveHandle} from '../../utils/deriveHandle';
 
 interface ConfigureNameProps {
   name: string;
   handle: string;
   delimiter?: string;
-  handleEdited?: boolean;
-  onHandleEditedChange?: (edited: boolean) => void;
   onNameChange: (name: string) => void;
   onHandleChange: (handle: string) => void;
   onReadyChange?: (isReady: boolean) => void;
@@ -38,8 +35,6 @@ export default function ConfigureName({
   name,
   handle,
   delimiter = undefined,
-  handleEdited = false,
-  onHandleEditedChange = undefined,
   onNameChange,
   onHandleChange,
   onReadyChange = undefined,
@@ -53,24 +48,17 @@ export default function ConfigureName({
     if (onReadyChange) {
       onReadyChange(name.trim().length > 0);
     }
-  }, [name, handle, onReadyChange]);
+  }, [name, onReadyChange]);
 
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>): void => {
-    const newName = e.target.value;
-    onNameChange(newName);
-    if (!handleEdited) {
-      onHandleChange(deriveHandle(newName, delimiter));
-    }
+    onNameChange(e.target.value);
   };
 
   const handleSuggestionClick = (suggestion: string): void => {
     onNameChange(suggestion);
-    onHandleChange(deriveHandle(suggestion, delimiter));
-    onHandleEditedChange?.(false);
   };
 
   const handleHandleChange = (e: ChangeEvent<HTMLInputElement>): void => {
-    onHandleEditedChange?.(true);
     const sanitized = e.target.value.toLowerCase().replace(/[^a-z0-9._\-:/]/g, '');
     onHandleChange(delimiter ? sanitized.replace(new RegExp(`\\${delimiter}`, 'g'), '') : sanitized);
   };
@@ -123,9 +111,9 @@ export default function ConfigureName({
         </Box>
       </Stack>
 
-      <FormControl fullWidth required>
+      <FormControl fullWidth>
         <FormLabel htmlFor="resource-server-handle-input">
-          {t('resourceServers:create.name.handleLabel', 'Handle')}
+          {t('resourceServers:create.name.handleLabel', 'Handle (Optional)')}
         </FormLabel>
         <TextField
           id="resource-server-handle-input"

--- a/frontend/packages/configure-resource-servers/src/components/create-resource-server/__tests__/ConfigureName.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/create-resource-server/__tests__/ConfigureName.test.tsx
@@ -38,7 +38,7 @@ describe('ConfigureName', () => {
     expect(screen.getByRole('textbox', {name: /handle/i})).toBeInTheDocument();
   });
 
-  it('calls onNameChange and derives handle when name input changes', () => {
+  it('calls onNameChange when name input changes without auto-deriving handle', () => {
     const onNameChange = vi.fn();
     const onHandleChange = vi.fn();
     render(<ConfigureName name="" handle="" onNameChange={onNameChange} onHandleChange={onHandleChange} />);
@@ -48,7 +48,7 @@ describe('ConfigureName', () => {
     });
 
     expect(onNameChange).toHaveBeenCalledWith('Payments API');
-    expect(onHandleChange).toHaveBeenCalledWith('payments-api');
+    expect(onHandleChange).not.toHaveBeenCalled();
   });
 
   it('calls onHandleChange with invalid characters stripped when handle input changes', () => {
@@ -114,7 +114,7 @@ describe('ConfigureName', () => {
     expect(screen.getByText('Beta Platform')).toBeInTheDocument();
   });
 
-  it('fills name and handle when a suggestion chip is clicked', () => {
+  it('fills name when a suggestion chip is clicked', () => {
     const onNameChange = vi.fn();
     const onHandleChange = vi.fn();
     render(<ConfigureName name="" handle="" onNameChange={onNameChange} onHandleChange={onHandleChange} />);
@@ -122,36 +122,6 @@ describe('ConfigureName', () => {
     fireEvent.click(screen.getByText('Alpha Service'));
 
     expect(onNameChange).toHaveBeenCalledWith('Alpha Service');
-    expect(onHandleChange).toHaveBeenCalledWith('alpha-service');
-  });
-
-  it('derives handle with underscore when delimiter is hyphen', () => {
-    const onHandleChange = vi.fn();
-    render(<ConfigureName name="" handle="" delimiter="-" onNameChange={vi.fn()} onHandleChange={onHandleChange} />);
-
-    fireEvent.change(screen.getByRole('textbox', {name: /resource server name/i}), {
-      target: {value: 'Shaky Trees Refuse'},
-    });
-
-    expect(onHandleChange).toHaveBeenCalledWith('shaky_trees_refuse');
-  });
-
-  it('does not auto-derive handle when handleEdited is true', () => {
-    const onHandleChange = vi.fn();
-    render(
-      <ConfigureName
-        name=""
-        handle="custom-handle"
-        handleEdited={true}
-        onNameChange={vi.fn()}
-        onHandleChange={onHandleChange}
-      />,
-    );
-
-    fireEvent.change(screen.getByRole('textbox', {name: /resource server name/i}), {
-      target: {value: 'New Name'},
-    });
-
     expect(onHandleChange).not.toHaveBeenCalled();
   });
 

--- a/frontend/packages/configure-resource-servers/src/components/permission-catalog/McpServerSectionContent.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/permission-catalog/McpServerSectionContent.tsx
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Alert, Box, CircularProgress, Typography} from '@wso2/oxygen-ui';
+import {type JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import {CatalogResourceNode, CatalogRow, type ServerSectionContentProps} from './PermissionCatalog';
+import useGetResources from '../../api/useGetResources';
+import useGetServerActions from '../../api/useGetServerActions';
+import type {Action, ResourcePermissions} from '../../models/resource-server';
+import {isPermissionSelected, togglePermission} from '../../utils/permissionSelection';
+
+interface CatalogSubsectionProps {
+  label: string;
+  actions: Action[];
+  resourceServerId: string;
+  selected: ResourcePermissions[];
+  readOnly: boolean;
+  onChange: (selected: ResourcePermissions[]) => void;
+}
+
+function CatalogSubsection({
+  label,
+  actions,
+  resourceServerId,
+  selected,
+  readOnly,
+  onChange,
+}: CatalogSubsectionProps): JSX.Element | null {
+  if (actions.length === 0) return null;
+
+  return (
+    <>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{
+          display: 'block',
+          pl: 3,
+          py: 0.25,
+          textTransform: 'uppercase',
+          letterSpacing: 0.5,
+        }}
+      >
+        {label}
+      </Typography>
+      {actions.map((action) => (
+        <CatalogRow
+          key={action.id}
+          name={action.name}
+          permission={action.permission}
+          depth={1}
+          checked={isPermissionSelected(selected, resourceServerId, action.permission)}
+          disabled={readOnly}
+          onToggle={() => onChange(togglePermission(selected, resourceServerId, action.permission))}
+        />
+      ))}
+    </>
+  );
+}
+
+export default function McpServerSectionContent({
+  server,
+  selected,
+  readOnly,
+  onChange,
+  collectSubtree,
+  getCachedSubtree,
+}: ServerSectionContentProps): JSX.Element {
+  const delimiter = server.delimiter;
+  const {t} = useTranslation();
+  const {data: resourcesData, isLoading: loadingResources, error: resourcesError} = useGetResources(server.id);
+  const {data: actionsData, isLoading: loadingActions, error: actionsError} = useGetServerActions(server.id);
+
+  if (loadingResources || loadingActions) {
+    return (
+      <Box sx={{display: 'flex', justifyContent: 'center', py: 3}}>
+        <CircularProgress size={20} />
+      </Box>
+    );
+  }
+
+  if (resourcesError ?? actionsError) {
+    return (
+      <Alert severity="error" sx={{my: 1}}>
+        {t('resourceServers:permissionCatalog.loadError', 'Failed to load permissions for this resource server.')}
+      </Alert>
+    );
+  }
+
+  const resources = resourcesData?.resources ?? [];
+  const serverActions = actionsData?.actions ?? [];
+
+  if (resources.length === 0 && serverActions.length === 0) {
+    return (
+      <Alert severity="info" sx={{my: 1}}>
+        {t('resourceServers:permissionCatalog.noPermissions', 'No permissions defined for this resource server.')}
+      </Alert>
+    );
+  }
+
+  const tools = serverActions.filter((a) => a.kind === 'tool');
+  const mcpResources = serverActions.filter((a) => a.kind === 'resource');
+
+  return (
+    <>
+      <CatalogSubsection
+        label={t('resourceServers:permissionCatalog.mcp.tools', 'Tools')}
+        actions={tools}
+        resourceServerId={server.id}
+        selected={selected}
+        readOnly={readOnly}
+        onChange={onChange}
+      />
+      <CatalogSubsection
+        label={t('resourceServers:permissionCatalog.mcp.resources', 'Resources')}
+        actions={mcpResources}
+        resourceServerId={server.id}
+        selected={selected}
+        readOnly={readOnly}
+        onChange={onChange}
+      />
+      {resources.map((resource) => (
+        <CatalogResourceNode
+          key={resource.id}
+          resourceServerId={server.id}
+          resource={resource}
+          depth={1}
+          selected={selected}
+          readOnly={readOnly}
+          delimiter={delimiter}
+          onChange={onChange}
+          collectSubtree={collectSubtree}
+          getCachedSubtree={getCachedSubtree}
+        />
+      ))}
+    </>
+  );
+}

--- a/frontend/packages/configure-resource-servers/src/components/permission-catalog/PermissionCatalog.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/permission-catalog/PermissionCatalog.tsx
@@ -32,6 +32,7 @@ import {
 import {ChevronDown, ChevronRight} from '@wso2/oxygen-ui-icons-react';
 import {useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
+import McpServerSectionContent from './McpServerSectionContent';
 import useGetResourceActions from '../../api/useGetResourceActions';
 import useGetResources from '../../api/useGetResources';
 import useGetResourceServers from '../../api/useGetResourceServers';
@@ -55,7 +56,7 @@ export interface PermissionCatalogProps {
 
 /* ---------- Row ---------- */
 
-interface CatalogRowProps {
+export interface CatalogRowProps {
   name: string;
   permission: string;
   depth: number;
@@ -67,7 +68,7 @@ interface CatalogRowProps {
   expandControl?: JSX.Element;
 }
 
-function CatalogRow({
+export function CatalogRow({
   name,
   permission,
   depth,
@@ -103,7 +104,7 @@ function CatalogRow({
 
 /* ---------- Resource node (recursive, tri-state) ---------- */
 
-interface CatalogResourceNodeProps {
+export interface CatalogResourceNodeProps {
   resourceServerId: string;
   resource: Resource;
   depth: number;
@@ -115,7 +116,7 @@ interface CatalogResourceNodeProps {
   getCachedSubtree: (resource: Resource) => string[] | null;
 }
 
-function CatalogResourceNode({
+export function CatalogResourceNode({
   resourceServerId,
   resource,
   depth,
@@ -230,17 +231,19 @@ interface ServerSectionProps {
   onChange: (selected: ResourcePermissions[]) => void;
 }
 
-function ServerSectionContent({
+export interface ServerSectionContentProps extends ServerSectionProps {
+  collectSubtree: (resource: Resource) => Promise<string[]>;
+  getCachedSubtree: (resource: Resource) => string[] | null;
+}
+
+function DefaultServerSectionContent({
   server,
   selected,
   readOnly,
   onChange,
   collectSubtree,
   getCachedSubtree,
-}: ServerSectionProps & {
-  collectSubtree: (resource: Resource) => Promise<string[]>;
-  getCachedSubtree: (resource: Resource) => string[] | null;
-}): JSX.Element {
+}: ServerSectionContentProps): JSX.Element {
   const delimiter = server.delimiter;
   const {t} = useTranslation();
   const {data: resourcesData, isLoading: loadingResources, error: resourcesError} = useGetResources(server.id);
@@ -302,6 +305,20 @@ function ServerSectionContent({
       ))}
     </>
   );
+}
+
+const SERVER_SECTION_CONTENT_BY_TYPE: Record<
+  ResourceServer['type'],
+  (props: ServerSectionContentProps) => JSX.Element
+> = {
+  API: DefaultServerSectionContent,
+  CUSTOM: DefaultServerSectionContent,
+  MCP: McpServerSectionContent,
+};
+
+function ServerSectionContent(props: ServerSectionContentProps): JSX.Element {
+  const Content = SERVER_SECTION_CONTENT_BY_TYPE[props.server.type];
+  return <Content {...props} />;
 }
 
 function ServerSection({server, selected, readOnly, onChange}: ServerSectionProps): JSX.Element {

--- a/frontend/packages/configure-resource-servers/src/components/permission-catalog/__tests__/PermissionCatalog.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/permission-catalog/__tests__/PermissionCatalog.test.tsx
@@ -445,4 +445,147 @@ describe('PermissionCatalog', () => {
       expect(screen.getByRole('checkbox', {name: 'Empty API'})).toBeDisabled();
     });
   });
+
+  it('renders MCP server actions split into Tools and Resources subsections', async () => {
+    const user = userEvent.setup();
+
+    const mcpServer = {
+      id: 'rs-mcp',
+      name: 'My MCP Server',
+      handle: 'my-mcp',
+      ouId: 'ou-1',
+      delimiter: ':',
+      type: 'MCP' as const,
+    };
+
+    const mcpTools = [
+      {
+        id: 'tool-1',
+        name: 'Search Files',
+        handle: 'search-files',
+        permission: 'my-mcp:search-files',
+        kind: 'tool' as const,
+      },
+    ];
+    const mcpResources = [
+      {
+        id: 'res-1',
+        name: 'File Contents',
+        handle: 'file-contents',
+        permission: 'my-mcp:file-contents',
+        kind: 'resource' as const,
+      },
+    ];
+
+    vi.mocked(useGetResourceServersModule.default).mockReturnValue(
+      queryResult({totalResults: 1, startIndex: 1, count: 1, resourceServers: [mcpServer]}),
+    );
+
+    vi.mocked(useGetServerActionsModule.default).mockReturnValue(
+      queryResult({totalResults: 2, startIndex: 1, count: 2, actions: [...mcpTools, ...mcpResources]}),
+    );
+
+    vi.mocked(useGetResourcesModule.default).mockReturnValue(
+      queryResult({totalResults: 0, startIndex: 1, count: 0, resources: []}),
+    );
+
+    vi.mocked(useGetResourceActionsModule.default).mockReturnValue(emptyQueryResult());
+
+    mockGetCachedServerPermissions.mockReturnValue(['my-mcp:search-files', 'my-mcp:file-contents']);
+    mockCollectServerPermissions.mockResolvedValue(['my-mcp:search-files', 'my-mcp:file-contents']);
+
+    renderCatalog({selected: []});
+
+    // Expand the MCP server
+    await user.click(screen.getByRole('button', {name: 'my-mcp'}));
+
+    // Both subsection labels should be visible
+    await waitFor(() => {
+      expect(screen.getByText('Search Files')).toBeInTheDocument();
+      expect(screen.getByText('File Contents')).toBeInTheDocument();
+    });
+
+    // Tools and Resources subsection label text should be rendered
+    const allTools = screen.getAllByText('Tools');
+    expect(allTools.length).toBeGreaterThanOrEqual(1);
+    const allResources = screen.getAllByText('Resources');
+    expect(allResources.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('preserves tri-state cascade for MCP servers — selecting a tool permission works', async () => {
+    const user = userEvent.setup();
+
+    const mcpServer = {
+      id: 'rs-mcp',
+      name: 'My MCP Server',
+      handle: 'my-mcp',
+      ouId: 'ou-1',
+      delimiter: ':',
+      type: 'MCP' as const,
+    };
+
+    const mcpTools = [
+      {
+        id: 'tool-1',
+        name: 'Search Files',
+        handle: 'search-files',
+        permission: 'my-mcp:search-files',
+        kind: 'tool' as const,
+      },
+    ];
+
+    vi.mocked(useGetResourceServersModule.default).mockReturnValue(
+      queryResult({totalResults: 1, startIndex: 1, count: 1, resourceServers: [mcpServer]}),
+    );
+
+    vi.mocked(useGetServerActionsModule.default).mockReturnValue(
+      queryResult({totalResults: 1, startIndex: 1, count: 1, actions: mcpTools}),
+    );
+
+    vi.mocked(useGetResourcesModule.default).mockReturnValue(
+      queryResult({totalResults: 0, startIndex: 1, count: 0, resources: []}),
+    );
+
+    vi.mocked(useGetResourceActionsModule.default).mockReturnValue(emptyQueryResult());
+
+    mockGetCachedServerPermissions.mockReturnValue(['my-mcp:search-files']);
+    mockCollectServerPermissions.mockResolvedValue(['my-mcp:search-files']);
+
+    const onChange = renderCatalog({selected: []});
+
+    // Expand the MCP server
+    await user.click(screen.getByRole('button', {name: 'my-mcp'}));
+
+    await waitFor(() => expect(screen.getByText('Search Files')).toBeInTheDocument());
+
+    // Click the Search Files permission checkbox
+    const searchFilesCheckbox = screen.getByRole('checkbox', {name: 'my-mcp:search-files'});
+    await user.click(searchFilesCheckbox);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        {
+          resourceServerId: 'rs-mcp',
+          permissions: expect.arrayContaining(['my-mcp:search-files']) as string[],
+        },
+      ]);
+    });
+  });
+
+  it('renders API-type server with flat action list (no Tools/Resources subsections)', async () => {
+    const user = userEvent.setup();
+
+    renderCatalog({selected: []});
+
+    // Expand the rs-1 server (API type)
+    await user.click(screen.getByRole('button', {name: 'booking-api'}));
+
+    await waitFor(() => expect(screen.getByText('Health Ping')).toBeInTheDocument());
+
+    // API-type sections should NOT show the "Tools" subsection label inside the expanded section
+    // (The section header "Tools"/"Resources" should not appear as the only text for API servers)
+    // Since rs-1 is API type, its actions are listed flat without subsection labels
+    const toolsLabels = screen.queryAllByText('Tools');
+    expect(toolsLabels.length).toBe(0);
+  });
 });

--- a/frontend/packages/configure-resource-servers/src/components/resource-server-detail/AdvancedTab.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-server-detail/AdvancedTab.tsx
@@ -17,57 +17,19 @@
  */
 
 import {SettingsCard} from '@thunderid/components';
-import {useToast} from '@thunderid/contexts';
-import {useLogger} from '@thunderid/logger/react';
-import {Box, Button, Stack, TextField} from '@wso2/oxygen-ui';
-import {useState, type JSX} from 'react';
+import {FormControl, FormLabel, Stack, TextField} from '@wso2/oxygen-ui';
+import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
-import useUpdateResourceServer from '../../api/useUpdateResourceServer';
 import type {ResourceServer} from '../../models/resource-server';
 
 interface AdvancedTabProps {
   resourceServer: ResourceServer;
-  onRefresh: () => void;
+  identifier: string;
+  onIdentifierChange: (value: string) => void;
 }
 
-export default function AdvancedTab({resourceServer, onRefresh}: AdvancedTabProps): JSX.Element {
+export default function AdvancedTab({resourceServer, identifier, onIdentifierChange}: AdvancedTabProps): JSX.Element {
   const {t} = useTranslation();
-  const {showToast} = useToast();
-  const logger = useLogger('AdvancedTab');
-  const updateRs = useUpdateResourceServer();
-
-  const [identifier, setIdentifier] = useState(resourceServer.identifier ?? '');
-  const [identifierDirty, setIdentifierDirty] = useState(false);
-
-  const handleIdentifierSave = (): void => {
-    updateRs.mutate(
-      {
-        id: resourceServer.id,
-        data: {
-          name: resourceServer.name,
-          description: resourceServer.description ?? null,
-          identifier: identifier || null,
-          ouId: resourceServer.ouId,
-        },
-      },
-      {
-        onSuccess: () => {
-          showToast(t('resourceServers:edit.advanced.identifier.saved', 'Identifier saved.'), 'success');
-          setIdentifierDirty(false);
-          onRefresh();
-        },
-        onError: (err: Error) => {
-          logger.error('Failed to save identifier', {error: err});
-          showToast(t('resourceServers:edit.advanced.identifier.saveError', 'Failed to save identifier.'), 'error');
-        },
-      },
-    );
-  };
-
-  const handleIdentifierDiscard = (): void => {
-    setIdentifier(resourceServer.identifier ?? '');
-    setIdentifierDirty(false);
-  };
 
   return (
     <Stack spacing={3}>
@@ -78,14 +40,14 @@ export default function AdvancedTab({resourceServer, onRefresh}: AdvancedTabProp
           'Configuration settings for this resource server.',
         )}
       >
-        <Stack spacing={2}>
+        <FormControl fullWidth>
+          <FormLabel htmlFor="resource-server-identifier">
+            {t('resourceServers:edit.advanced.identifier.label', 'Identifier (Audience)')}
+          </FormLabel>
           <TextField
-            label={t('resourceServers:edit.advanced.identifier.label', 'Identifier (Audience)')}
+            id="resource-server-identifier"
             value={identifier}
-            onChange={(e) => {
-              setIdentifier(e.target.value);
-              setIdentifierDirty(true);
-            }}
+            onChange={(e) => onIdentifierChange(e.target.value)}
             fullWidth
             size="small"
             helperText={t(
@@ -94,17 +56,7 @@ export default function AdvancedTab({resourceServer, onRefresh}: AdvancedTabProp
             )}
             disabled={resourceServer.isReadOnly}
           />
-          {!resourceServer.isReadOnly && identifierDirty && (
-            <Box sx={{display: 'flex', gap: 1}}>
-              <Button variant="outlined" size="small" onClick={handleIdentifierDiscard} disabled={updateRs.isPending}>
-                {t('common:discard', 'Discard')}
-              </Button>
-              <Button variant="contained" size="small" onClick={handleIdentifierSave} disabled={updateRs.isPending}>
-                {updateRs.isPending ? t('common:saving', 'Saving…') : t('common:save', 'Save')}
-              </Button>
-            </Box>
-          )}
-        </Stack>
+        </FormControl>
       </SettingsCard>
     </Stack>
   );

--- a/frontend/packages/configure-resource-servers/src/components/resource-server-detail/__tests__/AdvancedTab.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-server-detail/__tests__/AdvancedTab.test.tsx
@@ -16,33 +16,10 @@
  * under the License.
  */
 
-import {renderWithProviders, screen, fireEvent, waitFor} from '@thunderid/test-utils';
+import {renderWithProviders, screen, fireEvent} from '@thunderid/test-utils';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import type {ResourceServer} from '../../../models/resource-server';
 import AdvancedTab from '../AdvancedTab';
-
-vi.mock('@thunderid/react', () => ({
-  useThunderID: () => ({http: {request: vi.fn()}}),
-}));
-
-vi.mock('@thunderid/contexts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
-  return {
-    ...actual,
-    useConfig: () => ({getServerUrl: () => 'http://localhost:8090'}),
-    useToast: () => ({showToast: vi.fn()}),
-  };
-});
-
-vi.mock('@thunderid/logger/react', () => ({
-  useLogger: () => ({error: vi.fn(), info: vi.fn(), debug: vi.fn()}),
-}));
-
-const mockUpdateMutate = vi.fn();
-
-vi.mock('../../../api/useUpdateResourceServer', () => ({
-  default: () => ({mutate: mockUpdateMutate, isPending: false}),
-}));
 
 const mockResourceServer: ResourceServer = {
   id: 'rs-1',
@@ -66,67 +43,81 @@ describe('AdvancedTab', () => {
   });
 
   it('renders the Configurations section with the current identifier value', () => {
-    renderWithProviders(<AdvancedTab resourceServer={mockResourceServer} onRefresh={vi.fn()} />);
+    renderWithProviders(
+      <AdvancedTab
+        resourceServer={mockResourceServer}
+        identifier={mockResourceServer.identifier ?? ''}
+        onIdentifierChange={vi.fn()}
+      />,
+    );
 
     expect(screen.getByLabelText(/Identifier/i)).toHaveValue('https://api.example.com');
   });
 
-  it('shows Save and Discard buttons when the identifier field is edited', async () => {
-    renderWithProviders(<AdvancedTab resourceServer={mockResourceServer} onRefresh={vi.fn()} />);
-
-    const identifierInput = screen.getByLabelText(/Identifier/i);
-    fireEvent.change(identifierInput, {target: {value: 'https://new-api.example.com'}});
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: /Save/i})).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: /Discard/i})).toBeInTheDocument();
-    });
-  });
-
-  it('calls updateRs.mutate with the new identifier when Save is clicked', async () => {
-    renderWithProviders(<AdvancedTab resourceServer={mockResourceServer} onRefresh={vi.fn()} />);
-
-    const identifierInput = screen.getByLabelText(/Identifier/i);
-    fireEvent.change(identifierInput, {target: {value: 'https://new-api.example.com'}});
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: /Save/i})).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByRole('button', {name: /Save/i}));
-
-    expect(mockUpdateMutate).toHaveBeenCalledWith(
-      {
-        id: 'rs-1',
-        data: {
-          name: 'Test API',
-          description: 'Existing API description',
-          identifier: 'https://new-api.example.com',
-          ouId: 'ou-1',
-        },
-      },
-      expect.any(Object),
+  it('renders the identifier label as a top FormLabel, not a floating label', () => {
+    renderWithProviders(
+      <AdvancedTab
+        resourceServer={mockResourceServer}
+        identifier={mockResourceServer.identifier ?? ''}
+        onIdentifierChange={vi.fn()}
+      />,
     );
+
+    const label = screen.getByText('Identifier (Audience)');
+    expect(label.tagName.toLowerCase()).toBe('label');
+    expect(label).toHaveClass('MuiFormLabel-root');
   });
 
-  it('resets the identifier to the original value when Discard is clicked', async () => {
-    renderWithProviders(<AdvancedTab resourceServer={mockResourceServer} onRefresh={vi.fn()} />);
+  it('calls onIdentifierChange when the identifier field is edited', () => {
+    const onIdentifierChange = vi.fn();
+    renderWithProviders(
+      <AdvancedTab
+        resourceServer={mockResourceServer}
+        identifier={mockResourceServer.identifier ?? ''}
+        onIdentifierChange={onIdentifierChange}
+      />,
+    );
 
     const identifierInput = screen.getByLabelText(/Identifier/i);
     fireEvent.change(identifierInput, {target: {value: 'https://new-api.example.com'}});
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', {name: /Discard/i})).toBeInTheDocument();
-    });
+    expect(onIdentifierChange).toHaveBeenCalledWith('https://new-api.example.com');
+  });
 
-    fireEvent.click(screen.getByRole('button', {name: /Discard/i}));
+  it('reflects the identifier prop value in the field', () => {
+    renderWithProviders(
+      <AdvancedTab
+        resourceServer={mockResourceServer}
+        identifier="https://controlled.example.com"
+        onIdentifierChange={vi.fn()}
+      />,
+    );
 
-    expect(identifierInput).toHaveValue('https://api.example.com');
+    expect(screen.getByLabelText(/Identifier/i)).toHaveValue('https://controlled.example.com');
   });
 
   it('disables the identifier field for read-only resource servers', () => {
-    renderWithProviders(<AdvancedTab resourceServer={readOnlyResourceServer} onRefresh={vi.fn()} />);
+    renderWithProviders(
+      <AdvancedTab
+        resourceServer={readOnlyResourceServer}
+        identifier={readOnlyResourceServer.identifier ?? ''}
+        onIdentifierChange={vi.fn()}
+      />,
+    );
 
     expect(screen.getByLabelText(/Identifier/i)).toBeDisabled();
+  });
+
+  it('does not render inline Save or Discard buttons', () => {
+    renderWithProviders(
+      <AdvancedTab
+        resourceServer={mockResourceServer}
+        identifier={mockResourceServer.identifier ?? ''}
+        onIdentifierChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', {name: /Save/i})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /Discard/i})).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/AddNodeDialog.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/AddNodeDialog.tsx
@@ -35,20 +35,63 @@ import {type JSX, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import useCreateAction from '../../api/useCreateAction';
 import useCreateResource from '../../api/useCreateResource';
+import type {ActionKind} from '../../models/resource-server';
 import {deriveHandle} from '../../utils/deriveHandle';
 
-export type AddNodeMode = 'resource' | 'sub-resource' | 'server-action' | 'resource-action';
+export type AddNodeMode =
+  | 'resource'
+  | 'sub-resource'
+  | 'server-action'
+  | 'resource-action'
+  | 'mcp-server-tool'
+  | 'mcp-server-resource'
+  | 'mcp-namespace'
+  | 'mcp-namespace-tool'
+  | 'mcp-namespace-resource'
+  | 'mcp-sub-namespace';
 
 export interface AddNodeDialogProps {
+  /** Whether the dialog is open. */
   open: boolean;
+  /** The mode that determines what kind of node to create. */
   mode: AddNodeMode;
+  /** The ID of the resource server. */
   resourceServerId: string;
+  /** The ID of the parent resource (for in-namespace creates). */
   parentResourceId?: string;
+  /** The permission prefix used to derive the full permission string preview. */
   parentPermission: string;
+  /** The permission delimiter character. */
   delimiter: string;
+  /** Called when the dialog is closed without submitting. */
   onClose: () => void;
+  /** Called after a successful create. */
   onSuccess: () => void;
 }
+
+interface ModeConfig {
+  /** The action kind to send when creating an action, or undefined for resource/namespace modes. */
+  kind: ActionKind | undefined;
+  /** Whether this mode creates an action (vs. a resource/namespace). */
+  isAction: boolean;
+  /** Whether this mode nests the new node under `parentResourceId`. */
+  usesParentResourceId: boolean;
+  /** Whether this mode creates a sub-namespace under `parentResourceId`. */
+  isSubNamespace: boolean;
+}
+
+const MODE_CONFIG: Record<AddNodeMode, ModeConfig> = {
+  resource: {kind: undefined, isAction: false, usesParentResourceId: false, isSubNamespace: false},
+  'sub-resource': {kind: undefined, isAction: false, usesParentResourceId: false, isSubNamespace: false},
+  'server-action': {kind: undefined, isAction: true, usesParentResourceId: false, isSubNamespace: false},
+  'resource-action': {kind: undefined, isAction: true, usesParentResourceId: true, isSubNamespace: false},
+  'mcp-server-tool': {kind: 'tool', isAction: true, usesParentResourceId: false, isSubNamespace: false},
+  'mcp-server-resource': {kind: 'resource', isAction: true, usesParentResourceId: false, isSubNamespace: false},
+  'mcp-namespace': {kind: undefined, isAction: false, usesParentResourceId: false, isSubNamespace: false},
+  'mcp-namespace-tool': {kind: 'tool', isAction: true, usesParentResourceId: true, isSubNamespace: false},
+  'mcp-namespace-resource': {kind: 'resource', isAction: true, usesParentResourceId: true, isSubNamespace: false},
+  'mcp-sub-namespace': {kind: undefined, isAction: false, usesParentResourceId: false, isSubNamespace: true},
+};
 
 export default function AddNodeDialog({
   open,
@@ -69,8 +112,11 @@ export default function AddNodeDialog({
   const [description, setDescription] = useState('');
   const [handleEdited, setHandleEdited] = useState(false);
 
-  const isAction = mode === 'server-action' || mode === 'resource-action';
-  const resourceId = mode === 'resource-action' ? parentResourceId : undefined;
+  const isAction = MODE_CONFIG[mode].isAction;
+  const resourceId = MODE_CONFIG[mode].usesParentResourceId ? parentResourceId : undefined;
+  const kind = MODE_CONFIG[mode].kind;
+
+  const subNamespaceParent = MODE_CONFIG[mode].isSubNamespace ? parentResourceId : undefined;
 
   const createResource = useCreateResource(resourceServerId);
   const createAction = useCreateAction(resourceServerId, resourceId);
@@ -87,40 +133,93 @@ export default function AddNodeDialog({
     onClose();
   };
 
+  const resolveSuccessToast = (): string => {
+    if (mode === 'mcp-server-tool' || mode === 'mcp-namespace-tool') {
+      return t('resourceServers:mcp.addTool.success', 'Tool added.');
+    }
+    if (mode === 'mcp-server-resource' || mode === 'mcp-namespace-resource') {
+      return t('resourceServers:mcp.addResource.success', 'Resource added.');
+    }
+    if (mode === 'mcp-namespace' || mode === 'mcp-sub-namespace') {
+      return t('resourceServers:mcp.addNamespace.success', 'Namespace added.');
+    }
+    if (isAction) {
+      return t('resourceServers:tree.addAction.success', 'Action added.');
+    }
+    return t('resourceServers:tree.addResource.success', 'Resource added.');
+  };
+
+  const resolveErrorToast = (): string => {
+    if (mode === 'mcp-server-tool' || mode === 'mcp-namespace-tool') {
+      return t('resourceServers:mcp.addTool.error', 'Failed to add tool.');
+    }
+    if (mode === 'mcp-server-resource' || mode === 'mcp-namespace-resource') {
+      return t('resourceServers:mcp.addResource.error', 'Failed to add resource.');
+    }
+    if (mode === 'mcp-namespace' || mode === 'mcp-sub-namespace') {
+      return t('resourceServers:mcp.addNamespace.error', 'Failed to add namespace.');
+    }
+    if (isAction) {
+      return t('resourceServers:tree.addAction.error', 'Failed to add action.');
+    }
+    return t('resourceServers:tree.addResource.error', 'Failed to add resource.');
+  };
+
+  const resolveNamePlaceholder = (): string => {
+    if (kind === 'tool') return t('resourceServers:tree.fields.namePlaceholder.tool', 'e.g. Send message');
+    if (kind === 'resource') return t('resourceServers:tree.fields.namePlaceholder.resource', 'e.g. User profile');
+    if (mode === 'mcp-namespace' || mode === 'mcp-sub-namespace') {
+      return t('resourceServers:tree.fields.namePlaceholder.namespace', 'e.g. Messaging');
+    }
+    if (isAction) return t('resourceServers:tree.fields.namePlaceholder.action', 'e.g. Read');
+    return t('resourceServers:tree.fields.namePlaceholder.resourceGeneric', 'e.g. Orders');
+  };
+
+  const resolveHandlePlaceholder = (): string => {
+    if (kind === 'tool') return t('resourceServers:tree.fields.handlePlaceholder.tool', 'e.g. send-message');
+    if (kind === 'resource') return t('resourceServers:tree.fields.handlePlaceholder.resource', 'e.g. user-profile');
+    if (mode === 'mcp-namespace' || mode === 'mcp-sub-namespace') {
+      return t('resourceServers:tree.fields.handlePlaceholder.namespace', 'e.g. messaging');
+    }
+    if (isAction) return t('resourceServers:tree.fields.handlePlaceholder.action', 'e.g. read');
+    return t('resourceServers:tree.fields.handlePlaceholder.resourceGeneric', 'e.g. orders');
+  };
+
   const handleSubmit = (): void => {
     const trimmedName = name.trim();
     const trimmedHandle = handle.trim();
     if (!trimmedName || !trimmedHandle) return;
 
-    const data = {name: trimmedName, handle: trimmedHandle, description: description.trim() || undefined};
+    const baseData = {name: trimmedName, handle: trimmedHandle, description: description.trim() || undefined};
 
     if (isAction) {
-      createAction.mutate(data, {
-        onSuccess: () => {
-          showToast(t('resourceServers:tree.addAction.success', 'Action added.'), 'success');
-          handleClose();
-          onSuccess();
-        },
-        onError: (err: Error) => {
-          logger.error('Failed to create action', {error: err});
-          showToast(t('resourceServers:tree.addAction.error', 'Failed to add action.'), 'error');
-        },
-      });
-    } else {
-      createResource.mutate(
-        {
-          ...data,
-          parent: mode === 'sub-resource' ? parentResourceId : undefined,
-        },
+      createAction.mutate(
+        {...baseData, kind},
         {
           onSuccess: () => {
-            showToast(t('resourceServers:tree.addResource.success', 'Resource added.'), 'success');
+            showToast(resolveSuccessToast(), 'success');
+            handleClose();
+            onSuccess();
+          },
+          onError: (err: Error) => {
+            logger.error('Failed to create action', {error: err});
+            showToast(resolveErrorToast(), 'error');
+          },
+        },
+      );
+    } else {
+      const parent = mode === 'sub-resource' ? parentResourceId : subNamespaceParent;
+      createResource.mutate(
+        {...baseData, parent},
+        {
+          onSuccess: () => {
+            showToast(resolveSuccessToast(), 'success');
             handleClose();
             onSuccess();
           },
           onError: (err: Error) => {
             logger.error('Failed to create resource', {error: err});
-            showToast(t('resourceServers:tree.addResource.error', 'Failed to add resource.'), 'error');
+            showToast(resolveErrorToast(), 'error');
           },
         },
       );
@@ -132,6 +231,12 @@ export default function AddNodeDialog({
     'sub-resource': t('resourceServers:tree.addSubResource.title', 'Add Sub-resource'),
     'server-action': t('resourceServers:tree.addAction.title', 'Add Action'),
     'resource-action': t('resourceServers:tree.addAction.title', 'Add Action'),
+    'mcp-server-tool': t('resourceServers:mcp.addTool.title', 'Add Tool'),
+    'mcp-namespace-tool': t('resourceServers:mcp.addTool.title', 'Add Tool'),
+    'mcp-server-resource': t('resourceServers:mcp.addResource.title', 'Add Resource'),
+    'mcp-namespace-resource': t('resourceServers:mcp.addResource.title', 'Add Resource'),
+    'mcp-namespace': t('resourceServers:mcp.addNamespace.title', 'Add Namespace'),
+    'mcp-sub-namespace': t('resourceServers:mcp.addNamespace.title', 'Add Namespace'),
   };
 
   const isPending = createResource.isPending || createAction.isPending;
@@ -155,6 +260,7 @@ export default function AddNodeDialog({
               }}
               fullWidth
               size="small"
+              placeholder={resolveNamePlaceholder()}
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus
             />
@@ -170,6 +276,7 @@ export default function AddNodeDialog({
               }}
               fullWidth
               size="small"
+              placeholder={resolveHandlePlaceholder()}
               error={handleContainsDelimiter}
               helperText={
                 handleContainsDelimiter
@@ -193,6 +300,10 @@ export default function AddNodeDialog({
               size="small"
               multiline
               rows={2}
+              placeholder={t(
+                'resourceServers:tree.fields.descriptionPlaceholder',
+                'e.g. Optional. Describe what this is for.',
+              )}
             />
           </FormControl>
 

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/McpCapabilitiesPanel.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/McpCapabilitiesPanel.tsx
@@ -18,6 +18,7 @@
 
 import {
   Box,
+  Chip,
   CircularProgress,
   IconButton,
   ListItemIcon,
@@ -25,37 +26,26 @@ import {
   Menu,
   MenuItem,
   Paper,
+  Stack,
   Typography,
 } from '@wso2/oxygen-ui';
-import {Layers, Plus, Zap} from '@wso2/oxygen-ui-icons-react';
+import {Database, Folder, Plus, Wrench} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import AddNodeDialog, {type AddNodeMode} from './AddNodeDialog';
-import McpCapabilitiesPanel from './McpCapabilitiesPanel';
 import ResourceDetailPanel from './ResourceDetailPanel';
+import type {KindFilter, SelectedNode} from './ResourceTree';
 import {ActionNode, ResourceNode} from './ResourceTreeNode';
 import useGetResources from '../../api/useGetResources';
 import useGetServerActions from '../../api/useGetServerActions';
-import type {Action, Resource, ResourceServer} from '../../models/resource-server';
+import type {ResourceServer} from '../../models/resource-server';
 
-export type KindFilter = 'all' | 'tool' | 'resource';
-
-export type SelectedNode =
-  | {type: 'server'; id: string; data: ResourceServer}
-  | {type: 'resource'; id: string; data: Resource; breadcrumb?: string[]}
-  | {type: 'server-action'; id: string; data: Action; parentResourceId?: string; breadcrumb?: string[]}
-  | {type: 'resource-action'; id: string; data: Action; parentResourceId?: string; breadcrumb?: string[]};
-
-interface ResourceTreeProps {
+interface McpCapabilitiesPanelProps {
   resourceServer: ResourceServer;
   onRefresh: () => void;
 }
 
-/* -------------------------------------------------------------------------- */
-/*  Generic Resource Tree (API / CUSTOM — unchanged)                           */
-/* -------------------------------------------------------------------------- */
-
-function GenericResourceTree({resourceServer, onRefresh}: ResourceTreeProps): JSX.Element {
+export default function McpCapabilitiesPanel({resourceServer, onRefresh}: McpCapabilitiesPanelProps): JSX.Element {
   const {t} = useTranslation();
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
   const [addDialog, setAddDialog] = useState<{
@@ -64,12 +54,16 @@ function GenericResourceTree({resourceServer, onRefresh}: ResourceTreeProps): JS
     parentPermission: string;
   } | null>(null);
   const [addMenuAnchor, setAddMenuAnchor] = useState<HTMLElement | null>(null);
+  const [kindFilter, setKindFilter] = useState<KindFilter>('all');
 
   const {data: topLevelResources, isLoading: loadingResources} = useGetResources(resourceServer.id);
   const {data: serverActionsData, isLoading: loadingActions} = useGetServerActions(resourceServer.id);
 
-  const resources = useMemo(() => topLevelResources?.resources ?? [], [topLevelResources]);
+  const namespaces = useMemo(() => topLevelResources?.resources ?? [], [topLevelResources]);
   const serverActions = useMemo(() => serverActionsData?.actions ?? [], [serverActionsData]);
+
+  const serverTools = useMemo(() => serverActions.filter((a) => a.kind === 'tool'), [serverActions]);
+  const serverResources = useMemo(() => serverActions.filter((a) => a.kind === 'resource'), [serverActions]);
 
   const openAdd = (mode: AddNodeMode, parentResourceId?: string, parentPermission?: string): void => {
     setAddDialog({
@@ -80,18 +74,29 @@ function GenericResourceTree({resourceServer, onRefresh}: ResourceTreeProps): JS
   };
 
   const isLoading = loadingResources || loadingActions;
-  const isEmpty = resources.length === 0 && serverActions.length === 0;
+  const isEmpty = serverActions.length === 0 && namespaces.length === 0;
 
   const effectiveSelectedNode = useMemo<SelectedNode | null>(() => {
     if (selectedNode) return selectedNode;
-    if (serverActions.length > 0) return {type: 'server-action', id: serverActions[0].id, data: serverActions[0]};
-    if (resources.length > 0) return {type: 'resource', id: resources[0].id, data: resources[0]};
+    if (serverTools.length > 0) return {type: 'server-action', id: serverTools[0].id, data: serverTools[0]};
+    if (serverResources.length > 0) return {type: 'server-action', id: serverResources[0].id, data: serverResources[0]};
+    if (namespaces.length > 0) return {type: 'resource', id: namespaces[0].id, data: namespaces[0]};
     return null;
-  }, [selectedNode, serverActions, resources]);
+  }, [selectedNode, serverTools, serverResources, namespaces]);
+
+  const filteredServerActions = useMemo(
+    () =>
+      serverActions.filter((a) => {
+        if (kindFilter === 'tool') return a.kind === 'tool';
+        if (kindFilter === 'resource') return a.kind === 'resource';
+        return true;
+      }),
+    [serverActions, kindFilter],
+  );
 
   return (
     <Box sx={{display: 'flex', gap: 2, height: '100%'}}>
-      {/* Left: Tree */}
+      {/* Left: Capabilities panel */}
       <Paper
         variant="outlined"
         sx={{
@@ -102,6 +107,7 @@ function GenericResourceTree({resourceServer, onRefresh}: ResourceTreeProps): JS
           overflow: 'hidden',
         }}
       >
+        {/* Panel header */}
         <Box
           sx={{
             px: 1.5,
@@ -119,50 +125,129 @@ function GenericResourceTree({resourceServer, onRefresh}: ResourceTreeProps): JS
             color="text.secondary"
             sx={{textTransform: 'uppercase', letterSpacing: 0.5, fontWeight: 600}}
           >
-            {t('resourceServers:tree.title', 'Resource Hierarchy')}
+            {t('resourceServers:mcp.panel.title', 'Capabilities')}
           </Typography>
           <IconButton
             size="small"
+            aria-label={t('resourceServers:mcp.add', 'Add')}
             onClick={(e) => setAddMenuAnchor(e.currentTarget)}
-            aria-label={t('resourceServers:tree.add', 'Add')}
           >
             <Plus size={16} />
           </IconButton>
           <Menu anchorEl={addMenuAnchor} open={Boolean(addMenuAnchor)} onClose={() => setAddMenuAnchor(null)}>
             <MenuItem
               onClick={() => {
-                openAdd('resource');
+                openAdd('mcp-server-tool');
                 setAddMenuAnchor(null);
               }}
             >
               <ListItemIcon>
-                <Layers size={16} />
+                <Wrench size={16} />
               </ListItemIcon>
-              <ListItemText>{t('resourceServers:tree.addResource', 'Add resource')}</ListItemText>
+              <ListItemText>{t('resourceServers:mcp.addTool', 'Add tool')}</ListItemText>
             </MenuItem>
             <MenuItem
               onClick={() => {
-                openAdd('server-action');
+                openAdd('mcp-server-resource');
                 setAddMenuAnchor(null);
               }}
             >
               <ListItemIcon>
-                <Zap size={16} />
+                <Database size={16} />
               </ListItemIcon>
-              <ListItemText>{t('resourceServers:tree.addAction', 'Add action')}</ListItemText>
+              <ListItemText>{t('resourceServers:mcp.addResource', 'Add resource')}</ListItemText>
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                openAdd('mcp-namespace');
+                setAddMenuAnchor(null);
+              }}
+            >
+              <ListItemIcon>
+                <Folder size={16} />
+              </ListItemIcon>
+              <ListItemText>{t('resourceServers:mcp.addNamespace', 'Add namespace')}</ListItemText>
             </MenuItem>
           </Menu>
         </Box>
 
-        <Box sx={{flex: 1, overflowY: 'auto', p: 0.5, height: '100%'}}>
+        {/* Toolbar: filter chips */}
+        <Box sx={{px: 1.5, py: 1, borderBottom: '1px solid', borderColor: 'divider'}}>
+          <Stack
+            direction="row"
+            flexWrap="wrap"
+            useFlexGap
+            gap={0.75}
+            role="radiogroup"
+            aria-label={t('resourceServers:mcp.filter.label', 'Filter capabilities')}
+          >
+            <Chip
+              label={t('resourceServers:mcp.filter.all', 'All')}
+              size="small"
+              color={kindFilter === 'all' ? 'primary' : 'default'}
+              variant={kindFilter === 'all' ? 'filled' : 'outlined'}
+              onClick={() => setKindFilter('all')}
+              role="radio"
+              aria-checked={kindFilter === 'all'}
+              disabled={isLoading}
+              sx={{cursor: 'pointer'}}
+            />
+            <Chip
+              label={t('resourceServers:mcp.filter.tools', 'Tools')}
+              size="small"
+              color={kindFilter === 'tool' ? 'primary' : 'default'}
+              variant={kindFilter === 'tool' ? 'filled' : 'outlined'}
+              onClick={() => setKindFilter('tool')}
+              role="radio"
+              aria-checked={kindFilter === 'tool'}
+              disabled={isLoading}
+              sx={{cursor: 'pointer'}}
+            />
+            <Chip
+              label={t('resourceServers:mcp.filter.resources', 'Resources')}
+              size="small"
+              color={kindFilter === 'resource' ? 'primary' : 'default'}
+              variant={kindFilter === 'resource' ? 'filled' : 'outlined'}
+              onClick={() => setKindFilter('resource')}
+              role="radio"
+              aria-checked={kindFilter === 'resource'}
+              disabled={isLoading}
+              sx={{cursor: 'pointer'}}
+            />
+          </Stack>
+        </Box>
+
+        {/* Scroll body */}
+        <Box role="tree" sx={{flex: 1, overflowY: 'auto', height: '100%', pt: 1}}>
           {isLoading ? (
             <Box sx={{display: 'flex', justifyContent: 'center', py: 4}}>
               <CircularProgress size={24} />
             </Box>
+          ) : isEmpty ? (
+            <Box sx={{px: 2, py: 2}}>
+              <Typography variant="body2" color="text.disabled" sx={{textAlign: 'center'}}>
+                {t('resourceServers:mcp.empty', 'No capabilities yet. Use + to add a tool, resource, or namespace.')}
+              </Typography>
+            </Box>
           ) : (
             <>
-              {/* Server-level actions */}
-              {serverActions.map((action) => (
+              {namespaces.map((ns) => (
+                <ResourceNode
+                  key={ns.id}
+                  resourceServerId={resourceServer.id}
+                  delimiter={resourceServer.delimiter}
+                  node={ns}
+                  depth={0}
+                  selectedNodeId={effectiveSelectedNode?.id ?? null}
+                  onSelect={setSelectedNode}
+                  onAddChild={(mode, parentResourceId, parentPermission) =>
+                    openAdd(mode, parentResourceId, parentPermission)
+                  }
+                  isMcp
+                  kindFilter={kindFilter}
+                />
+              ))}
+              {filteredServerActions.map((action) => (
                 <ActionNode
                   key={action.id}
                   resourceServerId={resourceServer.id}
@@ -172,39 +257,6 @@ function GenericResourceTree({resourceServer, onRefresh}: ResourceTreeProps): JS
                   onSelect={setSelectedNode}
                 />
               ))}
-
-              {/* Top-level resources */}
-              {resources.map((resource) => (
-                <ResourceNode
-                  key={resource.id}
-                  resourceServerId={resourceServer.id}
-                  delimiter={resourceServer.delimiter}
-                  node={resource}
-                  depth={0}
-                  selectedNodeId={effectiveSelectedNode?.id ?? null}
-                  onSelect={setSelectedNode}
-                  onAddChild={(mode, parentResourceId, parentPermission) =>
-                    openAdd(mode, parentResourceId, parentPermission)
-                  }
-                />
-              ))}
-
-              {isEmpty && (
-                <Box
-                  sx={{
-                    height: '100%',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    px: 2,
-                    textAlign: 'center',
-                  }}
-                >
-                  <Typography variant="body2" color="text.disabled">
-                    {t('resourceServers:tree.empty', 'No resources yet — add a resource or action to get started.')}
-                  </Typography>
-                </Box>
-              )}
             </>
           )}
         </Box>
@@ -233,15 +285,4 @@ function GenericResourceTree({resourceServer, onRefresh}: ResourceTreeProps): JS
       )}
     </Box>
   );
-}
-
-/* -------------------------------------------------------------------------- */
-/*  Root component — branches on type                                          */
-/* -------------------------------------------------------------------------- */
-
-export default function ResourceTree({resourceServer, onRefresh}: ResourceTreeProps): JSX.Element {
-  if (resourceServer.type === 'MCP') {
-    return <McpCapabilitiesPanel resourceServer={resourceServer} onRefresh={onRefresh} />;
-  }
-  return <GenericResourceTree resourceServer={resourceServer} onRefresh={onRefresh} />;
 }

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/ResourceDetailPanel.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/ResourceDetailPanel.tsx
@@ -27,6 +27,7 @@ import {
   FormControl,
   FormLabel,
   IconButton,
+  InputAdornment,
   Stack,
   TextField,
   Tooltip,
@@ -39,6 +40,8 @@ import type {SelectedNode} from './ResourceTree';
 import useUpdateAction from '../../api/useUpdateAction';
 import useUpdateResource from '../../api/useUpdateResource';
 import useUpdateResourceServer from '../../api/useUpdateResourceServer';
+import {getActionKindIcon} from '../../config/get-action-kind-icon';
+import {getActionKindLabel} from '../../config/get-action-kind-label';
 import type {ResourceServer} from '../../models/resource-server';
 
 interface ResourceDetailPanelProps {
@@ -73,6 +76,7 @@ function DetailForm({selectedNode, resourceServer, onRefresh}: DetailFormProps):
   const [description, setDescription] = useState(initial.description);
   const [identifier, setIdentifier] = useState(initial.identifier);
   const [dirty, setDirty] = useState(false);
+  const [copiedPermission, setCopiedPermission] = useState(false);
 
   const updateRs = useUpdateResourceServer();
   const updateResource = useUpdateResource(resourceServer.id);
@@ -148,7 +152,6 @@ function DetailForm({selectedNode, resourceServer, onRefresh}: DetailFormProps):
     updateRs.isPending || updateResource.isPending || updateServerAction.isPending || updateResourceAction.isPending;
 
   const permission = selectedNode.type === 'server' ? selectedNode.data.handle : selectedNode.data.permission;
-  const [copiedPermission, setCopiedPermission] = useState(false);
 
   const handleCopyPermission = (): void => {
     navigator.clipboard
@@ -160,11 +163,15 @@ function DetailForm({selectedNode, resourceServer, onRefresh}: DetailFormProps):
       .catch((err: unknown) => logger.error('Failed to copy permission', {error: err}));
   };
 
-  const nodeTypeLabel: Record<SelectedNode['type'], string> = {
-    server: t('resourceServers:detail.types.resourceServer', 'Resource Server'),
-    resource: t('resourceServers:detail.types.resource', 'Resource'),
-    'server-action': t('resourceServers:detail.types.action', 'Action'),
-    'resource-action': t('resourceServers:detail.types.action', 'Action'),
+  const resolveNodeTypeLabel = (): string => {
+    if (selectedNode.type === 'server') return t('resourceServers:detail.types.resourceServer', 'Resource Server');
+    if (selectedNode.type === 'resource') {
+      if (resourceServer.type === 'MCP') return getActionKindLabel(undefined, t);
+      return t('resourceServers:detail.types.resource', 'Resource');
+    }
+    const action = selectedNode.data;
+    if (action.kind) return getActionKindLabel(action.kind, t);
+    return t('resourceServers:detail.types.action', 'Action');
   };
 
   const handleField = (setter: (v: string) => void) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -172,11 +179,47 @@ function DetailForm({selectedNode, resourceServer, onRefresh}: DetailFormProps):
     setDirty(true);
   };
 
+  const isMcpNonServer = resourceServer.type === 'MCP' && selectedNode.type !== 'server';
+
+  const resolveMcpKindLabel = (): string => {
+    if (selectedNode.type === 'server') return '';
+
+    if (selectedNode.type === 'resource') {
+      return t('resourceServers:mcp.types.namespace', 'Namespace');
+    }
+
+    const action = selectedNode.data;
+    if (action.kind === 'tool') {
+      return t('resourceServers:mcp.types.tool', 'Tool');
+    }
+    if (action.kind === 'resource') {
+      return t('resourceServers:mcp.types.resource', 'Resource');
+    }
+    return '';
+  };
+
+  const kindNoun = resolveMcpKindLabel().toLowerCase() || 'item';
+
   return (
     <Box sx={{display: 'flex', flexDirection: 'column', gap: 2, p: 2, height: '100%', overflowY: 'auto'}}>
-      <Typography variant="caption" color="text.secondary" sx={{textTransform: 'uppercase', letterSpacing: 0.5}}>
-        {nodeTypeLabel[selectedNode.type]}
-      </Typography>
+      {/* MCP non-server: Quick-Copy-style header (name + kind subtitle) */}
+      {isMcpNonServer ? (
+        <Stack spacing={0}>
+          <Typography variant="h5">{name}</Typography>
+          {resolveMcpKindLabel() && (
+            <Stack direction="row" alignItems="center" spacing={0.5} sx={{mt: 0.5, color: 'text.disabled'}}>
+              {getActionKindIcon(selectedNode.type === 'resource' ? undefined : selectedNode.data.kind, 14)}
+              <Typography variant="body2" color="inherit">
+                {resolveMcpKindLabel()}
+              </Typography>
+            </Stack>
+          )}
+        </Stack>
+      ) : (
+        <Typography variant="caption" color="text.secondary" sx={{textTransform: 'uppercase', letterSpacing: 0.5}}>
+          {resolveNodeTypeLabel()}
+        </Typography>
+      )}
 
       {isReadOnly && (
         <Alert severity="info">
@@ -187,8 +230,63 @@ function DetailForm({selectedNode, resourceServer, onRefresh}: DetailFormProps):
       <Stack spacing={2}>
         <FormControl fullWidth>
           <FormLabel>{t('resourceServers:detail.fields.name', 'Name')}</FormLabel>
-          <TextField value={name} onChange={handleField(setName)} fullWidth size="small" disabled={isReadOnly} />
+          <TextField
+            value={name}
+            onChange={handleField(setName)}
+            fullWidth
+            size="small"
+            disabled={isReadOnly}
+            helperText={
+              isMcpNonServer
+                ? t('resourceServers:mcp.detail.nameHint', 'A human-readable name for this {{kind}}.', {
+                    kind: kindNoun,
+                  })
+                : undefined
+            }
+          />
         </FormControl>
+
+        {isMcpNonServer && (
+          <>
+            <FormControl fullWidth>
+              <FormLabel htmlFor="mcp-detail-handle">
+                {t('resourceServers:detail.fields.handle', 'Handle (immutable)')}
+              </FormLabel>
+              <TextField
+                fullWidth
+                id="mcp-detail-handle"
+                value={selectedNode.data.handle}
+                InputProps={{readOnly: true}}
+                size="small"
+                helperText={t(
+                  'resourceServers:mcp.detail.handleHint',
+                  'Stable identifier for this {{kind}}, used to build the permission scope.',
+                  {kind: kindNoun},
+                )}
+                sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+              />
+            </FormControl>
+
+            <FormControl fullWidth>
+              <FormLabel htmlFor="mcp-detail-delimiter">
+                {t('resourceServers:detail.fields.delimiter', 'Delimiter (immutable)')}
+              </FormLabel>
+              <TextField
+                fullWidth
+                id="mcp-detail-delimiter"
+                value={resourceServer.delimiter}
+                InputProps={{readOnly: true}}
+                size="small"
+                helperText={t(
+                  'resourceServers:mcp.detail.delimiterHint',
+                  'Separates segments in the permission scope. Defined by the resource server.',
+                )}
+                sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
+              />
+            </FormControl>
+          </>
+        )}
+
         <FormControl fullWidth>
           <FormLabel>{t('resourceServers:detail.fields.description', 'Description')}</FormLabel>
           <TextField
@@ -199,67 +297,116 @@ function DetailForm({selectedNode, resourceServer, onRefresh}: DetailFormProps):
             multiline
             rows={3}
             disabled={isReadOnly}
+            helperText={
+              isMcpNonServer
+                ? t('resourceServers:mcp.detail.descriptionHint', 'Optional. Describe what this {{kind}} is for.', {
+                    kind: kindNoun,
+                  })
+                : undefined
+            }
           />
         </FormControl>
       </Stack>
 
       <Divider />
 
-      <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
-        <Typography variant="body2" color="text.secondary">
-          {t('resourceServers:detail.permission', 'Permission')}
-        </Typography>
-        <Chip label={permission} size="small" variant="outlined" sx={{fontFamily: 'monospace', fontSize: '0.78rem'}} />
-        <Tooltip title={copiedPermission ? t('common:copied', 'Copied!') : t('common:copy', 'Copy permission')}>
-          <IconButton size="small" sx={{p: 0.25}} onClick={handleCopyPermission}>
-            {copiedPermission ? <Check size={14} /> : <Copy size={14} />}
-          </IconButton>
-        </Tooltip>
-      </Box>
-
-      <Box>
-        <Typography variant="caption" color="text.secondary">
-          {t('resourceServers:detail.fields.handle', 'Handle (immutable)')}
-        </Typography>
-        <Box>
-          <Chip
-            label={selectedNode.data.handle}
-            size="small"
-            sx={{fontFamily: 'monospace', fontSize: '0.75rem', mt: 0.5}}
-          />
-        </Box>
-      </Box>
-
-      {selectedNode.type === 'server' && (
-        <Box>
-          <Typography variant="caption" color="text.secondary">
-            {t('resourceServers:detail.fields.delimiter', 'Delimiter (immutable)')}
-          </Typography>
-          <Box>
-            <Chip
-              label={selectedNode.data.delimiter}
-              size="small"
-              sx={{fontFamily: 'monospace', fontSize: '0.75rem', mt: 0.5}}
-            />
-          </Box>
-        </Box>
-      )}
-
-      {selectedNode.type === 'server' && (
+      {/* MCP non-server: read-only Permission field */}
+      {isMcpNonServer ? (
         <FormControl fullWidth>
-          <FormLabel>{t('resourceServers:detail.fields.identifier', 'Identifier')}</FormLabel>
+          <FormLabel htmlFor="mcp-detail-permission">{t('resourceServers:detail.permission', 'Permission')}</FormLabel>
           <TextField
-            value={identifier}
-            onChange={handleField(setIdentifier)}
             fullWidth
+            id="mcp-detail-permission"
+            value={permission}
+            InputProps={{
+              readOnly: true,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip title={copiedPermission ? t('common:copied', 'Copied!') : t('common:copy', 'Copy')}>
+                    <IconButton
+                      edge="end"
+                      size="small"
+                      onClick={handleCopyPermission}
+                      aria-label={t('common:copy', 'Copy')}
+                    >
+                      {copiedPermission ? <Check size={16} /> : <Copy size={16} />}
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            }}
             size="small"
             helperText={t(
-              'resourceServers:detail.fields.identifierHint',
-              'Used as audience parameter in OAuth2 flows.',
+              'resourceServers:mcp.detail.permissionScopeHelp',
+              'Built from the resource server handle, the resource path, and the name, joined by the delimiter.',
             )}
-            disabled={isReadOnly}
+            sx={{'& input': {fontFamily: 'monospace', fontSize: '0.875rem'}}}
           />
         </FormControl>
+      ) : (
+        <>
+          <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
+            <Typography variant="body2" color="text.secondary">
+              {t('resourceServers:detail.permission', 'Permission')}
+            </Typography>
+            <Chip
+              label={permission}
+              size="small"
+              variant="outlined"
+              sx={{fontFamily: 'monospace', fontSize: '0.78rem'}}
+            />
+            <Tooltip title={copiedPermission ? t('common:copied', 'Copied!') : t('common:copy', 'Copy permission')}>
+              <IconButton size="small" sx={{p: 0.25}} onClick={handleCopyPermission}>
+                {copiedPermission ? <Check size={14} /> : <Copy size={14} />}
+              </IconButton>
+            </Tooltip>
+          </Box>
+
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              {t('resourceServers:detail.fields.handle', 'Handle (immutable)')}
+            </Typography>
+            <Box>
+              <Chip
+                label={selectedNode.data.handle}
+                size="small"
+                sx={{fontFamily: 'monospace', fontSize: '0.75rem', mt: 0.5}}
+              />
+            </Box>
+          </Box>
+
+          {selectedNode.type === 'server' && (
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                {t('resourceServers:detail.fields.delimiter', 'Delimiter (immutable)')}
+              </Typography>
+              <Box>
+                <Chip
+                  label={selectedNode.data.delimiter}
+                  size="small"
+                  sx={{fontFamily: 'monospace', fontSize: '0.75rem', mt: 0.5}}
+                />
+              </Box>
+            </Box>
+          )}
+
+          {selectedNode.type === 'server' && (
+            <FormControl fullWidth>
+              <FormLabel>{t('resourceServers:detail.fields.identifier', 'Identifier')}</FormLabel>
+              <TextField
+                value={identifier}
+                onChange={handleField(setIdentifier)}
+                fullWidth
+                size="small"
+                helperText={t(
+                  'resourceServers:detail.fields.identifierHint',
+                  'Used as audience parameter in OAuth2 flows.',
+                )}
+                disabled={isReadOnly}
+              />
+            </FormControl>
+          )}
+        </>
       )}
 
       {!isReadOnly && dirty && (

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/ResourceTreeNode.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/ResourceTreeNode.tsx
@@ -30,15 +30,29 @@ import {
   Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
-import {Check, ChevronDown, ChevronRight, Copy, Layers, Plus, Trash2, Zap} from '@wso2/oxygen-ui-icons-react';
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  Database,
+  Folder,
+  FolderOpen,
+  Layers,
+  Plus,
+  Trash2,
+  Wrench,
+  Zap,
+} from '@wso2/oxygen-ui-icons-react';
 import {useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {AddNodeMode} from './AddNodeDialog';
-import type {SelectedNode} from './ResourceTree';
+import type {KindFilter, SelectedNode} from './ResourceTree';
 import useDeleteAction from '../../api/useDeleteAction';
 import useDeleteResource from '../../api/useDeleteResource';
 import useGetResourceActions from '../../api/useGetResourceActions';
 import useGetResources from '../../api/useGetResources';
+import {getActionKindLabel} from '../../config/get-action-kind-label';
 import type {Action, Resource} from '../../models/resource-server';
 
 interface ResourceTreeNodeProps {
@@ -49,6 +63,12 @@ interface ResourceTreeNodeProps {
   selectedNodeId: string | null;
   onSelect: (node: SelectedNode) => void;
   onAddChild: (mode: AddNodeMode, parentResourceId: string, parentPermission: string) => void;
+  /** When true, renders MCP-flavored namespace node with add menu (Add Tool / Add Resource / Add Namespace). */
+  isMcp?: boolean;
+  /** MCP only: which kind of children to show when rendering inline in a filtered pass. */
+  kindFilter?: KindFilter;
+  /** Ancestor namespace names for the breadcrumb in the detail panel. */
+  breadcrumb?: string[];
 }
 
 export function ResourceNode({
@@ -59,6 +79,9 @@ export function ResourceNode({
   selectedNodeId,
   onSelect,
   onAddChild,
+  isMcp = false,
+  kindFilter = 'all',
+  breadcrumb = [],
 }: ResourceTreeNodeProps): JSX.Element {
   const {t} = useTranslation();
   const {showToast} = useToast();
@@ -91,23 +114,56 @@ export function ResourceNode({
   const handleDelete = (e: React.MouseEvent): void => {
     e.stopPropagation();
     deleteResource.mutate(node.id, {
-      onSuccess: () => showToast(t('resourceServers:tree.deleteResource.success', 'Resource deleted.'), 'success'),
+      onSuccess: () => {
+        const successMsg = isMcp
+          ? t('resourceServers:mcp.deleteNamespace.success', 'Namespace deleted.')
+          : t('resourceServers:tree.deleteResource.success', 'Resource deleted.');
+        showToast(successMsg, 'success');
+      },
       onError: (err: Error) => {
         logger.error('Failed to delete resource', {error: err});
-        showToast(
-          t('resourceServers:tree.deleteResource.error', 'Cannot delete — remove child resources and actions first.'),
-          'error',
-        );
+        const errorMsg = isMcp
+          ? t(
+              'resourceServers:mcp.deleteNamespace.error',
+              "Cannot delete — remove the namespace's tools and resources first.",
+            )
+          : t('resourceServers:tree.deleteResource.error', 'Cannot delete — remove child resources and actions first.');
+        showToast(errorMsg, 'error');
       },
     });
   };
+
+  const nodeIcon = isMcp ? (
+    expanded ? (
+      <FolderOpen size={16} style={{flexShrink: 0, opacity: 0.7}} />
+    ) : (
+      <Folder size={16} style={{flexShrink: 0, opacity: 0.7}} />
+    )
+  ) : (
+    <Layers size={16} style={{flexShrink: 0, opacity: 0.7}} />
+  );
+
+  const namespaceLabel = t('resourceServers:mcp.types.namespace', 'Namespace');
+
+  const childBreadcrumb = [...breadcrumb, node.name];
 
   return (
     <Box>
       <Box
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        onClick={() => onSelect({type: 'resource', id: node.id, data: node})}
+        onClick={() =>
+          onSelect({
+            type: 'resource',
+            id: node.id,
+            data: node,
+            breadcrumb,
+          })
+        }
+        role="treeitem"
+        aria-expanded={isMcp ? expanded : undefined}
+        aria-level={depth + 1}
+        aria-label={isMcp ? `${namespaceLabel}: ${node.name}` : node.name}
         sx={{
           display: 'flex',
           alignItems: 'center',
@@ -132,7 +188,7 @@ export function ResourceNode({
           {expanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
         </IconButton>
 
-        <Layers size={16} style={{flexShrink: 0, opacity: 0.7}} />
+        {nodeIcon}
 
         <Box sx={{flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 0.75}}>
           <Typography
@@ -191,56 +247,216 @@ export function ResourceNode({
         onClose={() => setAddMenuAnchor(null)}
         slotProps={{paper: {sx: {minWidth: 160}}}}
       >
-        <MenuItem
-          onClick={() => {
-            onAddChild('sub-resource', node.id, node.permission);
-            setAddMenuAnchor(null);
-          }}
-        >
-          <ListItemIcon>
-            <Layers size={16} />
-          </ListItemIcon>
-          <ListItemText>{t('resourceServers:tree.addSubResource', 'Add sub-resource')}</ListItemText>
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            onAddChild('resource-action', node.id, node.permission);
-            setAddMenuAnchor(null);
-          }}
-        >
-          <ListItemIcon>
-            <Zap size={16} />
-          </ListItemIcon>
-          <ListItemText>{t('resourceServers:tree.addAction', 'Add action')}</ListItemText>
-        </MenuItem>
+        {isMcp
+          ? [
+              <MenuItem
+                key="add-tool"
+                onClick={() => {
+                  onAddChild('mcp-namespace-tool', node.id, node.permission);
+                  setAddMenuAnchor(null);
+                }}
+              >
+                <ListItemIcon>
+                  <Wrench size={16} />
+                </ListItemIcon>
+                <ListItemText>{t('resourceServers:mcp.addTool', 'Add tool')}</ListItemText>
+              </MenuItem>,
+              <MenuItem
+                key="add-resource"
+                onClick={() => {
+                  onAddChild('mcp-namespace-resource', node.id, node.permission);
+                  setAddMenuAnchor(null);
+                }}
+              >
+                <ListItemIcon>
+                  <Database size={16} />
+                </ListItemIcon>
+                <ListItemText>{t('resourceServers:mcp.addResource', 'Add resource')}</ListItemText>
+              </MenuItem>,
+              <MenuItem
+                key="add-sub-namespace"
+                onClick={() => {
+                  onAddChild('mcp-sub-namespace', node.id, node.permission);
+                  setAddMenuAnchor(null);
+                }}
+              >
+                <ListItemIcon>
+                  <Folder size={16} />
+                </ListItemIcon>
+                <ListItemText>{t('resourceServers:mcp.addNamespace', 'Add namespace')}</ListItemText>
+              </MenuItem>,
+            ]
+          : [
+              <MenuItem
+                key="sub-resource"
+                onClick={() => {
+                  onAddChild('sub-resource', node.id, node.permission);
+                  setAddMenuAnchor(null);
+                }}
+              >
+                <ListItemIcon>
+                  <Layers size={16} />
+                </ListItemIcon>
+                <ListItemText>{t('resourceServers:tree.addSubResource', 'Add sub-resource')}</ListItemText>
+              </MenuItem>,
+              <MenuItem
+                key="resource-action"
+                onClick={() => {
+                  onAddChild('resource-action', node.id, node.permission);
+                  setAddMenuAnchor(null);
+                }}
+              >
+                <ListItemIcon>
+                  <Zap size={16} />
+                </ListItemIcon>
+                <ListItemText>{t('resourceServers:tree.addAction', 'Add action')}</ListItemText>
+              </MenuItem>,
+            ]}
       </Menu>
 
       <Collapse in={expanded}>
-        {actions.map((action) => (
-          <ActionNode
-            key={action.id}
-            resourceServerId={resourceServerId}
-            action={action}
-            depth={depth + 1}
-            parentResourceId={node.id}
-            selectedNodeId={selectedNodeId}
-            onSelect={onSelect}
-          />
-        ))}
-        {children.map((child) => (
-          <ResourceNode
-            key={child.id}
-            resourceServerId={resourceServerId}
-            delimiter={delimiter}
-            node={child}
-            depth={depth + 1}
-            selectedNodeId={selectedNodeId}
-            onSelect={onSelect}
-            onAddChild={onAddChild}
-          />
-        ))}
+        {isMcp ? (
+          renderMcpNamespaceChildren({
+            actions,
+            children,
+            resourceServerId,
+            delimiter,
+            node,
+            depth,
+            selectedNodeId,
+            onSelect,
+            onAddChild,
+            kindFilter,
+            breadcrumb: childBreadcrumb,
+            t,
+          })
+        ) : (
+          <>
+            {actions.map((action) => (
+              <ActionNode
+                key={action.id}
+                resourceServerId={resourceServerId}
+                action={action}
+                depth={depth + 1}
+                parentResourceId={node.id}
+                selectedNodeId={selectedNodeId}
+                onSelect={onSelect}
+              />
+            ))}
+            {children.map((child) => (
+              <ResourceNode
+                key={child.id}
+                resourceServerId={resourceServerId}
+                delimiter={delimiter}
+                node={child}
+                depth={depth + 1}
+                selectedNodeId={selectedNodeId}
+                onSelect={onSelect}
+                onAddChild={onAddChild}
+              />
+            ))}
+          </>
+        )}
       </Collapse>
     </Box>
+  );
+}
+
+interface RenderMcpNamespaceChildrenParams {
+  actions: Action[];
+  children: Resource[];
+  resourceServerId: string;
+  delimiter: string;
+  node: Resource;
+  depth: number;
+  selectedNodeId: string | null;
+  onSelect: (node: SelectedNode) => void;
+  onAddChild: (mode: AddNodeMode, parentResourceId: string, parentPermission: string) => void;
+  kindFilter: KindFilter;
+  breadcrumb: string[];
+  t: (key: string, fallback: string) => string;
+}
+
+function renderMcpNamespaceChildren({
+  actions,
+  children,
+  resourceServerId,
+  delimiter,
+  node,
+  depth,
+  selectedNodeId,
+  onSelect,
+  onAddChild,
+  kindFilter,
+  breadcrumb,
+  t,
+}: RenderMcpNamespaceChildrenParams): JSX.Element {
+  const filteredTools = actions.filter((a) => {
+    if (kindFilter !== 'all' && kindFilter !== 'tool') return false;
+    return a.kind === 'tool';
+  });
+
+  const filteredResources = actions.filter((a) => {
+    if (kindFilter !== 'all' && kindFilter !== 'resource') return false;
+    return a.kind === 'resource';
+  });
+
+  const hasContent = filteredTools.length > 0 || filteredResources.length > 0 || children.length > 0;
+
+  if (!hasContent) {
+    const emptyMsg =
+      kindFilter !== 'all'
+        ? t('resourceServers:mcp.namespace.emptyForFilter', 'Nothing here matches the current filter.')
+        : t('resourceServers:mcp.namespace.empty', 'This namespace has no tools or resources yet.');
+    return (
+      <Typography variant="body2" color="text.disabled" sx={{pl: (depth + 2) * 2 + 0.5, py: 0.5}}>
+        {emptyMsg}
+      </Typography>
+    );
+  }
+
+  return (
+    <>
+      {filteredTools.map((action) => (
+        <ActionNode
+          key={action.id}
+          resourceServerId={resourceServerId}
+          action={action}
+          depth={depth + 1}
+          parentResourceId={node.id}
+          selectedNodeId={selectedNodeId}
+          onSelect={onSelect}
+          breadcrumb={breadcrumb}
+        />
+      ))}
+      {filteredResources.map((action) => (
+        <ActionNode
+          key={action.id}
+          resourceServerId={resourceServerId}
+          action={action}
+          depth={depth + 1}
+          parentResourceId={node.id}
+          selectedNodeId={selectedNodeId}
+          onSelect={onSelect}
+          breadcrumb={breadcrumb}
+        />
+      ))}
+      {children.map((child) => (
+        <ResourceNode
+          key={child.id}
+          resourceServerId={resourceServerId}
+          delimiter={delimiter}
+          node={child}
+          depth={depth + 1}
+          selectedNodeId={selectedNodeId}
+          onSelect={onSelect}
+          onAddChild={onAddChild}
+          isMcp
+          kindFilter={kindFilter}
+          breadcrumb={breadcrumb}
+        />
+      ))}
+    </>
   );
 }
 
@@ -251,6 +467,7 @@ interface ActionNodeProps {
   parentResourceId?: string;
   selectedNodeId: string | null;
   onSelect: (node: SelectedNode) => void;
+  breadcrumb?: string[];
 }
 
 export function ActionNode({
@@ -260,6 +477,7 @@ export function ActionNode({
   parentResourceId = undefined,
   selectedNodeId,
   onSelect,
+  breadcrumb = [],
 }: ActionNodeProps): JSX.Element {
   const {t} = useTranslation();
   const {showToast} = useToast();
@@ -282,10 +500,16 @@ export function ActionNode({
       .catch((err: unknown) => logger.error('Failed to copy permission', {error: err}));
   };
 
+  const resolveDeleteSuccessToast = (): string => {
+    if (action.kind === 'tool') return t('resourceServers:mcp.deleteTool.success', 'Tool deleted.');
+    if (action.kind === 'resource') return t('resourceServers:mcp.deleteResource.success', 'Resource deleted.');
+    return t('resourceServers:tree.deleteAction.success', 'Action deleted.');
+  };
+
   const handleDelete = (e: React.MouseEvent): void => {
     e.stopPropagation();
     deleteAction.mutate(action.id, {
-      onSuccess: () => showToast(t('resourceServers:tree.deleteAction.success', 'Action deleted.'), 'success'),
+      onSuccess: () => showToast(resolveDeleteSuccessToast(), 'success'),
       onError: (err: Error) => {
         logger.error('Failed to delete action', {error: err});
         showToast(t('resourceServers:tree.deleteAction.error', 'Failed to delete action.'), 'error');
@@ -293,11 +517,25 @@ export function ActionNode({
     });
   };
 
+  const kindAriaLabel = getActionKindLabel(action.kind, t);
+
+  const kindIcon =
+    action.kind === 'tool' ? (
+      <Wrench size={16} />
+    ) : action.kind === 'resource' ? (
+      <Database size={16} />
+    ) : (
+      <Zap size={16} />
+    );
+
   return (
     <Box
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      onClick={() => onSelect({type: nodeType, id: action.id, data: action, parentResourceId})}
+      onClick={() => onSelect({type: nodeType, id: action.id, data: action, parentResourceId, breadcrumb})}
+      role="treeitem"
+      aria-level={depth + 1}
+      aria-label={`${kindAriaLabel}: ${action.name}`}
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -310,7 +548,7 @@ export function ActionNode({
         bgcolor: isSelected ? 'action.selected' : hovered ? 'action.hover' : 'transparent',
       }}
     >
-      <Zap size={16} style={{flexShrink: 0, opacity: 0.6}} />
+      <Box sx={{flexShrink: 0, opacity: 0.7, display: 'flex', alignItems: 'center'}}>{kindIcon}</Box>
 
       <Box sx={{flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 0.75}}>
         <Typography

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/AddNodeDialog.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/AddNodeDialog.test.tsx
@@ -37,12 +37,15 @@ vi.mock('@thunderid/logger/react', () => ({
   useLogger: () => ({error: vi.fn(), info: vi.fn(), debug: vi.fn()}),
 }));
 
+const mockCreateResourceMutate = vi.fn();
+const mockCreateActionMutate = vi.fn();
+
 vi.mock('../../../api/useCreateResource', () => ({
-  default: () => ({mutate: vi.fn(), isPending: false}),
+  default: () => ({mutate: mockCreateResourceMutate, isPending: false}),
 }));
 
 vi.mock('../../../api/useCreateAction', () => ({
-  default: () => ({mutate: vi.fn(), isPending: false}),
+  default: () => ({mutate: mockCreateActionMutate, isPending: false}),
 }));
 
 const defaultProps = {
@@ -160,5 +163,168 @@ describe('AddNodeDialog', () => {
 
     const addButton = screen.getByRole('button', {name: /^add$/i});
     expect(addButton).toBeDisabled();
+  });
+
+  it('renders the Add Tool title when mode is mcp-server-tool', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-server-tool" />);
+
+    expect(screen.getByText('Add Tool')).toBeInTheDocument();
+  });
+
+  it('renders the Add Resource title when mode is mcp-server-resource', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-server-resource" />);
+
+    expect(screen.getByText('Add Resource')).toBeInTheDocument();
+  });
+
+  it('renders the Add Namespace title when mode is mcp-namespace', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-namespace" />);
+
+    expect(screen.getByText('Add Namespace')).toBeInTheDocument();
+  });
+
+  it('renders the Add Namespace title when mode is mcp-sub-namespace', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-sub-namespace" />);
+
+    expect(screen.getByText('Add Namespace')).toBeInTheDocument();
+  });
+
+  it('renders the Add Tool title when mode is mcp-namespace-tool', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-namespace-tool" />);
+
+    expect(screen.getByText('Add Tool')).toBeInTheDocument();
+  });
+
+  it('renders the Add Resource title when mode is mcp-namespace-resource', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-namespace-resource" />);
+
+    expect(screen.getByText('Add Resource')).toBeInTheDocument();
+  });
+
+  it('sends kind=tool in the create payload for mcp-server-tool mode', async () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-server-tool" delimiter=":" />);
+
+    const textboxes = screen.getAllByRole('textbox');
+    fireEvent.change(textboxes[0], {target: {value: 'Search Files'}});
+
+    await waitFor(() => expect(textboxes[1]).toHaveValue('search-files'));
+
+    fireEvent.click(screen.getByRole('button', {name: /^add$/i}));
+
+    await waitFor(() => {
+      expect(mockCreateActionMutate).toHaveBeenCalledWith(
+        expect.objectContaining({kind: 'tool', name: 'Search Files', handle: 'search-files'}),
+        expect.any(Object),
+      );
+    });
+  });
+
+  it('sends kind=resource in the create payload for mcp-server-resource mode', async () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-server-resource" delimiter=":" />);
+
+    const textboxes = screen.getAllByRole('textbox');
+    fireEvent.change(textboxes[0], {target: {value: 'File Contents'}});
+
+    await waitFor(() => expect(textboxes[1]).toHaveValue('file-contents'));
+
+    fireEvent.click(screen.getByRole('button', {name: /^add$/i}));
+
+    await waitFor(() => {
+      expect(mockCreateActionMutate).toHaveBeenCalledWith(
+        expect.objectContaining({kind: 'resource', name: 'File Contents', handle: 'file-contents'}),
+        expect.any(Object),
+      );
+    });
+  });
+
+  it('does not send kind in the create payload for mcp-namespace mode', async () => {
+    renderWithProviders(
+      <AddNodeDialog {...defaultProps} mode="mcp-namespace" delimiter=":" parentResourceId={undefined} />,
+    );
+
+    const textboxes = screen.getAllByRole('textbox');
+    fireEvent.change(textboxes[0], {target: {value: 'My Namespace'}});
+
+    await waitFor(() => expect(textboxes[1]).toHaveValue('my-namespace'));
+
+    fireEvent.click(screen.getByRole('button', {name: /^add$/i}));
+
+    await waitFor(() => {
+      expect(mockCreateResourceMutate).toHaveBeenCalledWith(
+        expect.objectContaining({name: 'My Namespace', handle: 'my-namespace'}),
+        expect.any(Object),
+      );
+      expect(mockCreateResourceMutate).toHaveBeenCalledWith(
+        expect.not.objectContaining({kind: expect.anything() as unknown}),
+        expect.any(Object),
+      );
+    });
+  });
+
+  it('shows generic resource placeholders in resource mode', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="resource" />);
+
+    const textboxes = screen.getAllByRole('textbox');
+    expect(textboxes[0]).toHaveAttribute('placeholder', 'e.g. Orders');
+    expect(textboxes[1]).toHaveAttribute('placeholder', 'e.g. orders');
+  });
+
+  it('shows action placeholders in server-action mode', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="server-action" />);
+
+    const textboxes = screen.getAllByRole('textbox');
+    expect(textboxes[0]).toHaveAttribute('placeholder', 'e.g. Read');
+    expect(textboxes[1]).toHaveAttribute('placeholder', 'e.g. read');
+  });
+
+  it('shows tool placeholders in mcp-server-tool mode', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-server-tool" />);
+
+    const textboxes = screen.getAllByRole('textbox');
+    expect(textboxes[0]).toHaveAttribute('placeholder', 'e.g. Send message');
+    expect(textboxes[1]).toHaveAttribute('placeholder', 'e.g. send-message');
+  });
+
+  it('shows resource placeholders in mcp-namespace-resource mode', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-namespace-resource" />);
+
+    const textboxes = screen.getAllByRole('textbox');
+    expect(textboxes[0]).toHaveAttribute('placeholder', 'e.g. User profile');
+    expect(textboxes[1]).toHaveAttribute('placeholder', 'e.g. user-profile');
+  });
+
+  it('shows namespace placeholders in mcp-namespace mode', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-namespace" />);
+
+    const textboxes = screen.getAllByRole('textbox');
+    expect(textboxes[0]).toHaveAttribute('placeholder', 'e.g. Messaging');
+    expect(textboxes[1]).toHaveAttribute('placeholder', 'e.g. messaging');
+  });
+
+  it('shows the description placeholder regardless of mode', () => {
+    renderWithProviders(<AddNodeDialog {...defaultProps} mode="mcp-server-tool" />);
+
+    const textboxes = screen.getAllByRole('textbox');
+    expect(textboxes[2]).toHaveAttribute('placeholder', 'e.g. Optional. Describe what this is for.');
+  });
+
+  it('sends kind=tool in the create payload for mcp-namespace-tool mode', async () => {
+    renderWithProviders(
+      <AddNodeDialog {...defaultProps} mode="mcp-namespace-tool" delimiter=":" parentResourceId="ns-1" />,
+    );
+
+    const textboxes = screen.getAllByRole('textbox');
+    fireEvent.change(textboxes[0], {target: {value: 'Search'}});
+
+    await waitFor(() => expect(textboxes[1]).toHaveValue('search'));
+
+    fireEvent.click(screen.getByRole('button', {name: /^add$/i}));
+
+    await waitFor(() => {
+      expect(mockCreateActionMutate).toHaveBeenCalledWith(
+        expect.objectContaining({kind: 'tool', name: 'Search', handle: 'search'}),
+        expect.any(Object),
+      );
+    });
   });
 });

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/ResourceDetailPanel.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/ResourceDetailPanel.test.tsx
@@ -68,6 +68,15 @@ const readOnlyResourceServer: ResourceServer = {
   isReadOnly: true,
 };
 
+const mockMcpResourceServer: ResourceServer = {
+  id: 'rs-mcp',
+  name: 'My MCP Server',
+  handle: 'my-mcp',
+  ouId: 'ou-1',
+  delimiter: ':',
+  type: 'MCP',
+};
+
 describe('ResourceDetailPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -226,5 +235,211 @@ describe('ResourceDetailPanel', () => {
     );
 
     expect(screen.queryByText(/This is a system resource server and cannot be modified/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('ResourceDetailPanel (MCP non-server node)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const toolNode: SelectedNode = {
+    type: 'server-action',
+    id: 'tool-1',
+    data: {id: 'tool-1', name: 'Search Files', handle: 'search-files', permission: 'my-mcp:search-files', kind: 'tool'},
+  };
+
+  const namespaceNode: SelectedNode = {
+    type: 'resource',
+    id: 'ns-1',
+    data: {id: 'ns-1', name: 'Booking', handle: 'booking', permission: 'my-mcp:booking'},
+  };
+
+  it('renders the node name as an h5 heading', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('heading', {level: 5, name: 'Search Files'})).toBeInTheDocument();
+  });
+
+  it('renders the kind label with an icon as a subtitle, not a chip', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    const label = screen.getByText('Tool');
+    expect(label).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Tool'})).not.toBeInTheDocument();
+    expect(label.parentElement?.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders the Namespace kind label with an icon for a namespace node', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={namespaceNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    const label = screen.getByText('Namespace');
+    expect(label).toBeInTheDocument();
+    expect(label.parentElement?.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('does not render a breadcrumb', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.queryByText(/›/)).not.toBeInTheDocument();
+  });
+
+  it('renders the Handle field as read-only with the node handle', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    const handleInput = screen.getByDisplayValue('search-files');
+    expect(handleInput).toHaveAttribute('readonly');
+  });
+
+  it('does not render a copy button for the Handle field', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    const handleInput = screen.getByDisplayValue('search-files');
+    const handleFormControl = handleInput.closest('.MuiFormControl-root');
+    expect(handleFormControl?.querySelector('button')).not.toBeInTheDocument();
+  });
+
+  it('renders the Delimiter field as read-only with the resource server delimiter', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    const delimiterInput = screen.getByDisplayValue(':');
+    expect(delimiterInput).toHaveAttribute('readonly');
+  });
+
+  it('renders Name, Handle, Delimiter and Description fields in that order', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    const labels = screen.getAllByText(/^(Name|Handle \(immutable\)|Delimiter \(immutable\)|Description)$/);
+    expect(labels.map((el) => el.textContent)).toEqual([
+      'Name',
+      'Handle (immutable)',
+      'Delimiter (immutable)',
+      'Description',
+    ]);
+  });
+
+  it('renders a copy button for the Permission field', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('button', {name: 'Copy'})).toBeInTheDocument();
+  });
+
+  it('does not render an Advanced toggle', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.queryByText(/Advanced/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the Permission field as a read-only text field with the derived permission', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.getByText('Permission')).toBeInTheDocument();
+    const permissionInput = screen.getByDisplayValue('my-mcp:search-files');
+    expect(permissionInput).toHaveAttribute('readonly');
+  });
+
+  it('renders the permission help text as helper text below the field', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/Built from the resource server handle/i)).toBeInTheDocument();
+  });
+
+  it('renders kind-aware helper text for Name, Handle, Delimiter and Description for a tool node', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={toolNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.getByText('A human-readable name for this tool.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Stable identifier for this tool, used to build the permission scope.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Separates segments in the permission scope. Defined by the resource server.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Optional. Describe what this tool is for.')).toBeInTheDocument();
+  });
+
+  it('renders kind-aware helper text for Name and Description for a namespace node', () => {
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={namespaceNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.getByText('A human-readable name for this namespace.')).toBeInTheDocument();
+    expect(screen.getByText('Optional. Describe what this namespace is for.')).toBeInTheDocument();
+  });
+});
+
+describe('ResourceDetailPanel (non-MCP nodes do not show MCP hints)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render MCP-specific helper text for a generic resource node', () => {
+    const selectedNode: SelectedNode = {
+      type: 'resource',
+      id: 'r-1',
+      data: {id: 'r-1', name: 'Documents', handle: 'documents', permission: 'dark-dodos/documents'},
+    };
+
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={selectedNode} resourceServer={mockResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.queryByText(/A human-readable name for this/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Optional\. Describe what this/i)).not.toBeInTheDocument();
+  });
+
+  it('does not render MCP-specific helper text for a server node', () => {
+    const selectedNode: SelectedNode = {
+      type: 'server',
+      id: 'rs-1',
+      data: mockResourceServer,
+    };
+
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={selectedNode} resourceServer={mockResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.queryByText(/A human-readable name for this/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Optional\. Describe what this/i)).not.toBeInTheDocument();
+  });
+
+  it('does not render MCP-specific helper text for an MCP server node', () => {
+    const selectedNode: SelectedNode = {
+      type: 'server',
+      id: 'rs-mcp',
+      data: mockMcpResourceServer,
+    };
+
+    renderWithProviders(
+      <ResourceDetailPanel selectedNode={selectedNode} resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />,
+    );
+
+    expect(screen.queryByText(/A human-readable name for this/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Optional\. Describe what this/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/ResourceTree.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/ResourceTree.test.tsx
@@ -31,6 +31,15 @@ const mockResourceServer = {
   type: 'API' as const,
 };
 
+const mockMcpResourceServer = {
+  id: 'rs-mcp',
+  name: 'My MCP Server',
+  handle: 'my-mcp',
+  ouId: 'ou-1',
+  delimiter: ':',
+  type: 'MCP' as const,
+};
+
 const mockUseGetResources = vi.fn();
 const mockUseGetServerActions = vi.fn();
 
@@ -81,8 +90,16 @@ vi.mock('../ResourceDetailPanel', () => ({
 }));
 
 vi.mock('../ResourceTreeNode', () => ({
-  ResourceNode: ({node}: {node: {name: string}}) => <div data-testid="resource-node">{node.name}</div>,
-  ActionNode: ({action}: {action: {name: string}}) => <div data-testid="action-node">{action.name}</div>,
+  ResourceNode: ({node, kindFilter = undefined}: {node: {name: string}; kindFilter?: string}) => (
+    <div data-testid="resource-node" data-kind-filter={kindFilter ?? 'all'}>
+      {node.name}
+    </div>
+  ),
+  ActionNode: ({action}: {action: {name: string; kind?: string}}) => (
+    <div data-testid="action-node" data-kind={action.kind ?? 'action'}>
+      {action.name}
+    </div>
+  ),
 }));
 
 const emptyResources: ResourceListResponse = {
@@ -113,7 +130,42 @@ const withActions: ActionListResponse = {
   actions: [{id: 'a-1', name: 'Read All', handle: 'read-all', permission: 'dark-dodos:read-all'}],
 };
 
-describe('ResourceTree', () => {
+const withMcpTools: ActionListResponse = {
+  totalResults: 1,
+  startIndex: 0,
+  count: 1,
+  actions: [
+    {id: 'tool-1', name: 'Search Files', handle: 'search-files', permission: 'my-mcp:search-files', kind: 'tool'},
+  ],
+};
+
+const withMcpResources: ActionListResponse = {
+  totalResults: 1,
+  startIndex: 0,
+  count: 1,
+  actions: [
+    {id: 'res-1', name: 'File Contents', handle: 'file-contents', permission: 'my-mcp:file-contents', kind: 'resource'},
+  ],
+};
+
+const withNamespaces: ResourceListResponse = {
+  totalResults: 1,
+  startIndex: 0,
+  count: 1,
+  resources: [{id: 'ns-1', name: 'Booking', handle: 'booking', permission: 'my-mcp:booking'}],
+};
+
+const withMcpMixed: ActionListResponse = {
+  totalResults: 2,
+  startIndex: 0,
+  count: 2,
+  actions: [
+    {id: 'tool-1', name: 'Search Files', handle: 'search-files', permission: 'my-mcp:search-files', kind: 'tool'},
+    {id: 'res-1', name: 'File Contents', handle: 'file-contents', permission: 'my-mcp:file-contents', kind: 'resource'},
+  ],
+};
+
+describe('ResourceTree (API type — generic tree)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseGetResources.mockReturnValue({data: emptyResources, isLoading: false});
@@ -230,5 +282,318 @@ describe('ResourceTree', () => {
 
     expect(screen.getByTestId('action-node')).toBeInTheDocument();
     expect(screen.getByText('Read All')).toBeInTheDocument();
+  });
+
+  it('does not render the Capabilities panel header for an API-type server', () => {
+    renderWithProviders(<ResourceTree resourceServer={mockResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.queryByText('Capabilities')).not.toBeInTheDocument();
+  });
+});
+
+describe('ResourceTree (MCP type — Capabilities panel)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseGetResources.mockReturnValue({data: emptyResources, isLoading: false});
+    mockUseGetServerActions.mockReturnValue({data: emptyActions, isLoading: false});
+  });
+
+  it('renders the Capabilities panel header', () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getByText('Capabilities')).toBeInTheDocument();
+  });
+
+  it('does not render separate TOOLS or RESOURCES subsection headers', () => {
+    mockUseGetServerActions.mockReturnValue({data: withMcpMixed, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    // The chip labels in the radiogroup use "Tools" / "Resources" text, but there must be
+    // no additional subsection header elements (i.e. no second occurrence as a section title).
+    // We verify there is no heading-level or caption element acting as a section divider.
+    // The only "Tools" / "Resources" text present should be inside the radiogroup chips.
+    const radioGroup = screen.getByRole('radiogroup');
+    expect(radioGroup).toBeInTheDocument();
+    // Both tools and resources render as action-nodes in a single list (no section grouping).
+    expect(screen.getByText('Search Files')).toBeInTheDocument();
+    expect(screen.getByText('File Contents')).toBeInTheDocument();
+  });
+
+  it('does not render a separate Groups section header', () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.queryByText('Groups')).not.toBeInTheDocument();
+  });
+
+  it('shows the loading spinner while data is loading', () => {
+    mockUseGetResources.mockReturnValue({data: undefined, isLoading: true});
+    mockUseGetServerActions.mockReturnValue({data: undefined, isLoading: true});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('shows the MCP empty message when all sections are empty', () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getByText('No capabilities yet. Use + to add a tool, resource, or namespace.')).toBeInTheDocument();
+  });
+
+  it('shows the whole-RS empty message (not subsection messages) when everything is empty', () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getByText('No capabilities yet. Use + to add a tool, resource, or namespace.')).toBeInTheDocument();
+    expect(screen.queryByText('No tools yet.')).not.toBeInTheDocument();
+    expect(screen.queryByText('No resources yet.')).not.toBeInTheDocument();
+  });
+
+  it('renders a namespace node exactly once in the unified tree', () => {
+    mockUseGetResources.mockReturnValue({data: withNamespaces, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    // Single-pass: a namespace appears once, not duplicated across two sections
+    expect(screen.getAllByTestId('resource-node').length).toBe(1);
+    expect(screen.getAllByText('Booking').length).toBe(1);
+  });
+
+  it('passes the active kindFilter down to namespace ResourceNodes', () => {
+    mockUseGetResources.mockReturnValue({data: withNamespaces, isLoading: false});
+    mockUseGetServerActions.mockReturnValue({data: emptyActions, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    const nsNode = screen.getByTestId('resource-node');
+    expect(nsNode).toHaveAttribute('data-kind-filter', 'all');
+  });
+
+  it('renders tools and resources intermixed in a single list (no section grouping)', () => {
+    mockUseGetServerActions.mockReturnValue({data: withMcpMixed, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    const actionNodes = screen.getAllByTestId('action-node');
+    expect(actionNodes.length).toBe(2);
+    // Both kinds present in same flat list
+    expect(actionNodes.some((n) => n.getAttribute('data-kind') === 'tool')).toBe(true);
+    expect(actionNodes.some((n) => n.getAttribute('data-kind') === 'resource')).toBe(true);
+  });
+
+  it('renders tools in the unified tree when kind=tool actions exist', () => {
+    mockUseGetServerActions.mockReturnValue({data: withMcpTools, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getAllByTestId('action-node').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Search Files')).toBeInTheDocument();
+  });
+
+  it('renders kind=resource actions in the unified tree', () => {
+    mockUseGetServerActions.mockReturnValue({data: withMcpResources, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getAllByTestId('action-node').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('File Contents')).toBeInTheDocument();
+  });
+
+  it('renders namespace nodes once even when both tools and resources exist', () => {
+    mockUseGetResources.mockReturnValue({data: withNamespaces, isLoading: false});
+    mockUseGetServerActions.mockReturnValue({data: emptyActions, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    const namespaceNodes = screen.getAllByTestId('resource-node');
+    expect(namespaceNodes.length).toBe(1);
+    expect(screen.getAllByText('Booking').length).toBe(1);
+  });
+
+  it('renders the filter chip group for MCP', () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getByRole('radiogroup', {name: /Filter capabilities/i})).toBeInTheDocument();
+  });
+
+  it('renders All, Tools, Resources filter chips', () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    const radioGroup = screen.getByRole('radiogroup');
+    expect(radioGroup).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: /All/i})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: /Tools/i})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: /Resources/i})).toBeInTheDocument();
+  });
+
+  it('hides resource ActionNodes when Tools filter chip is selected', async () => {
+    mockUseGetServerActions.mockReturnValue({data: withMcpMixed, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('radio', {name: /Tools/i}));
+
+    await waitFor(() => {
+      expect(screen.getByText('Search Files')).toBeInTheDocument();
+      expect(screen.queryByText('File Contents')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides tool ActionNodes when Resources filter chip is selected', async () => {
+    mockUseGetServerActions.mockReturnValue({data: withMcpMixed, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('radio', {name: /Resources/i}));
+
+    await waitFor(() => {
+      expect(screen.getByText('File Contents')).toBeInTheDocument();
+      expect(screen.queryByText('Search Files')).not.toBeInTheDocument();
+    });
+  });
+
+  it('passes kindFilter=tool to namespace ResourceNodes when Tools chip is selected', async () => {
+    mockUseGetResources.mockReturnValue({data: withNamespaces, isLoading: false});
+    mockUseGetServerActions.mockReturnValue({data: emptyActions, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('radio', {name: /Tools/i}));
+
+    await waitFor(() => {
+      const nsNode = screen.getByTestId('resource-node');
+      expect(nsNode).toHaveAttribute('data-kind-filter', 'tool');
+    });
+  });
+
+  it('passes kindFilter=resource to namespace ResourceNodes when Resources chip is selected', async () => {
+    mockUseGetResources.mockReturnValue({data: withNamespaces, isLoading: false});
+    mockUseGetServerActions.mockReturnValue({data: emptyActions, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('radio', {name: /Resources/i}));
+
+    await waitFor(() => {
+      const nsNode = screen.getByTestId('resource-node');
+      expect(nsNode).toHaveAttribute('data-kind-filter', 'resource');
+    });
+  });
+
+  it('shows All filter as active restores both tools and resources', async () => {
+    mockUseGetServerActions.mockReturnValue({data: withMcpMixed, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('radio', {name: /Tools/i}));
+
+    await waitFor(() => {
+      expect(screen.queryByText('File Contents')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('radio', {name: /All/i}));
+
+    await waitFor(() => {
+      expect(screen.getByText('Search Files')).toBeInTheDocument();
+      expect(screen.getByText('File Contents')).toBeInTheDocument();
+    });
+  });
+
+  it('opens the add dialog in mcp-server-tool mode from the header + menu', async () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Add'}));
+
+    await waitFor(() => {
+      expect(screen.getByText('Add tool')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Add tool'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', {name: 'add-node-dialog'})).toBeInTheDocument();
+      expect(screen.getByTestId('dialog-mode').textContent).toBe('mcp-server-tool');
+    });
+  });
+
+  it('opens the add dialog in mcp-server-resource mode from the header + menu', async () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Add'}));
+
+    await waitFor(() => {
+      expect(screen.getByText('Add resource')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Add resource'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', {name: 'add-node-dialog'})).toBeInTheDocument();
+      expect(screen.getByTestId('dialog-mode').textContent).toBe('mcp-server-resource');
+    });
+  });
+
+  it('opens the add dialog in mcp-namespace mode from the header + menu', async () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Add'}));
+
+    await waitFor(() => {
+      expect(screen.getByText('Add namespace')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Add namespace'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', {name: 'add-node-dialog'})).toBeInTheDocument();
+      expect(screen.getByTestId('dialog-mode').textContent).toBe('mcp-namespace');
+    });
+  });
+
+  it('does not render the generic Resource Hierarchy header for an MCP server', () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.queryByText('Resource Hierarchy')).not.toBeInTheDocument();
+  });
+
+  it('shows the All filter chip as selected by default (aria-checked=true)', () => {
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getByRole('radio', {name: /All/i})).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', {name: /Tools/i})).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByRole('radio', {name: /Resources/i})).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('shows filter chip labels without counts when the server has no namespaces', () => {
+    mockUseGetResources.mockReturnValue({data: emptyResources, isLoading: false});
+    mockUseGetServerActions.mockReturnValue({data: withMcpMixed, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getByRole('radio', {name: /^All$/})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: /^Tools$/})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: /^Resources$/})).toBeInTheDocument();
+  });
+
+  it('shows filter chip labels without counts when the server has namespaces', () => {
+    mockUseGetResources.mockReturnValue({data: withNamespaces, isLoading: false});
+    mockUseGetServerActions.mockReturnValue({data: withMcpMixed, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getByRole('radio', {name: /^All$/})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: /^Tools$/})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: /^Resources$/})).toBeInTheDocument();
+  });
+
+  it('shows filter chip labels without counts when namespaces exist but no server-level actions exist', () => {
+    mockUseGetResources.mockReturnValue({data: withNamespaces, isLoading: false});
+    mockUseGetServerActions.mockReturnValue({data: emptyActions, isLoading: false});
+
+    renderWithProviders(<ResourceTree resourceServer={mockMcpResourceServer} onRefresh={vi.fn()} />);
+
+    expect(screen.getByRole('radio', {name: /^All$/})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: /^Tools$/})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: /^Resources$/})).toBeInTheDocument();
   });
 });

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/ResourceTreeNode.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/__tests__/ResourceTreeNode.test.tsx
@@ -149,6 +149,7 @@ describe('ResourceNode', () => {
       type: 'resource',
       id: 'r-1',
       data: mockResource,
+      breadcrumb: [],
     });
   });
 
@@ -224,6 +225,7 @@ describe('ActionNode', () => {
       id: 'a-1',
       data: mockAction,
       parentResourceId: undefined,
+      breadcrumb: [],
     });
   });
 
@@ -238,6 +240,7 @@ describe('ActionNode', () => {
       id: 'a-1',
       data: mockAction,
       parentResourceId: 'r-1',
+      breadcrumb: [],
     });
   });
 

--- a/frontend/packages/configure-resource-servers/src/config/__tests__/action-kinds.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/config/__tests__/action-kinds.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render} from '@testing-library/react';
+import {describe, it, expect} from 'vitest';
+import {getActionKindIcon} from '../get-action-kind-icon';
+import {getActionKindLabel} from '../get-action-kind-label';
+import {getNamespaceIcon} from '../get-namespace-icon';
+
+const t = (key: string, fallback: string): string => fallback;
+
+describe('getActionKindLabel', () => {
+  it('should return "Tool" for kind tool', () => {
+    expect(getActionKindLabel('tool', t)).toBe('Tool');
+  });
+
+  it('should return "Resource" for kind resource', () => {
+    expect(getActionKindLabel('resource', t)).toBe('Resource');
+  });
+
+  it('should return "Namespace" for undefined kind', () => {
+    expect(getActionKindLabel(undefined, t)).toBe('Namespace');
+  });
+});
+
+describe('getActionKindIcon', () => {
+  it('should render an svg icon for kind tool', () => {
+    const {container} = render(getActionKindIcon('tool'));
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('should render an svg icon for kind resource', () => {
+    const {container} = render(getActionKindIcon('resource'));
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('should render an svg icon for undefined kind (namespace)', () => {
+    const {container} = render(getActionKindIcon(undefined));
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('should render an svg icon when a custom size is provided', () => {
+    const {container} = render(getActionKindIcon('tool', 24));
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+});
+
+describe('getNamespaceIcon', () => {
+  it('should render a FolderOpen icon when expanded is true', () => {
+    const {container} = render(getNamespaceIcon(true));
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('should render a Folder icon when expanded is false', () => {
+    const {container} = render(getNamespaceIcon(false));
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('should render with a custom size', () => {
+    const {container} = render(getNamespaceIcon(false, 24));
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+});

--- a/frontend/packages/configure-resource-servers/src/config/get-action-kind-icon.tsx
+++ b/frontend/packages/configure-resource-servers/src/config/get-action-kind-icon.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Database, Folder, Wrench} from '@wso2/oxygen-ui-icons-react';
+import type {JSX} from 'react';
+import type {ActionKind} from '../models/resource-server';
+
+/**
+ * Returns the icon element for the given action kind. Pass `undefined` to get the Namespace (Folder) icon.
+ *
+ * @param kind - The action kind ('tool', 'resource', or undefined for namespace).
+ * @param size - Icon size in pixels (default 16).
+ * @returns The icon JSX element.
+ */
+export function getActionKindIcon(kind: ActionKind | undefined, size = 16): JSX.Element {
+  if (kind === 'tool') return <Wrench size={size} />;
+  if (kind === 'resource') return <Database size={size} />;
+  return <Folder size={size} />;
+}

--- a/frontend/packages/configure-resource-servers/src/config/get-action-kind-label.ts
+++ b/frontend/packages/configure-resource-servers/src/config/get-action-kind-label.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {ActionKind} from '../models/resource-server';
+
+/**
+ * Returns the translated label for the given action kind. Pass `undefined` to get the Namespace label.
+ *
+ * @param kind - The action kind ('tool', 'resource', or undefined for namespace).
+ * @param t - The i18next translation function.
+ * @returns The translated label string.
+ */
+export function getActionKindLabel(kind: ActionKind | undefined, t: (key: string, fallback: string) => string): string {
+  if (kind === 'tool') return t('resourceServers:mcp.types.tool', 'Tool');
+  if (kind === 'resource') return t('resourceServers:mcp.types.resource', 'Resource');
+  return t('resourceServers:mcp.types.namespace', 'Namespace');
+}

--- a/frontend/packages/configure-resource-servers/src/config/get-namespace-icon.tsx
+++ b/frontend/packages/configure-resource-servers/src/config/get-namespace-icon.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Folder, FolderOpen} from '@wso2/oxygen-ui-icons-react';
+import type {JSX} from 'react';
+
+/**
+ * Returns the namespace icon, toggling between open and closed states.
+ *
+ * @param expanded - Whether the namespace is expanded.
+ * @param size - Icon size in pixels (default 16).
+ * @returns The icon JSX element.
+ */
+export function getNamespaceIcon(expanded: boolean, size = 16): JSX.Element {
+  return expanded ? <FolderOpen size={size} /> : <Folder size={size} />;
+}

--- a/frontend/packages/configure-resource-servers/src/models/resource-server.ts
+++ b/frontend/packages/configure-resource-servers/src/models/resource-server.ts
@@ -57,12 +57,15 @@ export interface ResourceListResponse {
   links?: {rel: string; href: string}[];
 }
 
+export type ActionKind = 'tool' | 'resource';
+
 export interface Action {
   id: string;
   name: string;
   handle: string;
   description?: string | null;
   permission: string;
+  kind?: ActionKind;
 }
 
 export interface ActionListResponse {
@@ -75,7 +78,7 @@ export interface ActionListResponse {
 
 export interface CreateResourceServerRequest {
   name: string;
-  handle: string | null;
+  handle?: string;
   description?: string;
   identifier?: string;
   delimiter?: PermissionDelimiter;
@@ -106,6 +109,7 @@ export interface CreateActionRequest {
   name: string;
   handle: string;
   description?: string;
+  kind?: ActionKind;
 }
 
 export interface UpdateActionRequest {

--- a/frontend/packages/configure-resource-servers/src/pages/CreateResourceServerPage.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/CreateResourceServerPage.tsx
@@ -42,7 +42,6 @@ import ConfigureType from '../components/create-resource-server/ConfigureType';
 import {DEFAULT_PERMISSION_DELIMITER} from '../constants/permission-constants';
 import type {PermissionDelimiter} from '../models/permissions';
 import type {ResourceServerType} from '../models/resource-server';
-import {deriveHandle} from '../utils/deriveHandle';
 
 const ResourceServerCreateStep = {
   TYPE: 'TYPE',
@@ -69,7 +68,6 @@ export default function CreateResourceServerPage(): JSX.Element {
   const [delimiter, setDelimiter] = useState<PermissionDelimiter>(DEFAULT_PERMISSION_DELIMITER);
   const [ouId, setOuId] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [handleEdited, setHandleEdited] = useState(false);
 
   const [stepReady, setStepReady] = useState<Record<ResourceServerCreateStep, boolean>>({
     TYPE: false,
@@ -78,15 +76,9 @@ export default function CreateResourceServerPage(): JSX.Element {
     ORGANIZATION_UNIT: false,
   });
 
-  const handleDelimiterChange = useCallback(
-    (newDelimiter: PermissionDelimiter): void => {
-      setDelimiter(newDelimiter);
-      if (!handleEdited && name) {
-        setHandle(deriveHandle(name, newDelimiter));
-      }
-    },
-    [handleEdited, name],
-  );
+  const handleDelimiterChange = useCallback((newDelimiter: PermissionDelimiter): void => {
+    setDelimiter(newDelimiter);
+  }, []);
 
   const steps: Record<ResourceServerCreateStep, {label: string; order: number}> = useMemo(
     () => ({
@@ -162,7 +154,7 @@ export default function CreateResourceServerPage(): JSX.Element {
 
     const payload = {
       name: name.trim(),
-      handle: handle.trim() || null,
+      handle: handle.trim() || undefined,
       ouId: resolvedOuId,
       type: selectedType,
       delimiter,
@@ -223,8 +215,6 @@ export default function CreateResourceServerPage(): JSX.Element {
             name={name}
             handle={handle}
             delimiter={delimiter}
-            handleEdited={handleEdited}
-            onHandleEditedChange={setHandleEdited}
             onNameChange={setName}
             onHandleChange={setHandle}
             onReadyChange={handleNameReadyChange}

--- a/frontend/packages/configure-resource-servers/src/pages/ResourceServerEditPage.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/ResourceServerEditPage.tsx
@@ -79,7 +79,9 @@ export default function ResourceServerEditPage(): JSX.Element {
   const initialTab = searchParams.get('tab') === 'advanced' ? TAB_ADVANCED : TAB_RESOURCES;
   const [activeTab, setActiveTab] = useState(initialTab);
 
-  const [editedFields, setEditedFields] = useState<Partial<{name: string; description: string}>>({});
+  const [editedFields, setEditedFields] = useState<Partial<{name: string; description: string; identifier: string}>>(
+    {},
+  );
   const [isEditingName, setIsEditingName] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [tempName, setTempName] = useState('');
@@ -90,9 +92,14 @@ export default function ResourceServerEditPage(): JSX.Element {
     setActiveTab(newValue);
   };
 
-  const handleFieldChange = (field: 'name' | 'description', value: string): void => {
+  const handleFieldChange = (field: 'name' | 'description' | 'identifier', value: string): void => {
     if (!resourceServer) return;
-    const original = field === 'name' ? resourceServer.name : (resourceServer.description ?? '');
+    const original =
+      field === 'name'
+        ? resourceServer.name
+        : field === 'description'
+          ? (resourceServer.description ?? '')
+          : (resourceServer.identifier ?? '');
     if (value === original) {
       setEditedFields((prev) => {
         const next = {...prev};
@@ -119,6 +126,12 @@ export default function ResourceServerEditPage(): JSX.Element {
                 ? editedFields.description
                 : null
               : (resourceServer.description ?? null),
+          identifier:
+            'identifier' in editedFields
+              ? editedFields.identifier?.trim()
+                ? editedFields.identifier
+                : null
+              : (resourceServer.identifier ?? null),
           ouId: resourceServer.ouId,
         },
       },
@@ -300,7 +313,11 @@ export default function ResourceServerEditPage(): JSX.Element {
         aria-label={t('resourceServers:edit.tabs', 'Resource server settings')}
       >
         <Tab
-          label={t('resourceServers:edit.tab.resources', 'Resources')}
+          label={
+            resourceServer.type === 'MCP'
+              ? t('resourceServers:edit.tab.capabilities', 'Capabilities')
+              : t('resourceServers:edit.tab.resources', 'Resources')
+          }
           id="resource-server-tab-0"
           aria-controls="resource-server-tabpanel-0"
           sx={{textTransform: 'none'}}
@@ -328,11 +345,20 @@ export default function ResourceServerEditPage(): JSX.Element {
             title={t('resourceServers:edit.dangerZone.title', 'Danger Zone')}
             description={t(
               'resourceServers:edit.dangerZone.description',
-              'Irreversible actions for this resource server.',
+              'Actions in this section are irreversible. Proceed with caution.',
             )}
-            slotProps={{root: {sx: {borderColor: 'error.main', mt: 3}}}}
+            slotProps={{root: {sx: {mt: 3}}}}
           >
-            <Button variant="outlined" color="error" onClick={() => setDeleteDialogOpen(true)}>
+            <Typography variant="h6" gutterBottom color="error">
+              {t('resourceServers:edit.dangerZone.deleteServer.title', 'Delete resource server')}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
+              {t(
+                'resourceServers:edit.dangerZone.deleteServer.description',
+                'Permanently delete this resource server and all associated data. This action cannot be undone.',
+              )}
+            </Typography>
+            <Button variant="contained" color="error" onClick={() => setDeleteDialogOpen(true)}>
               {t('resourceServers:edit.dangerZone.deleteServer', 'Delete resource server')}
             </Button>
           </SettingsCard>
@@ -356,9 +382,8 @@ export default function ResourceServerEditPage(): JSX.Element {
         <AdvancedTab
           key={resourceServer.id}
           resourceServer={resourceServer}
-          onRefresh={() => {
-            void refetch();
-          }}
+          identifier={editedFields.identifier ?? resourceServer.identifier ?? ''}
+          onIdentifierChange={(v) => handleFieldChange('identifier', v)}
         />
       </TabPanel>
 

--- a/frontend/packages/configure-resource-servers/src/pages/__tests__/CreateResourceServerPage.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/__tests__/CreateResourceServerPage.test.tsx
@@ -142,6 +142,10 @@ describe('CreateResourceServerPage', () => {
       target: {value: 'Payments API'},
     });
 
+    fireEvent.change(screen.getByRole('textbox', {name: /handle/i}), {
+      target: {value: 'payments-api'},
+    });
+
     fireEvent.click(screen.getByRole('button', {name: /Continue/i}));
 
     await waitFor(() => {

--- a/frontend/packages/configure-resource-servers/src/pages/__tests__/ResourceServerEditPage.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/__tests__/ResourceServerEditPage.test.tsx
@@ -125,7 +125,11 @@ vi.mock('../../components/resource-tree/ResourceTree', () => ({
 }));
 
 vi.mock('../../components/resource-server-detail/AdvancedTab', () => ({
-  default: () => <div data-testid="advanced-tab" />,
+  default: ({identifier, onIdentifierChange}: {identifier: string; onIdentifierChange: (value: string) => void}) => (
+    <div data-testid="advanced-tab">
+      <input aria-label="Identifier" value={identifier} onChange={(e) => onIdentifierChange(e.target.value)} />
+    </div>
+  ),
 }));
 
 const mockResourceServer: ResourceServer = {
@@ -250,6 +254,53 @@ describe('ResourceServerEditPage', () => {
     renderWithProviders(<ResourceServerEditPage />);
 
     expect(screen.getByText(/This resource is read-only and cannot be modified/i)).toBeInTheDocument();
+  });
+
+  it('shows the unsaved changes bar when the identifier is edited in the Advanced tab', async () => {
+    renderWithProviders(<ResourceServerEditPage />);
+
+    fireEvent.click(screen.getByRole('tab', {name: 'Advanced Settings'}));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('advanced-tab')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Identifier'), {target: {value: 'https://new-api.example.com'}});
+
+    await waitFor(() => {
+      expect(screen.getByTestId('unsaved-changes-bar')).toBeInTheDocument();
+    });
+  });
+
+  it('includes the edited identifier when Save is clicked from the unsaved changes bar', async () => {
+    renderWithProviders(<ResourceServerEditPage />);
+
+    fireEvent.click(screen.getByRole('tab', {name: 'Advanced Settings'}));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('advanced-tab')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Identifier'), {target: {value: 'https://new-api.example.com'}});
+
+    await waitFor(() => {
+      expect(screen.getByTestId('unsaved-changes-bar')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+    expect(mockUpdateMutate).toHaveBeenCalledWith(
+      {
+        id: 'rs-1',
+        data: {
+          name: 'Dark Dodos Smash',
+          description: null,
+          identifier: 'https://new-api.example.com',
+          ouId: 'ou-1',
+        },
+      },
+      expect.any(Object),
+    );
   });
 
   it('shows the name text field when the edit icon button is clicked', async () => {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3520,7 +3520,7 @@ const translations = {
     'create.name.nameLabel': 'Resource Server Name',
     'create.name.namePlaceholder': 'e.g. Payments API',
     'create.name.suggestions': 'Need inspiration? Pick one:',
-    'create.name.handleLabel': 'Handle',
+    'create.name.handleLabel': 'Handle (Optional)',
     'create.name.handlePlaceholder': 'e.g. payments-api',
     'create.name.handleHint':
       'The handle prefixes every permission in this resource server. It cannot be changed after creation.',


### PR DESCRIPTION
### Purpose

Make the Console speak MCP's language for **MCP-type** resource servers (#3465). Instead of the generic "Resources & Actions" tree, an MCP resource server now shows a **"Capabilities"** view: one tree of **tools** and **resources** with optional **namespaces** (grouping nodes) inline, `All / Tools / Resources` filter chips, search, and a detail panel that shows each capability's derived permission scope. API- and CUSTOM-type resource servers render exactly as before.

> UI change

<img width="1986" height="1190" alt="Screenshot 2026-06-25 at 10 18 34 PM" src="https://github.com/user-attachments/assets/797785d8-1ea0-483f-88bb-52f070203bdb" />


### Approach

- Gated entirely on `resourceServer.type === 'MCP'`; the generic tree is preserved unchanged for API/CUSTOM-type resource servers.
- A single intermixed tree: tools (`Wrench`), resources (`Database`), namespaces (`Folder`/`FolderOpen`). Kind is conveyed by icon + a detail-panel badge, not by separate sections. Filter chips narrow by kind (counts show `N+` when namespaces may hold uncounted nested items); search keeps ancestors visible.
- Add affordances (Add Tool / Resource / Namespace) derive `kind` from the chosen action — there is no kind selector, since `kind` is immutable. A new `config/action-kinds.tsx` centralizes kind icons/labels. The role permission picker splits server-level tools/resources into labeled subsections for MCP servers.
- The detail panel shows the derived permission scope plus an Advanced (raw permission / delimiter) expander. No per-primitive URI/schema is shown — that is owned by the MCP server.

### Related Issues
- #3465

### Related PRs
- Backend counterpart (adds the `kind` API and validation): _linked below_

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP “Capabilities” experience with tools/resources/namespace filtering, search, and MCP-aware add-node flows.
  * Enhanced permission catalogs to render MCP-specific permission sections.
  * Added Identifier editing in advanced resource server settings (MCP-ready labels).

* **Bug Fixes**
  * Allowed MCP resource servers to be created/updated without an empty handle.
  * Improved MCP permission/action selection and copy display behavior.

* **Tests**
  * Expanded UI and service tests for MCP capabilities, filtering/search, create payloads, and identifier behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->