### PR TITLE
Decouple JOSE config from the global server config

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/thunder-id/thunderid/internal/actorprovider"
 	"github.com/thunder-id/thunderid/internal/agent"
@@ -87,6 +88,7 @@ import (
 	i18nmgt "github.com/thunder-id/thunderid/internal/system/i18n/mgt"
 	"github.com/thunder-id/thunderid/internal/system/importer"
 	"github.com/thunder-id/thunderid/internal/system/jose"
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
@@ -127,7 +129,16 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		logger.Fatal(ctx, "Failed to initialize key manager provider", log.Error(err))
 	}
 
-	jwtService, jweService, err := jose.Initialize(runtimeCryptoSvc)
+	runtime := config.GetServerRuntime()
+	joseCfg := joseconfig.Config{
+		Issuer:         runtime.Config.JWT.Issuer,
+		ValidityPeriod: runtime.Config.JWT.ValidityPeriod,
+		Audience:       runtime.Config.JWT.Audience,
+		PreferredKeyID: runtime.Config.JWT.PreferredKeyID,
+		Leeway:         runtime.Config.JWT.Leeway,
+		JWKSCacheTTL:   time.Duration(runtime.Config.Server.SecurityConfig.JWKSCacheTTL) * time.Second,
+	}
+	jwtService, jweService, err := jose.Initialize(runtimeCryptoSvc, joseCfg)
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize JOSE services", log.Error(err))
 	}

--- a/backend/internal/system/jose/config/config.go
+++ b/backend/internal/system/jose/config/config.go
@@ -16,21 +16,17 @@
  * under the License.
  */
 
-// Package jwt provides functionalities for handling JSON Web Tokens (JWTs).
-package jwt
+// Package joseconfig holds JOSE-specific configuration injected at initialization.
+package joseconfig
 
-import (
-	"time"
+import "time"
 
-	httpservice "github.com/thunder-id/thunderid/internal/system/http"
-	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
-	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
-)
-
-// Initialize initializes the JWT service.
-func Initialize(
-	runtimeProvider kmprovider.RuntimeCryptoProvider, cfg joseconfig.Config,
-) (JWTServiceInterface, error) {
-	httpClient := httpservice.NewHTTPClientWithTimeout(10 * time.Second)
-	return newJWTService(httpClient, runtimeProvider, cfg)
+// Config holds configuration values required by the JOSE (JWT/JWE) services.
+type Config struct {
+	Issuer         string
+	ValidityPeriod int64
+	Audience       string
+	PreferredKeyID string
+	Leeway         int64
+	JWKSCacheTTL   time.Duration
 }

--- a/backend/internal/system/jose/init.go
+++ b/backend/internal/system/jose/init.go
@@ -21,6 +21,7 @@
 package jose
 
 import (
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
@@ -28,14 +29,14 @@ import (
 
 // Initialize initializes the JOSE services (JWT and JWE).
 func Initialize(
-	runtimeProvider kmprovider.RuntimeCryptoProvider,
+	runtimeProvider kmprovider.RuntimeCryptoProvider, cfg joseconfig.Config,
 ) (jwt.JWTServiceInterface, jwe.JWEServiceInterface, error) {
-	jwtService, err := jwt.Initialize(runtimeProvider)
+	jwtService, err := jwt.Initialize(runtimeProvider, cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	jweService, err := jwe.Initialize(runtimeProvider)
+	jweService, err := jwe.Initialize(runtimeProvider, cfg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/internal/system/jose/init_test.go
+++ b/backend/internal/system/jose/init_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
@@ -91,7 +92,7 @@ func (suite *JOSEInitTestSuite) TestInitialize_Success() {
 			},
 		}, nil)
 
-	jwtService, jweService, err := Initialize(suite.mockRuntime)
+	jwtService, jweService, err := Initialize(suite.mockRuntime, joseconfig.Config{PreferredKeyID: "test-key-id"})
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), jwtService)
@@ -105,7 +106,7 @@ func (suite *JOSEInitTestSuite) TestInitialize_JWTInitializationFailure() {
 		GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{KeyID: "test-key-id"}).
 		Return(nil, errors.New("provider unavailable"))
 
-	jwtService, jweService, err := Initialize(suite.mockRuntime)
+	jwtService, jweService, err := Initialize(suite.mockRuntime, joseconfig.Config{PreferredKeyID: "test-key-id"})
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), jwtService)
@@ -120,7 +121,7 @@ func (suite *JOSEInitTestSuite) TestInitialize_NilRuntimeProvider() {
 		}
 	}()
 
