### PR TITLE
Fix bootstrap YAML parser bug with CRLF line endings

### DIFF
--- a/backend/internal/system/importer/parser.go
+++ b/backend/internal/system/importer/parser.go
@@ -59,6 +59,8 @@ func parseDocuments(content string) ([]parsedDocument, error) {
 	decoder := yaml.NewDecoder(bytes.NewReader([]byte(content)))
 
 	docs := make([]parsedDocument, 0)
+	var previousFootComment string
+
 	for seq := 0; ; seq++ {
 		var doc yaml.Node
 		err := decoder.Decode(&doc)
@@ -78,9 +80,16 @@ func parseDocuments(content string) ([]parsedDocument, error) {
 			return nil, fmt.Errorf("document %d root must be a YAML mapping", seq+1)
 		}
 
-		resourceType := classifyResourceTypeWithComments(&doc, root)
+		resourceType := classifyResourceTypeWithComments(&doc, root, previousFootComment)
 		if resourceType == resourceTypeUnknown {
 			return nil, fmt.Errorf("unable to determine resource type for document %d", seq+1)
+		}
+
+		// Save the foot comments for the next document, because yaml.v3 attaches
+		// the next document's head comment (after ---) as the previous document's foot comment.
+		previousFootComment = doc.FootComment
+		if previousFootComment == "" {
+			previousFootComment = root.FootComment
 		}
 
 		docs = append(docs, parsedDocument{
@@ -93,21 +102,19 @@ func parseDocuments(content string) ([]parsedDocument, error) {
 	return docs, nil
 }
 
-func classifyResourceTypeWithComments(doc *yaml.Node, node *yaml.Node) string {
+func classifyResourceTypeWithComments(doc *yaml.Node, node *yaml.Node, previousFootComment string) string {
 	commentCandidates := []string{
+		previousFootComment,
 		doc.HeadComment,
 		doc.LineComment,
-		doc.FootComment,
 		node.HeadComment,
 		node.LineComment,
-		node.FootComment,
 	}
 	for _, contentNode := range node.Content {
 		commentCandidates = append(
 			commentCandidates,
 			contentNode.HeadComment,
 			contentNode.LineComment,
-			contentNode.FootComment,
 		)
 	}
 


### PR DESCRIPTION
### Purpose
Resolves a backend bootstrap failure (`FLM-1010: Invalid flow handle`) occurring on Windows environments, caused by a cross-platform line-ending incompatibility in the `yaml.v3` parser.

### Approach
When `01-default-resources.yaml` is checked out on Windows with standard `CRLF` (`\r\n`) line endings, the `yaml.v3` parser tokenizes carriage returns across the `---` document boundaries incorrectly. It falsely attaches `# resource_type: flow` as the `FootComment` of the preceding `System` resource rather than the `HeadComment` of the next document, causing the `parser.go` importer to misclassify the System resource as a flow. 

Updated `backend/internal/system/importer/parser.go` to explicitly carry over the `previousFootComment` across document iterations. This effectively normalizes the comment attribution natively, making the importer robust and resilient against differing OS line endings.

### Related Issues
- Fixes #3688 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
