### PR TITLE
Add usage support for users

### DIFF
--- a/api/user.yaml
+++ b/api/user.yaml
@@ -620,6 +620,84 @@ paths:
                   key: "error.internal_server_error_description"
                   defaultValue: "An unexpected error occurred while processing the request"
 
+  /users/{id}/usages:
+    get:
+      tags:
+        - Users
+      summary: Get user usages
+      description: |
+        Returns the resources that reference this user, aggregated across all resource types.
+        For example, agents that list this user as their owner. This endpoint is informational
+        only — it drives the pre-delete confirmation dialog in the UI and does not gate deletion
+        on the server.
+
+        Each usage entry includes a `behaviorOnDelete` field describing what happens to the
+        referencing resource if the user is deleted:
+        - `fallback`: the reference is kept as-is.
+        - `cascade`: the resource is permanently deleted along with the user.
+
+        When usage data is unavailable (e.g. the server has not fully initialised),
+        `totalResults` and `summary` are `null` rather than `0`/empty. Consumers must treat
+        `null` as "unknown" and `0` as "confirmed empty".
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: "The unique identifier of the user"
+          example: "9a475e1e-b0cb-4b29-8df5-2e5b24fb0ed3"
+      responses:
+        "200":
+          description: Resources that reference this user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceUsagesResponse'
+              example:
+                totalResults: 2
+                count: 2
+                summary:
+                  agent: 2
+                usages:
+                  - resourceType: agent
+                    id: "a1b2c3d4-0000-0000-0000-000000000001"
+                    displayName: "Support Agent"
+                    behaviorOnDelete: fallback
+                  - resourceType: agent
+                    id: "a1b2c3d4-0000-0000-0000-000000000002"
+                    displayName: "Billing Agent"
+                    behaviorOnDelete: fallback
+        "404":
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "USR-1003"
+                message:
+                  key: "error.userservice.user_not_found"
+                  defaultValue: "User not found"
+                description:
+                  key: "error.userservice.user_not_found_description"
+                  defaultValue: "The user with the specified id does not exist"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "USR-5000"
+                message:
+                  key: "error.internal_server_error"
+                  defaultValue: "Internal server error"
+                description:
+                  key: "error.internal_server_error_description"
+                  defaultValue: "An unexpected error occurred while processing the request"
+
   /users/tree/{path}:
     get:
       tags:
@@ -1732,6 +1810,73 @@ components:
           summary: Complex filtering
           value: 'address.city eq "Mountain View"'
   schemas:
+    ResourceUsage:
+      type: object
+      description: A single resource that references the target resource.
+      required:
+        - resourceType
+        - id
+        - displayName
+        - behaviorOnDelete
+      properties:
+        resourceType:
+          type: string
+          description: Type of the referencing resource.
+          enum: [application, agent]
+          example: agent
+        id:
+          type: string
+          format: uuid
+          description: Identifier of the referencing resource.
+          example: "a1b2c3d4-0000-0000-0000-000000000001"
+        displayName:
+          type: string
+          description: Human-readable name of the referencing resource.
+          example: "Support Agent"
+        behaviorOnDelete:
+          type: string
+          description: |
+            What happens to this resource when the target resource is deleted.
+            - `fallback`: the reference is kept as-is.
+            - `cascade`: the resource is permanently deleted.
+          enum: [fallback, cascade]
+          example: fallback
+
+    ResourceUsagesSummary:
+      type: object
+      nullable: true
+      description: |
+        Per-resource-type count of usages, keyed by resource type
+        (e.g. `agent`). Null when the counts could not be determined.
+      additionalProperties:
+        type: integer
+      example:
+        agent: 2
+
+    ResourceUsagesResponse:
+      type: object
+      description: |
+        Resources that reference a target resource, aggregated across all resource types.
+        Drives pre-delete confirmation dialogs; informational only.
+      properties:
+        totalResults:
+          type: integer
+          nullable: true
+          description: |
+            Total number of resources that reference the target resource.
+            Null when usage data is unavailable; 0 means confirmed empty.
+          example: 2
+        count:
+          type: integer
+          description: Number of results returned.
+          example: 2
+        summary:
+          $ref: '#/components/schemas/ResourceUsagesSummary'
+        usages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceUsage'
+
     User:
       type: object
       required: [id]

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -383,7 +383,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	// Wire the dependency registry into the theme and flow services (two-phase init to avoid
 	// cyclic imports).
-	registerDependencyRegistry(themeMgtService, flowMgtService, applicationService, agentService)
+	registerDependencyRegistry(themeMgtService, flowMgtService, userService, applicationService, agentService)
 
 	// Initialize design resolve service for theme and layout resolution
 	designResolveService := resolve.Initialize(mux, themeMgtService, layoutMgtService, applicationService)
@@ -447,15 +447,17 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 }
 
 // registerDependencyRegistry builds the dependency registry from the given providers and wires
-// it into the theme and flow management services.
+// it into the theme, flow and user management services.
 func registerDependencyRegistry(
 	themeMgtService thememgt.ThemeMgtServiceInterface,
 	flowMgtService flowmgt.FlowMgtServiceInterface,
+	userService user.UserServiceInterface,
 	providers ...resourcedependency.Provider,
 ) {
 	registry := resourcedependency.Initialize(providers...)
 	themeMgtService.SetDependencyRegistry(registry)
 	flowMgtService.SetDependencyRegistry(registry)
+	userService.SetDependencyRegistry(registry)
 }
 
 // unregisterServices unregisters all services that require cleanup during shutdown.

--- a/backend/internal/agent/service.go
+++ b/backend/internal/agent/service.go
@@ -392,12 +392,18 @@ func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *tidcomm
 }
 
 // GetResourceDependencies returns the agents that reference the resource identified by
