### PR TITLE
Reject invalid characters in schema property names

### DIFF
--- a/backend/internal/entitytype/model/schema.go
+++ b/backend/internal/entitytype/model/schema.go
@@ -283,7 +283,29 @@ func CompileSchema(schema json.RawMessage) (*Schema, error) {
 	return compiled, nil
 }
 
+// validatePropertyName ensures a schema property name only contains characters
+// that are safe to use as a database filter key (letters, digits, and underscores).
+// Names are used directly as JSON filter keys during value and uniqueness lookups,
+// so characters such as hyphens would later be rejected by the query builder.
+func validatePropertyName(name string) error {
+	if name == "" {
+		return fmt.Errorf("property name must not be empty")
+	}
+	for _, char := range name {
+		if !(char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' ||
+			char >= '0' && char <= '9' || char == '_') {
+			return fmt.Errorf("property name '%s' contains invalid characters; "+
+				"only letters, digits, and underscores are allowed", name)
+		}
+	}
+	return nil
+}
+
 func compileProperty(propName string, propRaw json.RawMessage) (property, error) {
+	if err := validatePropertyName(propName); err != nil {
+		return nil, err
+	}
+
 	var propMap map[string]json.RawMessage
 	if err := json.Unmarshal(propRaw, &propMap); err != nil {
 		return nil, fmt.Errorf("property definition must be an object")

--- a/backend/internal/entitytype/model/schema_test.go
+++ b/backend/internal/entitytype/model/schema_test.go
@@ -256,6 +256,32 @@ func (s *SchemaValidateTestSuite) TestDisplayNameInvalidType_CompileError() {
 	s.Require().Contains(err.Error(), "'displayName' field must be a string")
 }
 
+func (s *SchemaValidateTestSuite) TestPropertyNameWithHyphen_CompileError() {
+	_, err := CompileSchema(json.RawMessage(`{
+		"silver-mail": {"type": "string", "unique": true}
+	}`))
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "property name 'silver-mail' contains invalid characters")
+}
+
+func (s *SchemaValidateTestSuite) TestNestedPropertyNameWithHyphen_CompileError() {
+	_, err := CompileSchema(json.RawMessage(`{
+		"address": {"type": "object", "properties": {
+			"postal-code": {"type": "string"}
+		}}
+	}`))
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "property name 'postal-code' contains invalid characters")
+}
+
+func (s *SchemaValidateTestSuite) TestPropertyNameWithUnderscore_CompileSuccess() {
+	schema, err := CompileSchema(json.RawMessage(`{
+		"family_name": {"type": "string", "unique": true}
+	}`))
+	s.Require().NoError(err)
+	s.Require().NotNil(schema)
+}
+
 func (s *SchemaValidateTestSuite) TestSchemaWithoutDisplayName_CompileSuccess() {
 	schema, err := CompileSchema(json.RawMessage(`{
 		"email": {"type": "string", "required": true}

--- a/frontend/packages/configure-user-types/src/components/create-user-type/ConfigureProperties.tsx
+++ b/frontend/packages/configure-user-types/src/components/create-user-type/ConfigureProperties.tsx
@@ -42,6 +42,7 @@ import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {SchemaPropertyInput, UIPropertyType} from '../../types/user-types';
 import {invalidateI18nCache} from '../../utils/invalidateI18nCache';
+import {isValidPropertyName} from '../../utils/isValidPropertyName';
 
 /**
  * Props for the {@link ConfigureProperties} component.
@@ -116,11 +117,14 @@ export default function ConfigureProperties({
     }
   }, [eligibleDisplayProperties, displayAttribute, onDisplayAttributeChange]);
 
-  // Broadcast readiness - ready when at least one property has a name
+  // Broadcast readiness - ready when at least one property has a name and all names are valid
   useEffect((): void => {
     if (onReadyChange) {
-      const hasValidProperty = properties.some((prop) => prop.name.trim().length > 0);
-      onReadyChange(hasValidProperty);
+      const hasNamedProperty = properties.some((prop) => prop.name.trim().length > 0);
+      const allNamesValid = properties.every(
+        (prop) => prop.name.trim().length === 0 || isValidPropertyName(prop.name.trim()),
+      );
+      onReadyChange(hasNamedProperty && allNamesValid);
     }
   }, [properties, onReadyChange]);
 
@@ -257,6 +261,12 @@ export default function ConfigureProperties({
                 onChange={(e) => handlePropertyChange(property.id, 'name', e.target.value)}
                 placeholder={t('userTypes:propertyNamePlaceholder')}
                 size="small"
+                error={property.name.trim().length > 0 && !isValidPropertyName(property.name.trim())}
+                helperText={
+                  property.name.trim().length > 0 && !isValidPropertyName(property.name.trim())
+                    ? t('userTypes:propertyNameInvalid')
+                    : undefined
+                }
               />
             </FormControl>
 

--- a/frontend/packages/configure-user-types/src/components/edit-user-type/schema-settings/EditSchemaSettings.tsx
+++ b/frontend/packages/configure-user-types/src/components/edit-user-type/schema-settings/EditSchemaSettings.tsx
@@ -44,6 +44,7 @@ import {useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {SchemaPropertyInput, PropertyType} from '../../../types/user-types';
 import {invalidateI18nCache} from '../../../utils/invalidateI18nCache';
+import {isValidPropertyName} from '../../../utils/isValidPropertyName';
 
 export interface EditSchemaSettingsProps {
   properties: SchemaPropertyInput[];
@@ -178,6 +179,12 @@ export default function EditSchemaSettings({
                   placeholder={t('userTypes:propertyNamePlaceholder', 'e.g., email, age, address')}
                   size="small"
                   disabled={disabled}
+                  error={property.name.length > 0 && !isValidPropertyName(property.name)}
+                  helperText={
+                    property.name.length > 0 && !isValidPropertyName(property.name)
+                      ? t('userTypes:propertyNameInvalid', 'Only letters, digits, and underscores are allowed.')
+                      : undefined
+                  }
                 />
               </FormControl>
 

--- a/frontend/packages/configure-user-types/src/pages/ViewUserTypePage.tsx
+++ b/frontend/packages/configure-user-types/src/pages/ViewUserTypePage.tsx
@@ -43,6 +43,7 @@ import EditGeneralSettings from '../components/edit-user-type/general-settings/E
 import EditSchemaSettings from '../components/edit-user-type/schema-settings/EditSchemaSettings';
 import UserTypeDeleteDialog from '../components/edit-user-type/UserTypeDeleteDialog';
 import type {PropertyDefinition, UserTypeDefinition, PropertyType, SchemaPropertyInput} from '../types/user-types';
+import {isValidPropertyName} from '../utils/isValidPropertyName';
 
 interface TabPanelProps {
   children?: ReactNode;
@@ -199,6 +200,11 @@ export default function ViewUserTypePage(): JSX.Element {
   const hasChanges = useMemo(
     () => Object.keys(editedUserType).length > 0 || editedProperties !== null,
     [editedUserType, editedProperties],
+  );
+
+  const hasInvalidPropertyName = useMemo(
+    () => effectiveProperties.some((prop) => prop.name.length > 0 && !isValidPropertyName(prop.name)),
+    [effectiveProperties],
   );
 
   const handleBack = async (): Promise<void> => {
@@ -441,7 +447,7 @@ export default function ViewUserTypePage(): JSX.Element {
           saveLabel={t('common:actions.save', 'Save')}
           savingLabel={t('common:status.saving', 'Saving...')}
           isSaving={updateUserTypeMutation.isPending}
-          saveDisabled={userType.isReadOnly === true}
+          saveDisabled={userType.isReadOnly === true || hasInvalidPropertyName}
           onReset={handleReset}
           onSave={() => {
             handleSave().catch(() => null);

--- a/frontend/packages/configure-user-types/src/utils/__tests__/isValidPropertyName.test.ts
+++ b/frontend/packages/configure-user-types/src/utils/__tests__/isValidPropertyName.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {isValidPropertyName} from '../isValidPropertyName';
+
+describe('isValidPropertyName', () => {
+  it('accepts letters, digits, and underscores', () => {
+    expect(isValidPropertyName('email')).toBe(true);
+    expect(isValidPropertyName('family_name')).toBe(true);
+    expect(isValidPropertyName('address2')).toBe(true);
+    expect(isValidPropertyName('_internal')).toBe(true);
+  });
+
+  it('rejects names containing hyphens', () => {
+    expect(isValidPropertyName('silver-mail')).toBe(false);
+    expect(isValidPropertyName('postal-code')).toBe(false);
+  });
+
+  it('rejects names with other invalid characters', () => {
+    expect(isValidPropertyName('first name')).toBe(false);
+    expect(isValidPropertyName('email.address')).toBe(false);
+    expect(isValidPropertyName('name!')).toBe(false);
+  });
+
+  it('rejects an empty name', () => {
+    expect(isValidPropertyName('')).toBe(false);
+  });
+});

--- a/frontend/packages/configure-user-types/src/utils/isValidPropertyName.ts
+++ b/frontend/packages/configure-user-types/src/utils/isValidPropertyName.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const PROPERTY_NAME_PATTERN = /^[a-zA-Z0-9_]+$/;
+
+/**
+ * Checks whether a schema property name is valid.
+ *
+ * Property names are used directly as database filter keys for value and
+ * uniqueness lookups, so the backend only accepts letters, digits, and
+ * underscores. This mirrors that rule so the console can surface the error
+ * as the user types instead of failing on submission.
+ */
+export function isValidPropertyName(name: string): boolean {
+  return PROPERTY_NAME_PATTERN.test(name);
+}

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -759,6 +759,7 @@ const translations = {
     schemaProperties: 'Schema Properties',
     propertyName: 'Property Name',
     propertyNamePlaceholder: 'e.g., email, age, address',
+    propertyNameInvalid: 'Only letters, digits, and underscores are allowed.',
     propertyType: 'Type',
     addProperty: 'Add Property',
     credential: 'Credential',


### PR DESCRIPTION
## Purpose
User schema property names could be defined with characters such as hyphens (for example `silver-mail`), but property names are used directly as JSON filter keys during value and uniqueness lookups. The query builder only accepts letters, digits, underscores, and dots as filter keys, so such names passed schema compilation but later failed at lookup time. When the property was marked `unique: true`, user creation and identification failed with a generic internal server error.

## Related Issue
- https://github.com/thunder-id/thunderid/issues/1696

## Implementation
- Added `validatePropertyName` in `backend/internal/entitytype/model/schema.go` and call it at the start of `compileProperty`, which is the single point every property name flows through. Property names are now restricted to letters, digits, and underscores. Invalid names are rejected during schema compilation, which surfaces as a clear client-facing validation error on entity type create/update rather than a runtime failure during user creation. This covers both top-level and nested object properties.
- Added tests in `schema_test.go` for hyphenated top-level and nested property names (rejected) and an underscore name (accepted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User-type schema property names are now validated during compilation, rejecting invalid characters (for example hyphens) early with a clear error.
* **New Features**
  * The user-type configuration UI validates property names inline (letters, digits, underscores only), shows helpful guidance, and prevents saving when any property name is invalid.
* **Tests**
  * Added coverage for valid/invalid property names, including nested cases, on both backend compilation and the frontend validator.
* **Documentation**
  * Added the new English validation message for invalid property names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->