### PR TITLE
Add support for one time use inputs

### DIFF
--- a/backend/internal/flow/common/model_test.go
+++ b/backend/internal/flow/common/model_test.go
@@ -136,27 +136,6 @@ func (s *ModelTestSuite) TestInput_OneTimeUse_OmittedWhenFalse() {
 	s.NotContains(jsonStr, "oneTimeUse", "OneTimeUse must be omitted from JSON when false")
 }
 
-func (s *ModelTestSuite) TestInput_Consumed_ExcludedFromJSON() {
-	input := providers.Input{
-		Identifier: "challenge",
-		Type:       providers.InputTypeText,
-		Required:   true,
-		OneTimeUse: true,
-		Consumed:   true,
-	}
-
-	data, err := json.Marshal(input)
-	s.Require().NoError(err)
-
-	jsonStr := string(data)
-	s.NotContains(jsonStr, "Consumed", "Consumed field name must not appear in JSON")
-	s.NotContains(jsonStr, "consumed", "consumed key must not appear in JSON")
-
-	var decoded providers.Input
-	s.Require().NoError(json.Unmarshal(data, &decoded))
-	s.False(decoded.Consumed, "Consumed must remain false after unmarshalling")
-}
-
 func (s *ModelTestSuite) TestExecutionAttempt_GetDuration() {
 	tests := []struct {
 		name      string

--- a/backend/internal/flow/common/model_test.go
+++ b/backend/internal/flow/common/model_test.go
@@ -102,6 +102,61 @@ func (s *ModelTestSuite) TestInput_DisplayName_ExcludedFromJSON() {
 	s.Equal("email", decoded.Identifier)
 }
 
+func (s *ModelTestSuite) TestInput_OneTimeUse_IncludedInJSON() {
+	input := providers.Input{
+		Identifier: "challenge",
+		Type:       providers.InputTypeText,
+		Required:   true,
+		OneTimeUse: true,
+	}
+
+	data, err := json.Marshal(input)
+	s.Require().NoError(err)
+
+	jsonStr := string(data)
+	s.Contains(jsonStr, `"oneTimeUse":true`, "OneTimeUse must be serialized in JSON")
+
+	var decoded providers.Input
+	s.Require().NoError(json.Unmarshal(data, &decoded))
+	s.True(decoded.OneTimeUse, "OneTimeUse must be preserved after unmarshalling")
+}
+
+func (s *ModelTestSuite) TestInput_OneTimeUse_OmittedWhenFalse() {
+	input := providers.Input{
+		Identifier: "username",
+		Type:       providers.InputTypeText,
+		Required:   true,
+		OneTimeUse: false,
+	}
+
+	data, err := json.Marshal(input)
+	s.Require().NoError(err)
+
+	jsonStr := string(data)
+	s.NotContains(jsonStr, "oneTimeUse", "OneTimeUse must be omitted from JSON when false")
+}
+
+func (s *ModelTestSuite) TestInput_Consumed_ExcludedFromJSON() {
+	input := providers.Input{
+		Identifier: "challenge",
+		Type:       providers.InputTypeText,
+		Required:   true,
+		OneTimeUse: true,
+		Consumed:   true,
+	}
+
+	data, err := json.Marshal(input)
+	s.Require().NoError(err)
+
+	jsonStr := string(data)
+	s.NotContains(jsonStr, "Consumed", "Consumed field name must not appear in JSON")
+	s.NotContains(jsonStr, "consumed", "consumed key must not appear in JSON")
+
+	var decoded providers.Input
+	s.Require().NoError(json.Unmarshal(data, &decoded))
+	s.False(decoded.Consumed, "Consumed must remain false after unmarshalling")
+}
+
 func (s *ModelTestSuite) TestExecutionAttempt_GetDuration() {
 	tests := []struct {
 		name      string

--- a/backend/internal/flow/core/InterceptorInterface_mock_test.go
+++ b/backend/internal/flow/core/InterceptorInterface_mock_test.go
@@ -7,6 +7,7 @@ package core
 import (
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/flow/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
 // NewInterceptorInterfaceMock creates a new instance of InterceptorInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -94,6 +95,52 @@ func (_c *InterceptorInterfaceMock_Execute_Call) Return(interceptorResponse *com
 }
 
 func (_c *InterceptorInterfaceMock_Execute_Call) RunAndReturn(run func(ctx *InterceptorContext) (*common.InterceptorResponse, error)) *InterceptorInterfaceMock_Execute_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetInputs provides a mock function for the type InterceptorInterfaceMock
+func (_mock *InterceptorInterfaceMock) GetInputs() []providers.Input {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetInputs")
+	}
+
+	var r0 []providers.Input
+	if returnFunc, ok := ret.Get(0).(func() []providers.Input); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]providers.Input)
+		}
+	}
+	return r0
+}
+
+// InterceptorInterfaceMock_GetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInputs'
+type InterceptorInterfaceMock_GetInputs_Call struct {
+	*mock.Call
+}
+
+// GetInputs is a helper method to define mock.On call
+func (_e *InterceptorInterfaceMock_Expecter) GetInputs() *InterceptorInterfaceMock_GetInputs_Call {
+	return &InterceptorInterfaceMock_GetInputs_Call{Call: _e.mock.On("GetInputs")}
+}
+
+func (_c *InterceptorInterfaceMock_GetInputs_Call) Run(run func()) *InterceptorInterfaceMock_GetInputs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *InterceptorInterfaceMock_GetInputs_Call) Return(inputs []providers.Input) *InterceptorInterfaceMock_GetInputs_Call {
+	_c.Call.Return(inputs)
+	return _c
+}
+
+func (_c *InterceptorInterfaceMock_GetInputs_Call) RunAndReturn(run func() []providers.Input) *InterceptorInterfaceMock_GetInputs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/core/graph.go
+++ b/backend/internal/flow/core/graph.go
@@ -267,6 +267,7 @@ func (g *graph) ToJSON() (string, error) {
 		Identifier string   `json:"identifier"`
 		Type       string   `json:"type"`
 		Required   bool     `json:"required"`
+		OneTimeUse bool     `json:"oneTimeUse,omitempty"`
 		Options    []string `json:"options,omitempty"`
 	}
 
@@ -328,6 +329,7 @@ func (g *graph) ToJSON() (string, error) {
 						Identifier: input.Identifier,
 						Type:       input.Type,
 						Required:   input.Required,
+						OneTimeUse: input.OneTimeUse,
 						Options:    input.Options,
 					}
 				}

