### PR TITLE
Add AuthZEN protocol guide

### DIFF
--- a/docs/content/guides/guides/protocols/authzen/index.mdx
+++ b/docs/content/guides/guides/protocols/authzen/index.mdx
@@ -1,0 +1,54 @@
+---
+title: AuthZEN
+sidebar_position: 0
+description:
+  AuthZEN Authorization API 1.0 in {{ProductName}}, including policy decision point support and future policy
+  enforcement point guidance.
+---
+
+import {AuthZENFlowDiagram} from '../../../../../src/components/AuthZENFlowDiagram';
+
+# AuthZEN
+
+**OpenID AuthZEN** ([Authorization API 1.0](https://openid.github.io/authzen/)) defines a standard API for authorization
+decisions. A Policy Enforcement Point (PEP) asks a Policy Decision Point (PDP) whether a subject can perform an action
+on a resource.
+
+<ProductName /> supports AuthZEN as a policy decision point. Your gateway, adapter, service, or application acts as the
+PEP and sends the subject, resource, action, and request context to <ProductName />. <ProductName /> evaluates the
+request against resource servers, resources, actions, roles, and role assignments, then returns an allow or deny
+decision.
+
+Use AuthZEN when the authorization decision needs more than token validation or static scope checks. For example, use
+AuthZEN when an API gateway must ask <ProductName /> for a request-time decision before it forwards a request to an
+upstream API.
+
+## AuthZEN Roles
+
+| Role                           | Description                                                                   | <ProductName /> Support                        |
+| ------------------------------ | ----------------------------------------------------------------------------- | ---------------------------------------------- |
+| Policy Decision Point (PDP)    | Evaluates access requests and returns allow or deny decisions.                | Supported. See [Policy Decision Point](./pdp). |
+| Policy Enforcement Point (PEP) | Enforces the PDP decision before the protected resource receives the request. | Planned for future.                            |
+
+## How the AuthZEN Flow Works
+
+<AuthZENFlowDiagram />
+
+1. A client sends a request for a protected resource through the PEP.
+2. The PEP identifies the subject, resource, and action and collects any request context.
+3. The PEP sends an AuthZEN access evaluation request to the PDP.
+4. The PDP evaluates its authorization policies and returns `decision: true` or `decision: false`. The response can also
+   include context about the decision.
+5. When the decision is `false`, the PEP denies access without forwarding the request to the protected resource.
+6. When the decision is `true`, the PEP forwards the request and returns the protected resource response to the client.
+
+For the supported PDP endpoints, request and response examples, and configuration links, see
+[Policy Decision Point](./pdp).
+
+## Related Guides
+
+- [Policy Decision Point](./pdp) — call <ProductName /> as an AuthZEN PDP.
+- [Resource Servers](/docs/next/guides/guides/resource-servers) — define protected APIs, resources, and actions.
+- [Roles](/docs/next/guides/guides/users/manage-roles) — assign permissions to users, groups, applications, and agents.
+- [Envoy](/docs/next/guides/guides/integrations/apim-gateways/envoy) — configure Envoy to call <ProductName /> as an
+  AuthZEN PDP.

--- a/docs/content/guides/guides/protocols/authzen/pdp.mdx
+++ b/docs/content/guides/guides/protocols/authzen/pdp.mdx
@@ -1,0 +1,322 @@
+---
+title: Policy Decision Point
+sidebar_position: 1
+description:
+  Use {{ProductName}} as an AuthZEN policy decision point for metadata discovery, access evaluation, batch evaluation,
+  and action search.
+---
+
+import {AuthZENPDPDiagram} from '../../../../../src/components/AuthZENPDPDiagram';
+
+# Policy Decision Point
+
+<ProductName /> acts as an AuthZEN policy decision point (PDP). A Policy Enforcement Point (PEP), such as a gateway,
+adapter, service, or application, calls <ProductName /> before it allows access to a protected resource.
+
+## How the PDP Flow Works
+
+<AuthZENPDPDiagram />
+
+The PEP calls <ProductName /> with an access token that can invoke the AuthZEN API. Protected AuthZEN endpoints require
+the `system` scope. For service-to-service integrations, use the
+[Client Credentials](/docs/next/guides/guides/protocols/oauth-oidc/client-credentials) grant to issue the PEP token.
+
+```json
+{
+  "subject": {
+    "type": "user",
+    "id": "<subject-id>"
+  },
+  "resource": {
+    "type": "booking-api",
+    "id": "<booking-id>"
+  },
+  "action": {
+    "name": "booking-api:reservations:view"
+  }
+}
+```
+
+<ProductName /> evaluates the request and returns a decision:
+
+```json
+{
+  "decision": true
+}
+```
+
+<details>
+<summary>How <ProductName /> Implements It</summary>
+
+| Aspect                   | Behavior                                                                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PDP metadata             | `GET /.well-known/authzen-configuration`                                                                                                          |
+| Single access evaluation | `POST /access/v1/evaluation`                                                                                                                      |
+| Batch access evaluation  | `POST /access/v1/evaluations`                                                                                                                     |
+| Action search            | `POST /access/v1/search/action`                                                                                                                   |
+| `subject.id`             | Required. Identifies the user, application, or agent being evaluated.                                                                             |
+| `subject.type`           | Optional. When provided, <ProductName /> validates that the subject ID matches the subject category.                                              |
+| `resource.type`          | Required. Maps to the <ProductName /> resource server handle.                                                                                     |
+| `resource.id`            | Optional in <ProductName />. Identifies the protected resource instance when provided and is reserved for future resource-instance authorization. |
+| `action.name`            | Required. Must match a permission registered on the resource server.                                                                              |
+| `context`                | Optional object for request-time attributes.                                                                                                      |
+
+</details>
+
+## Configure <ProductName />
+
+The following example creates the `booking-api:reservations:view` permission and assigns it to a subject that can view
+reservations.
+
+### Create a Resource Server
+
+1. Sign in to the <ProductName /> Console at `https://<HOST>:<PORT>/console`.
+2. Select **Resource Servers**, then select **New Resource Server**.
+3. Enter the following values:
+   - **Name**: `Booking API`
+   - **Handle**: `booking-api`
+   - **Delimiter**: `:`
+4. Select **Create**.
+
+For details about resource server fields and permission formats, see
+[Resource Servers](/docs/next/guides/guides/resource-servers).
+
+### Create a Resource
+
+1. Open the **Booking API** resource server.
+2. Select the **Resources** tab, then select **New Resource**.
+3. Enter the following values:
+   - **Name**: `Reservations`
+   - **Handle**: `reservations`
+4. Select **Create**.
+
+### Create an Action
+
+1. Open the **Reservations** resource.
+2. Select the **Actions** tab, then select **New Action**.
+3. Enter the following values:
+   - **Name**: `View Reservations`
+   - **Handle**: `view`
+4. Select **Create**.
+5. Confirm that the generated permission is `booking-api:reservations:view`.
+
+The `action.name` value in an AuthZEN request must match this complete permission string.
+
+### Assign the Permission to a Subject
+
+1. Select **Roles**, then select **New Role**.
+2. Create a role named `Booking API Viewer`.
+3. Add the `booking-api:reservations:view` permission to the role.
+4. Complete the role creation.
+5. Open the role and select the **Assignments** tab.
+6. Add the users, groups, applications, or agents that can view reservations.
+
+The authorization decision evaluates the user, application, or agent identified by `subject.id`. For a group assignment,
+use the ID of a group member as `subject.id`; <ProductName /> includes the subject's group memberships in the
+evaluation. For more information, see [Roles](/docs/next/guides/guides/users/manage-roles).
+
+### Configure the PEP Application
+
+The PEP uses a separate application identity to call the protected AuthZEN endpoints. This application does not replace
+the subject in the evaluation request.
+
+1. Select **Applications**, then select **Add Application**.
+2. Select **Backend Service**.
+3. Enter a name such as `AuthZEN PEP`, select an organization unit, and create the application.
+4. Save the client ID and client secret.
+5. Assign the application to a role that grants the `system` permission. The default **Administrator** role grants this
+   permission.
+
+Request a Client Credentials token for the PEP application:
+
+```bash
+curl -X POST https://{{productSlug}}.example.com/oauth2/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -d "grant_type=client_credentials" \
+  -d "scope=system"
+```
+
+Use the returned access token in the `Authorization` header when the PEP calls an AuthZEN endpoint. For more
+information, see [Client Credentials](/docs/next/guides/guides/protocols/oauth-oidc/client-credentials).
+
+### Map the Configuration to AuthZEN
+
+Use the configured values in an access evaluation request:
+
+- Set `subject.id` to the ID of the user, application, or agent being evaluated.
+- Set `resource.type` to the resource server handle, `booking-api`.
+- Optionally set `resource.id` to the reservation instance identifier.
+- Set `action.name` to the generated permission, `booking-api:reservations:view`.
+
+## Discover AuthZEN Metadata
+
+Use the metadata endpoint to discover the <ProductName /> PDP base URL and supported AuthZEN API endpoints. This
+endpoint does not require authentication.
+
+```bash
+curl https://{{productSlug}}.example.com/.well-known/authzen-configuration
+```
+
+Response:
+
+```json
+{
+  "policy_decision_point": "https://{{productSlug}}.example.com",
+  "access_evaluation_endpoint": "https://{{productSlug}}.example.com/access/v1/evaluation",
+  "access_evaluations_endpoint": "https://{{productSlug}}.example.com/access/v1/evaluations",
+  "search_action_endpoint": "https://{{productSlug}}.example.com/access/v1/search/action"
+}
+```
+
+## Evaluate Single Access Request
+
+Use `/access/v1/evaluation` when the PEP needs one allow or deny decision. The response contains `decision: true` when
+the subject has the requested permission.
+
+```bash
+curl -X POST https://{{productSlug}}.example.com/access/v1/evaluation \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <access-token>' \
+  -d '{
+    "subject": {
+      "type": "user",
+      "id": "<subject-id>"
+    },
+    "resource": {
+      "type": "booking-api",
+      "id": "<booking-id>"
+    },
+    "action": {
+      "name": "booking-api:reservations:view"
+    }
+  }'
+```
+
+Allowed response:
+
+```json
+{
+  "decision": true
+}
+```
+
+Denied response:
+
+```json
+{
+  "decision": false,
+  "context": {
+    "reason": "Subject is not authorized to perform the requested action"
+  }
+}
+```
+
+If `resource.type` does not match a resource server handle, or `action.name` does not match a registered permission,
+
+<ProductName /> returns a denied decision with error context instead of allowing the request.
+
+## Evaluate Multiple Access Requests
+
+Use `/access/v1/evaluations` when the PEP needs decisions for multiple access requests in one call. <ProductName />
+preserves request order in the response, so each result maps to the evaluation at the same array index.
+
+```bash
+curl -X POST https://{{productSlug}}.example.com/access/v1/evaluations \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <access-token>' \
+  -d '{
+    "evaluations": [
+      {
+        "subject": {
+          "type": "user",
+          "id": "<subject-id>"
+        },
+        "resource": {
+          "type": "booking-api",
+          "id": "<booking-id>"
+        },
+        "action": {
+          "name": "booking-api:reservations:view"
+        }
+      },
+      {
+        "subject": {
+          "type": "user",
+          "id": "<subject-id>"
+        },
+        "resource": {
+          "type": "booking-api",
+          "id": "<booking-id>"
+        },
+        "action": {
+          "name": "booking-api:reservations:delete"
+        }
+      }
+    ]
+  }'
+```
+
+Response:
+
+```json
+{
+  "evaluations": [
+    {
+      "decision": true
+    },
+    {
+      "decision": false,
+      "context": {
+        "reason": "Subject is not authorized to perform the requested action"
+      }
+    }
+  ]
+}
+```
+
+An empty `evaluations` array returns a request error.
+
+## Search Allowed Actions
+
+Use `/access/v1/search/action` when the PEP needs to know which registered actions the subject can perform on a
+resource. <ProductName /> checks the permissions under the target resource server and returns only the allowed actions.
+
+```bash
+curl -X POST https://{{productSlug}}.example.com/access/v1/search/action \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <access-token>' \
+  -d '{
+    "subject": {
+      "type": "user",
+      "id": "<subject-id>"
+    },
+    "resource": {
+      "type": "booking-api",
+      "id": "<booking-id>"
+    }
+  }'
+```
+
+Response:
+
+```json
+{
+  "results": [
+    {
+      "name": "booking-api:reservations:view"
+    },
+    {
+      "name": "booking-api:reservations:update"
+    }
+  ]
+}
+```
+
+## Related Guides
+
+- [Resource Servers](/docs/next/guides/guides/resource-servers) — define protected APIs, resources, and actions.
+- [Roles](/docs/next/guides/guides/users/manage-roles) — assign permissions to users, groups, applications, and agents.
+- [Client Credentials](/docs/next/guides/guides/protocols/oauth-oidc/client-credentials) — issue service tokens for
+  machine-to-machine integrations.
+- [Envoy](/docs/next/guides/guides/integrations/apim-gateways/envoy) — configure Envoy to call <ProductName /> as an
+  AuthZEN PDP.

--- a/docs/content/guides/guides/protocols/index.mdx
+++ b/docs/content/guides/guides/protocols/index.mdx
@@ -27,3 +27,13 @@ Standards for requesting and verifying digital credentials held in a wallet. Cov
 [Browse the Verifiable Credentials catalogue →](./openid4vc/)
 
 </div>
+
+<div className="protocol-family-card">
+
+### [AuthZEN](./authzen/)
+
+Standard Authorization API for asking a policy decision point whether a subject can perform an action on a resource. Covers the AuthZEN roles and <ProductName /> as an AuthZEN policy decision point, including access evaluation, batch evaluation, action search, and metadata discovery.
+
+[Browse the AuthZEN guide →](./authzen/)
+
+</div>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -808,6 +808,23 @@ const sidebars: SidebarsConfig = {
                 },
               ],
             },
