### PR TITLE
Resolve federated users by a configurable IdP attribute

### DIFF
--- a/api/idp.yaml
+++ b/api/idp.yaml
@@ -578,8 +578,6 @@ components:
     AttributeConfiguration:
       type: object
       description: External-to-local attribute mapping configuration for the identity provider.
-      required:
-        - userTypeResolution
       properties:
         userTypeResolution:
           $ref: '#/components/schemas/UserTypeResolution'
@@ -588,6 +586,23 @@ components:
           description: Per-user-type attribute mapping profiles.
           items:
             $ref: '#/components/schemas/UserTypeAttributeMapping'
+        accountLinking:
+          $ref: '#/components/schemas/AccountLinking'
+
+    AccountLinking:
+      type: object
+      description: >
+        Configures how an incoming federated identity is resolved to an existing local user when the
+        subject identifier does not resolve one. All configured attributes that have a value are
+        combined into a single lookup filter.
+      properties:
+        attributes:
+          type: array
+          description: External attribute names used together to resolve the local user.
+          items:
+            type: string
+          example:
+            - "email"
 
     UserTypeResolution:
       type: object

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -287,7 +287,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	// Initialize federated authentication services.
 	oauthAuthnService := authnOAuth.Initialize(idpService, entityProvider)
-	oidcAuthnService := authnOIDC.Initialize(oauthAuthnService, jwtService, idpService)
+	oidcAuthnService := authnOIDC.Initialize(oauthAuthnService, jwtService)
 	googleAuthnService := google.Initialize(oidcAuthnService, jwtService)
 	githubAuthnService := github.Initialize(oauthAuthnService)
 

--- a/backend/internal/authn/github/service.go
+++ b/backend/internal/authn/github/service.go
@@ -177,10 +177,12 @@ func (g *githubOAuthAuthnService) Authenticate(ctx context.Context, idpID, code 
 		return nil, &authncm.ErrorSubClaimNotFound
 	}
 
-	return &authncm.AuthnResult{
-		Token: map[string]interface{}{
-			"sub": sub,
-		},
-		AuthenticatedClaims: userInfo,
-	}, nil
+	return g.internal.BuildFederatedAuthResult(ctx, idpID, sub, userInfo)
+}
+
+// BuildFederatedAuthResult delegates to the underlying OAuth service, which applies attribute mapping
+// and account-linking resolution uniformly for all federated authenticators.
+func (g *githubOAuthAuthnService) BuildFederatedAuthResult(ctx context.Context, idpID, sub string,
+	claims map[string]interface{}) (*authncm.AuthnResult, *tidcommon.ServiceError) {
+	return g.internal.BuildFederatedAuthResult(ctx, idpID, sub, claims)
 }

--- a/backend/internal/authn/github/service_test.go
+++ b/backend/internal/authn/github/service_test.go
@@ -542,6 +542,11 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestAuthenticateSuccess() {
 	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).Return(oauthConfig, nil)
 	suite.mockOAuthService.On("FetchUserInfoWithClientConfig", mock.Anything, oauthConfig, testAccessToken).
 		Return(userInfo, nil)
+	suite.mockOAuthService.On("BuildFederatedAuthResult", mock.Anything, testGithubIDPID, "12345", mock.Anything).
+		Return(&authncm.AuthnResult{
+			Token:               map[string]interface{}{"sub": "12345"},
+			AuthenticatedClaims: map[string]interface{}{"email": "test@example.com"},
+		}, nil)
 
 	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID, code)
 	suite.Nil(err)
@@ -673,4 +678,18 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestAuthenticateSubClaimNonString
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(authncm.ErrorSubClaimNotFound.Code, err.Code)
+}
+
+func (suite *GithubOAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultDelegates() {
+	expected := &authncm.AuthnResult{
+		Token:               map[string]interface{}{"email": "user@example.com"},
+		AuthenticatedClaims: map[string]interface{}{"email": "user@example.com"},
+	}
+	suite.mockOAuthService.On("BuildFederatedAuthResult", mock.Anything, testGithubIDPID, "sub-1", mock.Anything).
+		Return(expected, nil)
+
+	result, err := suite.service.BuildFederatedAuthResult(
+		context.Background(), testGithubIDPID, "sub-1", map[string]interface{}{"email": "user@example.com"})
+	suite.Nil(err)
+	suite.Equal(expected, result)
 }

--- a/backend/internal/authn/google/service.go
+++ b/backend/internal/authn/google/service.go
@@ -263,10 +263,12 @@ func (g *googleOIDCAuthnService) Authenticate(ctx context.Context, idpID, code s
 		return nil, &common.ErrorSubClaimNotFound
 	}
 
-	return &common.AuthnResult{
-		Token: map[string]interface{}{
-			"sub": sub,
-		},
-		AuthenticatedClaims: claims,
-	}, nil
+	return g.internal.BuildFederatedAuthResult(ctx, idpID, sub, claims)
+}
+
+// BuildFederatedAuthResult delegates to the underlying OIDC service, which applies attribute mapping
+// and account-linking resolution uniformly for all federated authenticators.
+func (g *googleOIDCAuthnService) BuildFederatedAuthResult(ctx context.Context, idpID, sub string,
+	claims map[string]interface{}) (*common.AuthnResult, *tidcommon.ServiceError) {
+	return g.internal.BuildFederatedAuthResult(ctx, idpID, sub, claims)
 }

--- a/backend/internal/authn/google/service_test.go
+++ b/backend/internal/authn/google/service_test.go
@@ -862,6 +862,11 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateSuccess() {
 		Return(nil)
 	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", mock.Anything, idToken).Return(validClaims, nil)
+	suite.mockOIDCService.On("BuildFederatedAuthResult", mock.Anything, testGoogleIDPID, "user123", mock.Anything).
+		Return(&common.AuthnResult{
+			Token:               map[string]interface{}{"sub": "user123"},
+			AuthenticatedClaims: validClaims,
+		}, nil)
 
 	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID, testAuthCode)
 	suite.Nil(err)
@@ -1250,4 +1255,18 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_IatJust
 	suite.NotNil(err)
 	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
 	suite.Contains(err.ErrorDescription.DefaultValue, "future")
+}
+
+func (suite *GoogleOIDCAuthnServiceTestSuite) TestBuildFederatedAuthResultDelegates() {
+	expected := &common.AuthnResult{
+		Token:               map[string]interface{}{"email": "user@example.com"},
+		AuthenticatedClaims: map[string]interface{}{"email": "user@example.com"},
+	}
+	suite.mockOIDCService.On("BuildFederatedAuthResult", mock.Anything, testGoogleIDPID, "sub-1", mock.Anything).
+		Return(expected, nil)
+
+	result, err := suite.service.BuildFederatedAuthResult(
+		context.Background(), testGoogleIDPID, "sub-1", map[string]interface{}{"email": "user@example.com"})
+	suite.Nil(err)
+	suite.Equal(expected, result)
 }

--- a/backend/internal/authn/oauth/service.go
+++ b/backend/internal/authn/oauth/service.go
@@ -48,6 +48,8 @@ type OAuthAuthnCoreServiceInterface interface {
 		map[string]interface{}, *tidcommon.ServiceError)
 	GetOAuthClientConfig(ctx context.Context, idpID string) (*OAuthClientConfig, *tidcommon.ServiceError)
 	Authenticate(ctx context.Context, idpID, code string) (*common.AuthnResult, *tidcommon.ServiceError)
+	BuildFederatedAuthResult(ctx context.Context, idpID, sub string, claims map[string]interface{}) (
+		*common.AuthnResult, *tidcommon.ServiceError)
 }
 
 // OAuthAuthnServiceInterface defines the contract for OAuth based authenticator services.
@@ -328,23 +330,99 @@ func (s *oAuthAuthnService) Authenticate(ctx context.Context, idpID, code string
 		return nil, &common.ErrorSubClaimNotFound
 	}
 