--- a/backend/internal/flow/core/interceptor.go
+++ b/backend/internal/flow/core/interceptor.go
@@ -20,6 +20,7 @@ package core
 
 import (
 	"github.com/thunder-id/thunderid/internal/flow/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
 // InterceptorInterface defines the contract for flow interceptors.
@@ -35,6 +36,9 @@ type InterceptorInterface interface {
 
 	// GetPriority returns the execution order within the same mode (lower runs first).
 	GetPriority() int
+
+	// GetInputs returns the inputs declared by the interceptor.
+	GetInputs() []providers.Input
 }
 
 // interceptor represents the basic implementation of an interceptor.
@@ -42,6 +46,7 @@ type interceptor struct {
 	Name      string
 	isDefault bool
 	Priority  int
+	Inputs    []providers.Input
 }
 
 var _ InterceptorInterface = (*interceptor)(nil)
@@ -68,6 +73,11 @@ func (i *interceptor) IsDefault() bool {
 // GetPriority returns the execution order within the same mode (lower runs first).
 func (i *interceptor) GetPriority() int {
 	return i.Priority
+}
+
+// GetInputs returns the inputs declared by the interceptor.
+func (i *interceptor) GetInputs() []providers.Input {
+	return i.Inputs
 }
 
 // Execute runs the interceptor logic and returns a result.

--- a/backend/internal/flow/core/interceptor_test.go
+++ b/backend/internal/flow/core/interceptor_test.go
@@ -141,3 +141,53 @@ func (s *InterceptorTestSuite) TestGetInputs_ReturnsPopulatedInputs() {
 func (s *InterceptorTestSuite) TestInterceptor_ImplementsInterface() {
 	var _ InterceptorInterface = (*interceptor)(nil)
 }
+
+// InterceptorContext consumed inputs
+
+func (s *InterceptorTestSuite) TestInterceptorContext_ConsumeInput_RecordsAndReturnsValue() {
+	ic := &InterceptorContext{UserInputs: map[string]string{"captcha": "abc"}}
+
+	v, ok := ic.ConsumeInput("captcha")
+
+	s.True(ok)
+	s.Equal("abc", v)
+	s.Equal([]string{"captcha"}, ic.GetConsumedInputs())
+}
+
+func (s *InterceptorTestSuite) TestInterceptorContext_ConsumeInput_MissingKeyDoesNotRecord() {
+	ic := &InterceptorContext{UserInputs: map[string]string{"other": "x"}}
+
+	v, ok := ic.ConsumeInput("captcha")
+
+	s.False(ok)
+	s.Equal("", v)
+	s.Empty(ic.GetConsumedInputs())
+}
+
+func (s *InterceptorTestSuite) TestInterceptorContext_AppendConsumedInputs_AppendsWithoutReading() {
+	ic := &InterceptorContext{UserInputs: map[string]string{"a": "1"}}
+
+	ic.AppendConsumedInputs([]string{"a", "b"})
+
+	s.Equal([]string{"a", "b"}, ic.GetConsumedInputs())
+	s.Equal("1", ic.UserInputs["a"], "AppendConsumedInputs must not mutate UserInputs")
+}
+
+func (s *InterceptorTestSuite) TestInterceptorContext_AppendConsumedInputs_EmptyIsNoop() {
+	ic := &InterceptorContext{}
+
+	ic.AppendConsumedInputs(nil)
+	ic.AppendConsumedInputs([]string{})
+
+	s.Empty(ic.GetConsumedInputs())
+}
+
+func (s *InterceptorTestSuite) TestInterceptorContext_ConsumeInput_AccumulatesAcrossCalls() {
+	ic := &InterceptorContext{UserInputs: map[string]string{"a": "1", "b": "2"}}
+
+	ic.ConsumeInput("a")
+	ic.AppendConsumedInputs([]string{"c"})
+	ic.ConsumeInput("b")
+
+	s.Equal([]string{"a", "c", "b"}, ic.GetConsumedInputs())
+}

--- a/backend/internal/flow/core/interceptor_test.go
+++ b/backend/internal/flow/core/interceptor_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/stretchr/testify/suite"
 
@@ -108,6 +109,31 @@ func (s *InterceptorTestSuite) TestInterceptorResponse_Fail() {
 	s.Equal(common.InterceptorStatusFailure, result.Status)
 	s.Equal("INT-001", result.Error.Code)
 	s.Nil(result.EngineOutputs)
+}
+
+// GetInputs tests
+
+func (s *InterceptorTestSuite) TestGetInputs_ReturnsNilByDefault() {
+	ic := newInterceptor(testInterceptorName, false, 1)
+	s.Nil(ic.GetInputs())
+}
+
+func (s *InterceptorTestSuite) TestGetInputs_ReturnsPopulatedInputs() {
+	ic := &interceptor{
+		Name:      testInterceptorName,
+		isDefault: false,
+		Priority:  1,
+		Inputs: []providers.Input{
+			{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true},
+			{Identifier: "token", Type: "TEXT_INPUT", OneTimeUse: true},
+		},
+	}
+
+	inputs := ic.GetInputs()
+	s.Len(inputs, 2)
+	s.Equal("challenge", inputs[0].Identifier)
+	s.True(inputs[0].OneTimeUse)
+	s.Equal("token", inputs[1].Identifier)
 }
 
 // Interface compliance

--- a/backend/internal/flow/core/model.go
+++ b/backend/internal/flow/core/model.go
@@ -43,6 +43,9 @@ type Segment struct {
 // InterceptorContext is the per-invocation context built by the InterceptorService for each
 // interceptor call. It is assembled from the EngineContext plus the matched interceptor
 // definition's properties and the cross-request SharedData.
+//
+// TODO: fields on InterceptorContext are currently exposed directly. Convert to unexported
+// fields accessed via getters and setters so that mutation can be encapsulated.
 type InterceptorContext struct {
 	Context context.Context
 
@@ -64,10 +67,41 @@ type InterceptorContext struct {
 	CurrentNodeInputs   []providers.Input
 	ForwardedData       map[string]interface{}
 	AdditionalData      map[string]string
-
+	// consumedInputs accumulates identifiers of inputs the interceptor has used
+	// up during this call
+	consumedInputs []string
 	// SharedData is interceptor-layer state shared across interceptors and preserved across
 	// the requests of a single flow instance. Interceptors may read and write this map directly.
 	// Each interceptor is responsible for reading any information it needs from SharedData and
 	// populating relevant values into EngineOutputs.
 	SharedData map[string]string
+}
+
+// ConsumeInput returns the value for key from UserInputs and records key on the consumed
+// inputs list. Interceptors should prefer this over direct UserInputs access so the engine
+// has a full audit trail of what was used.
+func (ic *InterceptorContext) ConsumeInput(key string) (string, bool) {
+	v, ok := ic.UserInputs[key]
+	if ok {
+		ic.consumedInputs = append(ic.consumedInputs, key)
+	}
+	return v, ok
+}
+
+// AppendConsumedInputs records the given keys on the consumed inputs list without
+// reading from UserInputs.
+func (ic *InterceptorContext) AppendConsumedInputs(keys []string) {
+	if len(keys) == 0 {
+		return
+	}
+	if ic.consumedInputs == nil {
+		ic.consumedInputs = make([]string, 0, len(keys))
+	}
+	ic.consumedInputs = append(ic.consumedInputs, keys...)
+}
+
+// GetConsumedInputs returns the list of input keys that have been consumed by the interceptor
+// during this call.
+func (ic *InterceptorContext) GetConsumedInputs() []string {
+	return ic.consumedInputs
 }

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -199,6 +199,9 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *tidcommon.ServiceE
 		// Clear sensitive inputs from context after executor has consumed them.
 		fe.clearSensitiveInputs(ctx, currentNode)
 
+		// Clear one-time-use inputs that have been marked as consumed.
+		fe.clearOneTimeUseInputs(ctx, currentNode)
+
 		recordNodeExecution(ctx, currentNode, nodeResp, nodeErr, executionStartTime, executionEndTime)
 
 		// Publish node execution completed or failed event
@@ -331,6 +334,9 @@ func (fe *flowEngine) runInterceptors(
 	if svcErr != nil {
 		return false, svcErr
 	}
+
+	// Clear one-time-use inputs that interceptors marked as consumed.
+	fe.clearConsumedOneTimeUseInputs(ctx, execCtx.CurrentNodeInputs)
 
 	fe.updateContextWithInterceptorResponse(ctx, resp)
 
@@ -531,6 +537,37 @@ func (fe *flowEngine) clearSensitiveInputs(ctx *EngineContext, node core.NodeInt
 	for _, input := range inputs {
 		if input.IsSensitive() {
 			delete(ctx.UserInputs, input.Identifier)
+		}
+	}
+}
+
+// clearOneTimeUseInputs removes inputs that are both OneTimeUse and Consumed
+// from the engine context's UserInputs, and resets the Consumed flag.
+func (fe *flowEngine) clearOneTimeUseInputs(ctx *EngineContext, node core.NodeInterface) {
+	execNode, ok := node.(core.ExecutorBackedNodeInterface)
+	if !ok {
+		return
+	}
+
+	// Get inputs from the node configuration. If the node does not define its own inputs,
+	// fall back to the executor's default inputs.
+	inputs := execNode.GetInputs()
+	if len(inputs) == 0 {
+		if executor := execNode.GetExecutor(); executor != nil {
+			inputs = executor.GetDefaultInputs()
+		}
+	}
+
+	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
+}
+
+// clearConsumedOneTimeUseInputs removes inputs that are both OneTimeUse and Consumed
+// from the engine context's UserInputs, and resets the Consumed flag.
+func (fe *flowEngine) clearConsumedOneTimeUseInputs(ctx *EngineContext, inputs []providers.Input) {
+	for i := range inputs {
+		if inputs[i].OneTimeUse && inputs[i].Consumed {
+			delete(ctx.UserInputs, inputs[i].Identifier)
+			inputs[i].Consumed = false
 		}
 	}
 }

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -120,139 +120,21 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *tidcommon.ServiceE
 
 	// Execute the graph nodes until a terminal condition is met or currentNode is nil
 	for currentNode != nil {
-		logger.Debug(ctx.Context, "Executing node", log.String("nodeID", currentNode.GetID()),
-			log.String("nodeType", string(currentNode.GetType())))
+		nodeForCleanup := currentNode
+		nextNode, exitFlow, svcErr := fe.executeNodePackage(ctx, currentNode, &flowStep, flowStartTime)
 
-		nodeCtx := &providers.NodeContext{
-			Context:          ctx.Context,
-			ExecutionID:      ctx.ExecutionID,
-			FlowType:         ctx.FlowType,
-			EntityID:         ctx.AppID,
-			CurrentAction:    ctx.CurrentAction,
-			Verbose:          ctx.Verbose,
-			NodeInputs:       getNodeInputs(ctx.CurrentNode),
-			UserInputs:       ctx.UserInputs,
-			CurrentNodeID:    ctx.CurrentNode.GetID(),
-			RuntimeData:      ctx.RuntimeData,
-			ForwardedData:    ctx.ForwardedData,
-			Application:      ctx.Application,
-			AuthUser:         ctx.AuthUser,
-			ExecutionHistory: ctx.ExecutionHistory,
-		}
-		if nodeCtx.NodeInputs == nil {
-			nodeCtx.NodeInputs = make([]providers.Input, 0)
-		}
-		if nodeCtx.UserInputs == nil {
-			nodeCtx.UserInputs = make(map[string]string)
-		}
-		if nodeCtx.RuntimeData == nil {
-			nodeCtx.RuntimeData = make(map[string]string)
-		}
-		if nodeCtx.ForwardedData == nil {
-			nodeCtx.ForwardedData = make(map[string]interface{})
-		}
-
-		// Clear ForwardedData from engine context after passing to node context
-		// This ensures ForwardedData is only available to the immediate next node
-		ctx.ForwardedData = nil
-
-		// Check if the node should be executed based on its condition
-		if !currentNode.ShouldExecute(nodeCtx) {
-			logger.Debug(ctx.Context, "Skipping node due to unmet condition",
-				log.String("nodeID", currentNode.GetID()))
-			nextNode, svcErr := fe.skipToNextNode(ctx, currentNode, logger)
-			if svcErr != nil {
-				return flowStep, svcErr
-			}
-			currentNode = nextNode
-			continue
-		}
-
-		svcErr := fe.setNodeExecutor(ctx.Context, currentNode, logger)
+		fe.clearNodePackageOneTimeUseInputs(ctx, nodeForCleanup)
 		if svcErr != nil {
 			return flowStep, svcErr
 		}
 
-		// Run PRE_NODE interceptors before the node executes.
-		isSuccess, svcErr := fe.runInterceptors(providers.InterceptorModePreNode, ctx, currentNode, &flowStep)
-		if svcErr != nil {
-			publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
-			return flowStep, svcErr
-		}
-		if !isSuccess {
-			if _, svcErr := fe.runPostRequestInterceptorsOnExit(ctx, &flowStep, flowStartTime); svcErr != nil {
-				// Ignore POST_REQUEST interceptor failures or continuation conditions,
-				// since this is already a flow exit scenario.
-				return flowStep, svcErr
-			}
-			return flowStep, nil
-		}
-
-		executionStartTime := time.Now().UnixMilli()
-
-		// Publish node execution started event
-		publishNodeExecutionStartedEvent(ctx, currentNode, fe.observabilitySvc)
-
-		nodeResp, nodeErr := currentNode.Execute(nodeCtx)
-		executionEndTime := time.Now().UnixMilli()
-
-		// Clear sensitive inputs from context after executor has consumed them.
-		fe.clearSensitiveInputs(ctx, currentNode)
-
-		// Clear one-time-use inputs that have been marked as consumed.
-		fe.clearOneTimeUseInputs(ctx, currentNode)
-
-		recordNodeExecution(ctx, currentNode, nodeResp, nodeErr, executionStartTime, executionEndTime)
-
-		// Publish node execution completed or failed event
-		publishNodeExecutionCompletedEvent(
-			ctx, currentNode, nodeResp, nodeErr,
-			executionStartTime, executionEndTime, fe.observabilitySvc,
-		)
-
-		if nodeErr != nil {
-			// Publish flow failed event before returning error
-			publishFlowFailedEvent(ctx, nodeErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
-			return flowStep, nodeErr
-		}
-
-		fe.trackPresentedOptionalInputs(ctx, nodeResp)
-		fe.updateContextWithNodeResponse(ctx, nodeResp)
-
-		nextNode, continueExecution, svcErr := fe.processNodeResponse(ctx, nodeResp, &flowStep, logger)
-		if svcErr != nil {
-			// Publish flow failed event before returning error
-			publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
-			return flowStep, svcErr
-		}
-		if !continueExecution {
-			// Run POST_REQUEST interceptors for incomplete flows to allow cleanup.
-			if _, svcErr := fe.runPostRequestInterceptorsOnExit(ctx, &flowStep, flowStartTime); svcErr != nil {
-				// Ignore POST_REQUEST interceptor failures or continuation conditions,
-				// since this is already a flow exit scenario.
-				return flowStep, svcErr
-			}
-			return flowStep, nil
-		}
-
-		// Run POST_NODE interceptors after the node executes.
-		isSuccess, svcErr = fe.runInterceptors(providers.InterceptorModePostNode, ctx, currentNode, &flowStep)
-		if svcErr != nil {
-			publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
-			return flowStep, svcErr
-		}
-		if !isSuccess {
-			if _, svcErr := fe.runPostRequestInterceptorsOnExit(ctx, &flowStep, flowStartTime); svcErr != nil {
-				// Ignore POST_REQUEST interceptor failures or continuation conditions,
-				// since this is already a flow exit scenario.
-				return flowStep, svcErr
-			}
+		if exitFlow {
 			return flowStep, nil
 		}
 		currentNode = nextNode
 	}
 
-	// If we reach here, it means the all flow nodes has been executed successfully.
+	// If we reach here, it means the all flow nodes has been executed successfully
 	flowStep.Status = providers.FlowStatusComplete
 	if ctx.Assertion != "" {
 		flowStep.Assertion = ctx.Assertion
@@ -261,7 +143,7 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *tidcommon.ServiceE
 		flowStep.Data.AdditionalData = ctx.AdditionalData
 	}
 
-	// Run POST_REQUEST interceptors after all nodes have been processed.
+	// Run POST_REQUEST interceptors after all nodes have been processed
 	isSuccess, svcErr = fe.runPostRequestInterceptorsOnExit(ctx, &flowStep, flowStartTime)
 	if svcErr != nil {
 		return flowStep, svcErr
@@ -275,6 +157,153 @@ func (fe *flowEngine) Execute(ctx *EngineContext) (FlowStep, *tidcommon.ServiceE
 	publishFlowCompletedEvent(ctx, flowStartTime, flowEndTime, fe.observabilitySvc)
 
 	return flowStep, nil
+}
+
+// executeNodePackage runs the PRE_NODE interceptors, the node, and the POST_NODE
+// interceptors as a single package. It returns the next node to execute, whether the outer
+// flow loop should exit (in which case the caller should return without treating it as an
+// error), and any service error.
+func (fe *flowEngine) executeNodePackage(ctx *EngineContext,
+	currentNode core.NodeInterface, flowStep *FlowStep, flowStartTime int64) (
+	core.NodeInterface, bool, *tidcommon.ServiceError) {
+	logger := fe.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID),
+		log.String("nodeID", currentNode.GetID()), log.String("nodeType", string(currentNode.GetType())))
+
+	logger.Debug(ctx.Context, "Executing node")
+
+	nodeCtx := &providers.NodeContext{
+		Context:          ctx.Context,
+		ExecutionID:      ctx.ExecutionID,
+		FlowType:         ctx.FlowType,
+		EntityID:         ctx.AppID,
+		CurrentAction:    ctx.CurrentAction,
+		Verbose:          ctx.Verbose,
+		NodeInputs:       getNodeInputs(ctx.CurrentNode),
+		UserInputs:       ctx.UserInputs,
+		CurrentNodeID:    ctx.CurrentNode.GetID(),
+		RuntimeData:      ctx.RuntimeData,
+		ForwardedData:    ctx.ForwardedData,
+		Application:      ctx.Application,
+		AuthUser:         ctx.AuthUser,
+		ExecutionHistory: ctx.ExecutionHistory,
+	}
+	if nodeCtx.NodeInputs == nil {
+		nodeCtx.NodeInputs = make([]providers.Input, 0)
+	}
+	if nodeCtx.UserInputs == nil {
+		nodeCtx.UserInputs = make(map[string]string)
+	}
+	if nodeCtx.RuntimeData == nil {
+		nodeCtx.RuntimeData = make(map[string]string)
+	}
+	if nodeCtx.ForwardedData == nil {
+		nodeCtx.ForwardedData = make(map[string]interface{})
+	}
+
+	// Clear ForwardedData from engine context after passing to node context
+	// This ensures ForwardedData is only available to the immediate next node
+	ctx.ForwardedData = nil
+
+	// Check if the node should be executed based on its condition
+	if !currentNode.ShouldExecute(nodeCtx) {
+		logger.Debug(ctx.Context, "Skipping node due to unmet condition",
+			log.String("nodeID", currentNode.GetID()))
+		nextNode, svcErr := fe.skipToNextNode(ctx, currentNode, logger)
+		if svcErr != nil {
+			return nil, false, svcErr
+		}
+		return nextNode, false, nil
+	}
+
+	if svcErr := fe.setNodeExecutor(ctx.Context, currentNode, logger); svcErr != nil {
+		return nil, false, svcErr
+	}
+
+	// Run PRE_NODE interceptors before the node executes
+	isSuccess, svcErr := fe.runInterceptors(providers.InterceptorModePreNode, ctx, currentNode, flowStep)
+	if svcErr != nil {
+		publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
+		return nil, false, svcErr
+	}
+	if !isSuccess {
+		// Drain node-scope consumed inputs before the request-scope cleanup wipes the list
+		fe.clearNodePackageOneTimeUseInputs(ctx, currentNode)
+		if _, svcErr := fe.runPostRequestInterceptorsOnExit(ctx, flowStep, flowStartTime); svcErr != nil {
+			// Ignore POST_REQUEST interceptor failures or continuation conditions,
+			// since this is already a flow exit scenario.
+			return nil, false, svcErr
+		}
+		return nil, true, nil
+	}
+
+	executionStartTime := time.Now().UnixMilli()
+
+	// Publish node execution started event
+	publishNodeExecutionStartedEvent(ctx, currentNode, fe.observabilitySvc)
+
+	nodeResp, nodeErr := currentNode.Execute(nodeCtx)
+	executionEndTime := time.Now().UnixMilli()
+
+	if consumed := nodeCtx.GetConsumedInputs(); len(consumed) > 0 {
+		ctx.consumedInputs = append(ctx.consumedInputs, consumed...)
+	}
+
+	// Clear sensitive inputs from context after executor has consumed them
+	fe.clearSensitiveInputs(ctx, currentNode)
+
+	recordNodeExecution(ctx, currentNode, nodeResp, nodeErr, executionStartTime, executionEndTime)
+
+	// Publish node execution completed or failed event
+	publishNodeExecutionCompletedEvent(
+		ctx, currentNode, nodeResp, nodeErr,
+		executionStartTime, executionEndTime, fe.observabilitySvc,
+	)
+
+	if nodeErr != nil {
+		// Publish flow failed event before returning error
+		publishFlowFailedEvent(ctx, nodeErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
+		return nil, false, nodeErr
+	}
+
+	fe.trackPresentedOptionalInputs(ctx, nodeResp)
+	fe.updateContextWithNodeResponse(ctx, nodeResp)
+
+	nextNode, continueExecution, svcErr := fe.processNodeResponse(ctx, nodeResp, flowStep, logger)
+	if svcErr != nil {
+		// Publish flow failed event before returning error
+		publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
+		return nil, false, svcErr
+	}
+	if !continueExecution {
+		// Drain node-scope consumed inputs before the request-scope cleanup wipes the list
+		fe.clearNodePackageOneTimeUseInputs(ctx, currentNode)
+		// Run POST_REQUEST interceptors for incomplete flows to allow cleanup
+		if _, svcErr := fe.runPostRequestInterceptorsOnExit(ctx, flowStep, flowStartTime); svcErr != nil {
+			// Ignore POST_REQUEST interceptor failures or continuation conditions,
+			// since this is already a flow exit scenario
+			return nil, false, svcErr
+		}
+		return nil, true, nil
+	}
+
+	// Run POST_NODE interceptors after the node executes
+	isSuccess, svcErr = fe.runInterceptors(providers.InterceptorModePostNode, ctx, currentNode, flowStep)
+	if svcErr != nil {
+		publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
+		return nil, false, svcErr
+	}
+	if !isSuccess {
+		// Drain node-scope consumed inputs before the request-scope cleanup wipes the list
+		fe.clearNodePackageOneTimeUseInputs(ctx, currentNode)
+		if _, svcErr := fe.runPostRequestInterceptorsOnExit(ctx, flowStep, flowStartTime); svcErr != nil {
+			// Ignore POST_REQUEST interceptor failures or continuation conditions,
+			// since this is already a flow exit scenario
+			return nil, false, svcErr
+		}
+		return nil, true, nil
+	}
+
+	return nextNode, false, nil
 }
 
 // runInterceptors builds an InterceptorRunnerContext from the engine context, delegates to the
@@ -335,9 +364,9 @@ func (fe *flowEngine) runInterceptors(
 		return false, svcErr
 	}
 
-	// Clear one-time-use inputs that interceptors marked as consumed.
-	fe.clearConsumedOneTimeUseInputs(ctx, execCtx.CurrentNodeInputs)
-
+	if consumed := execCtx.GetConsumedInputs(); len(consumed) > 0 {
+		ctx.consumedInputs = append(ctx.consumedInputs, consumed...)
+	}
 	fe.updateContextWithInterceptorResponse(ctx, resp)
 
 	continueExecution := fe.processInterceptorResponse(resp, flowStep)
@@ -369,13 +398,18 @@ func extractSkipInterceptors(node core.NodeInterface) []string {
 }
 
 // runPostRequestInterceptorsOnExit runs POST_REQUEST interceptors when the flow is about to return.
-// It handles error publishing for interceptor failures and flow error statuses.
+// It handles error publishing for interceptor failures and flow error statuses. Consumed
+// one-time-use inputs declared by request-scoped interceptors are cleared after the
+// POST_REQUEST stage completes.
 // Returns (true, nil) if execution should continue, (false, nil) if the flow should stop,
 // or (false, svcErr) on interceptor failure.
 func (fe *flowEngine) runPostRequestInterceptorsOnExit(
 	ctx *EngineContext, flowStep *FlowStep, flowStartTime int64) (bool, *tidcommon.ServiceError) {
 	interceptorExecSuccess, svcErr := fe.runInterceptors(
 		providers.InterceptorModePostRequest, ctx, nil, flowStep)
+
+	fe.clearRequestPackageOneTimeUseInputs(ctx)
+
 	if svcErr != nil {
 		publishFlowFailedEvent(ctx, svcErr, flowStartTime, time.Now().UnixMilli(), fe.observabilitySvc)
 		return false, svcErr
@@ -386,6 +420,7 @@ func (fe *flowEngine) runPostRequestInterceptorsOnExit(
 		}
 		return false, nil
 	}
+
 	return true, nil
 }
 
@@ -541,35 +576,107 @@ func (fe *flowEngine) clearSensitiveInputs(ctx *EngineContext, node core.NodeInt
 	}
 }
 
-// clearOneTimeUseInputs removes inputs that are both OneTimeUse and Consumed
-// from the engine context's UserInputs, and resets the Consumed flag.
-func (fe *flowEngine) clearOneTimeUseInputs(ctx *EngineContext, node core.NodeInterface) {
-	execNode, ok := node.(core.ExecutorBackedNodeInterface)
-	if !ok {
+// collectOneTimeUseIdentifiers appends identifiers declared as OneTimeUse from inputs into set.
+func (fe *flowEngine) collectOneTimeUseIdentifiers(inputs []providers.Input, set map[string]struct{}) {
+	for _, input := range inputs {
+		if input.OneTimeUse {
+			set[input.Identifier] = struct{}{}
+		}
+	}
+}
+
+// clearOneTimeUseInputsScope removes identifiers from ctx.consumedInputs that are declared
+// OneTimeUse in scoped, deleting each matched identifier from ctx.UserInputs. Unmatched
+// entries are preserved in ctx.consumedInputs for a later scope to handle.
+func (fe *flowEngine) clearOneTimeUseInputsScope(ctx *EngineContext,
+	scoped map[string]struct{}) {
+	if len(ctx.consumedInputs) == 0 || len(scoped) == 0 {
 		return
 	}
 
-	// Get inputs from the node configuration. If the node does not define its own inputs,
-	// fall back to the executor's default inputs.
-	inputs := execNode.GetInputs()
-	if len(inputs) == 0 {
-		if executor := execNode.GetExecutor(); executor != nil {
-			inputs = executor.GetDefaultInputs()
+	remaining := ctx.consumedInputs[:0]
+	for _, id := range ctx.consumedInputs {
+		if _, ok := scoped[id]; ok {
+			delete(ctx.UserInputs, id)
+			continue
 		}
+		remaining = append(remaining, id)
 	}
-
-	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
+	ctx.consumedInputs = remaining
 }
 
-// clearConsumedOneTimeUseInputs removes inputs that are both OneTimeUse and Consumed
-// from the engine context's UserInputs, and resets the Consumed flag.
-func (fe *flowEngine) clearConsumedOneTimeUseInputs(ctx *EngineContext, inputs []providers.Input) {
-	for i := range inputs {
-		if inputs[i].OneTimeUse && inputs[i].Consumed {
-			delete(ctx.UserInputs, inputs[i].Identifier)
-			inputs[i].Consumed = false
+// clearNodePackageOneTimeUseInputs removes any consumed identifier declared OneTimeUse on the
+// node or on an applicable PRE_NODE/POST_NODE interceptor from ctx.UserInputs, and drops it
+// from the shared consumed list.
+func (fe *flowEngine) clearNodePackageOneTimeUseInputs(ctx *EngineContext, node core.NodeInterface) {
+	if len(ctx.consumedInputs) == 0 || node == nil {
+		return
+	}
+
+	scoped := make(map[string]struct{})
+	if execNode, ok := node.(core.ExecutorBackedNodeInterface); ok {
+		// Use the node's declared inputs when present, falling back to the executor's default
+		// inputs otherwise.
+		inputs := execNode.GetInputs()
+		if len(inputs) == 0 {
+			if executor := execNode.GetExecutor(); executor != nil {
+				inputs = executor.GetDefaultInputs()
+			}
+		}
+		fe.collectOneTimeUseIdentifiers(inputs, scoped)
+	}
+
+	if ctx.Graph != nil {
+		nodeID := node.GetID()
+		skipInterceptors := extractSkipInterceptors(node)
+		for _, mode := range []providers.InterceptorMode{
+			providers.InterceptorModePreNode,
+			providers.InterceptorModePostNode,
+		} {
+			for _, unit := range ctx.Graph.GetInterceptors(mode) {
+				if !shouldApplyToNode(unit, nodeID, skipInterceptors) {
+					continue
+				}
+				ic := unit.GetInterceptor()
+				if ic == nil {
+					continue
+				}
+				fe.collectOneTimeUseIdentifiers(ic.GetInputs(), scoped)
+			}
 		}
 	}
+
+	fe.clearOneTimeUseInputsScope(ctx, scoped)
+}
+
+// clearRequestPackageOneTimeUseInputs removes any remaining consumed identifier declared
+// OneTimeUse on a PRE_REQUEST/POST_REQUEST interceptor from ctx.UserInputs, then drains the
+// consumed list.
+func (fe *flowEngine) clearRequestPackageOneTimeUseInputs(ctx *EngineContext) {
+	if len(ctx.consumedInputs) == 0 {
+		return
+	}
+
+	if ctx.Graph != nil {
+		scoped := make(map[string]struct{})
+		for _, mode := range []providers.InterceptorMode{
+			providers.InterceptorModePreRequest,
+			providers.InterceptorModePostRequest,
+		} {
+			for _, unit := range ctx.Graph.GetInterceptors(mode) {
+				ic := unit.GetInterceptor()
+				if ic == nil {
+					continue
+				}
+				fe.collectOneTimeUseIdentifiers(ic.GetInputs(), scoped)
+			}
+		}
+		fe.clearOneTimeUseInputsScope(ctx, scoped)
+	}
+
+	// Drop anything left over. Non-OneTimeUse signals are ignored by design; leftover entries
+	// have no declared scope in this graph and would otherwise leak across requests.
+	ctx.consumedInputs = nil
 }
 
 // updateContextWithNodeResponse updates the engine context with the node response and authenticated user.

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -901,6 +901,391 @@ func (s *EngineTestSuite) TestClearSensitiveInputs_UserOnboardingFlowRetainsPass
 	s.Equal("secret123", ctx.UserInputs["password"])
 }
 
+// Tests for clearConsumedOneTimeUseInputs
+
+func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_RemovesConsumedOneTimeUseInput() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge": "abc123",
+			"username":  "testuser",
+		},
+	}
+
+	inputs := []providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+		{Identifier: "username", Type: "TEXT_INPUT"},
+	}
+
+	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
+
+	_, exists := ctx.UserInputs["challenge"]
+	s.False(exists)
+	s.Equal("testuser", ctx.UserInputs["username"])
+}
+
+func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_PreservesOneTimeUseNotConsumed() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge": "abc123",
+		},
+	}
+
+	inputs := []providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: false},
+	}
+
+	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
+
+	s.Equal("abc123", ctx.UserInputs["challenge"])
+}
+
+func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_PreservesNonOneTimeUseInput() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"username": "testuser",
+		},
+	}
+
+	inputs := []providers.Input{
+		{Identifier: "username", Type: "TEXT_INPUT", Consumed: true},
+	}
+
+	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
+
+	s.Equal("testuser", ctx.UserInputs["username"])
+}
+
+func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_EmptyInputs() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"username": "testuser",
+		},
+	}
+
+	fe.clearConsumedOneTimeUseInputs(ctx, nil)
+
+	s.Equal("testuser", ctx.UserInputs["username"])
+}
+
+func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_InputNotInUserInputs() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"username": "testuser",
+		},
+	}
+
+	inputs := []providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+	}
+
+	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
+
+	s.Equal("testuser", ctx.UserInputs["username"])
+	s.Len(ctx.UserInputs, 1)
+}
+
+func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_ResetsConsumedFlag() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge": "abc123",
+		},
+	}
+
+	inputs := []providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+	}
+
+	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
+
+	s.False(inputs[0].Consumed)
+}
+
+// Tests for clearOneTimeUseInputs
+
+func (s *EngineTestSuite) TestClearOneTimeUseInputs_FallsBackToExecutorDefaults() {
+	t := s.T()
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge": "abc123",
+			"username":  "testuser",
+		},
+	}
+
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetDefaultInputs").Return([]providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+		{Identifier: "username", Type: "TEXT_INPUT"},
+	})
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetInputs").Return([]providers.Input(nil))
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe.clearOneTimeUseInputs(ctx, mockNode)
+
+	_, exists := ctx.UserInputs["challenge"]
+	s.False(exists)
+	s.Equal("testuser", ctx.UserInputs["username"])
+}
+
+func (s *EngineTestSuite) TestClearOneTimeUseInputs_UsesNodeInputsWhenAvailable() {
+	t := s.T()
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge": "abc123",
+		},
+	}
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetInputs").Return([]providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+	})
+
+	fe.clearOneTimeUseInputs(ctx, mockNode)
+
+	_, exists := ctx.UserInputs["challenge"]
+	s.False(exists)
+}
+
+func (s *EngineTestSuite) TestClearOneTimeUseInputs_SkipsNonExecutorBackedNode() {
+	t := s.T()
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge": "abc123",
+		},
+	}
+
+	mockNode := coremock.NewNodeInterfaceMock(t)
+
+	fe.clearOneTimeUseInputs(ctx, mockNode)
+
+	s.Equal("abc123", ctx.UserInputs["challenge"])
+}
+
+func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_MultipleInputsMixedState() {
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge":    "abc123",
+			"otp":          "999999",
+			"username":     "testuser",
+			"confirmation": "yes",
+		},
+	}
+
+	inputs := []providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+		{Identifier: "otp", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: false},
+		{Identifier: "username", Type: "TEXT_INPUT", OneTimeUse: false, Consumed: false},
+		{Identifier: "confirmation", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+	}
+
+	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
+
+	_, challengeExists := ctx.UserInputs["challenge"]
+	s.False(challengeExists, "challenge should be removed (OneTimeUse && Consumed)")
+	s.Equal("999999", ctx.UserInputs["otp"], "otp should be preserved (OneTimeUse but not Consumed)")
+	s.Equal("testuser", ctx.UserInputs["username"], "username should be preserved (not OneTimeUse)")
+	_, confirmationExists := ctx.UserInputs["confirmation"]
+	s.False(confirmationExists, "confirmation should be removed (OneTimeUse && Consumed)")
+	s.Len(ctx.UserInputs, 2)
+}
+
+func (s *EngineTestSuite) TestClearOneTimeUseInputs_ExecutorWithNilDefaults() {
+	t := s.T()
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge": "abc123",
+		},
+	}
+
+	mockExecutor := coremock.NewExecutorInterfaceMock(t)
+	mockExecutor.On("GetDefaultInputs").Return([]providers.Input(nil))
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetInputs").Return([]providers.Input(nil))
+	mockNode.On("GetExecutor").Return(mockExecutor)
+
+	fe.clearOneTimeUseInputs(ctx, mockNode)
+
+	s.Equal("abc123", ctx.UserInputs["challenge"])
+}
+
+func (s *EngineTestSuite) TestClearOneTimeUseInputs_NilExecutor() {
+	t := s.T()
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge": "abc123",
+		},
+	}
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetInputs").Return([]providers.Input(nil))
+	mockNode.On("GetExecutor").Return(nil)
+
+	fe.clearOneTimeUseInputs(ctx, mockNode)
+
+	s.Equal("abc123", ctx.UserInputs["challenge"])
+}
+
+func (s *EngineTestSuite) TestClearOneTimeUseInputs_NodeInputsTakePrecedenceOverExecutorDefaults() {
+	t := s.T()
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge": "abc123",
+			"otp":       "999999",
+		},
+	}
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetInputs").Return([]providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+	})
+
+	fe.clearOneTimeUseInputs(ctx, mockNode)
+
+	_, challengeExists := ctx.UserInputs["challenge"]
+	s.False(challengeExists, "challenge should be removed via node inputs")
+	s.Equal("999999", ctx.UserInputs["otp"], "otp should be preserved (not in node inputs)")
+}
+
+func (s *EngineTestSuite) TestClearOneTimeUseInputs_ResetsConsumedFlagViaNodePath() {
+	t := s.T()
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{
+			"challenge": "abc123",
+		},
+	}
+
+	nodeInputs := []providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+	}
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetInputs").Return(nodeInputs)
+
+	fe.clearOneTimeUseInputs(ctx, mockNode)
+
+	s.False(nodeInputs[0].Consumed, "Consumed flag should be reset after clearing")
+}
+
+func (s *EngineTestSuite) TestRunInterceptors_ClearsConsumedOneTimeUseInputsAfterInterceptors() {
+	t := s.T()
+	mockInterceptorSvc := NewInterceptorRunnerInterfaceMock(t)
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("HasSegments").Return(false)
+
+	nodeInputs := []providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true},
+		{Identifier: "username", Type: "TEXT_INPUT"},
+	}
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("node-1").Maybe()
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution).Maybe()
+	mockNode.On("GetProperties").Return(map[string]interface{}(nil)).Maybe()
+	mockNode.On("GetExecutionPolicy").Return((*providers.ExecutionPolicy)(nil)).Maybe()
+	mockNode.On("GetInputs").Return(nodeInputs)
+
+	fe := &flowEngine{
+		interceptorRunner: mockInterceptorSvc,
+		logger:            log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+
+	mockGraph.On("GetInterceptors", mock.Anything).Return([]core.InterceptorUnitInterface{
+		newTestInterceptorUnitMock(t, "stub", providers.InterceptorMode(""), providers.InterceptorScope(""), nil),
+	})
+
+	ctx := &EngineContext{
+		ExecutionID:           "exec-otu-001",
+		CurrentNode:           mockNode,
+		Graph:                 mockGraph,
+		UserInputs:            map[string]string{"challenge": "abc123", "username": "testuser"},
+		InterceptorSharedData: map[string]string{},
+	}
+
+	// Simulate the interceptor marking the challenge input as consumed on the shared slice.
+	mockInterceptorSvc.On("runInterceptors", providers.InterceptorModePreNode,
+		mock.AnythingOfType("*flowexec.InterceptorRunnerContext")).
+		Run(func(args mock.Arguments) {
+			execCtx := args.Get(1).(*InterceptorRunnerContext)
+			for i := range execCtx.CurrentNodeInputs {
+				if execCtx.CurrentNodeInputs[i].Identifier == "challenge" {
+					execCtx.CurrentNodeInputs[i].Consumed = true
+				}
+			}
+		}).
+		Return(&common.InterceptorResponse{Status: common.InterceptorStatusComplete}, nil)
+
+	continueExec, err := fe.runInterceptors(providers.InterceptorModePreNode, ctx, mockNode, &FlowStep{})
+
+	s.True(continueExec)
+	s.Nil(err)
+	_, challengeExists := ctx.UserInputs["challenge"]
+	s.False(challengeExists, "OneTimeUse input marked as consumed should be cleared from UserInputs")
+	s.Equal("testuser", ctx.UserInputs["username"], "Non-OneTimeUse input should be preserved")
+}
+
+func (s *EngineTestSuite) TestRunInterceptors_PreservesOneTimeUseInputsWhenNotConsumed() {
+	t := s.T()
+	mockInterceptorSvc := NewInterceptorRunnerInterfaceMock(t)
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("HasSegments").Return(false)
+
+	nodeInputs := []providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true},
+	}
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("node-1").Maybe()
+	mockNode.On("GetType").Return(common.NodeTypeTaskExecution).Maybe()
+	mockNode.On("GetProperties").Return(map[string]interface{}(nil)).Maybe()
+	mockNode.On("GetExecutionPolicy").Return((*providers.ExecutionPolicy)(nil)).Maybe()
+	mockNode.On("GetInputs").Return(nodeInputs)
+
+	fe := &flowEngine{
+		interceptorRunner: mockInterceptorSvc,
+		logger:            log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
+	}
+
+	mockGraph.On("GetInterceptors", mock.Anything).Return([]core.InterceptorUnitInterface{
+		newTestInterceptorUnitMock(t, "stub", providers.InterceptorMode(""), providers.InterceptorScope(""), nil),
+	})
+
+	ctx := &EngineContext{
+		ExecutionID:           "exec-otu-002",
+		CurrentNode:           mockNode,
+		Graph:                 mockGraph,
+		UserInputs:            map[string]string{"challenge": "abc123"},
+		InterceptorSharedData: map[string]string{},
+	}
+
+	// Interceptor does NOT mark any input as consumed.
+	mockInterceptorSvc.On("runInterceptors", providers.InterceptorModePreNode,
+		mock.AnythingOfType("*flowexec.InterceptorRunnerContext")).
+		Return(&common.InterceptorResponse{Status: common.InterceptorStatusComplete}, nil)
+
+	continueExec, err := fe.runInterceptors(providers.InterceptorModePreNode, ctx, mockNode, &FlowStep{})
+
+	s.True(continueExec)
+	s.Nil(err)
+	s.Equal("abc123", ctx.UserInputs["challenge"], "OneTimeUse input should be preserved when not consumed")
+}
+
 // Tests for display-only prompt node handling
 
 func (s *EngineTestSuite) TestIsDisplayOnlyPromptNode_WithDisplayOnlyPrompt() {

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -901,389 +901,214 @@ func (s *EngineTestSuite) TestClearSensitiveInputs_UserOnboardingFlowRetainsPass
 	s.Equal("secret123", ctx.UserInputs["password"])
 }
 