-// (resourceType, id). It implements the resourcedependency.Provider interface. The
-// inbound-client store resolves which reference types are tracked, so no per-type handling is
-// needed here. The number of referencing entities is bounded by MaxCompositeStoreRecords
-// (the inbound-client store limit).
+// (resourceType, id). It implements the resourcedependency.Provider interface.
+//
+// Agents reference a user through their owner attribute, which lives on the agent entity rather
+// than in the inbound-client store, so user dependencies are resolved separately. All other
+// reference types are resolved via the inbound-client store, which decides what is tracked. The
+// number of referencing entities is bounded by MaxCompositeStoreRecords.
 func (s *agentService) GetResourceDependencies(
 	ctx context.Context, resourceType, id string) ([]resourcedependency.ResourceDependency, error) {
+	if resourceType == resourcedependency.ResourceTypeUser {
+		return s.getAgentsByOwner(ctx, id)
+	}
+
 	ids, _, err := s.inboundClientService.GetEntityIDsByReference(
 		ctx, resourceType, id, serverconst.MaxCompositeStoreRecords, 0)
 	if err != nil {
@@ -421,6 +427,38 @@ func (s *agentService) GetResourceDependencies(
 			continue
 		}
 		name, _, _, _ := readSystemAttributes(e.SystemAttributes)
+		usages = append(usages, resourcedependency.ResourceDependency{
+			ResourceType:     resourcedependency.ResourceTypeAgent,
+			ID:               e.ID,
+			DisplayName:      name,
+			BehaviorOnDelete: resourcedependency.BehaviorFallback,
+		})
+	}
+	return usages, nil
+}
+
+// getAgentsByOwner returns the agents that list the given user as their owner. The owner is stored
+// in the agent entity's system attributes, which the entity list filter does not search (it only
+// matches the public attributes column), so agents are listed and matched on owner in memory. The
+// number of agents scanned is bounded by MaxCompositeStoreRecords.
+func (s *agentService) getAgentsByOwner(
+	ctx context.Context, ownerID string) ([]resourcedependency.ResourceDependency, error) {
+	entities, err := s.entityService.GetEntityList(
+		ctx, providers.EntityCategoryAgent, serverconst.MaxCompositeStoreRecords, 0, nil)
+	if err != nil {
+		s.logger.Error(ctx, "Failed to list agents", log.Error(err))
+		return nil, err
+	}
+
+	usages := make([]resourcedependency.ResourceDependency, 0)
+	for _, e := range entities {
+		if e.Category != providers.EntityCategoryAgent {
+			continue
+		}
+		name, _, owner, _ := readSystemAttributes(e.SystemAttributes)
+		if owner != ownerID {
+			continue
+		}
 		usages = append(usages, resourcedependency.ResourceDependency{
 			ResourceType:     resourcedependency.ResourceTypeAgent,
 			ID:               e.ID,

--- a/backend/internal/agent/service_test.go
+++ b/backend/internal/agent/service_test.go
@@ -2173,6 +2173,58 @@ func (suite *AgentServiceTestSuite) TestGetResourceDependencies_FiltersOutNonAge
 	assert.Equal(suite.T(), "agent-1", result[0].ID)
 }
 
+// Owner dependencies are resolved by listing agents and matching the owner system attribute in
+// memory, because the entity list filter only searches the public attributes column.
+func (suite *AgentServiceTestSuite) TestGetResourceDependencies_ByOwner_Success() {
+	svc, mockEntity, _, _ := suite.setupService()
+	clearMockCalls(mockEntity, "GetEntityList")
+
+	ownedAttrs, _ := json.Marshal(map[string]interface{}{"name": "Agent One", "owner": "user-1"})
+	otherAttrs, _ := json.Marshal(map[string]interface{}{"name": "Agent Two", "owner": "user-2"})
+	mockEntity.On("GetEntityList", mock.Anything, providers.EntityCategoryAgent,
+		serverconst.MaxCompositeStoreRecords, 0, mock.Anything).
+		Return([]providers.Entity{
+			{ID: "agent-1", Category: providers.EntityCategoryAgent, SystemAttributes: ownedAttrs},
+			{ID: "agent-2", Category: providers.EntityCategoryAgent, SystemAttributes: otherAttrs},
+		}, nil)
+
+	result, err := svc.GetResourceDependencies(context.Background(), resourcedependency.ResourceTypeUser, "user-1")
+	assert.NoError(suite.T(), err)
+	suite.Require().Len(result, 1)
+	assert.Equal(suite.T(), resourcedependency.ResourceTypeAgent, result[0].ResourceType)
+	assert.Equal(suite.T(), resourcedependency.BehaviorFallback, result[0].BehaviorOnDelete)
+	assert.Equal(suite.T(), "agent-1", result[0].ID)
+	assert.Equal(suite.T(), "Agent One", result[0].DisplayName)
+}
+
+func (suite *AgentServiceTestSuite) TestGetResourceDependencies_ByOwner_Empty() {
+	svc, mockEntity, _, _ := suite.setupService()
+	clearMockCalls(mockEntity, "GetEntityList")
+
+	otherAttrs, _ := json.Marshal(map[string]interface{}{"name": "Agent Two", "owner": "user-2"})
+	mockEntity.On("GetEntityList", mock.Anything, providers.EntityCategoryAgent,
+		serverconst.MaxCompositeStoreRecords, 0, mock.Anything).
+		Return([]providers.Entity{
+			{ID: "agent-2", Category: providers.EntityCategoryAgent, SystemAttributes: otherAttrs},
+		}, nil)
+
+	result, err := svc.GetResourceDependencies(context.Background(), resourcedependency.ResourceTypeUser, "user-1")
+	assert.NoError(suite.T(), err)
+	assert.Empty(suite.T(), result)
+}
+
+func (suite *AgentServiceTestSuite) TestGetResourceDependencies_ByOwner_Error() {
+	svc, mockEntity, _, _ := suite.setupService()
+	clearMockCalls(mockEntity, "GetEntityList")
+	mockEntity.On("GetEntityList", mock.Anything, providers.EntityCategoryAgent,
+		serverconst.MaxCompositeStoreRecords, 0, mock.Anything).
+		Return(nil, errors.New("store error"))
+
+	result, err := svc.GetResourceDependencies(context.Background(), resourcedependency.ResourceTypeUser, "user-1")
+	assert.Nil(suite.T(), result)
+	assert.Error(suite.T(), err)
+}
+
 // --- error-branch coverage ---
 
 func (suite *AgentServiceTestSuite) TestCreateAgent_EntityCreationFails_NonMappableError() {

--- a/backend/internal/system/resourcedependency/registry.go
+++ b/backend/internal/system/resourcedependency/registry.go
@@ -37,6 +37,7 @@ const BehaviorFallback = "fallback"
 const (
 	ResourceTypeTheme       = "theme"
 	ResourceTypeFlow        = "flow"
+	ResourceTypeUser        = "user"
 	ResourceTypeApplication = "application"
 	ResourceTypeAgent       = "agent"
 )

--- a/backend/internal/user/UserServiceInterface_mock_test.go
+++ b/backend/internal/user/UserServiceInterface_mock_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -490,6 +491,76 @@ func (_c *UserServiceInterfaceMock_GetUserList_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetUserUsages provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) GetUserUsages(ctx context.Context, userID string) (*resourcedependency.DependenciesResponse, *common.ServiceError) {
+	ret := _mock.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserUsages")
+	}
+
+	var r0 *resourcedependency.DependenciesResponse
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*resourcedependency.DependenciesResponse, *common.ServiceError)); ok {
+		return returnFunc(ctx, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *resourcedependency.DependenciesResponse); ok {
+		r0 = returnFunc(ctx, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcedependency.DependenciesResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, userID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserServiceInterfaceMock_GetUserUsages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserUsages'
+type UserServiceInterfaceMock_GetUserUsages_Call struct {
+	*mock.Call
+}
+
+// GetUserUsages is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *UserServiceInterfaceMock_Expecter) GetUserUsages(ctx interface{}, userID interface{}) *UserServiceInterfaceMock_GetUserUsages_Call {
+	return &UserServiceInterfaceMock_GetUserUsages_Call{Call: _e.mock.On("GetUserUsages", ctx, userID)}
+}
+
+func (_c *UserServiceInterfaceMock_GetUserUsages_Call) Run(run func(ctx context.Context, userID string)) *UserServiceInterfaceMock_GetUserUsages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUserUsages_Call) Return(dependenciesResponse *resourcedependency.DependenciesResponse, serviceError *common.ServiceError) *UserServiceInterfaceMock_GetUserUsages_Call {
+	_c.Call.Return(dependenciesResponse, serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUserUsages_Call) RunAndReturn(run func(ctx context.Context, userID string) (*resourcedependency.DependenciesResponse, *common.ServiceError)) *UserServiceInterfaceMock_GetUserUsages_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUsersByPath provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) GetUsersByPath(ctx context.Context, handlePath string, limit int, offset int, filters map[string]interface{}, includeDisplay bool) (*UserListResponse, *common.ServiceError) {
 	ret := _mock.Called(ctx, handlePath, limit, offset, filters, includeDisplay)
@@ -640,6 +711,46 @@ func (_c *UserServiceInterfaceMock_ResolveUserOUHandle_Call) Return(serviceError
 
 func (_c *UserServiceInterfaceMock_ResolveUserOUHandle_Call) RunAndReturn(run func(ctx context.Context, user *User) *common.ServiceError) *UserServiceInterfaceMock_ResolveUserOUHandle_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// SetDependencyRegistry provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) SetDependencyRegistry(r resourcedependency.Registry) {
+	_mock.Called(r)
+	return
+}
+
+// UserServiceInterfaceMock_SetDependencyRegistry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDependencyRegistry'
+type UserServiceInterfaceMock_SetDependencyRegistry_Call struct {
+	*mock.Call
+}
+
+// SetDependencyRegistry is a helper method to define mock.On call
+//   - r resourcedependency.Registry
+func (_e *UserServiceInterfaceMock_Expecter) SetDependencyRegistry(r interface{}) *UserServiceInterfaceMock_SetDependencyRegistry_Call {
+	return &UserServiceInterfaceMock_SetDependencyRegistry_Call{Call: _e.mock.On("SetDependencyRegistry", r)}
+}
+
+func (_c *UserServiceInterfaceMock_SetDependencyRegistry_Call) Run(run func(r resourcedependency.Registry)) *UserServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 resourcedependency.Registry
+		if args[0] != nil {
+			arg0 = args[0].(resourcedependency.Registry)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_SetDependencyRegistry_Call) Return() *UserServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run func(r resourcedependency.Registry)) *UserServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Run(run)
 	return _c
 }
 

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -197,6 +197,28 @@ func (uh *userHandler) HandleUserGroupsGetRequest(w http.ResponseWriter, r *http
 		log.Int("count", groupListResponse.Count))
 }
 
+// HandleUserUsagesGetRequest handles the get user usages request.
+func (uh *userHandler) HandleUserUsagesGetRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
+
+	id := r.PathValue("id")
+	if id == "" {
+		handleError(ctx, w, &ErrorMissingUserID)
+		return
+	}
+
+	result, svcErr := uh.userService.GetUserUsages(ctx, id)
+	if svcErr != nil {
+		handleError(ctx, w, svcErr)
+		return
+	}
+
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, result)
+
+	logger.Debug(ctx, "Successfully retrieved user usages", log.MaskedString(log.LoggerKeyUserID, id))
+}
+
 // HandleUserPutRequest handles the user request.
 func (uh *userHandler) HandleUserPutRequest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/backend/internal/user/handler_test.go