+            {
+              type: 'category',
+              label: 'AuthZEN',
+              collapsed: true,
+              collapsible: true,
+              link: {
+                type: 'doc',
+                id: 'guides/guides/protocols/authzen/index',
+              },
+              items: [
+                {
+                  type: 'doc',
+                  id: 'guides/guides/protocols/authzen/pdp',
+                  label: 'Policy Decision Point',
+                },
+              ],
+            },
           ],
         },
       ],

--- a/docs/src/components/AuthZENFlowDiagram.tsx
+++ b/docs/src/components/AuthZENFlowDiagram.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {SequenceDiagram} from './SequenceDiagram';
+
+export function AuthZENFlowDiagram() {
+  return (
+    <SequenceDiagram
+      actors={['Client', 'PEP', 'PDP', 'Protected Resource']}
+      gaps={[260, 280, 280]}
+      ariaLabel="AuthZEN authorization lifecycle: a client requests a protected resource through a policy enforcement point. The policy enforcement point asks a policy decision point for an access decision. A false decision causes the policy enforcement point to deny access. A true decision allows the policy enforcement point to forward the request to the protected resource and return its response."
+      rows={[
+        {from: 0, to: 1, label: 'Request protected resource'},
+        {
+          from: 1,
+          to: 2,
+          label: 'POST /access/v1/evaluation',
+          sublabel: ['subject, resource, action,', 'optional context'],
+        },
+        {
+          from: 2,
+          to: 1,
+          label: 'Access decision',
+          sublabel: ['decision: true | false,', 'optional context'],
+        },
+        {from: 1, to: 0, label: 'Deny access if false'},
+        {from: 1, to: 3, label: 'Forward request if true'},
+        {from: 3, to: 1, label: 'Resource response'},
+        {from: 1, to: 0, label: 'Return resource response'},
+      ]}
+    />
+  );
+}