-// Tests for clearConsumedOneTimeUseInputs
+// Tests for one-time-use cleanup
 
-func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_RemovesConsumedOneTimeUseInput() {
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge": "abc123",
-			"username":  "testuser",
-		},
-	}
-
-	inputs := []providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
-		{Identifier: "username", Type: "TEXT_INPUT"},
-	}
-
-	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
-
-	_, exists := ctx.UserInputs["challenge"]
-	s.False(exists)
-	s.Equal("testuser", ctx.UserInputs["username"])
-}
-
-func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_PreservesOneTimeUseNotConsumed() {
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge": "abc123",
-		},
-	}
-
-	inputs := []providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: false},
-	}
-
-	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
-
-	s.Equal("abc123", ctx.UserInputs["challenge"])
-}
-
-func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_PreservesNonOneTimeUseInput() {
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"username": "testuser",
-		},
-	}
-
-	inputs := []providers.Input{
-		{Identifier: "username", Type: "TEXT_INPUT", Consumed: true},
-	}
-
-	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
-
-	s.Equal("testuser", ctx.UserInputs["username"])
-}
-
-func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_EmptyInputs() {
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"username": "testuser",
-		},
-	}
-
-	fe.clearConsumedOneTimeUseInputs(ctx, nil)
-
-	s.Equal("testuser", ctx.UserInputs["username"])
-}
-
-func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_InputNotInUserInputs() {
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"username": "testuser",
-		},
-	}
-
-	inputs := []providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
-	}
-
-	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
-
-	s.Equal("testuser", ctx.UserInputs["username"])
-	s.Len(ctx.UserInputs, 1)
-}
-
-func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_ResetsConsumedFlag() {
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge": "abc123",
-		},
-	}
-
-	inputs := []providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
-	}
-
-	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
-
-	s.False(inputs[0].Consumed)
-}
-
-// Tests for clearOneTimeUseInputs
-
-func (s *EngineTestSuite) TestClearOneTimeUseInputs_FallsBackToExecutorDefaults() {
+func (s *EngineTestSuite) TestClearNodePackageOneTimeUseInputs_ClearsSignaledNodeInput() {
 	t := s.T()
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetInputs").Return([]providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true},
+		{Identifier: "username", Type: "TEXT_INPUT"},
+	})
+
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge": "abc123",
-			"username":  "testuser",
-		},
+		UserInputs:     map[string]string{"challenge": "abc123", "username": "testuser"},
+		consumedInputs: []string{"challenge"},
 	}
