### PR TITLE
Improvement to UX in Flow builder in senders and idp auto assignment

### DIFF
--- a/frontend/apps/console/src/features/flows/components/FlowBuilder.tsx
+++ b/frontend/apps/console/src/features/flows/components/FlowBuilder.tsx
@@ -25,7 +25,6 @@ import {useTranslation} from 'react-i18next';
 import {useParams} from 'react-router';
 import '@xyflow/react/dist/style.css';
 
-import {EXECUTOR_TO_IDP_TYPE_MAP} from '../components/resource-property-panel/extended-properties/execution-properties/constants';
 import SsoDisableConfirmDialog from '../components/SsoDisableConfirmDialog';
 import SsoToggle from '../components/SsoToggle';
 import CompactStacksContext from '../context/CompactStacksContext';
@@ -50,10 +49,9 @@ import FlowConstants from '@/features/flows/constants/FlowConstants';
 import useFlowConfig from '@/features/flows/hooks/useFlowConfig';
 import useFlowEvents from '@/features/flows/hooks/useFlowEvents';
 import useValidationStatus from '@/features/flows/hooks/useValidationStatus';
-import {ExecutionTypes, StepTypes, type StepData} from '@/features/flows/models/steps';
+
 import {GRAPH_VALIDATION_RULES} from '@/features/flows/validation/validation-rules';
 
-const SMS_EXECUTORS = new Set<string>([ExecutionTypes.SMSExecutor]);
 
 function FlowBuilder() {
   const {flowId} = useParams<{flowId: string}>();
@@ -123,82 +121,8 @@ function FlowBuilder() {
     onNeedsAutoLayout: setNeedsAutoLayout,
   });
 