--- a/docs/src/components/AuthZENPDPDiagram.tsx
+++ b/docs/src/components/AuthZENPDPDiagram.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {SequenceDiagram} from './SequenceDiagram';
+import type {DocusaurusProductConfig} from '@site/docusaurus.product.config';
+
+export function AuthZENPDPDiagram() {
+  const {siteConfig} = useDocusaurusContext();
+  const productName =
+    (siteConfig.customFields?.product as DocusaurusProductConfig | undefined)?.project.name ?? siteConfig.title;
+
+  return (
+    <SequenceDiagram
+      actors={['Application', 'PEP', `${productName} PDP`, 'Protected Resource']}
+      gaps={[260, 300, 300]}
+      ariaLabel={`${productName} AuthZEN PDP authorization lifecycle: an application requests a protected resource through a policy enforcement point. The policy enforcement point asks ${productName} for an access decision. A false decision causes the policy enforcement point to deny access. A true decision allows the policy enforcement point to forward the request to the protected resource and return its response.`}
+      rows={[
+        {from: 0, to: 1, label: 'Request protected resource'},
+        {
+          from: 1,
+          to: 2,
+          label: 'POST /access/v1/evaluation',
+          sublabel: ['subject, resource, action,', 'optional context'],
+        },
+        {
+          from: 2,
+          to: 1,
+          label: 'Access decision',
+          sublabel: ['decision: true | false,', 'optional context'],
+        },
+        {from: 1, to: 0, label: 'Deny access if false'},
+        {from: 1, to: 3, label: 'Forward request if true'},
+        {from: 3, to: 1, label: 'Resource response'},
+        {from: 1, to: 0, label: 'Return resource response'},
+      ]}
+    />
+  );
+}


### PR DESCRIPTION
### Purpose
Add AuthZEN guidance under **Guides → Protocols & Standards**, documenting AuthZEN concepts and ThunderID's Policy Decision Point support.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- Add an AuthZEN overview with PEP and PDP concepts and a protocol flow diagram.
- Document ThunderID PDP configuration, metadata discovery, access evaluation, batch evaluation, and action search.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3617

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added AuthZEN overview and “Policy Decision Point (PDP)” guides, including end-to-end request/decision/forwarding examples and evaluation endpoint details.
  * Added sequence diagrams to visualize the AuthZEN authorization lifecycle and PDP evaluation flow.
  * Expanded the Protocols & Standards navigation with a new AuthZEN family card and sidebar entries for the new guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->