### PR TITLE
Add verifiable credentials samples, try-out and protocol docs

### DIFF
--- a/.vale/styles/config/vocabularies/vocab/accept.txt
+++ b/.vale/styles/config/vocabularies/vocab/accept.txt
@@ -223,3 +223,5 @@ token_url
 static_token
 tls_verify
 refresh_skew
+Lissi
+[Dd]isclosable

--- a/docs/content/guides/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/guides/flows/advanced-configurations.mdx
@@ -1995,6 +1995,7 @@ Initiates an OpenID4VP presentation request and, on each subsequent poll, checks
 | Property | UI Label | Required | Default | Description |
 |---|---|---|---|---|
 | `presentation_definition_id` | Presentation Definition | No | `eudi-pid` | The identifier of the presentation definition to request. Must match a definition registered in the server configuration. |
+| `allowAuthenticationWithoutLocalUser` | Allow Auth Without Local User | No | `false` | When `true` in an authentication flow, sets the `userEligibleForProvisioning` runtime flag on completion so a downstream Provisioning executor can create the account. |
 
 **Input Configuration:** None. The executor generates the request internally; no user inputs are required.
 
@@ -2008,7 +2009,7 @@ Initiates an OpenID4VP presentation request and, on each subsequent poll, checks
 
 2. On **subsequent executions** (state present in runtime data): polls the request state. Returns `INCOMPLETE` again (re-emitting the QR data) if the wallet has not yet responded; completes the flow if the credential is verified; fails the flow if verification fails or the request expires.
 
-3. On **completion**: sets `AuthenticatedUser` with the verified holder's `subject` and all selectively disclosed credential claims, plus `openid4vp_issuer` and `openid4vp_vct` attributes. If an existing local account matches the disclosed attributes, `AuthenticatedUser.UserID` is populated automatically. If no existing local account is found, the runtime data `userEligibleForProvisioning` flag is set so a downstream **Provisioning** executor can create the account.
+3. On **completion**: sets `AuthenticatedUser` with the verified holder's `subject` and all selectively disclosed credential claims. If an existing local account matches the disclosed attributes, `AuthenticatedUser.UserID` is populated automatically. When `allowAuthenticationWithoutLocalUser` is `true`, the `userEligibleForProvisioning` runtime flag is set so a downstream **Provisioning** executor can create the account.
 
 **Example:**
 

