### PR TITLE
Fix IdP PUT request to handle secret properties

### DIFF
--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -207,7 +207,7 @@ func (is *idpService) UpdateIdentityProvider(ctx context.Context, idpID string, 
 	if strings.TrimSpace(idpID) == "" {
 		return nil, &ErrorInvalidIDPID
 	}
-	if svcErr := validateIDP(ctx, idp, logger); svcErr != nil {
+	if svcErr := validateIDPMeta(idp); svcErr != nil {
 		return nil, svcErr
 	}
 
@@ -223,6 +223,18 @@ func (is *idpService) UpdateIdentityProvider(ctx context.Context, idpID string, 
 			}
 			return err
 		}
+
+		// Carry over existing secret property values that are absent from the request,
+		// so callers are not required to re-supply secrets they cannot read from GET.
+		mergeSecretProperties(idp, existingIDP)
+
+		// Validate and apply defaults to the complete (merged) property set.
+		updatedProperties, propSvcErr := validateIDPProperties(txCtx, idp.Type, idp.Properties, logger)
+		if propSvcErr != nil {
+			svcErr = propSvcErr
+			return errors.New("property validation failed")
+		}
+		idp.Properties = updatedProperties
 
 		// If the name is being updated, check whether another IdP with the same name exists
 		if existingIDP.Name != idp.Name {

--- a/backend/internal/idp/service_test.go
+++ b/backend/internal/idp/service_test.go
@@ -617,6 +617,144 @@ func (s *IDPServiceTestSuite) TestUpdateIdentityProvider_InvalidData() {
 	}
 }
 
+// TestUpdateIdentityProvider_SecretPropertyPreservedWhenAbsent tests that existing secret properties
+// are carried over when the update request omits them.
+func (s *IDPServiceTestSuite) TestUpdateIdentityProvider_SecretPropertyPreservedWhenAbsent() {
+	secretProp, _ := cmodels.NewProperty("client_secret", "original-secret", true)
+	existingIDP := &IDPDTO{
+		ID:   "idp-123",
+		Name: "Test IDP",
+		Type: IDPTypeOIDC,
+		Properties: []cmodels.Property{
+			*secretProp,
+			func() cmodels.Property { p, _ := cmodels.NewProperty("client_id", "test-client", false); return *p }(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("redirect_uri", "http://localhost/callback", false)
+				return *p
+			}(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("authorization_endpoint", "http://idp/auth", false)
+				return *p
+			}(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("token_endpoint", "http://idp/token", false)
+				return *p
+			}(),
+		},
+	}
+
+	// Incoming update omits client_secret entirely.
+	updateIDP := &IDPDTO{
+		Name: "Test IDP",
+		Type: IDPTypeOIDC,
+		Properties: []cmodels.Property{
+			func() cmodels.Property { p, _ := cmodels.NewProperty("client_id", "test-client", false); return *p }(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("redirect_uri", "http://localhost/callback", false)
+				return *p
+			}(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("authorization_endpoint", "http://idp/auth", false)
+				return *p
+			}(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("token_endpoint", "http://idp/token", false)
+				return *p
+			}(),
+		},
+	}
+
+	s.mockStore.On("GetIdentityProvider", mock.Anything, "idp-123").Return(existingIDP, nil)
+	s.mockStore.On("UpdateIdentityProvider", mock.Anything, mock.MatchedBy(func(dto *IDPDTO) bool {
+		for _, prop := range dto.Properties {
+			if prop.GetName() == "client_secret" && prop.IsSecret() {
+				return true
+			}
+		}
+		return false
+	})).Return(nil)
+
+	result, svcErr := s.idpService.UpdateIdentityProvider(context.Background(), "idp-123", updateIDP)
+
+	s.Nil(svcErr)
+	s.NotNil(result)
+	var found bool
+	for _, prop := range result.Properties {
+		if prop.GetName() == "client_secret" && prop.IsSecret() {
+			found = true
+			break
+		}
+	}
+	s.True(found, "client_secret should be present in the updated IDP")
+	s.mockStore.AssertExpectations(s.T())
+}
+
+// TestUpdateIdentityProvider_SecretPropertyUpdatedWhenProvided tests that a secret property
+// is replaced when an explicit new value is included in the update request.
+func (s *IDPServiceTestSuite) TestUpdateIdentityProvider_SecretPropertyUpdatedWhenProvided() {
+	existingSecret, _ := cmodels.NewProperty("client_secret", "original-secret", true)
+	existingIDP := &IDPDTO{
+		ID:   "idp-123",
+		Name: "Test IDP",
+		Type: IDPTypeOIDC,
+		Properties: []cmodels.Property{
+			*existingSecret,
+			func() cmodels.Property { p, _ := cmodels.NewProperty("client_id", "test-client", false); return *p }(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("redirect_uri", "http://localhost/callback", false)
+				return *p
+			}(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("authorization_endpoint", "http://idp/auth", false)
+				return *p
+			}(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("token_endpoint", "http://idp/token", false)
+				return *p
+			}(),
+		},
+	}
+
+	newSecret, _ := cmodels.NewProperty("client_secret", "new-secret", true)
+	updateIDP := &IDPDTO{
+		Name: "Test IDP",
+		Type: IDPTypeOIDC,
+		Properties: []cmodels.Property{
+			*newSecret,
+			func() cmodels.Property { p, _ := cmodels.NewProperty("client_id", "test-client", false); return *p }(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("redirect_uri", "http://localhost/callback", false)
+				return *p
+			}(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("authorization_endpoint", "http://idp/auth", false)
+				return *p
+			}(),
+			func() cmodels.Property {
+				p, _ := cmodels.NewProperty("token_endpoint", "http://idp/token", false)
+				return *p
+			}(),
+		},
+	}
+
+	s.mockStore.On("GetIdentityProvider", mock.Anything, "idp-123").Return(existingIDP, nil)
+	s.mockStore.On("UpdateIdentityProvider", mock.Anything, mock.MatchedBy(func(dto *IDPDTO) bool {
+		secretCount := 0
+		for _, prop := range dto.Properties {
+			if prop.GetName() == "client_secret" {
+				secretCount++
+			}
+		}
+		return secretCount == 1
+	})).Return(nil)
+
+	result, svcErr := s.idpService.UpdateIdentityProvider(context.Background(), "idp-123", updateIDP)
+
+	s.Nil(svcErr)
+	s.NotNil(result)
+	s.mockStore.AssertExpectations(s.T())
+}
+
 // TestUpdateIdentityProvider_GetStoreError tests store error when checking existing IDP
 func (s *IDPServiceTestSuite) TestUpdateIdentityProvider_GetStoreError() {
 	idp := &IDPDTO{Name: "Test", Type: IDPTypeOIDC, Properties: createOIDCProperties()}

--- a/backend/internal/idp/utils.go
+++ b/backend/internal/idp/utils.go
@@ -48,20 +48,8 @@ func GetPropertyValue(properties []cmodels.Property, name string) string {
 
 // validateIDP validates the identity provider details.
 func validateIDP(ctx context.Context, idp *IDPDTO, logger *log.Logger) *serviceerror.ServiceError {
-	if idp == nil {
-		return &ErrorIDPNil
-	}
-	if strings.TrimSpace(idp.Name) == "" {
-		return &ErrorInvalidIDPName
-	}
-
-	// Validate identity provider type
-	if strings.TrimSpace(string(idp.Type)) == "" {
-		return &ErrorInvalidIDPType
-	}
-	isValidType := slices.Contains(supportedIDPTypes, idp.Type)
-	if !isValidType {
-		return &ErrorInvalidIDPType
+	if svcErr := validateIDPMeta(idp); svcErr != nil {
+		return svcErr
 	}
 
 	// Validate and apply default properties based on IDP type
@@ -72,6 +60,40 @@ func validateIDP(ctx context.Context, idp *IDPDTO, logger *log.Logger) *servicee
 	idp.Properties = updatedProperties
 
 	return nil
+}
+
+// validateIDPMeta validates the structural fields of an IDP (nil, name, type).
+func validateIDPMeta(idp *IDPDTO) *serviceerror.ServiceError {
+	if idp == nil {
+		return &ErrorIDPNil
+	}
+	if strings.TrimSpace(idp.Name) == "" {
+		return &ErrorInvalidIDPName
+	}
+	if strings.TrimSpace(string(idp.Type)) == "" {
+		return &ErrorInvalidIDPType
+	}
+	if !slices.Contains(supportedIDPTypes, idp.Type) {
+		return &ErrorInvalidIDPType
+	}
+	return nil
+}
+
+// mergeSecretProperties carries over secret property values from existing into incoming
+// for any secret property that is absent from the incoming update request.
+func mergeSecretProperties(incoming *IDPDTO, existing *IDPDTO) {
+	presentKeys := make(map[string]bool, len(incoming.Properties))
+	for _, prop := range incoming.Properties {
+		if prop.IsSecret() {
+			presentKeys[prop.GetName()] = true
+		}
+	}
+
+	for _, prop := range existing.Properties {
+		if prop.IsSecret() && !presentKeys[prop.GetName()] {
+			incoming.Properties = append(incoming.Properties, prop)
+		}
+	}
 }
 
 // validateIDPProperties validates the properties of the identity provider based on its type.


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This PR fixes the issue of not being able to update IDP configurations when secret properties are not present with its value in the body.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
This fix checks the existence of the secret properties from the API request body. If no secret properties exists, persisted secret property values are retrieved and attached with the update IDP DTO. This satisfies the IDP property validation and continue the flow towards updating the IDP configurations.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Identity provider updates now preserve existing secret values when you don’t resend them.
  * Secret fields are correctly replaced when a new value is provided.
  * Update requests now apply validation and defaults more reliably before saving changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->