### PR TITLE
Allow hyphens in database filter keys

### DIFF
--- a/backend/internal/system/database/utils/querybuilder.go
+++ b/backend/internal/system/database/utils/querybuilder.go
@@ -91,12 +91,13 @@ func BuildSQLiteJSONCondition(columnName, key string) string {
 	return fmt.Sprintf(" AND json_extract(%s, '$.%s') = ?", columnName, key)
 }
 
-// ValidateKey ensures that the provided key contains only safe characters (alphanumeric, underscores, and dots).
+// ValidateKey ensures that the provided key contains only safe characters
+// (alphanumeric, underscores, dots, and hyphens).
 // This validation prevents SQL injection by ensuring keys can be safely used in queries.
 func ValidateKey(key string) error {
 	for _, char := range key {
 		if !(char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' ||
-			char >= '0' && char <= '9' || char == '_' || char == '.') {
+			char >= '0' && char <= '9' || char == '_' || char == '.' || char == '-') {
 			return fmt.Errorf("key '%s' contains invalid characters", key)
 		}
 	}

--- a/backend/internal/system/database/utils/querybuilder_test.go
+++ b/backend/internal/system/database/utils/querybuilder_test.go
@@ -120,7 +120,7 @@ func (suite *QueryBuilderTestSuite) TestBuildFilterQueryWithInvalidFilterKey() {
 	columnName := testColumnName
 	filters := map[string]interface{}{
 		"valid":              "value",
-		"invalid-filter-key": "value", // Contains invalid character '-'
+		"invalid;filter;key": "value", // Contains invalid character ';'
 	}
 
 	query, args, err := BuildFilterQuery(queryID, baseQuery, columnName, filters)
@@ -141,6 +141,9 @@ func (suite *QueryBuilderTestSuite) TestValidateKey() {
 		"with_underscore",
 		"_leading_underscore",
 		"trailing_underscore_",
+		"silver-mail",
+		"with-hyphen",
+		"a-b.c-d",
 	}
 
 	for _, key := range validKeys {
@@ -152,7 +155,6 @@ func (suite *QueryBuilderTestSuite) TestValidateKey() {
 func (suite *QueryBuilderTestSuite) TestValidateKeyInvalid() {
 	invalidKeys := []string{
 		"space key",
-		"hyphen-key",
 		"special!char",
 		"sql;injection",
 		"quote'test",


### PR DESCRIPTION
## Purpose
User schema property names can be defined with hyphens (for example `silver-mail`), but the database filter key validator only permitted alphanumeric characters, underscores, and dots. When such a property was marked `unique: true`, uniqueness validation and identification built a filter map keyed by the property name and the key was rejected, causing user creation and identification to fail with a generic internal server error.

## Related Issue
- https://github.com/thunder-id/thunderid/issues/1696

## Behaviour
<img width="1280" height="719" alt="ScreenRecording2026-06-26at09 25 36-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/eba03a61-4901-4678-be88-12655e4e8e74" />



## Implementation
- Added the hyphen to the allowed character set in `ValidateKey` (`backend/internal/system/database/utils/querybuilder.go`), the single chokepoint that all filter key validation routes through. Characters that could break out of the JSON path (quotes, semicolons, whitespace) remain rejected, so the existing protection is preserved. Hyphenated keys work in both dialects (`attributes->>'silver-mail'` on PostgreSQL and `json_extract(attributes, '$.silver-mail')` on SQLite), so no path builder changes were needed.
- Updated `querybuilder_test.go`: added hyphenated keys to the valid set, removed the hyphen case from the invalid set, and adjusted the invalid filter key fixture to use a still-rejected character.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Keys used in queries can now include hyphens, improving compatibility with more column and filter names.
  * Validation behavior has been aligned so hyphenated keys are no longer incorrectly rejected.
  * Related validation checks were updated to continue flagging truly invalid key formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->