-	mappedClaims, svcErr := s.resolveAttributeMappings(ctx, idpID, userInfo)
+	return s.BuildFederatedAuthResult(ctx, idpID, sub, userInfo)
+}
+
+// BuildFederatedAuthResult maps the federated identity's raw claims to local attributes and derives
+// the local-user lookup filter. It is the shared entry point every federated authenticator (OAuth,
+// OIDC, Google, GitHub) calls, so mapping and account-linking resolution are applied uniformly.
+func (s *oAuthAuthnService) BuildFederatedAuthResult(ctx context.Context, idpID, sub string,
+	claims map[string]interface{}) (*common.AuthnResult, *tidcommon.ServiceError) {
+	idpDTO, svcErr := s.getIDP(ctx, idpID)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	mappings := idp.GetAttributeMappings(idpDTO)
+	mappedClaims := idp.ApplyAttributeMappings(claims, mappings)
+
+	token, svcErr := s.buildAccountLinkingFilter(ctx, idpDTO, sub, mappedClaims, mappings)
 	if svcErr != nil {
 		return nil, svcErr
 	}
 
 	return &common.AuthnResult{
-		Token: map[string]interface{}{
-			"sub": sub,
-		},
+		Token:               token,
 		AuthenticatedClaims: mappedClaims,
 	}, nil
 }
 
