### PR TITLE
Add import/export support to server_configs

### DIFF
--- a/frontend/apps/console/src/features/import-export/components/ConfigureExport.tsx
+++ b/frontend/apps/console/src/features/import-export/components/ConfigureExport.tsx
@@ -32,6 +32,7 @@ import {
   Layout as LayoutIcon,
   Palette,
   Server,
+  Settings,
   Terminal,
   UserRoundCog,
   Users,
@@ -109,6 +110,7 @@ export default function ConfigureExport({
   const [expandedRoles, setExpandedRoles] = useState(false);
   const [expandedGroups, setExpandedGroups] = useState(false);
   const [expandedAgents, setExpandedAgents] = useState(false);
+  const [expandedServerConfigs, setExpandedServerConfigs] = useState(false);
 
   const nextSteps = [
     t('importExport:configureExport.nextSteps.startWithConfig', {productName}),
@@ -285,6 +287,8 @@ export default function ConfigureExport({
   const rolesCount = resourceCounts?.role ?? (Array.isArray(configData?.role) ? configData.role.length : 0);
   const groupsCount = resourceCounts?.group ?? (Array.isArray(configData?.group) ? configData.group.length : 0);
   const agentsCount = resourceCounts?.agent ?? (Array.isArray(configData?.agent) ? configData.agent.length : 0);
+  const serverConfigsCount =
+    resourceCounts?.server_config ?? (Array.isArray(configData?.server_config) ? configData.server_config.length : 0);
 
   const items: ConfigSummaryItem[] = [];
 
@@ -1112,6 +1116,55 @@ export default function ConfigureExport({
                   size="small"
                   variant="outlined"
                   onClick={() => setExpandedAgents(!expandedAgents)}
+                  sx={{cursor: 'pointer'}}
+                />
+              </Box>
+            )}
+          </Stack>
+        </Box>
+      ),
+    });
+  }
+
+  // Add server configurations if present
+  if (serverConfigsCount > 0) {
+    const serverConfigs = (configData?.server_config as {name?: string}[]) ?? [];
+    const displayedServerConfigs = expandedServerConfigs ? serverConfigs : serverConfigs.slice(0, 5);
+    const remainingCount = serverConfigs.length - 5;
+
+    items.push({
+      id: 'server-configs',
+      label: t('importExport:configureExport.labels.serverConfigs'),
+      icon: <Settings size={16} />,
+      value: serverConfigsCount,
+      status: 'ready',
+      dependencyCount: 0,
+      content: (
+        <Box sx={{px: 3, py: 2, bgcolor: 'background.default'}}>
+          <Stack spacing={2}>
+            <Stack spacing={2} divider={<Box sx={{borderBottom: 1, borderColor: 'divider'}} />}>
+              {displayedServerConfigs.map((serverConfig, idx) => (
+                <Stack key={serverConfig.name ?? `server-config-${idx}`} spacing={0.5}>
+                  <Stack direction="row" spacing={1} sx={{alignItems: 'center'}}>
+                    <Settings size={14} />
+                    <Typography variant="body2" fontWeight={600}>
+                      {serverConfig.name ?? t('importExport:configureExport.fallback.unnamedServerConfig')}
+                    </Typography>
+                  </Stack>
+                </Stack>
+              ))}
+            </Stack>
+            {remainingCount > 0 && (
+              <Box sx={{pt: 1, textAlign: 'center'}}>
+                <Chip
+                  label={
+                    expandedServerConfigs
+                      ? t('importExport:configureExport.actions.showLess')
+                      : t('importExport:configureExport.actions.more', {count: remainingCount})
+                  }
+                  size="small"
+                  variant="outlined"
+                  onClick={() => setExpandedServerConfigs(!expandedServerConfigs)}
                   sx={{cursor: 'pointer'}}
                 />
               </Box>

--- a/frontend/apps/console/src/features/import-export/components/__tests__/ConfigureExport.test.tsx
+++ b/frontend/apps/console/src/features/import-export/components/__tests__/ConfigureExport.test.tsx
@@ -76,6 +76,7 @@ vi.mock('@wso2/oxygen-ui-icons-react', async (importOriginal) => {
     Layout: () => <span data-testid="icon-layout" />,
     Palette: () => <span data-testid="icon-palette" />,
     Server: () => <span data-testid="icon-server" />,
+    Settings: () => <span data-testid="icon-settings" />,
     Terminal: () => <span data-testid="icon-terminal" />,
     UserRoundCog: () => <span data-testid="icon-user-round-cog" />,
     Users: () => <span data-testid="icon-users" />,
@@ -188,6 +189,11 @@ name: Valid Flow
 
       render(<ConfigureExport resourceCounts={resourceCounts} />);
       expect(screen.getByTestId('icon-terminal')).toBeInTheDocument();
+    });
+
+    it('adds a server configurations row when server configs are present', () => {
+      render(<ConfigureExport resourceCounts={{server_config: 2}} />);
+      expect(screen.getByTestId('icon-settings')).toBeInTheDocument();
     });
 
     it('shows loading state when exporting', () => {

--- a/frontend/apps/console/src/features/import-export/constants/resource-types.ts
+++ b/frontend/apps/console/src/features/import-export/constants/resource-types.ts
@@ -35,6 +35,7 @@ export const ALLOWED_RESOURCE_TYPES = [
   'agent',
   'presentation_definition',
   'credential_configuration',
+  'server_config',
 ] as const;
 
 export type ResourceType = (typeof ALLOWED_RESOURCE_TYPES)[number];

--- a/frontend/apps/console/src/features/import-export/models/export-configuration.ts
+++ b/frontend/apps/console/src/features/import-export/models/export-configuration.ts
@@ -79,6 +79,10 @@ export interface ExportRequest {
    */
   agents?: string[];
   /**
+   * List of server config names to export. Use `["*"]` to export all.
+   */
+  serverConfigs?: string[];
+  /**
    * Optional configuration for export behavior
    */
   options?: ExportOptions;

--- a/frontend/apps/console/src/features/import-export/pages/ExportPage.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/ExportPage.tsx
@@ -49,6 +49,7 @@ export default function ExportPage(): JSX.Element {
       roles: ['*'],
       groups: ['*'],
       agents: ['*'],
+      serverConfigs: ['*'],
     });
   }, [mutate]);
 

--- a/frontend/apps/console/src/features/import-export/pages/ImportConfigurationSummaryPage.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/ImportConfigurationSummaryPage.tsx
@@ -44,6 +44,7 @@ import {
   Layers,
   Palette,
   Server,
+  Settings,
   ShieldCheck,
   Upload,
   UserRoundCog,
@@ -417,6 +418,14 @@ const RESOURCE_VIEWS: ResourceView[] = [
     getKey: (item, idx) => item.id ?? item.name ?? `group-${idx}`,
     getName: (item, t) => item.name ?? t('configureExport.fallback.unnamedGroup'),
     renderDetails: (item) => (item.description ? detailLine(item.description) : null),
+  },
+  {
+    type: 'server_config',
+    id: 'server-configs',
+    icon: Settings,
+    getLabel: (t) => t('configureExport.labels.serverConfigs'),
+    getKey: (item, idx) => item.name ?? `server-config-${idx}`,
+    getName: (item, t) => item.name ?? t('configureExport.fallback.unnamedServerConfig'),
   },
 ];
 

--- a/frontend/apps/console/src/features/import-export/pages/__tests__/ExportPage.test.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/__tests__/ExportPage.test.tsx
@@ -84,6 +84,7 @@ describe('ExportPage', () => {
           flows: ['*'],
           groups: ['*'],
           agents: ['*'],
+          serverConfigs: ['*'],
         }),
       );
     });

--- a/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationSummaryPage.test.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationSummaryPage.test.tsx
@@ -176,6 +176,17 @@ describe('ImportConfigurationSummaryPage', () => {
       expect(screen.getByText(/user.*1/i)).toBeInTheDocument();
       expect(screen.getByText(/flow.*1/i)).toBeInTheDocument();
     });
+
+    it('displays a server configurations section', () => {
+      const original = mockLocationState.configData;
+      mockLocationState.configData = {server_config: [{name: 'cors'}]} as ProductConfig;
+
+      render(<ImportConfigurationSummaryPage />);
+
+      expect(screen.getByText(/serverConfigs.*1/i)).toBeInTheDocument();
+
+      mockLocationState.configData = original;
+    });
   });
 
   describe('breadcrumb navigation', () => {

--- a/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationUploadPage.test.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationUploadPage.test.tsx
@@ -223,6 +223,35 @@ describe('ImportConfigurationUploadPage', () => {
     );
   });
 
+  it('accepts a server_config resource without flagging it as unknown', async () => {
+    const user = userEvent.setup();
+    render(<ImportConfigurationUploadPage />);
+
+    const yamlContent =
+      '---\n# resource_type: server_config\nname: cors\nvalue:\n  allowedOrigins:\n    - https://example.com\n';
+    const yamlFile = new File([yamlContent], 'config.yaml', {type: 'text/yaml'});
+    Object.defineProperty(yamlFile, 'text', {value: () => Promise.resolve(yamlContent)});
+
+    await user.upload(document.getElementById('file-upload') as HTMLInputElement, yamlFile);
+    await user.click(screen.getByRole('button', {name: 'common:actions.continue'}));
+
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/welcome/import-configuration/validate',
+          expect.objectContaining({
+            state: expect.objectContaining({
+              method: 'file',
+              parseErrors: [],
+              parseStats: {successCount: 1, failCount: 0},
+            }) as Record<string, unknown>,
+          }),
+        );
+      },
+      {timeout: 5000},
+    );
+  });
+
   it('shows error when file.text() throws during continue', async () => {
     const user = userEvent.setup();
     render(<ImportConfigurationUploadPage />);

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -2343,6 +2343,8 @@ const translations = {
     'configureExport.fallback.unnamedCredentialConfiguration': 'Unnamed Credential Configuration',
     'configureExport.labels.agents': 'Agents',
     'configureExport.fallback.unnamedAgent': 'Unnamed Agent',
+    'configureExport.labels.serverConfigs': 'Server Configurations',
+    'configureExport.fallback.unnamedServerConfig': 'Unnamed Server Configuration',
     'configureExport.fallback.unnamedUser': 'User {{index}}',
     'configureExport.labels.projectDetails': 'Project Details',
     'configureExport.labels.totalResources': 'Total Resources',


### PR DESCRIPTION
### Purpose

Server configurations (e.g. `cors`) are a declarative resource type that is fully supported by the backend import/export APIs (delivered in `480fb8876`, "Support Server-wide generic store support"), but were never wired into the Console's import/export feature. As a result, an already-delivered resource type was silently unavailable through the UI:

- **Export:** the Console export request omitted `serverConfigs`, so server configs were never included in an exported configuration.
- **Import:** `server_config` was missing from the Console's `ALLOWED_RESOURCE_TYPES`, so an uploaded file containing a server-config resource was flagged as an unknown resource type and blocked at the validation step, it could never be imported through the UI.

This PR wires `server_config` into the Console import/export flow and adds a "Server Configurations" row to both the export and import summary tables. No backend changes are required.

<!-- Screenshots: add captures of the export summary and import summary tables showing the new "Server Configurations" row. -->

### Approach

- **Import allow-list** — added `'server_config'` to `ALLOWED_RESOURCE_TYPES` (`constants/resource-types.ts`). The upload page flags any type outside this list as an unknown-resource parse error, and the validate page halts on parse errors before reaching the import step. This single addition unblocks the whole import path — the raw YAML (`configContent`) is what is posted to `/import`, which the backend classifies via the `# resource_type: server_config` comment.
- **Export request** — added `serverConfigs?: string[]` to the `ExportRequest` model (`models/export-configuration.ts`) and requested `serverConfigs: ['*']` in `ExportPage.tsx`. The backend only exports resource types present in the request, so this makes the Console ask for them.
- **Summary display parity** — added a `server_config` row to the export summary (`ConfigureExport.tsx`) and the import summary (`ImportConfigurationSummaryPage.tsx`), reusing the existing per-type row pattern with the `Settings` icon, plus two new i18n labels in `en-US.ts`.

Key design note: the backend already supports `server_config` import/export end-to-end; the gap was entirely in the Console. Naming mirrors the backend contract (`serverConfigs` ↔ `json:"serverConfigs"`, `server_config` ↔ the resource-type constant).

### Related Issues
- Fixes thunder-id/thunderid#3705

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. 
- [ ] Documentation provided. (Add links if there are any) <!-- N/A — bug fix, no doc changes -->
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export and import screens now support server configurations as a selectable resource type.
  * Export summaries now include a “Server Configurations” row with expand/collapse and name preview.
  * Import summaries now show a server configurations section with counts and names.
* **Bug Fixes**
  * Server configuration YAML files are recognized during upload/validation instead of being flagged as unknown.
* **Documentation / Localization**
  * Added UI text for server configurations labels and unnamed items.
* **Tests**
  * Updated and added coverage for the new server configuration UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->