### PR TITLE
Fix pagination link issue in OU handle based user and group listing APIs

### DIFF
--- a/backend/internal/ou/service.go
+++ b/backend/internal/ou/service.go
@@ -991,6 +991,10 @@ func (ous *organizationUnitService) GetOrganizationUnitUsersByPath(
 		return nil, serviceError
 	}
 
+	if ous.userResolver == nil {
+		return nil, &tidcommon.InternalServerError
+	}
+
 	ou, err := ous.ouStore.GetOrganizationUnitByPath(ctx, handles)
 	if err != nil {
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
@@ -1000,7 +1004,30 @@ func (ous *organizationUnitService) GetOrganizationUnitUsersByPath(
 		return nil, &tidcommon.InternalServerError
 	}
 
-	return ous.GetOrganizationUnitUsers(ctx, ou.ID, limit, offset, includeDisplay)
+	if svcErr := ous.checkOUAccess(ctx, security.ActionReadUser, ou.ID); svcErr != nil {
+		return nil, svcErr
+	}
+
+	items, totalCount, svcErr := ous.getResourceListWithExistenceCheck(
+		ctx, ou.ID, limit, offset, "users",
+		func(ctx context.Context, id string, limit, offset int) (interface{}, error) {
+			return ous.userResolver.GetUserListByOUID(ctx, id, limit, offset, includeDisplay)
+		},
+		ous.userResolver.GetUserCountByOUID,
+		false,
+	)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	users, ok := items.([]User)
+	if !ok {
+		logger.Error(ctx, "Failed to cast user list response for organization unit", log.String("ouPath", handlePath))
+		return nil, &tidcommon.InternalServerError
+	}
+
+	base := fmt.Sprintf("/organization-units/tree/%s/users", handlePath)
+	return buildUserListResponse(base, users, totalCount, limit, offset, includeDisplay)
 }
 
 // GetOrganizationUnitGroupsByPath retrieves a list of groups by hierarchical handle path.
@@ -1015,6 +1042,10 @@ func (ous *organizationUnitService) GetOrganizationUnitGroupsByPath(
 		return nil, serviceError
 	}
 
