### PR TITLE
Clarifying default owner behaviour in agent create wizard

### DIFF
--- a/frontend/apps/console/src/features/agents/components/create-agent/ConfigureOwner.tsx
+++ b/frontend/apps/console/src/features/agents/components/create-agent/ConfigureOwner.tsx
@@ -18,7 +18,7 @@
 
 import {useGetUsers} from '@thunderid/configure-users';
 import {useThunderID} from '@thunderid/react';
-import {FormControl, FormLabel, MenuItem, Select, Stack, Typography} from '@wso2/oxygen-ui';
+import {FormControl, FormHelperText, FormLabel, MenuItem, Select, Stack, Typography} from '@wso2/oxygen-ui';
 import {useEffect, useMemo, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 
@@ -80,7 +80,7 @@ export default function ConfigureOwner({
         </Typography>
       </div>
 
-      <FormControl fullWidth required>
+      <FormControl fullWidth>
         <FormLabel htmlFor="agent-owner-user-select">{t('agents:createWizard.owner.userLabel', 'Owner')}</FormLabel>
         <Select
           id="agent-owner-user-select"
@@ -88,6 +88,7 @@ export default function ConfigureOwner({
           onChange={(e) => onOwnerIdChange(e.target.value || null)}
           displayEmpty
           disabled={usersLoading}
+          aria-describedby="agent-owner-user-select-helper-text"
         >
           <MenuItem value="" disabled>
             <em>
@@ -102,6 +103,12 @@ export default function ConfigureOwner({
             </MenuItem>
           ))}
         </Select>
+        <FormHelperText id="agent-owner-user-select-helper-text">
+          {t(
+            'agents:createWizard.owner.helperText',
+            'Defaults to you if left unchanged. You can assign ownership to another user instead.',
+          )}
+        </FormHelperText>
       </FormControl>
     </Stack>
   );

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -993,6 +993,8 @@ const translations = {
     'createWizard.owner.subtitle': 'Choose the user that owns this agent.',
     'createWizard.owner.userLabel': 'Owner',
     'createWizard.owner.userPlaceholder': 'Select a user',
+    'createWizard.owner.helperText':
+      'Defaults to you if left unchanged. You can assign ownership to another user instead.',
 
     // Client secret (creation)
     'clientSecret.saveTitle': 'Save your client secret',


### PR DESCRIPTION
### Purpose
The "Owner" step of the Create Agent wizard marked the Owner field as required (`FormControl required`), showing a required asterisk on the label. This was misleading: the field is never actually empty when the user reaches this step — it auto-fills with the currently authenticated user before any interaction — and the API (`CreateAgentRequest.owner` in `api/agent.yaml`) documents `owner` as optional, defaulting to the authenticated principal. The required marker implied users must actively pick an owner, when in fact they can just leave the default and move on.

### Approach
- Removed the `required` prop from the `FormControl` wrapping the owner `Select` in `ConfigureOwner.tsx`, since the field's "required" state was never enforced by anything downstream — the owner always resolves to a value (current user by default, or an explicitly chosen one).
- Added a `FormHelperText` under the Select explaining "Defaults to you if left unchanged. You can assign ownership to another user instead," so the optional/default nature is now explicit for the user instead of only implied by seeing an asterisk that made it look mandatory.
- Added the new `agents:createWizard.owner.helperText` translation key in `en-US.ts` for the helper text.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Added helper text under the owner selector in the agent creation flow to explain how ownership is assigned.
  * Updated the owner field to remove the required visual indicator while keeping selection behavior the same.
  * Improved accessibility by linking the selector to its helper text.
  * Added an English translation string for the new owner helper message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->