### PR TITLE
Preserve documentation deployment URLs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,11 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "build/**", "modules/**"]
     },
+    "@thunderid/docs#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["build/**"],
+      "env": ["DOCUSAURUS_URL", "DOCUSAURUS_BASE_URL"]
+    },
     "@thunderid/eslint-plugin#build": {
       "dependsOn": [],
       "outputs": ["dist/**"]


### PR DESCRIPTION
### Purpose
Fork-based GitHub Pages deployments lose `DOCUSAURUS_URL` and `DOCUSAURUS_BASE_URL` after the Nx-to-Turbo migration. Docusaurus consequently builds with `baseUrl=/`, causing deployed assets to return 404.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Declare the Docusaurus URL variables for the `@thunderid/docs#build` Turbo task. This passes them to Docusaurus and includes their values in the task cache key.

Verified using a fork deployment. The generated site used `/thunderid/`, and its JavaScript assets and AuthZEN pages returned HTTP 200.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3639

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation build setup to better align with the main build process.
  * Added support for new documentation environment settings during builds.
  * Configured documentation build outputs to be tracked more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->