+	if ous.groupResolver == nil {
+		return nil, &tidcommon.InternalServerError
+	}
+
 	ou, err := ous.ouStore.GetOrganizationUnitByPath(ctx, handles)
 	if err != nil {
 		if errors.Is(err, ErrOrganizationUnitNotFound) {
@@ -1024,7 +1055,24 @@ func (ous *organizationUnitService) GetOrganizationUnitGroupsByPath(
 		return nil, &tidcommon.InternalServerError
 	}
 
-	return ous.GetOrganizationUnitGroups(ctx, ou.ID, limit, offset)
+	if svcErr := ous.checkOUAccess(ctx, security.ActionReadGroup, ou.ID); svcErr != nil {
+		return nil, svcErr
+	}
+
+	items, totalCount, svcErr := ous.getResourceListWithExistenceCheck(
+		ctx, ou.ID, limit, offset, "groups",
+		func(ctx context.Context, id string, limit, offset int) (interface{}, error) {
+			return ous.groupResolver.GetGroupListByOUID(ctx, id, limit, offset)
+		},
+		ous.groupResolver.GetGroupCountByOUID,
+		false,
+	)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	base := fmt.Sprintf("/organization-units/tree/%s/groups", handlePath)
+	return buildGroupListResponse(base, items, totalCount, limit, offset)
 }
 
 // checkCircularDependency checks if setting the parent would create a circular dependency.

--- a/backend/internal/ou/service_test.go
+++ b/backend/internal/ou/service_test.go
@@ -1996,6 +1996,8 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 // runResolverPathListTests runs common path-based list tests for user/group resolver-backed endpoints.
 func (suite *OrganizationUnitServiceTestSuite) runResolverPathListTests(
 	invalidPath string,
+	makeResolvers func() (OUUserResolver, OUGroupResolver),
+	errorResolvers func() (OUUserResolver, OUGroupResolver),
 	setupResolvers func() (OUUserResolver, OUGroupResolver),
 	invoke func(*organizationUnitService, string, int, int) (interface{}, *tidcommon.ServiceError),
 ) {
@@ -2008,12 +2010,22 @@ func (suite *OrganizationUnitServiceTestSuite) runResolverPathListTests(
 		suite.Require().Equal(ErrorInvalidHandlePath, *err)
 	})
 
+	suite.Run("nil resolver", func() {
+		store := newOrganizationUnitStoreInterfaceMock(suite.T())
+		service := suite.newServiceWithResolvers(store, newAllowAllAuthz(suite.T()), nil, nil)
+
+		resp, err := invoke(service, "root", 5, 0)
+		suite.Require().Nil(resp)
+		suite.Require().Equal(tidcommon.InternalServerError, *err)
+	})
+
 	suite.Run("not found", func() {
 		store := newOrganizationUnitStoreInterfaceMock(suite.T())
 		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(providers.OrganizationUnit{}, ErrOrganizationUnitNotFound).Once()
 
-		service := suite.newService(store, newAllowAllAuthz(suite.T()))
+		userRes, groupRes := makeResolvers()
+		service := suite.newServiceWithResolvers(store, newAllowAllAuthz(suite.T()), userRes, groupRes)
 		resp, err := invoke(service, "root", 5, 0)
 		suite.Require().Nil(resp)
 		suite.Require().Equal(ErrorOrganizationUnitNotFound, *err)
@@ -2024,7 +2036,22 @@ func (suite *OrganizationUnitServiceTestSuite) runResolverPathListTests(
 		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
 			Return(providers.OrganizationUnit{}, errors.New("db connection failed")).Once()
 
-		service := suite.newService(store, newAllowAllAuthz(suite.T()))
+		userRes, groupRes := makeResolvers()
+		service := suite.newServiceWithResolvers(store, newAllowAllAuthz(suite.T()), userRes, groupRes)
+		resp, err := invoke(service, "root", 5, 0)
+		suite.Require().Nil(resp)
+		suite.Require().Equal(tidcommon.InternalServerError, *err)
+	})
+
+	suite.Run("resolver error", func() {
+		store := newOrganizationUnitStoreInterfaceMock(suite.T())
+		store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
+			Return(providers.OrganizationUnit{ID: "ou-1"}, nil).Once()
+		store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
+			Return(true, nil).Once()
+
+		userRes, groupRes := errorResolvers()
+		service := suite.newServiceWithResolvers(store, newAllowAllAuthz(suite.T()), userRes, groupRes)
 		resp, err := invoke(service, "root", 5, 0)
 		suite.Require().Nil(resp)
 		suite.Require().Equal(tidcommon.InternalServerError, *err)
@@ -2049,6 +2076,15 @@ func (suite *OrganizationUnitServiceTestSuite) runResolverPathListTests(
 
 func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnitUsersByPath() {
 	suite.runResolverPathListTests("   ",
+		func() (OUUserResolver, OUGroupResolver) {
+			return NewOUUserResolverMock(suite.T()), nil
+		},
+		func() (OUUserResolver, OUGroupResolver) {
+			userRes := NewOUUserResolverMock(suite.T())
+			userRes.On("GetUserListByOUID", mock.Anything, "ou-1", 5, 0, false).
+				Return(nil, errors.New("resolver unavailable")).Once()
+			return userRes, nil
+		},
 		func() (OUUserResolver, OUGroupResolver) {
 			userRes := new(OUUserResolverMock)
 			userRes.On("GetUserListByOUID", mock.Anything, "ou-1", 5, 0, false).
@@ -2094,12 +2130,31 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 	suite.Equal("employee", resp.Users[1].Type)
 	suite.Equal("bob@example.com", resp.Users[1].Display)
 
-	// Verify pagination links preserve the include=display query parameter
+	// Verify pagination links preserve the include=display query parameter and use the tree path
 	suite.Require().NotEmpty(resp.Links)
 	for _, link := range resp.Links {
 		suite.Contains(link.Href, "include=display",
 			"pagination link %q should preserve include=display", link.Rel)
+		suite.Contains(link.Href, "/organization-units/tree/engineering/users",
+			"pagination link %q href must use tree path, got %q", link.Rel, link.Href)
 	}
+}
+
+func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnitUsersByPath_AccessDenied() {
+	store := newOrganizationUnitStoreInterfaceMock(suite.T())
+	store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
+		Return(providers.OrganizationUnit{ID: "ou-1"}, nil).Once()
+
+	authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(suite.T())
+	authzMock.On("IsActionAllowed", mock.Anything, mock.Anything, mock.Anything).
+		Return(false, nil).Once()
+
+	userRes := NewOUUserResolverMock(suite.T())
+	service := suite.newServiceWithResolvers(store, authzMock, userRes, nil)
+
+	resp, err := service.GetOrganizationUnitUsersByPath(context.Background(), "root", 5, 0, false)
+	suite.Require().Nil(resp)
+	suite.Require().Equal(tidcommon.ErrorUnauthorized.Code, err.Code)
 }
 
 func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnitGroups() {
@@ -2222,6 +2277,15 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_BuildOrganizationUn
 func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnitGroupsByPath() {
 	suite.runResolverPathListTests("  ",
 		func() (OUUserResolver, OUGroupResolver) {
+			return nil, NewOUGroupResolverMock(suite.T())
+		},
+		func() (OUUserResolver, OUGroupResolver) {
+			groupRes := NewOUGroupResolverMock(suite.T())
+			groupRes.On("GetGroupListByOUID", mock.Anything, "ou-1", 5, 0).
+				Return(nil, errors.New("resolver unavailable")).Once()
+			return nil, groupRes
+		},
+		func() (OUUserResolver, OUGroupResolver) {
 			groupRes := new(OUGroupResolverMock)
 			groupRes.On("GetGroupListByOUID", mock.Anything, "ou-1", 5, 0).
 				Return([]Group{}, nil).Once()
@@ -2234,6 +2298,48 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnit
 			return svc.GetOrganizationUnitGroupsByPath(context.Background(), path, limit, offset)
 		},
 	)
+}
+
+func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnitGroupsByPath_LinksUseTreePath() {
+	store := newOrganizationUnitStoreInterfaceMock(suite.T())
+	store.On("GetOrganizationUnitByPath", mock.Anything, []string{"finance"}).
+		Return(providers.OrganizationUnit{ID: "ou-1"}, nil).Once()
+	store.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
+		Return(true, nil).Once()
+
+	groupRes := NewOUGroupResolverMock(suite.T())
+	groupRes.On("GetGroupListByOUID", mock.Anything, "ou-1", 2, 2).
+		Return([]Group{{ID: "g1"}, {ID: "g2"}}, nil).Once()
+	groupRes.On("GetGroupCountByOUID", mock.Anything, "ou-1").
+		Return(5, nil).Once()
+
+	service := suite.newServiceWithResolvers(store, newAllowAllAuthz(suite.T()), nil, groupRes)
+	resp, err := service.GetOrganizationUnitGroupsByPath(context.Background(), "finance", 2, 2)
+	suite.Require().Nil(err)
+	suite.Require().NotNil(resp)
+	suite.Require().Equal(5, resp.TotalResults)
+	suite.Require().Len(resp.Links, 4)
+	for _, link := range resp.Links {
+		suite.Contains(link.Href, "/organization-units/tree/finance/groups",
+			"link %q href must use tree path, got %q", link.Rel, link.Href)
+	}
+}
+
+func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnitGroupsByPath_AccessDenied() {
+	store := newOrganizationUnitStoreInterfaceMock(suite.T())
+	store.On("GetOrganizationUnitByPath", mock.Anything, []string{"root"}).
+		Return(providers.OrganizationUnit{ID: "ou-1"}, nil).Once()
+
+	authzMock := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(suite.T())
+	authzMock.On("IsActionAllowed", mock.Anything, mock.Anything, mock.Anything).
+		Return(false, nil).Once()
+
+	groupRes := NewOUGroupResolverMock(suite.T())
+	service := suite.newServiceWithResolvers(store, authzMock, nil, groupRes)
+
+	resp, err := service.GetOrganizationUnitGroupsByPath(context.Background(), "root", 5, 0)
+	suite.Require().Nil(resp)
+	suite.Require().Equal(tidcommon.ErrorUnauthorized.Code, err.Code)
 }
 
 func TestOUService_ValidateAndProcessHandlePath(t *testing.T) {


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

The `/organization-units/tree/{path}/users` and `/organization-units/tree/{path}/groups` endpoints returned pagination links pointing to the ID-based paths (e.g. `/organization-units/{id}/users`) instead of the handle-based tree paths. This caused clients following pagination links to lose the handle-path context and hit the wrong API variant.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->


---
### ⚠️ Breaking Changes


#### 🔧 Summary of Breaking Changes
The `Links[].Href` values in the responses of `/organization-units/tree/{path}/users` and `/organization-units/tree/{path}/groups` now use the handle-based tree path format instead of the ID-based format.

Before:
/organization-units/{id}/users?limit=...&offset=...
/organization-units/{id}/groups?limit=...&offset=...


After:
/organization-units/tree/{path}/users?limit=...&offset=...
/organization-units/tree/{path}/groups?limit=...&offset=...

#### 💥 Impact
Clients that parsed, stored, or made assumptions about the format of pagination `href` values returned by these endpoints will receive structurally different URLs. The previous behavior was a bug — the ID-based links were never the intended response for tree-path endpoints — but any client built against the broken behavior will be affected.

#### 🔄 Migration Guide
Update any code that consumes pagination links from these endpoints to expect the tree-path format (`/organization-units/tree/{path}/...`) instead of the ID-based format (`/organization-units/{id}/...`). Clients that follow pagination links opaquely without parsing the `href` structure are unaffected.

---

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
`GetOrganizationUnitUsersByPath` and `GetOrganizationUnitGroupsByPath` previously delegated to their ID-based counterparts (`GetOrganizationUnitUsers` / `GetOrganizationUnitGroups`), inheriting those methods' base URLs for pagination link construction.

Both path-based methods now directly call `getResourceListWithExistenceCheck` and the corresponding list/count resolvers, then build the response with an explicit base URL derived from the handle path (e.g. `/organization-units/tree/{path}/users`). This keeps the two code paths independent and ensures pagination links always reflect the URL surface through which the request arrived.

Additionally:
- Added nil-resolver guards at the entry of both methods to return a clean internal server error rather than a nil-pointer panic.
- Added per-method `checkOUAccess` calls that were previously implicitly handled inside the delegated ID-based methods.

Tests verify the correct base path appears in all pagination link `href` values for both the users and groups endpoints.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/3721

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [x] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated path-based organization unit user/group pagination links to consistently use tree-path URLs (`/organization-units/tree/<path>/users` and `/groups`).
  * Preserved `include=display` for paginated user results.
  * Improved path-based listings to correctly error when resolvers are missing and to enforce authorization before fetching results.

* **Tests**
  * Added coverage for nil-resolver, resolver-error, and authorization-denied scenarios for both users and groups.
  * Strengthened assertions for pagination link format and `include=display` retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->