+++ b/backend/internal/user/handler_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/security"
 )
 
@@ -1095,4 +1096,61 @@ func TestHandleSelfUserExits_MissingContextTokens(t *testing.T) {
 		handler.HandleSelfUserCredentialUpdateRequest(rr, req)
 		require.Equal(t, http.StatusUnauthorized, rr.Code)
 	})
+}
+
+func TestHandleUserUsagesGetRequest_Success(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	total := 1
+	mockSvc.On("GetUserUsages", mock.Anything, testUserID123).
+		Return(&resourcedependency.DependenciesResponse{
+			TotalResults: &total,
+			Count:        1,
+			Summary:      map[string]int{resourcedependency.ResourceTypeAgent: 1},
+			Usages: []resourcedependency.ResourceDependency{
+				{ResourceType: resourcedependency.ResourceTypeAgent, ID: "agent-1",
+					DisplayName: "Support Agent", BehaviorOnDelete: resourcedependency.BehaviorFallback},
+			},
+		}, nil)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/users/"+testUserID123+"/usages", nil)
+	req.SetPathValue("id", testUserID123)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserUsagesGetRequest(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var response resourcedependency.DependenciesResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&response))
+	require.NotNil(t, response.TotalResults)
+	require.Equal(t, 1, *response.TotalResults)
+	require.Len(t, response.Usages, 1)
+	require.Equal(t, resourcedependency.ResourceTypeAgent, response.Usages[0].ResourceType)
+}
+
+func TestHandleUserUsagesGetRequest_MissingID(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/users//usages", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserUsagesGetRequest(rr, req)
+
+	// ErrorMissingUserID maps to 404 in the user handler's error mapping.
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestHandleUserUsagesGetRequest_NotFound(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	mockSvc.On("GetUserUsages", mock.Anything, testUserID123).
+		Return(nil, &ErrorUserNotFound)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/users/"+testUserID123+"/usages", nil)
+	req.SetPathValue("id", testUserID123)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserUsagesGetRequest(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
 }

--- a/backend/internal/user/init.go
+++ b/backend/internal/user/init.go
@@ -115,6 +115,8 @@ func registerRoutes(mux *http.ServeMux, userHandler *userHandler) {
 				userHandler.HandleUserGetRequest(w, r)
 			} else if len(segments) == 2 && segments[1] == "groups" {
 				userHandler.HandleUserGroupsGetRequest(w, r)
+			} else if len(segments) == 2 && segments[1] == "usages" {
+				userHandler.HandleUserUsagesGetRequest(w, r)
 			} else {
 				http.NotFound(w, r)
 			}

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -35,6 +35,7 @@ import (
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/internal/system/utils"
@@ -61,15 +62,19 @@ type UserServiceInterface interface {
 		credentials json.RawMessage) *tidcommon.ServiceError
 	DeleteUser(ctx context.Context, userID string) *tidcommon.ServiceError
 	ResolveUserOUHandle(ctx context.Context, user *User) *tidcommon.ServiceError
+	SetDependencyRegistry(r resourcedependency.Registry)
+	GetUserUsages(ctx context.Context, userID string) (
+		*resourcedependency.DependenciesResponse, *tidcommon.ServiceError)
 }
 
 // userService is the default implementation of the UserServiceInterface.
 type userService struct {
-	authzService      sysauthz.SystemAuthorizationServiceInterface
-	entityService     entity.EntityServiceInterface
-	ouService         oupkg.OrganizationUnitServiceInterface
-	entityTypeService entitytype.EntityTypeServiceInterface
-	uuidGenerator     func() (string, error)
+	authzService       sysauthz.SystemAuthorizationServiceInterface
+	entityService      entity.EntityServiceInterface
+	ouService          oupkg.OrganizationUnitServiceInterface
+	entityTypeService  entitytype.EntityTypeServiceInterface
+	uuidGenerator      func() (string, error)
+	dependencyRegistry resourcedependency.Registry
 }
 
 // newUserService creates a new instance of userService with injected dependencies.
@@ -781,6 +786,56 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *tidcommon
 
 	logger.Debug(ctx, "Successfully deleted user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return nil
+}
+
+// SetDependencyRegistry injects the dependency registry. Called by servicemanager after the
+// provider services are initialized to avoid a cyclic import.
+func (us *userService) SetDependencyRegistry(r resourcedependency.Registry) {
+	us.dependencyRegistry = r
+}
+
+// GetUserUsages returns the resources that reference this user, such as agents that list the user
+// as their owner. It is informational — it drives the pre-delete confirmation dialog and does not
+// gate deletion on the server.
+func (us *userService) GetUserUsages(
+	ctx context.Context, userID string,
+) (*resourcedependency.DependenciesResponse, *tidcommon.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+	if userID == "" {
+		return nil, &ErrorMissingUserID
+	}
+
+	existingEntity, err := us.entityService.GetEntity(ctx, userID)
+	if err != nil {
+		if errors.Is(err, entity.ErrEntityNotFound) {
+			return nil, &ErrorUserNotFound
+		}
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to retrieve user", err,
+			log.MaskedString(log.LoggerKeyUserID, userID))
+	}
+	if existingEntity.Category != providers.EntityCategoryUser {
+		return nil, &ErrorUserNotFound
+	}
+
+	if us.dependencyRegistry == nil {
+		logger.Warn(ctx, "Dependency registry not set; returning unknown dependencies",
+			log.MaskedString(log.LoggerKeyUserID, userID))
+		return &resourcedependency.DependenciesResponse{
+			TotalResults: nil,
+			Count:        0,
+			Summary:      nil,
+			Usages:       []resourcedependency.ResourceDependency{},
+		}, nil
+	}
+
+	result, err := us.dependencyRegistry.GetDependencies(ctx, resourcedependency.ResourceTypeUser, userID)
+	if err != nil {
+		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to get user usages", err,
+			log.MaskedString(log.LoggerKeyUserID, userID))
+	}
+
+	return result, nil
 }
 
 // populateUserDisplayNames resolves display names for a slice of users in-place.

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/entitytype"
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/internal/system/utils"
@@ -3476,4 +3477,120 @@ func TestUserDeclarativeYAML_OUHandleParsed(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "default", user.OUHandle)
 	require.Empty(t, user.OUID)
