### PR TITLE
Update build script for run

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1036,6 +1036,7 @@ function run() {
     echo "=== Ensuring server certificates exist ==="
     ensure_certificates "$BACKEND_DIR/$SECURITY_DIR" "server"
     ensure_certificates "$BACKEND_DIR/$SECURITY_DIR" "signing"
+    ensure_certificates "$BACKEND_DIR/$SECURITY_DIR" "ecdsa-signing"
 
     echo "=== Ensuring sample app certificates exist ==="
     ensure_certificates "$VANILLA_SAMPLE_APP_DIR" "server"


### PR DESCRIPTION
### Purpose
This pull request makes a minor update to the `build.sh` script to ensure that ECDSA signing certificates are generated along with the existing server and signing certificates.

* Script improvement:
  * Added a call to `ensure_certificates` for `"ecdsa-signing"` in the `run` function of `build.sh` to generate ECDSA signing certificates.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the required `ecdsa-signing` server certificate is included during the standard startup flow, helping the backend initialize and run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->