### PR TITLE
Restore project coverage Codecov check as a blocking PR gate

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -64,20 +64,20 @@ coverage:
         enabled: true
         target: 60%
         threshold: 1%
-        informational: true
+        informational: false
       backend-unit:
         flags:
           - backend-unit
         target: 60%
         threshold: 1%
-        informational: true
+        informational: false
       backend-integration:
         flags:
           - backend-integration-sqlite
           - backend-integration-postgres
         target: 60%
         threshold: 1%
-        informational: true
+        informational: false
       backend-combined:
         flags:
           - backend-unit
@@ -97,19 +97,19 @@ coverage:
           - frontend-apps-gate-unit
         target: auto
         threshold: 1%
-        informational: true
+        informational: false
       frontend-apps-console-unit:
         flags:
           - frontend-apps-console-unit
         target: 60%
         threshold: 1%
-        informational: true
+        informational: false
       frontend-apps-gate-unit:
         flags:
           - frontend-apps-gate-unit
         target: 60%
         threshold: 1%
-        informational: true
+        informational: false
     patch:
       default:
         target: 80%


### PR DESCRIPTION
### Purpose
Restore the **project coverage** Codecov check as a blocking gate on pull requests.

The project coverage status stopped gating PRs after #2658 ("Update codecov action version and make project codecov informational", merged 2026-05-11, commit `fd3d96d10`), which flipped every `coverage.status.project.*` entry from `informational: false` to `informational: true`. An `informational: true` status is non-blocking and always passes, so the project coverage gate that used to appear on PRs (e.g. #2500) effectively disappeared.

### Approach
Set `informational: false` on all `coverage.status.project.*` entries in `codecov.yml` (`default`, `backend-unit`, `backend-integration`, `combined`, `frontend-apps-console-unit`, `frontend-apps-gate-unit`). `backend-combined` and `patch/default` were already blocking. No workflow changes are needed — `pr-builder.yml` already uploads coverage correctly.

### Related Issues
- Fixes #3557

### Related PRs
- Regressed in #2658

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Coverage checks for several backend and frontend test groups are now enforced instead of being informational only.
  * Coverage targets and thresholds remain unchanged, but these checks will now affect pass/fail status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->