+}
+
+// --- GetUserUsages tests ---
+
+// stubUsageRegistry is a minimal resourcedependency.Registry for tests.
+type stubUsageRegistry struct {
+	resp *resourcedependency.DependenciesResponse
+	err  error
+}
+
+func (s *stubUsageRegistry) RegisterProvider(resourcedependency.Provider) {}
+
+func (s *stubUsageRegistry) GetDependencies(
+	_ context.Context, _, _ string) (*resourcedependency.DependenciesResponse, error) {
+	return s.resp, s.err
+}
+
+func newUserForUsages(id string) *providers.Entity {
+	return &providers.Entity{ID: id, Category: providers.EntityCategoryUser, Type: "Person"}
+}
+
+func TestUserService_GetUserUsages_MissingID(t *testing.T) {
+	service := &userService{}
+
+	result, err := service.GetUserUsages(context.Background(), "")
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorMissingUserID.Code, err.Code)
+}
+
+func TestUserService_GetUserUsages_NotFound(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.On("GetEntity", mock.Anything, svcTestUserID1).
+		Return((*providers.Entity)(nil), entitypkg.ErrEntityNotFound).Once()
+
+	service := &userService{entityService: entityMock}
+
+	result, err := service.GetUserUsages(context.Background(), svcTestUserID1)
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorUserNotFound.Code, err.Code)
+}
+
+func TestUserService_GetUserUsages_WrongCategory(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.On("GetEntity", mock.Anything, svcTestUserID1).
+		Return(&providers.Entity{ID: svcTestUserID1, Category: providers.EntityCategoryAgent}, nil).Once()
+
+	service := &userService{entityService: entityMock}
+
+	result, err := service.GetUserUsages(context.Background(), svcTestUserID1)
+	require.Nil(t, result)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorUserNotFound.Code, err.Code)
+}
+
+func TestUserService_GetUserUsages_RegistryNotSet(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.On("GetEntity", mock.Anything, svcTestUserID1).
+		Return(newUserForUsages(svcTestUserID1), nil).Once()
+
+	service := &userService{entityService: entityMock}
+
+	result, err := service.GetUserUsages(context.Background(), svcTestUserID1)
+	require.Nil(t, err)
+	require.NotNil(t, result)
+	require.Nil(t, result.TotalResults)
+	require.Nil(t, result.Summary)
+	require.Empty(t, result.Usages)
+}
+
+func TestUserService_GetUserUsages_WithUsages(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.On("GetEntity", mock.Anything, svcTestUserID1).
+		Return(newUserForUsages(svcTestUserID1), nil).Once()
+
+	total := 1
+	service := &userService{
+		entityService: entityMock,
+		dependencyRegistry: &stubUsageRegistry{
+			resp: &resourcedependency.DependenciesResponse{
+				TotalResults: &total,
+				Count:        1,
+				Summary:      map[string]int{resourcedependency.ResourceTypeAgent: 1},
+				Usages: []resourcedependency.ResourceDependency{
+					{ResourceType: resourcedependency.ResourceTypeAgent, ID: "agent-1",
+						DisplayName: "Support Agent", BehaviorOnDelete: resourcedependency.BehaviorFallback},
+				},
+			},
+		},
+	}
+
+	result, err := service.GetUserUsages(context.Background(), svcTestUserID1)
+	require.Nil(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.TotalResults)
+	require.Equal(t, 1, *result.TotalResults)
+	require.Equal(t, 1, result.Summary[resourcedependency.ResourceTypeAgent])
+	require.Len(t, result.Usages, 1)
+	require.Equal(t, resourcedependency.ResourceTypeAgent, result.Usages[0].ResourceType)
+	require.Equal(t, "agent-1", result.Usages[0].ID)
+}
+
+func TestUserService_GetUserUsages_RegistryError(t *testing.T) {
+	entityMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityMock.On("GetEntity", mock.Anything, svcTestUserID1).
+		Return(newUserForUsages(svcTestUserID1), nil).Once()
+
+	service := &userService{
+		entityService:      entityMock,
+		dependencyRegistry: &stubUsageRegistry{err: errors.New("registry error")},
+	}
+
+	result, err := service.GetUserUsages(context.Background(), svcTestUserID1)
+	require.Nil(t, result)
+	require.NotNil(t, err)
 }

