### PR TITLE
Add `/integrate` commands to ThunderID CLI

### DIFF
--- a/tools/cli/cmd/thunderid/main.go
+++ b/tools/cli/cmd/thunderid/main.go
@@ -21,7 +21,6 @@ package main
 import (
 	"fmt"
 	"os"
-
 	"github.com/thunder-id/thunderid/tools/cli/internal/cli"
 	"github.com/thunder-id/thunderid/tools/cli/internal/commands/sample"
 	"github.com/thunder-id/thunderid/tools/cli/internal/commands/upgrade"
@@ -36,7 +35,7 @@ func main() {
 	// upgrade [--direct] — explicit upgrade with optional blue/green staging.
 	if len(args) > 0 && args[0] == "upgrade" {
 		verbose, direct := parseUpgradeFlags(args[1:])
-		if err := upgrade.Run(cli.BaseDir(), upgrade.Opts{Direct: direct, Verbose: verbose}); err != nil {
+		if _, err := upgrade.Run(cli.BaseDir(), upgrade.Opts{Direct: direct, Verbose: verbose}); err != nil {
 			os.Exit(1)
 		}
 		return
@@ -81,7 +80,6 @@ Commands:
   (none)               Install and start %s
   upgrade              Upgrade to the latest release (side-by-side by default)
   try <usecase>        Download and launch a use-case sample app
-  integrate <tech>     Configure a technology integration (coming soon)
 
 Flags:
   --verbose, -v        Show detailed output

--- a/tools/cli/internal/cli/root.go
+++ b/tools/cli/internal/cli/root.go
@@ -21,6 +21,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -100,16 +101,11 @@ func Run(verbose, forceSetup bool) {
 		ui.Note("Already running",
 			fmt.Sprintf("%s is already running on port %d.\nAttaching to the existing instance.",
 				product.Name, health.DefaultPort))
-		upgradeRequested, err := ui.RunREPL(runVersion, nil, path, verbose, isFirstRun, newVersion)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "\nREPL error: %v\n", err)
-			os.Exit(1)
-		}
-		if upgradeRequested {
-			runUpgrade(verbose)
-		}
+		replLoop(runVersion, path, nil, verbose, isFirstRun, newVersion, 0)
 		return
 	}
+
+	port := health.DefaultPort
 
 	if alreadyInstalled && !forceSetup {
 		ui.Note("Starting "+product.Name, fmt.Sprintf("%s v%s is ready\n%s", product.Name, runVersion, path))
@@ -128,6 +124,7 @@ func Run(verbose, forceSetup bool) {
 		} else {
 			ui.Note("First-time setup", fmt.Sprintf("Setting up %s v%s\n%s", product.Name, runVersion, path))
 		}
+		port = resolvePort(path)
 		runSetupPhase(runVersion, path, verbose)
 	} else {
 		// If the previously-active version is no longer in the manifest we'd need
@@ -147,6 +144,7 @@ func Run(verbose, forceSetup bool) {
 			os.Exit(1)
 		}
 		path = absPath
+		port = resolvePort(path)
 		runSetupPhase(runVersion, path, verbose)
 		if err := config.WriteActiveVersion(runVersion); err != nil {
 			ui.Fatal("Failed to record active version: " + err.Error())
@@ -154,13 +152,13 @@ func Run(verbose, forceSetup bool) {
 		}
 	}
 
-	if !setup.WaitForPortFree(health.DefaultPort, 10*time.Second) {
-		setup.KillPort(health.DefaultPort)
-		setup.WaitForPortFree(health.DefaultPort, 5*time.Second)
+	if !setup.WaitForPortFree(port, 10*time.Second) {
+		setup.KillPort(port)
+		setup.WaitForPortFree(port, 5*time.Second)
 	}
 
 	fmt.Print(ui.Dim("\n  Starting " + product.Name + " in the background..."))
-	proc, err := setup.StartBackground(path, verbose)
+	proc, err := setup.StartBackgroundOnPort(path, verbose, port)
 	if err != nil {
 		fmt.Println()
 		ui.Fatal("Failed to start " + product.Name + ": " + err.Error())
@@ -168,19 +166,73 @@ func Run(verbose, forceSetup bool) {
 	}
 	fmt.Printf("\r\033[2K  %s %s started  %s\n", ui.Green("✓"), product.Name, ui.Dim("logs: "+setup.LogDir(path)))
 
-	upgradeRequested, err := ui.RunREPL(runVersion, proc, path, verbose, isFirstRun, newVersion)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "\nREPL error: %v\n", err)
-		os.Exit(1)
-	}
-	if upgradeRequested {
-		runUpgrade(verbose)
+	replLoop(runVersion, path, proc, verbose, isFirstRun, newVersion, port)
+}
+
+// replLoop runs the REPL repeatedly, re-entering after no-op upgrades or version switches.
+// An actual upgrade or normal exit breaks the loop.
+func replLoop(version, installPath string, proc *exec.Cmd, verbose, isFirstRun bool, newVersion string, port int) {
+	for {
+		upgradeRequested, switchRequested, err := ui.RunREPL(version, proc, installPath, verbose, isFirstRun, newVersion, port)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "\nREPL error: %v\n", err)
+			os.Exit(1)
+		}
+		isFirstRun = false
+		newVersion = ""
+
+		if upgradeRequested {
+			upgraded, err := upgrade.Run(BaseDir(), upgrade.Opts{Verbose: verbose})
+			if err != nil {
+				os.Exit(1)
+			}
+			if upgraded {
+				return // upgrade ran its own REPL internally
+			}
+			// Already latest or cancelled — Thunder is still running; reattach.
+			continue
+		}
+
+		if switchRequested {
+			switched, err := upgrade.Switch(BaseDir(), version, verbose)
+			if err != nil {
+				os.Exit(1)
+			}
+			if switched {
+				return // Switch ran its own REPL internally
+			}
+			// Cancelled — reattach to the still-running instance.
+			continue
+		}
+
+		return // normal exit
 	}
 }
 
-func runUpgrade(verbose bool) {
-	if err := upgrade.Run(BaseDir(), upgrade.Opts{Verbose: verbose}); err != nil {
-		os.Exit(1)
+// resolvePort checks whether the default port is available and, if not, prompts
+// the user to either kill the occupying process or switch to a free alternate port.
+func resolvePort(installPath string) int {
+	if !setup.IsPortInUse(health.DefaultPort) {
+		return health.DefaultPort
+	}
+	altPort := setup.FindFreePort(health.DefaultPort + 1)
+	choice, selectedPort := ui.PromptPortConflict(health.DefaultPort, altPort)
+	switch choice {
+	case ui.KillAndUsePort:
+		setup.KillPort(health.DefaultPort)
+		setup.WaitForPortFree(health.DefaultPort, 5*time.Second)
+		return health.DefaultPort
+	case ui.UseAlternatePort:
+		if err := setup.UpdateServerPort(installPath, selectedPort); err != nil {
+			ui.Warn("Could not update port configuration: " + err.Error())
+			setup.KillPort(health.DefaultPort)
+			setup.WaitForPortFree(health.DefaultPort, 5*time.Second)
+			return health.DefaultPort
+		}
+		return selectedPort
+	default: // ui.AbortSetup
+		os.Exit(0)
+		return 0
 	}
 }
 

--- a/tools/cli/internal/commands/integrate/integrate.go
+++ b/tools/cli/internal/commands/integrate/integrate.go
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package integrate provides step definitions for the in-REPL integration guides.
+package integrate
+
+// Step is one pane of the integration guide.
+// Code lines may contain {{.KEY}} placeholders that are substituted with
+// collected values at render time (e.g. {{.ClientID}}).
+type Step struct {
+	Title        string
+	Body         []string // description lines shown above the code block
+	CodeFile     string   // display label: "src/main.jsx", "terminal", etc.
+	CodeLang     string   // "bash" or "jsx" — shown as a hint in the border
+	Code         []string // code lines; {{.KEY}} is replaced at render time
+	CollectKey   string   // if non-empty, pause to collect this value before showing Code
+	CollectLabel string   // prompt header shown while collecting
+	CollectHint  string   // textinput placeholder
+	CollectURL   string   // optional URL shown in the collect prompt for the user to open
+}
+
+// VueSteps returns the ordered integration steps for adding @thunderid/vue
+// to an existing Vue 3 app.
+func VueSteps(baseURL string) []Step {
+	return []Step{
+		{
+			Title:    "Install @thunderid/vue",
+			Body:     []string{"Install the ThunderID Vue SDK in your project:"},
+			CodeFile: "terminal",
+			CodeLang: "bash",
+			Code:     []string{"npm install @thunderid/vue"},
+		},
+		{
+			Title:    "Register the Plugin",
+			Body:     []string{"Register ThunderIDPlugin in src/main.js:"},
+			CodeFile: "src/main.js",
+			CodeLang: "js",
+			Code: []string{
+				`import { createApp } from 'vue'`,
+				`import { ThunderIDPlugin } from '@thunderid/vue'`,
+				`import App from './App.vue'`,
+				`import './style.css'`,
+				``,
+				`const app = createApp(App)`,
+				`app.use(ThunderIDPlugin)`,
+				`app.mount('#app')`,
+			},
+		},
+		{
+			Title:        "Add ThunderIDProvider",
+			Body:         []string{"Wrap your app in src/App.vue with ThunderIDProvider:"},
+			CollectKey:   "ClientID",
+			CollectLabel: "Your Client ID",
+			CollectHint:  "Console → Applications → your app → Client ID",
+			CodeFile:     "src/App.vue",
+			CodeLang:     "vue",
+			Code: []string{
+				`<script setup>`,
+				`import {`,
+				`  SignedIn, SignedOut,`,
+				`  SignInButton, SignOutButton,`,
+				`} from '@thunderid/vue'`,
+				`</script>`,
+				``,
+				`<template>`,
+				`  <ThunderIDProvider`,
+				`    client-id="{{.ClientID}}"`,
+				`    base-url="` + baseURL + `"`,
+				`  >`,
+				`    <SignedIn>`,
+				`      <SignOutButton>Sign Out</SignOutButton>`,
+				`    </SignedIn>`,
+				`    <SignedOut>`,
+				`      <SignInButton>Sign In</SignInButton>`,
+				`    </SignedOut>`,
+				`  </ThunderIDProvider>`,
+				`</template>`,
+			},
+		},
+		{
+			Title:    "Start Your App",
+			Body:     []string{"Start the development server:"},
+			CodeFile: "terminal",
+			CodeLang: "bash",
+			Code:     []string{"npm run dev"},
+		},
+	}
+}
+
+// NextJSSteps returns the ordered integration steps for adding @thunderid/nextjs
+// to an existing Next.js app.
+func NextJSSteps(baseURL string) []Step {
+	return []Step{
+		{
+			Title:    "Install @thunderid/nextjs",
+			Body:     []string{"Install the ThunderID Next.js SDK in your project:"},
+			CodeFile: "terminal",
+			CodeLang: "bash",
+			Code:     []string{"npm install @thunderid/nextjs"},
+		},
+		{
+			Title:        "Set Environment Variables",
+			Body:         []string{"Create .env.local with your credentials:"},
+			CollectKey:   "ClientID",
+			CollectLabel: "Your Client ID",
+			CollectHint:  "Console → Applications → your app → Client ID",
+			CodeFile:     ".env.local",
+			CodeLang:     "dotenv",
+			Code: []string{
+				`NEXT_PUBLIC_THUNDERID_BASE_URL=` + baseURL,
+				`NEXT_PUBLIC_THUNDERID_CLIENT_ID={{.ClientID}}`,
+				`THUNDERID_CLIENT_SECRET=<your-client-secret>`,
+				`THUNDERID_SECRET=<run: openssl rand -base64 32>`,
+				`# Remove in production:`,
+				`NODE_TLS_REJECT_UNAUTHORIZED=0`,
+			},
+		},
+		{
+			Title:    "Add ThunderIDProvider to Layout",
+			Body:     []string{"Wrap your root layout in app/layout.tsx:"},
+			CodeFile: "app/layout.tsx",
+			CodeLang: "tsx",
+			Code: []string{
+				`import { ThunderIDProvider }`,
+				`  from '@thunderid/nextjs/server'`,
+				``,
+				`export default function RootLayout({ children }) {`,
+				`  return (`,
+				`    <html lang="en">`,
+				`      <body>`,
+				`        <ThunderIDProvider>`,
+				`          {children}`,
+				`        </ThunderIDProvider>`,
+				`      </body>`,
+				`    </html>`,
+				`  )`,
+				`}`,
+			},
+		},
+		{
+			Title:    "Add the ThunderID Proxy",
+			Body:     []string{"Create proxy.ts to handle auth routing:"},
+			CodeFile: "proxy.ts",
+			CodeLang: "ts",
+			Code: []string{
+				`import {`,
+				`  thunderIDProxy,`,
+				`  createRouteMatcher,`,
+				`} from '@thunderid/nextjs/server'`,
+				``,
+				`const isProtected = createRouteMatcher([])`,
+				``,
+				`export default thunderIDProxy(`,
+				`  async (thunderid, request) => {`,
+				`    if (isProtected(request))`,
+				`      await thunderid.protectRoute()`,
+				`  }`,
+				`)`,
+				``,
+				`export const config = {`,
+				`  matcher: [`,
+				`    '/((?!_next/static|_next/image|favicon.ico).*)',`,
+				`  ],`,
+				`}`,
+			},
+		},
+		{
+			Title:    "Build with ThunderID Components",
+			Body:     []string{"Update app/page.tsx with auth components:"},
+			CodeFile: "app/page.tsx",
+			CodeLang: "tsx",
+			Code: []string{
+				`import {`,
+				`  SignedIn, SignedOut,`,
+				`  SignInButton, UserDropdown,`,
+				`} from "@thunderid/nextjs"`,
+				``,
+				`export default function Home() {`,
+				`  return (`,
+				`    <section>`,
+				`      <SignedIn>`,
+				`        <UserDropdown />`,
+				`      </SignedIn>`,
+				`      <SignedOut>`,
+				`        <SignInButton>Sign In</SignInButton>`,
+				`      </SignedOut>`,
+				`    </section>`,
+				`  )`,
+				`}`,
+			},
+		},
+		{
+			Title:    "Start Your App",
+			Body:     []string{"Start the development server:"},
+			CodeFile: "terminal",
+			CodeLang: "bash",
+			Code:     []string{"npm run dev"},
+		},
+	}
+}
+
+// NuxtSteps returns the ordered integration steps for adding @thunderid/nuxt
+// to an existing Nuxt 3 app.
+func NuxtSteps(baseURL string) []Step {
+	return []Step{
+		{
+			Title:    "Install @thunderid/nuxt",
+			Body:     []string{"Install the ThunderID Nuxt module:"},
+			CodeFile: "terminal",
+			CodeLang: "bash",
+			Code:     []string{"npm install @thunderid/nuxt"},
+		},
+		{
+			Title:    "Register the Module",
+			Body:     []string{"Add @thunderid/nuxt to nuxt.config.ts:"},
+			CodeFile: "nuxt.config.ts",
+			CodeLang: "ts",
+			Code: []string{
+				`export default defineNuxtConfig({`,
+				`  modules: ['@thunderid/nuxt'],`,
+				`})`,
+			},
+		},
+		{
+			Title:        "Set Up Environment Variables",
+			Body:         []string{"Create .env with your credentials:"},
+			CollectKey:   "ClientID",
+			CollectLabel: "Your Client ID",
+			CollectHint:  "Console → Applications → your app → Client ID",
+			CodeFile:     ".env",
+			CodeLang:     "dotenv",
+			Code: []string{
+				`NUXT_PUBLIC_THUNDERID_BASE_URL=` + baseURL,
+				`NUXT_PUBLIC_THUNDERID_CLIENT_ID={{.ClientID}}`,
+				`THUNDERID_CLIENT_SECRET=<your-client-secret>`,
+				`THUNDERID_SESSION_SECRET=<run: openssl rand -base64 32>`,
+			},
+		},
+		{
+			Title:    "Wrap App with ThunderIDRoot",
+			Body:     []string{"Update app.vue to use ThunderIDRoot:"},
+			CodeFile: "app.vue",
+			CodeLang: "vue",
+			Code: []string{
+				`<template>`,
+				`  <ThunderIDRoot>`,
+				`    <NuxtPage />`,
+				`  </ThunderIDRoot>`,
+				`</template>`,
+			},
+		},
+		{
+			Title:    "Add Sign-In and Sign-Out",
+			Body:     []string{"Create pages/index.vue with auth components:"},
+			CodeFile: "pages/index.vue",
+			CodeLang: "vue",
+			Code: []string{
+				`<template>`,
+				`  <main>`,
+				`    <SignedIn>`,
+				`      <SignOutButton>Sign Out</SignOutButton>`,
+				`    </SignedIn>`,
+				`    <SignedOut>`,
+				`      <SignInButton>Sign In</SignInButton>`,
+				`    </SignedOut>`,
+				`  </main>`,
+				`</template>`,
+			},
+		},
+		{
+			Title:    "Start Your App",
+			Body:     []string{"Start the development server:"},
+			CodeFile: "terminal",
+			CodeLang: "bash",
+			Code:     []string{"npm run dev"},
+		},
+	}
+}
+
+
+// ReactSteps returns the ordered integration steps for adding @thunderid/react
+// to an existing React app. baseURL is the running ThunderID instance URL and
+// is embedded directly into the ThunderIDProvider code snippet.
+func ReactSteps(baseURL string) []Step {
+	return []Step{
+		{
+			Title:        "Get your Client ID",
+			CollectKey:   "ClientID",
+			CollectLabel: "Your Client ID",
+			CollectHint:  "Console → Applications → your app → Client ID",
+			CollectURL:   baseURL + "/console",
+		},
+		{
+			Title:    "Install @thunderid/react",
+			Body:     []string{"Install the ThunderID React SDK in your project:"},
+			CodeFile: "terminal",
+			CodeLang: "bash",
+			Code:     []string{"npm install @thunderid/react"},
+		},
+		{
+			Title:    "Add ThunderIDProvider",
+			Body:     []string{"Wrap your root component with ThunderIDProvider in src/main.jsx:"},
+			CodeFile: "src/main.jsx",
+			CodeLang:     "jsx",
+			Code: []string{
+				`import { StrictMode } from 'react'`,
+				`import { createRoot } from 'react-dom/client'`,
+				`import { ThunderIDProvider } from '@thunderid/react'`,
+				`import App from './App.jsx'`,
+				`import './index.css'`,
+				``,
+				`createRoot(document.getElementById('root')).render(`,
+				`  <StrictMode>`,
+				`    <ThunderIDProvider`,
+				`      clientId="{{.ClientID}}"`,
+				`      baseUrl="` + baseURL + `"`,
+				`    >`,
+				`      <App />`,
+				`    </ThunderIDProvider>`,
+				`  </StrictMode>`,
+				`)`,
+			},
+		},
+		{
+			Title:    "Add Sign-In and Sign-Out",
+			Body:     []string{"Update src/App.jsx to add auth components:"},
+			CodeFile: "src/App.jsx",
+			CodeLang: "jsx",
+			Code: []string{
+				`import {`,
+				`  SignedIn, SignedOut,`,
+				`  SignInButton, SignOutButton, Loading`,
+				`} from '@thunderid/react'`,
+				``,
+				`function App() {`,
+				`  return (`,
+				`    <>`,
+				`      <Loading>`,
+				`        <div>Loading authentication...</div>`,
+				`      </Loading>`,
+				`      <SignedOut>`,
+				`        <SignInButton>Sign In</SignInButton>`,
+				`      </SignedOut>`,
+				`      <SignedIn>`,
+				`        <SignOutButton>Sign Out</SignOutButton>`,
+				`      </SignedIn>`,
+				`    </>`,
+				`  )`,
+				`}`,
+			},
+		},
+		{
+			Title:    "Display User Profile",
+			Body:     []string{"Use the User component to show profile info in src/App.jsx:"},
+			CodeFile: "src/App.jsx",
+			CodeLang: "jsx",
+			Code: []string{
+				`import {`,
+				`  SignedIn, SignedOut,`,
+				`  SignInButton, SignOutButton, Loading, User`,
+				`} from '@thunderid/react'`,
+				``,
+				`function App() {`,
+				`  return (`,
+				`    <>`,
+				`      <Loading><div>Loading...</div></Loading>`,
+				`      <SignedOut><SignInButton>Sign In</SignInButton></SignedOut>`,
+				`      <SignedIn>`,
+				`        <SignOutButton>Sign Out</SignOutButton>`,
+				`        <User>`,
+				`          {(user) => user && (`,
+				`            <div>`,
+				`              <h2>Welcome, {user.name}!</h2>`,
+				`              <p>{user.email}</p>`,
+				`            </div>`,
+				`          )}`,
+				`        </User>`,
+				`      </SignedIn>`,
+				`    </>`,
+				`  )`,
+				`}`,
+			},
+		},
+		{
+			Title: "Start Your App",
+			Body: []string{
+				"Start the development server:",
+			},
+			CodeFile: "terminal",
+			CodeLang: "bash",
+			Code:     []string{"npm run dev"},
+		},
+	}
+}

--- a/tools/cli/internal/commands/upgrade/upgrade.go
+++ b/tools/cli/internal/commands/upgrade/upgrade.go
@@ -49,20 +49,21 @@ type Opts struct {
 }
 
 // Run executes the upgrade workflow. baseDir is the parent thunderid directory (e.g. "./thunderid").
-func Run(baseDir string, opts Opts) error {
+// Returns (upgraded, err): upgraded is false when already on the latest version or the user cancelled.
+func Run(baseDir string, opts Opts) (bool, error) {
 	fmt.Print(ui.Dim("  Fetching latest " + product.Name + " release..."))
 	latestVersion, err := release.FetchLatestVersion()
 	if err != nil {
 		fmt.Println()
 		ui.Fatal("Could not fetch latest " + product.Name + " release: " + err.Error())
-		return err
+		return false, err
 	}
 	fmt.Printf("\r\033[2K  %s Latest %s release: v%s\n\n", ui.Green("✓"), product.Name, latestVersion)
 
 	activeVersion := config.ReadActiveVersion()
 	if activeVersion == latestVersion {
 		ui.Success(product.Name + " v" + latestVersion + " is already the latest version.")
-		return nil
+		return false, nil
 	}
 
 	if activeVersion != "" {
@@ -74,7 +75,7 @@ func Run(baseDir string, opts Opts) error {
 	}
 
 	if opts.Direct || activeVersion == "" {
-		return runDirect(baseDir, activeVersion, latestVersion, opts.Verbose)
+		return true, runDirect(baseDir, activeVersion, latestVersion, opts.Verbose)
 	}
 
 	var mode string
@@ -93,13 +94,71 @@ func Run(baseDir string, opts Opts) error {
 		).
 		Value(&mode).
 		Run(); err != nil {
-		return nil // cancelled
+		return false, nil // cancelled
 	}
 
 	if mode == "direct" {
-		return runDirect(baseDir, activeVersion, latestVersion, opts.Verbose)
+		return true, runDirect(baseDir, activeVersion, latestVersion, opts.Verbose)
 	}
-	return runSideBySide(baseDir, activeVersion, latestVersion, opts.Verbose)
+	return true, runSideBySide(baseDir, activeVersion, latestVersion, opts.Verbose)
+}
+
+// Switch stops the running ThunderID instance and starts the selected installed version.
+// It shows an interactive version picker and returns false if the user cancels or no other
+// versions are installed. On success it starts the new instance and runs a REPL for it.
+func Switch(baseDir, currentVersion string, verbose bool) (bool, error) {
+	versions := config.ListInstalledVersions(currentVersion)
+	if len(versions) == 0 {
+		ui.Warn("No other installed versions found. Use /upgrade to install a new version.")
+		return false, nil
+	}
+
+	options := make([]huh.Option[string], len(versions))
+	for i, v := range versions {
+		options[i] = huh.NewOption("v"+v, v)
+	}
+
+	var selected string
+	if err := huh.NewSelect[string]().
+		Title("Switch to version:").
+		Options(options...).
+		Value(&selected).
+		Run(); err != nil {
+		return false, nil // cancelled
+	}
+
+	installPath := config.ReadInstallPath(selected)
+	if installPath == "" {
+		ui.Fatal("Install path not found for v" + selected + ". Re-run setup to restore it.")
+		return false, nil
+	}
+
+	// Validate the install is launchable before touching the running instance.
+	if _, err := setup.FindThunderRoot(installPath); err != nil {
+		ui.Fatal(fmt.Sprintf("v%s is not usable (%s). The install may have been moved or deleted.", selected, err))
+		return false, nil
+	}
+
+	fmt.Print(ui.Dim("  Stopping " + product.Name + " v" + currentVersion + "..."))
+	setup.KillPort(health.DefaultPort)
+	setup.WaitForPortFree(health.DefaultPort, 10*time.Second)
+	fmt.Printf("\r\033[2K  %s Stopped v%s\n", ui.Green("✓"), currentVersion)
+
+	if err := config.WriteActiveVersion(selected); err != nil {
+		return false, fmt.Errorf("failed to update active version: %w", err)
+	}
+
+	fmt.Print(ui.Dim("\n  Starting " + product.Name + " v" + selected + "..."))
+	proc, err := setup.StartBackground(installPath, verbose)
+	if err != nil {
+		fmt.Println()
+		ui.Fatal("Failed to start v" + selected + ": " + err.Error())
+		return false, err
+	}
+	fmt.Printf("\r\033[2K  %s Switched to %s v%s  %s\n", ui.Green("✓"), product.Name, selected, ui.Dim("logs: "+setup.LogDir(installPath)))
+
+	_, _, err = ui.RunREPL(selected, proc, installPath, verbose, false, "", 0)
+	return true, err
 }
 
 func runDirect(baseDir, activeVersion, newVersion string, verbose bool) error {
@@ -145,7 +204,7 @@ func runDirect(baseDir, activeVersion, newVersion string, verbose bool) error {
 	}
 	fmt.Printf("\r\033[2K  %s %s v%s started  %s\n", ui.Green("✓"), product.Name, newVersion, ui.Dim("logs: "+setup.LogDir(newPath)))
 
-	_, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "")
+	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", 0)
 	return err
 }
 
@@ -213,7 +272,7 @@ func performCutover(baseDir, activeVersion, newVersion, newPath string, stagingP
 	}
 	fmt.Printf("\r\033[2K  %s %s v%s is now live on port %d\n", ui.Green("✓"), product.Name, newVersion, health.DefaultPort)
 
-	_, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "")
+	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", 0)
 	return err
 }
 

--- a/tools/cli/internal/product/product.go
+++ b/tools/cli/internal/product/product.go
@@ -26,8 +26,9 @@ const (
 
 // Distribution URLs.
 const (
-	ReleasesURL = "https://thunderid.dev/data/releases.json"
-	GitHubAPI   = "https://api.github.com/repos/thunder-id/thunderid/releases/latest"
+	ReleasesURL      = "https://thunderid.dev/data/releases.json"
+	GitHubAPI        = "https://api.github.com/repos/thunder-id/thunderid/releases/latest"
+	GitHubArchiveURL = "https://codeload.github.com/thunder-id/thunderid/zip/refs/heads/main"
 )
 
 // Brand colors.

--- a/tools/cli/internal/services/config/config.go
+++ b/tools/cli/internal/services/config/config.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
 )
@@ -148,6 +149,24 @@ func IsVersionSkipped(version string) bool {
 		}
 	}
 	return false
+}
+
+// ListInstalledVersions returns all versions that have completed setup and a recorded
+// install path, sorted in ascending order. Pass exceptVersion to exclude one entry
+// (e.g. the currently active version).
+func ListInstalledVersions(exceptVersion string) []string {
+	s := load()
+	var versions []string
+	for v, state := range s.Versions {
+		if v == exceptVersion {
+			continue
+		}
+		if state.SetupComplete && state.InstallPath != "" {
+			versions = append(versions, v)
+		}
+	}
+	sort.Strings(versions)
+	return versions
 }
 
 // MarkVersionSkipped records that the user skipped upgrading to version.