-// resolveAttributeMappings loads the identity provider and applies its configured attribute mappings to
-// claims. IDP-retrieval errors are wrapped in the authn domain so the IDP error code is not leaked.
-func (s *oAuthAuthnService) resolveAttributeMappings(ctx context.Context, idpID string,
-	claims map[string]interface{}) (map[string]interface{}, *tidcommon.ServiceError) {
+// buildAccountLinkingFilter resolves the local-user lookup filter for the federated identity: without
+// account linking configured it returns the subject filter unchanged; otherwise it tries the subject
+// first, then the configured account-linking attributes, falling back to the subject filter.
+func (s *oAuthAuthnService) buildAccountLinkingFilter(ctx context.Context, idpDTO *providers.IDPDTO,
+	sub string, mappedClaims map[string]interface{}, mappings []providers.AttributeMapping) (
+	map[string]interface{}, *tidcommon.ServiceError) {
+	subFilter := map[string]interface{}{"sub": sub}
+	if idpDTO.AttributeConfiguration == nil || idpDTO.AttributeConfiguration.AccountLinking == nil {
+		return subFilter, nil
+	}
+
+	resolved, ok, svcErr := s.resolveFilter(ctx, subFilter)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+	if ok {
+		return resolved, nil
+	}
+
+	externalToLocal := make(map[string]string)
+	for _, m := range mappings {
+		externalToLocal[m.ExternalAttribute] = m.LocalAttribute
+	}
+
+	linkFilter := make(map[string]interface{})
+	for _, attr := range idpDTO.AttributeConfiguration.AccountLinking.Attributes {
+		local := attr
+		if mapped, ok := externalToLocal[attr]; ok {
+			local = mapped
+		}
+		if value := sysutils.ConvertInterfaceValueToString(mappedClaims[local]); value != "" {
+			linkFilter[local] = value
+		}
+	}
+	if len(linkFilter) > 0 {
+		return linkFilter, nil
+	}
+
+	return subFilter, nil
+}
+
+// resolveFilter looks up the filter and, on a unique match, returns a userID token so the caller need
+// not repeat the lookup. "Not found" and "ambiguous" report ok=false with no error so the caller can
+// try the next candidate filter; any other (server) error is surfaced.
+func (s *oAuthAuthnService) resolveFilter(ctx context.Context, filter map[string]interface{}) (
+	map[string]interface{}, bool, *tidcommon.ServiceError) {
+	entityID, epErr := s.entityProvider.IdentifyEntity(filter)
+	if epErr != nil {
+		if epErr.Code == entityprovider.ErrorCodeEntityNotFound ||
+			epErr.Code == entityprovider.ErrorCodeAmbiguousEntity {
+			return nil, false, nil
+		}
+		s.logger.Error(ctx, "Error while identifying user for account linking",
+			log.String("errorCode", string(epErr.Code)), log.String("description", epErr.Description))
+		return nil, false, &tidcommon.InternalServerError
+	}
+	if entityID == nil {
+		return nil, false, nil
+	}
+	return map[string]interface{}{common.UserAttributeUserID: *entityID}, true, nil
+}
+
+// getIDP loads the identity provider, wrapping IDP-retrieval errors in the authn domain so the IDP
+// error code is not leaked to the caller.
+func (s *oAuthAuthnService) getIDP(ctx context.Context, idpID string) (
+	*providers.IDPDTO, *tidcommon.ServiceError) {
 	idpDTO, svcErr := s.idpService.GetIdentityProvider(ctx, idpID)
 	if svcErr != nil {
 		if svcErr.Type == tidcommon.ClientErrorType {
@@ -360,5 +438,5 @@ func (s *oAuthAuthnService) resolveAttributeMappings(ctx context.Context, idpID 
 	if idpDTO == nil {
 		return nil, &ErrorInvalidIDP
 	}
-	return idp.ApplyAttributeMappings(claims, idp.GetAttributeMappings(idpDTO)), nil
+	return idpDTO, nil
 }

--- a/backend/internal/authn/oauth/service_test.go
+++ b/backend/internal/authn/oauth/service_test.go
@@ -49,6 +49,8 @@ const (
 	testUserID        = "user123"
 )
 
+var errEntityNotFound = &entityprovider.EntityProviderError{Code: entityprovider.ErrorCodeEntityNotFound}
+
 type OAuthAuthnServiceTestSuite struct {
 	suite.Suite
 	mockHTTPClient     *httpmock.HTTPClientInterfaceMock
@@ -75,7 +77,7 @@ func (suite *OAuthAuthnServiceTestSuite) SetupTest() {
 	suite.service = newOAuthAuthnService(suite.mockHTTPClient, suite.mockIDPService, suite.mockEntityProvider)
 }
 
-func createTestIDPDTO(idpID string) *providers.IDPDTO {
+func createTestIDPDTO() *providers.IDPDTO {
 	clientIDProp, _ := cmodels.NewProperty("client_id", "test_client", false)
 	clientSecretProp, _ := cmodels.NewProperty("client_secret", "test_secret", false)
 	redirectURIProp, _ := cmodels.NewProperty("redirect_uri", "https://app.com/callback", false)
@@ -83,7 +85,7 @@ func createTestIDPDTO(idpID string) *providers.IDPDTO {
 	tokenEndpointProp, _ := cmodels.NewProperty("token_endpoint", "https://idp.com/token", false)
 
 	return &providers.IDPDTO{
-		ID:   idpID,
+		ID:   testIDPID,
 		Name: "Test IDP",
 		Type: providers.IDPTypeOAuth,
 		Properties: []cmodels.Property{
@@ -409,7 +411,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestExchangeCodeForTokenWithFailure() {
 		{
 			name: "Non200StatusCode",
 			setupMocks: func() {
-				idpData := createTestIDPDTO(testIDPID)
+				idpData := createTestIDPDTO()
 				resp := &http.Response{
 					StatusCode: 401,
 					Body:       io.NopCloser(bytes.NewReader([]byte(`{"error":"invalid_grant"}`))),
@@ -423,7 +425,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestExchangeCodeForTokenWithFailure() {
 		{
 			name: "InvalidJSONResponse",
 			setupMocks: func() {
-				idpData := createTestIDPDTO(testIDPID)
+				idpData := createTestIDPDTO()
 				resp := &http.Response{
 					StatusCode: 200,
 					Body:       io.NopCloser(bytes.NewReader([]byte(`invalid json`))),
@@ -964,65 +966,217 @@ func (suite *OAuthAuthnServiceTestSuite) TestAuthenticateMissingSub() {
 	}
 }
 
-func (suite *OAuthAuthnServiceTestSuite) TestResolveAttributeMappings_AppliesMappings() {
-	svcImpl := suite.service.(*oAuthAuthnService)
-	idpDTO := &providers.IDPDTO{AttributeConfiguration: &providers.AttributeConfiguration{
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultAppliesMappings() {
+	idpDTO := createTestIDPDTO()
+	idpDTO.AttributeConfiguration = &providers.AttributeConfiguration{
 		UserTypeResolution: &providers.UserTypeResolution{Default: "person"},
 		UserTypeAttributeMappings: []providers.UserTypeAttributeMapping{{
 			UserType:   "person",
 			Attributes: []providers.AttributeMapping{{ExternalAttribute: "given_name", LocalAttribute: "firstName"}},
 		}},
-	}}
+	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-	result, svcErr := svcImpl.resolveAttributeMappings(context.Background(), testIDPID,
-		map[string]interface{}{"given_name": "Jane", "sub": "abc"})
-
+	result, svcErr := suite.service.BuildFederatedAuthResult(
+		context.Background(), testIDPID, testSub, map[string]interface{}{"given_name": "Jane", "sub": testSub})
 	suite.Nil(svcErr)
-	suite.Equal("Jane", result["firstName"])
-	suite.NotContains(result, "given_name")
-	suite.Equal("abc", result["sub"])
+	suite.Equal("Jane", result.AuthenticatedClaims["firstName"])
+	suite.NotContains(result.AuthenticatedClaims, "given_name")
+	// No account linking configured, so the lookup falls back to sub without a query.
+	suite.Equal(testSub, result.Token["sub"])
 }
 
-func (suite *OAuthAuthnServiceTestSuite) TestResolveAttributeMappings_ClientError() {
-	svcImpl := suite.service.(*oAuthAuthnService)
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultLinksByAttribute() {
+	// sub does not resolve, so the configured account-linking attribute is returned as the filter,
+	// deferring the actual lookup to the caller.
+	idpDTO := createTestIDPDTO()
+	idpDTO.AttributeConfiguration = &providers.AttributeConfiguration{
+		AccountLinking: &providers.AccountLinking{Attributes: []string{"email"}},
+	}
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
+	suite.mockEntityProvider.On("IdentifyEntity",
+		map[string]interface{}{"sub": testSub}).Return(nil, errEntityNotFound)
+
+	result, svcErr := suite.service.BuildFederatedAuthResult(
+		context.Background(), testIDPID, testSub, map[string]interface{}{"email": "user@example.com"})
+	suite.Nil(svcErr)
+	suite.Equal("user@example.com", result.Token["email"])
+	suite.NotContains(result.Token, "sub")
+}
+
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultPrefersSubWhenResolved() {
+	// When sub resolves an existing user, the configured account-linking attributes are not consulted.
+	idpDTO := createTestIDPDTO()
+	idpDTO.AttributeConfiguration = &providers.AttributeConfiguration{
+		AccountLinking: &providers.AccountLinking{Attributes: []string{"email"}},
+	}
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
+	resolvedID := testUserID
+	suite.mockEntityProvider.On("IdentifyEntity",
+		map[string]interface{}{"sub": testSub}).Return(&resolvedID, nil)
+
+	result, svcErr := suite.service.BuildFederatedAuthResult(
+		context.Background(), testIDPID, testSub, map[string]interface{}{"email": "user@example.com"})
+	suite.Nil(svcErr)
+	suite.Equal(testUserID, result.Token[common.UserAttributeUserID])
+	suite.mockEntityProvider.AssertNotCalled(suite.T(), "IdentifyEntity",
+		map[string]interface{}{"email": "user@example.com"})
+}
+
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultCombinesLinkedAttributes() {
+	// All configured account-linking attributes with a value are combined into a single filter, so
+	// the caller's lookup resolves a unique user by all of them together.
+	idpDTO := createTestIDPDTO()
+	idpDTO.AttributeConfiguration = &providers.AttributeConfiguration{
+		AccountLinking: &providers.AccountLinking{Attributes: []string{"email", "username"}},
+	}
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
+	suite.mockEntityProvider.On("IdentifyEntity",
+		map[string]interface{}{"sub": testSub}).Return(nil, errEntityNotFound)
+
+	result, svcErr := suite.service.BuildFederatedAuthResult(context.Background(), testIDPID, testSub,
+		map[string]interface{}{"email": "user@example.com", "username": "jdoe"})
+	suite.Nil(svcErr)
+	suite.Equal("user@example.com", result.Token["email"])
+	suite.Equal("jdoe", result.Token["username"])
+	suite.NotContains(result.Token, "sub")
+}
+
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultResolvesExternalToLocalAttribute() {
+	// The account-linking attribute is an external name mapped to a different local attribute; both the
+	// mapped claim and the lookup key must be the local attribute.
+	idpDTO := createTestIDPDTO()
+	idpDTO.AttributeConfiguration = &providers.AttributeConfiguration{
+		UserTypeResolution: &providers.UserTypeResolution{Default: "Person"},
+		UserTypeAttributeMappings: []providers.UserTypeAttributeMapping{
+			{UserType: "Person", Attributes: []providers.AttributeMapping{
+				{ExternalAttribute: "email", LocalAttribute: "family_name"},
+			}},
+		},
+		AccountLinking: &providers.AccountLinking{Attributes: []string{"email"}},
+	}
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
+	suite.mockEntityProvider.On("IdentifyEntity",
+		map[string]interface{}{"sub": testSub}).Return(nil, errEntityNotFound)
+
+	result, svcErr := suite.service.BuildFederatedAuthResult(
+		context.Background(), testIDPID, testSub, map[string]interface{}{"email": "sadil@wso2.com"})
+	suite.Nil(svcErr)
+	suite.Equal("sadil@wso2.com", result.AuthenticatedClaims["family_name"])
+	suite.Equal("sadil@wso2.com", result.Token["family_name"])
+	suite.NotContains(result.Token, "sub")
+}
+
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultAmbiguousSubFallsBackToSubWhenNoAttributeValue() {
+	// An ambiguous sub match does not short-circuit; account-linking attributes are still tried. With
+	// none of them having a value here, the original sub filter is returned, so the ambiguity is
+	// surfaced when the caller looks it up.
+	idpDTO := createTestIDPDTO()
+	idpDTO.AttributeConfiguration = &providers.AttributeConfiguration{
+		AccountLinking: &providers.AccountLinking{Attributes: []string{"email"}},
+	}
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
+	ambiguousErr := &entityprovider.EntityProviderError{Code: entityprovider.ErrorCodeAmbiguousEntity}
+	suite.mockEntityProvider.On("IdentifyEntity",
+		map[string]interface{}{"sub": testSub}).Return(nil, ambiguousErr)
+
+	result, svcErr := suite.service.BuildFederatedAuthResult(context.Background(), testIDPID, testSub, nil)
+	suite.Nil(svcErr)
+	suite.Equal(testSub, result.Token["sub"])
+	suite.NotContains(result.Token, common.UserAttributeUserID)
+}
+
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultAmbiguousSubFallsThroughToAccountLinking() {
+	// An ambiguous sub match must not skip account-linking resolution: a configured attribute that
+	// would uniquely identify the user still gets a chance to resolve the login.
+	idpDTO := createTestIDPDTO()
+	idpDTO.AttributeConfiguration = &providers.AttributeConfiguration{
+		AccountLinking: &providers.AccountLinking{Attributes: []string{"email"}},
+	}
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
+	ambiguousErr := &entityprovider.EntityProviderError{Code: entityprovider.ErrorCodeAmbiguousEntity}
+	suite.mockEntityProvider.On("IdentifyEntity",
+		map[string]interface{}{"sub": testSub}).Return(nil, ambiguousErr)
+
+	result, svcErr := suite.service.BuildFederatedAuthResult(
+		context.Background(), testIDPID, testSub, map[string]interface{}{"email": "user@example.com"})
+	suite.Nil(svcErr)
+	suite.Equal("user@example.com", result.Token["email"])
+	suite.NotContains(result.Token, "sub")
+}
+
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultSurfacesServerErrorOnSubLookup() {
+	// A real (non not-found/ambiguous) entity provider error while resolving the sub must be surfaced,
+	// not silently treated as "not found".
+	idpDTO := createTestIDPDTO()
+	idpDTO.AttributeConfiguration = &providers.AttributeConfiguration{
+		AccountLinking: &providers.AccountLinking{Attributes: []string{"email"}},
+	}
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
+	serverErr := &entityprovider.EntityProviderError{Code: entityprovider.ErrorCodeSystemError}
+	suite.mockEntityProvider.On("IdentifyEntity", map[string]interface{}{"sub": testSub}).Return(nil, serverErr)
+
+	result, svcErr := suite.service.BuildFederatedAuthResult(
+		context.Background(), testIDPID, testSub, map[string]interface{}{"email": "user@example.com"})
+	suite.Nil(result)
+	suite.NotNil(svcErr)
+	suite.Equal(tidcommon.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultFallsBackToSubWhenNotConfigured() {
+	// No account linking configured: the sub filter is returned as-is, with no lookup performed here
+	// (original, pre-account-linking behavior).
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(createTestIDPDTO(), nil)
+
+	result, svcErr := suite.service.BuildFederatedAuthResult(context.Background(), testIDPID, testSub, nil)
+	suite.Nil(svcErr)
+	suite.Equal(testSub, result.Token["sub"])
+}
+
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultFallsBackToSubWhenAttributeMissing() {
+	idpDTO := createTestIDPDTO()
+	idpDTO.AttributeConfiguration = &providers.AttributeConfiguration{
+		AccountLinking: &providers.AccountLinking{Attributes: []string{"email"}},
+	}
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
+	suite.mockEntityProvider.On("IdentifyEntity", mock.Anything).Return(nil, errEntityNotFound)
+
+	result, svcErr := suite.service.BuildFederatedAuthResult(
+		context.Background(), testIDPID, testSub, map[string]interface{}{"name": "no-email"})
+	suite.Nil(svcErr)
+	suite.Equal(testSub, result.Token["sub"])
+}
+
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultClientError() {
 	clientErr := &tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType, Code: "IDP-1001",
 		ErrorDescription: tidcommon.I18nMessage{DefaultValue: "not found"},
 	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(nil, clientErr)
 
-	result, svcErr := svcImpl.resolveAttributeMappings(context.Background(), testIDPID,
-		map[string]interface{}{"sub": "abc"})
-
+	result, svcErr := suite.service.BuildFederatedAuthResult(context.Background(), testIDPID, testSub, nil)
 	suite.Nil(result)
 	suite.NotNil(svcErr)
 	suite.Equal(ErrorClientErrorWhileRetrievingIDP.Code, svcErr.Code)
 }
 
-func (suite *OAuthAuthnServiceTestSuite) TestResolveAttributeMappings_ServerError() {
-	svcImpl := suite.service.(*oAuthAuthnService)
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultServerError() {
 	serverErr := &tidcommon.ServiceError{
 		Type: tidcommon.ServerErrorType, Code: "IDP-5000",
 		ErrorDescription: tidcommon.I18nMessage{DefaultValue: "boom"},
 	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(nil, serverErr)
 
-	result, svcErr := svcImpl.resolveAttributeMappings(context.Background(), testIDPID,
-		map[string]interface{}{"sub": "abc"})
-
+	result, svcErr := suite.service.BuildFederatedAuthResult(context.Background(), testIDPID, testSub, nil)
 	suite.Nil(result)
 	suite.NotNil(svcErr)
 	suite.Equal(tidcommon.InternalServerError.Code, svcErr.Code)
 }
 
-func (suite *OAuthAuthnServiceTestSuite) TestResolveAttributeMappings_NilIDP() {
-	svcImpl := suite.service.(*oAuthAuthnService)
+func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultNilIDP() {
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(nil, nil)
 
-	result, svcErr := svcImpl.resolveAttributeMappings(context.Background(), testIDPID,
-		map[string]interface{}{"sub": "abc"})
-
+	result, svcErr := suite.service.BuildFederatedAuthResult(context.Background(), testIDPID, testSub, nil)
 	suite.Nil(result)
 	suite.NotNil(svcErr)
 	suite.Equal(ErrorInvalidIDP.Code, svcErr.Code)

--- a/backend/internal/authn/oidc/init.go
+++ b/backend/internal/authn/oidc/init.go
@@ -20,12 +20,11 @@ package oidc
 
 import (
 	authnoauth "github.com/thunder-id/thunderid/internal/authn/oauth"
-	"github.com/thunder-id/thunderid/internal/idp"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 )
 
 // Initialize initializes the OIDC authentication service.
 func Initialize(oauthSvc authnoauth.OAuthAuthnServiceInterface,
-	jwtSvc jwt.JWTServiceInterface, idpSvc idp.IDPServiceInterface) OIDCAuthnServiceInterface {
-	return newOIDCAuthnService(oauthSvc, jwtSvc, idpSvc)
+	jwtSvc jwt.JWTServiceInterface) OIDCAuthnServiceInterface {
+	return newOIDCAuthnService(oauthSvc, jwtSvc)
 }

--- a/backend/internal/authn/oidc/service.go
+++ b/backend/internal/authn/oidc/service.go
@@ -27,7 +27,6 @@ import (
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	authnoauth "github.com/thunder-id/thunderid/internal/authn/oauth"
-	"github.com/thunder-id/thunderid/internal/idp"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
@@ -54,17 +53,15 @@ type OIDCAuthnServiceInterface interface {
 type oidcAuthnService struct {
 	internal   authnoauth.OAuthAuthnServiceInterface
 	jwtService jwt.JWTServiceInterface
-	idpService idp.IDPServiceInterface
 	logger     *log.Logger
 }
 
 // newOIDCAuthnService creates a new instance of OIDC authenticator service.
 func newOIDCAuthnService(internal authnoauth.OAuthAuthnServiceInterface,
-	jwtSvc jwt.JWTServiceInterface, idpSvc idp.IDPServiceInterface) OIDCAuthnServiceInterface {
+	jwtSvc jwt.JWTServiceInterface) OIDCAuthnServiceInterface {
 	return &oidcAuthnService{
 		internal:   internal,
 		jwtService: jwtSvc,
-		idpService: idpSvc,
 		logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName)),
 	}
 }
@@ -241,34 +238,12 @@ func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID, code string)
 		}
 	}
 
-	mappedClaims, svcErr := s.resolveAttributeMappings(ctx, idpID, claims)
-	if svcErr != nil {
-		return nil, svcErr
-	}
-
-	return &authncm.AuthnResult{
-		Token: map[string]interface{}{
-			"sub": sub,
-		},
-		AuthenticatedClaims: mappedClaims,
-	}, nil
+	return s.internal.BuildFederatedAuthResult(ctx, idpID, sub, claims)
 }
 
-// resolveAttributeMappings loads the identity provider and applies its configured attribute mappings to
-// claims. IDP-retrieval errors are wrapped in the authn domain so the IDP error code is not leaked.
-func (s *oidcAuthnService) resolveAttributeMappings(ctx context.Context, idpID string,
-	claims map[string]interface{}) (map[string]interface{}, *tidcommon.ServiceError) {
-	idpDTO, svcErr := s.idpService.GetIdentityProvider(ctx, idpID)
-	if svcErr != nil {
-		if svcErr.Type == tidcommon.ClientErrorType {
-			return nil, &authncm.ErrorClientErrorWhileRetrievingIDP
-		}
-		s.logger.Error(ctx, "Error while retrieving identity provider", log.String("errorCode", svcErr.Code),
-			log.String("description", svcErr.ErrorDescription.DefaultValue))
-		return nil, &tidcommon.InternalServerError
-	}
-	if idpDTO == nil {
-		return nil, &tidcommon.InternalServerError
-	}
-	return idp.ApplyAttributeMappings(claims, idp.GetAttributeMappings(idpDTO)), nil
+// BuildFederatedAuthResult delegates to the underlying OAuth service, which applies attribute mapping
+// and account-linking resolution uniformly for all federated authenticators.
+func (s *oidcAuthnService) BuildFederatedAuthResult(ctx context.Context, idpID, sub string,
+	claims map[string]interface{}) (*authncm.AuthnResult, *tidcommon.ServiceError) {
+	return s.internal.BuildFederatedAuthResult(ctx, idpID, sub, claims)
 }

--- a/backend/internal/authn/oidc/service_test.go
+++ b/backend/internal/authn/oidc/service_test.go
@@ -20,7 +20,6 @@ package oidc
 
 import (
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
-	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"context"
 	"testing"
@@ -32,7 +31,6 @@ import (
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/authn/oauth"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/oauthmock"
-	"github.com/thunder-id/thunderid/tests/mocks/idp/idpmock"
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
 )
 
@@ -44,7 +42,6 @@ type OIDCAuthnServiceTestSuite struct {
 	suite.Suite
 	mockOAuthService *oauthmock.OAuthAuthnServiceInterfaceMock
 	mockJWTService   *jwtmock.JWTServiceInterfaceMock
-	mockIDPService   *idpmock.IDPServiceInterfaceMock
 	endpoints        oauth.OAuthEndpoints
 	service          oidcAuthnService
 }
@@ -56,14 +53,13 @@ func TestOIDCAuthnServiceTestSuite(t *testing.T) {
 func (suite *OIDCAuthnServiceTestSuite) SetupTest() {
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
-	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
 	suite.endpoints = oauth.OAuthEndpoints{
 		AuthorizationEndpoint: "https://localhost:8090/oauth/authorize",
 		TokenEndpoint:         "https://localhost:8090/oauth/token",
 		UserInfoEndpoint:      "https://localhost:8090/oauth/userinfo",
 	}
 
-	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 
 	cast, ok := service.(*oidcAuthnService)
 	suite.True(ok, "service is not of type *oidcAuthnService")
@@ -181,7 +177,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestExchangeCodeForTokenSuccess() {
 			suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 			suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 
-			service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+			service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 			cast, ok := service.(*oidcAuthnService)
 			suite.True(ok, "service is not of type *oidcAuthnService")
 			suite.service = *cast
@@ -229,7 +225,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateTokenResponseSuccess() {
 			suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 			suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 
-			service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+			service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 			cast, ok := service.(*oidcAuthnService)
 			suite.True(ok, "service is not of type *oidcAuthnService")
 			suite.service = *cast
@@ -310,7 +306,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateIDTokenSuccess() {
 			suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 			suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 
-			service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+			service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 			cast, ok := service.(*oidcAuthnService)
 			suite.True(ok, "service is not of type *oidcAuthnService")
 			suite.service = *cast
@@ -377,7 +373,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestValidateTokenResponseValidateIDToken
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 
-	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 	cast, ok := service.(*oidcAuthnService)
 	suite.True(ok)
 	suite.service = *cast
@@ -462,7 +458,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateSuccess() {
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 
-	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 	cast, ok := service.(*oidcAuthnService)
 	suite.True(ok)
 	suite.service = *cast
@@ -470,11 +466,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateSuccess() {
 	idToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
 		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
 		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: "access_token",
-		IDToken:     idToken,
-		TokenType:   "Bearer",
-	}
+	tokenResp := &oauth.TokenResponse{AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer"}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(tokenResp, nil)
 	cfg := &oauth.OAuthClientConfig{
@@ -483,13 +475,16 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateSuccess() {
 	}
 	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).Return(cfg, nil)
 	suite.mockJWTService.On("VerifyJWTWithJWKS", mock.Anything, idToken, "https://example.com/jwks", "", "").Return(nil)
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testOIDCIDPID).Return(&providers.IDPDTO{}, nil)
+	suite.mockOAuthService.On("BuildFederatedAuthResult", mock.Anything, testOIDCIDPID, "1234567890", mock.Anything).
+		Return(&authncm.AuthnResult{
+			Token:               map[string]interface{}{"sub": "1234567890"},
+			AuthenticatedClaims: map[string]interface{}{"sub": "1234567890", "name": "John Doe"},
+		}, nil)
 
 	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID, "auth_code")
 	suite.Nil(svcErr)
 	suite.NotNil(result)
 	suite.Equal("1234567890", result.Token["sub"])
-	suite.Equal("1234567890", result.AuthenticatedClaims["sub"])
 	suite.Equal("John Doe", result.AuthenticatedClaims["name"])
 }
 
@@ -497,7 +492,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateWithUserInfoMerge() {
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 
-	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 	cast, ok := service.(*oidcAuthnService)
 	suite.True(ok)
 	suite.service = *cast
@@ -505,11 +500,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateWithUserInfoMerge() {
 	idToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
 		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
 		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: "access_token",
-		IDToken:     idToken,
-		TokenType:   "Bearer",
-	}
+	tokenResp := &oauth.TokenResponse{AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer"}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(tokenResp, nil)
 	cfg := &oauth.OAuthClientConfig{
@@ -519,16 +510,20 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateWithUserInfoMerge() {
 	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).Return(cfg, nil)
 	suite.mockJWTService.On("VerifyJWTWithJWKS", mock.Anything, idToken, "https://example.com/jwks", "", "").Return(nil)
 	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testOIDCIDPID, "access_token").Return(
-		map[string]interface{}{
-			"sub":   "1234567890",
-			"email": "john@example.com",
+		map[string]interface{}{"sub": "1234567890", "email": "john@example.com"}, nil)
+	// The merged claims (ID token + userinfo) must be passed to BuildFederatedAuthResult.
+	suite.mockOAuthService.On("BuildFederatedAuthResult", mock.Anything, testOIDCIDPID, "1234567890",
+		mock.MatchedBy(func(c map[string]interface{}) bool {
+			return c["email"] == "john@example.com" && c["name"] == "John Doe"
+		})).
+		Return(&authncm.AuthnResult{
+			Token:               map[string]interface{}{"sub": "1234567890"},
+			AuthenticatedClaims: map[string]interface{}{"email": "john@example.com", "name": "John Doe"},
 		}, nil)
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testOIDCIDPID).Return(&providers.IDPDTO{}, nil)
 
 	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID, "auth_code")
 	suite.Nil(svcErr)
 	suite.NotNil(result)
-	suite.Equal("1234567890", result.Token["sub"])
 	suite.Equal("john@example.com", result.AuthenticatedClaims["email"])
 	suite.Equal("John Doe", result.AuthenticatedClaims["name"])
 }
@@ -537,7 +532,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateUserInfoSubMismatch() {
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 
-	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 	cast, ok := service.(*oidcAuthnService)
 	suite.True(ok)
 	suite.service = *cast
@@ -545,11 +540,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateUserInfoSubMismatch() {
 	idToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
 		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
 		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: "access_token",
-		IDToken:     idToken,
-		TokenType:   "Bearer",
-	}
+	tokenResp := &oauth.TokenResponse{AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer"}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(tokenResp, nil)
 	cfg := &oauth.OAuthClientConfig{
@@ -559,24 +550,23 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateUserInfoSubMismatch() {
 	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).Return(cfg, nil)
 	suite.mockJWTService.On("VerifyJWTWithJWKS", mock.Anything, idToken, "https://example.com/jwks", "", "").Return(nil)
 	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testOIDCIDPID, "access_token").Return(
-		map[string]interface{}{
-			"sub":   "different_user",
-			"email": "other@example.com",
-		}, nil)
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testOIDCIDPID).Return(&providers.IDPDTO{}, nil)
+		map[string]interface{}{"sub": "different_user", "email": "other@example.com"}, nil)
+	// UserInfo sub mismatch → merge skipped, so email must NOT reach BuildFederatedAuthResult.
+	suite.mockOAuthService.On("BuildFederatedAuthResult", mock.Anything, testOIDCIDPID, "1234567890",
+		mock.MatchedBy(func(c map[string]interface{}) bool { _, ok := c["email"]; return !ok })).
+		Return(&authncm.AuthnResult{Token: map[string]interface{}{"sub": "1234567890"}}, nil)
 
 	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID, "auth_code")
 	suite.Nil(svcErr)
 	suite.NotNil(result)
 	suite.Equal("1234567890", result.Token["sub"])
-	suite.Nil(result.AuthenticatedClaims["email"])
 }
 
 func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateExchangeCodeError() {
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 
-	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 	cast, ok := service.(*oidcAuthnService)
 	suite.True(ok)
 	suite.service = *cast
@@ -594,7 +584,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateSubClaimNotFound() {
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 
-	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 	cast, ok := service.(*oidcAuthnService)
 	suite.True(ok)
 	suite.service = *cast
@@ -602,16 +592,10 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateSubClaimNotFound() {
 	idToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
 		"eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9." +
 		"hqWGSaFpvbrXR1LDcB2vlcSBCB0pT5D8N3f7Ox6SaKM"
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: "access_token",
-		IDToken:     idToken,
-		TokenType:   "Bearer",
-	}
+	tokenResp := &oauth.TokenResponse{AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer"}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(tokenResp, nil)
-	cfg := &oauth.OAuthClientConfig{
-		OAuthEndpoints: oauth.OAuthEndpoints{JwksEndpoint: "https://example.com/jwks"},
-	}
+	cfg := &oauth.OAuthClientConfig{OAuthEndpoints: oauth.OAuthEndpoints{JwksEndpoint: "https://example.com/jwks"}}
 	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).Return(cfg, nil)
 	suite.mockJWTService.On("VerifyJWTWithJWKS", mock.Anything, idToken, "https://example.com/jwks", "", "").Return(nil)
 
@@ -625,7 +609,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateUserInfoFetchError() {
 	suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 
-	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService, suite.mockIDPService)
+	service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
 	cast, ok := service.(*oidcAuthnService)
 	suite.True(ok)
 	suite.service = *cast
@@ -633,11 +617,7 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateUserInfoFetchError() {
 	idToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
 		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
 		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-	tokenResp := &oauth.TokenResponse{
-		AccessToken: "access_token",
-		IDToken:     idToken,
-		TokenType:   "Bearer",
-	}
+	tokenResp := &oauth.TokenResponse{AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer"}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(tokenResp, nil)
 	cfg := &oauth.OAuthClientConfig{
@@ -648,71 +628,26 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateUserInfoFetchError() {
 	suite.mockJWTService.On("VerifyJWTWithJWKS", mock.Anything, idToken, "https://example.com/jwks", "", "").Return(nil)
 	suite.mockOAuthService.On("FetchUserInfo", mock.Anything, testOIDCIDPID, "access_token").Return(
 		nil, &tidcommon.ServiceError{Code: "USERINFO-ERR"})
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testOIDCIDPID).Return(&providers.IDPDTO{}, nil)
+	// UserInfo fetch failed → claims unchanged; the flow still proceeds with the ID token claims.
+	suite.mockOAuthService.On("BuildFederatedAuthResult", mock.Anything, testOIDCIDPID, "1234567890", mock.Anything).
+		Return(&authncm.AuthnResult{Token: map[string]interface{}{"sub": "1234567890"}}, nil)
 
 	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID, "auth_code")
 	suite.Nil(svcErr)
 	suite.NotNil(result)
 	suite.Equal("1234567890", result.Token["sub"])
-	suite.Nil(result.AuthenticatedClaims["email"])
 }
 
-func (suite *OIDCAuthnServiceTestSuite) TestResolveAttributeMappings_AppliesMappings() {
-	idpDTO := &providers.IDPDTO{AttributeConfiguration: &providers.AttributeConfiguration{
-		UserTypeResolution: &providers.UserTypeResolution{Default: "person"},
-		UserTypeAttributeMappings: []providers.UserTypeAttributeMapping{{
-			UserType:   "person",
-			Attributes: []providers.AttributeMapping{{ExternalAttribute: "given_name", LocalAttribute: "firstName"}},
-		}},
-	}}
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testOIDCIDPID).Return(idpDTO, nil)
+func (suite *OIDCAuthnServiceTestSuite) TestBuildFederatedAuthResultDelegates() {
+	expected := &authncm.AuthnResult{
+		Token:               map[string]interface{}{"email": "user@example.com"},
+		AuthenticatedClaims: map[string]interface{}{"email": "user@example.com"},
+	}
+	suite.mockOAuthService.On("BuildFederatedAuthResult", mock.Anything, testOIDCIDPID, "sub-1", mock.Anything).
+		Return(expected, nil)
 
-	result, svcErr := suite.service.resolveAttributeMappings(context.Background(), testOIDCIDPID,
-		map[string]interface{}{"given_name": "Jane", "sub": "abc"})
-
+	result, svcErr := suite.service.BuildFederatedAuthResult(
+		context.Background(), testOIDCIDPID, "sub-1", map[string]interface{}{"email": "user@example.com"})
 	suite.Nil(svcErr)
-	suite.Equal("Jane", result["firstName"])
-	suite.NotContains(result, "given_name")
-	suite.Equal("abc", result["sub"])
-}
-
-func (suite *OIDCAuthnServiceTestSuite) TestResolveAttributeMappings_ClientError() {
-	clientErr := &tidcommon.ServiceError{
-		Type: tidcommon.ClientErrorType, Code: "IDP-1001",
-		ErrorDescription: tidcommon.I18nMessage{DefaultValue: "not found"},
-	}
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testOIDCIDPID).Return(nil, clientErr)
-
-	result, svcErr := suite.service.resolveAttributeMappings(context.Background(), testOIDCIDPID,
-		map[string]interface{}{"sub": "abc"})
-
-	suite.Nil(result)
-	suite.NotNil(svcErr)
-	suite.Equal(authncm.ErrorClientErrorWhileRetrievingIDP.Code, svcErr.Code)
-}
-
-func (suite *OIDCAuthnServiceTestSuite) TestResolveAttributeMappings_ServerError() {
-	serverErr := &tidcommon.ServiceError{
-		Type: tidcommon.ServerErrorType, Code: "IDP-5000",
-		ErrorDescription: tidcommon.I18nMessage{DefaultValue: "boom"},
-	}
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testOIDCIDPID).Return(nil, serverErr)
-
-	result, svcErr := suite.service.resolveAttributeMappings(context.Background(), testOIDCIDPID,
-		map[string]interface{}{"sub": "abc"})
-
-	suite.Nil(result)
-	suite.NotNil(svcErr)
-	suite.Equal(tidcommon.InternalServerError.Code, svcErr.Code)
-}
-
-func (suite *OIDCAuthnServiceTestSuite) TestResolveAttributeMappings_NilIDP() {
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testOIDCIDPID).Return(nil, nil)
-
-	result, svcErr := suite.service.resolveAttributeMappings(context.Background(), testOIDCIDPID,
-		map[string]interface{}{"sub": "abc"})
-
-	suite.Nil(result)
-	suite.NotNil(svcErr)
-	suite.Equal(tidcommon.InternalServerError.Code, svcErr.Code)
+	suite.Equal(expected, result)
 }

--- a/backend/internal/idp/handler.go
+++ b/backend/internal/idp/handler.go
@@ -290,6 +290,14 @@ func sanitizeAttributeConfiguration(profile *providers.AttributeConfiguration) *
 			sanitized.UserTypeAttributeMappings = append(sanitized.UserTypeAttributeMappings, sanitizedEntry)
 		}
 	}
+	if profile.AccountLinking != nil {
+		sanitized.AccountLinking = &providers.AccountLinking{}
+		for _, attr := range profile.AccountLinking.Attributes {
+			if trimmed := sysutils.SanitizeString(attr); trimmed != "" {
+				sanitized.AccountLinking.Attributes = append(sanitized.AccountLinking.Attributes, trimmed)
+			}
+		}
+	}
 	return sanitized
 }
 

--- a/backend/internal/idp/handler_test.go
+++ b/backend/internal/idp/handler_test.go
@@ -607,3 +607,19 @@ func (s *IDPHandlerTestSuite) TestSanitizeAttributeConfiguration_TrimsMappings()
 	s.Equal("given_name", result.UserTypeAttributeMappings[0].Attributes[0].ExternalAttribute)
 	s.Equal("firstName", result.UserTypeAttributeMappings[0].Attributes[0].LocalAttribute)
 }
+
+func (s *IDPHandlerTestSuite) TestSanitizeAttributeConfiguration_TrimsAccountLinkingAttributes() {
+	am := &providers.AttributeConfiguration{
+		AccountLinking: &providers.AccountLinking{Attributes: []string{" email ", "  ", "username"}},
+	}
+	result := sanitizeAttributeConfiguration(am)
+	s.Require().NotNil(result.AccountLinking)
+	s.Equal([]string{"email", "username"}, result.AccountLinking.Attributes)
+}
+
+func (s *IDPHandlerTestSuite) TestSanitizeAttributeConfiguration_NilAccountLinking() {
+	result := sanitizeAttributeConfiguration(&providers.AttributeConfiguration{
+		UserTypeResolution: &providers.UserTypeResolution{Default: "person"},
+	})
+	s.Nil(result.AccountLinking)
+}

--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -383,9 +383,11 @@ func (is *idpService) ensureNoBlockingDependencies(ctx context.Context, idpID st
 	})
 }
 
-// validateAttributeConfiguration validates the IDP's attribute configuration: a required default user type, and
-// for each user type's attributes a valid claim-mapping shape with every local (target) claim a
-// non-credential attribute defined in that user type's schema. No-op when no profile is configured.
+// validateAttributeConfiguration validates the IDP's attribute configuration: a default user type is
+// required only when user-type attribute mappings are configured (it selects which mapping profile
+// applies), and for each user type's attributes a valid claim-mapping shape with every local (target)
+// claim a non-credential attribute defined in that user type's schema. No-op when no profile is
+// configured.
 func (is *idpService) validateAttributeConfiguration(
 	ctx context.Context,
 	idp *providers.IDPDTO,
@@ -394,7 +396,8 @@ func (is *idpService) validateAttributeConfiguration(
 	if profile == nil {
 		return nil
 	}
-	if profile.UserTypeResolution == nil || strings.TrimSpace(profile.UserTypeResolution.Default) == "" {
+	if len(profile.UserTypeAttributeMappings) > 0 &&
+		(profile.UserTypeResolution == nil || strings.TrimSpace(profile.UserTypeResolution.Default) == "") {
 		return tidcommon.CustomServiceError(ErrorInvalidAttributeConfiguration, tidcommon.I18nMessage{
 			Key:          "error.idpservice.attribute_configuration_user_type_required_description",
 			DefaultValue: "attribute configuration requires an user type",

--- a/backend/internal/idp/service_test.go
+++ b/backend/internal/idp/service_test.go
@@ -1139,6 +1139,13 @@ func (s *IDPServiceTestSuite) TestValidateAttributeConfiguration_NilMapping_OK()
 	s.Nil(svcErr)
 }
 
+func (s *IDPServiceTestSuite) TestValidateAttributeConfiguration_AccountLinkingOnly_NoUserTypeResolutionRequired() {
+	idp := &providers.IDPDTO{AttributeConfiguration: &providers.AttributeConfiguration{
+		AccountLinking: &providers.AccountLinking{Attributes: []string{"email"}},
+	}}
+	s.Nil(s.idpService.validateAttributeConfiguration(context.Background(), idp))
+}
+
 func (s *IDPServiceTestSuite) TestValidateAttributeConfiguration_Valid() {
 	s.mockET.On("GetAttributes", mock.Anything, entitytype.TypeCategoryUser, "person", false, true, false).
 		Return([]entitytype.AttributeInfo{{Attribute: "firstName"}, {Attribute: "email"}},

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -714,11 +714,20 @@ type UserTypeAttributeMapping struct {
 	Attributes []AttributeMapping `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 }
 
+// AccountLinking configures which attributes resolve the local user for an incoming federated
+// identity when the subject identifier does not. Attributes is a list of external claim names (each
+// resolved to its local counterpart via the IdP's attribute mappings); those with a value are matched
+// together to resolve a unique local user.
+type AccountLinking struct {
+	Attributes []string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
+}
+
 // AttributeConfiguration holds the user-type resolution and per-user-type attribute mappings for an
 // identity provider.
 type AttributeConfiguration struct {
 	UserTypeResolution        *UserTypeResolution        `json:"userTypeResolution,omitempty"        yaml:"user_type_resolution,omitempty"`         //nolint:lll
 	UserTypeAttributeMappings []UserTypeAttributeMapping `json:"userTypeAttributeMappings,omitempty" yaml:"user_type_attribute_mappings,omitempty"` //nolint:lll
+	AccountLinking            *AccountLinking            `json:"accountLinking,omitempty"            yaml:"accountLinking,omitempty"`               //nolint:lll
 }
 
 // ConsentElementApproval represents a user's approval decision for a specific element.

--- a/backend/tests/mocks/authn/githubmock/GithubOAuthAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/githubmock/GithubOAuthAuthnServiceInterface_mock.go
@@ -184,6 +184,88 @@ func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndRet
 	return _c
 }
 
+// BuildFederatedAuthResult provides a mock function for the type GithubOAuthAuthnServiceInterfaceMock
+func (_mock *GithubOAuthAuthnServiceInterfaceMock) BuildFederatedAuthResult(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, sub, claims)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BuildFederatedAuthResult")
+	}
+
+	var r0 *common.AuthnResult
+	var r1 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, sub, claims)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.AuthnResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, map[string]interface{}) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common0.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// GithubOAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildFederatedAuthResult'
+type GithubOAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call struct {
+	*mock.Call
+}
+
+// BuildFederatedAuthResult is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - sub string
+//   - claims map[string]interface{}
+func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) BuildFederatedAuthResult(ctx interface{}, idpID interface{}, sub interface{}, claims interface{}) *GithubOAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	return &GithubOAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call{Call: _e.mock.On("BuildFederatedAuthResult", ctx, idpID, sub, claims)}
+}
+
+func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) Run(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{})) *GithubOAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 map[string]interface{}
+		if args[3] != nil {
+			arg3 = args[3].(map[string]interface{})
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) Return(authnResult *common.AuthnResult, serviceError *common0.ServiceError) *GithubOAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(authnResult, serviceError)
+	return _c
+}
+
+func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) RunAndReturn(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExchangeCodeForToken provides a mock function for the type GithubOAuthAuthnServiceInterfaceMock
 func (_mock *GithubOAuthAuthnServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID, code, validateResponse)

--- a/backend/tests/mocks/authn/googlemock/GoogleOIDCAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/googlemock/GoogleOIDCAuthnServiceInterface_mock.go
@@ -184,6 +184,88 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndRetu
 	return _c
 }
 
+// BuildFederatedAuthResult provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
+func (_mock *GoogleOIDCAuthnServiceInterfaceMock) BuildFederatedAuthResult(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, sub, claims)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BuildFederatedAuthResult")
+	}
+
+	var r0 *common.AuthnResult
+	var r1 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, sub, claims)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.AuthnResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, map[string]interface{}) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common0.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// GoogleOIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildFederatedAuthResult'
+type GoogleOIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call struct {
+	*mock.Call
+}
+
+// BuildFederatedAuthResult is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - sub string
+//   - claims map[string]interface{}
+func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) BuildFederatedAuthResult(ctx interface{}, idpID interface{}, sub interface{}, claims interface{}) *GoogleOIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	return &GoogleOIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call{Call: _e.mock.On("BuildFederatedAuthResult", ctx, idpID, sub, claims)}
+}
+
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) Run(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{})) *GoogleOIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 map[string]interface{}
+		if args[3] != nil {
+			arg3 = args[3].(map[string]interface{})
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) Return(authnResult *common.AuthnResult, serviceError *common0.ServiceError) *GoogleOIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(authnResult, serviceError)
+	return _c
+}
+
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) RunAndReturn(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExchangeCodeForToken provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
 func (_mock *GoogleOIDCAuthnServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID, code, validateResponse)

--- a/backend/tests/mocks/authn/oauthmock/OAuthAuthnCoreServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oauthmock/OAuthAuthnCoreServiceInterface_mock.go
@@ -184,6 +184,88 @@ func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndRetur
 	return _c
 }
 
+// BuildFederatedAuthResult provides a mock function for the type OAuthAuthnCoreServiceInterfaceMock
+func (_mock *OAuthAuthnCoreServiceInterfaceMock) BuildFederatedAuthResult(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, sub, claims)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BuildFederatedAuthResult")
+	}
+
+	var r0 *common.AuthnResult
+	var r1 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, sub, claims)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.AuthnResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, map[string]interface{}) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common0.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OAuthAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildFederatedAuthResult'
+type OAuthAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call struct {
+	*mock.Call
+}
+
+// BuildFederatedAuthResult is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - sub string
+//   - claims map[string]interface{}
+func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) BuildFederatedAuthResult(ctx interface{}, idpID interface{}, sub interface{}, claims interface{}) *OAuthAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	return &OAuthAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call{Call: _e.mock.On("BuildFederatedAuthResult", ctx, idpID, sub, claims)}
+}
+
+func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call) Run(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{})) *OAuthAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 map[string]interface{}
+		if args[3] != nil {
+			arg3 = args[3].(map[string]interface{})
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call) Return(authnResult *common.AuthnResult, serviceError *common0.ServiceError) *OAuthAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(authnResult, serviceError)
+	return _c
+}
+
+func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call) RunAndReturn(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExchangeCodeForToken provides a mock function for the type OAuthAuthnCoreServiceInterfaceMock
 func (_mock *OAuthAuthnCoreServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID, code, validateResponse)

--- a/backend/tests/mocks/authn/oauthmock/OAuthAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oauthmock/OAuthAuthnServiceInterface_mock.go
@@ -184,6 +184,88 @@ func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(ru
 	return _c
 }
 
+// BuildFederatedAuthResult provides a mock function for the type OAuthAuthnServiceInterfaceMock
+func (_mock *OAuthAuthnServiceInterfaceMock) BuildFederatedAuthResult(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, sub, claims)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BuildFederatedAuthResult")
+	}
+
+	var r0 *common.AuthnResult
+	var r1 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, sub, claims)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.AuthnResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, map[string]interface{}) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common0.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildFederatedAuthResult'
+type OAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call struct {
+	*mock.Call
+}
+
+// BuildFederatedAuthResult is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - sub string
+//   - claims map[string]interface{}
+func (_e *OAuthAuthnServiceInterfaceMock_Expecter) BuildFederatedAuthResult(ctx interface{}, idpID interface{}, sub interface{}, claims interface{}) *OAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	return &OAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call{Call: _e.mock.On("BuildFederatedAuthResult", ctx, idpID, sub, claims)}
+}
+
+func (_c *OAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) Run(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{})) *OAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 map[string]interface{}
+		if args[3] != nil {
+			arg3 = args[3].(map[string]interface{})
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *OAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) Return(authnResult *common.AuthnResult, serviceError *common0.ServiceError) *OAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(authnResult, serviceError)
+	return _c
+}
+
+func (_c *OAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) RunAndReturn(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)) *OAuthAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExchangeCodeForToken provides a mock function for the type OAuthAuthnServiceInterfaceMock
 func (_mock *OAuthAuthnServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID, code, validateResponse)

--- a/backend/tests/mocks/authn/oidcmock/OIDCAuthnCoreServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oidcmock/OIDCAuthnCoreServiceInterface_mock.go
@@ -184,6 +184,88 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn
 	return _c
 }
 
+// BuildFederatedAuthResult provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
+func (_mock *OIDCAuthnCoreServiceInterfaceMock) BuildFederatedAuthResult(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, sub, claims)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BuildFederatedAuthResult")
+	}
+
+	var r0 *common.AuthnResult
+	var r1 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, sub, claims)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.AuthnResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, map[string]interface{}) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common0.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OIDCAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildFederatedAuthResult'
+type OIDCAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call struct {
+	*mock.Call
+}
+
+// BuildFederatedAuthResult is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - sub string
+//   - claims map[string]interface{}
+func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) BuildFederatedAuthResult(ctx interface{}, idpID interface{}, sub interface{}, claims interface{}) *OIDCAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	return &OIDCAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call{Call: _e.mock.On("BuildFederatedAuthResult", ctx, idpID, sub, claims)}
+}
+
+func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call) Run(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{})) *OIDCAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 map[string]interface{}
+		if args[3] != nil {
+			arg3 = args[3].(map[string]interface{})
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call) Return(authnResult *common.AuthnResult, serviceError *common0.ServiceError) *OIDCAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(authnResult, serviceError)
+	return _c
+}
+
+func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call) RunAndReturn(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExchangeCodeForToken provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
 func (_mock *OIDCAuthnCoreServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID, code, validateResponse)

--- a/backend/tests/mocks/authn/oidcmock/OIDCAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oidcmock/OIDCAuthnServiceInterface_mock.go
@@ -184,6 +184,88 @@ func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run
 	return _c
 }
 
+// BuildFederatedAuthResult provides a mock function for the type OIDCAuthnServiceInterfaceMock
+func (_mock *OIDCAuthnServiceInterfaceMock) BuildFederatedAuthResult(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, sub, claims)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BuildFederatedAuthResult")
+	}
+
+	var r0 *common.AuthnResult
+	var r1 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, sub, claims)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]interface{}) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.AuthnResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, map[string]interface{}) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, sub, claims)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common0.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildFederatedAuthResult'
+type OIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call struct {
+	*mock.Call
+}
+
+// BuildFederatedAuthResult is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+//   - sub string
+//   - claims map[string]interface{}
+func (_e *OIDCAuthnServiceInterfaceMock_Expecter) BuildFederatedAuthResult(ctx interface{}, idpID interface{}, sub interface{}, claims interface{}) *OIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	return &OIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call{Call: _e.mock.On("BuildFederatedAuthResult", ctx, idpID, sub, claims)}
+}
+
+func (_c *OIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) Run(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{})) *OIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 map[string]interface{}
+		if args[3] != nil {
+			arg3 = args[3].(map[string]interface{})
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *OIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) Return(authnResult *common.AuthnResult, serviceError *common0.ServiceError) *OIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(authnResult, serviceError)
+	return _c
+}
+
+func (_c *OIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call) RunAndReturn(run func(ctx context.Context, idpID string, sub string, claims map[string]interface{}) (*common.AuthnResult, *common0.ServiceError)) *OIDCAuthnServiceInterfaceMock_BuildFederatedAuthResult_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExchangeCodeForToken provides a mock function for the type OIDCAuthnServiceInterfaceMock
 func (_mock *OIDCAuthnServiceInterfaceMock) ExchangeCodeForToken(ctx context.Context, idpID string, code string, validateResponse bool) (*oauth.TokenResponse, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID, code, validateResponse)

--- a/docs/content/guides/guides/identity-providers/add-oidc-provider.mdx
+++ b/docs/content/guides/guides/identity-providers/add-oidc-provider.mdx
@@ -114,7 +114,7 @@ External providers emit attributes under their own names, which may differ from 
 
 | Field | Description |
 |-------|-------------|
-| `userTypeResolution` | **Required.** Resolves the local user type for an incoming identity. |
+| `userTypeResolution` | Resolves the local user type for an incoming identity. **Required** when `userTypeAttributeMappings` is configured (it selects which mapping profile applies); otherwise optional. |
 | `userTypeAttributeMappings` | An array where each entry holds the attribute mappings for one user type. |
 
 Each entry has a `userType` (the user type whose schema defines the valid local targets) and an `attributes` array. Each item in `attributes` has the following fields:
@@ -155,6 +155,31 @@ curl -kL -X POST https://localhost:8090/identity-providers \
     ]
   }'
 ```
+
+## Account Linking
+
+To resolve an incoming federated identity to an existing local user by attributes when the subject identifier (`sub`) does not match, configure `accountLinking` under `attributeConfiguration`:
+
+```json
+{
+  "attributeConfiguration": {
+    "accountLinking": {
+      "attributes": ["email"]
+    }
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `accountLinking.attributes` | External attribute names matched together to resolve a unique local user when `sub` does not. |
+
+Behavior:
+
+- Resolution tries the subject identifier (`sub`) first. If it resolves an existing user, that user is used.
+- Otherwise, all configured attributes that have a value are matched together (as a single query) to resolve a unique local user.
+- Each attribute is an external claim name; if it's mapped via `userTypeAttributeMappings` (e.g. `email` → `work_email`), the mapped local attribute is used for the lookup instead.
+- If neither `sub` nor the configured attributes resolve a user, the user is treated as new (subject to the flow's provisioning configuration).
 
 ## Next Steps
 


### PR DESCRIPTION
### Purpose

Federated login currently resolves the local user solely by the `sub` claim. This adds optional **account-linking attributes** to match an existing user by other attributes (e.g. `email`) when `sub` doesn't match.

### How it works

1. Try `sub` — if it resolves a unique user, use it.
2. If not, and `accountLinking.attributes` is configured, combine every configured attribute that has a value into one filter (e.g. `{email, username}`) and use that.
3. Otherwise, fall back to `sub` (treated as a new user).

If `accountLinking` isn't configured, behavior is unchanged — no extra lookup, filter is always `{"sub": sub}`.

### Approach

- New `AccountLinking { Attributes []string }` on the IdP's `AttributeConfiguration` (`pkg/thunderidengine/providers`), sanitized in `internal/idp/handler.go`.
- A shared `BuildFederatedAuthResult` on the OAuth authn service does the resolution above; OIDC, Google, and GitHub all delegate to it, so mapping + linking apply uniformly. This also fixes a pre-existing gap where Google/GitHub never applied `userTypeAttributeMappings`.
- `userTypeResolution` is now required only when `userTypeAttributeMappings` is configured, not for `accountLinking` alone.
- No storage, indexing, or provisioning changes.

### Out of scope (follow-ups)

- Persisting a federated-subject index so repeat logins skip resolution, and syncing federated attributes onto the linked user.
- Honoring `email_verified` before trusting an email-based link.

### Related Issues
- #3269
- #3007

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided.
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