--- a/backend/tests/mocks/usermock/UserServiceInterface_mock.go
+++ b/backend/tests/mocks/usermock/UserServiceInterface_mock.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/user"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
@@ -491,6 +492,76 @@ func (_c *UserServiceInterfaceMock_GetUserList_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetUserUsages provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) GetUserUsages(ctx context.Context, userID string) (*resourcedependency.DependenciesResponse, *common.ServiceError) {
+	ret := _mock.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserUsages")
+	}
+
+	var r0 *resourcedependency.DependenciesResponse
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*resourcedependency.DependenciesResponse, *common.ServiceError)); ok {
+		return returnFunc(ctx, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *resourcedependency.DependenciesResponse); ok {
+		r0 = returnFunc(ctx, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcedependency.DependenciesResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, userID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserServiceInterfaceMock_GetUserUsages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserUsages'
+type UserServiceInterfaceMock_GetUserUsages_Call struct {
+	*mock.Call
+}
+
+// GetUserUsages is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *UserServiceInterfaceMock_Expecter) GetUserUsages(ctx interface{}, userID interface{}) *UserServiceInterfaceMock_GetUserUsages_Call {
+	return &UserServiceInterfaceMock_GetUserUsages_Call{Call: _e.mock.On("GetUserUsages", ctx, userID)}
+}
+
+func (_c *UserServiceInterfaceMock_GetUserUsages_Call) Run(run func(ctx context.Context, userID string)) *UserServiceInterfaceMock_GetUserUsages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUserUsages_Call) Return(dependenciesResponse *resourcedependency.DependenciesResponse, serviceError *common.ServiceError) *UserServiceInterfaceMock_GetUserUsages_Call {
+	_c.Call.Return(dependenciesResponse, serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUserUsages_Call) RunAndReturn(run func(ctx context.Context, userID string) (*resourcedependency.DependenciesResponse, *common.ServiceError)) *UserServiceInterfaceMock_GetUserUsages_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUsersByPath provides a mock function for the type UserServiceInterfaceMock
 func (_mock *UserServiceInterfaceMock) GetUsersByPath(ctx context.Context, handlePath string, limit int, offset int, filters map[string]interface{}, includeDisplay bool) (*user.UserListResponse, *common.ServiceError) {
 	ret := _mock.Called(ctx, handlePath, limit, offset, filters, includeDisplay)
@@ -641,6 +712,46 @@ func (_c *UserServiceInterfaceMock_ResolveUserOUHandle_Call) Return(serviceError
 
 func (_c *UserServiceInterfaceMock_ResolveUserOUHandle_Call) RunAndReturn(run func(ctx context.Context, user1 *user.User) *common.ServiceError) *UserServiceInterfaceMock_ResolveUserOUHandle_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// SetDependencyRegistry provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) SetDependencyRegistry(r resourcedependency.Registry) {
+	_mock.Called(r)
+	return
+}
+
+// UserServiceInterfaceMock_SetDependencyRegistry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDependencyRegistry'
+type UserServiceInterfaceMock_SetDependencyRegistry_Call struct {
+	*mock.Call
+}
+
+// SetDependencyRegistry is a helper method to define mock.On call
+//   - r resourcedependency.Registry
+func (_e *UserServiceInterfaceMock_Expecter) SetDependencyRegistry(r interface{}) *UserServiceInterfaceMock_SetDependencyRegistry_Call {
+	return &UserServiceInterfaceMock_SetDependencyRegistry_Call{Call: _e.mock.On("SetDependencyRegistry", r)}
+}
+
+func (_c *UserServiceInterfaceMock_SetDependencyRegistry_Call) Run(run func(r resourcedependency.Registry)) *UserServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 resourcedependency.Registry
+		if args[0] != nil {
+			arg0 = args[0].(resourcedependency.Registry)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_SetDependencyRegistry_Call) Return() *UserServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run func(r resourcedependency.Registry)) *UserServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Run(run)
 	return _c
 }
 

--- a/frontend/packages/configure-users/src/api/useGetUserUsages.ts
+++ b/frontend/packages/configure-users/src/api/useGetUserUsages.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import {useConfig} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import UserQueryKeys from '../constants/user-query-keys';
+import type {UserUsagesResponse} from '../models/users';
+
+/**
+ * Custom hook to fetch resources that reference a user, such as agents that list the user
+ * as their owner. Used to populate the pre-delete confirmation dialog.
+ *
+ * @param userId - The unique identifier of the user
+ * @param enabled - Whether the query should run (default true)
+ * @returns TanStack Query result with user usages data
+ */
+export default function useGetUserUsages(userId: string | null, enabled = true): UseQueryResult<UserUsagesResponse> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+
+  return useQuery<UserUsagesResponse>({
+    queryKey: [UserQueryKeys.USER_USAGES, userId],
+    queryFn: async (): Promise<UserUsagesResponse> => {
+      const serverUrl: string = getServerUrl();
+
+      const response: {data: UserUsagesResponse} = await http.request({
+        url: `${serverUrl}/users/${encodeURIComponent(userId!)}/usages`,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      return response.data;
+    },
+    enabled: Boolean(userId) && enabled,
+  });
+}

--- a/frontend/packages/configure-users/src/components/UserDeleteDialog.tsx
+++ b/frontend/packages/configure-users/src/components/UserDeleteDialog.tsx
@@ -16,10 +16,26 @@
  * under the License.
  */
 
-import {Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Alert} from '@wso2/oxygen-ui';
+import {
+  Alert,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+} from '@wso2/oxygen-ui';
 import {useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import useDeleteUser from '../api/useDeleteUser';
+import useGetUserUsages from '../api/useGetUserUsages';
+
+const MAX_VISIBLE_USAGES = 5;
 
 export interface UserDeleteDialogProps {
   open: boolean;
@@ -40,6 +56,12 @@ export default function UserDeleteDialog({
   const {t} = useTranslation();
   const deleteUser = useDeleteUser();
   const [error, setError] = useState<string | null>(null);
+
+  const {data: usagesData, isLoading: isLoadingUsages} = useGetUserUsages(userId, open);
+
+  const usagesKnown = usagesData !== undefined && usagesData.totalResults !== null;
+  const visibleUsages = usagesData?.usages.slice(0, MAX_VISIBLE_USAGES) ?? [];
+  const hiddenCount = (usagesData?.totalResults ?? 0) - visibleUsages.length;
 
   const handleCancel = (): void => {
     if (deleteUser.isPending) return;
@@ -70,9 +92,45 @@ export default function UserDeleteDialog({
         <DialogContentText sx={{mb: 2}}>
           {t('users:delete.message', 'Are you sure you want to delete this user? This action cannot be undone.')}
         </DialogContentText>
-        <Alert severity="warning" sx={{mb: 2}}>
-          {t('users:delete.disclaimer', 'All associated data will be permanently removed.')}
-        </Alert>
+
+        {isLoadingUsages ? (
+          <Alert severity="info" icon={<CircularProgress size={16} />} sx={{mb: 2}}>
+            {t('users:delete.usages.loading', 'Checking affected resources…')}
+          </Alert>
+        ) : !usagesKnown ? (
+          <Alert severity="warning" sx={{mb: 2}}>
+            {t('users:delete.disclaimer', 'All associated data will be permanently removed.')}
+          </Alert>
+        ) : (usagesData?.totalResults ?? 0) > 0 ? (
+          <Alert severity="warning" sx={{mb: 2}}>
+            <Typography variant="body2" sx={{mb: 1}}>
+              {t('users:delete.usages.title', 'The following agents list this user as their owner:')}
+            </Typography>
+            <List dense disablePadding>
+              {visibleUsages.map((usage) => (
+                <ListItem key={usage.id} disableGutters sx={{py: 0}}>
+                  <ListItemText primary={<Typography variant="body2">{usage.displayName}</Typography>} />
+                </ListItem>
+              ))}
+              {hiddenCount > 0 && (
+                <ListItem disableGutters sx={{py: 0}}>
+                  <ListItemText
+                    primary={
+                      <Typography variant="body2" color="text.secondary">
+                        {t('users:delete.usages.more', {count: hiddenCount, defaultValue: '+{{count}} more'})}
+                      </Typography>
+                    }
+                  />
+                </ListItem>
+              )}
+            </List>
+          </Alert>
+        ) : (
+          <Alert severity="info" sx={{mb: 2}}>
+            {t('users:delete.usages.none', 'No agents currently list this user as their owner.')}
+          </Alert>
+        )}
+
         {error && (
           <Alert severity="error" sx={{mt: 2}}>
             {error}
@@ -83,7 +141,12 @@ export default function UserDeleteDialog({
         <Button onClick={handleCancel} disabled={deleteUser.isPending}>
           {t('common:actions.cancel')}
         </Button>
-        <Button onClick={handleConfirm} color="error" variant="contained" disabled={deleteUser.isPending || !userId}>
+        <Button
+          onClick={handleConfirm}
+          color="error"
+          variant="contained"
+          disabled={deleteUser.isPending || !userId || isLoadingUsages}
+        >
           {deleteUser.isPending ? t('common:status.deleting', 'Deleting...') : t('common:actions.delete', 'Delete')}
         </Button>
       </DialogActions>

--- a/frontend/packages/configure-users/src/components/UsersList.tsx
+++ b/frontend/packages/configure-users/src/components/UsersList.tsx
@@ -19,26 +19,12 @@
 import {ResourceAvatar, getInitials} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
-import {
-  IconButton,
-  Tooltip,
-  Typography,
-  Snackbar,
-  Alert,
-  ListingTable,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
-  Button,
-  DataGrid,
-} from '@wso2/oxygen-ui';
+import {IconButton, Tooltip, Typography, Snackbar, Alert, ListingTable, DataGrid} from '@wso2/oxygen-ui';
 import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useState, useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
-import useDeleteUser from '../api/useDeleteUser';
+import UserDeleteDialog from './UserDeleteDialog';
 import useGetUsers from '../api/useGetUsers';
 import type {UserWithDetails} from '../models/users';
 
@@ -49,7 +35,6 @@ export default function UsersList() {
   const dataGridLocaleText = useDataGridLocaleText();
 
   const {data: userData, isLoading, error: usersRequestError} = useGetUsers();
-  const deleteUserMutation = useDeleteUser();
 
   const error = usersRequestError;
 
@@ -89,20 +74,6 @@ export default function UsersList() {
   const handleDeleteCancel = () => {
     setDeleteDialogOpen(false);
     setSelectedUserId(null);
-  };
-
-  const handleDeleteConfirm = async () => {
-    if (!selectedUserId) return;
-
-    try {
-      await deleteUserMutation.mutateAsync(selectedUserId);
-      setDeleteDialogOpen(false);
-      setSelectedUserId(null);
-    } catch (err) {
-      // Error is already handled in the hook
-      setDeleteDialogOpen(false);
-      logger.error('Failed to delete user', {error: err, userId: selectedUserId});
-    }
   };
 
   const columns: DataGrid.GridColDef<UserWithDetails>[] = useMemo(
@@ -229,36 +200,7 @@ export default function UsersList() {
       </ListingTable.Provider>
 
       {/* Delete Confirmation Dialog */}
-      <Dialog open={deleteDialogOpen} onClose={handleDeleteCancel}>
-        <DialogTitle>{t('users:deleteUser')}</DialogTitle>
-        <DialogContent>
-          <DialogContentText>{t('users:confirmDeleteUser')}</DialogContentText>
-          {deleteUserMutation.error && (
-            <Alert severity="error" sx={{mt: 2}}>
-              <Typography variant="body2" sx={{fontWeight: 'bold'}}>
-                {deleteUserMutation.error.message}
-              </Typography>
-            </Alert>
-          )}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleDeleteCancel} disabled={deleteUserMutation.isPending}>
-            {t('common:actions.cancel')}
-          </Button>
-          <Button
-            onClick={() => {
-              handleDeleteConfirm().catch(() => {
-                // Handle error
-              });
-            }}
-            color="error"
-            variant="contained"
-            disabled={deleteUserMutation.isPending}
-          >
-            {deleteUserMutation.isPending ? t('common:status.loading') : t('common:actions.delete')}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <UserDeleteDialog open={deleteDialogOpen} userId={selectedUserId} onClose={handleDeleteCancel} />
 
       <Snackbar
         open={snackbarOpen}

--- a/frontend/packages/configure-users/src/components/__tests__/UserDeleteDialog.test.tsx
+++ b/frontend/packages/configure-users/src/components/__tests__/UserDeleteDialog.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent, waitFor} from '@thunderid/test-utils';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import type {UserUsagesResponse} from '../../models/users';
+import UserDeleteDialog from '../UserDeleteDialog';
+
+// Mock react-i18next. Resolves inline defaults (string or {defaultValue}) like the real i18n.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, arg?: unknown): string => {
+      const translations: Record<string, string> = {
+        'users:delete.title': 'Delete User',
+        'users:delete.message': 'Are you sure you want to delete this user?',
+        'users:delete.disclaimer': 'All associated data will be permanently removed.',
+        'users:delete.usages.loading': 'Checking affected resources…',
+        'users:delete.usages.none': 'No agents currently list this user as their owner.',
+        'users:delete.usages.title': 'The following agents list this user as their owner:',
+        'common:actions.cancel': 'Cancel',
+        'common:actions.delete': 'Delete',
+        'common:status.deleting': 'Deleting...',
+      };
+      if (translations[key]) return translations[key];
+      if (typeof arg === 'string') return arg;
+      if (arg && typeof arg === 'object') {
+        const obj = arg as {defaultValue?: string; count?: number};
+        if (obj.defaultValue) return obj.defaultValue.replace('{{count}}', String(obj.count ?? ''));
+      }
+      return key;
+    },
+  }),
+}));
+
+// Mock useDeleteUser hook.
+const mockMutate = vi.fn();
+const mockDeleteUser = {
+  mutate: mockMutate,
+  isPending: false,
+};
+vi.mock('../../api/useDeleteUser', () => ({
+  default: () => mockDeleteUser,
+}));
+
+// Mock useGetUserUsages hook.
+const {getUsagesMock} = vi.hoisted(() => ({
+  getUsagesMock: vi.fn<() => {data: UserUsagesResponse | undefined; isLoading: boolean}>(),
+}));
+vi.mock('../../api/useGetUserUsages', () => ({
+  default: () => getUsagesMock(),
+}));
+
+describe('UserDeleteDialog', () => {
+  const mockOnClose = vi.fn();
+  const mockOnSuccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteUser.isPending = false;
+    getUsagesMock.mockReturnValue({data: undefined, isLoading: false});
+  });
+
+  it('should render dialog when open is true', () => {
+    render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Delete User')).toBeInTheDocument();
+  });
+
+  it('should not render dialog when open is false', () => {
+    render(<UserDeleteDialog open={false} userId="user-123" onClose={mockOnClose} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should call mutate with userId when delete button is clicked', () => {
+    render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+    expect(mockMutate).toHaveBeenCalledWith('user-123', expect.any(Object));
+  });
+
+  it('should call onClose when cancel button is clicked', () => {
+    render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe('Usages', () => {
+    it('should show a loading alert while usages are being fetched', () => {
+      getUsagesMock.mockReturnValue({data: undefined, isLoading: true});
+
+      render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} />);
+
+      expect(screen.getByText('Checking affected resources…')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
+    });
+
+    it('should list the agents that own the user', () => {
+      const usages: UserUsagesResponse = {
+        totalResults: 2,
+        count: 2,
+        summary: {agent: 2},
+        usages: [
+          {resourceType: 'agent', id: 'agent-1', displayName: 'Support Agent', behaviorOnDelete: 'fallback'},
+          {resourceType: 'agent', id: 'agent-2', displayName: 'Billing Agent', behaviorOnDelete: 'fallback'},
+        ],
+      };
+      getUsagesMock.mockReturnValue({data: usages, isLoading: false});
+
+      render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} />);
+
+      expect(screen.getByText('The following agents list this user as their owner:')).toBeInTheDocument();
+      expect(screen.getByText('Support Agent')).toBeInTheDocument();
+      expect(screen.getByText('Billing Agent')).toBeInTheDocument();
+    });
+
+    it('should show a "+N more" row when usages exceed the visible limit', () => {
+      const usages: UserUsagesResponse = {
+        totalResults: 7,
+        count: 7,
+        summary: {agent: 7},
+        usages: Array.from({length: 7}, (_, i) => ({
+          resourceType: 'agent',
+          id: `agent-${i}`,
+          displayName: `Agent ${i}`,
+          behaviorOnDelete: 'fallback' as const,
+        })),
+      };
+      getUsagesMock.mockReturnValue({data: usages, isLoading: false});
+
+      render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} />);
+
+      expect(screen.getByText('+2 more')).toBeInTheDocument();
+    });
+
+    it('should show a "no usages" alert when there are none', () => {
+      getUsagesMock.mockReturnValue({
+        data: {totalResults: 0, count: 0, summary: {}, usages: []},
+        isLoading: false,
+      });
+
+      render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} />);
+
+      expect(screen.getByText('No agents currently list this user as their owner.')).toBeInTheDocument();
+    });
+
+    it('should fall back to the disclaimer when usage data is unknown', () => {
+      getUsagesMock.mockReturnValue({
+        data: {totalResults: null, count: 0, summary: null, usages: []},
+        isLoading: false,
+      });
+
+      render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} />);
+
+      expect(screen.getByText('All associated data will be permanently removed.')).toBeInTheDocument();
+    });
+  });
+
+  describe('Callbacks', () => {
+    it('should call onClose and onSuccess on successful deletion', async () => {
+      mockMutate.mockImplementation((_userId: string, options: {onSuccess: () => void}) => {
+        options.onSuccess();
+      });
+
+      render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+
+      fireEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalled();
+        expect(mockOnSuccess).toHaveBeenCalled();
+      });
+    });
+
+    it('should display an error alert on deletion failure', async () => {
+      mockMutate.mockImplementation((_userId: string, options: {onError: (err: Error) => void}) => {
+        options.onError(new Error('Network error'));
+      });
+
+      render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} />);
+
+      fireEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+      await waitFor(() => {
+        expect(screen.getByText('Network error')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/packages/configure-users/src/components/__tests__/UsersList.test.tsx
+++ b/frontend/packages/configure-users/src/components/__tests__/UsersList.test.tsx
@@ -29,7 +29,6 @@ const {mockLoggerError} = vi.hoisted(() => ({
 }));
 
 const mockNavigate = vi.fn();
-const mockDeleteMutateAsync = vi.fn();
 
 // Mock DataGrid to avoid CSS import issues
 interface MockRow {
@@ -167,27 +166,24 @@ interface UseGetUsersReturn {
   error: Error | null;
 }
 
-interface UseDeleteUserReturn {
-  mutate: ReturnType<typeof vi.fn>;
-  mutateAsync: ReturnType<typeof vi.fn>;
-  isPending: boolean;
-  error: Error | null;
-  data: unknown;
-  isError: boolean;
-  isSuccess: boolean;
-  isIdle: boolean;
-  reset: () => void;
-}
-
 const mockUseGetUsers = vi.fn<() => UseGetUsersReturn>();
-const mockUseDeleteUser = vi.fn<() => UseDeleteUserReturn>();
 
 vi.mock('@/api/useGetUsers', () => ({
   default: () => mockUseGetUsers(),
 }));
 
-vi.mock('@/api/useDeleteUser', () => ({
-  default: () => mockUseDeleteUser(),
+// The delete flow lives in UserDeleteDialog (covered by its own test). Stub it here so these
+// tests focus on UsersList's responsibility: opening the dialog for the selected user.
+vi.mock('@/components/UserDeleteDialog', () => ({
+  default: ({open, userId, onClose}: {open: boolean; userId: string | null; onClose: () => void}) =>
+    open ? (
+      <div data-testid="user-delete-dialog">
+        <span data-testid="delete-dialog-user-id">{userId}</span>
+        <button type="button" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    ) : null,
 }));
 
 describe('UsersList', () => {
@@ -223,27 +219,13 @@ describe('UsersList', () => {
     ],
   };
 
-  const defaultDeleteReturn: UseDeleteUserReturn = {
-    mutate: vi.fn(),
-    mutateAsync: mockDeleteMutateAsync,
-    isPending: false,
-    error: null,
-    data: undefined,
-    isError: false,
-    isSuccess: false,
-    isIdle: true,
-    reset: vi.fn(),
-  };
-
   beforeEach(() => {
     vi.clearAllMocks();
-    mockDeleteMutateAsync.mockResolvedValue(undefined);
     mockUseGetUsers.mockReturnValue({
       data: mockUsersData,
       isLoading: false,
       error: null,
     });
-    mockUseDeleteUser.mockReturnValue({...defaultDeleteReturn});
   });
 
   it('renders DataGrid with users', async () => {
@@ -318,7 +300,7 @@ describe('UsersList', () => {
     });
   });
 
-  it('opens delete dialog when Delete is clicked', async () => {
+  it('opens delete dialog for the selected user when Delete is clicked', async () => {
     const user = userEvent.setup();
     render(<UsersList />);
 
@@ -326,40 +308,18 @@ describe('UsersList', () => {
       expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
     });
 
+    expect(screen.queryByTestId('user-delete-dialog')).not.toBeInTheDocument();
+
     const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
     await user.click(deleteButtons[0]);
 
     await waitFor(() => {
-      expect(screen.getByText('Delete User')).toBeInTheDocument();
-      expect(screen.getByText('Are you sure you want to delete this user?')).toBeInTheDocument();
+      expect(screen.getByTestId('user-delete-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-dialog-user-id')).toHaveTextContent('user1');
     });
   });
 
-  it('deletes user when confirmed', async () => {
-    const user = userEvent.setup();
-
-    render(<UsersList />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
-    });
-
-    const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
-    await user.click(deleteButtons[0]);
-
-    await waitFor(() => {
-      expect(screen.getByText('Delete User')).toBeInTheDocument();
-    });
-
-    const confirmButton = screen.getByRole('button', {name: /^delete$/i});
-    await user.click(confirmButton);
-
-    await waitFor(() => {
-      expect(mockDeleteMutateAsync).toHaveBeenCalledWith('user1');
-    });
-  });
-
-  it('cancels delete when Cancel button is clicked', async () => {
+  it('cancels delete when the dialog requests close', async () => {
     const user = userEvent.setup();
     render(<UsersList />);
 
@@ -371,38 +331,14 @@ describe('UsersList', () => {
     await user.click(deleteButtons[0]);
 
     await waitFor(() => {
-      expect(screen.getByText('Delete User')).toBeInTheDocument();
+      expect(screen.getByTestId('user-delete-dialog')).toBeInTheDocument();
     });
 
     const cancelButton = screen.getByRole('button', {name: /cancel/i});
     await user.click(cancelButton);
 
     await waitFor(() => {
-      expect(screen.queryByText('Delete User')).not.toBeInTheDocument();
-    });
-  });
-
-  it('displays delete error in dialog', async () => {
-    const user = userEvent.setup();
-
-    mockUseDeleteUser.mockReturnValue({
-      ...defaultDeleteReturn,
-      error: new Error('Failed to delete'),
-      isError: true,
-      isIdle: false,
-    });
-
-    render(<UsersList />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
-    });
-
-    const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
-    await user.click(deleteButtons[0]);
-
-    await waitFor(() => {
-      expect(screen.getByText('Failed to delete')).toBeInTheDocument();
+      expect(screen.queryByTestId('user-delete-dialog')).not.toBeInTheDocument();
     });
   });
 
@@ -426,36 +362,6 @@ describe('UsersList', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Failed to load users')).not.toBeInTheDocument();
-    });
-  });
-
-  it('handles error when delete user fails', async () => {
-    const user = userEvent.setup();
-    const deleteError = new Error('Delete failed');
-    const failingDeleteMutateAsync = vi.fn().mockRejectedValue(deleteError);
-    mockUseDeleteUser.mockReturnValue({
-      ...defaultDeleteReturn,
-      mutateAsync: failingDeleteMutateAsync,
-    });
-
-    render(<UsersList />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
-    });
-
-    const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
-    await user.click(deleteButtons[0]);
-
-    await waitFor(() => {
-      expect(screen.getByText('Delete User')).toBeInTheDocument();
-    });
-
-    const confirmButton = screen.getByRole('button', {name: /^delete$/i});
-    await user.click(confirmButton);
-
-    await waitFor(() => {
-      expect(failingDeleteMutateAsync).toHaveBeenCalledWith('user1');
     });
   });
 
@@ -594,28 +500,5 @@ describe('UsersList', () => {
 
     const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
     expect(deleteButtons.length).toBeGreaterThanOrEqual(2);
-  });
-
-  it('displays loading state when deleting user', async () => {
-    const user = userEvent.setup();
-    mockUseDeleteUser.mockReturnValue({
-      ...defaultDeleteReturn,
-      isPending: true,
-      isIdle: false,
-    });
-
-    render(<UsersList />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('row-user1')).toHaveTextContent('John Doe');
-    });
-
-    const deleteButtons = screen.getAllByRole('button', {name: /delete/i});
-    await user.click(deleteButtons[0]);
-
-    await waitFor(() => {
-      const confirmButton = screen.getByRole('button', {name: /loading/i});
-      expect(confirmButton).toBeDisabled();
-    });
   });
 });

--- a/frontend/packages/configure-users/src/constants/user-query-keys.ts
+++ b/frontend/packages/configure-users/src/constants/user-query-keys.ts
@@ -29,6 +29,10 @@ const UserQueryKeys = {
    */
   USER: 'user',
   /**
+   * Key for a user usages query.
+   */
+  USER_USAGES: 'user-usages',
+  /**
    * Base key for user type list queries.
    */
   USER_TYPES: 'userTypes',

--- a/frontend/packages/configure-users/src/index.ts
+++ b/frontend/packages/configure-users/src/index.ts
@@ -20,6 +20,7 @@
 export {default as useCreateUser} from './api/useCreateUser';
 export {default as useDeleteUser} from './api/useDeleteUser';
 export {default as useGetUser} from './api/useGetUser';
+export {default as useGetUserUsages} from './api/useGetUserUsages';
 export {default as useGetUsers} from './api/useGetUsers';
 export {default as useGetUserType} from './api/useGetUserType';
 export {default as useGetUserTypes} from './api/useGetUserTypes';

--- a/frontend/packages/configure-users/src/models/users.ts
+++ b/frontend/packages/configure-users/src/models/users.ts
@@ -201,3 +201,30 @@ export interface SchemaInterface {
   name: string;
   ouId: string;
 }
+
+/**
+ * A single resource that references a user (e.g. an agent that lists the user as its owner).
+ */
+export interface UserUsage {
+  resourceType: string;
+  id: string;
+  displayName: string;
+  behaviorOnDelete: 'fallback' | 'cascade';
+}
+
+/**
+ * Per-resource-type count of usages, keyed by resource type (e.g. `agent`).
+ * Null when the counts could not be determined.
+ */
+export type UserUsagesSummary = Record<string, number> | null;
+
+/**
+ * Response for the user usages endpoint.
+ * totalResults is null when usage data is unavailable; 0 means confirmed empty.
+ */
+export interface UserUsagesResponse {
+  totalResults: number | null;
+  count: number;
+  summary: UserUsagesSummary;
+  usages: UserUsage[];
+}

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -734,6 +734,10 @@ const translations = {
     'delete.disclaimer': 'All associated data will be permanently removed.',
     'delete.success': 'User deleted successfully.',
     'delete.error': 'Failed to delete user. Please try again.',
+    'delete.usages.loading': 'Checking affected resources…',
+    'delete.usages.none': 'No agents currently list this user as their owner.',
+    'delete.usages.title': 'The following agents list this user as their owner:',
+    'delete.usages.more': '+{{count}} more',
   },
 
   // ============================================================================


### PR DESCRIPTION
### Purpose

Adds usage support for users. Introduces a new `GET /users/{id}/usages` endpoint that returns the resources referencing a given user (currently agents that list the user as their owner), aggregated across resource types. This is informational only — it drives the pre-delete confirmation dialog in the Console and does not gate deletion on the server.

Each usage entry includes a `behaviorOnDelete` field (`fallback` keeps the reference as-is, `cascade` deletes the referencing resource with the user). When usage data is unavailable, `totalResults` and `summary` are returned as `null` rather than `0`/empty, so consumers can distinguish "unknown" from "confirmed empty".

### Approach

- **Backend**: Added `HandleUserUsagesGetRequest` handler and `GetUserUsages` service method. The user service resolves usages through the shared `resourcedependency.Registry`, which is injected via `SetDependencyRegistry` from the service manager after provider services initialise (avoiding a cyclic import). Registered the user resource in the dependency registry.
- **API**: Documented the new endpoint and the `ResourceUsage`, `ResourceUsagesSummary`, and `ResourceUsagesResponse` schemas in `api/user.yaml`.
- **Frontend**: Added `useGetUserUsages` query hook and models, and wired the results into `UserDeleteDialog` so the delete confirmation surfaces referencing resources. Added i18n keys.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GET /users/{id}/usages` to fetch aggregated user usage details with per-resource summaries.
  * Updated user deletion flow to display affected owning agents/resources (including overflow via “+N more”) using the new usages API.
* **Bug Fixes**
  * Clarified and surfaced “unknown” vs “confirmed empty” usage states in the UI.
  * Disabled the Delete action while usages are loading.
* **Tests**
  * Added/updated unit tests for the new endpoint, routing/handler behavior, and deletion dialog UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->