-  // Auto-assign connections for executor nodes with placeholder IDP/sender IDs
-  const {data: identityProviders, isPending: isIdentityProvidersPending} = useIdentityProviders();
-  const {data: smsProviders, isPending: isSMSProvidersPending} = useSMSProviders();
-  const hasAutoAssignedRef = useRef<boolean>(false);
-
-  useEffect(() => {
-    if (nodes.length === 0 || hasAutoAssignedRef.current) {
-      return;
-    }
-
-    // Wait until both data sources are available
-    if (!identityProviders || !smsProviders) {
-      return;
-    }
-
-    setNodes((currentNodes: Node[]) => {
-      let changed = false;
-
-      const updated = currentNodes.map((node: Node) => {
-        if (node.type !== StepTypes.Execution) return node;
-
-        const stepData = node.data as StepData | undefined;
-        const executorName = (stepData?.action as {executor?: {name?: string}} | undefined)?.executor?.name;
-        if (!executorName) return node;
-
-        const {senderId: currentSenderId = '', idpId: currentIdpId = ''} =
-          (stepData?.properties as Record<string, string> | undefined) ?? {};
-
-        // Handle SMS executors - auto-assign senderId
-        if (SMS_EXECUTORS.has(executorName) && smsProviders) {
-          if (currentSenderId === '{{SENDER_ID}}' || currentSenderId === '') {
-            if (smsProviders.length === 1) {
-              changed = true;
-              return {
-                ...node,
-                data: {
-                  ...node.data,
-                  properties: {
-                    ...(stepData?.properties ?? {}),
-                    senderId: smsProviders[0].id,
-                  },
-                },
-              };
-            }
-          }
-          return node;
-        }
-
-        // Handle IDP executors - auto-assign idpId
-        const idpType = EXECUTOR_TO_IDP_TYPE_MAP[executorName];
-        if (!idpType || !identityProviders) return node;
-
-        if (currentIdpId !== '{{IDP_ID}}' && currentIdpId !== '') return node;
-
-        const matching = identityProviders.filter((idp) => idp.type === idpType);
-        if (matching.length !== 1) return node;
-
-        changed = true;
-        return {
-          ...node,
-          data: {
-            ...node.data,
-            properties: {...(stepData?.properties ?? {}), idpId: matching[0].id},
-          },
-        };
-      });
-
-      if (changed) {
-        hasAutoAssignedRef.current = true;
-        return updated;
-      }
-
-      return currentNodes;
-    });
-  }, [identityProviders, smsProviders, nodes.length, setNodes]);
-
+  const {isPending: isIdentityProvidersPending} = useIdentityProviders();
+  const {isPending: isSMSProvidersPending} = useSMSProviders();
   // Element addition hook
   const {handleAddElementToView, handleAddElementToForm} = useElementAddition({
     setNodes,
@@ -331,6 +255,7 @@ function FlowBuilder() {
     setOpenValidationPanel,
     onSaved: handleSaved,
   });
+
 
   // SSO toggle orchestration (enable/disable transformations, placement mode)
   const sso = useSsoToggle({

--- a/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
@@ -79,6 +79,7 @@ import {type Template} from '../../models/templates';
 import type {Widget} from '../../models/widget';
 import applyAutoLayout, {hasUnpositionedNodes} from '../../utils/applyAutoLayout';
 import {EXECUTION_STACK_NODE_TYPE, getExecutionStackWidth} from '../../utils/compactGraphTransforms';
+import autoAssignConnections from '../../utils/autoAssignConnections';
 import computeExecutorConnections from '../../utils/computeExecutorConnections';
 import generateResourceId from '../../utils/generateResourceId';
 import {resolveCollisions} from '../../utils/resolveCollisions';
@@ -299,11 +300,22 @@ function DecoratedVisualFlow({
     pendingDropRef.current = null;
   }, []);
 
+  const handleStepLoad = useCallback(
+    (step: Step): Step => {
+      const loadedStep = onStepLoad(step);
+      if (computedMetadata?.executorConnections) {
+        autoAssignConnections([loadedStep], computedMetadata.executorConnections);
+      }
+      return loadedStep;
+    },
+    [onStepLoad, computedMetadata],
+  );
+
   const handleContainerDialogConfirm = useContainerDialogConfirm({
     dropScenario,
     handleContainerDialogClose,
     generateStepElement,
-    onStepLoad,
+    onStepLoad: handleStepLoad,
     setNodes,
     setEdges,
     onResourceDropOnCanvas,
@@ -315,7 +327,7 @@ function DecoratedVisualFlow({
   const handleOnAdd = useResourceAdd({
     onTemplateLoad,
     onWidgetLoad,
-    onStepLoad,
+    onStepLoad: handleStepLoad,
     setNodes,
     setEdges,
     generateStepElement,
@@ -329,7 +341,7 @@ function DecoratedVisualFlow({
   });
 
   const {addCanvasNode, addToView, addToForm, addToViewAtIndex, addToFormAtIndex} = useDragDropHandlers({
-    onStepLoad,
+    onStepLoad: handleStepLoad,
     setNodes,
     setEdges,
     onResourceDropOnCanvas,

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
@@ -22,7 +22,9 @@ import {render, screen, fireEvent, waitFor, cleanup, act} from '@thunderid/test-
 import type {Node, Edge} from '@xyflow/react';
 import React from 'react';
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import type {UseResourceAddProps} from '../../../hooks/useResourceAdd';
 import type {Resources} from '../../../models/resources';
+import type {Step} from '../../../models/steps';
 import DecoratedVisualFlow from '../DecoratedVisualFlow';
 
 const mockNavigate = vi.fn();
@@ -81,8 +83,12 @@ vi.mock('../../../hooks/useComponentDelete', () => ({
   }),
 }));
 
+const {mockUseResourceAdd} = vi.hoisted(() => ({
+  mockUseResourceAdd: vi.fn(() => vi.fn()),
+}));
+
 vi.mock('../../../hooks/useResourceAdd', () => ({
-  default: () => vi.fn(),
+  default: mockUseResourceAdd,
 }));
 
 vi.mock('../../../hooks/useGenerateStepElement', () => ({
@@ -144,8 +150,17 @@ vi.mock('../../../utils/resolveCollisions', () => ({
   resolveCollisions: vi.fn((nodes) => nodes),
 }));
 
+const {mockComputeExecutorConnections, mockAutoAssignConnections} = vi.hoisted(() => ({
+  mockComputeExecutorConnections: vi.fn(() => [] as unknown[]),
+  mockAutoAssignConnections: vi.fn(),
+}));
+
 vi.mock('../../../utils/computeExecutorConnections', () => ({
-  default: vi.fn(() => []),
+  default: mockComputeExecutorConnections,
+}));
+
+vi.mock('../../../utils/autoAssignConnections', () => ({
+  default: mockAutoAssignConnections,
 }));
 
 vi.mock('@thunderid/configure-connections', async (importOriginal) => ({
@@ -1747,6 +1762,35 @@ describe('DecoratedVisualFlow', () => {
       await waitFor(() => {
         expect(screen.getByTestId('visual-flow')).toBeInTheDocument();
       });
+    });
+  });
+  describe('Step Load Handling', () => {
+    it('should call autoAssignConnections when step is loaded and executorConnections exist', () => {
+      mockComputeExecutorConnections.mockReturnValue([{id: 'test'}] as unknown[]);
+      renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+
+      const propsPassed = (mockUseResourceAdd.mock.calls[0] as unknown[])[0] as UseResourceAddProps;
+      const step = {id: 'step-1', type: 'execution'} as unknown as Step;
+
+      const loadedStep = propsPassed.onStepLoad(step);
+
+      expect(defaultProps.onStepLoad).toHaveBeenCalledWith(step);
+      expect(mockAutoAssignConnections).toHaveBeenCalledWith([step], [{id: 'test'}]);
+      expect(loadedStep).toEqual(step);
+    });
+
+    it('should not call autoAssignConnections when executorConnections do not exist', () => {
+      // computeExecutorConnections returns [] and metadata is undefined → computedMetadata is undefined
+      mockComputeExecutorConnections.mockReturnValue([]);
+      mockAutoAssignConnections.mockClear();
+      renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+
+      const propsPassed = (mockUseResourceAdd.mock.calls[0] as unknown[])[0] as UseResourceAddProps;
+      const step = {id: 'step-1', type: 'execution'} as unknown as Step;
+
+      propsPassed.onStepLoad(step);
+
+      expect(mockAutoAssignConnections).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/pages/FlowCreatePage.tsx
+++ b/frontend/apps/console/src/features/flows/pages/FlowCreatePage.tsx
@@ -18,6 +18,7 @@
 
 import {useLogger} from '@thunderid/logger/react';
 import {Alert, Box, Button, CircularProgress, IconButton, LinearProgress, Stack, AppBreadcrumbs} from '@wso2/oxygen-ui';
+import {useIdentityProviders, useSMSProviders} from '@thunderid/configure-connections';
 import {X} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
 import {useMemo, useState} from 'react';
@@ -30,6 +31,7 @@ import SelectFlowTemplate from '../components/create-flow/SelectFlowTemplate';
 import SelectFlowType from '../components/create-flow/SelectFlowType';
 import useFlowRoutes from '../hooks/useFlowRoutes';
 import type {FlowType} from '../models/flows';
+import {ExecutionTypes} from '../models/steps';
 import type {FlowTemplate} from '../models/templates';
 
 const FlowCreateStep = {
@@ -48,6 +50,8 @@ export default function FlowCreatePage(): JSX.Element {
   const flowRoutes = useFlowRoutes();
   const logger = useLogger('FlowCreatePage');
   const createFlow = useCreateFlow();
+  const {data: identityProviders} = useIdentityProviders();
+  const {data: smsProviders} = useSMSProviders();
 
   const [currentStep, setCurrentStep] = useState<FlowCreateStep>(FlowCreateStep.TYPE);
   const [selectedType, setSelectedType] = useState<FlowType | null>(null);
@@ -81,11 +85,26 @@ export default function FlowCreatePage(): JSX.Element {
     }
     if (currentStep === FlowCreateStep.CONFIGURE) {
       if (!selectedType || !selectedTemplate) return;
+
+      let nodesToSave = selectedTemplate.config.nodes;
+
+      const smsProvider = smsProviders?.length === 1 ? smsProviders[0] : null;
+      if (smsProvider || identityProviders?.length) {
+        nodesToSave = structuredClone(nodesToSave);
+        nodesToSave.forEach((node) => {
+          if (!node.executor?.name) return;
+          const props = node.properties as Record<string, string> | undefined;
+          if (node.executor.name === ExecutionTypes.SMSExecutor && smsProvider && (!props?.senderId || props.senderId === '{{SENDER_ID}}')) {
+            node.properties = {...node.properties, senderId: smsProvider.id};
+          }
+        });
+      }
+
       const flowRequest = {
         name: nameValue.name,
         handle: nameValue.handle,
         flowType: selectedType,
-        nodes: selectedTemplate.config.nodes,
+        nodes: nodesToSave,
       };
       setError(null);
       createFlow.mutate(flowRequest, {


### PR DESCRIPTION
fixes https://github.com/thunder-id/thunderid/issues/3434
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
In an existing flow the UI, shows as if the sender/idp is auto assigned in the UI, eventhough the backend is not actually assigned.
The issue is the auto assignment logic was done to all senders/idps
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
Moved the auto assignment logic from the flow builder to Template and Widget loading, this get's the convenience of auto assignment, while preserving the actual state displayed in pre existing flows of the flow builder.
### Related Issues
- https://github.com/thunder-id/thunderid/issues/3434

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login flow steps now automatically populate sender and identity provider values when the relevant fields are placeholders (or empty) and there is exactly one valid option available (common SMS and IDP cases).

* **Bug Fixes**
  * Improved consistency of placeholder handling and execution-step initialization across step, template, and widget loading—reducing the need for manual placeholder replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->