### PR TITLE
Add Server Configurations UI support.

### DIFF
--- a/frontend/apps/console/src/App.tsx
+++ b/frontend/apps/console/src/App.tsx
@@ -113,6 +113,7 @@ const LoginFlowBuilderPage = lazy(() => import('./features/login-flow/pages/Logi
 const CreateRolePage = lazy(() => import('./features/roles/pages/CreateRolePage'));
 const RoleEditPage = lazy(() => import('./features/roles/pages/RoleEditPage'));
 const RolesListPage = lazy(() => import('./features/roles/pages/RolesListPage'));
+const SettingsPage = lazy(() => import('./features/settings/pages/SettingsPage'));
 const VerifiablePresentationsListPage = lazy(
   () => import('./features/verifiable-presentations/pages/VerifiablePresentationsListPage'),
 );
@@ -181,6 +182,7 @@ export default function App(): JSX.Element {
               <Route path="flows" element={<FlowsListPage />} />
               <Route path="resource-servers" element={<ResourceServersListPage />} />
               <Route path="resource-servers/:resourceServerId" element={<ResourceServerEditPage />} />
+              <Route path="settings" element={<SettingsPage />} />
             </Route>
             {/* Organization Units - wrapped in OrganizationUnitProvider to preserve tree state across navigation */}
             <Route

--- a/frontend/apps/console/src/features/settings/api/__tests__/useGetCorsConfig.test.ts
+++ b/frontend/apps/console/src/features/settings/api/__tests__/useGetCorsConfig.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {waitFor} from '@testing-library/react';
+import {renderHook} from '@thunderid/test-utils';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import type {CorsConfigResponse} from '../../models/responses';
+
+const mockHttpRequest = vi.fn();
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
+    http: {request: mockHttpRequest},
+  }),
+}));
+
+const mockGetServerUrl = vi.fn<() => string>(() => 'https://localhost:8090');
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({getServerUrl: mockGetServerUrl}),
+  };
+});
+
+const {default: useGetCorsConfig} = await import('../useGetCorsConfig');
+
+describe('useGetCorsConfig', () => {
+  const mockResponse: CorsConfigResponse = {
+    readOnly: {allowedOrigins: ['https://localhost:5190']},
+    writable: {allowedOrigins: ['https://app.acme.com']},
+    merged: {allowedOrigins: ['https://localhost:5190', 'https://app.acme.com']},
+  };
+
+  beforeEach(() => {
+    mockHttpRequest.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches the CORS config from /server-config/cors', async () => {
+    mockHttpRequest.mockResolvedValue({data: mockResponse});
+    const {result} = renderHook(() => useGetCorsConfig());
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockResponse);
+    expect(mockHttpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://localhost:8090/server-config/cors',
+        method: 'GET',
+      }),
+    );
+  });
+
+  it('surfaces fetch errors', async () => {
+    mockHttpRequest.mockRejectedValue(new Error('boom'));
+    const {result} = renderHook(() => useGetCorsConfig());
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe('boom');
+    });
+  });
+});

--- a/frontend/apps/console/src/features/settings/api/__tests__/useUpdateCorsConfig.test.ts
+++ b/frontend/apps/console/src/features/settings/api/__tests__/useUpdateCorsConfig.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {waitFor} from '@testing-library/react';
+import {renderHook} from '@thunderid/test-utils';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import type {CorsConfigResponse} from '../../models/responses';
+
+const mockHttpRequest = vi.fn();
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
+    http: {request: mockHttpRequest},
+  }),
+}));
+
+const mockGetServerUrl = vi.fn<() => string>(() => 'https://localhost:8090');
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({getServerUrl: mockGetServerUrl}),
+  };
+});
+
+const {default: useUpdateCorsConfig} = await import('../useUpdateCorsConfig');
+
+describe('useUpdateCorsConfig', () => {
+  const mockResponse: CorsConfigResponse = {
+    readOnly: {allowedOrigins: ['https://localhost:5190']},
+    writable: {allowedOrigins: ['https://app.example.com']},
+    merged: {allowedOrigins: ['https://localhost:5190', 'https://app.example.com']},
+  };
+
+  beforeEach(() => {
+    mockHttpRequest.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('PUTs the writable value to /server-config/cors', async () => {
+    mockHttpRequest.mockResolvedValue({data: mockResponse});
+    const {result} = renderHook(() => useUpdateCorsConfig());
+
+    result.current.mutate({data: {allowedOrigins: ['https://app.example.com']}});
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockHttpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://localhost:8090/server-config/cors',
+        method: 'PUT',
+        data: {allowedOrigins: ['https://app.example.com']},
+      }),
+    );
+  });
+
+  it('writes the returned config into the query cache on success', async () => {
+    mockHttpRequest.mockResolvedValue({data: mockResponse});
+    const {result, queryClient} = renderHook(() => useUpdateCorsConfig());
+
+    result.current.mutate({data: {allowedOrigins: ['https://app.example.com']}});
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(queryClient.getQueryData(['server-config', 'cors'])).toEqual(mockResponse);
+  });
+
+  it('surfaces update errors', async () => {
+    mockHttpRequest.mockRejectedValue(new Error('nope'));
+    const {result} = renderHook(() => useUpdateCorsConfig());
+
+    result.current.mutate({data: {allowedOrigins: []}});
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe('nope');
+    });
+  });
+});

