### PR TITLE
Support configuring the log level via deployment.yaml

### DIFF
--- a/backend/cmd/server/deployment.yaml
+++ b/backend/cmd/server/deployment.yaml
@@ -2,6 +2,9 @@ server:
   hostname: "localhost"
   port: 8090
 
+log:
+  level: "info"
+
 tls:
   min_version: "1.3"
   cert_file: "config/certs/server.cert"

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -67,6 +67,13 @@ func main() {
 		logger.Fatal(ctx, "Failed to initialize configurations")
 	}
 
+	// Apply the configured log level from deployment.yaml, now that config is loaded.
+	if cfg.Log.Level != "" {
+		if err := logger.SetLevel(cfg.Log.Level); err != nil {
+			logger.Fatal(ctx, "Invalid log level in configuration", log.Error(err))
+		}
+	}
+
 	// Initialize the cache manager.
 	cacheManager := cache.Initialize(cfg.Cache, cfg.Server.Identifier)
 

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -402,9 +402,15 @@ type TranslationConfig struct {
 	Store string `yaml:"store" json:"store"`
 }
 
+// LogConfig holds logging configuration.
+type LogConfig struct {
+	Level string `yaml:"level" json:"level"`
+}
+
 // Config holds the complete configuration details of the server.
 type Config struct {
 	Server               engineconfig.ServerConfig        `yaml:"server"                json:"server"`
+	Log                  LogConfig                        `yaml:"log"                   json:"log"`
 	GateClient           engineconfig.GateClientConfig    `yaml:"gate_client"           json:"gate_client"`
 	TLS                  TLSConfig                        `yaml:"tls"                   json:"tls"`
 	Database             DatabaseConfig                   `yaml:"database"              json:"database"`

--- a/backend/internal/system/config/config_test.go
+++ b/backend/internal/system/config/config_test.go
@@ -180,6 +180,32 @@ notification:
 	assert.Equal(suite.T(), "mysql", config.Database.Config.SQLite.Path)
 }
 