--- a/tools/cli/internal/services/setup/setup.go
+++ b/tools/cli/internal/services/setup/setup.go
@@ -215,7 +215,7 @@ func StartBackgroundOnPort(installPath string, verbose bool, port int) (*exec.Cm
 
 	cmd.Dir = root
 	if port > 0 {
-		cmd.Env = append(os.Environ(), fmt.Sprintf("THUNDER_PORT=%d", port))
+		cmd.Env = append(os.Environ(), fmt.Sprintf("BACKEND_PORT=%d", port))
 	}
 	if verbose {
 		cmd.Stdout = io.MultiWriter(out, os.Stderr)
@@ -289,6 +289,69 @@ func WaitForPortFree(port int, timeout time.Duration) bool {
 		time.Sleep(250 * time.Millisecond)
 	}
 	return false
+}
+
+// IsPortInUse returns true if a process is already accepting connections on the given TCP port.
+func IsPortInUse(port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// FindFreePort returns the first free TCP port at or above start.
+func FindFreePort(start int) int {
+	for port := start; port < 65535; port++ {
+		if !IsPortInUse(port) {
+			return port
+		}
+	}
+	return start
+}
+
+// UpdateServerPort rewrites the server.port value in the deployment.yaml found under installPath.
+func UpdateServerPort(installPath string, port int) error {
+	candidates := []string{
+		filepath.Join(installPath, "deployment.yaml"),
+		filepath.Join(installPath, "backend", "cmd", "server", "deployment.yaml"),
+	}
+	var configPath string
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			configPath = p
+			break
+		}
+	}
+	if configPath == "" {
+		return fmt.Errorf("deployment.yaml not found in %s", installPath)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	inServer := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "server:" {
+			inServer = true
+			continue
+		}
+		if inServer {
+			if len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
+				inServer = false
+				continue
+			}
+			if strings.HasPrefix(trimmed, "port:") {
+				indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+				lines[i] = indent + fmt.Sprintf("port: %d", port)
+				return os.WriteFile(configPath, []byte(strings.Join(lines, "\n")), 0o644)
+			}
+		}
+	}
+	return fmt.Errorf("server.port not found in %s", configPath)
 }
 
 // KillPort sends SIGTERM to all processes listening on the given TCP port.

