### PR TITLE
Add REVOKED_TOKEN schema to operation database

### DIFF
--- a/backend/dbscripts/operationdb/postgres-cleanup.sql
+++ b/backend/dbscripts/operationdb/postgres-cleanup.sql
@@ -1,0 +1,58 @@
+-- ----------------------------------------------------------------------------
+-- Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+--
+-- WSO2 LLC. licenses this file to you under the Apache License,
+-- Version 2.0 (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+-- ----------------------------------------------------------------------------
+
+-- ============================================================
+-- Stored procedure: purge expired operationdb rows.
+--
+-- Unlike runtimedb, operation data is authoritative and must survive a
+-- runtime flush; only rows past their EXPIRY_TIME are safe to delete. A revoked
+-- token's row is removable once the token itself would have naturally expired.
+--
+-- Run once manually (ad-hoc / on-demand):
+--   PGPASSWORD=<pass> psql -h <host> -p <port> -U <user> -d <operationdb> \
+--     -c "CALL cleanup_expired_operationdb_data();"
+--
+-- Scheduled execution options:
+--
+--   1. pg_cron (RECOMMENDED, requires the pg_cron extension):
+--      CREATE EXTENSION IF NOT EXISTS pg_cron;
+--      SELECT cron.schedule(
+--        'cleanup-operationdb-expired',
+--        '*/60 * * * *',
+--        $$CALL cleanup_expired_operationdb_data()$$
+--      );
+--      -- To verify: SELECT * FROM cron.job WHERE jobname = 'cleanup-operationdb-expired';
+--      -- To remove: SELECT cron.unschedule('cleanup-operationdb-expired');
+--
+--   2. Kubernetes CronJob: call CALL cleanup_expired_operationdb_data()
+--      via a psql container on the desired schedule.
+--
+--   3. OS cron (every 60 minutes):
+-- --      */60 * * * * postgres PGPASSWORD=<pass> psql -h <host> -p <port> \
+-- --        -U <user> -d <operationdb> -c "CALL cleanup_expired_operationdb_data();" \
+-- --        >> /var/log/thunderid-operation-cleanup.log 2>&1
+-- ============================================================
+
+CREATE OR REPLACE PROCEDURE cleanup_expired_operationdb_data()
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_now TIMESTAMP := NOW() AT TIME ZONE 'UTC';
+BEGIN
+    DELETE FROM "REVOKED_TOKEN" WHERE EXPIRY_TIME < v_now;
+END;
+$$;

--- a/backend/dbscripts/operationdb/postgres.sql
+++ b/backend/dbscripts/operationdb/postgres.sql
@@ -15,6 +15,20 @@
 -- under the License.
 -- ----------------------------------------------------------------------------
 
--- Schema for the database.operation classification.
--- Holds authoritative authorization-operation state that must survive a runtime
--- database flush. Tables are introduced by the features that own them.
+-- Table to store revoked token JTIs (single-token revocation deny list).
+-- Part of the database.operation classification: authoritative authorization
+-- enforcement state that must survive a runtime database flush.
+CREATE TABLE "REVOKED_TOKEN" (
+    DEPLOYMENT_ID VARCHAR(255) NOT NULL,
+    ID VARCHAR(36) NOT NULL PRIMARY KEY,
+    JTI VARCHAR(255) NOT NULL,
+    REVOCATION_REASON VARCHAR(30) NOT NULL CHECK (REVOCATION_REASON IN ('explicit', 'refresh_rotation')),
+    REVOKED_AT TIMESTAMP NOT NULL,
+    EXPIRY_TIME TIMESTAMP NOT NULL
+);
+
+-- Unique index backs the hot deny-list lookup by (deployment, jti) and enforces idempotent revocation writes.
+CREATE UNIQUE INDEX idx_revoked_token_jti_deployment ON "REVOKED_TOKEN" (DEPLOYMENT_ID, JTI);
+
+-- Index for expiry time on REVOKED_TOKEN (supports cleanup and expiry checks).
+CREATE INDEX idx_revoked_token_expiry_time ON "REVOKED_TOKEN" (EXPIRY_TIME);

--- a/backend/dbscripts/operationdb/sqlite.sql
+++ b/backend/dbscripts/operationdb/sqlite.sql
@@ -15,6 +15,20 @@
 -- under the License.
 -- ----------------------------------------------------------------------------
 
--- Schema for the database.operation classification.
--- Holds authoritative authorization-operation state that must survive a runtime
--- database flush. Tables are introduced by the features that own them.
+-- Table to store revoked token JTIs (single-token revocation deny list).
+-- Part of the database.operation classification: authoritative authorization
+-- enforcement state that must survive a runtime database flush.
+CREATE TABLE "REVOKED_TOKEN" (
+    DEPLOYMENT_ID VARCHAR(255) NOT NULL,
+    ID VARCHAR(36) NOT NULL PRIMARY KEY,
+    JTI VARCHAR(255) NOT NULL,
+    REVOCATION_REASON VARCHAR(30) NOT NULL CHECK (REVOCATION_REASON IN ('explicit', 'refresh_rotation')),
+    REVOKED_AT DATETIME NOT NULL,
+    EXPIRY_TIME DATETIME NOT NULL
+);
+
+-- Unique index backs the hot deny-list lookup by (deployment, jti) and enforces idempotent revocation writes.
+CREATE UNIQUE INDEX idx_revoked_token_jti_deployment ON "REVOKED_TOKEN" (DEPLOYMENT_ID, JTI);
+
+-- Index for expiry time on REVOKED_TOKEN (supports cleanup and expiry checks).
+CREATE INDEX idx_revoked_token_expiry_time ON "REVOKED_TOKEN" (EXPIRY_TIME);


### PR DESCRIPTION
Introduce the single-token revocation deny list in the database.operation classification. This is schema only — no repository layer or functional behaviour yet.

- REVOKED_TOKEN table (postgres + sqlite): UUID ID primary key with a unique index on (DEPLOYMENT_ID, JTI) that backs the hot deny-list lookup and enforces idempotent revocation writes, plus an EXPIRY_TIME index for cleanup.
- cleanup_expired_operationdb_data() procedure (postgres): purges rows past EXPIRY_TIME. Operation data is authoritative and survives a runtime flush, so only naturally-expired rows are removed. Run ad-hoc or scheduled (pg_cron / k8s CronJob / OS cron); not wired into init, matching the runtimedb precedent.

Refs https://github.com/thunder-id/thunderid/discussions/3321

### Purpose
Single token revocation deny list

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3602

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3621

### Checklist
- [X] Followed the contribution guidelines.
- [X] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [X] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token revocation storage for deployments, allowing revoked tokens to be tracked and checked efficiently.
  * Added support for removing expired revocation records from the database.

* **Bug Fixes**
  * Improved consistency and performance of token revocation lookups with new indexing.
  * Ensured revocation entries can be added safely without duplicates for the same token and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->