+func (suite *ConfigTestSuite) TestLoadConfigLogLevel() {
+	tempDir := suite.T().TempDir()
+
+	notification := `
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
+`
+
+	// A deployment.yaml with a log level should parse into cfg.Log.Level.
+	withLevel := suite.createTempFile(tempDir, "user*.yaml", "log:\n  level: \"debug\"\n"+notification)
+	config, err := LoadConfig(withLevel, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+	assert.Equal(suite.T(), "debug", config.Log.Level)
+
+	// Omitting the log section leaves the level empty.
+	withoutLevel := suite.createTempFile(tempDir, "user*.yaml", "server:\n  hostname: \"test\"\n"+notification)
+	config, err = LoadConfig(withoutLevel, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+	assert.Equal(suite.T(), "", config.Log.Level)
+}
+
 func (suite *ConfigTestSuite) TestLoadConfigWithDefaults_ErrorCases() {
 	tempDir := suite.T().TempDir()
 

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -19,12 +19,8 @@
 // Package constants defines global constants used across the system module.
 package constants
 
-const (
-	// LogLevelEnvironmentVariable is the environment variable name for the log level.
-	LogLevelEnvironmentVariable = "LOG_LEVEL"
-	// DefaultLogLevel is the default log level used if not specified.
-	DefaultLogLevel = "info"
-)
+// DefaultLogLevel is the default log level used if not specified.
+const DefaultLogLevel = "info"
 
 // AuthorizationHeaderName is the name of the authorization header used in HTTP requests.
 const AuthorizationHeaderName = "Authorization"

--- a/backend/internal/system/log/log.go
+++ b/backend/internal/system/log/log.go
@@ -39,6 +39,7 @@ var (
 // Logger is a wrapper around the slog logger.
 type Logger struct {
 	internal *slog.Logger
+	levelVar *slog.LevelVar
 }
 
 // contextHandler decorates a slog.Handler to add the trace ID (correlation ID)
@@ -85,19 +86,19 @@ func GetLogger() *Logger {
 
 // initLogger initializes the slog logger.
 func initLogger() error {
-	// Read log level from the environment variable.
-	logLevel := os.Getenv(constants.LogLevelEnvironmentVariable)
-	if logLevel == "" {
-		logLevel = constants.DefaultLogLevel
-	}
-	// Parse the log level.
-	level, err := parseLogLevel(logLevel)
+	// The logger is initialized before the deployment configuration is loaded, so it
+	// boots at the default level. The configured level from deployment.yaml is applied
+	// afterwards via SetLevel.
+	level, err := parseLogLevel(constants.DefaultLogLevel)
 	if err != nil {
 		return errors.New("error parsing log level: " + err.Error())
 	}
 
+	levelVar := new(slog.LevelVar)
+	levelVar.Set(level)
+
 	handlerOptions := &slog.HandlerOptions{
-		Level: level,
+		Level: levelVar,
 	}
 
 	logHandler := slog.NewTextHandler(os.Stdout, handlerOptions)
@@ -107,8 +108,19 @@ func initLogger() error {
 
 	logger = &Logger{
 		internal: slog.New(&contextHandler{Handler: logHandler}),
+		levelVar: levelVar,
 	}
 
+	return nil
+}
+
+// SetLevel updates the minimum log level at runtime.
+func (l *Logger) SetLevel(logLevel string) error {
+	level, err := parseLogLevel(logLevel)
+	if err != nil {
+		return err
+	}
+	l.levelVar.Set(level)
 	return nil
 }
 
@@ -116,6 +128,7 @@ func initLogger() error {
 func (l *Logger) With(fields ...Field) *Logger {
 	return &Logger{
 		internal: l.internal.With(convertFields(fields)...),
+		levelVar: l.levelVar,
 	}
 }
 

--- a/backend/internal/system/log/log_test.go
+++ b/backend/internal/system/log/log_test.go
@@ -30,15 +30,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/thunder-id/thunderid/internal/system/constants"
 	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 )
 
 type LogTestSuite struct {
 	suite.Suite
-	originalLogLevel string
-	originalStdout   *os.File
-	buffer           *bytes.Buffer
+	originalStdout *os.File
+	buffer         *bytes.Buffer
 }
 
 func TestLogSuite(t *testing.T) {
@@ -46,9 +44,6 @@ func TestLogSuite(t *testing.T) {
 }
 
 func (suite *LogTestSuite) SetupTest() {
-	// Save original environment variable
-	suite.originalLogLevel = os.Getenv(constants.LogLevelEnvironmentVariable)
-
 	// Capture stdout
 	suite.originalStdout = os.Stdout
 	suite.buffer = &bytes.Buffer{}
@@ -64,12 +59,6 @@ func (suite *LogTestSuite) SetupTest() {
 }
 
 func (suite *LogTestSuite) TearDownTest() {
-	// Restore original environment variable
-	err := os.Setenv(constants.LogLevelEnvironmentVariable, suite.originalLogLevel)
-	if err != nil {
-		suite.T().Errorf("Failed to restore environment variable: %v", err)
-	}
-
 	// Restore stdout
 	os.Stdout = suite.originalStdout
 
@@ -78,44 +67,34 @@ func (suite *LogTestSuite) TearDownTest() {
 	once = sync.Once{}
 }
 
-func (suite *LogTestSuite) TestInitLoggerWithEnvironmentVariable() {
-	testCases := []struct {
-		name     string
-		logLevel string
-		isValid  bool
-	}{
-		{"DefaultLevel", "", true},
-		{"DebugLevel", "debug", true},
-		{"InfoLevel", "info", true},
-		{"WarnLevel", "warn", true},
-		{"ErrorLevel", "error", true},
-		{"InvalidLevel", "unknown", false},
-	}
+func (suite *LogTestSuite) TestInitLoggerUsesDefaultLevel() {
+	logger = nil
+	once = sync.Once{}
 
-	for _, tc := range testCases {
-		suite.T().Run(tc.name, func(t *testing.T) {
-			logger = nil
-			once = sync.Once{}
+	assert.NotPanics(suite.T(), func() {
+		_ = GetLogger()
+	})
+	// The logger boots at the default level (info), so debug is not enabled.
+	assert.False(suite.T(), GetLogger().IsDebugEnabled())
+}
 
-			if tc.logLevel != "" {
-				err := os.Setenv(constants.LogLevelEnvironmentVariable, tc.logLevel)
-				assert.NoError(t, err)
-			} else {
-				err := os.Unsetenv(constants.LogLevelEnvironmentVariable)
-				assert.NoError(t, err)
-			}
+func (suite *LogTestSuite) TestSetLevel() {
+	logger = nil
+	once = sync.Once{}
+	log := GetLogger()
 
-			if tc.isValid {
-				assert.NotPanics(t, func() {
-					_ = GetLogger()
-				})
-			} else {
-				assert.Panics(t, func() {
-					_ = GetLogger()
-				})
-			}
-		})
-	}
+	err := log.SetLevel("debug")
+	assert.NoError(suite.T(), err)
+	assert.True(suite.T(), log.IsDebugEnabled())
+
+	err = log.SetLevel("error")
+	assert.NoError(suite.T(), err)
+	assert.False(suite.T(), log.IsDebugEnabled())
+
+	// An invalid level returns an error and leaves the level unchanged.
+	err = log.SetLevel("bogus")
+	assert.Error(suite.T(), err)
+	assert.False(suite.T(), log.IsDebugEnabled())
 }
 
 func (suite *LogTestSuite) TestParseLogLevel() {
@@ -148,9 +127,6 @@ func (suite *LogTestSuite) TestParseLogLevel() {
 
 func (suite *LogTestSuite) TestLogMethods() {
 	var buf bytes.Buffer
-
-	err := os.Setenv(constants.LogLevelEnvironmentVariable, "debug")
-	assert.NoError(suite.T(), err)
 
 	logger = nil
 	once = sync.Once{}
@@ -412,9 +388,6 @@ func (suite *LogTestSuite) TestContextHandlerPreservedByWithGroup() {
 func (suite *LogTestSuite) TestGetLoggerUsesContextHandler() {
 	logger = nil
 	once = sync.Once{}
-
-	err := os.Setenv(constants.LogLevelEnvironmentVariable, "info")
-	assert.NoError(suite.T(), err)
 
 	log := GetLogger()
 	_, ok := log.internal.Handler().(*contextHandler)

--- a/backend/internal/system/sysauthz/service_test.go
+++ b/backend/internal/system/sysauthz/service_test.go
@@ -29,13 +29,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/security"
 )
 
 // TestMain enables debug-level logging for the entire package test binary so that
 // every logger.IsDebugEnabled() branch in service.go is exercised.
 func TestMain(m *testing.M) {
-	_ = os.Setenv("LOG_LEVEL", "debug")
+	_ = log.GetLogger().SetLevel("debug")
 	security.InitSystemPermissions("")
 	os.Exit(m.Run())
 }

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -58,6 +58,21 @@ Controls HTTPS/TLS settings for secure communication.
 <ProductName /> ships with a self-signed certificate for local development at `config/certs/server.cert`. For production, replace it with a certificate from a trusted Certificate Authority.
 :::
 
+## Logging Configuration
+
+Controls the verbosity of server logs.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `log.level` | `info` | Minimum log level to emit (`debug`, `info`, `warn`, or `error`) |
+
+```yaml
+log:
+  level: "info"
+```
+
+If `log.level` is omitted, <ProductName /> defaults to `info`. An unrecognized value causes the server to exit at startup.
+
 ## Database Configuration
 
 <ProductName /> uses three separate databases for different purposes. Each database can be configured independently.

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -749,11 +749,11 @@ Example:
 ```yaml
 deployment:
   env:
-    - name: LOG_LEVEL
-      value: debug
     - name: EXTERNAL_API_BASE_URL
       value: https://api.example.com
 ```
+
+The log level is configured via `deployment.yaml` (`log.level`).
 
 Environment variable item structure for secret-backed environment variables in `deployment.secretEnv` and `setup.secretEnv`:
 

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -62,10 +62,9 @@ deployment:
       cpu: 100m
       memory: 50Mi
   # Additional environment variables with plain values.
+  # The log level is configured via deployment.yaml (log.level), not an environment variable.
   # Example:
   # env:
-  #   - name: LOG_LEVEL
-  #     value: debug
   #   - name: EXTERNAL_API_BASE_URL
   #     value: https://api.example.com
   env: []


### PR DESCRIPTION
### Purpose

The application log level could previously only be set through the `LOG_LEVEL` environment variable, read once at logger initialization and baked into a static slog level. This moves log-level configuration into `deployment.yaml` under a `log.level` setting, so verbosity is configured consistently with the rest of the server configuration, and removes the `LOG_LEVEL` environment-variable capability.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
The `LOG_LEVEL` environment variable is no longer honored. The log level is now configured exclusively via `deployment.yaml` (`log.level`).

#### 💥 Impact
Any deployment that sets `LOG_LEVEL` (env var, container `-e LOG_LEVEL=...`, or a compose `environment:` entry) will silently fall back to the default `info` level after upgrading.

#### 🔄 Migration Guide
Move the setting into `deployment.yaml`:

```yaml
log:
  level: "debug"   # debug | info | warn | error
```

If omitted, the level defaults to `info`. An unrecognized value now fails startup.

---

### Approach

- Made the slog level mutable via a `slog.LevelVar`. The logger initializes before the deployment config is loaded, so it boots at the default level (`info`) and the configured value is applied immediately after config load through a new `Logger.SetLevel` method.
- Added a `LogConfig` struct with a `Level` field and a `Log` field on the top-level `Config`.
- Applied `cfg.Log.Level` after config load in `main.go`; an invalid value calls `logger.Fatal`, preserving the previous fail-fast behavior on a bad level.
- Removed the now-dead `LogLevelEnvironmentVariable` constant and the `LOG_LEVEL` env read.
- Updated the configuration reference docs, the sample `deployment.yaml`, and the Helm chart docs/examples to reflect the new `log.level` setting.

### Related Issues
- Fixes #3682

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
