### PR TITLE
Force consent reprompt on every CIBA request

### DIFF
--- a/backend/internal/oauth/oauth2/ciba/service.go
+++ b/backend/internal/oauth/oauth2/ciba/service.go
@@ -154,6 +154,7 @@ func (s *cibaService) InitiateBackchannelAuth(
 			append(oidcScopes, permissionScopes...), oauthApp),
 		flowcm.RuntimeKeyUserAttributesCacheTTLSeconds: cacheTTL,
 		flowcm.RuntimeKeyBindingMessage:                bindingMessage,
+		flowcm.RuntimeKeyForceConsentReprompt:          "true",
 	}
 	if request.ACRValues != "" {
 		runtimeData[flowcm.RuntimeKeyRequestedAuthClasses] = request.ACRValues

--- a/backend/internal/oauth/oauth2/ciba/service_test.go
+++ b/backend/internal/oauth/oauth2/ciba/service_test.go
@@ -234,6 +234,22 @@ func (suite *CIBAServiceTestSuite) TestInitiate_ACRValuesOmittedFromRuntimeWhenE
 	suite.NotNil(resp)
 }
 
+func (suite *CIBAServiceTestSuite) TestInitiate_ForceConsentRepromptAlwaysSet() {
+	suite.mockFlowExec.EXPECT().InitiateAndExecute(mock.Anything, mock.MatchedBy(
+		func(initCtx *flowexec.FlowInitContext) bool {
+			return initCtx.RuntimeData[flowcm.RuntimeKeyForceConsentReprompt] == "true"
+		})).Return(&flowexec.FlowStep{ExecutionID: "exec-1", Status: flowcm.FlowStatusIncomplete}, nil)
+	suite.expectStoreAddSuccess()
+
+	resp, cibaErr := suite.service.InitiateBackchannelAuth(context.Background(), &BackchannelAuthRequest{
+		LoginHint: "alice",
+		Scope:     "openid",
+	}, suite.oauthApp)
+
+	suite.Nil(cibaErr)
+	suite.NotNil(resp)
+}
+
 func (suite *CIBAServiceTestSuite) TestInitiate_StripsStandardScopesFromRuntime() {
 	suite.mockFlowExec.EXPECT().InitiateAndExecute(mock.Anything, mock.MatchedBy(
 		func(initCtx *flowexec.FlowInitContext) bool {


### PR DESCRIPTION
### Purpose
Fix CIBA consent being reused across requests. Per CIBA Core 1.0 §7.1, the user must explicitly approve each backchannel authentication request on the Authentication Device, so consent must never be served from a prior flow for the same user+application pair.

### Approach
Set **RuntimeKeyForceConsentReprompt** in the CIBA flow runtime data on every InitiateBackchannelAuth call. This reuses the existing mechanism introduced for prompt=consent in the authorization code flow — the consent executor checks this flag and skips any cached consent, forcing a fresh prompt regardless of prior approvals.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3379

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3341


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backchannel login flows now consistently prompt for consent again during initiation, improving approval handling and reducing unexpected skips.
* **Tests**
  * Added coverage to verify the consent reprompt setting is always included during backchannel authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->