### PR TITLE
Restructure agent guidance into a scoped router

### DIFF
--- a/.agent/skills/console/SKILL.md
+++ b/.agent/skills/console/SKILL.md
@@ -93,112 +93,34 @@ playwright-cli state-load thunderid-auth -s=thunderid
 playwright-cli goto {CONSOLE_URL} -s=thunderid
 ```
 
-## Route Map
+## Routes
 
-The ThunderID Console base path is `/console`. Append routes below to the resolved `{CONSOLE_URL}`. The sidebar is organized into categories.
+Routes change often, so they are not duplicated here — a copied table goes stale. Derive routes from these source files, relative to the repository root:
 
-### Sidebar Navigation
+- Route definitions: `frontend/apps/console/src/App.tsx`
+- Sidebar navigation and categories: `frontend/apps/console/src/layouts/DashboardLayout.tsx`
 
-| Category | Page | Path |
-|---|---|---|
-| - | Home | `/console/home` |
-| Resources | Applications | `/console/applications` |
-| Identities | Users | `/console/users` |
-| Identities | Groups | `/console/groups` |
-| Identities | Roles | `/console/roles` |
-| Identities | User Types | `/console/user-types` |
-| Configure | Organization Units | `/console/organization-units` |
-| Configure | Flows | `/console/flows` |
-| Configure | Integrations | `/console/integrations` |
-| Customize | Design | `/console/design` |
-| Customize | Translations | `/console/translations` |
-
-### Creation Routes
-
-| Resource | Path |
-|---|---|
-| Application | `/console/applications/create` |
-| User | `/console/users/create` |
-| Invite User | `/console/users/invite` |
-| Group | `/console/groups/create` |
-| Role | `/console/roles/create` |
-| User Type | `/console/user-types/create` |
-| Organization Unit | `/console/organization-units/create` |
-| Theme | `/console/design/themes/create` |
-| Translation | `/console/translations/create` |
-
-### Detail/Edit Routes
-
-| Resource | Path |
-|---|---|
-| Application | `/console/applications/:applicationId` |
-| User | `/console/users/:userId` |
-| Group | `/console/groups/:groupId` |
-| Role | `/console/roles/:roleId` |
-| User Type | `/console/user-types/:id` |
-| Organization Unit | `/console/organization-units/:id` |
-| Theme Builder | `/console/design/themes/:themeId` |
-| Layout Builder | `/console/design/layouts/:layoutId` |
-| Login Flow | `/console/flows/signin` or `/console/flows/signin/:flowId` |
-| Translation | `/console/translations/:language` |
+The Console base path is `/console`; append a route from `App.tsx` to the resolved `{CONSOLE_URL}` (e.g. `{CONSOLE_URL}/users`).
 
 ## Common Patterns
 
-### Navigate to a Page
+Almost every interaction is the same loop: `goto` (or `click` a sidebar/button ref) → `snapshot` to get fresh refs → `fill`/`click` by ref → `snapshot` to confirm. Always re-snapshot after a navigation or action, since refs change. Examples — navigating, creating a resource, and searching:
 
 ```bash
+# Navigate / create / search all follow the goto → snapshot → act → snapshot loop
 playwright-cli goto {CONSOLE_URL}/users -s=thunderid
-playwright-cli snapshot -s=thunderid
-```
-
-### Navigate via Sidebar
-
-```bash
-# Snapshot to see sidebar element refs
-playwright-cli snapshot -s=thunderid
-# Click a sidebar item by its ref
-playwright-cli click <sidebar-item-ref> -s=thunderid
-```
-
-### Create a Resource (e.g., User)
-
-```bash
-# Navigate to users list
-playwright-cli goto {CONSOLE_URL}/users -s=thunderid
-playwright-cli snapshot -s=thunderid
-
-# Click the "Add User" or create button
+playwright-cli snapshot -s=thunderid                 # get current refs
 playwright-cli click <create-button-ref> -s=thunderid
 playwright-cli snapshot -s=thunderid