--- a/frontend/apps/console/src/features/settings/api/useGetCorsConfig.ts
+++ b/frontend/apps/console/src/features/settings/api/useGetCorsConfig.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import {useConfig} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import SettingsQueryKeys from '../constants/settings-query-keys';
+import type {CorsConfigResponse} from '../models/responses';
+
+/**
+ * Fetches the CORS server-config section.
+ *
+ * @returns TanStack Query result containing the CORS config layers.
+ *
+ * @public
+ */
+export default function useGetCorsConfig(): UseQueryResult<CorsConfigResponse> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+
+  return useQuery<CorsConfigResponse>({
+    queryKey: [SettingsQueryKeys.SERVER_CONFIG, SettingsQueryKeys.CORS],
+    queryFn: async (): Promise<CorsConfigResponse> => {
+      const serverUrl: string = getServerUrl();
+
+      const response: {
+        data: CorsConfigResponse;
+      } = await http.request({
+        url: `${serverUrl}/server-config/cors`,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      return response.data;
+    },
+  });
+}

--- a/frontend/apps/console/src/features/settings/api/useUpdateCorsConfig.ts
+++ b/frontend/apps/console/src/features/settings/api/useUpdateCorsConfig.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
+import {useConfig, useToast} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import {getErrorMessage} from '@thunderid/utils';
+import {useTranslation} from 'react-i18next';
+import SettingsQueryKeys from '../constants/settings-query-keys';
+import type {CorsConfigResponse, CorsValue} from '../models/responses';
+
+/**
+ * Variables for the {@link useUpdateCorsConfig} mutation.
+ *
+ * @public
+ */
+export interface UpdateCorsConfigVariables {
+  /**
+   * The writable CORS value to persist.
+   */
+  data: CorsValue;
+}
+
+/**
+ * Updates the writable layer of the CORS server-config section.
+ *
+ * @returns TanStack Query mutation for updating allowed origins.
+ *
+ * @public
+ */
+export default function useUpdateCorsConfig(): UseMutationResult<CorsConfigResponse, Error, UpdateCorsConfigVariables> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+  const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation();
+  const {showToast} = useToast();
+
+  return useMutation<CorsConfigResponse, Error, UpdateCorsConfigVariables>({
+    mutationFn: async ({data}: UpdateCorsConfigVariables): Promise<CorsConfigResponse> => {
+      const serverUrl: string = getServerUrl();
+
+      const response: {
+        data: CorsConfigResponse;
+      } = await http.request({
+        url: `${serverUrl}/server-config/cors`,
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data,
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      return response.data;
+    },
+    onSuccess: (data) => {
+      // PUT returns the full config, so keep the read model in sync without a refetch.
+      queryClient.setQueryData([SettingsQueryKeys.SERVER_CONFIG, SettingsQueryKeys.CORS], data);
+      showToast(t('settings:cors.save.success'), 'success');
+    },
+    onError: (error) => {
+      showToast(getErrorMessage(error, t, 'settings:cors.save.error'), 'error');
+    },
+  });
+}

--- a/frontend/apps/console/src/features/settings/components/cors/CorsSection.tsx
+++ b/frontend/apps/console/src/features/settings/components/cors/CorsSection.tsx
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {SettingsCard, UnsavedChangesBar} from '@thunderid/components';
+import {getErrorMessage} from '@thunderid/utils';
+import {Alert, Box, Button, Divider, Skeleton, Stack, TextField, Typography} from '@wso2/oxygen-ui';
+import {InfoIcon, Plus} from '@wso2/oxygen-ui-icons-react';
+import type {JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import OriginRow from './OriginRow';
+import useGetCorsConfig from '../../api/useGetCorsConfig';
+import useUpdateCorsConfig from '../../api/useUpdateCorsConfig';
+import useAllowedOriginsDraft from '../../hooks/useAllowedOriginsDraft';
+import type {AllowedOrigin} from '../../models/responses';
+
+const ROW_ACTION_WIDTH = 40;
+
+/** Renders an allowed origin for display: a literal string as-is, a regex entry as its pattern. */
+function originText(entry: AllowedOrigin): string {
+  return typeof entry === 'string' ? entry : entry.regex;
+}
+
+/** A single non-editable origin row: a muted read-only field plus a spacer that aligns with editable rows. */
+function OriginDisplayRow({value}: {value: string}): JSX.Element {
+  return (
+    <Stack direction="row" spacing={1} alignItems="center">
+      <TextField
+        fullWidth
+        size="small"
+        value={value}
+        slotProps={{input: {readOnly: true}}}
+        sx={{flex: 1, opacity: 0.65}}
+      />
+      <Box aria-hidden sx={{width: ROW_ACTION_WIDTH, flex: 'none'}} />
+    </Stack>
+  );
+}
+
+export default function CorsSection(): JSX.Element {
+  const {t} = useTranslation();
+  const {data, isLoading, error} = useGetCorsConfig();
+  const updateCors = useUpdateCorsConfig();
+  const origins = useAllowedOriginsDraft(data);
+
+  const readOnlyOrigins: AllowedOrigin[] = data?.readOnly.allowedOrigins ?? [];
+  const hasReadOnlyOrigins: boolean = readOnlyOrigins.length > 0;
+
+  const handleSave = (): void => {
+    if (!origins.validateAll()) {
+      return;
+    }
+    updateCors.mutate(
+      {data: origins.buildPayload()},
+      {
+        onSuccess: () => {
+          origins.reset();
+        },
+      },
+    );
+  };
+
+  let body: JSX.Element;
+  if (isLoading) {
+    body = (
+      <Stack spacing={1}>
+        <Skeleton variant="rounded" height={40} />
+        <Skeleton variant="rounded" height={40} />
+      </Stack>
+    );
+  } else if (error) {
+    body = <Alert severity="error">{getErrorMessage(error, t, 'settings:cors.load.error')}</Alert>;
+  } else {
+    body = (
+      <>
+        <Stack spacing={1}>
+          {readOnlyOrigins.map((entry, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <OriginDisplayRow key={`readonly-${index}`} value={originText(entry)} />
+          ))}
+          {origins.draft.map((value, index) => (
+            <OriginRow
+              // eslint-disable-next-line react/no-array-index-key
+              key={`origin-${index}`}
+              value={value}
+              error={origins.errors[index]}
+              placeholder={t('settings:cors.originPlaceholder')}
+              removeLabel={t('settings:cors.removeOrigin')}
+              onChange={(next) => origins.changeRow(index, next)}
+              onBlur={() => origins.blurRow(index)}
+              onRemove={() => origins.removeRow(index)}
+            />
+          ))}
+        </Stack>
+
+        <Button variant="outlined" startIcon={<Plus size={18} />} onClick={origins.addRow} sx={{mt: 2}}>
+          {t('settings:cors.addOrigin')}
+        </Button>
+
+        {hasReadOnlyOrigins && (
+          <>
+            <Divider sx={{mt: 2, mb: 1.5}} />
+            <Stack direction="row" spacing={1} alignItems="flex-start">
+              <Box aria-hidden sx={{flex: 'none', display: 'inline-flex', mt: '2px', color: 'text.secondary'}}>
+                <InfoIcon size={16} />
+              </Box>
+              <Typography variant="body2" color="text.secondary">
+                {t('settings:cors.readOnlyHint')}
+              </Typography>
+            </Stack>
+          </>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SettingsCard title={t('settings:cors.card.title')} description={t('settings:cors.card.description')}>
+        {body}
+      </SettingsCard>
+      {origins.dirty && (
+        <UnsavedChangesBar
+          message={t('settings:cors.unsavedChanges')}
+          resetLabel={t('settings:cors.discard')}
+          saveLabel={t('settings:cors.save')}
+          savingLabel={t('settings:cors.saving')}
+          isSaving={updateCors.isPending}
+          saveDisabled={origins.hasErrors}
+          onReset={origins.reset}
+          onSave={handleSave}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/apps/console/src/features/settings/components/cors/OriginRow.tsx
+++ b/frontend/apps/console/src/features/settings/components/cors/OriginRow.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {IconButton, Stack, TextField, Tooltip} from '@wso2/oxygen-ui';
+import {Trash} from '@wso2/oxygen-ui-icons-react';
+import type {JSX} from 'react';
+
+interface OriginRowProps {
+  value: string;
+  error?: string;
+  placeholder: string;
+  removeLabel: string;
+  onChange: (value: string) => void;
+  onBlur: () => void;
+  onRemove: () => void;
+}
+
+/** A single editable allowed-origin row: a validated text field plus a remove action. */
+export default function OriginRow({
+  value,
+  error = undefined,
+  placeholder,
+  removeLabel,
+  onChange,
+  onBlur,
+  onRemove,
+}: OriginRowProps): JSX.Element {
+  return (
+    <Stack direction="row" spacing={1} alignItems="flex-start">
+      <TextField
+        fullWidth
+        size="small"
+        value={value}
+        placeholder={placeholder}
+        error={Boolean(error)}
+        helperText={error}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={onBlur}
+        sx={{flex: 1}}
+      />
+      <Tooltip title={removeLabel}>
+        <IconButton aria-label={removeLabel} color="error" onClick={onRemove} sx={{mt: 0.5}}>
+          <Trash size={18} />
+        </IconButton>
+      </Tooltip>
+    </Stack>
+  );
+}

--- a/frontend/apps/console/src/features/settings/components/cors/__tests__/CorsSection.test.tsx
+++ b/frontend/apps/console/src/features/settings/components/cors/__tests__/CorsSection.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {fireEvent, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {renderWithProviders} from '@thunderid/test-utils';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import type {CorsConfigResponse} from '../../../models/responses';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}));
+
+const mockUseGetCorsConfig =
+  vi.fn<() => {data: CorsConfigResponse | undefined; isLoading: boolean; error: Error | null}>();
+vi.mock('../../../api/useGetCorsConfig', () => ({
+  default: () => mockUseGetCorsConfig(),
+}));
+
+const mockMutate = vi.fn();
+vi.mock('../../../api/useUpdateCorsConfig', () => ({
+  default: () => ({mutate: mockMutate, isPending: false}),
+}));
+
+const {default: CorsSection} = await import('../CorsSection');
+
+function makeData(overrides?: Partial<CorsConfigResponse>): CorsConfigResponse {
+  return {
+    readOnly: {allowedOrigins: ['https://console.example.com']},
+    writable: {allowedOrigins: ['https://app.acme.com']},
+    merged: {allowedOrigins: []},
+    ...overrides,
+  };
+}
+
+describe('CorsSection', () => {
+  beforeEach(() => {
+    mockUseGetCorsConfig.mockReset();
+    mockMutate.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render the editor while loading', () => {
+    mockUseGetCorsConfig.mockReturnValue({data: undefined, isLoading: true, error: null});
+    renderWithProviders(<CorsSection />);
+    expect(screen.queryByRole('button', {name: 'settings:cors.addOrigin'})).toBeNull();
+  });
+
+  it('shows an alert on load error', () => {
+    mockUseGetCorsConfig.mockReturnValue({data: undefined, isLoading: false, error: new Error('load failed')});
+    renderWithProviders(<CorsSection />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('renders read-only origins (incl. regex patterns), editable origins, and the Add control', () => {
+    mockUseGetCorsConfig.mockReturnValue({
+      data: makeData({readOnly: {allowedOrigins: ['https://console.example.com', {regex: '^https://x$'}]}}),
+      isLoading: false,
+      error: null,
+    });
+    renderWithProviders(<CorsSection />);
+
+    expect(screen.getByDisplayValue('https://console.example.com')).toHaveAttribute('readonly');
+    expect(screen.getByDisplayValue('^https://x$')).toHaveAttribute('readonly');
+    expect(screen.getByDisplayValue('https://app.acme.com')).not.toHaveAttribute('readonly');
+    expect(screen.getByRole('button', {name: 'settings:cors.addOrigin'})).toBeInTheDocument();
+    expect(screen.getByText('settings:cors.readOnlyHint')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'settings:cors.removeOrigin'})).toBeInTheDocument();
+  });
+
+  it('removes an editable origin when its delete button is clicked', async () => {
+    const user = userEvent.setup();
+    mockUseGetCorsConfig.mockReturnValue({
+      data: makeData({readOnly: {allowedOrigins: []}, writable: {allowedOrigins: ['https://remove.example.com']}}),
+      isLoading: false,
+      error: null,
+    });
+    renderWithProviders(<CorsSection />);
+
+    expect(screen.getByDisplayValue('https://remove.example.com')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', {name: 'settings:cors.removeOrigin'}));
+    expect(screen.queryByDisplayValue('https://remove.example.com')).toBeNull();
+  });
+
+  it('adds an editable row when Add origin is clicked', async () => {
+    const user = userEvent.setup();
+    mockUseGetCorsConfig.mockReturnValue({
+      data: makeData({writable: {allowedOrigins: []}}),
+      isLoading: false,
+      error: null,
+    });
+    renderWithProviders(<CorsSection />);
+
+    expect(screen.queryByPlaceholderText('settings:cors.originPlaceholder')).toBeNull();
+    await user.click(screen.getByRole('button', {name: 'settings:cors.addOrigin'}));
+    expect(screen.getByPlaceholderText('settings:cors.originPlaceholder')).toBeInTheDocument();
+  });
+
+  it('saves the edited origins via the update mutation and clears the unsaved bar on success', async () => {
+    const user = userEvent.setup();
+    mockMutate.mockImplementation((...args: unknown[]) => {
+      const opts = args[1] as {onSuccess?: () => void} | undefined;
+      opts?.onSuccess?.();
+    });
+    mockUseGetCorsConfig.mockReturnValue({
+      data: makeData({readOnly: {allowedOrigins: []}, writable: {allowedOrigins: []}}),
+      isLoading: false,
+      error: null,
+    });
+    renderWithProviders(<CorsSection />);
+
+    await user.click(screen.getByRole('button', {name: 'settings:cors.addOrigin'}));
+    await user.type(screen.getByPlaceholderText('settings:cors.originPlaceholder'), 'https://new.example.com');
+
+    const saveButton = await screen.findByRole('button', {name: 'settings:cors.save'});
+    await user.click(saveButton);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({data: {allowedOrigins: ['https://new.example.com']}}),
+      expect.anything(),
+    );
+    // onSuccess → reset() clears the overlay, so the unsaved bar disappears.
+    await waitFor(() => {
+      expect(screen.queryByRole('button', {name: 'settings:cors.save'})).toBeNull();
+    });
+  });
+
+  it('does not save when a row fails the submit-time validation guard', async () => {
+    const user = userEvent.setup();
+    mockUseGetCorsConfig.mockReturnValue({
+      data: makeData({readOnly: {allowedOrigins: []}, writable: {allowedOrigins: []}}),
+      isLoading: false,
+      error: null,
+    });
+    renderWithProviders(<CorsSection />);
+
+    await user.click(screen.getByRole('button', {name: 'settings:cors.addOrigin'}));
+    // Change without blurring (fireEvent), so the row-level error isn't shown yet and Save is enabled.
+    // '(bad' is neither a valid origin nor a compilable regex, so the submit-time guard must block it.
+    fireEvent.change(screen.getByPlaceholderText('settings:cors.originPlaceholder'), {target: {value: '(bad'}});
+    fireEvent.click(screen.getByRole('button', {name: 'settings:cors.save'}));
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('blocks Save when a row is a duplicate', async () => {
+    const user = userEvent.setup();
+    mockUseGetCorsConfig.mockReturnValue({
+      data: makeData({readOnly: {allowedOrigins: []}, writable: {allowedOrigins: []}}),
+      isLoading: false,
+      error: null,
+    });
+    renderWithProviders(<CorsSection />);
+
+    await user.click(screen.getByRole('button', {name: 'settings:cors.addOrigin'}));
+    await user.click(screen.getByRole('button', {name: 'settings:cors.addOrigin'}));
+    const inputs = screen.getAllByPlaceholderText('settings:cors.originPlaceholder');
+    await user.type(inputs[0], 'https://dup.example.com');
+    await user.type(inputs[1], 'https://dup.example.com');
+
+    const saveButton = await screen.findByRole('button', {name: 'settings:cors.save'});
+    expect(saveButton).toBeDisabled();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/console/src/features/settings/constants/settings-query-keys.ts
+++ b/frontend/apps/console/src/features/settings/constants/settings-query-keys.ts
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
@@ -6,17 +6,24 @@
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
-export { ConsoleSigninPage } from "./authentication";
-export { UsersPage, type UserFormData } from "./user-management";
-export { ApplicationsPage, type ApplicationFormData } from "./applications";
-export { SettingsPage } from "./settings";
+/**
+ * Query key constants for the settings feature cache management.
+ */
+const SettingsQueryKeys = {
+  /** Base key for all server-config section queries */
+  SERVER_CONFIG: 'server-config',
+  /** Name segment for the CORS section */
+  CORS: 'cors',
+} as const;
+
+export default SettingsQueryKeys;

--- a/frontend/apps/console/src/features/settings/hooks/__tests__/useAllowedOriginsDraft.test.ts
+++ b/frontend/apps/console/src/features/settings/hooks/__tests__/useAllowedOriginsDraft.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {act} from '@testing-library/react';
+import {renderHook} from '@thunderid/test-utils';
+import {describe, it, expect} from 'vitest';
+import type {AllowedOrigin, CorsConfigResponse} from '../../models/responses';
+import useAllowedOriginsDraft from '../useAllowedOriginsDraft';
+
+function makeData(readOnly: AllowedOrigin[], writable: AllowedOrigin[]): CorsConfigResponse {
+  return {
+    readOnly: {allowedOrigins: readOnly},
+    writable: {allowedOrigins: writable},
+    merged: {allowedOrigins: []},
+  };
+}
+
+describe('useAllowedOriginsDraft', () => {
+  it('loads writable entries as editable rows (strings as-is, regex as its pattern)', () => {
+    const {result} = renderHook(() =>
+      useAllowedOriginsDraft(makeData([], ['https://app.acme.com', {regex: '^https://[a-z]+\\.acme\\.io$'}])),
+    );
+    expect(result.current.draft).toEqual(['https://app.acme.com', '^https://[a-z]+\\.acme\\.io$']);
+    expect(result.current.dirty).toBe(false);
+    expect(result.current.hasErrors).toBe(false);
+  });
+
+  it('adding an empty row is not dirty; typing a value makes it dirty', () => {
+    const {result} = renderHook(() => useAllowedOriginsDraft(makeData([], ['https://app.acme.com'])));
+    act(() => result.current.addRow());
+    expect(result.current.dirty).toBe(false);
+    act(() => result.current.changeRow(1, 'https://new.example.com'));
+    expect(result.current.dirty).toBe(true);
+  });
+
+  it('removing a row marks the draft dirty', () => {
+    const {result} = renderHook(() =>
+      useAllowedOriginsDraft(makeData([], ['https://app.acme.com', 'https://other.acme.com'])),
+    );
+    act(() => result.current.removeRow(0));
+    expect(result.current.dirty).toBe(true);
+    expect(result.current.draft).toEqual(['https://other.acme.com']);
+  });
+
+  it('reset clears local edits and reverts to the saved value', () => {
+    const {result} = renderHook(() => useAllowedOriginsDraft(makeData([], ['https://app.acme.com'])));
+    act(() => result.current.changeRow(0, 'https://changed.example.com'));
+    expect(result.current.dirty).toBe(true);
+    act(() => result.current.reset());
+    expect(result.current.dirty).toBe(false);
+    expect(result.current.draft).toEqual(['https://app.acme.com']);
+  });
+
+  it('normalizes a row on blur (lowercase + trailing slash), preserving an explicit port', () => {
+    const {result} = renderHook(() => useAllowedOriginsDraft(makeData([], ['https://app.acme.com'])));
+    act(() => result.current.changeRow(0, 'HTTPS://Example.COM:443/'));
+    act(() => result.current.blurRow(0));
+    expect(result.current.draft[0]).toBe('https://example.com:443');
+    expect(result.current.hasErrors).toBe(false);
+  });
+
+  it('flags a row that is neither a valid origin nor a compilable regex', () => {
+    const {result} = renderHook(() => useAllowedOriginsDraft(makeData([], ['(bad'])));
+    let ok = true;
+    act(() => {
+      ok = result.current.validateAll();
+    });
+    expect(ok).toBe(false);
+    expect(result.current.errors[0]).toBeTruthy();
+  });
+
+  it('accepts both a valid origin and a valid regex row', () => {
+    const {result} = renderHook(() =>
+      useAllowedOriginsDraft(makeData([], ['https://ok.example.com', {regex: '^https://.*\\.ok\\.io$'}])),
+    );
+    let ok = false;
+    act(() => {
+      ok = result.current.validateAll();
+    });
+    expect(ok).toBe(true);
+    expect(result.current.hasErrors).toBe(false);
+  });
+
+  it('flags duplicates within the draft and clears them when a counterpart row is removed', () => {
+    const {result} = renderHook(() =>
+      useAllowedOriginsDraft(makeData([], ['https://dup.example.com', 'https://dup.example.com'])),
+    );
+    act(() => {
+      result.current.validateAll();
+    });
+    expect(result.current.errors[0]).toBeTruthy();
+    expect(result.current.errors[1]).toBeTruthy();
+
+    act(() => result.current.removeRow(1));
+    expect(result.current.errors[0]).toBeUndefined();
+  });
+
+  it('clears a duplicate error when the counterpart is edited to a unique value', () => {
+    const {result} = renderHook(() =>
+      useAllowedOriginsDraft(makeData([], ['https://dup.example.com', 'https://dup.example.com'])),
+    );
+    act(() => {
+      result.current.validateAll();
+    });
+    expect(result.current.errors[0]).toBeTruthy();
+
+    act(() => result.current.changeRow(1, 'https://unique.example.com'));
+    expect(result.current.errors[0]).toBeUndefined();
+  });
+
+  it('treats a default port as distinct from the port-less origin (no false duplicate)', () => {
+    const {result} = renderHook(() =>
+      useAllowedOriginsDraft(makeData([], ['https://example.com', 'https://example.com:443'])),
+    );
+    act(() => {
+      result.current.validateAll();
+    });
+    expect(result.current.hasErrors).toBe(false);
+  });
+
+  it('flags a custom origin that duplicates a read-only origin', () => {
+    const {result} = renderHook(() =>
+      useAllowedOriginsDraft(makeData(['https://console.example.com'], ['https://console.example.com'])),
+    );
+    act(() => {
+      result.current.validateAll();
+    });
+    expect(result.current.errors[0]).toBeTruthy();
+  });
+
+  it('flags a custom regex that duplicates a read-only regex', () => {
+    const {result} = renderHook(() =>
+      useAllowedOriginsDraft(
+        makeData([{regex: '^https://[a-z]+\\.acme\\.io$'}], [{regex: '^https://[a-z]+\\.acme\\.io$'}]),
+      ),
+    );
+    act(() => {
+      result.current.validateAll();
+    });
+    expect(result.current.errors[0]).toBeTruthy();
+  });
+
+  describe('buildPayload', () => {
+    it('classifies origins as strings and non-origins as regex entries, dropping empty rows', () => {
+      const {result} = renderHook(() =>
+        useAllowedOriginsDraft(makeData([], ['https://app.example.com', {regex: '^https://[a-z]+\\.example\\.com$'}])),
+      );
+      // Add a trailing empty row that Save must drop.
+      act(() => result.current.addRow());
+
+      expect(result.current.buildPayload()).toEqual({
+        allowedOrigins: ['https://app.example.com', {regex: '^https://[a-z]+\\.example\\.com$'}],
+      });
+    });
+
+    it('preserves an explicit default port in the saved string entry', () => {
+      const {result} = renderHook(() => useAllowedOriginsDraft(makeData([], ['https://example.com:443'])));
+      expect(result.current.buildPayload()).toEqual({allowedOrigins: ['https://example.com:443']});
+    });
+
+    it('round-trips a loaded regex entry back to a {regex} entry', () => {
+      const {result} = renderHook(() => useAllowedOriginsDraft(makeData([], [{regex: '^https://x\\.io$'}])));
+      expect(result.current.draft).toEqual(['^https://x\\.io$']);
+      expect(result.current.buildPayload()).toEqual({allowedOrigins: [{regex: '^https://x\\.io$'}]});
+    });
+
+    it('keeps the "null" literal as a string entry', () => {
+      const {result} = renderHook(() => useAllowedOriginsDraft(makeData([], ['null'])));
+      expect(result.current.buildPayload()).toEqual({allowedOrigins: ['null']});
+    });
+  });
+});

--- a/frontend/apps/console/src/features/settings/hooks/useAllowedOriginsDraft.ts
+++ b/frontend/apps/console/src/features/settings/hooks/useAllowedOriginsDraft.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useCallback, useMemo, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import type {AllowedOrigin, CorsConfigResponse, CorsValue} from '../models/responses';
+import baselineKey from '../utils/baselineKey';
+import {isValidOrigin, isValidRegex, normalizeOrigin} from '../utils/origin';
+import originValueText from '../utils/originValueText';
+
+/**
+ * The editable draft of writable CORS origins returned by {@link useAllowedOriginsDraft}.
+ *
+ * @public
+ */
+export interface AllowedOriginsDraft {
+  /** Editable rows. Each is a literal origin (incl. `"null"`) or a regex pattern, kept as text. */
+  draft: string[];
+  /** Per-row validation/duplicate error messages, keyed by draft index. */
+  errors: Record<number, string>;
+  /** Whether the normalized draft differs from the saved baseline. */
+  dirty: boolean;
+  /** Whether any row currently has a validation/duplicate error. */
+  hasErrors: boolean;
+  /** Appends an empty editable row. */
+  addRow: () => void;
+  /** Removes the row at the given index and re-validates the remaining rows. */
+  removeRow: (index: number) => void;
+  /** Updates the row at the given index; its own error stays hidden until blur. */
+  changeRow: (index: number, value: string) => void;
+  /** Normalizes and validates the row at the given index. */
+  blurRow: (index: number) => void;
+  /** Clears local edits, reverting to the saved server value (used by Discard and after a save). */
+  reset: () => void;
+  /** Validates every row, sets errors, and returns whether the draft is savable. */
+  validateAll: () => boolean;
+  /** Builds the PUT body, classifying each row as a literal origin or a `{regex}` entry. */
+  buildPayload: () => CorsValue;
+}
+
+/**
+ * Manages the editable draft of writable CORS origins as a local overlay over the server value, so a
+ * background refetch does not clobber in-progress edits. On save, each row is classified as a literal
+ * origin or a `{regex}` entry.
+ *
+ * @param data - The fetched CORS config, or `undefined` while loading
+ * @returns The draft state and operations: add/remove/edit, validation, dirty tracking, and payload building
+ *
+ * @public
+ */
+export default function useAllowedOriginsDraft(data: CorsConfigResponse | undefined): AllowedOriginsDraft {
+  const {t} = useTranslation();
+  const [editedDraft, setEditedDraft] = useState<string[] | undefined>(undefined);
+  const [errors, setErrors] = useState<Record<number, string>>({});
+
+  const savedValues = useMemo<string[]>(() => (data?.writable.allowedOrigins ?? []).map(originValueText), [data]);
+  const readOnlyNormalized = useMemo<string[]>(
+    () => (data?.readOnly.allowedOrigins ?? []).map(originValueText).map(normalizeOrigin),
+    [data],
+  );
+
+  const draft = editedDraft ?? savedValues;
+
+  const computeErrors = useCallback(
+    (rows: string[]): Record<number, string> => {
+      const normalized = rows.map(normalizeOrigin);
+      const counts = new Map<string, number>();
+      normalized.forEach((value) => {
+        if (value !== '') {
+          counts.set(value, (counts.get(value) ?? 0) + 1);
+        }
+      });
+      const readOnlySet = new Set(readOnlyNormalized);
+      const nextErrors: Record<number, string> = {};
+      normalized.forEach((value, index) => {
+        if (value === '') {
+          return;
+        }
+        if (!isValidOrigin(value) && !isValidRegex(value)) {
+          nextErrors[index] = t('settings:cors.validation.invalid');
+        } else if ((counts.get(value) ?? 0) > 1 || readOnlySet.has(value)) {
+          nextErrors[index] = t('settings:cors.validation.duplicate');
+        }
+      });
+      return nextErrors;
+    },
+    [readOnlyNormalized, t],
+  );
+
+  const addRow = useCallback((): void => {
+    setEditedDraft([...draft, '']);
+  }, [draft]);
+
+  const removeRow = useCallback(
+    (index: number): void => {
+      const next = draft.filter((_, i) => i !== index);
+      setEditedDraft(next);
+      // Removing a row can clear duplicate errors on the remaining rows.
+      setErrors(computeErrors(next));
+    },
+    [draft, computeErrors],
+  );
+
+  const changeRow = useCallback(
+    (index: number, value: string): void => {
+      const next = [...draft];
+      next[index] = value;
+      setEditedDraft(next);
+      // Keep the active row quiet until blur, while clearing stale errors on other rows.
+      const recomputed = computeErrors(next);
+      delete recomputed[index];
+      setErrors(recomputed);
+    },
+    [draft, computeErrors],
+  );
+
+  const blurRow = useCallback(
+    (index: number): void => {
+      const next = [...draft];
+      next[index] = normalizeOrigin(next[index] ?? '');
+      setEditedDraft(next);
+      setErrors(computeErrors(next));
+    },
+    [draft, computeErrors],
+  );
+
+  const reset = useCallback((): void => {
+    setEditedDraft(undefined);
+    setErrors({});
+  }, []);
+
+  const validateAll = useCallback((): boolean => {
+    const nextErrors = computeErrors(draft);
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  }, [draft, computeErrors]);
+
+  const buildPayload = useCallback((): CorsValue => {
+    const entries: AllowedOrigin[] = [];
+    draft.forEach((raw) => {
+      const value = normalizeOrigin(raw);
+      if (value === '') {
+        return;
+      }
+      entries.push(isValidOrigin(value) ? value : {regex: value});
+    });
+    return {allowedOrigins: entries};
+  }, [draft]);
+
+  const dirty = useMemo<boolean>(() => baselineKey(draft) !== baselineKey(savedValues), [draft, savedValues]);
+  const hasErrors: boolean = Object.keys(errors).length > 0;
+
+  return {
+    draft,
+    errors,
+    dirty,
+    hasErrors,
+    addRow,
+    removeRow,
+    changeRow,
+    blurRow,
+    reset,
+    validateAll,
+    buildPayload,
+  };
+}

--- a/frontend/apps/console/src/features/settings/models/responses.ts
+++ b/frontend/apps/console/src/features/settings/models/responses.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface RegexOrigin {
+  regex: string;
+}
+
+/**
+ * A single allowed origin: a literal string (including the `"null"` literal) or a regex entry.
+ */
+export type AllowedOrigin = string | RegexOrigin;
+
+export interface CorsValue {
+  allowedOrigins: AllowedOrigin[];
+}
+
+/**
+ * A server-config section returned as three layers: `readOnly` (declarative), `writable`
+ * (runtime-mutable), and `merged` (effective).
+ */
+export interface ServerConfigLayers<T> {
+  /** Declarative baseline, not editable at runtime */
+  readOnly: T;
+  /** Runtime-mutable layer edited through the console */
+  writable: T;
+  /** Effective union of the read-only and writable layers */
+  merged: T;
+}
+
+export type CorsConfigResponse = ServerConfigLayers<CorsValue>;

--- a/frontend/apps/console/src/features/settings/pages/SettingsPage.tsx
+++ b/frontend/apps/console/src/features/settings/pages/SettingsPage.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, PageContent, PageTitle, Tab, Tabs} from '@wso2/oxygen-ui';
+import {useState, type JSX, type SyntheticEvent} from 'react';
+import {useTranslation} from 'react-i18next';
+import CorsSection from '../components/cors/CorsSection';
+
+export default function SettingsPage(): JSX.Element {
+  const {t} = useTranslation();
+  // Controlled Tabs; only the CORS tab exists for now.
+  const [activeTab, setActiveTab] = useState(0);
+
+  const handleTabChange = (_event: SyntheticEvent, newValue: number): void => {
+    setActiveTab(newValue);
+  };
+
+  return (
+    <PageContent>
+      <PageTitle>
+        <PageTitle.Header>{t('settings:page.title')}</PageTitle.Header>
+        <PageTitle.SubHeader>{t('settings:page.subtitle')}</PageTitle.SubHeader>
+      </PageTitle>
+
+      <Tabs value={activeTab} onChange={handleTabChange} aria-label={t('settings:tabs.ariaLabel')}>
+        <Tab
+          label={t('settings:tabs.cors')}
+          id="settings-tab-0"
+          aria-controls="settings-tabpanel-0"
+          sx={{textTransform: 'none'}}
+        />
+      </Tabs>
+
+      <Box role="tabpanel" id="settings-tabpanel-0" aria-labelledby="settings-tab-0" sx={{py: 3}}>
+        <CorsSection />
+      </Box>
+    </PageContent>
+  );
+}

--- a/frontend/apps/console/src/features/settings/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/apps/console/src/features/settings/pages/__tests__/SettingsPage.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {renderWithProviders} from '@thunderid/test-utils';
+import {describe, it, expect, vi} from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}));
+
+vi.mock('../../components/cors/CorsSection', () => ({
+  default: () => <div data-testid="cors-section" />,
+}));
+
+const {default: SettingsPage} = await import('../SettingsPage');
+
+describe('SettingsPage', () => {
+  it('renders the title, subtitle, the CORS tab, and the CORS panel', () => {
+    renderWithProviders(<SettingsPage />);
+
+    expect(screen.getByText('settings:page.title')).toBeInTheDocument();
+    expect(screen.getByText('settings:page.subtitle')).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'settings:tabs.cors'})).toBeInTheDocument();
+    expect(screen.getByTestId('cors-section')).toBeInTheDocument();
+  });
+
+  it('keeps the CORS panel active when its tab is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SettingsPage />);
+    await user.click(screen.getByRole('tab', {name: 'settings:tabs.cors'}));
+    expect(screen.getByTestId('cors-section')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/settings/utils/__tests__/baselineKey.test.ts
+++ b/frontend/apps/console/src/features/settings/utils/__tests__/baselineKey.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import baselineKey from '../baselineKey';
+
+describe('baselineKey', () => {
+  it('is equal for inputs that normalize to the same origins', () => {
+    expect(baselineKey(['HTTPS://App.IO/', ''])).toBe(baselineKey(['https://app.io']));
+  });
+
+  it('differs when the origins differ', () => {
+    expect(baselineKey(['https://a.io'])).not.toBe(baselineKey(['https://b.io']));
+  });
+
+  it('is order-sensitive', () => {
+    expect(baselineKey(['https://a.io', 'https://b.io'])).not.toBe(baselineKey(['https://b.io', 'https://a.io']));
+  });
+});

--- a/frontend/apps/console/src/features/settings/utils/__tests__/isStringOrigin.test.ts
+++ b/frontend/apps/console/src/features/settings/utils/__tests__/isStringOrigin.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import type {AllowedOrigin} from '../../models/responses';
+import isStringOrigin from '../isStringOrigin';
+
+describe('isStringOrigin', () => {
+  it('returns true for a literal string origin', () => {
+    expect(isStringOrigin('https://app.example.com')).toBe(true);
+  });
+
+  it('treats the "null" literal as a string origin', () => {
+    expect(isStringOrigin('null')).toBe(true);
+  });
+
+  it('returns false for a regex entry', () => {
+    const entry: AllowedOrigin = {regex: '^https://x$'};
+    expect(isStringOrigin(entry)).toBe(false);
+  });
+});

--- a/frontend/apps/console/src/features/settings/utils/__tests__/normalizedNonEmpty.test.ts
+++ b/frontend/apps/console/src/features/settings/utils/__tests__/normalizedNonEmpty.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import normalizedNonEmpty from '../normalizedNonEmpty';
+
+describe('normalizedNonEmpty', () => {
+  it('normalizes each value (lowercase + trailing slash) and preserves order', () => {
+    expect(normalizedNonEmpty(['HTTPS://Example.COM/', 'https://app.io'])).toEqual([
+      'https://example.com',
+      'https://app.io',
+    ]);
+  });
+
+  it('drops empty and whitespace-only entries', () => {
+    expect(normalizedNonEmpty(['', '   ', 'https://app.io'])).toEqual(['https://app.io']);
+  });
+
+  it('returns an empty array when there are no non-empty values', () => {
+    expect(normalizedNonEmpty(['', '  '])).toEqual([]);
+  });
+});

--- a/frontend/apps/console/src/features/settings/utils/__tests__/origin.test.ts
+++ b/frontend/apps/console/src/features/settings/utils/__tests__/origin.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {isValidOrigin, isValidRegex, normalizeOrigin} from '../origin';
+
+describe('isValidOrigin', () => {
+  it.each(['https://app.example.com', 'http://localhost:3000', 'https://example.com:8443', 'https://[::1]:8443'])(
+    'accepts the valid origin %s',
+    (value) => {
+      expect(isValidOrigin(value)).toBe(true);
+    },
+  );
+
+  it('accepts the "null" literal', () => {
+    expect(isValidOrigin('null')).toBe(true);
+  });
+
+  it.each([
+    '',
+    'https://example.com/path',
+    'https://example.com/foo/..',
+    'https://example.com/.',
+    'http:example.com/..',
+    'https:example.com',
+    'https://example.com\\path',
+    'https://example.com?q=1',
+    'https://example.com#frag',
+    'https://user@example.com',
+    'ftp://example.com',
+    'https://*.example.com',
+    '*',
+  ])('rejects the non-origin %s', (value) => {
+    expect(isValidOrigin(value)).toBe(false);
+  });
+});
+
+describe('isValidRegex', () => {
+  it.each(['^https://.*\\.example\\.com$', 'abc', 'https://example.com/path'])(
+    'accepts the compilable pattern %s',
+    (value) => {
+      expect(isValidRegex(value)).toBe(true);
+    },
+  );
+
+  it.each(['', '[', '(unbalanced'])('rejects the non-compilable pattern %s', (value) => {
+    expect(isValidRegex(value)).toBe(false);
+  });
+});
+
+describe('normalizeOrigin', () => {
+  it('lowercases scheme and host and strips a trailing slash', () => {
+    expect(normalizeOrigin('HTTPS://Example.COM/')).toBe('https://example.com');
+  });
+
+  it('preserves an explicit default port (unlike URL.origin)', () => {
+    expect(normalizeOrigin('https://example.com:443')).toBe('https://example.com:443');
+    expect(normalizeOrigin('https://example.com')).not.toBe(normalizeOrigin('https://example.com:443'));
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeOrigin('  https://app.io  ')).toBe('https://app.io');
+  });
+
+  it('leaves the "null" literal and regex/invalid input unchanged', () => {
+    expect(normalizeOrigin('null')).toBe('null');
+    expect(normalizeOrigin('^https://x$')).toBe('^https://x$');
+    expect(normalizeOrigin('')).toBe('');
+  });
+});

--- a/frontend/apps/console/src/features/settings/utils/__tests__/originValueText.test.ts
+++ b/frontend/apps/console/src/features/settings/utils/__tests__/originValueText.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import originValueText from '../originValueText';
+
+describe('originValueText', () => {
+  it('returns a string origin unchanged', () => {
+    expect(originValueText('https://app.example.com')).toBe('https://app.example.com');
+  });
+
+  it('returns the pattern of a regex entry', () => {
+    expect(originValueText({regex: '^https://[a-z]+\\.acme\\.io$'})).toBe('^https://[a-z]+\\.acme\\.io$');
+  });
+});

--- a/frontend/apps/console/src/features/settings/utils/baselineKey.ts
+++ b/frontend/apps/console/src/features/settings/utils/baselineKey.ts
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
@@ -6,17 +6,24 @@
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
-export { ConsoleSigninPage } from "./authentication";
-export { UsersPage, type UserFormData } from "./user-management";
-export { ApplicationsPage, type ApplicationFormData } from "./applications";
-export { SettingsPage } from "./settings";
+import normalizedNonEmpty from './normalizedNonEmpty';
+
+/**
+ * Builds a stable key for a set of origins, used to compare a draft against its saved baseline.
+ *
+ * @param values - The origin values to key
+ * @returns A stable string key derived from the normalized, non-empty origins
+ */
+export default function baselineKey(values: string[]): string {
+  return JSON.stringify(normalizedNonEmpty(values));
+}

--- a/frontend/apps/console/src/features/settings/utils/isStringOrigin.ts
+++ b/frontend/apps/console/src/features/settings/utils/isStringOrigin.ts
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
@@ -6,17 +6,24 @@
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
-export { ConsoleSigninPage } from "./authentication";
-export { UsersPage, type UserFormData } from "./user-management";
-export { ApplicationsPage, type ApplicationFormData } from "./applications";
-export { SettingsPage } from "./settings";
+import type {AllowedOrigin} from '../models/responses';
+
+/**
+ * Type guard for a literal (string) allowed origin, distinguishing it from a `{regex}` entry.
+ *
+ * @param entry - The allowed origin to test
+ * @returns Whether the entry is a literal string origin
+ */
+export default function isStringOrigin(entry: AllowedOrigin): entry is string {
+  return typeof entry === 'string';
+}

--- a/frontend/apps/console/src/features/settings/utils/normalizedNonEmpty.ts
+++ b/frontend/apps/console/src/features/settings/utils/normalizedNonEmpty.ts
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
@@ -6,17 +6,24 @@
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
-export { ConsoleSigninPage } from "./authentication";
-export { UsersPage, type UserFormData } from "./user-management";
-export { ApplicationsPage, type ApplicationFormData } from "./applications";
-export { SettingsPage } from "./settings";
+import {normalizeOrigin} from './origin';
+
+/**
+ * Normalizes each value and drops the empty ones.
+ *
+ * @param values - The raw origin values to normalize
+ * @returns The normalized origins with empty entries removed
+ */
+export default function normalizedNonEmpty(values: string[]): string[] {
+  return values.map(normalizeOrigin).filter((value) => value !== '');
+}

--- a/frontend/apps/console/src/features/settings/utils/origin.ts
+++ b/frontend/apps/console/src/features/settings/utils/origin.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Parses a CORS origin and rejects values with userinfo, paths, query strings, fragments, or
+ * wildcards. IPv6 hosts are accepted.
+ */
+function parseOrigin(raw: string): URL | null {
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed.includes('*')) {
+    return null;
+  }
+  // Validate the raw shape before new URL() can normalize a disguised path into a bare origin
+  // (e.g. `https://host/foo/..` → `/`) or accept a scheme-relative form like `http:host/..`.
+  const schemeEnd = trimmed.indexOf(':');
+  if (schemeEnd === -1 || trimmed.slice(schemeEnd + 1, schemeEnd + 3) !== '//') {
+    return null;
+  }
+  const authority = trimmed.slice(schemeEnd + 3);
+  const boundary = authority.search(/[/\\?#]/);
+  if (boundary !== -1 && authority.slice(boundary) !== '/') {
+    return null;
+  }
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return null;
+  }
+  if (url.username !== '' || url.password !== '') {
+    return null;
+  }
+  return url;
+}
+
+/**
+ * Canonicalizes an origin: trims and, for a valid origin, lowercases it and strips a trailing slash.
+ * Unlike `URL.origin`, an explicit default port is preserved, so `https://example.com` and
+ * `https://example.com:443` stay distinct.
+ */
+export function normalizeOrigin(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed === 'null') {
+    return trimmed;
+  }
+  if (parseOrigin(trimmed) === null) {
+    return trimmed;
+  }
+  return trimmed.replace(/\/+$/, '').toLowerCase();
+}
+
+/**
+ * Reports whether a value is a literal origin, including the `"null"` origin.
+ */
+export function isValidOrigin(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed === 'null' || parseOrigin(trimmed) !== null;
+}
+
+/**
+ * Reports whether a value compiles as a JavaScript regular expression. The backend remains the
+ * authoritative regex validator because it uses RE2 semantics.
+ */
+export function isValidRegex(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return false;
+  }
+  try {
+    return Boolean(new RegExp(trimmed));
+  } catch {
+    return false;
+  }
+}

--- a/frontend/apps/console/src/features/settings/utils/originValueText.ts
+++ b/frontend/apps/console/src/features/settings/utils/originValueText.ts
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
@@ -6,17 +6,25 @@
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
-export { ConsoleSigninPage } from "./authentication";
-export { UsersPage, type UserFormData } from "./user-management";
-export { ApplicationsPage, type ApplicationFormData } from "./applications";
-export { SettingsPage } from "./settings";
+import isStringOrigin from './isStringOrigin';
+import type {AllowedOrigin} from '../models/responses';
+
+/**
+ * Returns the editable text for an allowed origin entry.
+ *
+ * @param entry - The allowed origin entry
+ * @returns The literal string, or the pattern of a regex entry
+ */
+export default function originValueText(entry: AllowedOrigin): string {
+  return isStringOrigin(entry) ? entry : entry.regex;
+}

--- a/frontend/apps/console/src/layouts/DashboardLayout.tsx
+++ b/frontend/apps/console/src/layouts/DashboardLayout.tsx
@@ -44,6 +44,7 @@ import {
   LayoutGrid,
   Palette,
   Server,
+  Settings,
   ShieldCheck,
   SquareArrowRightEnter,
   UserRoundCog,
@@ -280,6 +281,17 @@ export default function DashboardLayout(): ReactNode {
             text: t('navigation:pages.translations'),
             icon: <Languages size={16} />,
             path: '/translations',
+          },
+        ],
+      },
+      {
+        category: t('navigation:categories.system'),
+        routes: [
+          {
+            id: 'settings',
+            text: t('navigation:pages.settings'),
+            icon: <Settings size={16} />,
+            path: '/settings',
           },
         ],
       },

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -631,6 +631,7 @@ const translations = {
     'categories.resources': 'Resources',
     'categories.configure': 'Configure',
     'categories.customize': 'Customize',
+    'categories.system': 'System',
     'pages.importConfiguration': 'Import Configuration',
     'pages.openProject': 'Import Configuration',
     'pages.home': 'Home',
@@ -651,6 +652,7 @@ const translations = {
     'pages.flows': 'Flows',
     'pages.design': 'Design',
     'pages.translations': 'Translations',
+    'pages.settings': 'Settings',
     'breadcrumb.console': 'Console',
   },
 
@@ -3769,6 +3771,31 @@ const translations = {
     'delete.disclaimer': 'Wallets will no longer be able to request this credential.',
     'delete.success': 'Credential configuration deleted',
     'delete.error': 'Failed to delete credential configuration',
+  },
+
+  // ============================================================================
+  // Settings namespace - Server-wide settings translations
+  // ============================================================================
+  settings: {
+    'page.title': 'Settings',
+    'page.subtitle': 'Settings that apply across your entire ThunderID deployment.',
+    'tabs.ariaLabel': 'Settings sections',
+    'tabs.cors': 'CORS',
+    'cors.card.title': 'Allowed origins',
+    'cors.card.description': 'Manage which origins are allowed to access your APIs.',
+    'cors.readOnlyHint': "Some origins are read-only because they're managed declaratively.",
+    'cors.addOrigin': 'Add origin',
+    'cors.originPlaceholder': 'https://app.example.com',
+    'cors.removeOrigin': 'Remove origin',
+    'cors.validation.invalid': 'Enter a valid origin (e.g. https://app.example.com) or a valid regular expression.',
+    'cors.validation.duplicate': 'This origin is already in the list.',
+    'cors.unsavedChanges': 'You have unsaved changes',
+    'cors.discard': 'Discard',
+    'cors.save': 'Save changes',
+    'cors.saving': 'Saving…',
+    'cors.load.error': 'Failed to load allowed origins.',
+    'cors.save.success': 'Allowed origins updated.',
+    'cors.save.error': 'Failed to update allowed origins.',
   },
 } as const;
 

--- a/tests/e2e/fixtures/console/console-pom.fixture.ts
+++ b/tests/e2e/fixtures/console/console-pom.fixture.ts
@@ -29,6 +29,7 @@ import { test as base } from "./console-auth.fixture";
 import { ConsoleSigninPage } from "../../pages/authentication";
 import { UsersPage } from "../../pages/user-management";
 import { ApplicationsPage } from "../../pages/applications";
+import { SettingsPage } from "../../pages/settings";
 
 const baseUrl = process.env.BASE_URL || "";
 
@@ -36,6 +37,7 @@ type POMFixtures = {
   signinPage: ConsoleSigninPage;
   usersPage: UsersPage;
   applicationsPage: ApplicationsPage;
+  settingsPage: SettingsPage;
 };
 
 export const test = base.extend<POMFixtures>({
@@ -53,9 +55,15 @@ export const test = base.extend<POMFixtures>({
   applicationsPage: async ({ authenticatedPage }, use) => {
     await use(new ApplicationsPage(authenticatedPage, baseUrl));
   },
+
+  // Settings page requires auth, uses authenticatedPage fixture
+  settingsPage: async ({ authenticatedPage }, use) => {
+    await use(new SettingsPage(authenticatedPage, baseUrl));
+  },
 });
 
 export { expect } from "@playwright/test";
 export { ConsoleSigninPage } from "../../pages/authentication";
 export { UsersPage, type UserFormData } from "../../pages/user-management";
 export { ApplicationsPage, type ApplicationFormData } from "../../pages/applications";
+export { SettingsPage } from "../../pages/settings";

--- a/tests/e2e/fixtures/console/index.ts
+++ b/tests/e2e/fixtures/console/index.ts
@@ -41,3 +41,4 @@ export { routes, ConsoleRoutes };
 export { ConsoleSigninPage } from "../../pages/authentication";
 export { UsersPage, type UserFormData } from "../../pages/user-management";
 export { ApplicationsPage, type ApplicationFormData } from "../../pages/applications";
+export { SettingsPage } from "../../pages/settings";

--- a/tests/e2e/pages/settings/index.ts
+++ b/tests/e2e/pages/settings/index.ts
@@ -16,7 +16,8 @@
  * under the License.
  */
 
-export { ConsoleSigninPage } from "./authentication";
-export { UsersPage, type UserFormData } from "./user-management";
-export { ApplicationsPage, type ApplicationFormData } from "./applications";
-export { SettingsPage } from "./settings";
+/**
+ * Settings Pages Index
+ */
+
+export { SettingsPage } from "./settings.page";

--- a/tests/e2e/pages/settings/settings.page.ts
+++ b/tests/e2e/pages/settings/settings.page.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Settings Page Object Model (CORS allowed origins)
+ *
+ * Encapsulates the Settings > CORS panel: adding/removing custom allowed origins and saving.
+ *
+ * @example
+ * const settingsPage = new SettingsPage(page, baseUrl);
+ * await settingsPage.goto();
+ * await settingsPage.addAllowedOrigin("https://app.example.com");
+ */
+
+import { Page, Locator, expect } from "@playwright/test";
+import { ConsoleRoutes } from "../../configs/routes/console-routes";
+import { BasePage } from "../base.page";
+import { Timeouts } from "../../constants/timeouts";
+
+// Matches the placeholder rendered on each editable (custom) origin input.
+const ORIGIN_PLACEHOLDER = "https://app.example.com";
+
+export class SettingsPage extends BasePage {
+  readonly baseUrl: string;
+
+  readonly corsTab: Locator;
+  readonly addOriginButton: Locator;
+  readonly saveButton: Locator;
+  readonly discardButton: Locator;
+  // Editable (custom) origin inputs and their delete buttons render in the same row order,
+  // so the Nth input aligns with the Nth remove button. Read-only rows carry neither.
+  readonly originInputs: Locator;
+  readonly removeButtons: Locator;
+
+  constructor(page: Page, baseUrl: string) {
+    super(page);
+    this.baseUrl = baseUrl;
+
+    this.corsTab = page.getByRole("tab", { name: /cors/i });
+    this.addOriginButton = page.getByRole("button", { name: /add origin/i });
+    this.saveButton = page.getByRole("button", { name: /save changes/i });
+    this.discardButton = page.getByRole("button", { name: /discard/i });
+    this.originInputs = page.getByPlaceholder(ORIGIN_PLACEHOLDER);
+    this.removeButtons = page.getByRole("button", { name: /remove origin/i });
+  }
+
+  /** Navigate to the Settings (CORS) page. */
+  async goto() {
+    await this.page.goto(`${this.baseUrl}${ConsoleRoutes.settings}`, {
+      waitUntil: "networkidle",
+      timeout: Timeouts.PAGE_LOAD,
+    });
+    await this.corsTab.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+  }
+
+  /** Index of the editable row holding the given origin, or -1 if absent. */
+  private async indexOfOrigin(origin: string): Promise<number> {
+    const count = await this.originInputs.count();
+    for (let i = 0; i < count; i++) {
+      if ((await this.originInputs.nth(i).inputValue()) === origin) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /** Whether a custom (editable) origin with the given value is currently listed. */
+  async hasCustomOrigin(origin: string): Promise<boolean> {
+    return (await this.indexOfOrigin(origin)) !== -1;
+  }
+
+  /** Add a custom allowed origin and persist it. */
+  async addAllowedOrigin(origin: string) {
+    await this.addOriginButton.click();
+    const input = this.originInputs.last();
+    await input.fill(origin);
+    await input.blur();
+    await this.save();
+  }
+
+  /** Remove a custom allowed origin (no-op if absent) and persist. */
+  async removeAllowedOrigin(origin: string) {
+    const index = await this.indexOfOrigin(origin);
+    if (index === -1) {
+      return;
+    }
+    await this.removeButtons.nth(index).click();
+    await this.save();
+  }
+
+  /** Click Save changes and wait for the unsaved-changes bar to clear (success). */
+  private async save() {
+    await expect(this.saveButton).toBeEnabled({ timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.saveButton.click();
+    await expect(this.saveButton).toBeHidden({ timeout: Timeouts.ELEMENT_VISIBILITY });
+  }
+}

--- a/tests/e2e/tests/settings/cors-allowed-origins.spec.ts
+++ b/tests/e2e/tests/settings/cors-allowed-origins.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Settings — CORS allowed origins (end-to-end)
+ *
+ * Verifies that configuring a custom allowed origin through the console changes the server's CORS
+ * decision at runtime, without a server restart: an unconfigured origin is not echoed back, and once
+ * added via the console the server echoes it in Access-Control-Allow-Origin.
+ *
+ * Each check sends a GET to a CORS-wrapped public endpoint (the OIDC discovery document) with an
+ * explicit `Origin` header and asserts on the server's Access-Control-Allow-Origin response header.
+ *
+ * Required environment variables:
+ *   - BASE_URL: ThunderID server URL (default https://localhost:8090).
+ *   - SAMPLE_APP_URL: probe origin that is NOT in the CORS baseline (default https://localhost:3000).
+ */
+
+import { test, expect } from "../../fixtures/console";
+import { TestTags } from "../../constants/test-tags";
+import type { Page } from "@playwright/test";
+
+const BASE_URL = process.env.BASE_URL || "https://localhost:8090";
+const DISCOVERY_PATH = "/.well-known/openid-configuration";
+// Used only as an `Origin` header value; it must not be part of the CORS baseline.
+const TEST_ORIGIN = (process.env.SAMPLE_APP_URL || "https://localhost:3000").replace(/\/$/, "");
+
+/**
+ * Sends a GET to the CORS-wrapped discovery endpoint with `TEST_ORIGIN` as the `Origin` header and
+ * returns the server's Access-Control-Allow-Origin response header — `undefined` when the origin is
+ * not allowed.
+ */
+async function corsAllowOriginHeader(page: Page): Promise<string | undefined> {
+  // Use the request client to avoid page navigation, CSP, or on-load redirects.
+  const response = await page.request.get(`${BASE_URL}${DISCOVERY_PATH}`, {
+    headers: { Origin: TEST_ORIGIN },
+    failOnStatusCode: false,
+  });
+  return response.headers()["access-control-allow-origin"];
+}
+
+test.describe("Settings — CORS allowed origins", { tag: [TestTags.SMOKE] }, () => {
+  test.beforeEach(async ({ settingsPage }) => {
+    // Ensure a clean starting state (origin not yet configured).
+    await settingsPage.goto();
+    await settingsPage.removeAllowedOrigin(TEST_ORIGIN);
+  });
+
+  test.afterEach(async ({ settingsPage }) => {
+    // Remove the origin added by the test so the shared deployment config stays clean.
+    await settingsPage.goto();
+    await settingsPage.removeAllowedOrigin(TEST_ORIGIN);
+  });
+
+  test("denies a cross-origin request from an origin that is not configured", async ({ settingsPage }) => {
+    const acao = await corsAllowOriginHeader(settingsPage.page);
+    expect(acao, "an unconfigured origin must not be echoed in Access-Control-Allow-Origin").toBeUndefined();
+  });
+
+  test("persists a new allowed origin added through the console", async ({ settingsPage }) => {
+    await settingsPage.addAllowedOrigin(TEST_ORIGIN);
+    expect(await settingsPage.hasCustomOrigin(TEST_ORIGIN)).toBe(true);
+  });
+
+  test("allows a cross-origin request once the origin is configured (no server restart)", async ({ settingsPage }) => {
+    await settingsPage.addAllowedOrigin(TEST_ORIGIN);
+
+    const acao = await corsAllowOriginHeader(settingsPage.page);
+    expect(acao, "a configured origin must be echoed in Access-Control-Allow-Origin").toBe(TEST_ORIGIN);
+  });
+
+  test("denies the origin again after it is removed through the console", async ({ settingsPage }) => {
+    await settingsPage.addAllowedOrigin(TEST_ORIGIN);
+    await settingsPage.removeAllowedOrigin(TEST_ORIGIN);
+
+    expect(await settingsPage.hasCustomOrigin(TEST_ORIGIN)).toBe(false);
+    const acao = await corsAllowOriginHeader(settingsPage.page);
+    expect(acao, "a removed origin must no longer be echoed in Access-Control-Allow-Origin").toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Purpose

Adds a **Server Configurations UI** to the Console so administrators can view and manage
server-wide configuration from the browser instead of only through REST APIs. Server-wide
config (introduced in #3424) and Dynamic CORS (#3260) were previously API-only, which is not
administrator-friendly.

This PR introduces a new **Settings** page with a tabbed layout and lands the first section:
**Dynamic CORS Allowed Origins**. Administrators can view declarative (read-only) origins,
add/remove runtime-managed origins, and persist them with immediate effect (no server restart).

<img width="1502" height="859" alt="Screenshot 2026-07-02 at 20 06 01" src="https://github.com/user-attachments/assets/78366a78-12cf-4988-9108-1e522434ade2" />

<img width="1512" height="861" alt="Screenshot 2026-07-02 at 20 07 14" src="https://github.com/user-attachments/assets/6753eb1a-98b0-4b32-8843-0982449d2d7e" />


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->

### Approach

- **New `settings` feature module** in the console app (`api`, `components`, `constants`,
  `hooks`, `models`, `pages`, `utils`), exposed at the `/settings` route and surfaced under a
  new **System** navigation category.
- **Data model — three layers.** `GET`/`PUT /server-config/cors` returns the section as
  `readOnly` (declarative baseline), `writable` (runtime-mutable), and `merged` (effective).
  The UI renders read-only origins as disabled rows and lets admins edit only the writable set.
  Regex origin entries are passed through unchanged (the UI never authors them, but never drops them).
- **Editing follows the repo's existing overlay pattern** used by `RoleEditPage` /
  `ApplicationEditPage` (`edited ?? server` + `UnsavedChangesBar`), factored here into a dedicated
  `useAllowedOriginsDraft` hook. It holds local edits as an overlay so background refetches never
  clobber in-progress edits, and centralizes add/remove/change/blur, normalization, origin-or-regex
  validation, duplicate detection (including against read-only origins), dirty tracking, and PUT
  payload building.
- **Save behaviour.** `PUT` returns the full authoritative config, which is written straight into
  the TanStack Query cache (no follow-up refetch) with a success toast; the shared
  `UnsavedChangesBar` drives discard/save.
- **Tests.** Unit tests for the API hooks, the draft hook, the origin utils, the CORS section, and
  the settings page; plus an e2e smoke spec asserting the server's actual
  `Access-Control-Allow-Origin` decision changes at runtime after an origin is added/removed through
  the console.

### Related Issues
- Fixes #3611
- Context: #3424 (server-config APIs), #3260 (Dynamic CORS)

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [x] Integration Tests (e2e: `tests/e2e/tests/settings/cors-allowed-origins.spec.ts`)
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added **System → Settings** and a **/settings** page with a **CORS** tab.
  * Enabled **CORS allowed origins** management: load, edit, add/remove rows, save/discard, and handle both literal origins and **regex** patterns.
* **Bug Fixes**
  * Improved origin normalization and validation, including duplicate/conflict detection and consistent formatting.
* **Tests**
  * Added unit, component, and end-to-end coverage verifying UI behavior and runtime CORS header changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->