+
+	fe.clearNodePackageOneTimeUseInputs(ctx, mockNode)
+
+	_, challengeExists := ctx.UserInputs["challenge"]
+	s.False(challengeExists, "signaled OneTimeUse node input should be removed")
+	s.Equal("testuser", ctx.UserInputs["username"], "non-OneTimeUse input should be preserved")
+	s.Empty(ctx.consumedInputs, "pending list should be drained")
+}
+
+func (s *EngineTestSuite) TestClearNodePackageOneTimeUseInputs_FallsBackToExecutorDefaults() {
+	t := s.T()
 
 	mockExecutor := coremock.NewExecutorInterfaceMock(t)
 	mockExecutor.On("GetDefaultInputs").Return([]providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
-		{Identifier: "username", Type: "TEXT_INPUT"},
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true},
 	})
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetInputs").Return([]providers.Input(nil))
 	mockNode.On("GetExecutor").Return(mockExecutor)
 
-	fe.clearOneTimeUseInputs(ctx, mockNode)
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs:     map[string]string{"challenge": "abc123"},
+		consumedInputs: []string{"challenge"},
+	}
+
+	fe.clearNodePackageOneTimeUseInputs(ctx, mockNode)
 
 	_, exists := ctx.UserInputs["challenge"]
 	s.False(exists)