--- a/tools/cli/internal/services/setup/setup_test.go
+++ b/tools/cli/internal/services/setup/setup_test.go
@@ -96,3 +96,47 @@ func TestWaitForPortFree_UnoccupiedPort(t *testing.T) {
 	free := setup.WaitForPortFree(19999, 2*time.Second)
 	assert.True(t, free, "expected unoccupied port to be detected as free")
 }
+
+func TestIsPortInUse_FreePort(t *testing.T) {
+	assert.False(t, setup.IsPortInUse(19998), "expected unused port to not be in use")
+}
+
+func TestFindFreePort_ReturnsUnoccupied(t *testing.T) {
+	port := setup.FindFreePort(19990)
+	assert.False(t, setup.IsPortInUse(port), "FindFreePort should return a port that is not in use")
+}
+
+func TestUpdateServerPort_UpdatesDeploymentYAML(t *testing.T) {
+	dir := t.TempDir()
+	serverDir := filepath.Join(dir, "backend", "cmd", "server")
+	require.NoError(t, os.MkdirAll(serverDir, 0o755))
+
+	content := "server:\n  hostname: \"localhost\"\n  port: 8090\n\nother:\n  port: 9000\n"
+	require.NoError(t, os.WriteFile(filepath.Join(serverDir, "deployment.yaml"), []byte(content), 0o644))
+
+	require.NoError(t, setup.UpdateServerPort(dir, 8091))
+
+	updated, err := os.ReadFile(filepath.Join(serverDir, "deployment.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "port: 8091")
+	assert.Contains(t, string(updated), "port: 9000", "non-server port should be unchanged")
+}
+
+func TestUpdateServerPort_RootDeploymentYAMLTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	rootYAML := filepath.Join(dir, "deployment.yaml")
+	require.NoError(t, os.WriteFile(rootYAML, []byte("server:\n  port: 8090\n"), 0o644))
+
+	require.NoError(t, setup.UpdateServerPort(dir, 8092))
+
+	data, err := os.ReadFile(rootYAML)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "port: 8092")
+}
+
+func TestUpdateServerPort_MissingConfig(t *testing.T) {
+	dir := t.TempDir()
+	err := setup.UpdateServerPort(dir, 8091)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deployment.yaml not found")
+}

