### PR TITLE
Auto-configure CORS allowed origins for source dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ docs/static/api/next/postman/
 # Claude Code
 .claude/
 
+# Dev-only CORS seed staged by `build.sh run` / `build.ps1 run` for the bootstrap one-shot (never committed or packaged)
+backend/cmd/server/bootstrap/02-server-configurations.yaml
+

--- a/build.ps1
+++ b/build.ps1
@@ -677,6 +677,8 @@ function Prepare-Backend-For-Packaging {
     # Copy bootstrap directory
     Write-Host "Copying bootstrap scripts..."
     Copy-Item -Path (Join-Path $BACKEND_DIR "bootstrap") -Destination $package_folder -Recurse -Force
+    # Never ship the dev-only CORS seed that Run stages into the source bootstrap dir.
+    Remove-Item -Path (Join-Path $package_folder "bootstrap/02-server-configurations.yaml") -Force -ErrorAction SilentlyContinue
 
     Write-Host "=== Ensuring server certificates exist in the distribution ==="
     Ensure-Certificates -cert_dir $security_dir -cert_name_prefix "server"
@@ -1547,6 +1549,20 @@ function Run {
     # enabled; the bootstrap runs through the service layer under a runtime context).
     Write-Host "⚙️  Creating default resources..."
     Write-Host ""
+
+    # Dev-only: seed CORS allowed origins for the Gate and Console apps so they can call
+    # the backend without manual configuration. Regenerated on every run and picked up by
+    # the bootstrap one-shot; it is git-ignored and never packaged (see Build).
+    $devServerConfig = @"
+# resource_type: server_config
+name: cors
+value:
+  allowedOrigins:
+    - "https://localhost:$GATE_APP_DEFAULT_PORT"
+    - "https://localhost:$CONSOLE_APP_DEFAULT_PORT"
+"@
+    Set-Content -Path (Join-Path $BACKEND_DIR "bootstrap/02-server-configurations.yaml") -Value $devServerConfig
+
     $env:PUBLIC_URL = $PUBLIC_URL
     Push-Location $BACKEND_DIR
     try {

--- a/build.sh
+++ b/build.sh
@@ -496,6 +496,8 @@ function prepare_backend_for_packaging() {
     # Copy bootstrap directory
     echo "Copying bootstrap scripts..."
     cp -r "$BACKEND_DIR/bootstrap" "$DIST_DIR/$PRODUCT_FOLDER/"
+    # Never ship the dev-only CORS seed that `run` stages into the source bootstrap dir.
+    rm -f "$DIST_DIR/$PRODUCT_FOLDER/bootstrap/02-server-configurations.yaml"
     # Ensure execute permissions on bootstrap scripts
     chmod +x "$DIST_DIR/$PRODUCT_FOLDER/bootstrap/"*.sh 2>/dev/null || true
 
@@ -1051,6 +1053,19 @@ function run() {
     # enabled; the bootstrap runs through the service layer under a runtime context).
     echo "⚙️  Creating default resources..."
     echo ""
+
+    # Dev-only: seed CORS allowed origins for the Gate and Console apps so they can call
+    # the backend without manual configuration. Regenerated on every run and picked up by
+    # the bootstrap one-shot; it is git-ignored and never packaged (see build()).
+    cat > "$BACKEND_DIR/bootstrap/02-server-configurations.yaml" <<EOF
+# resource_type: server_config
+name: cors
+value:
+  allowedOrigins:
+    - "https://localhost:$GATE_APP_DEFAULT_PORT"
+    - "https://localhost:$CONSOLE_APP_DEFAULT_PORT"
+EOF
+
     if ! ( cd "$BACKEND_DIR" && \
         ADMIN_USERNAME="${ADMIN_USERNAME:-}" \
         ADMIN_PASSWORD="${ADMIN_PASSWORD:-}" \

--- a/docs/content/community/contributing/contributing-code/configure-and-run.mdx
+++ b/docs/content/community/contributing/contributing-code/configure-and-run.mdx
@@ -9,20 +9,12 @@ hide_table_of_contents: false
 
 ## Configure the Server
 
-**Add CORS allowed origins:**
+**CORS allowed origins:**
 
-Create or open `backend/cmd/server/config/resources/server_configs/cors.yaml` and make the following changes:
-
-```yaml
-name: cors
-value:
-  allowedOrigins:
-    - "https://localhost:5190"
-    - "https://localhost:5191"
-```
+`make run` (and `.\build.ps1 run` on Windows) automatically configures the Gate and Console development origins (`https://localhost:5190` and `https://localhost:5191`) on startup, so no manual CORS setup is required for the standard flow.
 
 :::tip
-This lets the <ProductName /> Gate and <ProductName /> Console development servers call the backend. You can also update the same CORS section at runtime with `PUT /server-config/cors`.
+To allow additional origins, add them to `backend/cmd/server/config/resources/server_configs/cors.yaml` or set them at runtime with `PUT /server-config/cors`.
 :::
 
 Open `backend/cmd/server/deployment.yaml` and make the following change:

--- a/docs/content/use-cases/b2c/try-it-out/setup.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/setup.mdx
@@ -25,6 +25,10 @@ Get <ProductName /> running locally. Follow [Get <ProductName />](/docs/next/gui
 
 Add the Wayfinder origin to the server-config `cors` section. Create or update `config/resources/server_configs/cors.yaml`, or use `PUT /server-config/cors` after startup.
 
+:::note Running from source with make run
+In development, `make run` (or `.\build.ps1 run` on Windows) seeds the Console and Gate origins automatically, so you only need to add the sample app's origin here. Distributions started with `start.sh` are not seeded; configure all origins manually.
+:::
+
 ```yaml
 name: cors
 value:


### PR DESCRIPTION
### Purpose

When running ThunderID from source, contributors currently have to configure CORS allowed origins **by hand** before the frontend can talk to the backend — the setup docs instruct everyone to create/edit `backend/cmd/server/config/resources/server_configs/cors.yaml` with the local Gate (`https://localhost:5190`) and Console (`https://localhost:5191`) origins on every fresh checkout. It's repetitive boilerplate, and a missing entry surfaces as opaque CORS failures.

This change makes `make run` and `.\build.ps1 run` stage a **dev-only** `server_config` seed for the `cors` section (Gate and Console origins) into the existing bootstrap one-shot, so contributors no longer configure CORS manually. The seed ist-ignored, and stripped from packaged builds so it never reachesproduction. Contribution and B2C setup docs are updated accordingly.                                                                                                 
### Approach                                                                                                                                                         
- **Reuse the existing bootstrap one-shot, no new mechanism.** `build.sh run` / `build.ps1 Run` write `backend/cmd/server/bootstrap/02-server-configurations.yaml` (aresource_type: server_config` document) just before invoking `go run . ber already discovers and applies every `*.yaml` in that directory, andthe importer already handles `server_config`.                                                                                                                        - **Dynamic origins.** Origins are derived from `GATE_APP_DEFAULT_PORT`  so they track the configured dev ports.
- **Strictly dev-only.** Generation lives only in the `run` path — never in `build` / `start.sh` / production. Because the `bootstrap/` directory is copied into the distribution and run by `start.sh`, two guards keep the seed out of proded, and the packaging step (`build`) removes it from the packaged`bootstrap/` dir.
- **Regenerated each run.** The file is rewritten every run (kept as a gorigins always match the current ports; no cleanup step needed.
- **Docs.** `configure-and-run.mdx` and the B2C `setup.mdx` now note that `make run` / `.\build.ps1 run` pre-configures the Gate and Console origins, keeping manual CORS
steps scoped to non-dev / production setups.

### Related Issues
- Resolves #3709

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. <!-- please run `make rundows) to confirm the cors config is seeded and no 02-*.yaml iscommitted/packaged -->
- [x] Documentation provided. (Add links if there are any)
    - `docs/content/community/contributing/contributing-code/configure-and-run.mdx`
    - `docs/content/use-cases/b2c/try-it-out/setup.mdx`
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any) <!-- N/A — build-scritable surface. build.sh/build.ps1 have no test harness; the server_config import path is already covered by existing tests. -->
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guideliness/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development startup now automatically seeds local Gate and Console origins for the server, reducing manual setup when running from source.
* **Bug Fixes**
  * Distributed/packaged builds no longer include the dev-only CORS configuration file.
* **Documentation**
  * Updated “Configure the Server” instructions to remove manual CORS editing steps and clarify differences between local run workflows and packaged/start-based deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->