+}
+
+func (s *EngineTestSuite) TestClearNodePackageOneTimeUseInputs_IgnoresNonOneTimeUseSignals() {
+	t := s.T()
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetInputs").Return([]providers.Input{
+		{Identifier: "username", Type: "TEXT_INPUT"},
+	})
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs:     map[string]string{"username": "testuser"},
+		consumedInputs: []string{"username"},
+	}
+
+	fe.clearNodePackageOneTimeUseInputs(ctx, mockNode)
+
+	s.Equal("testuser", ctx.UserInputs["username"],
+		"identifier not declared as OneTimeUse should not be cleared even if signaled")
+}
+
+func (s *EngineTestSuite) TestClearNodePackageOneTimeUseInputs_NoPendingIsNoop() {
+	t := s.T()
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		UserInputs: map[string]string{"challenge": "abc123"},
+	}
+
+	fe.clearNodePackageOneTimeUseInputs(ctx, mockNode)
+
+	s.Equal("abc123", ctx.UserInputs["challenge"])
+}
+
+func (s *EngineTestSuite) TestClearNodePackageOneTimeUseInputs_ClearsInterceptorDeclaredInput() {
+	t := s.T()
+
+	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
+	mockNode.On("GetInputs").Return([]providers.Input{{Identifier: "username", Type: "TEXT_INPUT"}})
+	mockNode.On("GetID").Return("node-1")
+	mockNode.On("GetProperties").Return(map[string]interface{}(nil))
+
+	interceptorMock := coremock.NewInterceptorInterfaceMock(t)
+	interceptorMock.On("GetInputs").Return([]providers.Input{
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true},
+	})
+
+	unit := newTestInterceptorUnitMock(t, "captcha", providers.InterceptorModePreNode,
+		providers.InterceptorScopeAll, nil)
+	unit.SetInterceptor(interceptorMock)
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetInterceptors", providers.InterceptorModePreNode).
+		Return([]core.InterceptorUnitInterface{unit})
+	mockGraph.On("GetInterceptors", providers.InterceptorModePostNode).
+		Return([]core.InterceptorUnitInterface{})
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		Graph:          mockGraph,
+		UserInputs:     map[string]string{"challenge": "abc123", "username": "testuser"},
+		consumedInputs: []string{"challenge"},
+	}
+
+	fe.clearNodePackageOneTimeUseInputs(ctx, mockNode)
+
+	_, challengeExists := ctx.UserInputs["challenge"]
+	s.False(challengeExists,
+		"OneTimeUse input declared by a scoped interceptor should be cleared when signaled")
 	s.Equal("testuser", ctx.UserInputs["username"])
 }
 
-func (s *EngineTestSuite) TestClearOneTimeUseInputs_UsesNodeInputsWhenAvailable() {
+func (s *EngineTestSuite) TestClearRequestPackageOneTimeUseInputs_ClearsSignaledInput() {
 	t := s.T()
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge": "abc123",
-		},
-	}
 
-	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
-	mockNode.On("GetInputs").Return([]providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+	interceptorMock := coremock.NewInterceptorInterfaceMock(t)
+	interceptorMock.On("GetInputs").Return([]providers.Input{
+		{Identifier: "captchaToken", Type: "TEXT_INPUT", OneTimeUse: true},
 	})
 
-	fe.clearOneTimeUseInputs(ctx, mockNode)
+	unit := newTestInterceptorUnitMock(t, "captcha", providers.InterceptorModePreRequest,
+		providers.InterceptorScopeAll, nil)
+	unit.SetInterceptor(interceptorMock)
 
-	_, exists := ctx.UserInputs["challenge"]
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetInterceptors", providers.InterceptorModePreRequest).
+		Return([]core.InterceptorUnitInterface{unit})
+	mockGraph.On("GetInterceptors", providers.InterceptorModePostRequest).
+		Return([]core.InterceptorUnitInterface{})
+
+	fe := &flowEngine{}
+	ctx := &EngineContext{
+		Graph:          mockGraph,
+		UserInputs:     map[string]string{"captchaToken": "abc123"},
+		consumedInputs: []string{"captchaToken"},
+	}
+
+	fe.clearRequestPackageOneTimeUseInputs(ctx)
+
+	_, exists := ctx.UserInputs["captchaToken"]
 	s.False(exists)
+	s.Empty(ctx.consumedInputs, "pending request list should be drained")
 }
 
-func (s *EngineTestSuite) TestClearOneTimeUseInputs_SkipsNonExecutorBackedNode() {
+func (s *EngineTestSuite) TestClearRequestPackageOneTimeUseInputs_DrainsUnmatchedEntries() {
 	t := s.T()
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetInterceptors", providers.InterceptorModePreRequest).
+		Return([]core.InterceptorUnitInterface{})
+	mockGraph.On("GetInterceptors", providers.InterceptorModePostRequest).
+		Return([]core.InterceptorUnitInterface{})
+
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge": "abc123",
-		},
+		Graph:          mockGraph,
+		UserInputs:     map[string]string{"leftover": "value"},
+		consumedInputs: []string{"leftover"},
 	}
 
-	mockNode := coremock.NewNodeInterfaceMock(t)
+	fe.clearRequestPackageOneTimeUseInputs(ctx)
 