-
-# Fill the creation form fields using refs from snapshot
-playwright-cli fill <field-ref> "value" -s=thunderid
-
-# Submit
+playwright-cli fill <field-ref> "value" -s=thunderid # or <search-input-ref> "john"
 playwright-cli click <submit-ref> -s=thunderid
 playwright-cli snapshot -s=thunderid
 ```
 
-### Search in a List
-
-```bash
-playwright-cli goto {CONSOLE_URL}/users -s=thunderid
-playwright-cli snapshot -s=thunderid
-playwright-cli fill <search-input-ref> "john" -s=thunderid
-playwright-cli snapshot -s=thunderid
-```
-
-### Inspect an Element
+Inspect an element, or capture a screenshot:
 
 ```bash
 playwright-cli eval "el => el.getAttribute('data-testid')" <ref> -s=thunderid
-playwright-cli eval "el => el.textContent" <ref> -s=thunderid
-```
-
-### Take a Screenshot
-
-```bash
-playwright-cli screenshot -s=thunderid
 playwright-cli screenshot --filename=console-users.png -s=thunderid
 ```
 

--- a/.agent/skills/db/SKILL.md
+++ b/.agent/skills/db/SKILL.md
@@ -5,8 +5,6 @@ description: Database schema and query conventions for ThunderID. Use when chang
 
 # Database Schema Design Principles and Conventions
 
-This document explains the database schema design principles and conventions used in ThunderID. AI agents and contributors should follow these conventions when generating or modifying database schemas and queries.
-
 ## Logical Database Separation
 
 ThunderID uses three logically separated databases. Each database owns a specific category of data.
@@ -64,26 +62,11 @@ CREATE TABLE "ROLE_ASSIGNMENT" (
 );
 ```
 
-This approach:
-
-- Reduces index size compared to adding a separate surrogate key.
-- Aligns with the natural query patterns for many-to-many relationships.
-- Prevents duplicate association rows at the database level.
+This reduces index size, matches natural many-to-many query patterns, and prevents duplicate association rows at the database level.
 
 ## Foreign Key Strategy
 
-Foreign keys reference UUID primary keys directly. Integer-based foreign keys are not used anywhere in the schema.
-
-The system does not introduce:
-
-- `INT`-based surrogate identifiers.
-- UUID-to-integer resolution layers.
-
-This avoids unnecessary lookup overhead and architectural complexity when joining across tables or deployments.
-
-## No Auto-Increment IDs
-
-The schema does not use auto-increment integer identifiers. UUID v7 identifiers serve as the only primary key mechanism across all tables.
+Foreign keys reference UUID primary keys directly. Do not introduce `INT`-based surrogate identifiers, UUID-to-integer resolution layers, or auto-increment IDs anywhere in the schema — UUID v7 is the only primary key mechanism.
 
 ## Multi-Deployment Isolation
 
@@ -173,20 +156,7 @@ WHERE f.ID = $1 AND f.DEPLOYMENT_ID = $2
 
 ## Indexing Philosophy
 
-Indexes in ThunderID are designed to match real query patterns. The process for defining or revising indexes is:
-
-1. Review the queries associated with each table.
-2. Identify missing or inefficient indexes.
-3. Optimize existing indexes, including composite primary keys.
-4. Introduce composite indexes where they improve common query patterns.
-5. Update both the PostgreSQL and SQLite schema scripts accordingly.
-
-### Indexing Goals
-
-- Improve lookup speed for primary access patterns.
-- Optimize join performance between related tables.
-- Improve filtering performance for deployment-scoped queries.
-- Reduce full table scans.
+Indexes match real query patterns. When defining or revising indexes: review each table's queries, identify missing or inefficient indexes, optimize existing ones (including composite primary keys), add composite indexes for common patterns, and update both the PostgreSQL and SQLite schema scripts.
 
 ### Composite Indexes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,35 @@
 # Project Overview
 