-	jwtService, jweService, err := Initialize(nil)
+	jwtService, jweService, err := Initialize(nil, joseconfig.Config{PreferredKeyID: "test-key-id"})
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), jwtService)
@@ -139,7 +140,7 @@ func (suite *JOSEInitTestSuite) TestInitialize_ValidatesServiceInterfaces() {
 			},
 		}, nil)
 
-	jwtService, jweService, err := Initialize(suite.mockRuntime)
+	jwtService, jweService, err := Initialize(suite.mockRuntime, joseconfig.Config{PreferredKeyID: "test-key-id"})
 
 	assert.NoError(suite.T(), err)
 	if jwtService != nil {

--- a/backend/internal/system/jose/jwe/init.go
+++ b/backend/internal/system/jose/jwe/init.go
@@ -19,9 +19,14 @@
 // Package jwe provides functionalities for handling JSON Web Encryption (JWE).
 package jwe
 
-import kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
+import (
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
+	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
+)
 
 // Initialize initializes the JWE service.
-func Initialize(cryptoProvider kmprovider.RuntimeCryptoProvider) (JWEServiceInterface, error) {
-	return newJWEService(cryptoProvider)
+func Initialize(
+	cryptoProvider kmprovider.RuntimeCryptoProvider, cfg joseconfig.Config,
+) (JWEServiceInterface, error) {
+	return newJWEService(cryptoProvider, cfg)
 }

--- a/backend/internal/system/jose/jwe/service.go
+++ b/backend/internal/system/jose/jwe/service.go
@@ -28,8 +28,8 @@ import (
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
@@ -49,13 +49,14 @@ type jweService struct {
 }
 
 // newJWEService creates a new JWE service instance.
-func newJWEService(cryptoProvider kmprovider.RuntimeCryptoProvider) (JWEServiceInterface, error) {
-	preferredKid := config.GetServerRuntime().Config.JWT.PreferredKeyID
+func newJWEService(
+	cryptoProvider kmprovider.RuntimeCryptoProvider, cfg joseconfig.Config,
+) (JWEServiceInterface, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWEService"))
 
 	return &jweService{
 		cryptoProvider: cryptoProvider,
-		keyRef:         kmprovider.KeyRef{KeyID: preferredKid},
+		keyRef:         kmprovider.KeyRef{KeyID: cfg.PreferredKeyID},
 		logger:         logger,
 	}, nil
 }

--- a/backend/internal/system/jose/jwe/service_test.go
+++ b/backend/internal/system/jose/jwe/service_test.go
@@ -29,10 +29,8 @@ import (
 	"strings"
 	"testing"
 
-	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
-
-	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
@@ -54,20 +52,11 @@ func TestJWEServiceSuite(t *testing.T) {
 }
 
 func (suite *JWEServiceTestSuite) SetupTest() {
-	config.ResetServerRuntime()
-
 	rsaKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	suite.testRSAPrivateKey = rsaKey
 
 	ecKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	suite.testECPrivateKey = ecKey
-
-	testConfig := &config.Config{
-		JWT: engineconfig.JWTConfig{
-			PreferredKeyID: "test-kid",
-		},
-	}
-	_ = config.InitializeServerRuntime("", testConfig)
 }
 
 func (suite *JWEServiceTestSuite) TestEncryptDecrypt_RSA() {
@@ -233,7 +222,8 @@ func (suite *JWEServiceTestSuite) TestDecrypt_Errors() {
 func (suite *JWEServiceTestSuite) TestInitialize() {
 	mockProvider := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
 
-	service, err := Initialize(mockProvider)
+	cfg := joseconfig.Config{PreferredKeyID: "test-kid"}
+	service, err := Initialize(mockProvider, cfg)
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), service)
 }

--- a/backend/internal/system/jose/jwt/init_test.go
+++ b/backend/internal/system/jose/jwt/init_test.go
@@ -27,14 +27,13 @@ import (
 	"os"
 	"testing"
 
-	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )
@@ -92,20 +91,20 @@ func (suite *InitTestSuite) TearDownSuite() {
 }
 
 func (suite *InitTestSuite) SetupTest() {
-	// Reset server runtime before each test
+	// jwt.Initialize builds an HTTP client that reads the TLS config from the global
+	// runtime; initialize a minimal runtime so construction does not panic.
 	config.ResetServerRuntime()
+	if err := config.InitializeServerRuntime("", &config.Config{}); err != nil {
+		suite.T().Fatalf("Failed to initialize server runtime: %v", err)
+	}
 }
 
 func (suite *InitTestSuite) TestInitialize_Success() {
-	testConfig := &config.Config{
-		JWT: engineconfig.JWTConfig{
-			Issuer:         "https://auth.example.com",
-			ValidityPeriod: 3600,
-			PreferredKeyID: "test-kid",
-		},
+	cfg := joseconfig.Config{
+		Issuer:         "https://auth.example.com",
+		ValidityPeriod: 3600,
+		PreferredKeyID: "test-kid",
 	}
-	err := config.InitializeServerRuntime("", testConfig)
-	assert.NoError(suite.T(), err)
 
 	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
 	cryptoMock.EXPECT().
@@ -117,44 +116,36 @@ func (suite *InitTestSuite) TestInitialize_Success() {
 			Thumbprint: "test-kid",
 		}}, nil)
 
-	jwtService, err := Initialize(cryptoMock)
+	jwtService, err := Initialize(cryptoMock, cfg)
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), jwtService)
 	assert.Implements(suite.T(), (*JWTServiceInterface)(nil), jwtService)
 }
 
 func (suite *InitTestSuite) TestInitialize_PublicKeyRetrievalError() {
-	testConfig := &config.Config{
-		JWT: engineconfig.JWTConfig{
-			Issuer:         "https://auth.example.com",
-			ValidityPeriod: 3600,
-			PreferredKeyID: "test-kid",
-		},
+	cfg := joseconfig.Config{
+		Issuer:         "https://auth.example.com",
+		ValidityPeriod: 3600,
+		PreferredKeyID: "test-kid",
 	}
-	err := config.InitializeServerRuntime("", testConfig)
-	assert.NoError(suite.T(), err)
 
 	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
 	cryptoMock.EXPECT().
 		GetPublicKeys(mock.Anything, kmprovider.PublicKeyFilter{KeyID: "test-kid"}).
 		Return(nil, errors.New("provider unavailable"))
 
-	jwtService, err := Initialize(cryptoMock)
+	jwtService, err := Initialize(cryptoMock, cfg)
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), jwtService)
 	assert.Contains(suite.T(), err.Error(), "failed to retrieve public key")
 }
 
 func (suite *InitTestSuite) TestInitialize_WithoutPreferredKeyID() {
-	testConfig := &config.Config{
-		JWT: engineconfig.JWTConfig{
-			Issuer:         "https://auth.example.com",
-			ValidityPeriod: 3600,
-			// PreferredKeyID is empty
-		},
+	cfg := joseconfig.Config{
+		Issuer:         "https://auth.example.com",
+		ValidityPeriod: 3600,
+		// PreferredKeyID is empty
 	}
-	err := config.InitializeServerRuntime("", testConfig)
-	assert.NoError(suite.T(), err)
 
 	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
 	cryptoMock.EXPECT().
@@ -166,7 +157,7 @@ func (suite *InitTestSuite) TestInitialize_WithoutPreferredKeyID() {
 			Thumbprint: "test-kid",
 		}}, nil)
 
-	jwtService, err := Initialize(cryptoMock)
+	jwtService, err := Initialize(cryptoMock, cfg)
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), jwtService)
 }