-	fe.clearOneTimeUseInputs(ctx, mockNode)
-
-	s.Equal("abc123", ctx.UserInputs["challenge"])
+	s.Equal("value", ctx.UserInputs["leftover"],
+		"unmatched identifiers should not be deleted from UserInputs")
+	s.Empty(ctx.consumedInputs, "consumed list should be drained after request package cleanup")
 }
 
-func (s *EngineTestSuite) TestClearConsumedOneTimeUseInputs_MultipleInputsMixedState() {
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge":    "abc123",
-			"otp":          "999999",
-			"username":     "testuser",
-			"confirmation": "yes",
-		},
-	}
-
-	inputs := []providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
-		{Identifier: "otp", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: false},
-		{Identifier: "username", Type: "TEXT_INPUT", OneTimeUse: false, Consumed: false},
-		{Identifier: "confirmation", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
-	}
-
-	fe.clearConsumedOneTimeUseInputs(ctx, inputs)
-
-	_, challengeExists := ctx.UserInputs["challenge"]
-	s.False(challengeExists, "challenge should be removed (OneTimeUse && Consumed)")
-	s.Equal("999999", ctx.UserInputs["otp"], "otp should be preserved (OneTimeUse but not Consumed)")
-	s.Equal("testuser", ctx.UserInputs["username"], "username should be preserved (not OneTimeUse)")
-	_, confirmationExists := ctx.UserInputs["confirmation"]
-	s.False(confirmationExists, "confirmation should be removed (OneTimeUse && Consumed)")
-	s.Len(ctx.UserInputs, 2)
-}
-
-func (s *EngineTestSuite) TestClearOneTimeUseInputs_ExecutorWithNilDefaults() {
+func (s *EngineTestSuite) TestClearNodePackageOneTimeUseInputs_PreservesUnmatchedForRequestScope() {
 	t := s.T()
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge": "abc123",
-		},
-	}
-
-	mockExecutor := coremock.NewExecutorInterfaceMock(t)
-	mockExecutor.On("GetDefaultInputs").Return([]providers.Input(nil))
-
-	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
-	mockNode.On("GetInputs").Return([]providers.Input(nil))
-	mockNode.On("GetExecutor").Return(mockExecutor)
-
-	fe.clearOneTimeUseInputs(ctx, mockNode)
-
-	s.Equal("abc123", ctx.UserInputs["challenge"])
-}
-
-func (s *EngineTestSuite) TestClearOneTimeUseInputs_NilExecutor() {
-	t := s.T()
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge": "abc123",
-		},
-	}
-
-	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
-	mockNode.On("GetInputs").Return([]providers.Input(nil))
-	mockNode.On("GetExecutor").Return(nil)
-
-	fe.clearOneTimeUseInputs(ctx, mockNode)
-
-	s.Equal("abc123", ctx.UserInputs["challenge"])
-}
-
-func (s *EngineTestSuite) TestClearOneTimeUseInputs_NodeInputsTakePrecedenceOverExecutorDefaults() {
-	t := s.T()
-	fe := &flowEngine{}
-	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge": "abc123",
-			"otp":       "999999",
-		},
-	}
 
 	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
 	mockNode.On("GetInputs").Return([]providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
+		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true},
 	})
+	mockNode.On("GetID").Return("node-1")
+	mockNode.On("GetProperties").Return(map[string]interface{}(nil))
 
-	fe.clearOneTimeUseInputs(ctx, mockNode)
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("GetInterceptors", providers.InterceptorModePreNode).
+		Return([]core.InterceptorUnitInterface{})
+	mockGraph.On("GetInterceptors", providers.InterceptorModePostNode).
+		Return([]core.InterceptorUnitInterface{})
 
-	_, challengeExists := ctx.UserInputs["challenge"]
-	s.False(challengeExists, "challenge should be removed via node inputs")
-	s.Equal("999999", ctx.UserInputs["otp"], "otp should be preserved (not in node inputs)")
-}
-
-func (s *EngineTestSuite) TestClearOneTimeUseInputs_ResetsConsumedFlagViaNodePath() {
-	t := s.T()
 	fe := &flowEngine{}
 	ctx := &EngineContext{
-		UserInputs: map[string]string{
-			"challenge": "abc123",
-		},
+		Graph:          mockGraph,
+		UserInputs:     map[string]string{"challenge": "abc123", "captchaToken": "xyz"},
+		consumedInputs: []string{"challenge", "captchaToken"},
 	}
 
-	nodeInputs := []providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true, Consumed: true},
-	}
-	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
-	mockNode.On("GetInputs").Return(nodeInputs)
+	fe.clearNodePackageOneTimeUseInputs(ctx, mockNode)
 
-	fe.clearOneTimeUseInputs(ctx, mockNode)
-
-	s.False(nodeInputs[0].Consumed, "Consumed flag should be reset after clearing")
-}
-
-func (s *EngineTestSuite) TestRunInterceptors_ClearsConsumedOneTimeUseInputsAfterInterceptors() {
-	t := s.T()
-	mockInterceptorSvc := NewInterceptorRunnerInterfaceMock(t)
-
-	mockGraph := coremock.NewGraphInterfaceMock(t)
-	mockGraph.On("HasSegments").Return(false)
-
-	nodeInputs := []providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true},
-		{Identifier: "username", Type: "TEXT_INPUT"},
-	}
-
-	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
-	mockNode.On("GetID").Return("node-1").Maybe()
-	mockNode.On("GetType").Return(common.NodeTypeTaskExecution).Maybe()
-	mockNode.On("GetProperties").Return(map[string]interface{}(nil)).Maybe()
-	mockNode.On("GetExecutionPolicy").Return((*providers.ExecutionPolicy)(nil)).Maybe()
-	mockNode.On("GetInputs").Return(nodeInputs)
-
-	fe := &flowEngine{
-		interceptorRunner: mockInterceptorSvc,
-		logger:            log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
-	}
-
-	mockGraph.On("GetInterceptors", mock.Anything).Return([]core.InterceptorUnitInterface{
-		newTestInterceptorUnitMock(t, "stub", providers.InterceptorMode(""), providers.InterceptorScope(""), nil),
-	})
-
-	ctx := &EngineContext{
-		ExecutionID:           "exec-otu-001",
-		CurrentNode:           mockNode,
-		Graph:                 mockGraph,
-		UserInputs:            map[string]string{"challenge": "abc123", "username": "testuser"},
-		InterceptorSharedData: map[string]string{},
-	}
-
-	// Simulate the interceptor marking the challenge input as consumed on the shared slice.
-	mockInterceptorSvc.On("runInterceptors", providers.InterceptorModePreNode,
-		mock.AnythingOfType("*flowexec.InterceptorRunnerContext")).
-		Run(func(args mock.Arguments) {
-			execCtx := args.Get(1).(*InterceptorRunnerContext)
-			for i := range execCtx.CurrentNodeInputs {
-				if execCtx.CurrentNodeInputs[i].Identifier == "challenge" {
-					execCtx.CurrentNodeInputs[i].Consumed = true
-				}
-			}
-		}).
-		Return(&common.InterceptorResponse{Status: common.InterceptorStatusComplete}, nil)
-
-	continueExec, err := fe.runInterceptors(providers.InterceptorModePreNode, ctx, mockNode, &FlowStep{})
-
-	s.True(continueExec)
-	s.Nil(err)
 	_, challengeExists := ctx.UserInputs["challenge"]
-	s.False(challengeExists, "OneTimeUse input marked as consumed should be cleared from UserInputs")
-	s.Equal("testuser", ctx.UserInputs["username"], "Non-OneTimeUse input should be preserved")
-}
-
-func (s *EngineTestSuite) TestRunInterceptors_PreservesOneTimeUseInputsWhenNotConsumed() {
-	t := s.T()
-	mockInterceptorSvc := NewInterceptorRunnerInterfaceMock(t)
-
-	mockGraph := coremock.NewGraphInterfaceMock(t)
-	mockGraph.On("HasSegments").Return(false)
-
-	nodeInputs := []providers.Input{
-		{Identifier: "challenge", Type: "TEXT_INPUT", OneTimeUse: true},
-	}
-
-	mockNode := coremock.NewExecutorBackedNodeInterfaceMock(t)
-	mockNode.On("GetID").Return("node-1").Maybe()
-	mockNode.On("GetType").Return(common.NodeTypeTaskExecution).Maybe()
-	mockNode.On("GetProperties").Return(map[string]interface{}(nil)).Maybe()
-	mockNode.On("GetExecutionPolicy").Return((*providers.ExecutionPolicy)(nil)).Maybe()
-	mockNode.On("GetInputs").Return(nodeInputs)
-
-	fe := &flowEngine{
-		interceptorRunner: mockInterceptorSvc,
-		logger:            log.GetLogger().With(log.String(log.LoggerKeyComponentName, "FlowEngine")),
-	}
-
-	mockGraph.On("GetInterceptors", mock.Anything).Return([]core.InterceptorUnitInterface{
-		newTestInterceptorUnitMock(t, "stub", providers.InterceptorMode(""), providers.InterceptorScope(""), nil),
-	})
-
-	ctx := &EngineContext{
-		ExecutionID:           "exec-otu-002",
-		CurrentNode:           mockNode,
-		Graph:                 mockGraph,
-		UserInputs:            map[string]string{"challenge": "abc123"},
-		InterceptorSharedData: map[string]string{},
-	}
-
-	// Interceptor does NOT mark any input as consumed.
-	mockInterceptorSvc.On("runInterceptors", providers.InterceptorModePreNode,
-		mock.AnythingOfType("*flowexec.InterceptorRunnerContext")).
-		Return(&common.InterceptorResponse{Status: common.InterceptorStatusComplete}, nil)
-
-	continueExec, err := fe.runInterceptors(providers.InterceptorModePreNode, ctx, mockNode, &FlowStep{})
-
-	s.True(continueExec)
-	s.Nil(err)
-	s.Equal("abc123", ctx.UserInputs["challenge"], "OneTimeUse input should be preserved when not consumed")
+	s.False(challengeExists, "node-scope OneTimeUse identifier should be cleared")
+	s.Equal("xyz", ctx.UserInputs["captchaToken"],
+		"identifier not declared for this node should be preserved for the request-scope cleanup")
+	s.Equal([]string{"captchaToken"}, ctx.consumedInputs,
+		"unmatched identifiers stay in the list for later scopes")
 }
 
 // Tests for display-only prompt node handling
@@ -2652,6 +2477,169 @@ func (s *EngineTestSuite) TestPublishNodeExecutionCompletedEvent_DefaultStatus()
 }
 
 // --- Execute (flowEngine) ---