--- a/docs/content/guides/guides/protocols/openid4vc/index.mdx
+++ b/docs/content/guides/guides/protocols/openid4vc/index.mdx
@@ -6,10 +6,13 @@ description: Catalogue of verifiable credential specifications implemented by {{
 
 # Verifiable Credentials
 
-<ProductName /> implements **OpenID for Verifiable Presentations (OpenID4VP)** — the protocol for requesting and verifying digital identity credentials held in a user's wallet. Verifiable credentials complement the OAuth 2.1 and OpenID Connect stack: instead of prompting for a username and password, the relying party requests cryptographic proof from an existing government- or institution-issued credential.
+<ProductName /> implements the OpenID for Verifiable Credentials family of specifications — both issuance and presentation — allowing you to issue digital identity credentials to wallets and accept cryptographic proof of those credentials at relying parties.
+
+Verifiable credentials complement the OAuth 2.1 and OpenID Connect stack: instead of prompting for a username and password, the relying party requests cryptographic proof from an existing government- or institution-issued credential.
 
 For other identity standards, see the [Protocols & Standards](../) overview.
 
 | Protocol | Spec | Summary |
 |---|---|---|
+| [OpenID for Verifiable Credential Issuance](./openid4vci) | OpenID4VCI draft | Issue SD-JWT VCs to digital wallets via the OAuth 2.1 authorization code grant. |
 | [OpenID for Verifiable Presentations](./openid4vp) | OpenID4VP draft | Request an SD-JWT VC from a wallet and verify the presentation response in-band. |

--- a/docs/content/guides/guides/protocols/openid4vc/openid4vci.mdx
+++ b/docs/content/guides/guides/protocols/openid4vc/openid4vci.mdx
@@ -1,0 +1,164 @@
+---
+title: OpenID for Verifiable Credential Issuance (OpenID4VCI)
+sidebar_position: 1
+description: OpenID4VCI in {{ProductName}} — issue SD-JWT VCs to digital wallets via the authorization code grant and generate credential offers for wallet onboarding.
+---
+
+# OpenID for Verifiable Credential Issuance (OpenID4VCI)
+
+**OpenID for Verifiable Credential Issuance** ([OpenID4VCI](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html)) is the protocol wallets use to request a credential from an issuer. <ProductName /> acts as the **credential issuer**: it authenticates the user through the OAuth 2.1 authorization code flow and issues a signed **SD-JWT VC** bound to the wallet's key. The credential can later be presented at relying parties without disclosing unnecessary attributes.
+
+Credential configurations are managed resources you create through the <ProductName /> Console. The issuer engine reflects them immediately in the public metadata document.
+
+## How It Works
+
+<ProductName /> uses the authorization code grant as the issuance flow. The wallet acts as an OAuth client; the user signs in through the normal <ProductName /> login pages.
+
+1. An operator creates a **credential configuration** in the <ProductName /> Console, specifying the credential type (`vct`) and which user profile claims to include as selectively disclosable attributes.
+2. <ProductName /> advertises the credential configuration in its issuer metadata at `GET /.well-known/openid-credential-issuer`.
+3. A relying party (or <ProductName /> itself) generates a **credential offer** — a compact `openid-credential-offer://` deep link the user opens in their wallet.
+4. The wallet resolves the offer and redirects the user to the <ProductName /> authorization endpoint with the credential configuration handle as the OAuth scope.
+5. The user authenticates. <ProductName /> issues an access token scoped to the credential configuration.
+6. The wallet requests a fresh `c_nonce` from `POST /openid4vci/nonce` to bind the credential to its key.
+7. The wallet posts a credential request to `POST /openid4vci/credential` with the access token and a holder proof JWT signed with its private key.
+8. <ProductName /> verifies the access token and holder proof, resolves the user's profile claims, signs an SD-JWT VC bound to the wallet's public key, and returns it.
+
+<details>
+<summary>How <ProductName /> Implements It</summary>
+
+| Aspect | Behavior |
+|---|---|
+| **Credential format** | `dc+sd-jwt`. Every configured claim is individually selectively disclosable. |
+| **Holder binding** | The wallet's public key is embedded in the SD-JWT VC `cnf` claim as a JWK. One credential is issued per holder proof JWT. |
+| **Issuer-initiated offer** | `GET /openid4vci/offer?credential_configuration_id=<handle>` returns the JSON offer and an `openid-credential-offer://` deep link. The stored offer resolves at `GET /openid4vci/credential-offer/{id}` and expires after 5 minutes. |
+| **Proof type** | Holder proofs must use `proof_type: "jwt"` with `typ: openid4vci-proof+jwt`. The `aud` must equal the credential issuer URL; the `nonce` must match a valid, unexpired `c_nonce`. |
+| **Batch issuance** | Multiple proofs may be submitted via `proofs.jwt`. One SD-JWT VC is issued per proof, up to the configured `batch_size`. When `batch_size > 1`, `batch_credential_issuance` is advertised in the metadata. |
+| **DPoP** | When the access token carries `cnf.jkt`, the credential request must include a matching DPoP proof header (RFC 9449). |
+| **Claim sourcing** | Claims are resolved from the user's profile attributes. Missing attributes are silently omitted from the issued credential. Only claims with a `displayName` are advertised in the metadata `claims` object; all configured claims are issued. |
+| **Signing** | Signed with the key set as `signing_key_id`. The certificate chain is included in the SD-JWT VC `x5c` header. Omitting `signing_key_id` disables the issuer engine at startup. |
+| **Scope enforcement** | When `enforce_scope` is enabled, the access token must carry a scope matching the `credential_configuration_id`. |
+
+</details>
+
+## Credential Configurations
+
+A **credential configuration** defines one credential type the issuer can produce. Its `handle` becomes the `credential_configuration_id` in the issuer metadata document and the OAuth scope wallets request.
+
+Manage configurations in **Verifiable Credentials → Templates** in the <ProductName /> Console, or declare them in YAML for file-based deployments (`resource_type: credential_configuration`).
+
+| Field | Description |
+|---|---|
+| **Handle** | Unique identifier for this credential type. Becomes the OAuth scope and `credential_configuration_id` in issuer metadata. Required. |
+| **Credential Type (VCT)** | The `vct` URI that identifies this credential type to wallets and verifiers. Required. |
+| **Claims** | Each entry maps a user profile attribute name to an optional wallet display name. The attribute value is sourced from the user's profile at issuance. Claims with a display name are advertised in the metadata `claims` object; all configured claims are included in the issued credential regardless. |
+| **Display** | Wallet presentation display settings: locale (BCP 47 tag, e.g. `en-US`) and `logoUri` (a hosted image URL shown as the credential logo in the wallet). |
+| **Validity** | Lifetime of issued credentials in seconds. Overrides the server-level `credential_validity_seconds` when set. |
+
+## Server Configurations
+
+Configure the issuer engine under the `openid4vci:` key in `deployment.yaml`. All values can be overridden there; the defaults below come from the built-in server defaults.
+
+| Key | Default | Description |
+|---|---|---|
+| `signing_key_id` | `ecdsa-key` | Key used to sign issued SD-JWT VCs. Must be certificate-backed (`x5c` required). Omitting this key disables the issuer engine entirely. |
+| `credential_issuer` | server URL | The `credential_issuer` identifier in the metadata document. |
+| `base_url` | server URL | Base URL for endpoint URLs advertised in metadata. |
+| `authorization_servers` | `[server URL]` | Authorization server list advertised in metadata. |
+| `nonce_ttl_seconds` | `300` | How long a `c_nonce` is valid (seconds). |
+| `proof_max_age_seconds` | `300` | Maximum age of the holder proof JWT `iat` claim. |
+| `credential_validity_seconds` | `2592000` | Lifetime of issued SD-JWT VCs (seconds; default is 30 days). |
+| `batch_size` | `5` | Maximum number of proofs per credential request. Values above `1` enable batch issuance. |
+| `enforce_scope` | `false` | When `true`, the access token must carry a scope matching the `credential_configuration_id`. |
+
+## Issuer Metadata
+
+`GET /.well-known/openid-credential-issuer` returns the credential issuer metadata document built dynamically from active credential configurations.
+
+```json
+{
+  "credential_issuer": "https://auth.example.com",
+  "credential_endpoint": "https://auth.example.com/openid4vci/credential",
+  "nonce_endpoint": "https://auth.example.com/openid4vci/nonce",
+  "authorization_servers": ["https://auth.example.com"],
+  "credential_configurations_supported": {
+    "example-pid": {
+      "format": "dc+sd-jwt",
+      "scope": "example-pid",
+      "vct": "urn:example:pid:1",
+      "cryptographic_binding_methods_supported": ["jwk"],
+      "credential_signing_alg_values_supported": ["ES256"],
+      "proof_types_supported": {
+        "jwt": { "proof_signing_alg_values_supported": ["ES256"] }
+      },
+      "display": [{ "name": "Example PID" }],
+      "claims": {
+        "given_name": { "display": [{ "name": "First Name" }] }
+      }
+    }
+  }
+}
+```
+
+## Try It in <ProductName />
+
+### Generate a Credential Offer
+
+```http
+GET /openid4vci/offer?credential_configuration_id=example-pid
+```
+
+Response includes the offer JSON and a deep link:
+
+```json
+{
+  "credential_offer": {
+    "credential_issuer": "https://auth.example.com",
+    "credential_configuration_ids": ["example-pid"],
+    "grants": { "authorization_code": {} }
+  },
+  "credential_offer_uri": "openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fauth.example.com%2Fopenid4vci%2Fcredential-offer%2Fabc123"
+}
+```
+
+### Request a `c_nonce` and Issue a Credential
+
+```http
+POST /openid4vci/nonce
+```
+
+```json
+{ "c_nonce": "wKI4LTs208I3EgjkuYpvRQ" }
+```
+
+Then issue the credential with the access token (from the authorization code flow) and a holder proof JWT:
+
+```http
+POST /openid4vci/credential
+Authorization: Bearer <access-token>
+Content-Type: application/json
+
+{
+  "credential_configuration_id": "example-pid",
+  "proof": {
+    "proof_type": "jwt",
+    "jwt": "<holder-proof-jwt>"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "credentials": [{ "credential": "<sd-jwt-vc>" }]
+}
+```
+
+For batch issuance, pass multiple proof JWTs in `proofs.jwt` — one SD-JWT VC is returned per proof.
+
+## Related Guides
+
+- [OpenID for Verifiable Presentations](../openid4vp) — verify a previously issued SD-JWT VC at a relying party
+- [DPoP](../../oauth-oidc/dpop) — bind access tokens to a wallet key to prevent token theft
+- [Authorization Code](../../oauth-oidc/authorization-code) — the underlying grant used in the issuance flow
+- [JWKS](../../oauth-oidc/jwks) — public keys used by wallets to verify the issued credential signature

--- a/docs/content/guides/guides/protocols/openid4vc/openid4vp.mdx
+++ b/docs/content/guides/guides/protocols/openid4vc/openid4vp.mdx
@@ -1,133 +1,110 @@
 ---
 title: OpenID for Verifiable Presentations (OpenID4VP)
-sidebar_position: 1
+sidebar_position: 2
 description: OpenID4VP in {{ProductName}} — request an SD-JWT VC from a digital wallet, verify the presentation response, and authenticate the holder without a password.
 ---
 
 # OpenID for Verifiable Presentations (OpenID4VP)
 
-**OpenID for Verifiable Presentations** ([OpenID4VP](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html)) lets a relying party request cryptographic proof of identity from a credential held in a user's digital wallet. Instead of supplying a username and password, the user's wallet presents a **Selective Disclosure JWT Verifiable Credential (SD-JWT VC)** — a credential signed by a trusted authority such as a government identity provider.
+**OpenID for Verifiable Presentations** ([OpenID4VP](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html)) lets a relying party request cryptographic proof of identity from a credential held in a user's digital wallet. Instead of a username and password, the wallet presents a **Selective Disclosure JWT VC** (SD-JWT VC). The credential is signed by a trusted authority — a government identity provider or a <ProductName /> credential issuer.
 
 <ProductName /> acts as the **verifier**: it generates a signed authorization request, the wallet responds with an encrypted presentation, and <ProductName /> verifies the SD-JWT VC against a configured trust store. On success, it issues a signed result token to the relying party.
 
+Presentation definitions are managed resources you create through the <ProductName /> Console. The verifier engine picks them up immediately when a relying party initiates a verification transaction.
+
 ## How It Works
 
-The protocol uses a polling model with two parallel channels: a **back-channel** between <ProductName /> and the relying party, and an **out-of-band channel** to the wallet via a QR code or deep link.
+The protocol uses a polling model: a **back-channel** between <ProductName /> and the relying party, and an **out-of-band channel** to the wallet via QR code or deep link.
 
-1. The relying party calls `POST /openid4vp/initiate` and receives a transaction identifier, a wallet authorization URI, and a status polling URL.
-2. The relying party displays the wallet authorization URI as a QR code or deep link.
-3. The user scans the QR code. The wallet fetches the signed authorization request from `GET /openid4vp/request`.
-4. The wallet selects matching credentials, applies selective disclosure, and posts the encrypted response to `POST /openid4vp/response`.
-5. <ProductName /> decrypts the response, verifies the SD-JWT VC signature and key binding, and enforces the presentation policy.
-6. The relying party polls `GET /openid4vp/status/{txn_id}` until <ProductName /> returns `COMPLETED` with a signed `result_token`.
-7. The relying party validates the `result_token` to read the verified subject and claims.
+1. An operator creates a **presentation definition** in the <ProductName /> Console, specifying which credential type (`vct`) to request and which claims are mandatory or optional.
+2. The relying party calls `POST /openid4vp/initiate` with the definition `handle` and receives a `txn_id`, `wallet_url`, and `status_url`.
+3. The relying party displays `wallet_url` as a QR code or deep link.
+4. The user scans. The wallet fetches the signed authorization request from `GET /openid4vp/request`.
+5. The wallet selects matching credentials, applies selective disclosure, and posts the encrypted response to `POST /openid4vp/response`.
+6. <ProductName /> decrypts the response, verifies the SD-JWT VC, and enforces the presentation policy.
+7. The relying party polls `GET /openid4vp/status/{txn_id}` until `COMPLETED` with a signed `result_token`.
+8. The relying party validates the `result_token` to read the verified subject and claims.
 
 <details>
 <summary>How <ProductName /> Implements It</summary>
 
 | Aspect | Behavior |
 |---|---|
-| **Client identification** | The verifier's `client_id` is configured directly (e.g. `x509_hash:<thumbprint>`). The optional `client_id_scheme` field is configurable. The wallet receives the signing certificate chain in the request object's `x5c` header. |
-| **Request object (JAR)** | <ProductName /> signs the authorization request as a compact JWS and serves it at `GET /openid4vp/request?state=...` with `Content-Type: application/oauth-authz-req+jwt`. |
-| **Response encryption** | The wallet encrypts its VP token as a compact JWE using ECDH-ES with the ephemeral public key advertised in `client_metadata.jwks`. The encryption algorithm defaults to `A128GCM`. |
-| **Credential format** | SD-JWT VC (`vc+sd-jwt`). The DCQL query targets a specific `vct` (Verifiable Credential Type) and claims list. |
-| **Selective disclosure** | Only the claims listed in `requested_claims` for the matching presentation definition are accepted. The wallet may disclose fewer optional claims, but extra disclosures beyond the list fail verification. |
+| **Client identification** | The verifier's `client_id` is derived from `client_id_scheme` and the signing certificate at startup — not configured directly. Supported schemes: `x509_hash` (SHA-256 thumbprint), `x509_san_dns` (first DNS SAN), `redirect_uri` (response URI). The full certificate chain is included in the request object's `x5c` header. |
+| **Request object (JAR)** | Signed as a compact JWS and served at `GET /openid4vp/request?state=...` with `Content-Type: application/oauth-authz-req+jwt`. |
+| **Response mode** | `direct_post.jwt`. The wallet encrypts its VP token as a compact JWE using ECDH-ES key agreement with `A128GCM` content encryption (configurable via `response_enc_values`). The ephemeral public key is advertised in `client_metadata.jwks`. |
+| **Query language** | DCQL (Digital Credentials Query Language). The query targets a specific `vct` and claims list. |
+| **Credential format** | `dc+sd-jwt`. |
+| **Selective disclosure** | Disclosures beyond the combined requested claims list fail verification. Optional claims may be omitted by the wallet. |
 | **Key binding** | When `enforce_key_binding` is enabled, the wallet must include a `kb+jwt` binding the presentation to the nonce and verifier audience. |
-| **Issuer trust** | When `enforce_trusted_issuer` is enabled, <ProductName /> verifies the SD-JWT issuer signature against a pinned certificate for the issuer URL. |
-| **Result token** | On `COMPLETED`, the status endpoint issues a short-lived signed JWT containing `subject`, `verified_claims`, `txn`, and `definition_id` as claims. |
-| **State TTL** | Each transaction expires after `state_ttl_seconds` (default: 300 seconds). The status endpoint returns `EXPIRED` for past-TTL transactions. |
+| **Issuer trust** | Each definition may override the engine-level default via `enforceTrustedIssuer`. When enabled, the SD-JWT issuer is verified against a pinned certificate. A definition's `trustedAuthorities` restricts which named anchors are acceptable. Active trust anchors are listed at `GET /openid4vp/trust-anchors` (returns `name`, `subject`, `ski`, `not_after` per anchor). |
+| **Claim value constraints** | `claimValues` maps a dotted claim path to an allowed set of values. The constraint is advertised in the DCQL query and enforced at verification — but only when the claim is disclosed; undisclosed claims pass silently. |
+| **Result token** | Signed JWT issued on `COMPLETED`. Claims: `iss`, `sub`, `aud` (issuer URL), `jti`, `txn`, `definition_id`, `subject`, `verified_claims`, `verifier`. |
+| **State TTL** | Transactions expire after `state_ttl_seconds`. The status endpoint returns `EXPIRED` for past-TTL transactions. |
+| **Wallet errors** | A wallet may POST an OAuth error instead of a VP token (OpenID4VP §6.4). <ProductName /> records the error and reflects it as `FAILED` in the status response. |
 
 </details>
 
-## Endpoints
+## Presentation Definitions
 
-### RP-Facing Endpoints
+A **presentation definition** specifies the credential type to request and which claims the wallet must or may disclose. Its `handle` is the `definition_id` used when initiating a verification.
 
-These endpoints are called by the relying party application.
+Manage definitions in **Verifiable Credentials → Presentations** in the <ProductName /> Console, or declare them in YAML for file-based deployments (`resource_type: presentation_definition`).
 
-| Endpoint | Method | Description |
+| Field | Description |
+|---|---|
+| **Handle** | Unique identifier for this definition. Used as the `definition_id` in the initiate request and in flow step configuration. Required. |
+| **Credential Type (VCT)** | The `vct` URI the wallet must present to satisfy this request. Required. |
+| **Claims** | Each entry has a dotted claim path, a requirement (**Mandatory** or **Optional**), and an optional allowed-values list. Mandatory claims must be disclosed; optional claims may be withheld. When allowed values are set, the disclosed value must match one — enforced at verification. Undisclosed optional claims pass silently regardless of allowed values. |
+| **Enforce Trusted Issuer** | When enabled, the SD-JWT VC issuer certificate chain is validated against the engine-level trust anchors. |
+| **Trusted Issuers** | Restricts which named trust anchors are acceptable for this definition. Leave empty to accept any trust anchor configured at the engine level. |
+
+## Server Configurations
+
+Configure the verifier engine under the `openid4vp:` key in `deployment.yaml`. All values can be overridden there; the defaults below come from the built-in server defaults.
+
+| Key | Default | Description |
 |---|---|---|
-| `/openid4vp/initiate` | `POST` | Start a new presentation transaction. Returns `txn_id`, `wallet_url`, `status_url`, and `expires_at`. |
-| `/openid4vp/status/{txn_id}` | `GET` | Poll for transaction status. Returns `PENDING`, `FAILED`, `EXPIRED`, or `COMPLETED` with a `result_token`. |
+| `client_id_scheme` | `x509_san_dns` | How the verifier `client_id` is derived from the signing certificate: `x509_san_dns` (first DNS SAN), `x509_hash` (SHA-256 thumbprint), or `redirect_uri` (response URI). |
+| `signing_key_id` | `ecdsa-key` | Key used to sign request objects. Must be certificate-backed. |
+| `ephemeral_key_id` | `vp-enc` | Key used for ECDH-ES decryption of wallet responses. |
+| `registration_cert_file` | — | Path to a PEM file containing the signing certificate chain advertised in `client_metadata`. |
+| `trusted_anchors` | `[]` | List of `{name, cert_file}` entries. Each entry pins a root CA whose chains are accepted as SD-JWT VC issuer certificates. Empty list disables certificate-chain validation. |
+| `enforce_key_binding` | `true` | Require wallets to include a `kb+jwt` binding the presentation to the nonce and verifier. |
+| `response_enc_values` | `["A128GCM","A256GCM","A128CBC-HS256","A256CBC-HS512"]` | Supported content-encryption algorithms for the wallet's JWE response. |
+| `request_audience` | — | `aud` claim placed in the signed request object sent to the wallet. Omit for `vp_token` flows (some wallets treat a non-empty `aud` as a SIOP request). |
+| `request_validity_seconds` | `300` | How long the signed request object is valid. |
+| `state_ttl_seconds` | `300` | Verification transaction lifetime (seconds). |
+| `leeway_seconds` | `30` | Clock-skew tolerance when validating credential timestamps. |
+| `key_binding_max_age_seconds` | `300` | Maximum age of the key-binding JWT `iat`. |
+| `result_token_validity_seconds` | `300` | Lifetime of the signed result token. |
 
-### Wallet-Facing Endpoints
+`trusted_anchors` is a list of objects:
 
-These endpoints are called by the credential wallet after scanning the QR code.
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/openid4vp/request` | `GET` | Serve the signed authorization request object (JAR) to the wallet. Requires a `state` query parameter. |
-| `/openid4vp/response` | `POST` | Receive the wallet's encrypted VP token response. Accepts `state` and `response` as form parameters. |
+```yaml
+openid4vp:
+  trusted_anchors:
+    - name: my-gov-ca
+      cert_file: /path/to/ca.pem
+```
 
 ## Result Token Claims
 
-When the relying party polls the status endpoint and receives `COMPLETED`, the response includes a signed JWT `result_token`. Validate the token against the <ProductName /> JWKS before trusting its claims.
+When the status endpoint returns `COMPLETED`, the response includes a signed JWT `result_token`. Validate it against the <ProductName /> [JWKS](../../oauth-oidc/jwks) before trusting its claims.
 
 | Claim | Description |
 |---|---|
 | `iss` | The <ProductName /> instance base URL. |
-| `aud` | The relying party identifier supplied in the `POST /openid4vp/initiate` request. |
+| `sub` | The holder's stable identifier — from the credential `sub` claim, or a key-binding thumbprint URN when `sub` is absent. |
+| `aud` | The <ProductName /> issuer URL. |
+| `jti` | Unique token identifier (same value as `txn`). |
 | `txn` | The transaction identifier (`txn_id`). |
-| `definition_id` | The presentation definition identifier that was requested. |
-| `subject` | The holder's stable identifier, derived from the credential's `sub` claim or from the configured `subject_claims` hash. |
-| `verified_claims` | A map of the selectively disclosed claim values from the credential (e.g., `given_name`, `family_name`, `birthdate`). |
+| `definition_id` | The presentation definition handle that was requested. |
+| `subject` | Same as `sub`. |
+| `verified_claims` | Map of selectively disclosed claim values from the credential. |
 | `verifier` | The verifier's `client_id`. |
 
-## Presentation Definitions
-
-A **presentation definition** specifies which credential to request and which claims are mandatory or optional. Define presentation definitions in the `openid4vp.presentation_definitions` array in the server configuration.
-
-| Configuration Key | Required | Description |
-|---|---|---|
-| `id` | Yes | Unique identifier referenced by the relying party or flow executor (e.g., `eudi-pid`). |
-| `display_name` | No | Human-readable name for the credential type. |
-| `credential_id` | Yes | DCQL query credential identifier. |
-| `vct` | Yes | The expected Verifiable Credential Type URI (e.g., `urn:eudi:pid:de:1`). |
-| `mandatory_claims` | No | Claims that must be present in the presentation. Verification fails if any are absent. |
-| `optional_claims` | No | Claims the wallet may disclose. Disclosure of claims not in the combined list is rejected. |
-| `subject_claims` | No | Ordered list of claim names used to derive a stable `subject` identifier when the credential has no `sub` claim. |
-| `trusted_issuers` | No | List of `{ issuer, cert_file }` entries. Required when `enforce_trusted_issuer: true`. |
-
-**Minimal configuration example:**
-
-```json
-{
-  "openid4vp": {
-    "client_id": "x509_hash:<thumbprint>",
-    "signing_key_id": "vp-signing-key",
-    "base_url": "https://auth.example.com",
-    "ephemeral_key_id": "vp-enc-key",
-    "state_ttl_seconds": 300,
-    "enforce_trusted_issuer": true,
-    "enforce_key_binding": true,
-    "presentation_definitions": [
-      {
-        "id": "eudi-pid",
-        "display_name": "EUDI Wallet PID",
-        "credential_id": "pid-sd-jwt",
-        "vct": "urn:eudi:pid:de:1",
-        "mandatory_claims": ["given_name", "family_name"],
-        "optional_claims": ["birthdate"],
-        "subject_claims": ["family_name", "given_name", "birthdate"],
-        "trusted_issuers": [
-          {
-            "issuer": "https://pid-issuer.example.eu/c",
-            "cert_file": "config/certs/pid-issuer.cert"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
 ## Try It in <ProductName />
-
-### Prerequisites
-
-- The OpenID4VP service must be enabled and configured with at least one presentation definition.
-- A certificate-backed signing key (`signing_key_id`) and an ephemeral encryption key (`ephemeral_key_id`) must be registered in the <ProductName /> key store.
-- To enforce issuer trust, add a PEM certificate for each trusted issuer under `trusted_issuers`.
 
 ### Initiate a Presentation Transaction
 
@@ -135,56 +112,44 @@ A **presentation definition** specifies which credential to request and which cl
 POST /openid4vp/initiate
 Content-Type: application/json
 
-{
-  "definition_id": "eudi-pid",
-  "rp_id": "my-application"
-}
+{ "definition_id": "example-pid" }
 ```
 
 Response:
 
 ```json
 {
-  "txn_id": "a1b2c3...",
-  "wallet_url": "openid4vp://?client_id=x509_hash%3A...&request_uri=https%3A%2F%2Fauth.example.com%2Fopenid4vp%2Frequest%3Fstate%3Da1b2c3...",
-  "status_url": "https://auth.example.com/openid4vp/status/a1b2c3...",
+  "txn_id": "a1b2c3d4e5f6",
+  "wallet_url": "openid4vp://?client_id=x509_hash%3A...&request_uri=https%3A%2F%2Fauth.example.com%2Fopenid4vp%2Frequest%3Fstate%3Da1b2c3d4e5f6&request_uri_method=get",
+  "status_url": "/openid4vp/status/a1b2c3d4e5f6",
   "expires_at": "2026-01-01T12:05:00Z"
 }
 ```
 
-Render `wallet_url` as a QR code or as an `openid4vp://` deep link so the user can open the request in their wallet.
-
-### Poll for Status
+Display `wallet_url` as a QR code or deep link. Then poll until the wallet responds:
 
 ```http
-GET /openid4vp/status/a1b2c3...
+GET /openid4vp/status/a1b2c3d4e5f6
 ```
-
-While the wallet is presenting:
-
-```json
-{ "status": "PENDING" }
-```
-
-After successful verification:
 
 ```json
 {
   "status": "COMPLETED",
-  "result_token": "eyJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJteS1hcHBsaWNhdGlvbiIsInN1YmplY3QiOiJl..."
+  "result_token": "<signed-jwt>"
 }
 ```
 
-Decode and verify the `result_token` signature against the <ProductName /> [JWKS](/docs/next/guides/guides/protocols/oauth-oidc/jwks) endpoint, then read `verified_claims` to extract the user's identity attributes.
+Verify the `result_token` signature against the <ProductName /> [JWKS](../../oauth-oidc/jwks) endpoint, then read `verified_claims`.
 
 ### Use in a Sign-In Flow
 
-To integrate OpenID4VP into an authentication flow, add the **Continue with EUDI Wallet** widget or configure the **OpenID4VP Verify** executor directly. The executor manages the initiate-and-poll lifecycle automatically.
+To integrate OpenID4VP into an authentication flow, configure the **OpenID4VP Verify** executor. It manages the initiate-and-poll lifecycle automatically, presenting the wallet QR to the user and resolving their identity on completion.
 
 See [Advanced Configurations — OpenID4VP Verify](/docs/next/guides/guides/flows/advanced-configurations#verifiable-credentials) for the executor reference.
 
 ## Related Guides
 
-- [Advanced Configurations](/docs/next/guides/guides/flows/advanced-configurations) — Flow executor reference, including the OpenID4VP Verify executor
-- [JWKS](/docs/next/guides/guides/protocols/oauth-oidc/jwks) — Verify the `result_token` signature against the <ProductName /> public key endpoint
-- [Flows](/docs/next/guides/guides/flows/what-are-flows) — Build authentication flows that include credential presentation steps
+- [OpenID for Verifiable Credential Issuance](../openid4vci) — issue SD-JWT VCs that users can later present
+- [JWKS](../../oauth-oidc/jwks) — verify the `result_token` signature against the <ProductName /> public key endpoint
+- [Flows](../../../flows/what-are-flows) — build authentication flows that include credential presentation steps
+- [Advanced Configurations](../../../flows/advanced-configurations) — flow executor reference including the OpenID4VP Verify executor

--- a/docs/content/use-cases/ai-agents/configure-it-yourself.mdx
+++ b/docs/content/use-cases/ai-agents/configure-it-yourself.mdx
@@ -244,7 +244,7 @@ Navigate to **Flows** and create a flow with these steps:
 
 Attach the flow to the `WAYFINDER-CONCIERGE` agent (set `auth_flow_handle` on the agent to the flow's handle).
 
-The complete flow definition is in the Wayfinder sample distribution at `thunderid-config/thunderid-config.yaml` under the `wayfinder-agent-auth-flow` entry — copy it as a reference.
+The complete flow definition is in the Wayfinder sample distribution at `thunderid-config/redirect/thunderid-config.yaml` under the `wayfinder-agent-auth-flow` entry — copy it as a reference.
 
 See [Build a Flow](/docs/next/guides/guides/flows/build-a-flow).
 

--- a/docs/content/use-cases/ai-agents/try-it-out.mdx
+++ b/docs/content/use-cases/ai-agents/try-it-out.mdx
@@ -122,7 +122,7 @@ Before you begin, make sure you have:
       - "http://localhost:5173"
   ```
 
-- The Wayfinder sample distribution. The [Get <ProductName />](/docs/next/guides/getting-started/get-thunderid) step above already pulls the archive that ships it. It contains a `thunderid-config/` directory with an importable YAML config and a `thunderid.env` file, plus the Wayfinder web frontend and the Concierge services.
+- The Wayfinder sample distribution. The [Get <ProductName />](/docs/next/guides/getting-started/get-thunderid) step above already pulls the archive that ships it. It contains a `thunderid-config/redirect/` bundle with an importable YAML config and a `thunderid.env` file, plus the Wayfinder web frontend and the Concierge services.
 - **Node.js 20+** for running the sample's services.
 - **An LLM API key.** One of an Anthropic API key from [console.anthropic.com](https://console.anthropic.com) or a Google Gemini API key from [aistudio.google.com](https://aistudio.google.com).
 
@@ -131,14 +131,14 @@ Before you begin, make sure you have:
 
 Import the Wayfinder configuration bundle.
 
-1. **Edit `thunderid-config/thunderid.env`** if you want to change the agent's client secret. The default value (`wayfinder-agent-secret`) matches the sample's defaults.
+1. **Edit `thunderid-config/redirect/thunderid.env`** if you want to change the agent's client secret. The default value (`wayfinder-agent-secret`) matches the sample's defaults.
 
 2. **Import the bundle into <ProductName />.**
 
    - Sign in to the <ProductName /> Console at [https://localhost:8090/console](https://localhost:8090/console).
    - On first sign-in, a welcome screen appears with an **Open** button. (Later, reach the same screen from the user profile menu in the top-right corner of the Console.)
-   - Click **Open** and select your `thunderid-config/thunderid-config.yaml` file from the sample distribution.
-   - Select your `thunderid-config/thunderid.env` file to provide the environment variables referenced in the YAML.
+   - Click **Open** and select your `thunderid-config/redirect/thunderid-config.yaml` file from the sample distribution.
+   - Select your `thunderid-config/redirect/thunderid.env` file to provide the environment variables referenced in the YAML.
    - The Console imports the files and reports the resources it created when the import completes.
 
    The import creates:

--- a/docs/content/use-cases/b2c/try-it-out/setup.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/setup.mdx
@@ -51,8 +51,8 @@ Apply the bundle through the <ProductName /> Console. It creates everything the 
 
 1. Sign in to the <ProductName /> Console at <ConsoleUrl />.
 2. On first sign-in, a welcome screen appears with an **Open** button. (Later, reach the same screen from the user profile menu in the top-right corner of the Console.)
-3. Click **Open** and select your `thunderid-config/thunderid-config.yaml` file from the sample distribution.
-4. Select your `thunderid-config/thunderid.env` file to provide the environment variables referenced in the YAML.
+3. Click **Open** and select your `thunderid-config/redirect/thunderid-config.yaml` file from the sample distribution.
+4. Select your `thunderid-config/redirect/thunderid.env` file to provide the environment variables referenced in the YAML.
 5. The Console imports the files and reports the resources it created when the import completes.
 
 ### Run the Sample

--- a/docs/content/use-cases/vc/try-it-out/_category_.json
+++ b/docs/content/use-cases/vc/try-it-out/_category_.json
@@ -1,0 +1,10 @@
+{
+  "position": 2,
+  "label": "Try It Out",
+  "collapsible": true,
+  "collapsed": true,
+  "link": {
+    "type": "doc",
+    "id": "use-cases/vc/try-it-out"
+  }
+}

--- a/docs/content/use-cases/vc/try-it-out/configure-it-yourself.mdx
+++ b/docs/content/use-cases/vc/try-it-out/configure-it-yourself.mdx
@@ -1,0 +1,89 @@
+---
+title: Configure It Yourself
+description: Build the same Wayfinder Sky Pass setup manually, resource by resource, instead of importing the declarative bundle.
+sidebar_position: 4
+---
+
+# Configure It Yourself
+
+Use this page to build the Sky Pass setup manually instead of importing the declarative bundle. Pick this path when you want to see exactly what gets created, adapt the setup to your own project, or learn the moving parts step by step.
+
+:::note Prerequisites
+Complete the environment steps in [Set Up the Sample](../setup#set-up-your-environment) first — get <ProductName /> behind a public URL, point it at that URL, start it, and get the Wayfinder sample and the Skyline Lounge running. Then return here and follow the steps below instead of the bundle import.
+:::
+
+The first section is the shared foundation — required regardless of which walkthrough you run. The remaining sections build on it.
+
+- [Set Up the Foundation](#set-up-the-foundation) — create the `Customer` user type and John Doe's account.
+- [Set Up the Sky Pass Credential](#set-up-the-sky-pass-credential) — needed for [Issue Credential](../issue-credential).
+- [Set Up the Lounge Presentation](#set-up-the-lounge-presentation) — needed for [Verify Credential](../verify-at-lounge).
+- [Register the Wallet Clients](#register-the-wallet-clients) — needed for both walkthroughs.
+
+## Set Up the Foundation
+
+The Sky Pass claims come from the credential subject's profile. The tryout needs a `Customer` user type with the loyalty attributes, and a test user (John Doe) whose values become the issued credential.
+
+1. **Create the `Customer` user type.**
+
+   Navigate to **User Types** and create a new type. Set the name to `Customer` (category: User) and add the following attributes:
+
+   | Attribute     | Type   | Properties        |
+   | ------------- | ------ | ----------------- |
+   | `username`    | string | Required, unique  |
+   | `password`    | string | Required, credential |
+   | `email`       | string | Required, unique  |
+   | `given_name`  | string | Optional          |
+   | `family_name` | string | Optional          |
+   | `full_name`   | string | Optional          |
+   | `member_id`   | string | Optional          |
+   | `tier`        | string | Optional          |
+
+   See [User Types](/docs/next/guides/guides/users/user-types).
+
+2. **Create John Doe.**
+
+   Navigate to **Users** and create a new user of type `Customer`. Set these values — they are what the walkthrough signs in as and what appears in the issued credential:
+
+   | Attribute     | Value                    |
+   | ------------- | ------------------------ |
+   | `username`    | `john.doe`               |
+   | `password`    | `john.doe`               |
+   | `email`       | `john.doe@example.com`   |
+   | `given_name`  | `John`                   |
+   | `family_name` | `Doe`                    |
+   | `full_name`   | `John Doe`               |
+   | `member_id`   | `WF-100245`              |
+   | `tier`        | `Gold`                   |
+
+## Set Up the Sky Pass Credential
+
+The credential configuration defines what <ProductName /> issues over OpenID4VCI. In the Console, navigate to **Verifiable Credentials** → **Templates** and create a new template:
+
+- **Name:** Wayfinder Sky Pass
+- **Handle (identifier / scope):** `wayfinder-skypass` — the create wizard auto-derives the handle from the name (as `wayfinder-sky-pass`); change it to `wayfinder-skypass` so it matches the sample's frontend and kiosk.
+- **Type (`vct`):** `urn:wayfinder:skypass:1`
+- **Claims:** `full_name`, `given_name`, `family_name`, `email`, `member_id`, `tier` — each sourced from the subject's profile and individually disclosable (SD-JWT).
+
+The credential configuration's identifier doubles as the OAuth scope the wallet requests, so no extra scope registration is needed.
+
+## Set Up the Lounge Presentation
+
+The presentation definition is what the Skyline Lounge asks the wallet to disclose. In the Console, navigate to **Verifiable Credentials** → **Presentations** and create a new definition:
+
+- **Name:** Skyline Lounge Access
+- **Handle (identifier):** `wayfinder-skypass` — as with the credential, override the auto-derived handle so it stays `wayfinder-skypass` (the kiosk requests this definition by that id).
+- **Type (`vct`):** `urn:wayfinder:skypass:1`
+- **Mandatory claims:** `tier`
+- **Optional claims:** `full_name`
+
+Because only `tier` and `full_name` are requested, the wallet discloses just those two of the pass's six claims — the rest stay hidden.
+
+## Register the Wallet Clients
+
+Each wallet vendor uses a fixed OAuth `client_id` and redirect URI for the OpenID4VCI flow, so register one application per wallet you want to support.
+
+**Using the Console (recommended)**
+
+In the Console, go to **Applications** → **Add Application** and select **Digital Wallet** as the application type. On the **Connect Your Wallet** step, pick **Heidi** from the wallet dropdown — the Console pre-fills the client ID (`c3ce7a6c-2bbb-4abe-909c-41bc9463d3c5`) and redirect URI (`ch.ubique.funke://issuance`) automatically. Set **Allowed User Types** to `Customer` and finish the wizard. Repeat for **Lissi** (pre-fills `9c481dc3-2ad0-4fe0-881d-c32ad02fe0fc` / `https://oob.lissi.io/vci-cb`).
+
+With the foundation, credential, presentation, and wallet clients in place, continue to [Issue Credential](../issue-credential).

--- a/docs/content/use-cases/vc/try-it-out/index.mdx
+++ b/docs/content/use-cases/vc/try-it-out/index.mdx
@@ -1,0 +1,59 @@
+---
+title: Try It Out
+description: Issue a verifiable credential from Wayfinder to a real wallet, then verify it at the Skyline Lounge, to see decentralized identity in action with ThunderID.
+sidebar_position: 0
+---
+
+# Try It Out
+
+The walkthroughs in this section use Wayfinder, a fictional consumer travel-booking app, as the sample. Wayfinder **issues** John Doe a **Sky Pass** loyalty credential into his mobile wallet. The **Skyline Lounge** — a separate relying party — **verifies** it to grant access by tier. Both run against a local <ProductName />.
+
+## Cast
+
+The tryout centers on one member. John Doe is the credential subject: he receives the Sky Pass from Wayfinder and presents it at the Skyline Lounge.
+
+<WayfinderVcCast />
+
+## Architecture
+
+Decentralized identity forms a **trust triangle** of three roles: **Issuer**, **Holder**, and **Verifier**. <ProductName /> powers both the Issuer and the Verifier from the inside — neither Wayfinder nor the Skyline Lounge implement any credential protocol themselves.
+
+In **issuance** (OpenID4VCI), Wayfinder triggers a credential offer and delegates everything else to <ProductName />: it authenticates John, signs the Sky Pass, and delivers it to his wallet.
+
+In **verification** (OpenID4VP), the Skyline Lounge creates a presentation request and delegates the rest to <ProductName />. <ProductName /> sends the request to the wallet, receives the VP token, validates the credential, and returns the access decision. The wallet holds and presents the credential; it never calls back to the original issuer to check.
+
+<WayfinderVcArchitecture />
+
+## Set Up the Sample
+
+Before running any walkthrough, set up the Wayfinder sample. Two paths lead to the same end state:
+
+<NextSteps>
+  <NextStepsCard
+    title="Quick Start"
+    description="Import a pre-built configuration bundle and run the sample apps. Everything the walkthroughs need is created in one step."
+    href="./setup"
+  />
+  <NextStepsCard
+    title="Configure It Yourself"
+    description="Create the same resources step by step through the console and API. Use this path to understand how each piece is set up."
+    href="./configure-it-yourself"
+  />
+</NextSteps>
+
+## Walkthroughs
+
+Once the sample is running, do them in order — issue the pass before you verify it:
+
+<NextSteps>
+  <NextStepsCard
+    title="Issue Credential"
+    description="John adds his Wayfinder Sky Pass to a mobile wallet from his profile page."
+    href="./issue-credential"
+  />
+  <NextStepsCard
+    title="Verify Credential"
+    description="John presents the Sky Pass at the Skyline Lounge kiosk, which grants access by tier."
+    href="./verify-at-lounge"
+  />
+</NextSteps>

--- a/docs/content/use-cases/vc/try-it-out/issue-credential.mdx
+++ b/docs/content/use-cases/vc/try-it-out/issue-credential.mdx
@@ -1,0 +1,43 @@
+---
+title: Issue Credential
+description: John adds his Wayfinder Sky Pass to a mobile wallet from his profile page using OpenID4VCI.
+sidebar_position: 2
+---
+
+# Issue Credential
+
+In this walkthrough, John Doe adds his **Wayfinder Sky Pass** to his mobile wallet. Wayfinder acts as the **issuer**: it shows John a credential offer, his wallet runs the OpenID4VCI flow, and John signs in to authorize. The pass then lands in the wallet, carrying his tier, name, and member ID.
+
+:::note Prerequisites
+Complete [Set Up Your Environment](../setup#set-up-your-environment) before starting this walkthrough.
+:::
+
+:::info Background
+The [Decentralized Identity overview](../../overview) covers the issuer–holder–verifier trust triangle behind this use case.
+:::
+
+## Try the Use Case
+
+1. Open <WayFinderSampleUrl /> and select **Sign in**. Sign in as John (`john.doe` / `john.doe`).
+2. Open the account menu and select **Profile**. The **Wayfinder Sky Pass** panel shows John's pass — tier **Gold**, **John Doe**, member ID **WF-100245** — and a QR code.
+3. Open your wallet (**Heidi** or **Lissi**) and scan the QR. The wallet reads the credential offer from <ProductName /> and starts the issuance flow. The wallet may warn that the issuer is unverified — this is expected for a local development setup using a self-signed certificate. Proceed past the warning.
+4. When the wallet prompts you to sign in to authorize, sign in again as John (`john.doe` / `john.doe`) on the <ProductName /> login page rendered in the wallet.
+5. Approve the request. The wallet receives and stores the Sky Pass. John now holds a verifiable credential issued by Wayfinder.
+
+**What happened**
+
+- The offer QR encodes a `credential_offer_uri` pointing at <ProductName />. The wallet fetched the issuer metadata, ran an `authorization_code` flow (PAR → authorize → token) scoped to `wayfinder-skypass`, then called the credential endpoint.
+- <ProductName /> minted an **SD-JWT VC**: the claims (`tier`, `full_name`, `member_id`, `given_name`, `family_name`, `email`) come straight from John's profile, and each is individually disclosable — the wallet decides what to reveal later.
+- The credential is bound to a holder key the wallet generated (`cnf`), so only that wallet can present it.
+
+## Try a Variant
+
+- Change John's `tier` to `Silver` on his profile (or in the Console) and re-add the pass — the card and the issued credential update to match.
+- Issue to a second wallet. Each wallet gets its own holder-key-bound copy of the same pass.
+- Skip the Wayfinder app entirely: in the Console go to **Verifiable Credentials** → **Templates**, click **Generate offer** next to the Wayfinder Sky Pass, and scan the QR that appears. The same OpenID4VCI flow runs — the wallet still authenticates John and receives the credential — but the offer comes straight from <ProductName /> rather than through the app.
+
+## Going Deeper
+
+- Curious what the wallet reveals at verification time? Continue to [Verify Credential](../verify-at-lounge) — the lounge asks for only a subset of the pass's claims.
+- Prefer to define the Sky Pass credential manually? See [Set Up the Sky Pass Credential](../configure-it-yourself#set-up-the-sky-pass-credential) in Configure It Yourself.
+- Want the full protocol detail? The [OpenID for Verifiable Credential Issuance](/docs/next/guides/guides/protocols/openid4vc/openid4vci) guide covers the authorization code flow, credential endpoint, and SD-JWT VC format.

--- a/docs/content/use-cases/vc/try-it-out/setup.mdx
+++ b/docs/content/use-cases/vc/try-it-out/setup.mdx
@@ -1,0 +1,146 @@
+---
+title: Set Up the Sample
+description: Run the ThunderID distribution behind a public URL, import the Wayfinder Sky Pass bundle, and run the Wayfinder and Skyline Lounge sample apps.
+sidebar_position: 1
+sidebar_label: Set up the sample
+---
+
+# Set Up the Sample
+
+This page walks you through the quick path: get <ProductName /> running behind a public URL, import a pre-built bundle, and run the apps. Everything the walkthroughs need is created in one step.
+
+:::tip Prefer to build the setup manually?
+Skip the bundle import and follow [Configure It Yourself](../configure-it-yourself) instead.
+:::
+
+## Set Up Your Environment
+
+<Stepper stepNode="h3" as="h4">
+
+### Get <ProductName />
+
+Download and extract the <ProductName /> distribution — follow [Get <ProductName />](/docs/next/guides/getting-started/get-thunderid) for the steps.
+
+Don't start the server yet — you need to point it at your public URL first.
+
+### Get a public HTTPS URL for <ProductName />
+
+The wallet scans QR codes that point at <ProductName />, so it must be reachable over public HTTPS. Two options:
+
+**Option A — Tunnel a local instance** (free, no infrastructure needed)
+
+Use [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/do-more-with-tunnels/trycloudflare/) or any HTTPS tunnel:
+
+```bash
+cloudflared tunnel --url https://localhost:8090 --no-tls-verify
+```
+
+The terminal prints a public URL such as `https://<random>.trycloudflare.com`.
+
+**Option B — Deploy to a server**
+
+Deploy <ProductName /> to any cloud or on-premise host where it is reachable over HTTPS. See [Deployment Patterns](/docs/next/guides/deployment-patterns/production-guidelines) for guidance.
+
+---
+
+Either way, note your base URL as **`<PUBLIC_URL>`** and the hostname without `https://` as **`<PUBLIC_HOST>`** — used in the steps below.
+
+### Point <ProductName /> at the public URL
+
+In the distribution's `deployment.yaml`, set:
+
+```yaml
+server:
+  public_url: "<PUBLIC_URL>"
+
+gate_client:
+  hostname: "<PUBLIC_HOST>"
+  port: 443
+  scheme: "https"
+  path: "/gate"
+```
+
+Then update the Gate and Console frontend config files so the browser-side apps call the public URL instead of `localhost`. In `apps/gate/config.js` and `apps/console/config.js`, set:
+
+```js
+server: {
+  hostname: '<PUBLIC_HOST>',
+  port: 443,
+  http_only: false,
+},
+```
+
+See [Configuration](/docs/next/guides/getting-started/configuration) for a full reference.
+
+### Configure the Server
+
+Add the Wayfinder origin to the server-config `cors` section so the browser app can call <ProductName />. Create or update `config/resources/server_configs/cors.yaml`:
+
+```yaml
+name: cors
+value:
+  allowedOrigins:
+    # ...existing entries...
+    - "http://localhost:5173"
+```
+
+### Start <ProductName />
+
+```bash
+./start.sh --bootstrap-and-serve
+```
+
+<ProductName /> is now running and reachable at `<PUBLIC_URL>`.
+
+### Get the Wayfinder Sample
+
+Download the latest Wayfinder sample distribution.
+
+<SampleDownload sample="sample-app-wayfinder" />
+
+### Import the Sample Bundle
+
+1. Open the <ProductName /> Console at **`<PUBLIC_URL>/console`**.
+2. On first sign-in, a welcome screen appears with an **Open** button. (Later, reach it from the user profile menu.)
+3. Click **Open** and select `thunderid-config/redirect/thunderid-config.yaml`.
+4. Select `thunderid-config/redirect/thunderid.env` for environment variables.
+5. The Console imports the files and reports the resources created.
+
+### Run the Sample
+
+From the extracted sample directory:
+
+```bash
+npm install
+VITE_THUNDER_BASE_URL=<PUBLIC_URL> npm run dev
+```
+
+Wayfinder opens at `http://localhost:5173` and the Skyline Lounge kiosk at `http://localhost:8795`.
+
+### Install a Wallet
+
+Install **Heidi** or **Lissi** on your phone. Both are pre-registered in the bundle.
+
+</Stepper>
+
+## Walkthroughs
+
+Pick a walkthrough to begin. Each one starts from the setup above.
+
+<NextSteps>
+  <NextStepsCard
+    title="Issue Credential"
+    description="John adds his Wayfinder Sky Pass to a mobile wallet from his profile page."
+    href="../issue-credential"
+  />
+  <NextStepsCard
+    title="Verify Credential"
+    description="John presents the Sky Pass at the Skyline Lounge kiosk, which grants access by tier."
+    href="../verify-at-lounge"
+  />
+</NextSteps>
+
+## Going Deeper
+
+- New to decentralized identity? See the [Decentralized Identity overview](../../overview).
+- Ready for production? See the [Production Deployment Guidelines](/docs/next/guides/deployment-patterns/production-guidelines).

--- a/docs/content/use-cases/vc/try-it-out/verify-at-lounge.mdx
+++ b/docs/content/use-cases/vc/try-it-out/verify-at-lounge.mdx
@@ -1,0 +1,43 @@
+---
+title: Verify Credential
+description: John presents his Sky Pass at the Skyline Lounge kiosk, which verifies it with OpenID4VP and grants access by tier.
+sidebar_position: 3
+---
+
+# Verify Credential
+
+In this walkthrough, John presents the **Sky Pass** he holds in his wallet at the **Skyline Lounge** kiosk. The lounge is a separate relying party from Wayfinder — it never calls Wayfinder and stores nothing about John. It asks <ProductName /> to verify the presentation over OpenID4VP, reads only the claims it needs, and grants or denies entry based on the verified tier.
+
+:::note Prerequisites
+Complete [Issue Credential](../issue-credential) first — the wallet must already hold a Sky Pass issued by this <ProductName /> instance.
+:::
+
+:::info Background
+The [Decentralized Identity overview](../../overview) covers the issuer–holder–verifier trust triangle behind this use case.
+:::
+
+## Try the Use Case
+
+1. Open the Skyline Lounge kiosk at `http://localhost:8795` and select **Present Sky Pass**. The kiosk shows a QR code.
+2. Open your wallet and scan it. The wallet fetches the signed presentation request from <ProductName /> and shows what the lounge is asking for: your **tier**, and optionally your **name**. The wallet may warn that the verifier is unverified — expected for a local setup. Proceed past the warning.
+3. Approve the presentation. The wallet discloses only those claims — nothing else from the pass — and posts the proof to <ProductName />.
+4. The kiosk polls the result and shows the decision: **access granted** for a `Gold` or `Platinum` tier (with a greeting by name), or **access denied** otherwise.
+
+**What happened**
+
+- The lounge called <ProductName />'s `/openid4vp/initiate` with the `wayfinder-skypass` presentation definition and rendered the returned wallet URL as a QR. No OAuth client registration was needed — <ProductName /> signs the request object with its verifier key (`x509_san_dns`), which the wallet trusts.
+- The wallet presented the pass with **selective disclosure**: the credential carries six claims, but the definition asks only for `tier` (mandatory) and `full_name` (optional), so that is all the lounge receives.
+- <ProductName /> checked the issuer signature, the holder key binding, and the nonce, then returned the verified claims. The lounge made the **access decision itself** — comparing the verified `tier` against its allowed list — proving the verifier trusts the proof, not a live call back to the issuer.
+
+## Try a Variant
+
+- Set `ALLOWED_TIERS=Platinum` in the lounge's `.env` and re-verify John's `Gold` pass — access is now denied, decided entirely on the verified claim.
+- Edit the `wayfinder-skypass` presentation definition to also request `member_id`, and watch the wallet's disclosure prompt change to include it.
+- Skip the Skyline Lounge kiosk entirely: in the Console go to **Verifiable Credentials** → **Presentations**, click **Verify** next to the Skyline Lounge Access definition, and scan the QR that appears. The Console polls live and shows the verified claims — including the `tier` and `full_name` John disclosed — as soon as the wallet responds.
+- By default, the presentation definition accepts credentials from any issuer. To restrict it to a specific issuer, add the issuer's x509 certificate to `openid4vp.trusted_anchors` in the server configuration, then open the **Skyline Lounge Access** definition in the Console (**Verifiable Credentials → Presentations**), open the **Issuer Trust** tab, and select the certificate.
+
+## Going Deeper
+
+- The [Decentralized Identity overview](../../overview) explains why offline, cryptographic verification removes the central intermediary that traditional federation requires.
+- Prefer to define the lounge's request manually? See [Set Up the Lounge Presentation](../configure-it-yourself#set-up-the-lounge-presentation) in Configure It Yourself.
+- Want the full protocol detail? The [OpenID for Verifiable Presentations](/docs/next/guides/guides/protocols/openid4vc/openid4vp) guide covers the presentation request, response token, and SD-JWT VC verification.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -324,12 +324,35 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
-          label: 'Decentralised Identity',
+          label: 'Decentralized Identity',
           collapsible: true,
           collapsed: true,
           key: 'use-cases-vc',
           items: [
             {type: 'doc', id: 'use-cases/vc/overview', label: 'Overview', key: 'vc-overview'},
+            {
+              type: 'category',
+              label: 'Try It Out',
+              collapsible: true,
+              collapsed: true,
+              key: 'vc-try-it-out',
+              link: {type: 'doc', id: 'use-cases/vc/try-it-out/index'},
+              items: [
+                {type: 'doc', id: 'use-cases/vc/try-it-out/setup', label: 'Set up the sample', key: 'vc-setup'},
+                {type: 'doc', id: 'use-cases/vc/try-it-out/configure-it-yourself', label: 'Configure It Yourself', key: 'vc-configure'},
+                {
+                  type: 'category',
+                  label: 'Walkthroughs',
+                  collapsible: true,
+                  collapsed: true,
+                  key: 'vc-walkthroughs',
+                  items: [
+                    {type: 'doc', id: 'use-cases/vc/try-it-out/issue-credential', label: 'Issue Credential', key: 'vc-issue'},
+                    {type: 'doc', id: 'use-cases/vc/try-it-out/verify-at-lounge', label: 'Verify Credential', key: 'vc-verify'},
+                  ],
+                },
+              ],
+            },
           ],
         },
       ],
@@ -738,6 +761,11 @@ const sidebars: SidebarsConfig = {
                 id: 'guides/guides/protocols/openid4vc/index',
               },
               items: [
+                {
+                  type: 'doc',
+                  id: 'guides/guides/protocols/openid4vc/openid4vci',
+                  label: 'OpenID for Verifiable Credential Issuance',
+                },
                 {
                   type: 'doc',
                   id: 'guides/guides/protocols/openid4vc/openid4vp',

--- a/docs/src/components/WayfinderDiagrams.css
+++ b/docs/src/components/WayfinderDiagrams.css
@@ -598,3 +598,51 @@
   font-size: 13px !important;
 }
 
+/* ── VC Architecture — boundary box and delegation edge ────────────────── */
+
+.uc-vc-arch__boundary rect {
+  fill: transparent;
+  stroke: color-mix(in srgb, var(--ifm-color-primary) 28%, var(--ifm-color-emphasis-300));
+  stroke-width: 1.5;
+  stroke-dasharray: 6 3;
+}
+
+[data-theme='dark'] .uc-vc-arch__boundary rect {
+  stroke: color-mix(in srgb, var(--ifm-color-primary) 35%, rgba(255, 255, 255, 0.15));
+}
+
+.uc-vc-arch__boundary-label {
+  font-weight: 700;
+  font-size: 10px !important;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  fill: color-mix(in srgb, var(--ifm-color-primary) 65%, var(--ifm-color-emphasis-700)) !important;
+}
+
+.uc-vc-arch__delegate line {
+  stroke: color-mix(in srgb, var(--ifm-color-primary) 45%, var(--ifm-color-emphasis-400));
+  stroke-width: 1.2;
+}
+
+.uc-vc-arch__delegate-label {
+  font-size: 10.5px !important;
+  fill: color-mix(in srgb, var(--ifm-font-color-base) 55%, transparent) !important;
+  font-style: italic;
+}
+
+.uc-vc-arch__icon-circle {
+  fill: color-mix(in srgb, var(--ifm-color-primary) 10%, var(--ifm-color-emphasis-100));
+}
+
+[data-theme='dark'] .uc-vc-arch__icon-circle {
+  fill: color-mix(in srgb, var(--ifm-color-primary) 15%, rgba(255, 255, 255, 0.08));
+}
+
+.uc-vc-arch__icon {
+  fill: none;
+  stroke: color-mix(in srgb, var(--ifm-color-primary) 55%, var(--ifm-color-emphasis-600));
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+

--- a/docs/src/components/WayfinderDiagrams.tsx
+++ b/docs/src/components/WayfinderDiagrams.tsx
@@ -264,6 +264,37 @@ export function WayfinderCast() {
 }
 
 /**
+ * Cast diagram for the Decentralized Identity (VC) Try It Out. The tryout
+ * centres on one member — John Doe — who receives the Sky Pass and presents it
+ * at the lounge. Reuses the b2c cast card styling.
+ */
+export function WayfinderVcCast() {
+  return (
+    <div className="uc-b2c-wayfinder-cast">
+      <svg
+        className="uc-b2c-wayfinder-cast__svg"
+        viewBox="0 0 960 176"
+        xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-label="Wayfinder cast: the Sky Pass holder"
+      >
+        <rect x="20" y="12" width="3" height="16" className="uc-b2c-wayfinder-cast__group-accent" />
+        <text x="30" y="24" className="uc-b2c-wayfinder-cast__group-label">Member</text>
+
+        <g className="uc-b2c-wayfinder-cast__card uc-b2c-wayfinder-cast__card--lead" transform="translate(20, 36)">
+          <rect width="920" height="128" rx="10" />
+          <text x="16" y="32" className="uc-b2c-wayfinder-cast__card-name">John Doe</text>
+          <text x="16" y="56" className="uc-b2c-wayfinder-cast__card-role">Wayfinder member · Gold tier</text>
+          <line x1="16" y1="69" x2="904" y2="69" className="uc-b2c-wayfinder-cast__card-divider" />
+          <text x="16" y="92" className="uc-b2c-wayfinder-cast__card-desc">Signs in to Wayfinder and adds the Sky Pass to his wallet,</text>
+          <text x="16" y="114" className="uc-b2c-wayfinder-cast__card-desc">then presents it at the Skyline Lounge for access</text>
+        </g>
+      </svg>
+    </div>
+  );
+}
+
+/**
  * Architecture diagram. Consumers (John, Jane, Emma) sit at the top next
  * to the Wayfinder Web app; ThunderID and Wayfinder Server sit below
  * the app, symmetrically. Pattern-agnostic — the arrow labels do not
@@ -368,6 +399,157 @@ export function WayfinderArchitecture() {
           <g transform="translate(778,346)"><g transform="scale(0.65)"><PersonIcon className="uc-b2c-wayfinder-arch__icon" /></g></g>
           <text x="796" y="403" textAnchor="middle" className="uc-b2c-wayfinder-arch__cast-name">Maya</text>
         </g>
+      </svg>
+    </div>
+  );
+}
+
+/**
+ * One flow panel for the VC architecture. A dashed boundary box labelled with
+ * the trust-triangle role (Issuer / Verifier) encloses both the app and
+ * ThunderID, showing that ThunderID powers the role from the inside. The
+ * delegation arrow sits mid-box in the gap between the two inner nodes so it
+ * never touches a title or divider. External arrows connect ThunderID directly
+ * to the wallet (Holder) below the boundary.
+ *
+ * Coordinate notes (all in panel-local space, i.e. after translate(20,y)):
+ *   App box:        translate(66, 46)  w=292  h=92  → right edge x=358, bottom y=138
+ *   ThunderID box:  translate(552, 46) w=278  h=92  → left edge x=552,  bottom y=138
+ *   Gap:            x=358–552  (194 px)
+ *   Titles:         panel y=80  (base 46 + relative 34)
+ *   Subs:           panel y=118 (base 46 + relative 72)
+ *   Delegate label: panel y=90  — 10 px below title, 28 px above sub
+ *   Delegate arrow: panel y=100 — 10 px below label, 18 px above sub
+ *   Boundary:       y=34–156   (height 122)
+ *   Wallet:         translate(415, 168)
+ */
+function VcFlowPanel({
+  y,
+  sectionLabel,
+  roleLabel,
+  appTitle,
+  appSub,
+  idpSub,
+  delegateLabel,
+  edgeAppWallet,
+  edgeWalletThunder,
+}: {
+  y: number;
+  sectionLabel: string;
+  roleLabel: string;
+  appTitle: string;
+  appSub: string;
+  idpSub: string;
+  delegateLabel: string;
+  edgeAppWallet: string;
+  edgeWalletThunder: string;
+}) {
+  return (
+    <g transform={`translate(20,${y})`}>
+      {/* section header */}
+      <rect x="4" y="0" width="3" height="16" className="uc-b2c-wayfinder-cast__group-accent" />
+      <text x="14" y="13" className="uc-b2c-wayfinder-cast__group-label">{sectionLabel}</text>
+
+      {/* Role label sits just above the boundary's top-right corner */}
+      <text x="860" y="30" textAnchor="end" className="uc-vc-arch__boundary-label">{roleLabel}</text>
+
+      {/* Dashed boundary — encloses App + ThunderID as the Issuer / Verifier */}
+      <g className="uc-vc-arch__boundary">
+        <rect x="50" y="34" width="820" height="122" rx="14" />
+      </g>
+
+      {/* App node (left, inside boundary) */}
+      <g className="uc-b2c-wayfinder-arch__app" transform="translate(66,46)">
+        <rect width="292" height="92" rx="12" />
+        <text x="146" y="40" textAnchor="middle" className="uc-b2c-wayfinder-arch__app-title">{appTitle}</text>
+        <text x="146" y="60" textAnchor="middle" className="uc-b2c-wayfinder-arch__sub">{appSub}</text>
+      </g>
+
+      {/* ThunderID node (right, inside boundary) */}
+      <g className="uc-b2c-wayfinder-arch__idp" transform="translate(552,46)">
+        <rect width="278" height="92" rx="12" />
+        <text x="139" y="40" textAnchor="middle" className="uc-b2c-wayfinder-arch__idp-title">ThunderID</text>
+        <text x="139" y="60" textAnchor="middle" className="uc-b2c-wayfinder-arch__sub">{idpSub}</text>
+      </g>
+
+      {/* Delegation arrow in the gap (x 358–552) */}
+      <g className="uc-vc-arch__delegate">
+        <text x="455" y="90" textAnchor="middle" className="uc-vc-arch__delegate-label">{delegateLabel}</text>
+        <line x1="362" y1="100" x2="548" y2="100" markerEnd="url(#uc-vc-arch-arrow)" />
+      </g>
+
+      {/* Wallet / Holder (below boundary which ends at y=156) */}
+      <g className="uc-b2c-wayfinder-arch__consumers">
+        <g transform="translate(415,168)"><g transform="scale(0.72)"><PersonIcon className="uc-b2c-wayfinder-arch__icon" /></g></g>
+        <text x="435" y="234" textAnchor="middle" className="uc-b2c-wayfinder-arch__cast-name">John&apos;s wallet</text>
+        <text x="435" y="252" textAnchor="middle" className="uc-b2c-wayfinder-arch__sub">Holder</text>
+      </g>
+
+      {/* External edges */}
+      <g className="uc-b2c-wayfinder-arch__edges">
+        {/* App → Wallet (QR display) */}
+        <line x1="198" y1="138" x2="414" y2="190" markerEnd="url(#uc-vc-arch-arrow)" />
+        <text x="272" y="176" textAnchor="middle" className="uc-b2c-wayfinder-arch__edge-label">{edgeAppWallet}</text>
+        {/* ThunderID ↔ Wallet (protocol) */}
+        <line x1="456" y1="190" x2="656" y2="138" markerEnd="url(#uc-vc-arch-arrow)" markerStart="url(#uc-vc-arch-arrow)" />
+        <text x="610" y="176" textAnchor="middle" className="uc-b2c-wayfinder-arch__edge-label">{edgeWalletThunder}</text>
+      </g>
+    </g>
+  );
+}
+
+/**
+ * Architecture diagrams for the Decentralized Identity (VC) Try It Out — one
+ * trust triangle per flow (issuance, then verification). Each shows the three
+ * components and how they connect, with plain arrows and no step-by-step
+ * labels. Reuses the b2c architecture styling.
+ */
+export function WayfinderVcArchitecture() {
+  return (
+    <div className="uc-b2c-wayfinder-arch">
+      <svg
+        className="uc-b2c-wayfinder-arch__svg"
+        viewBox="0 0 960 540"
+        xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-label="Sky Pass issuance and verification architecture — ThunderID powers the Issuer and Verifier roles, with John's wallet as the Holder"
+      >
+        <defs>
+          <marker
+            id="uc-vc-arch-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L10,5 L0,10 z" fill="currentColor" />
+          </marker>
+        </defs>
+
+        <VcFlowPanel
+          y={10}
+          sectionLabel="Issuance · OpenID4VCI"
+          roleLabel="Issuer"
+          appTitle="Wayfinder Web"
+          appSub="Presents offer, shows QR"
+          idpSub="Authenticates, signs, issues"
+          delegateLabel="delegates OID4VCI"
+          edgeAppWallet="Credential QR"
+          edgeWalletThunder="Claim credential"
+        />
+        <VcFlowPanel
+          y={272}
+          sectionLabel="Verification · OpenID4VP"
+          roleLabel="Verifier"
+          appTitle="Skyline Lounge"
+          appSub="Requests proof, shows QR"
+          idpSub="Validates presentation"
+          delegateLabel="delegates OID4VP"
+          edgeAppWallet="Request QR"
+          edgeWalletThunder="Present credential"
+        />
       </svg>
     </div>
   );

--- a/docs/src/theme/MDXComponents.tsx
+++ b/docs/src/theme/MDXComponents.tsx
@@ -75,7 +75,9 @@ import {UseCaseStepper, UseCaseStepperCard} from '@site/src/components/UseCaseSt
 import {UseCaseVerticalCards, UseCaseVerticalCard, UseCaseCardSection} from '@site/src/components/UseCaseVerticalCards';
 import {
   WayfinderCast,
+  WayfinderVcCast,
   WayfinderArchitecture,
+  WayfinderVcArchitecture,
   WayfinderAgentOrganization,
   WayfinderAgentArchitecture,
   WayfinderMcpOrganization,
@@ -129,7 +131,9 @@ export default {
   RepoLink,
   RunThunderID,
   WayfinderCast,
+  WayfinderVcCast,
   WayfinderArchitecture,
+  WayfinderVcArchitecture,
   WayfinderAgentOrganization,
   WayfinderAgentArchitecture,
   WayfinderMcpOrganization,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2572,11 +2572,14 @@ importers:
   samples/apps/wayfinder-sample/frontend:
     dependencies:
       '@thunderid/react':
-        specifier: 0.3.0
-        version: 0.3.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 0.3.5
+        version: 0.3.5(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@19.2.3)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.3)
       react:
         specifier: ^19.1.0
         version: 19.2.3
@@ -2593,6 +2596,8 @@ importers:
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@25.0.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
+
+  samples/apps/wayfinder-sample/lounge: {}
 
   samples/apps/wayfinder-sample/smtp-server:
     dependencies:
@@ -6170,11 +6175,17 @@ packages:
   '@thunderid/browser@0.3.2':
     resolution: {integrity: sha512-2FleXbJe8aBbplvzzEBDLQti5CWxgzCYXepuOLKK7c9FDTq2F5+Y1puo2IMZzkRXQt90ReKI1G7/cBq4yA7RrA==}
 
+  '@thunderid/browser@0.3.3':
+    resolution: {integrity: sha512-HFmwvwsXTM6VzND7M7OTRdtlk4XQSY1PudI/UldYv43TfND+6zg9s6+10A17UlQA7GxSOvMjxLe2Ye4UnbTofg==}
+
   '@thunderid/javascript@0.0.5':
     resolution: {integrity: sha512-lMjbHCsNgYWclUiPlN3CA6vjKSyjIBIxVGSnuJwiC9eVakVsWmRuxkO8KX6AWlA4SRHgpGLMnD4ZE5lpM+gi9g==}
 
   '@thunderid/javascript@0.3.7':
     resolution: {integrity: sha512-/ipYhs46TsNxfVvwPI0x5Ki5aL1GNn5vPhVzL8m9yG+OrFBY05CS33hhGHDj/AvYiqrxE0j9H2NvCCoCOCwinA==}
+
+  '@thunderid/javascript@0.3.8':
+    resolution: {integrity: sha512-v58Cr/OTQyM/9bRY3OyyMFvUlSXrZ4Dq174+EQiODmpauPIYmQIfBVgX9TyrFReBPlbclDU8wRjqpXsmGpae7Q==}
 
   '@thunderid/react-router@0.2.3':
     resolution: {integrity: sha512-m78BrOtJO15PoBXHBfLOG7bewWuCqenb+iyTR4sbyXIvbjxK5Dyw2pnYt6BKaM0FdCY6VFNldXrqSH2SX1wnXg==}
@@ -6183,15 +6194,15 @@ packages:
       react: '>=16.8.0'
       react-router: '>=6.30.1'
 
-  '@thunderid/react@0.3.0':
-    resolution: {integrity: sha512-SYPuwsGk7/AqJFhePzxGMzJU/QGWvzCrBxe05X5RgIDYrLmhMl9tco6BwFvyNuWssiIaCOJGBzXLdRV1PmJtKQ==}
+  '@thunderid/react@0.3.4':
+    resolution: {integrity: sha512-lJujwXrx7P+k8gYn9FhXgpqYdVkFubKbA7iASyb/1OCNDwusBu/P2HLvYKg/Mb9paxJjP9t/DutcoIXaQNYhcw==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@thunderid/react@0.3.4':
-    resolution: {integrity: sha512-lJujwXrx7P+k8gYn9FhXgpqYdVkFubKbA7iASyb/1OCNDwusBu/P2HLvYKg/Mb9paxJjP9t/DutcoIXaQNYhcw==}
+  '@thunderid/react@0.3.5':
+    resolution: {integrity: sha512-aKW7CWl2JBbhlkbrZ+lSdFAQFE9TA4g2G4MAfnnNDoF5gv7fH5NM0rgXD4D7BHLjMhUb4ZWaT3OcrHUBsjok7w==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -13238,7 +13249,7 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3
       lodash.debounce: 4.0.8
@@ -13249,7 +13260,7 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@8.0.0)':
     dependencies:
       '@babel/core': 8.0.0
-      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3
       lodash.debounce: 4.0.8
@@ -13789,7 +13800,7 @@ snapshots:
   '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
@@ -13801,7 +13812,7 @@ snapshots:
   '@babel/plugin-transform-runtime@7.29.0(@babel/core@8.0.0)':
     dependencies:
       '@babel/core': 8.0.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@8.0.0)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@8.0.0)
@@ -15801,7 +15812,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.29.7
       '@babel/runtime': 7.29.2
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -18077,12 +18088,30 @@ snapshots:
       stream-browserify: 3.0.0
       tslib: 2.8.1
 
+  '@thunderid/browser@0.3.3':
+    dependencies:
+      '@thunderid/javascript': 0.3.8
+      base64url: 3.0.1
+      buffer: 6.0.3
+      core-js: 3.42.0
+      fast-sha256: 1.3.0
+      jose: 5.2.0
+      process: 0.11.10
+      randombytes: 2.1.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+
   '@thunderid/javascript@0.0.5':
     dependencies:
       jose: 5.2.0
       tslib: 2.8.1
 
   '@thunderid/javascript@0.3.7':
+    dependencies:
+      jose: 5.2.0
+      tslib: 2.8.1
+
+  '@thunderid/javascript@0.3.8':
     dependencies:
       jose: 5.2.0
       tslib: 2.8.1
@@ -18094,7 +18123,7 @@ snapshots:
       react-router: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
 
-  '@thunderid/react@0.3.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@thunderid/react@0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -18107,11 +18136,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@thunderid/react@0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@thunderid/react@0.3.5(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@thunderid/browser': 0.3.2
+      '@thunderid/browser': 0.3.3
       '@types/react': 19.2.14
       dompurify: 3.4.11
       react: 19.2.3
@@ -18608,7 +18637,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18851,7 +18880,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.34':
     dependencies:
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@vue/shared': 3.5.34
       entities: 7.0.1
       estree-walker: 2.0.2
@@ -18864,7 +18893,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.34':
     dependencies:
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@vue/compiler-core': 3.5.34
       '@vue/compiler-dom': 3.5.34
       '@vue/compiler-ssr': 3.5.34
@@ -19337,7 +19366,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
     dependencies:
-      '@babel/compat-data': 7.29.3
+      '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       semver: 6.3.1
@@ -19346,7 +19375,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@8.0.0):
     dependencies:
-      '@babel/compat-data': 7.29.3
+      '@babel/compat-data': 7.29.7
       '@babel/core': 8.0.0
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@8.0.0)
       semver: 6.3.1
@@ -22302,8 +22331,8 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-asynchronous@1.1.0:

--- a/samples/apps/wayfinder-sample/README.md
+++ b/samples/apps/wayfinder-sample/README.md
@@ -61,13 +61,14 @@ The sample uses two OAuth clients and three token types:
 - A **self-service profile page** at `/profile` that calls Thunder's `/users/me` directly with the `WAYFINDER` user token to read account details, edit attributes, and change the password.
 - **Multi-LLM support** — the Wayfinder Concierge works with both **Anthropic Claude** and **Google Gemini**, selectable via an environment variable.
 - **CIBA-based flight upgrade** — a background upgrade scheduler uses CIBA (Client-Initiated Backchannel Authentication) to authenticate the customer out-of-band via email or SMS notification. The customer approves the upgrade on their own device; the scheduler then processes it with a CIBA-issued token carrying `upgrade:process` scope.
+- **Verifiable Credentials (OID4VCI / OID4VP)** — members can add a Wayfinder Sky Pass to their EUDI wallet straight from the profile page (OpenID4VCI issuance). The Skyline Lounge kiosk (`lounge/`) verifies the pass using OpenID4VP selective disclosure, reading only the `tier` and `full_name` claims.
 
 ## Project Structure
 
 ```
 wayfinder-sample/
-├── frontend/          React + Vite UI. Hosts the chat widget and the
-│                      /agent-callback route used by the consent popup.
+├── frontend/          React + Vite UI. Hosts the chat widget, the
+│                      /agent-callback route, and the Sky Pass issuance QR.
 ├── backend/           Node server backed by SQLite. Hosts both the REST API
 │                      (/api/*) and the MCP server (/mcp), validates JWTs,
 │                      enforces scopes per route and per MCP tool.
@@ -75,6 +76,8 @@ wayfinder-sample/
 │                      Captures emails sent by ThunderID flows (recovery,
 │                      onboarding, CIBA). No external email relay required.
 ├── ai-agent/          HTTP Wayfinder Concierge API (LangChain + Claude/Gemini).
+├── lounge/            Skyline Lounge kiosk. Verifies the Sky Pass via OID4VP
+│                      and grants access based on the disclosed tier claim.
 ├── thunderid-config/  Importable YAML config for ThunderID setup.
 └── README.md
 ```

--- a/samples/apps/wayfinder-sample/frontend/package.json
+++ b/samples/apps/wayfinder-sample/frontend/package.json
@@ -13,8 +13,9 @@
     "react-router": "6.30.4"
   },
   "dependencies": {
-    "@thunderid/react": "0.3.0",
+    "@thunderid/react": "0.3.5",
     "lucide-react": "^0.511.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "6.30.4"

--- a/samples/apps/wayfinder-sample/frontend/src/api/userApi.js
+++ b/samples/apps/wayfinder-sample/frontend/src/api/userApi.js
@@ -66,3 +66,13 @@ export async function updateMyCredentials(accessToken, attributes) {
     body: JSON.stringify({ attributes })
   });
 }
+
+// Issuer-initiated OpenID4VCI credential offer for the Wayfinder Sky Pass. The
+// endpoint is public (the wallet authenticates during the flow), so no token is
+// sent. Returns { credential_offer, credential_offer_uri } — render the
+// credential_offer_uri as a QR for the wallet to scan.
+export async function getSkyPassOffer() {
+  return thunderRequest(
+    `/openid4vci/offer?credential_configuration_id=wayfinder-skypass`
+  );
+}

--- a/samples/apps/wayfinder-sample/frontend/src/pages/ProfilePage.jsx
+++ b/samples/apps/wayfinder-sample/frontend/src/pages/ProfilePage.jsx
@@ -18,8 +18,14 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "../auth/useAuth";
-import { KeyRound, RefreshCw, Save } from "lucide-react";
-import { getMyUser, updateMyCredentials, updateMyUser } from "../api/userApi";
+import { KeyRound, RefreshCw, Save, Wallet } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
+import {
+  getMyUser,
+  getSkyPassOffer,
+  updateMyCredentials,
+  updateMyUser
+} from "../api/userApi";
 
 export function ProfilePage() {
   const { isSignedIn, isLoading: authLoading, signIn, getAccessToken } = useAuth();
@@ -193,6 +199,8 @@ function Profile({ getAccessToken }) {
             </dl>
           </section>
 
+          <SkyPassSection user={user} />
+
           <section className="management-panel" aria-label="Profile attributes" style={profilePanelStyle}>
             <h2 style={sectionHeadingStyle}>Profile attributes</h2>
             {rows.length === 0 ? (
@@ -328,6 +336,97 @@ function PasswordSection({ getAccessTokenRef, disabled }) {
   );
 }
 
+function SkyPassSection({ user }) {
+  const [offerUri, setOfferUri] = useState("");
+  const [offerError, setOfferError] = useState("");
+  const [offerLoading, setOfferLoading] = useState(false);
+
+  // The QR is generated on demand — only when the guest chooses to add the pass.
+  const loadOffer = useCallback(async () => {
+    setOfferLoading(true);
+    setOfferError("");
+    try {
+      const offer = await getSkyPassOffer();
+      setOfferUri(offer?.credential_offer_uri || "");
+    } catch (err) {
+      setOfferUri("");
+      setOfferError(formatError(err));
+    } finally {
+      setOfferLoading(false);
+    }
+  }, []);
+
+  const attrs = user?.attributes || {};
+  const tier = attrs.tier || "Member";
+  const name =
+    attrs.full_name ||
+    [attrs.given_name, attrs.family_name].filter(Boolean).join(" ") ||
+    attrs.username ||
+    "";
+  const memberId = attrs.member_id || "";
+  const showQr = Boolean(offerUri) && !offerError;
+
+  return (
+    <section className="management-panel" aria-label="Wayfinder Sky Pass" style={profilePanelStyle}>
+      <h2 style={sectionHeadingStyle}>
+        <Wallet size={18} style={{ verticalAlign: "-3px", marginRight: 6 }} />
+        Wayfinder Sky Pass
+      </h2>
+      <p style={{ marginTop: 0, color: "#64748b" }}>
+        Add your loyalty pass to your digital wallet, then present it at the Skyline Lounge for access.
+      </p>
+      <div style={skyPassLayoutStyle}>
+        <div style={skyPassCardStyle}>
+          <span style={skyPassEyebrowStyle}>Wayfinder Sky Pass</span>
+          <span style={skyPassTierStyle}>{tier}</span>
+          <span style={skyPassNameStyle}>{name}</span>
+          {memberId && <span style={skyPassIdStyle}>{memberId}</span>}
+        </div>
+
+        <div style={skyPassActionStyle}>
+          {!showQr ? (
+            <>
+              <button
+                className="dashboard-action"
+                type="button"
+                onClick={loadOffer}
+                disabled={offerLoading}
+              >
+                <Wallet size={16} /> {offerLoading ? "Preparing pass…" : "Add to Wallet"}
+              </button>
+              {offerError ? (
+                <div className="api-status api-status--error" role="status">
+                  {offerError}
+                </div>
+              ) : (
+                <p style={skyPassHintStyle}>
+                  Generates a one-time QR to scan with your EUDI wallet (Heidi or Lissi).
+                </p>
+              )}
+            </>
+          ) : (
+            <>
+              <QRCodeSVG value={offerUri} size={168} marginSize={2} />
+              <p style={skyPassHintStyle}>
+                Scan with your wallet and sign in to authorize. Once added, present it at
+                the Skyline Lounge kiosk.
+              </p>
+              <button
+                className="dashboard-action dashboard-action--secondary"
+                type="button"
+                onClick={loadOffer}
+                disabled={offerLoading}
+              >
+                <RefreshCw size={16} /> {offerLoading ? "Refreshing…" : "New QR"}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function ReadOnlyRow({ label, value }) {
   return (
     <div style={metaRowStyle}>
@@ -349,6 +448,64 @@ const profilePanelStyle = {
   padding: 24,
   marginTop: 16,
   minHeight: 0
+};
+
+const skyPassLayoutStyle = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 28,
+  alignItems: "flex-start"
+};
+
+const skyPassCardStyle = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 2,
+  padding: "20px 22px",
+  borderRadius: 14,
+  minWidth: 240,
+  color: "#fff",
+  background: "linear-gradient(135deg, #172554 0%, #2563eb 100%)",
+  boxShadow: "0 10px 24px rgba(37, 99, 235, 0.28)"
+};
+
+const skyPassEyebrowStyle = {
+  fontSize: "0.68rem",
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+  opacity: 0.85
+};
+
+const skyPassTierStyle = {
+  fontSize: "1.6rem",
+  fontWeight: 700,
+  marginTop: 6
+};
+
+const skyPassNameStyle = {
+  fontSize: "1rem",
+  marginTop: 8
+};
+
+const skyPassIdStyle = {
+  fontSize: "0.85rem",
+  opacity: 0.85,
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  marginTop: 2
+};
+
+const skyPassActionStyle = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+  alignItems: "flex-start"
+};
+
+const skyPassHintStyle = {
+  color: "#64748b",
+  fontSize: "0.9rem",
+  maxWidth: 260,
+  margin: 0
 };
 
 const sectionHeadingStyle = {

--- a/samples/apps/wayfinder-sample/lounge/.env.example
+++ b/samples/apps/wayfinder-sample/lounge/.env.example
@@ -1,0 +1,13 @@
+# ThunderID base URL (must be reachable over public HTTPS — the wallet calls back to it).
+# The lounge calls its OpenID4VP /initiate + /status endpoints.
+THUNDER_BASE_URL=https://thunderid.example.com
+
+# Port the lounge kiosk serves on.
+LOUNGE_PORT=8795
+
+# Presentation definition handle to verify (must exist in ThunderID).
+SKYPASS_DEFINITION_ID=wayfinder-skypass
+
+# Tiers allowed into the lounge (comma-separated). The decision is made here,
+# after verification, on the verified `tier` claim.
+ALLOWED_TIERS=Gold,Platinum

--- a/samples/apps/wayfinder-sample/lounge/README.md
+++ b/samples/apps/wayfinder-sample/lounge/README.md
@@ -1,0 +1,42 @@
+# Skyline Lounge — Sky Pass verifier
+
+A standalone **OpenID4VP verifier** kiosk for the Skyline Lounge. Wayfinder *issues* the Sky Pass into the guest's wallet; this kiosk — a **separate relying party** — *verifies* it at the door and grants or denies entry based on the loyalty tier.
+
+The wallet is the only thing that travels between the two apps; the lounge never
+talks to Wayfinder. It is a thin client of ThunderID's OpenID4VP API, so it needs
+no OAuth client registration — the request object is signed by ThunderID's verifier
+key (`x509_san_dns`), which the wallet trusts.
+
+## How It Works
+
+1. Guest taps **Present Sky Pass** → the lounge calls ThunderID
+   `POST /openid4vp/initiate` (`definition_id=wayfinder-skypass`) and shows the
+   returned wallet URL as a QR.
+2. Guest scans it and approves the disclosure in their wallet.
+3. The lounge polls `GET /openid4vp/status/{txn_id}`; on `COMPLETED` it decodes
+   the signed result token, then shows **"Welcome, <name> — <tier> member"** and
+   **access granted** if the verified `tier` is in `ALLOWED_TIERS` (Gold/Platinum
+   by default), otherwise **access denied**.
+
+## Run
+
+Prerequisites: a running ThunderID with the `wayfinder-skypass` presentation definition,
+reachable at a public HTTPS URL, and a guest who has already been issued the Sky Pass
+in their wallet.
+
+```bash
+cp .env.example .env          # set THUNDER_BASE_URL to your public ThunderID URL
+node --env-file=.env server.js
+# or: THUNDER_BASE_URL=https://thunderid.example.com npm start
+```
+
+Open http://localhost:8795 and present a Sky Pass.
+
+## Configuration (`.env`)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `THUNDER_BASE_URL` | — | ThunderID's public HTTPS URL. Required. |
+| `LOUNGE_PORT` | `8795` | Kiosk port. |
+| `SKYPASS_DEFINITION_ID` | `wayfinder-skypass` | Presentation definition to verify. |
+| `ALLOWED_TIERS` | `Gold,Platinum` | Tiers granted lounge access. |

--- a/samples/apps/wayfinder-sample/lounge/package.json
+++ b/samples/apps/wayfinder-sample/lounge/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "skyline-lounge",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "OpenID4VP verifier kiosk that grants lounge access from a Wayfinder Sky Pass. Part of the Wayfinder sample; runs on its own port.",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node server.js"
+  }
+}

--- a/samples/apps/wayfinder-sample/lounge/public/index.html
+++ b/samples/apps/wayfinder-sample/lounge/public/index.html
@@ -1,0 +1,184 @@
+<!--
+ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+
+ WSO2 LLC. licenses this file to you under the Apache License,
+ Version 2.0 (the "License"); you may not use this file except
+ in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Skyline Lounge</title>
+    <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.4/build/qrcode.min.js"></script>
+    <style>
+      :root { color-scheme: dark; }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; margin: 0; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        color: #e8edf6;
+        background: radial-gradient(1400px 800px at 50% -15%, #1d3a8a 0%, #0b1020 55%, #060912 100%);
+        transition: background 600ms ease;
+        display: flex; flex-direction: column; min-height: 100%; overflow: hidden;
+      }
+      /* Whole-screen state tints, readable from across a room. */
+      body.granted { background: radial-gradient(1400px 900px at 50% -10%, #0f6b46 0%, #08130d 60%, #050a07 100%); }
+      body.denied  { background: radial-gradient(1400px 900px at 50% -10%, #7a1f24 0%, #160a0b 60%, #0a0506 100%); }
+
+      header {
+        padding: 4vmin 6vmin 0; display: flex; align-items: center; gap: 14px;
+        letter-spacing: .34em; text-transform: uppercase; font-size: clamp(.7rem, 1.4vmin, 1rem); color: #aab8d6;
+      }
+      header .dot { width: 12px; height: 12px; border-radius: 50%; background: linear-gradient(135deg,#8ec5ff,#4f8cff); box-shadow: 0 0 18px #4f8cff; }
+
+      main { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 4vmin 6vmin; }
+      h1 { margin: 0 0 1vmin; font-size: clamp(2rem, 6vmin, 4.5rem); font-weight: 800; line-height: 1.05; }
+      .sub { color: #9fb0d0; margin: 0 0 5vmin; font-size: clamp(1rem, 2.2vmin, 1.6rem); }
+
+      button.primary {
+        appearance: none; border: 0; cursor: pointer; font-weight: 700;
+        font-size: clamp(1.1rem, 2.6vmin, 1.8rem); padding: clamp(16px,2.4vmin,26px) clamp(34px,6vmin,72px);
+        border-radius: 999px; color: #08122b; background: linear-gradient(135deg, #8ec5ff, #4f8cff);
+        box-shadow: 0 16px 50px rgba(79,140,255,.45);
+      }
+      button.primary:active { transform: translateY(1px); }
+
+      .qr { width: clamp(240px, 38vmin, 420px); aspect-ratio: 1; background: #fff; border-radius: 24px; padding: clamp(14px,2vmin,22px); box-shadow: 0 24px 70px rgba(0,0,0,.5); }
+      .qr img { width: 100%; height: 100%; display: block; }
+      .hint { color: #9fb0d0; font-size: clamp(.95rem, 2vmin, 1.4rem); min-height: 1.3em; margin-top: 3vmin; }
+
+      .name { font-size: clamp(2.2rem, 7vmin, 5.5rem); font-weight: 800; margin: 0 0 1vmin; }
+      .tier { color: #cfe0ff; font-size: clamp(1.1rem, 2.6vmin, 2rem); margin: 0 0 4vmin; }
+      .muted { color: #93a1c2; font-family: ui-monospace, Menlo, monospace; font-size: .85em; }
+      .badge {
+        display: inline-flex; align-items: center; gap: 12px; font-weight: 800; letter-spacing: .03em;
+        font-size: clamp(1.2rem, 3.2vmin, 2.4rem); padding: clamp(12px,1.8vmin,20px) clamp(24px,4vmin,44px); border-radius: 999px;
+      }
+      .badge .mark { font-size: 1.3em; line-height: 1; }
+      .ok { background: rgba(45,196,124,.18); color: #5bf0a0; border: 2px solid rgba(91,240,160,.5); }
+      .deny { background: rgba(248,113,113,.16); color: #ff9a9a; border: 2px solid rgba(255,154,154,.5); }
+      .err { color: #ff9a9a; font-size: clamp(1rem,2.2vmin,1.5rem); }
+
+      footer { display: flex; align-items: flex-start; justify-content: center; padding: 0 6vmin 12vmin; min-height: 10vmin; }
+      .ghost {
+        appearance: none; cursor: pointer; font-weight: 600; letter-spacing: .01em;
+        font-size: clamp(.95rem, 1.9vmin, 1.25rem); padding: clamp(11px,1.5vmin,16px) clamp(24px,3.4vmin,40px);
+        border-radius: 999px; color: #d6e3ff; background: rgba(255,255,255,.06);
+        border: 1px solid rgba(255,255,255,.18); transition: background 150ms ease, border-color 150ms ease;
+      }
+      .ghost:hover { background: rgba(255,255,255,.12); border-color: rgba(255,255,255,.34); }
+      .ghost:active { transform: translateY(1px); }
+      .stack { display: flex; flex-direction: column; align-items: center; gap: 1vmin; }
+    </style>
+  </head>
+  <body>
+    <header><span class="dot"></span> Skyline Lounge</header>
+    <main id="main"></main>
+    <footer id="footer"></footer>
+
+    <script>
+      const main = document.getElementById("main");
+      const footer = document.getElementById("footer");
+      let pollTimer = null;
+
+      function setBody(state) { document.body.className = state || ""; }
+
+      function idle() {
+        clearInterval(pollTimer);
+        setBody("");
+        main.innerHTML =
+          '<h1>Members’ Entrance</h1>' +
+          '<p class="sub">Present your Wayfinder Sky Pass to enter the lounge.</p>' +
+          '<button class="primary" id="start">Present Sky Pass</button>';
+        footer.innerHTML = "";
+        document.getElementById("start").onclick = start;
+      }
+
+      async function start() {
+        setBody("");
+        main.innerHTML = '<p class="hint">Preparing…</p>';
+        footer.innerHTML = "";
+        try {
+          const r = await fetch("/api/verify/start", { method: "POST" });
+          const data = await r.json();
+          if (!r.ok) throw new Error(data.error || "Failed to start");
+          showQr(data.walletUrl, data.txnId);
+        } catch (e) {
+          main.innerHTML = '<p class="err">' + escapeHtml(e.message) + '</p>';
+          setTimeout(idle, 2800);
+        }
+      }
+
+      function showQr(walletUrl, txnId) {
+        main.innerHTML =
+          '<div class="stack">' +
+          '<div class="qr"><img id="qr-img" alt="Scan with your wallet" /></div>' +
+          '<p class="hint" id="hint">Scan with your wallet and approve the request…</p>' +
+          '</div>';
+        footer.innerHTML = '<button class="ghost" id="cancel">Cancel</button>';
+        document.getElementById("cancel").onclick = idle;
+        QRCode.toDataURL(walletUrl, { width: 480, margin: 1 }, function(err, url) {
+          if (err) {
+            main.innerHTML = '<p class="err">Failed to generate QR: ' + escapeHtml(err.message) + '</p>';
+            return;
+          }
+          const img = document.getElementById("qr-img");
+          if (img) img.src = url;
+        });
+        poll(txnId);
+      }
+
+      function poll(txnId, maxAttempts = 150) {
+        clearInterval(pollTimer);
+        let attempts = 0;
+        pollTimer = setInterval(async () => {
+          if (++attempts > maxAttempts) {
+            clearInterval(pollTimer);
+            const h = document.getElementById("hint");
+            if (h) { h.className = "err"; h.textContent = "Verification timed out. Please try again."; }
+            setTimeout(idle, 3500);
+            return;
+          }
+          try {
+            const r = await fetch("/api/verify/status/" + encodeURIComponent(txnId));
+            const data = await r.json();
+            if (data.status === "COMPLETED") { clearInterval(pollTimer); showResult(data); }
+            else if (data.status === "FAILED") {
+              clearInterval(pollTimer);
+              const h = document.getElementById("hint");
+              if (h) { h.className = "err"; h.textContent = data.error || "Verification failed."; }
+              setTimeout(idle, 3500);
+            }
+          } catch (_) { /* keep polling */ }
+        }, 2000);
+      }
+
+      function showResult(data) {
+        const name = data.name || "Traveler";
+        const granted = data.accessGranted;
+        setBody(granted ? "granted" : "denied");
+        main.innerHTML =
+          '<p class="name">Welcome, ' + escapeHtml(name) + '</p>' +
+          (data.tier ? '<p class="tier">' + escapeHtml(data.tier) + ' member' +
+            (data.memberId ? ' · <span class="muted">' + escapeHtml(data.memberId) + '</span>' : '') + '</p>' : '') +
+          '<div class="badge ' + (granted ? 'ok' : 'deny') + '">' +
+            '<span class="mark">' + (granted ? '✓' : '✕') + '</span>' +
+            (granted ? 'Lounge access granted' : 'Lounge access denied') + '</div>' +
+          (granted ? '' : '<p class="hint">Lounge access requires ' +
+            escapeHtml((data.allowedTiers || []).join(" or ")) + ' tier.</p>');
+        footer.innerHTML = '<button class="ghost" id="again">Scan another pass</button>';
+        document.getElementById("again").onclick = idle;
+      }
+
+      function escapeHtml(s) {
+        return String(s).replace(/[&<>"']/g, (c) =>
+          ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+      }
+
+      idle();
+    </script>
+  </body>
+</html>

--- a/samples/apps/wayfinder-sample/lounge/server.js
+++ b/samples/apps/wayfinder-sample/lounge/server.js
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Skyline Lounge — a standalone OpenID4VP *verifier* kiosk.
+//
+// It is a separate relying party from Wayfinder (the issuer): a guest presents
+// the Wayfinder Sky Pass they hold in their wallet, the lounge verifies it
+// through ThunderID's OpenID4VP API, and grants/denies entry based on the verified
+// tier. No OAuth client registration is needed — the request object is signed by
+// ThunderID's verifier key (x509_san_dns), which the wallet trusts.
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// A dedicated var (not PORT) so the kiosk never collides with the Wayfinder
+// backend when both run under `npm run dev` and PORT happens to be set.
+const PORT = Number(process.env.LOUNGE_PORT || 8795);
+// Reuse the Wayfinder frontend's tunnel URL when a lounge-specific one isn't set,
+// so one env var (VITE_THUNDER_BASE_URL) points the whole sample at ThunderID.
+const THUNDER_BASE_URL =
+  process.env.THUNDER_BASE_URL || process.env.VITE_THUNDER_BASE_URL || "";
+const DEFINITION_ID = process.env.SKYPASS_DEFINITION_ID || "wayfinder-skypass";
+const ALLOWED_TIERS = (process.env.ALLOWED_TIERS || "Gold,Platinum")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+// Local-dev TLS bypass: ThunderID ships a self-signed cert on localhost. Only
+// relax verification when the configured base URL points at localhost.
+if (/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/.test(THUNDER_BASE_URL)) {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+  console.warn("[lounge] Local ThunderID detected — TLS verification disabled. Dev only.");
+}
+
+function decodeJwtPayload(token) {
+  try {
+    return JSON.parse(Buffer.from(String(token).split(".")[1], "base64url").toString());
+  } catch {
+    return null;
+  }
+}
+
+async function thunderFetch(path, options = {}) {
+  if (!THUNDER_BASE_URL) {
+    const error = new Error("THUNDER_BASE_URL is not configured.");
+    error.statusCode = 500;
+    throw error;
+  }
+  const abort = new AbortController();
+  const timeout = setTimeout(() => abort.abort(), 10_000);
+  try {
+    const response = await fetch(`${THUNDER_BASE_URL}${path}`, {
+      ...options,
+      headers: { ...options.headers },
+      signal: abort.signal,
+    });
+    const text = await response.text();
+    let body;
+    try {
+      body = text ? JSON.parse(text) : {};
+    } catch {
+      body = { raw: text };
+    }
+    if (!response.ok) {
+      const error = new Error(body.error || body.message || `ThunderID request failed (${response.status})`);
+      error.statusCode = response.status;
+      throw error;
+    }
+    return body;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function sendJson(response, statusCode, body) {
+  response.writeHead(statusCode, { "Content-Type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+const server = createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url, `http://localhost:${PORT}`);
+
+    if (request.method === "GET" && (url.pathname === "/" || url.pathname === "/index.html")) {
+      const html = await readFile(join(__dirname, "public", "index.html"));
+      response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      response.end(html);
+      return;
+    }
+
+    // Start a verification: ask ThunderID for a presentation request the wallet can scan.
+    if (request.method === "POST" && url.pathname === "/api/verify/start") {
+      const initiated = await thunderFetch("/openid4vp/initiate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ definition_id: DEFINITION_ID }),
+      });
+      return sendJson(response, 200, {
+        txnId: initiated.txn_id,
+        walletUrl: initiated.wallet_url,
+      });
+    }
+
+    // Poll status; on completion surface the verified claims + the access decision.
+    if (request.method === "GET" && url.pathname.startsWith("/api/verify/status/")) {
+      const txnId = decodeURIComponent(url.pathname.replace("/api/verify/status/", ""));
+      const result = await thunderFetch(`/openid4vp/status/${encodeURIComponent(txnId)}`, { method: "GET" });
+      const claims = result.result_token
+        ? decodeJwtPayload(result.result_token)?.verified_claims || null
+        : null;
+
+      let name = null;
+      let tier = null;
+      let accessGranted = null;
+      if (result.status === "COMPLETED" && claims) {
+        tier = claims.tier || null;
+        name =
+          claims.full_name ||
+          [claims.given_name, claims.family_name].filter(Boolean).join(" ") ||
+          null;
+        accessGranted = tier != null && ALLOWED_TIERS.includes(tier);
+      }
+
+      return sendJson(response, 200, {
+        status: result.status,
+        name,
+        tier,
+        memberId: claims?.member_id || null,
+        accessGranted,
+        allowedTiers: ALLOWED_TIERS,
+        error: result.error || null,
+      });
+    }
+
+    sendJson(response, 404, { error: "Not found" });
+  } catch (error) {
+    sendJson(response, error.statusCode || 500, { error: error.message });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Skyline Lounge verifier listening on http://localhost:${PORT}`);
+  console.log(`  ThunderID  : ${THUNDER_BASE_URL || "(set THUNDER_BASE_URL)"}`);
+  console.log(`  Definition : ${DEFINITION_ID}`);
+  console.log(`  Lounge tiers: ${ALLOWED_TIERS.join(", ")}`);
+});

--- a/samples/apps/wayfinder-sample/package.json
+++ b/samples/apps/wayfinder-sample/package.json
@@ -7,11 +7,12 @@
     "backend",
     "smtp-server",
     "ai-agent",
-    "frontend"
+    "frontend",
+    "lounge"
   ],
   "scripts": {
-    "dev": "concurrently \"npm --workspace backend run dev\" \"npm --workspace smtp-server run dev\" \"npm --workspace ai-agent run dev\" \"npm --workspace frontend run dev\"",
-    "dev:b2c": "concurrently \"npm --workspace backend run dev\" \"npm --workspace smtp-server run dev\" \"npm --workspace frontend run dev\""
+    "dev": "concurrently \"npm --workspace backend run dev\" \"npm --workspace smtp-server run dev\" \"npm --workspace ai-agent run dev\" \"npm --workspace frontend run dev\" \"npm --workspace lounge run dev\"",
+    "dev:b2c": "concurrently \"npm --workspace backend run dev\" \"npm --workspace smtp-server run dev\" \"npm --workspace frontend run dev\" \"npm --workspace lounge run dev\""
   },
   "devDependencies": {
     "concurrently": "10.0.3"

--- a/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
@@ -40,6 +40,21 @@ schema: {
       "type": "string",
       "displayName": "Mobile Number",
       "required": false
+    },
+    "full_name": {
+      "type": "string",
+      "displayName": "Full Name",
+      "required": false
+    },
+    "member_id": {
+      "type": "string",
+      "displayName": "Member ID",
+      "required": false
+    },
+    "tier": {
+      "type": "string",
+      "displayName": "Tier",
+      "required": false
     }
   }
 
@@ -1663,8 +1678,11 @@ attributes:
   username: john.doe
   given_name: John
   family_name: Doe
+  full_name: "John Doe"
   email: john.doe@example.com
   mobile_number: "+15550192837"
+  member_id: "WF-100245"
+  tier: "Gold"
 credentials:
   password: "{{.JOHN_DOE_PASSWORD}}"
 
@@ -1695,10 +1713,103 @@ credentials:
   password: "{{.ALEX_CARTER_PASSWORD}}"
 
 ---
-# resource_type: server_config
-# Allows the Wayfinder web app's browser origin to call Thunder. CORS origins come only from the
-# server-config "cors" section (no default ships), so importing this bundle sets the frontend origin.
-name: cors
-value:
-  allowedOrigins:
-    - "http://localhost:5173"
+# resource_type: credential_configuration
+# The Wayfinder Sky Pass issued to the wallet via OID4VCI. handle =
+# credential_configuration_id (and the OAuth scope). Every claim is individually
+# disclosable (SD-JWT); the lounge requests only a subset at verification time.
+id: wayfinder-skypass
+handle: wayfinder-skypass
+ouHandle: default
+vct: urn:wayfinder:skypass:1
+name: Wayfinder Sky Pass
+display:
+  locale: en-US
+claims:
+  - name: full_name
+    displayName: Full Name
+  - name: given_name
+    displayName: First Name
+  - name: family_name
+    displayName: Last Name
+  - name: email
+    displayName: Email
+  - name: member_id
+    displayName: Member ID
+  - name: tier
+    displayName: Tier
+
+---
+# resource_type: presentation_definition
+# The Skyline Lounge kiosk's OpenID4VP request. Selective disclosure: it asks only
+# for `tier` (to prove status) and optionally `full_name` (to greet the guest) —
+# the wallet discloses nothing else from the pass.
+id: wayfinder-skypass
+handle: wayfinder-skypass
+ouHandle: default
+name: Skyline Lounge Access
+vct: urn:wayfinder:skypass:1
+mandatoryClaims:
+  - tier
+optionalClaims:
+  - full_name
+
+---
+# resource_type: application
+# The Heidi / Funke wallet's OAuth client for the OID4VCI issuance flow (its fixed
+# vendor client_id + redirect). Lets the Heidi wallet receive the Sky Pass.
+id: heidi-wallet-app
+name: Heidi Wallet
+description: OpenID4VCI issuance client for the Heidi / Funke wallet
+template: wallet
+ouHandle: default
+url: http://localhost:3000
+logoUrl: "emoji:🪪"
+authFlowHandle: default-basic-flow
+isRegistrationFlowEnabled: false
+isRecoveryFlowEnabled: false
+allowedUserTypes:
+  - Customer
+inboundAuthConfig:
+  - type: oauth2
+    config:
+      clientId: "c3ce7a6c-2bbb-4abe-909c-41bc9463d3c5"
+      redirectUris:
+        - "ch.ubique.funke://issuance"
+      grantTypes:
+        - authorization_code
+      responseTypes:
+        - code
+      tokenEndpointAuthMethod: none
+      pkceRequired: true
+      publicClient: true
+
+---
+# resource_type: application
+# The Lissi wallet's OAuth client for the OID4VCI issuance flow (its fixed vendor
+# client_id + redirect). Lets the Lissi wallet receive the Sky Pass.
+id: lissi-wallet-app
+name: Lissi Wallet
+description: OpenID4VCI issuance client for the Lissi wallet
+template: wallet
+ouHandle: default
+url: http://localhost:3000
+logoUrl: "emoji:🪪"
+authFlowHandle: default-basic-flow
+isRegistrationFlowEnabled: false
+isRecoveryFlowEnabled: false
+allowedUserTypes:
+  - Customer
+inboundAuthConfig:
+  - type: oauth2
+    config:
+      clientId: "9c481dc3-2ad0-4fe0-881d-c32ad02fe0fc"
+      redirectUris:
+        - "https://oob.lissi.io/vci-cb"
+      grantTypes:
+        - authorization_code
+      responseTypes:
+        - code
+      tokenEndpointAuthMethod: none
+      pkceRequired: true
+      publicClient: true
+


### PR DESCRIPTION
## Summary

- Adds a **Verifiable Credentials try-it-out** to the Wayfinder sample, covering the full OID4VCI (issuance) and OpenID4VP (verification) flow end to end
- Adds a **Skyline Lounge kiosk** (`lounge/`) — a standalone Node server that verifies the Sky Pass via OpenID4VP and grants access by loyalty tier
- Adds a **Sky Pass panel** to the Wayfinder profile page so members can add the credential to their EUDI wallet (Heidi or Lissi) directly from the app
- Adds VC resources to the Wayfinder bundle: `wayfinder-skypass` credential configuration, Skyline Lounge presentation definition, and wallet OAuth clients for Heidi and Lissi
- Adds **try-it-out documentation** (`docs/content/use-cases/vc/try-it-out/`) with setup, configure-it-yourself, issue credential, and verify credential pages, plus architecture diagrams


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VC “Try It Out” walkthroughs for “Wayfinder Sky Pass” (issue) and “Skyline Lounge” (verify), including “Set up the sample” and “Configure it yourself”.
  * Added VC architecture diagrams and an in-profile Sky Pass section with QR-based offer generation.
  * Added a standalone Skyline Lounge verifier kiosk sample (OpenID4VP).
* **Bug Fixes**
  * Updated documentation and sample import steps to use the latest redirect bundle layout.
* **Documentation**
  * Refreshed OpenID4VC / OpenID4VCI / OpenID4VP guides, corrected sidebar entries, and fixed reference spelling.
* **Chores**
  * Updated the Wayfinder sample layout, dependencies, and workspace setup; improved documentation support terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->