### PR TITLE
Fix broken contributors link in community overview page

### DIFF
--- a/docs/src/components/ContributorCloud.tsx
+++ b/docs/src/components/ContributorCloud.tsx
@@ -102,7 +102,7 @@ export default function ContributorCloud(): React.ReactElement | null {
       {remaining > 0 && (
         <Avatar
           component="a"
-          href="contributors"
+          href="../contributors"
           sx={{
             width: 40,
             height: 40,


### PR DESCRIPTION
### Purpose
Fixes a broken link on the [community overview page](https://thunderid.dev/docs/next/community/overview/). The +48 contributors button used a relative path (`../contributors`) that resolved incorrectly. Updated it to the correct absolute path.

### Approach
Changed the `href` in `CommunityOverview.tsx` from the relative `../contributors` to the absolute `/docs/next/community/contributors/`.

### Related Issues
- Fixes #3613

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “remaining contributors” link to point to the correct contributors page, improving navigation from the contributor cloud.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->