+
+// executeNodePackage coverage
+
+// setupNodePackageMockObs returns an observability mock that reports disabled so publish
+// helpers short-circuit; the engine still calls IsEnabled.
+func setupNodePackageMockObs(t *testing.T) *observabilitymock.ObservabilityServiceInterfaceMock {
+	m := observabilitymock.NewObservabilityServiceInterfaceMock(t)
+	m.EXPECT().IsEnabled().Return(false).Maybe()
+	return m
+}
+
+func (s *EngineTestSuite) TestExecuteNodePackage_SkipsNodeWhenShouldExecuteFalse() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("n1").Maybe()
+	mockNode.On("GetType").Return(common.NodeTypeStart).Maybe()
+	mockNode.On("ShouldExecute", mock.Anything).Return(false)
+	mockNode.On("GetCondition").Return(&core.NodeCondition{OnSkip: ""}).Maybe()
+
+	fe := &flowEngine{
+		logger:           log.GetLogger(),
+		observabilitySvc: setupNodePackageMockObs(t),
+	}
+	ctx := &EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "exec-skip",
+		CurrentNode:      mockNode,
+		UserInputs:       map[string]string{},
+		ExecutionHistory: map[string]*providers.NodeExecutionRecord{},
+	}
+
+	nextNode, exit, err := fe.executeNodePackage(ctx, mockNode, &FlowStep{}, 0)
+
+	s.Nil(nextNode)
+	s.False(exit)
+	s.NotNil(err, "missing OnSkip target should surface an internal server error")
+}
+
+func (s *EngineTestSuite) TestExecuteNodePackage_CompletesAndReturnsNilNextNode() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("n1").Maybe()
+	mockNode.On("GetType").Return(common.NodeTypeStart).Maybe()
+	mockNode.On("ShouldExecute", mock.Anything).Return(true)
+	mockNode.On("GetProperties").Return(map[string]interface{}(nil)).Maybe()
+	mockNode.On("Execute", mock.Anything).Return(&common.NodeResponse{
+		Status: common.NodeStatusComplete,
+	}, nil)
+
+	fe := &flowEngine{
+		logger:           log.GetLogger(),
+		observabilitySvc: setupNodePackageMockObs(t),
+	}
+	ctx := &EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "exec-happy",
+		CurrentNode:      mockNode,
+		UserInputs:       map[string]string{},
+		ExecutionHistory: map[string]*providers.NodeExecutionRecord{},
+	}
+
+	nextNode, exit, err := fe.executeNodePackage(ctx, mockNode, &FlowStep{}, 0)
+
+	s.Nil(err)
+	s.False(exit)
+	s.Nil(nextNode, "empty NextNodeID resolves to nil")
+}
+
+func (s *EngineTestSuite) TestExecuteNodePackage_NodeExecuteErrorPropagates() {
+	t := s.T()
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("n1").Maybe()
+	mockNode.On("GetType").Return(common.NodeTypeStart).Maybe()
+	mockNode.On("ShouldExecute", mock.Anything).Return(true)
+	mockNode.On("GetProperties").Return(map[string]interface{}(nil)).Maybe()
+	execErr := &tidcommon.ServiceError{Code: "boom"}
+	mockNode.On("Execute", mock.Anything).Return((*common.NodeResponse)(nil), execErr)
+
+	fe := &flowEngine{
+		logger:           log.GetLogger(),
+		observabilitySvc: setupNodePackageMockObs(t),
+	}
+	ctx := &EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "exec-err",
+		CurrentNode:      mockNode,
+		UserInputs:       map[string]string{},
+		ExecutionHistory: map[string]*providers.NodeExecutionRecord{},
+	}
+
+	nextNode, exit, err := fe.executeNodePackage(ctx, mockNode, &FlowStep{}, 0)
+
+	s.Nil(nextNode)
+	s.False(exit)
+	s.Same(execErr, err)
+}
+
+func (s *EngineTestSuite) TestExecuteNodePackage_IncompleteExitClearsNodeScopeBeforeRequestScope() {
+	t := s.T()
+
+	// Interceptor declares "captcha" as OneTimeUse and the node signals it consumed on Execute.
+	interceptorMock := coremock.NewInterceptorInterfaceMock(t)
+	interceptorMock.On("GetInputs").Return([]providers.Input{
+		{Identifier: "captcha", Type: "TEXT_INPUT", OneTimeUse: true},
+	}).Maybe()
+
+	unit := newTestInterceptorUnitMock(t, "captcha-intr", providers.InterceptorModePreNode,
+		providers.InterceptorScopeAll, nil)
+	unit.SetInterceptor(interceptorMock)
+
+	mockGraph := coremock.NewGraphInterfaceMock(t)
+	mockGraph.On("HasSegments").Return(false).Maybe()
+	mockGraph.On("GetInterceptors", providers.InterceptorModePreNode).
+		Return([]core.InterceptorUnitInterface{unit}).Maybe()
+	mockGraph.On("GetInterceptors", providers.InterceptorModePostNode).
+		Return([]core.InterceptorUnitInterface{}).Maybe()
+	mockGraph.On("GetInterceptors", providers.InterceptorModePostRequest).
+		Return([]core.InterceptorUnitInterface{}).Maybe()
+
+	mockNode := coremock.NewNodeInterfaceMock(t)
+	mockNode.On("GetID").Return("n1").Maybe()
+	mockNode.On("GetType").Return(common.NodeTypeStart).Maybe()
+	mockNode.On("GetProperties").Return(map[string]interface{}(nil)).Maybe()
+	mockNode.On("GetExecutionPolicy").Return((*providers.ExecutionPolicy)(nil)).Maybe()
+	mockNode.On("ShouldExecute", mock.Anything).Return(true)
+	mockNode.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
+		nodeCtx := args.Get(0).(*providers.NodeContext)
+		nodeCtx.AppendConsumedInputs([]string{"captcha"})
+	}).Return(&common.NodeResponse{
+		Status: common.NodeStatusIncomplete,
+		Type:   common.NodeResponseTypeView,
+		Inputs: []providers.Input{{Identifier: "email", Required: true}},
+	}, nil)
+
+	mockRunner := NewInterceptorRunnerInterfaceMock(t)
+	mockRunner.On("runInterceptors", mock.Anything, mock.Anything).
+		Return(&common.InterceptorResponse{Status: common.InterceptorStatusComplete}, nil)
+
+	fe := &flowEngine{
+		logger:            log.GetLogger(),
+		observabilitySvc:  setupNodePackageMockObs(t),
+		interceptorRunner: mockRunner,
+	}
+	ctx := &EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "exec-incomplete",
+		Graph:            mockGraph,
+		CurrentNode:      mockNode,
+		UserInputs:       map[string]string{"captcha": "abc", "email": "e@x"},
+		ExecutionHistory: map[string]*providers.NodeExecutionRecord{},
+	}
+
+	nextNode, exit, err := fe.executeNodePackage(ctx, mockNode, &FlowStep{}, 0)
+
+	s.Nil(err)
+	s.True(exit, "incomplete node response must signal flow exit")
+	s.Nil(nextNode)
+	_, captchaStillHere := ctx.UserInputs["captcha"]
+	s.False(captchaStillHere,
+		"node-scope OneTimeUse input must be cleared before request-scope cleanup wipes the list")
+	s.Equal("e@x", ctx.UserInputs["email"], "non-OneTimeUse input should remain")
+	s.Empty(ctx.consumedInputs, "consumed list should be fully drained at this exit path")
+}
 
 func (s *EngineTestSuite) TestFlowEngineExecute_NilGraph() {
 	t := s.T()

--- a/backend/internal/flow/flowexec/interceptor_runner.go
+++ b/backend/internal/flow/flowexec/interceptor_runner.go
@@ -204,6 +204,8 @@ func (s *interceptorRunner) executeInterceptor(
 		return nil, &tidcommon.InternalServerError
 	}
 
+	execCtx.AppendConsumedInputs(ctx.GetConsumedInputs())
+
 	return result, nil
 }
 

--- a/backend/internal/flow/flowexec/interceptor_runner_test.go
+++ b/backend/internal/flow/flowexec/interceptor_runner_test.go
@@ -436,6 +436,26 @@ func (s *InterceptorRunnerTestSuite) TestRunInterceptors_NilCurrentNodeInputsPas
 	assert.Nil(s.T(), receivedInputs)
 }
 
