### PR TITLE
Remove obsolete bootstrap.sh chmod and stale SKIP_SECURITY comment

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -683,8 +683,8 @@ jobs:
       
       - name: 🔑 Obtain Admin Access Token
         run: |
-          # The server now runs with security enabled (SKIP_SECURITY is gone), so the
-          # management /import and /applications calls below need an admin token.
+          # The server runs with security enabled, so the management /import and
+          # /applications calls below need an admin token.
           # Obtain one via OAuth2 authorization code + PKCE through the CONSOLE app,
           # authenticating the bootstrapped admin user.
           SERVER_URL="https://localhost:8090"

--- a/build.sh
+++ b/build.sh
@@ -498,8 +498,6 @@ function prepare_backend_for_packaging() {
     cp -r "$BACKEND_DIR/bootstrap" "$DIST_DIR/$PRODUCT_FOLDER/"
     # Never ship the dev-only CORS seed that `run` stages into the source bootstrap dir.
     rm -f "$DIST_DIR/$PRODUCT_FOLDER/bootstrap/02-server-configurations.yaml"
-    # Ensure execute permissions on bootstrap scripts
-    chmod +x "$DIST_DIR/$PRODUCT_FOLDER/bootstrap/"*.sh 2>/dev/null || true
 
     echo "=== Ensuring server certificates exist in the distribution ==="
     ensure_certificates "$DIST_DIR/$PRODUCT_FOLDER/$SECURITY_DIR" "server"


### PR DESCRIPTION
### Purpose
Follow-up cleanup after #3381, which removed the `SKIP_SECURITY` env variable and the `.sh` scripts from the `bootstrap` folder.

Two now-dead references remained:
- `build.sh` still ran `chmod +x .../bootstrap/*.sh`, but the `bootstrap` folder no longer contains any `.sh` files (only `.yaml` default resources).
- `.github/workflows/pr-builder.yml` had a comment referencing `SKIP_SECURITY` by name.

### Approach
- Removed the `chmod +x` line (and its comment) in `build.sh`. The `cp -r` of the `bootstrap` directory is kept since it still holds the default-resources YAML.
- Simplified the PR-builder workflow comment to drop the `(SKIP_SECURITY is gone)` parenthetical; the remaining note is still accurate.

No functional/runtime behavior changes.

### Related Issues
- N/A

### Related PRs
- #3381

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated packaging behavior so backend bootstrap scripts retain their existing file permissions, rather than being modified during build preparation.
  * Clarified an end-to-end testing workflow note: when security is enabled, management endpoints (such as import and applications) require an admin access token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->