### PR TITLE
Fix release Node setup cache post-cleanup failure

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -371,11 +371,9 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: ⚙️ Set up Node.js for Frontend Build
-        uses: ./.github/actions/setup-node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager: 'pnpm'
-          dependency-path: '.'
 
       - name: 🔨 Build Release Artifacts
         uses: ./.github/actions/build-multiplatform
@@ -623,11 +621,9 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: ⚙️ Set up Node.js for Version Update
-        uses: ./.github/actions/setup-node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          package-manager: 'pnpm'
-          dependency-path: '.'
 
       - name: 🏷️ Update Sample Apps Version
         run: |


### PR DESCRIPTION
### Purpose

The `📦 Build and Package Release` job in the release workflow fails during post-job cleanup with:

```
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

All the actual release work (build, Docker push, Helm charts, version bump) succeeds, but this post-cleanup error flips the job to failed and aborts the downstream `Package Samples`, `Release`, and trigger jobs.

Root cause: the `Set up Node.js` steps use the composite `setup-node` action with `cache: pnpm`. setup-node resolves the pnpm store path to `/home/runner/setup-pnpm/node_modules/.bin/store/v11` — inside the pnpm install directory. The job runs `Install pnpm` more than once, and each reinstall recreates that directory and wipes the store setup-node recorded. At post-cleanup, setup-node tries to save the now-missing store path and errors out. The logs also confirm the cache never actually helped (`pnpm cache is not found` on every run).

### Approach

Drop the broken pnpm caching from both `Set up Node.js` steps in the `build-and-package` job (`Set up Node.js for Frontend Build` and `Set up Node.js for Version Update`) by calling `actions/setup-node` directly without `cache`. The build still performs a full `pnpm install --frozen-lockfile`, so no caching benefit is lost — the cache was already missing on every run.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. (Release workflow run completes past both post-cleanup steps successfully.)
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
- [ ] Breaking changes. (Fill if applicable)

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