--- a/tools/cli/internal/ui/banner.go
+++ b/tools/cli/internal/ui/banner.go
@@ -182,6 +182,44 @@ const (
 	SkipRelease
 )
 
+// PortConflictChoice represents the user's response to a port-in-use prompt.
+type PortConflictChoice int
+
+const (
+	// KillAndUsePort kills the process on the default port and continues.
+	KillAndUsePort PortConflictChoice = iota
+	// UseAlternatePort starts ThunderID on an alternate port instead.
+	UseAlternatePort
+	// AbortSetup exits without starting ThunderID.
+	AbortSetup
+)
+
+// PromptPortConflict shows a port-in-use warning and asks how to proceed.
+// altPort is the next free port the caller pre-computed as an alternative.
+// Returns the chosen action and the port to use.
+func PromptPortConflict(port, altPort int) (PortConflictChoice, int) {
+	title := redStyle.Render(fmt.Sprintf("Port %d is already in use", port))
+	body := greyStyle.Render(fmt.Sprintf("%s cannot start because another process is using port %d.", product.Name, port))
+	fmt.Println(noteBoxStyle.Render(title + "\n\n" + body))
+
+	var choice PortConflictChoice
+	if err := huh.NewSelect[PortConflictChoice]().
+		Title("How would you like to proceed?").
+		Options(
+			huh.NewOption(fmt.Sprintf("Kill the process on port %d and continue", port), KillAndUsePort),
+			huh.NewOption(fmt.Sprintf("Use port %d instead", altPort), UseAlternatePort),
+			huh.NewOption("Abort", AbortSetup),
+		).
+		Value(&choice).
+		Run(); err != nil {
+		return AbortSetup, port
+	}
+	if choice == UseAlternatePort {
+		return choice, altPort
+	}
+	return choice, port
+}
+
 // PromptUpgrade shows the "new version available" banner and asks the user what to do.
 // Returns the chosen action, or StartCurrent if the prompt is cancelled.
 func PromptUpgrade(currentVersion, newVersion string) UpgradeChoice {

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -32,6 +32,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/thunder-id/thunderid/tools/cli/internal/commands/integrate"
 	"github.com/thunder-id/thunderid/tools/cli/internal/commands/sample"
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
 	"github.com/thunder-id/thunderid/tools/cli/internal/services/health"
@@ -52,19 +53,9 @@ type SlashCommand struct {
 
 var defaultCommands = []SlashCommand{
 	{
-		Name:        "/open-console",
-		Description: "Open the Console in your browser",
-		Action: func(baseURL string) ([]string, error) {
-			url := baseURL + "/console"
-			if err := utils.OpenBrowser(url); err != nil {
-				return nil, err
-			}
-			return []string{Dim("Opening " + url + "...")}, nil
-		},
-	},
-	{
 		Name:        "/status",
 		Description: "Show server status",
+		Section:     "Server",
 		Action: func(baseURL string) ([]string, error) {
 			if health.CheckReady(baseURL) {
 				return []string{Green("●") + " " + product.Name + " is running at " + Cyan(baseURL)}, nil
@@ -73,16 +64,38 @@ var defaultCommands = []SlashCommand{
 		},
 	},
 	{
+		Name:        "/stop",
+		Description: "Stop " + product.Name + " and exit",
+		Section:     "Server",
+		Action:      nil, // handled specially in Update
+	},
+	{
 		Name:        "/upgrade",
 		Description: "Upgrade " + product.Name + " to the latest version",
+		Section:     "Versioning",
 		AsyncAction: func(_ string) tea.Cmd {
 			return func() tea.Msg { return upgradeMsg{} }
 		},
 	},
 	{
-		Name:        "/stop",
-		Description: "Stop " + product.Name + " and exit",
-		Action:      nil, // handled specially in Update
+		Name:        "/switch",
+		Description: "Switch to another installed version",
+		Section:     "Versioning",
+		AsyncAction: func(_ string) tea.Cmd {
+			return func() tea.Msg { return switchVersionMsg{} }
+		},
+	},
+	{
+		Name:        "/open-console",
+		Description: "Open the Console in your browser",
+		Section:     "Apps",
+		Action: func(baseURL string) ([]string, error) {
+			url := baseURL + "/console"
+			if err := utils.OpenBrowser(url); err != nil {
+				return nil, err
+			}
+			return []string{Dim("Opening " + url + "...")}, nil
+		},
 	},
 }
 
@@ -91,6 +104,7 @@ var defaultCommands = []SlashCommand{
 type healthCheckMsg struct{ ready bool }
 type cutoverMsg struct{}
 type upgradeMsg struct{}
+type switchVersionMsg struct{}
 type thunderExitedMsg struct {
 	err error
 	pid int // PID of the process that exited — used to ignore stale watches
@@ -124,6 +138,9 @@ type sampleDoneMsg struct {
 
 // sampleErrMsg signals that the try-* operation failed.
 type sampleErrMsg struct{ err error }
+
+// integrateFrameworkMsg triggers the step-by-step integration guide for a framework.
+type integrateFrameworkMsg struct{ framework string }
 
 // usecaseConfigRequestMsg is sent when a use case requires additional config before starting.
 type usecaseConfigRequestMsg struct {
@@ -310,6 +327,7 @@ type ReplModel struct {
 	checkPort         int  // non-zero overrides health.DefaultPort for health checks
 	cutoverRequested  bool // set when the /cutover command is executed
 	upgradeRequested  bool // set when the /upgrade command is executed
+	switchRequested   bool // set when the /use command is executed
 	newVersion        string
 
 	showWalkthrough  bool
@@ -326,6 +344,16 @@ type ReplModel struct {
 	ucSampleName      string
 	ucEnvTarget       string
 	ucFeatures        []string
+	ucComplete        func(values map[string]string) tea.Cmd
+
+	// Step-by-step integration guide — active when showIntegrate is true.
+	showIntegrate       bool
+	integrateFramework  string // display label, e.g. "React", "Vue"
+	integrateSteps      []integrate.Step
+	integrateStepIdx    int
+	integrateValues     map[string]string
+	integrateInput      textinput.Model
+	integrateCollecting bool
 }
 
 // NewReplModel initializes the REPL model.
@@ -380,9 +408,31 @@ func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bo
 			})
 		}
 	}
+	for _, it := range []struct {
+		name      string
+		framework string
+		label     string
+	}{
+		{"/integrate-react", "react", "React"},
+		{"/integrate-vue", "vue", "Vue"},
+		{"/integrate-nextjs", "nextjs", "Next.js"},
+		{"/integrate-nuxt", "nuxt", "Nuxt"},
+	} {
+		it := it
+		commands = append(commands, SlashCommand{
+			Name:        it.name,
+			Description: "Add ThunderID auth to your " + it.label + " app",
+			Section:     "Integrate",
+			AsyncAction: func(_ string) tea.Cmd {
+				return func() tea.Msg { return integrateFrameworkMsg{framework: it.framework} }
+			},
+		})
+	}
+
 	logCmd := SlashCommand{
 		Name:        "/logs",
 		Description: "Show recent server logs",
+		Section:     "Server",
 		Action: func(_ string) ([]string, error) {
 			logPath := setup.LogFile(installPath)
 			data, err := os.ReadFile(logPath)
@@ -405,6 +455,10 @@ func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bo
 	commands = append(commands, logCmd)
 	commands = append(commands, defaultCommands...)
 
+	ii := textinput.New()
+	ii.Prompt = "> "
+	ii.CharLimit = 256
+
 	return ReplModel{
 		input:          ti,
 		spinner:        s,
@@ -417,6 +471,7 @@ func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bo
 		width:          80,
 		showOnboarding: isFirstRun,
 		onboardingList: newOnboardingList(80),
+		integrateInput: ii,
 	}
 }
 
@@ -536,7 +591,7 @@ func (m *ReplModel) initUCStep() {
 }
 
 // advanceUCStep records value for the current step then moves to the next.
-// When all steps are done it clears the config state and returns a makeTryCmd.
+// When all steps are done it clears the config state and invokes ucComplete.
 func (m *ReplModel) advanceUCStep(value string) tea.Cmd {
 	m.ucValues[m.ucInputs[m.ucStep].Key] = value
 	m.ucStep++
@@ -547,12 +602,7 @@ func (m *ReplModel) advanceUCStep(value string) tea.Cmd {
 	m.showUsecaseConfig = false
 	m.tryingOut = true
 	m.input.Blur()
-	opts := sample.Options{
-		Config:    m.ucValues,
-		EnvTarget: m.ucEnvTarget,
-		Features:  m.ucFeatures,
-	}
-	return makeTryCmd(m.ucSampleName, m.installPath, m.verbose, opts)
+	return m.ucComplete(m.ucValues)
 }
 
 // Update implements tea.Model.
@@ -623,6 +673,8 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 					m.input.Focus()
 					m.input.SetValue("/")
 					m.input.CursorEnd()
+					m.updateCompletions()
+					return m, tea.Batch(cmds...)
 				} else {
 					prevIdx := m.onboardingList.Index()
 					var listCmd tea.Cmd
@@ -652,7 +704,8 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 			} else {
 				switch msg.Type {
 				case tea.KeyEnter:
-					if val := strings.TrimSpace(m.ucText.Value()); val != "" {
+					val := strings.TrimSpace(m.ucText.Value())
+					if val != "" || m.ucInputs[m.ucStep].Optional {
 						if cmd := m.advanceUCStep(val); cmd != nil {
 							cmds = append(cmds, cmd)
 						}
@@ -686,6 +739,57 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 				m.input.Focus()
 				m.input.SetValue("/")
 				m.input.CursorEnd()
+				m.updateCompletions()
+				return m, tea.Batch(cmds...)
+			}
+		} else if m.showIntegrate {
+			// ── Integration guide navigation ───────────────────────────────────
+			if m.integrateCollecting {
+				switch msg.Type {
+				case tea.KeyEnter:
+					val := strings.TrimSpace(m.integrateInput.Value())
+					m.integrateValues[m.integrateSteps[m.integrateStepIdx].CollectKey] = val
+					m.integrateCollecting = false
+					m.integrateInput.Blur()
+					if len(m.integrateSteps[m.integrateStepIdx].Code) == 0 && m.integrateStepIdx < len(m.integrateSteps)-1 {
+						m.integrateStepIdx++
+					}
+				case tea.KeyEsc:
+					m.integrateCollecting = false
+					m.integrateInput.Blur()
+					if len(m.integrateSteps[m.integrateStepIdx].Code) == 0 && m.integrateStepIdx < len(m.integrateSteps)-1 {
+						m.integrateStepIdx++
+					}
+				default:
+					var tiCmd tea.Cmd
+					m.integrateInput, tiCmd = m.integrateInput.Update(msg)
+					cmds = append(cmds, tiCmd)
+				}
+			} else {
+				switch msg.Type {
+				case tea.KeyEnter:
+					step := m.integrateSteps[m.integrateStepIdx]
+					if step.CollectKey != "" && m.integrateValues[step.CollectKey] == "" {
+						m.integrateCollecting = true
+						m.integrateInput.SetValue("")
+						m.integrateInput.Placeholder = step.CollectHint
+						m.integrateInput.Focus()
+					} else if m.integrateStepIdx < len(m.integrateSteps)-1 {
+						m.integrateStepIdx++
+					} else {
+						m.showIntegrate = false
+						m.walkthroughPanes = integrateWalkthroughPanes(m.integrateFramework, m.baseURL)
+						m.walkthroughTab = 0
+						m.showWalkthrough = true
+					}
+				case tea.KeyLeft:
+					if m.integrateStepIdx > 0 {
+						m.integrateStepIdx--
+					}
+				case tea.KeyEsc:
+					m.showIntegrate = false
+					m.input.Focus()
+				}
 			}
 		} else {
 			// ── Regular REPL ───────────────────────────────────────────────────
@@ -730,6 +834,14 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 		m.ucEnvTarget = msg.envTarget
 		m.ucFeatures = msg.features
 
+		// Capture msg fields for the completion closure.
+		sampleName, ip, envTarget, features := msg.sampleName, m.installPath, msg.envTarget, msg.features
+		m.ucComplete = func(values map[string]string) tea.Cmd {
+			return makeTryCmd(sampleName, ip, m.verbose, sample.Options{
+				Config: values, EnvTarget: envTarget, Features: features,
+			})
+		}
+
 		// Pre-populate from a previous run so the user is not re-prompted.
 		sampleDir := sample.SampleDir(m.installPath, msg.sampleName)
 		m.ucValues = sample.ReadServiceEnv(sampleDir, msg.envTarget)
@@ -748,16 +860,42 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 			// All values already present — launch immediately without prompting.
 			m.tryingOut = true
 			m.input.Blur()
-			opts := sample.Options{
-				Config:    m.ucValues,
-				EnvTarget: m.ucEnvTarget,
-				Features:  m.ucFeatures,
-			}
-			cmds = append(cmds, makeTryCmd(m.ucSampleName, m.installPath, m.verbose, opts))
+			cmds = append(cmds, m.ucComplete(m.ucValues))
 		} else {
 			m.showUsecaseConfig = true
 			m.input.Blur()
 			m.initUCStep()
+		}
+
+	case integrateFrameworkMsg:
+		stepsFns := map[string]func(string) []integrate.Step{
+			"react":  integrate.ReactSteps,
+			"vue":    integrate.VueSteps,
+			"nextjs": integrate.NextJSSteps,
+			"nuxt":   integrate.NuxtSteps,
+		}
+		labels := map[string]string{
+			"react":  "React",
+			"vue":    "Vue",
+			"nextjs": "Next.js",
+			"nuxt":   "Nuxt",
+		}
+		if fn, ok := stepsFns[msg.framework]; ok {
+			m.integrateSteps = fn(m.baseURL)
+			m.integrateFramework = labels[msg.framework]
+			m.integrateStepIdx = 0
+			m.integrateValues = map[string]string{}
+			m.showIntegrate = true
+			m.input.Blur()
+			first := m.integrateSteps[0]
+			if first.CollectKey != "" && len(first.Code) == 0 {
+				m.integrateCollecting = true
+				m.integrateInput.SetValue("")
+				m.integrateInput.Placeholder = first.CollectHint
+				m.integrateInput.Focus()
+			} else {
+				m.integrateCollecting = false
+			}
 		}
 
 	case healthCheckMsg:
@@ -901,8 +1039,12 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 		return m, tea.Quit
 
 	case upgradeMsg:
-		m.killThunder()
 		m.upgradeRequested = true
+		m.quitting = true
+		return m, tea.Quit
+
+	case switchVersionMsg:
+		m.switchRequested = true
 		m.quitting = true
 		return m, tea.Quit
 
@@ -1069,6 +1211,158 @@ func renderWalkthrough(m ReplModel) string {
 	return b.String()
 }
 
+func integrateWalkthroughPanes(framework, baseURL string) []walkthroughPane {
+	return []walkthroughPane{
+		{
+			Title: "What's Next",
+			Lines: []string{
+				Green("✓") + " Your " + framework + " app is wired to ThunderID.",
+				"",
+				"  " + Cyan("Flow Designer") + "  " + Dim("— add MFA, passkeys, or social login"),
+				"  " + Cyan(framework+" SDK Docs") + "  " + Dim("— full API reference"),
+				"",
+				Dim("  Open the console to get started  →"),
+			},
+			URL: baseURL + "/console",
+		},
+		{
+			Title: "Find Your Client ID",
+			Lines: []string{
+				"  Open the ThunderID Console and navigate to:",
+				"",
+				"  " + Bold("Applications") + "  →  " + Bold("your app") + "  →  " + Bold("Client ID"),
+			},
+			URL: baseURL + "/console",
+		},
+	}
+}
+
+// substituteCodeLine replaces {{.KEY}} tokens in a code line with styled values.
+// If a key has a collected value it is rendered in brand blue; otherwise a dim
+// placeholder is shown so the code block still makes sense before collection.
+func substituteCodeLine(line string, values map[string]string) string {
+	codeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#AAAAAA"))
+	blueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(colorBrandBlue))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(colorGrey))
+
+	var result strings.Builder
+	remaining := line
+	for {
+		start := strings.Index(remaining, "{{.")
+		if start == -1 {
+			result.WriteString(codeStyle.Render(remaining))
+			break
+		}
+		if start > 0 {
+			result.WriteString(codeStyle.Render(remaining[:start]))
+		}
+		rest := remaining[start+3:]
+		end := strings.Index(rest, "}}")
+		if end == -1 {
+			result.WriteString(codeStyle.Render(remaining[start:]))
+			break
+		}
+		key := rest[:end]
+		if val, ok := values[key]; ok && val != "" {
+			result.WriteString(blueStyle.Render(val))
+		} else {
+			result.WriteString(dimStyle.Render("<your-" + strings.ToLower(key) + ">"))
+		}
+		remaining = rest[end+2:]
+	}
+	return result.String()
+}
+
+// renderCodeBlock draws a bordered box containing syntax-highlighted code lines.
+// Lines with {{.KEY}} tokens are substituted from values.
+func renderCodeBlock(codeFile string, lines []string, values map[string]string, boxWidth int) string {
+	borderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(colorGrey))
+	codeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#AAAAAA"))
+
+	innerWidth := boxWidth - 4 // subtract "│ " and " │"
+
+	// Top border with filename label.
+	labelPart := "─ " + codeFile + " "
+	dashCount := clamp(innerWidth-len(labelPart), 0, innerWidth)
+	top := "┌" + labelPart + strings.Repeat("─", dashCount) + "─┐"
+
+	var b strings.Builder
+	b.WriteString("  " + borderStyle.Render(top) + "\n")
+
+	for _, line := range lines {
+		var rendered string
+		if strings.Contains(line, "{{.") {
+			rendered = substituteCodeLine(line, values)
+		} else {
+			rendered = codeStyle.Render(line)
+		}
+		visWidth := lipgloss.Width(rendered)
+		padding := clamp(innerWidth-visWidth, 0, innerWidth)
+		b.WriteString("  " + borderStyle.Render("│") + " " + rendered + strings.Repeat(" ", padding) + " " + borderStyle.Render("│") + "\n")
+	}
+
+	bottom := "└" + strings.Repeat("─", innerWidth+2) + "┘"
+	b.WriteString("  " + borderStyle.Render(bottom) + "\n")
+	return b.String()
+}
+
+func renderIntegrate(m ReplModel) string {
+	if len(m.integrateSteps) == 0 {
+		return ""
+	}
+	var b strings.Builder
+
+	total := len(m.integrateSteps)
+	idx := m.integrateStepIdx
+	step := m.integrateSteps[idx]
+
+	// Progress header.
+	progress := fmt.Sprintf("Step %d of %d", idx+1, total)
+	b.WriteString("  " + Dim(m.integrateFramework+" Integration") + "  " + Dim("·") + "  " + Bold(progress) + "\n")
+	b.WriteString("  " + Dim(strings.Repeat("─", clamp(m.width-4, 20, 76))) + "\n\n")
+
+	// Step title and body.
+	b.WriteString("  " + Bold(step.Title) + "\n\n")
+	for _, line := range step.Body {
+		b.WriteString("  " + Dim(line) + "\n")
+	}
+	if len(step.Body) > 0 {
+		b.WriteString("\n")
+	}
+
+	if m.integrateCollecting {
+		// Collect prompt — mirrors showUsecaseConfig style.
+		b.WriteString("  " + Bold(step.CollectLabel) + "\n\n")
+		if step.CollectURL != "" {
+			b.WriteString("  " + Cyan(step.CollectURL) + "\n\n")
+		}
+		b.WriteString("  " + Dim(step.CollectHint) + "\n")
+		b.WriteString("  " + Dim("(press Esc to skip — you can set it in src/main.jsx later)") + "\n\n")
+		b.WriteString(m.integrateInput.View() + "\n")
+		b.WriteString("\n" + Dim("  Enter to continue"))
+	} else {
+		// Code block.
+		boxWidth := clamp(m.width-6, 50, 78)
+		b.WriteString(renderCodeBlock(step.CodeFile, step.Code, m.integrateValues, boxWidth))
+		b.WriteString("\n")
+
+		// Key hints.
+		hint := ""
+		if step.CollectKey != "" && m.integrateValues[step.CollectKey] == "" {
+			hint = Dim("  Enter to set Client ID  •  ")
+		} else {
+			hint = Dim("  Enter to continue  •  ")
+		}
+		if idx > 0 {
+			hint += Dim("← back  •  ")
+		}
+		hint += Dim("esc dismiss")
+		b.WriteString(hint + "\n")
+	}
+
+	return b.String()
+}
+
 // View implements tea.Model.
 func (m ReplModel) View() string {
 	if m.quitting {
@@ -1109,12 +1403,22 @@ func (m ReplModel) View() string {
 	if m.showUsecaseConfig {
 		inp := m.ucInputs[m.ucStep]
 		b.WriteString("  " + Bold(inp.Label) + "\n\n")
+		for _, line := range inp.Instructions {
+			b.WriteString("  " + Dim(line) + "\n")
+		}
+		if len(inp.Instructions) > 0 {
+			b.WriteString("\n")
+		}
 		if len(inp.Choices) > 0 {
 			b.WriteString(m.ucList.View())
 			b.WriteString("\n" + Dim("  ↑/↓ select  •  Enter to continue"))
 		} else {
 			b.WriteString(m.ucText.View() + "\n")
-			b.WriteString("\n" + Dim("  Enter to continue"))
+			if inp.Optional {
+				b.WriteString("\n" + Dim("  Enter to continue  •  leave empty to skip"))
+			} else {
+				b.WriteString("\n" + Dim("  Enter to continue"))
+			}
 		}
 		return b.String()
 	}
@@ -1124,6 +1428,11 @@ func (m ReplModel) View() string {
 	}
 	if len(m.messages) > 0 {
 		b.WriteString("\n")
+	}
+
+	if m.showIntegrate {
+		b.WriteString(renderIntegrate(m))
+		return b.String()
 	}
 
 	if m.showWalkthrough {
@@ -1158,19 +1467,23 @@ func clamp(v, min, max int) int {
 
 // RunREPL starts the interactive REPL and blocks until the user exits.
 // newVersion, if non-empty, causes a banner to appear prompting the user to /upgrade.
-// Returns upgradeRequested=true when the user ran /upgrade.
+// port overrides the default health-check port when non-zero.
+// Returns upgradeRequested=true when the user ran /upgrade, switchRequested=true when /use.
 func RunREPL(
 	version string, proc *exec.Cmd, installPath string,
-	verbose, isFirstRun bool, newVersion string,
-) (upgradeRequested bool, err error) {
+	verbose, isFirstRun bool, newVersion string, port int,
+) (upgradeRequested, switchRequested bool, err error) {
 	m := NewReplModel(version, proc, installPath, verbose, isFirstRun)
 	m.newVersion = newVersion
+	if port > 0 {
+		m.checkPort = port
+	}
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	finalModel, runErr := p.Run()
 	if rm, ok := finalModel.(ReplModel); ok {
-		return rm.upgradeRequested, runErr
+		return rm.upgradeRequested, rm.switchRequested, runErr
 	}
-	return false, runErr
+	return false, false, runErr
 }
 
 // RunStagingREPL runs the REPL connected to a staging instance on stagingPort.

--- a/tools/cli/internal/ui/usecases.go
+++ b/tools/cli/internal/ui/usecases.go
@@ -20,10 +20,12 @@ package ui
 // ConfigInput describes one value the user must supply before the sample runs.
 // If Choices is non-empty the TUI renders a list picker; otherwise a text input.
 type ConfigInput struct {
-	Key     string   // env var key written to the target .env, e.g. "LLM_PROVIDER"
-	Label   string   // prompt text shown to the user
-	Choices []Choice // non-empty → list picker; empty → text input
-	Secret  bool     // mask text input with EchoPassword
+	Key          string   // env var key written to the target .env, e.g. "LLM_PROVIDER"
+	Label        string   // prompt text shown to the user
+	Instructions []string // dimmed lines shown below the label, before the input
+	Choices      []Choice // non-empty → list picker; empty → text input
+	Secret       bool     // mask text input with EchoPassword
+	Optional     bool     // allow Enter with empty value to skip this step
 }
 
 // Choice is a single option in a ConfigInput list picker.


### PR DESCRIPTION
### Purpose

Adds in-REPL integration guides for React, Vue, Next.js, and Nuxt that walk developers step-by-step through adding ThunderID auth to an existing app — without leaving the terminal. Also ships a set of REPL polish improvements: command categorisation, a `/switch` command for version switching, and a fix for the double-slash bug when opening the command overlay.

### Approach

**Integration guides (`/integrate-*` commands)**
- New `integrate` package (`internal/commands/integrate`) defines ordered `Step` slices for React, Vue, Next.js, and Nuxt, each with title, body, code snippets, and optional value-collection prompts.
- `renderIntegrate` in `repl.go` renders a paginated walkthrough (step N of M) with a syntax-highlighted code block and ← / → navigation.
- Before showing any code, the React guide prompts the developer to open the Console and supply their Client ID — the value is substituted into all `{{.ClientID}}` placeholders in subsequent code blocks.

**REPL polish**
- Renamed `/use` → `/switch` for clarity.
- Grouped slash commands into labelled sections: **Try**, **Integrate**, **Versioning**, **Server**, **Apps**.
- Removed scaffolding (`/create-*`) commands from the REPL — will be re-added later.
- Fixed a bug where pressing `/` on the onboarding screen produced `//` in the input: the onboarding and walkthrough `/` handlers now return early before the unconditional `m.input.Update(msg)` call runs.

**Version switching (`/switch`)**
- `upgrade.Switch` lists installed versions, stops the current instance, swaps the active-version pointer, and re-enters the REPL for the selected version.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3609

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