-ThunderID is a lightweight user and identity management product. Go backend + React frontend in a monorepo. It provides authentication and authorization via OAuth2/OIDC, flexible orchestration flows, and individual auth mechanisms (password, passwordless, social login).
+ThunderID is a lightweight user and identity management product: a Go backend (`backend/`) and React frontend (`frontend/`) in a monorepo. It provides authentication and authorization via OAuth2/OIDC, flexible orchestration flows, and individual auth mechanisms (password, passwordless, social login).
 
-- [ARCHITECTURE.md](ARCHITECTURE.md)
-- For build and running - [Makefile](Makefile) and [README.md](README.md)
+- [ARCHITECTURE.md](ARCHITECTURE.md) — read only for cross-cutting changes
+- Build and run: [Makefile](Makefile) and [README.md](README.md)
 - Documentation at [docs/content](docs/content)
 
-Login Gate leverages v2 of the [ThunderID JavaScript SDK](https://github.com/thunder-id/thunderid/tree/main/sdks/javascript), consumed via its published package in typical setups.
-Clone the SDK repository only if you are developing or debugging the SDK itself, or testing the product against unreleased SDK changes.
+## Where to Look Next
+
+Load only the guidance the task needs:
+
+| Working on… | Read |
+|---|---|
+| Backend Go code | [backend/AGENTS.md](backend/AGENTS.md) |
+| Frontend React code | [frontend/AGENTS.md](frontend/AGENTS.md) |
+| Documentation | [docs/AGENTS.md](docs/AGENTS.md) |
+| Database schema, queries, or stores | [.agent/skills/db/SKILL.md](.agent/skills/db/SKILL.md) |
+| Browser automation / Console UI verification | [.agent/skills/console/SKILL.md](.agent/skills/console/SKILL.md) |
+
+The `.agent/skills/` entries above are internal guidance for **developing** ThunderID. Consumer-facing setup and framework-integration skills (`setup-thunderid`, `integrate-*`) live in the separate ThunderID Skills repository (installable via `/plugin marketplace add thunder-id/skills`) and are not used when working in this repo.
+
+## Search Hygiene
+
+- `rg` honors `.gitignore`, which already excludes build outputs, `node_modules`, `.claude/`, `/coverage`, `tests/e2e/distribution/`, `.turbo`, and generated API specs — don't search them.
+- Do not search mirror worktrees under `.claude/worktrees/` (they duplicate the repo and double your results).
+
+## Validation Ladder
+
+- **Inner loop**: run the smallest relevant checks for the area you touched. The scoped AGENTS files say which tests to run.
+- **Pre-PR gate**: `make pr_checks` — the authoritative gate (verify_mocks → lint → format_check → unit/frontend/integration tests → builds).
+- Note: `make test` is backend-only (unit + integration), not full-repo validation.
 
 ## Product Name Rules
 
@@ -22,43 +44,18 @@ Clone the SDK repository only if you are developing or debugging the SDK itself,
 - Prefer editing existing files over creating new ones.
 - Do not add new dependencies or modify CI/CD pipelines, GitHub Actions, or Makefiles without explicit approval.
 - Do not over-engineer. No premature abstractions, no feature flags, no backwards-compatibility shims.
-- Mocks are auto-generated via `make mockery`. Do not generate or modify mock files manually.
 - Delete dead code cleanly. No `// removed` or `// deprecated` placeholder comments. No renaming unused variables to `_` prefixed names — remove them entirely unless required by an interface, callback, or framework signature.
 - Do not create fallback tests with mock/hardcoded data when original tests fail. Fix the actual failing tests.
-- Do not add error handling for scenarios that cannot happen.
 - Write tests for new features and bug fixes (target 80%+ coverage).
-- Ensure proper error handling and logging at appropriate layers — not everywhere, just where failures are expected and actionable.
-- Ensure all identity-related code aligns with relevant RFC specifications.
-- Declarative resource attributes use camelCase, matching the REST API. The `yaml` struct tag must use the same camelCase name as the field's `json` tag (for example `yaml:"ouId"`, not `yaml:"ou_id"`). This does not apply to non-declarative YAML such as `deployment.yaml` server config, or to `json` tags for protocol payloads (OAuth, DCR) that follow their own RFC conventions.
-- Use `make lint` and `make test` to verify code quality and correctness before committing.
-- For architecture diagrams, flow diagrams, sequence diagrams, and similar visuals in documentation, prefer Mermaid over hand-drawn rect/box components (e.g. raw SVG, ASCII art, or manually positioned shapes). Only fall back to non-Mermaid components when the diagram requires layout Mermaid cannot express.
+- Add error handling and logging only where failures are expected and actionable — not for scenarios that cannot happen, and not everywhere.
 
 ## Git and PR Conventions
 
-- Adhere to .github/pull_request_template.md
+- Adhere to [.github/pull_request_template.md](.github/pull_request_template.md).
 
 ### Commit Messages
 - Use short imperative sentences without conventional commit prefixes (no `feat:`, `fix:`, etc.).
 - Reference the related issue or pull request when applicable (e.g., `Refs #123` or `Fixes #123`).
 
 ### One Commit Per Pull Request
-- Each PR must have a single commit. Only add a second commit when strictly necessary. Never leave intermediate or fixup commits in the PR.
-
-## Agent Skills
-
-- [Console Navigator](.agent/skills/console/SKILL.md) — Browse and interact with the Console UI using `playwright-cli`. Use when asked to navigate the console, test UI changes, or create/edit resources through the browser.
-- [Database](.agent/skills/db/SKILL.md) — Database schema design principles and query conventions. Use for any database-related work.
-
-## Contributing Guidelines
-
-- [`docs/content/community/contributing/contributing-code/backend-development/overview.mdx`](docs/content/community/contributing/contributing-code/backend-development/overview.mdx) — Go backend: package structure, database patterns, error handling, service initialization, transactions, testing
-- [`docs/content/community/contributing/contributing-code/frontend-development/overview.mdx`](docs/content/community/contributing/contributing-code/frontend-development/overview.mdx) — React/TypeScript: component patterns, testing, linting
-- [`docs/AGENTS.md`](/docs/AGENTS.md) — Documentation authoring standards and component development standards (product name templating, Oxygen UI components, icons, styling, custom.css governance)
-
-# Agent Guidance Index
-
-Agent skills live under `.agent/skills/`.
-
-- Database schema and query conventions: `.agent/skills/db/SKILL.md`
-
-For any database-related work, follow `.agent/skills/db/SKILL.md`.
+- Each PR must have a single commit. Never leave intermediate or fixup commits in the PR.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,23 @@
+# Backend — Agent Guide
+
+Read with the root [AGENTS.md](../AGENTS.md). The backend is a Go application under `backend/` (module `github.com/thunder-id/thunderid`): domain packages under `backend/internal/`, entry points under `backend/cmd/`, public packages under `backend/pkg/`.
+
+For the canonical, deeper reference (flat package/file layout, export rules, logging), see the [Backend Development overview](../docs/content/community/contributing/contributing-code/backend-development/overview.mdx).
+
+## When to Load Other Guides
+
+- Touching `store.go`, schema, or queries → read [.agent/skills/db/SKILL.md](../.agent/skills/db/SKILL.md).
+- Changing any interface → regenerate mocks with `make mockery`. CI's `verify_mocks` job fails if mocks are out of sync. Never hand-edit mock files.
+
+## Conventions
+
+- Ensure all identity-related code aligns with relevant RFC specifications.
+- Declarative resource attributes use camelCase, matching the REST API. The `yaml` struct tag must use the same camelCase name as the field's `json` tag (for example `yaml:"ouId"`, not `yaml:"ou_id"`). This does not apply to non-declarative YAML such as `deployment.yaml` server config, or to `json` tags for protocol payloads (OAuth, DCR) that follow their own RFC conventions.
+- Logging: use the `log` package from `internal/system` and pass the request `context.Context` first so entries carry the trace ID; avoid PII. See the overview for the full conventions (non-request contexts, `MaskString`).
+
+## Test Selection
+
+- **Inner loop**:
+  - service / store / API handler change → `make test_unit` first.
+  - DB or API-contract change → also add `make test_integration` (filter with `RUN="TestName"` or `PACKAGE="pkg/path"`).
+- **Final gate**: `make test_unit` + `make test_integration`, or `make pr_checks` before opening a PR.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,8 +5,6 @@ description: AI agents should use this file when creating and reviewing document
 
 # ThunderID Documentation Creation Instructions
 
-Follow these instructions when creating new documentation content for ThunderID. Adhere to all guidelines to ensure consistency, clarity, and quality.
-
 ## Scope and Boundaries
 
 
@@ -18,15 +16,12 @@ Follow these instructions when creating new documentation content for ThunderID.
 
 ### What You Must Do
 
-- Strictly adhere to the authoring standards outlined below.
 - Choose the appropriate navigation location for the new content based on its topic and relevance.
 - Create content that is clear, concise, and actionable for the intended audience.
 - Ensure all technical details are accurate and up-to-date.
 - Use the provided templates and formatting rules consistently.
 
 ## Authoring Standards
-
-You must follow these standards when creating documentation content for ThunderID.
 
 ### Voice and Tone
 
@@ -128,7 +123,15 @@ Reduce unnecessary use of:
 - was  
 - were  
 
-Prefer direct verbs.
+Prefer direct verbs, using “is” only when it improves clarity.
+
+**Instead of:**
+
+> The token is used to authenticate requests.
+
+**Write:**
+
+> The token authenticates requests.
 
 **Instead of:**
 
@@ -139,16 +142,6 @@ Prefer direct verbs.
 > The configuration file is `deployment.toml`.  
 > Or:  
 > Find the configuration in `deployment.toml`.
-
-**Instead of:**
-
-> The token is used to authenticate requests.
-
-**Write:**
-
-> The token authenticates requests.
-
-Use “is” only when it improves clarity.
 
 ### 7. Prefer Concrete Language
 
@@ -365,8 +358,6 @@ When Vale feedback is provided through CI checks:
 - If the latest CI run is clean, do not comment on earlier issues.
 
 ## Vocabulary Guidelines
-
-Strictly follow these vocabulary guidelines when writing ThunderID documentation.
 
 ### Use of "Multiple"
 

--- a/docs/content/community/contributing/contributing-code/pull-request-workflow.mdx
+++ b/docs/content/community/contributing/contributing-code/pull-request-workflow.mdx
@@ -13,8 +13,8 @@ For area-specific coding standards, see the [Backend Development](backend-develo
 
 Follow coding guidelines and best practices:
 
-- **Backend**: Review `.github/instructions/` for package structure, services, data access, API handlers, and testing patterns
-- **Frontend**: See `.github/instructions/frontend.instructions.md`
+- **Backend**: See the [Backend Development](backend-development/overview.mdx) guide and `backend/AGENTS.md` for package structure, services, data access, API handlers, and testing patterns
+- **Frontend**: See the [Frontend Development](frontend-development/overview.mdx) guide and `frontend/AGENTS.md`
 - **Security**: Avoid SQL injection, XSS, command injection, and OWASP top 10 vulnerabilities
 
 **Best practices:**

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,38 @@
+# Frontend — Agent Guide
+
+Read with the root [AGENTS.md](../AGENTS.md). The frontend is a pnpm monorepo under `frontend/` with two React apps —
+`frontend/apps/console` (admin console) and `frontend/apps/gate` (login, registration, recovery) — plus shared and
+feature packages under `frontend/packages/`.
+
+For feature-package layout and app boundaries, see the
+[Frontend Development overview](../docs/content/community/contributing/contributing-code/frontend-development/overview.mdx).
+
+## Feature Packages
+
+Console management features ship as `@thunderid/configure-*` packages (e.g. `@thunderid/configure-users`) under
+`frontend/packages/`. Shared building blocks live in packages such as `@thunderid/components`, `@thunderid/hooks`,
+`@thunderid/contexts`, and `@thunderid/i18n`.
+
+Gate consumes ThunderID's published SDK packages — `@thunderid/react` and `@thunderid/react-router` — from the separate
+[javascript-sdks](https://github.com/thunder-id/javascript-sdks) repository. Clone that repository only to develop or
+debug the SDK itself, or to test against unreleased SDK changes.
+
+## Console Route Source of Truth
+
+Routes are defined in `frontend/apps/console/src/App.tsx`; sidebar navigation and categories in
+`frontend/apps/console/src/layouts/DashboardLayout.tsx`. Read those files directly — do not trust copied route tables,
+which go stale.
+
+## Build & Test
+
+Use `make` / `pnpm` targets, not Nx (frontend build tooling is migrating to Turborepo).
+
+- **Inner loop**: run the touched feature/page/component tests first (`pnpm test` in the relevant app or package).
+- **Final gate**: run only the tests, lints, and Prettier formatting checks targeting the files you changed
+  (`pnpm test`, `pnpm lint`, and `pnpm prettier --check` scoped to the affected app or package), not the full frontend
+  suite.
+
+## Browser Automation
+
+Load [.agent/skills/console/SKILL.md](../.agent/skills/console/SKILL.md) only when browser navigation or UI verification
+is actually required.


### PR DESCRIPTION
### Purpose
Improve the repository's agent guidance (`AGENTS.md` and `.agent/skills`): restructure it into a scoped router, correct a stale SDK reference left behind when the SDKs moved to their own repositories, and reduce the context an AI coding agent loads per session. Documentation/guidance changes only — no product code is touched.

### Approach
- **Scoped router.** The root `AGENTS.md` is now a thin dispatcher: project summary, a "Where to Look Next" routing table, search hygiene, and a single validation ladder. Area-specific guidance lives in scoped `backend/AGENTS.md` and `frontend/AGENTS.md`, which point to the existing contribution docs and to source-of-truth files rather than duplicating them.
- **Source-of-truth pointers.** Replaced the stale, copy-prone Console route table with pointers to `frontend/apps/console/src/App.tsx` and `DashboardLayout.tsx`, and fixed the broken `.github/instructions/` links in the PR-workflow doc.
- **SDK reference fix.** The SDKs now live in the separate [`javascript-sdks`](https://github.com/thunder-id/javascript-sdks) repo; Gate consumes the published `@thunderid/react` / `@thunderid/react-router` packages. Updated the guidance accordingly and added a note distinguishing the internal `.agent/skills/` (developing ThunderID) from the external ThunderID Skills marketplace repo (consuming ThunderID).
- **Context reduction.** Only `CLAUDE.md → @AGENTS.md` (the root) auto-loads into every session, so backend/frontend/DB-specific rules were moved out of the root into the on-demand scoped guides, duplicated guidance was deduped, and filler was trimmed from the large on-demand skill/docs files. No actionable rule or example was removed.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified. _(N/A — Markdown agent-guidance only; no runtime behavior)_
- [ ] Documentation provided. (Add links if there are any) _(N/A — these files are internal agent guidance, outside `docs/content`; Vale does not lint them)_
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any) _(N/A — no code changes)_
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable) _(None)_
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and agent guidance across backend, frontend, docs, and console references.
  * Clarified where to find the latest route, schema, logging, and testing guidance.
  * Simplified several writing standards and interaction patterns for clearer, more consistent instructions.
  * Replaced outdated direct instruction links with the current guidance locations for backend and frontend workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->