+// InterceptorRunnerContext consumed inputs
+
+func (s *InterceptorRunnerTestSuite) TestInterceptorRunnerContext_AppendConsumedInputs_Appends() {
+	c := &InterceptorRunnerContext{}
+
+	c.AppendConsumedInputs([]string{"a"})
+	c.AppendConsumedInputs([]string{"b", "c"})
+
+	assert.Equal(s.T(), []string{"a", "b", "c"}, c.GetConsumedInputs())
+}
+
+func (s *InterceptorRunnerTestSuite) TestInterceptorRunnerContext_AppendConsumedInputs_EmptyIsNoop() {
+	c := &InterceptorRunnerContext{}
+
+	c.AppendConsumedInputs(nil)
+	c.AppendConsumedInputs([]string{})
+
+	assert.Empty(s.T(), c.GetConsumedInputs())
+}
+
 // --- Test helpers ---
 
 func newTestInterceptorMock(t interface {

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -50,6 +50,9 @@ type frame struct {
 }
 
 // EngineContext holds the overall context used by the flow engine during execution.
+//
+// TODO: fields on EngineContext are currently exposed directly. Convert to unexported
+// fields accessed via getters and setters so that mutation can be encapsulated.
 type EngineContext struct {
 	Context context.Context
 
@@ -77,7 +80,9 @@ type EngineContext struct {
 	ExecutionHistory  map[string]*providers.NodeExecutionRecord
 
 	InterceptorSharedData map[string]string
-
+	// consumedInputs accumulates identifiers reported as consumed by executors and
+	// interceptors within the current request
+	consumedInputs []string
 	// frameStack holds saved call frames. Top is the most recent caller.
 	frameStack []*frame
 	// sharedRuntimeData is a cross-frame key-value store available to executors that opt in.
@@ -157,6 +162,9 @@ func (e *EngineContext) getSharedRuntimeData(key string) (string, bool) {
 // InterceptorRunnerContext is a self-contained, request-scoped context built by the engine
 // for each RunInterceptors call. It carries everything the interceptor service needs without
 // requiring access to the engine context itself.
+//
+// TODO: fields on EngineContext are currently exposed directly. Convert to unexported
+// fields accessed via getters and setters so that mutation can be encapsulated.
 type InterceptorRunnerContext struct {
 	Ctx                  context.Context
 	ExecutionID          string
@@ -174,6 +182,27 @@ type InterceptorRunnerContext struct {
 	CurrentNodeInputs    []providers.Input
 	ResolvedInterceptors []core.InterceptorUnitInterface
 	SharedData           map[string]string
+	// consumedInputs accumulates identifiers reported as consumed by interceptors
+	// during this RunInterceptors call
+	consumedInputs []string
+}
+
+// AppendConsumedInputs appends the given keys to the accumulator of inputs consumed during
+// this RunInterceptors call.
+func (c *InterceptorRunnerContext) AppendConsumedInputs(keys []string) {
+	if len(keys) == 0 {
+		return
+	}
+	if c.consumedInputs == nil {
+		c.consumedInputs = make([]string, 0, len(keys))
+	}
+	c.consumedInputs = append(c.consumedInputs, keys...)
+}
+
+// GetConsumedInputs returns the keys reported via ConsumeInput by interceptors during this
+// RunInterceptors call.
+func (c *InterceptorRunnerContext) GetConsumedInputs() []string {
+	return c.consumedInputs
 }
 
 // FlowStep represents the outcome of a individual flow step

--- a/backend/internal/flow/graphbuilder/graph_builder.go
+++ b/backend/internal/flow/graphbuilder/graph_builder.go
@@ -369,6 +369,7 @@ func (b *graphBuilder) configureNodeInputs(
 			Identifier: input.Identifier,
 			Type:       input.Type,
 			Required:   input.Required,
+			OneTimeUse: input.OneTimeUse,
 		}
 	}
 	executorNode.SetInputs(inputs)
@@ -462,6 +463,7 @@ func (b *graphBuilder) configureNodePrompts(
 				Identifier: inputDef.Identifier,
 				Type:       inputDef.Type,
 				Required:   inputDef.Required,
+				OneTimeUse: inputDef.OneTimeUse,
 				Validation: validation,
 			}
 		}

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -868,6 +868,12 @@ type Input struct {
 	Options     []string         `json:"options,omitempty"`
 	DisplayName string           `json:"-"`
 	Validation  []ValidationRule `json:"validation,omitempty"`
+
+	// OneTimeUse indicates that the input can only be consumed once.
+	OneTimeUse bool `json:"oneTimeUse,omitempty"`
+
+	// Consumed indicates whether a OneTimeUse input has already been consumed and is pending cleanup.
+	Consumed bool `json:"-"`
 }
 
 // IsSensitive checks whether this input's type is considered sensitive.

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -316,6 +316,7 @@ type InputDefinition struct {
 	Type       string                     `json:"type"                 yaml:"type"                 jsonschema:"Input type (e.g., 'text', 'password', 'email')."`
 	Identifier string                     `json:"identifier"           yaml:"identifier"           jsonschema:"Field identifier or name."`
 	Required   bool                       `json:"required"             yaml:"required"             jsonschema:"Whether this input is mandatory."`
+	OneTimeUse bool                       `json:"oneTimeUse,omitempty" yaml:"oneTimeUse,omitempty" jsonschema:"When true, the input is removed from the flow context after being consumed."`
 	Validation []ValidationRuleDefinition `json:"validation,omitempty" yaml:"validation,omitempty" jsonschema:"Server-enforced validation rules applied to the submitted value."`
 }
 
@@ -868,12 +869,8 @@ type Input struct {
 	Options     []string         `json:"options,omitempty"`
 	DisplayName string           `json:"-"`
 	Validation  []ValidationRule `json:"validation,omitempty"`
-
-	// OneTimeUse indicates that the input can only be consumed once.
+	// OneTimeUse indicates that the input can only be consumed once
 	OneTimeUse bool `json:"oneTimeUse,omitempty"`
-
-	// Consumed indicates whether a OneTimeUse input has already been consumed and is pending cleanup.
-	Consumed bool `json:"-"`
 }
 
 // IsSensitive checks whether this input's type is considered sensitive.
@@ -955,6 +952,9 @@ type InboundAuthConfigWithSecret struct {
 }
 
 // NodeContext holds the context for a specific node in the flow execution.
+//
+// TODO: fields on NodeContext are currently exposed directly. Convert to unexported
+// fields accessed via getters and setters so that mutation can be encapsulated.
 type NodeContext struct {
 	Context context.Context
 
@@ -971,10 +971,40 @@ type NodeContext struct {
 	UserInputs     map[string]string
 	RuntimeData    map[string]string
 	ForwardedData  map[string]interface{}
-
+	// consumedInputs accumulates identifiers of inputs the node has used up
+	consumedInputs   []string
 	Application      Application
 	AuthUser         AuthUser
 	ExecutionHistory map[string]*NodeExecutionRecord
+}
+
+// ConsumeInput returns the value for key from UserInputs and records key on the consumed
+// inputs list. Nodes/ executors should prefer this over direct UserInputs access so the engine
+// has a full audit trail of what was used.
+func (nc *NodeContext) ConsumeInput(key string) (string, bool) {
+	v, ok := nc.UserInputs[key]
+	if ok {
+		nc.consumedInputs = append(nc.consumedInputs, key)
+	}
+	return v, ok
+}
+
+// AppendConsumedInputs records the given keys on the consumed inputs list without
+// reading from UserInputs.
+func (nc *NodeContext) AppendConsumedInputs(keys []string) {
+	if len(keys) == 0 {
+		return
+	}
+	if nc.consumedInputs == nil {
+		nc.consumedInputs = make([]string, 0, len(keys))
+	}
+	nc.consumedInputs = append(nc.consumedInputs, keys...)
+}
+
+// GetConsumedInputs returns the list of input keys that have been consumed by the node
+// during this call.
+func (nc *NodeContext) GetConsumedInputs() []string {
+	return nc.consumedInputs
 }
 
 // NodeExecutionRecord represents a record of a node execution in the flow.

--- a/backend/pkg/thunderidengine/providers/model_test.go
+++ b/backend/pkg/thunderidengine/providers/model_test.go
@@ -298,3 +298,53 @@ func (suite *ModelTestSuite) TestEvent_Validate() {
 		}
 	})
 }
+
+// ----- NodeContext consumed inputs -----
+
+func (suite *ModelTestSuite) TestNodeContext_ConsumeInput_RecordsAndReturnsValue() {
+	nc := &NodeContext{UserInputs: map[string]string{"captcha": "abc"}}
+
+	v, ok := nc.ConsumeInput("captcha")
+
+	assert.True(suite.T(), ok)
+	assert.Equal(suite.T(), "abc", v)
+	assert.Equal(suite.T(), []string{"captcha"}, nc.GetConsumedInputs())
+}
+
+func (suite *ModelTestSuite) TestNodeContext_ConsumeInput_MissingKeyDoesNotRecord() {
+	nc := &NodeContext{UserInputs: map[string]string{"other": "x"}}
+
+	v, ok := nc.ConsumeInput("captcha")
+
+	assert.False(suite.T(), ok)
+	assert.Equal(suite.T(), "", v)
+	assert.Empty(suite.T(), nc.GetConsumedInputs())
+}
+
+func (suite *ModelTestSuite) TestNodeContext_AppendConsumedInputs_AppendsWithoutReading() {
+	nc := &NodeContext{UserInputs: map[string]string{"a": "1"}}
+
+	nc.AppendConsumedInputs([]string{"a", "b"})
+
+	assert.Equal(suite.T(), []string{"a", "b"}, nc.GetConsumedInputs())
+	assert.Equal(suite.T(), "1", nc.UserInputs["a"], "AppendConsumedInputs must not mutate UserInputs")
+}
+
+func (suite *ModelTestSuite) TestNodeContext_AppendConsumedInputs_EmptyIsNoop() {
+	nc := &NodeContext{}
+
+	nc.AppendConsumedInputs(nil)
+	nc.AppendConsumedInputs([]string{})
+
+	assert.Empty(suite.T(), nc.GetConsumedInputs())
+}
+
+func (suite *ModelTestSuite) TestNodeContext_ConsumeInput_AccumulatesAcrossCalls() {
+	nc := &NodeContext{UserInputs: map[string]string{"a": "1", "b": "2"}}
+
+	nc.ConsumeInput("a")
+	nc.AppendConsumedInputs([]string{"c"})
+	nc.ConsumeInput("b")
+
+	assert.Equal(suite.T(), []string{"a", "c", "b"}, nc.GetConsumedInputs())
+}

--- a/backend/tests/mocks/flow/coremock/InterceptorInterface_mock.go
+++ b/backend/tests/mocks/flow/coremock/InterceptorInterface_mock.go
@@ -8,6 +8,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
 // NewInterceptorInterfaceMock creates a new instance of InterceptorInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -95,6 +96,52 @@ func (_c *InterceptorInterfaceMock_Execute_Call) Return(interceptorResponse *com
 }
 
 func (_c *InterceptorInterfaceMock_Execute_Call) RunAndReturn(run func(ctx *core.InterceptorContext) (*common.InterceptorResponse, error)) *InterceptorInterfaceMock_Execute_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetInputs provides a mock function for the type InterceptorInterfaceMock
+func (_mock *InterceptorInterfaceMock) GetInputs() []providers.Input {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetInputs")
+	}
+
+	var r0 []providers.Input
+	if returnFunc, ok := ret.Get(0).(func() []providers.Input); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]providers.Input)
+		}
+	}
+	return r0
+}
+
+// InterceptorInterfaceMock_GetInputs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInputs'
+type InterceptorInterfaceMock_GetInputs_Call struct {
+	*mock.Call
+}
+
+// GetInputs is a helper method to define mock.On call
+func (_e *InterceptorInterfaceMock_Expecter) GetInputs() *InterceptorInterfaceMock_GetInputs_Call {
+	return &InterceptorInterfaceMock_GetInputs_Call{Call: _e.mock.On("GetInputs")}
+}
+
+func (_c *InterceptorInterfaceMock_GetInputs_Call) Run(run func()) *InterceptorInterfaceMock_GetInputs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *InterceptorInterfaceMock_GetInputs_Call) Return(inputs []providers.Input) *InterceptorInterfaceMock_GetInputs_Call {
+	_c.Call.Return(inputs)
+	return _c
+}
+
+func (_c *InterceptorInterfaceMock_GetInputs_Call) RunAndReturn(run func() []providers.Input) *InterceptorInterfaceMock_GetInputs_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
Add support for one-time-use flow inputs so that values collected for a single-use challenge (captcha, OTP, etc.) are removed from the flow context after they've been consumed. Executors and interceptors declare which inputs they used via a context helper; the engine removes those declared as `OneTimeUse` at the next package boundary. This lets the same input identifier be re-prompted across subsequent nodes or interceptor executions within the same flow.

### Approach

**Declaration**
- Added `OneTimeUse bool` to `providers.Input` (runtime type) and `providers.InputDefinition` (declarative type with `json` / `yaml` / `jsonschema` tags).
- Propagated `OneTimeUse` in the graph builder for both executor inputs and prompt inputs, and in the `ToJSON` serializer so the field round-trips through the flow endpoints.

**Consumption signal (getter-based, concurrency-safe)**
- Added `ConsumeInput(key) (string, bool)` on `providers.NodeContext` and `core.InterceptorContext`. It reads from `UserInputs` and records the key on a per-invocation `consumedInputs` slice held on the context. Executors and interceptors should prefer this over direct `UserInputs` access so the engine has a full audit trail of what was used.
- Added a bulk `AppendConsumedInputs(keys)` helper for cases where a value is obtained via a different path but should still be marked consumed.
- Both context types expose `GetConsumedInputs()` for the engine to read the accumulated list; the underlying slice is unexported.
- `InterceptorRunnerContext` and `EngineContext` also hold unexported `consumedInputs` slices with the same accessor pattern.
- All state lives on per-execution contexts. No mutation of the cached graph, shared interceptor instances, or any registry singletons.

**Engine cleanup**
- After `node.Execute()`, the engine appends `nodeCtx.GetConsumedInputs()` into `ctx.consumedInputs`. After each `runInterceptors` call, it appends `execCtx.GetConsumedInputs()`.
- Added `InterceptorInterface.GetInputs()` so interceptors can declare their own inputs, allowing the engine to know which identifiers are `OneTimeUse` at each scope.
- `clearNodePackageOneTimeUseInputs` runs once after the PRE_NODE → node → POST_NODE package completes. It collects `OneTimeUse` identifiers declared on the node (or executor defaults) plus applicable PRE_NODE / POST_NODE interceptors, deletes matching entries from `ctx.UserInputs`, and drops them from the shared consumed list. Identifiers not declared at node scope are preserved for the request-scope pass.
- `clearRequestPackageOneTimeUseInputs` runs inside `runPostRequestInterceptorsOnExit` — covering both the normal completion path and every early-exit path — for PRE_REQUEST / POST_REQUEST interceptor-declared identifiers. Anything left in the consumed list is dropped so state doesn't leak across requests.
- The two cleanup helpers share `collectInterceptorOneTimeUseIDs` and `clearOneTimeUseInputsScope` for the interceptor-walk and delete-filter logic.

**Loop restructuring**
- Extracted the per-node loop body into `executeNodePackage` so the caller can guarantee `clearNodePackageOneTimeUseInputs` runs once per iteration regardless of exit path.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3723

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for one-time use inputs, including flow and graph serialization of this setting.
* **Bug Fixes**
  * Ensured one-time use inputs are cleared in the correct scope after consumption, including proper handling across node and request execution paths and for unmatched pending inputs.
  * Improved interceptor input consumption tracking so consumed values are cleaned up reliably without affecting others.
* **Tests**
  * Expanded coverage for one-time use input cleanup, interceptor/node execution paths, and consumption bookkeeping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->