--- a/backend/internal/system/jose/jwt/service.go
+++ b/backend/internal/system/jose/jwt/service.go
@@ -33,9 +33,9 @@ import (
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
-	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	httpservice "github.com/thunder-id/thunderid/internal/system/http"
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jws"
 	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -65,6 +65,7 @@ type jwksCacheEntry struct {
 // jwtService implements the JWTServiceInterface for generating and managing JWT tokens.
 type jwtService struct {
 	cryptoProvider kmprovider.RuntimeCryptoProvider
+	cfg            joseconfig.Config
 	keyRef         kmprovider.KeyRef
 	jwsAlg         jws.Algorithm
 	kid            string
@@ -76,8 +77,9 @@ type jwtService struct {
 // newJWTService creates a new JWT service instance.
 func newJWTService(
 	httpClient httpservice.HTTPClientInterface, cryptoProvider kmprovider.RuntimeCryptoProvider,
+	cfg joseconfig.Config,
 ) (JWTServiceInterface, error) {
-	preferredKid := config.GetServerRuntime().Config.JWT.PreferredKeyID
+	preferredKid := cfg.PreferredKeyID
 	keyRef := kmprovider.KeyRef{KeyID: preferredKid}
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService"))
 
@@ -96,6 +98,7 @@ func newJWTService(
 
 	return &jwtService{
 		cryptoProvider: cryptoProvider,
+		cfg:            cfg,
 		keyRef:         keyRef,
 		jwsAlg:         jws.Algorithm(key.Algorithm),
 		kid:            key.Thumbprint,
@@ -140,8 +143,6 @@ func (js *jwtService) GenerateJWT(
 		return "", 0, &tidcommon.InternalServerError
 	}
 
-	serverRuntime := config.GetServerRuntime()
-
 	// Create the JWT header.
 	if typ == "" {
 		typ = TokenTypeJWT
@@ -160,12 +161,12 @@ func (js *jwtService) GenerateJWT(
 
 	tokenIssuer := iss
 	if tokenIssuer == "" {
-		tokenIssuer = serverRuntime.Config.JWT.Issuer
+		tokenIssuer = js.cfg.Issuer
 	}
 
 	// Calculate the expiration time based on the validity period.
 	if validityPeriod == 0 {
-		validityPeriod = serverRuntime.Config.JWT.ValidityPeriod
+		validityPeriod = js.cfg.ValidityPeriod
 	}
 	iat := time.Now()
 	expirationTime := iat.Add(time.Duration(validityPeriod) * time.Second).Unix()
@@ -429,10 +430,9 @@ func (js *jwtService) getJWKSKeys(
 		return nil, &ErrorFailedToParseJWKS
 	}
 
-	ttl := time.Duration(config.GetServerRuntime().Config.Server.SecurityConfig.JWKSCacheTTL) * time.Second
 	js.jwksCache.Store(jwksURL, &jwksCacheEntry{
 		keys:      jwks.Keys,
-		expiresAt: time.Now().Add(ttl),
+		expiresAt: time.Now().Add(js.cfg.JWKSCacheTTL),
 	})
 
 	return jwks.Keys, nil
@@ -449,7 +449,7 @@ func (js *jwtService) verifyJWTClaims(
 	}
 
 	// Get leeway from config to account for clock skew
-	leeway := config.GetServerRuntime().Config.JWT.Leeway
+	leeway := js.cfg.Leeway
 
 	// Validate standard claims (exp, nbf, aud, iss)
 	now := time.Now().Unix()

--- a/backend/internal/system/jose/jwt/service_test.go
+++ b/backend/internal/system/jose/jwt/service_test.go
@@ -28,7 +28,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -41,8 +40,6 @@ import (
 	"testing"
 	"time"
 
-	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
-
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
 	"github.com/stretchr/testify/assert"
@@ -53,6 +50,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	httpservice "github.com/thunder-id/thunderid/internal/system/http"
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jws"
 	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -80,13 +78,6 @@ type JWTServiceTestSuite struct {
 
 func TestJWTServiceSuite(t *testing.T) {
 	suite.Run(t, new(JWTServiceTestSuite))
-}
-
-func generateTestEncryptionKey(t *testing.T) string {
-	key := make([]byte, 32)
-	_, err := rand.Read(key)
-	require.NoError(t, err)
-	return hex.EncodeToString(key)
 }
 
 func (suite *JWTServiceTestSuite) SetupSuite() {
@@ -131,8 +122,12 @@ func (suite *JWTServiceTestSuite) AfterTest(_, _ string) {
 }
 
 func (suite *JWTServiceTestSuite) SetupTest() {
-	// Reset server runtime before each test
+	// The JWT service reads no global config; the runtime is initialized only so
+	// httpservice.NewHTTPClientWithTimeout can read the TLS min-version config.
 	config.ResetServerRuntime()
+	if err := config.InitializeServerRuntime("", &config.Config{}); err != nil {
+		suite.T().Fatalf("Failed to initialize server runtime: %v", err)
+	}
 
 	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
 	cryptoMock.EXPECT().
@@ -169,38 +164,18 @@ func (suite *JWTServiceTestSuite) SetupTest() {
 
 	suite.jwtService = &jwtService{
 		cryptoProvider: cryptoMock,
-		keyRef:         kmprovider.KeyRef{KeyID: "test-kid"},
-		jwsAlg:         jws.RS256,
-		kid:            "test-kid",
-		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
-	}
-
-	testConfig := &config.Config{
-		TLS: config.TLSConfig{
-			KeyFile: suite.testKeyPath,
-		},
-		JWT: engineconfig.JWTConfig{
+		cfg: joseconfig.Config{
 			Issuer:         "https://auth.example.com",
 			ValidityPeriod: 3600, // Default validity period
 			PreferredKeyID: "test-kid",
 			Leeway:         30, // 30 seconds leeway for clock skew
 		},
-		Crypto: config.CryptoConfig{
-			Encryption: engineconfig.EncryptionConfig{
-				Key: generateTestEncryptionKey(suite.T()),
-			},
-			Keys: []engineconfig.KeyConfig{
-				{
-					ID:       "test-kid",
-					CertFile: suite.testKeyPath,
-					KeyFile:  suite.testKeyPath,
-				},
-			},
-		},
+		keyRef:     kmprovider.KeyRef{KeyID: "test-kid"},
+		jwsAlg:     jws.RS256,
+		kid:        "test-kid",
+		logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTService")),
+		httpClient: httpservice.NewHTTPClientWithTimeout(10 * time.Second),
 	}
-	err := config.InitializeServerRuntime("", testConfig)
-	assert.NoError(suite.T(), err)
-	suite.jwtService.httpClient = httpservice.NewHTTPClientWithTimeout(10 * time.Second)
 }
 
 func (suite *JWTServiceTestSuite) TestNewJWTService() {
@@ -216,7 +191,8 @@ func (suite *JWTServiceTestSuite) TestNewJWTService() {
 			},
 		}, nil)
 
-	service, err := Initialize(cryptoMock)
+	cfg := joseconfig.Config{PreferredKeyID: "test-kid"}
+	service, err := Initialize(cryptoMock, cfg)
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), service)
 	assert.Implements(suite.T(), (*JWTServiceInterface)(nil), service)
@@ -283,7 +259,8 @@ func (suite *JWTServiceTestSuite) TestInitScenarios() {
 					}, nil)
 			}
 
-			service, err := Initialize(cryptoMock)
+			cfg := joseconfig.Config{PreferredKeyID: "test-kid"}
+			service, err := Initialize(cryptoMock, cfg)
 
 			if tc.expectSuccess {
 				assert.NoError(t, err)
@@ -1583,25 +1560,10 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTSignatureWithJWKSUsesCache() {
 	// Point 3 catches a buggy cache that stores or returns entries without keying by
 	// URL — without it, a single shared `cached` slot would still pass points 1 and 2.
 	//
-	// The default SetupTest config has SecurityConfig.JWKSCacheTTL == 0, which would
-	// cause the cache to expire instantly (Now().Before(Now()) == false). Re-initialize
-	// the runtime here with a positive TTL so the cache actually retains entries.
-	config.ResetServerRuntime()
-	defer config.ResetServerRuntime()
-	testConfig := &config.Config{
-		JWT: engineconfig.JWTConfig{
-			Issuer:         testIssuer,
-			ValidityPeriod: 3600,
-			Leeway:         30,
-		},
-		Server: engineconfig.ServerConfig{
-			SecurityConfig: engineconfig.SecurityConfig{
-				JWKSCacheTTL: 300,
-			},
-		},
-	}
-	err := config.InitializeServerRuntime("", testConfig)
-	assert.NoError(suite.T(), err)
+	// The default SetupTest config has JWKSCacheTTL == 0, which would cause the cache to
+	// expire instantly (Now().Before(Now()) == false). Inject a positive TTL here so the
+	// cache actually retains entries.
+	suite.jwtService.cfg.JWKSCacheTTL = 300 * time.Second
 
 	jwksData := suite.createMockJWKSData()
 	makeServer := func(counter *int32) *httptest.Server {
@@ -2068,7 +2030,8 @@ func (suite *JWTServiceTestSuite) TestInitWithECDSAKeys() {
 					return cryptolib.Verify(content, sig, tc.expectedSignAlg, &ecKey.PublicKey)
 				}).Maybe()
 
-			service, err := Initialize(cryptoMock)
+			cfg := joseconfig.Config{PreferredKeyID: "test-kid"}
+			service, err := Initialize(cryptoMock, cfg)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, service)
@@ -2120,7 +2083,8 @@ func (suite *JWTServiceTestSuite) TestInitWithEd25519Key() {
 			return cryptolib.Verify(content, sig, cryptolib.ED25519, priv.Public())
 		}).Maybe()
 
-	service, err := Initialize(cryptoMock)
+	cfg := joseconfig.Config{PreferredKeyID: "test-kid"}
+	service, err := Initialize(cryptoMock, cfg)
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), service)
 
@@ -2155,7 +2119,8 @@ func (suite *JWTServiceTestSuite) TestInitWithECPrivateKeyFormat() {
 			Thumbprint: "test-kid",
 		}}, nil)
 
-	service, err := Initialize(cryptoMock)
+	cfg := joseconfig.Config{PreferredKeyID: "test-kid"}
+	service, err := Initialize(cryptoMock, cfg)
 
 	assert.NoError(suite.T(), err)
 
@@ -2178,7 +2143,8 @@ func (suite *JWTServiceTestSuite) TestInitWithUnsupportedECCurve() {
 			Thumbprint: "test-kid",
 		}}, nil)
 
-	_, err = Initialize(cryptoMock)
+	cfg := joseconfig.Config{PreferredKeyID: "test-kid"}
+	_, err = Initialize(cryptoMock, cfg)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "unsupported algorithm")
@@ -2494,29 +2460,7 @@ func (suite *JWTServiceTestSuite) TestVerifyJWTWithLeeway() {
 
 func (suite *JWTServiceTestSuite) TestVerifyJWTWithZeroLeeway() {
 	// Test behavior when leeway is set to 0
-	config.ResetServerRuntime()
-	testConfig := &config.Config{
-		TLS: config.TLSConfig{
-			KeyFile: suite.testKeyPath,
-		},
-		JWT: engineconfig.JWTConfig{
-			Issuer:         "https://auth.example.com",
-			ValidityPeriod: 3600,
-			PreferredKeyID: "test-kid",
-			Leeway:         0, // No leeway
-		},
-		Crypto: config.CryptoConfig{
-			Keys: []engineconfig.KeyConfig{
-				{
-					ID:       "test-kid",
-					CertFile: suite.testKeyPath,
-					KeyFile:  suite.testKeyPath,
-				},
-			},
-		},
-	}
-	err := config.InitializeServerRuntime("", testConfig)
-	assert.NoError(suite.T(), err)
+	suite.jwtService.cfg.Leeway = 0
 
 	// Token expired 1 second ago should fail with zero leeway
 	expiredTime := time.Now().Add(-1 * time.Second).Unix()

--- a/backend/pkg/thunderidengine/engine.go
+++ b/backend/pkg/thunderidengine/engine.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/thunder-id/thunderid/internal/attributecache"
 	"github.com/thunder-id/thunderid/internal/authn/assert"
@@ -37,6 +38,7 @@ import (
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/system/cache"
 	"github.com/thunder-id/thunderid/internal/system/jose"
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider"
@@ -78,7 +80,8 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize key manager provider", log.Error(err))
 	}
-	engineCtx.jwtService, engineCtx.jweService, err = jose.Initialize(engineCtx.runtimeCryptoSvc)
+	engineCtx.jwtService, engineCtx.jweService, err = jose.Initialize(
+		engineCtx.runtimeCryptoSvc, engineCtx.joseConfig())
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize JOSE services", log.Error(err))
 	}
@@ -171,6 +174,19 @@ func validateEngineContext(ctx *engineContext) error {
 		return errors.New("thunderidengine: authorization provider is not set")
 	}
 	return nil
+}
+
+// joseConfig builds the JOSE configuration from the engine's injected JWT and server
+// configuration, decoupling the JOSE services from the global server runtime.
+func (e *engineContext) joseConfig() joseconfig.Config {
+	return joseconfig.Config{
+		Issuer:         e.jwtConfig.Issuer,
+		ValidityPeriod: e.jwtConfig.ValidityPeriod,
+		Audience:       e.jwtConfig.Audience,
+		PreferredKeyID: e.jwtConfig.PreferredKeyID,
+		Leeway:         e.jwtConfig.Leeway,
+		JWKSCacheTTL:   time.Duration(e.serverConfig.SecurityConfig.JWKSCacheTTL) * time.Second,
+	}
 }
 
 // applyCustomExecutors registers the custom executors with the executor registry.

--- a/backend/pkg/thunderidengine/engine_test.go
+++ b/backend/pkg/thunderidengine/engine_test.go
@@ -20,11 +20,13 @@ package thunderidengine
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/authzmock"
@@ -169,6 +171,31 @@ func (suite *EngineTestSuite) TestEngineOptions() {
 	assert.Equal(suite.T(), customExec["custom"], ctx.customExecutors["custom"])
 	assert.NotNil(suite.T(), ctx.observabilitySvc)
 	assert.NotNil(suite.T(), ctx.authzProvider)
+}
+
+func (suite *EngineTestSuite) TestJOSEConfig() {
+	ctx := &engineContext{
+		jwtConfig: engineconfig.JWTConfig{
+			Issuer:         "https://auth.example.com",
+			ValidityPeriod: 3600,
+			Audience:       "https://api.example.com",
+			PreferredKeyID: "key-1",
+			Leeway:         30,
+		},
+		serverConfig: engineconfig.ServerConfig{
+			SecurityConfig: engineconfig.SecurityConfig{JWKSCacheTTL: 120},
+		},
+	}
+
+	expected := joseconfig.Config{
+		Issuer:         "https://auth.example.com",
+		ValidityPeriod: 3600,
+		Audience:       "https://api.example.com",
+		PreferredKeyID: "key-1",
+		Leeway:         30,
+		JWKSCacheTTL:   120 * time.Second,
+	}
+	assert.Equal(suite.T(), expected, ctx.joseConfig())
 }
 
 func (suite *EngineTestSuite) TestWithCustomExecutors_MergesIntoExistingMap() {


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

The JOSE services (JWT and JWE) previously reached into the global server runtime config (`config.GetServerRuntime()`) to read JWT-related settings such as the issuer, validity period, audience, leeway, preferred key ID, and JWKS cache TTL. 
This PR introduces a dedicated `joseconfig.Config` struct that carries exactly the configuration the JOSE services need. Callers now construct this config and inject it at initialization.


-->

### Approach
-  Defining a Config struct with the fields the JOSE services require: Issuer, ValidityPeriod, Audience, PreferredKeyID, Leeway, and JWKSCacheTTL.
- The config goes through the initialization chain: jose.Initialize to jwt.Initialize / jwe.Initialize to newJWTService / newJWEService now all accept a joseconfig.Config argument.
- The jwtService struct now holds its cfg and reads issuer, validity period, leeway, and JWKS cache TTL from it instead of calling config.GetServerRuntime() at request time.
- Updated the two call sites that build the JOSE services — the server's `servicemanager.go` and the embeddable thunderidengine engine — to populate joseconfig.Config from their respective sources (the global runtime config and the engine's own config, respectively).
- Updated unit tests to inject joseconfig.Config directly rather than initializing a full server runtime. The JWT init tests still initialize a minimal runtime only because the HTTP client construction reads the TLS min-version setting; this is now documented inline. Removed test scaffolding (encryption key generation, crypto/TLS config setup) that is no longer needed.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3391

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWT and JWE initialization so configured security settings (issuer, audience, token validity, clock-skew/leeway, and preferred key selection) are applied consistently at startup.
  * Authentication now uses the configured issuer/audience, token lifetime, and clock skew more reliably.
  * JWKS caching now respects the configured cache duration, reducing unnecessary key fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->