### PR TITLE
Add call node components to the flow builder and gate UI

### DIFF
--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -39,7 +39,7 @@ import (
 )
 
 // maxCallDepth is the maximum number of nested call frames allowed
-const maxCallDepth = 5
+const maxCallDepth = 10
 
 // flowEngineInterface defines the interface for the flow engine.
 type flowEngineInterface interface {
@@ -822,10 +822,9 @@ func (fe *flowEngine) handleCallResponse(ctx *EngineContext,
 	nodeResp *common.NodeResponse, logger *log.Logger) (
 	core.NodeInterface, *tidcommon.ServiceError) {
 	if ctx.frameDepth() >= maxCallDepth {
-		logger.Error(ctx.Context, "Maximum call depth exceeded",
-			log.String("callNodeID", ctx.CurrentNode.GetID()),
-			log.String("targetFlowID", nodeResp.CallTargetFlowID))
-		return nil, &tidcommon.InternalServerError
+		logger.Debug(ctx.Context, "Maximum call depth exceeded", log.Int("frameDepth", ctx.frameDepth()),
+			log.Int("maxCallDepth", maxCallDepth))
+		return nil, &ErrorMaxCallDepthExceeded
 	}
 
 	flow, svcErr := fe.flowProvider.GetFlow(ctx.Context, nodeResp.CallTargetFlowID)

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -3432,7 +3432,6 @@ func (s *EngineTestSuite) TestRunPostRequestInterceptorsOnExit_PassesFlowStatusT
 func (s *EngineTestSuite) TestHandleCallResponse_DepthExceeded() {
 	t := s.T()
 	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
-	mockCurrentNode.On("GetID").Return("call-node-1")
 
 	fe := &flowEngine{logger: log.GetLogger()}
 	ctx := &EngineContext{Context: context.Background(), CurrentNode: mockCurrentNode}
@@ -3449,7 +3448,7 @@ func (s *EngineTestSuite) TestHandleCallResponse_DepthExceeded() {
 	next, svcErr := fe.handleCallResponse(ctx, nodeResp, log.GetLogger())
 	s.Nil(next)
 	s.NotNil(svcErr)
-	s.Equal(tidcommon.InternalServerError.Code, svcErr.Code)
+	s.Equal(ErrorMaxCallDepthExceeded.Code, svcErr.Code)
 }
 
 func (s *EngineTestSuite) TestHandleCallResponse_FlowProviderError() {
@@ -3860,7 +3859,6 @@ func (s *EngineTestSuite) TestHandleCalleeFailure_OnFailureNodeNotFound() {
 func (s *EngineTestSuite) TestProcessNodeResponse_CallStatus_DepthExceeded() {
 	t := s.T()
 	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
-	mockCurrentNode.On("GetID").Return("call-node-1")
 
 	fe := &flowEngine{logger: log.GetLogger()}
 	ctx := &EngineContext{Context: context.Background(), CurrentNode: mockCurrentNode}

--- a/backend/internal/flow/flowexec/error_constants.go
+++ b/backend/internal/flow/flowexec/error_constants.go
@@ -194,3 +194,18 @@ var ErrorFlowSecretInvalid = tidcommon.ServiceError{
 		DefaultValue: "The provided flow secret is invalid",
 	},
 }
+
+// ErrorMaxCallDepthExceeded defines the error when the maximum allowed call depth is exceeded
+// during flow execution.
+var ErrorMaxCallDepthExceeded = tidcommon.ServiceError{
+	Code: "FES-1013",
+	Type: tidcommon.ClientErrorType,
+	Error: tidcommon.I18nMessage{
+		Key:          "error.flowexecservice.max_call_depth_exceeded",
+		DefaultValue: "Maximum call depth exceeded",
+	},
+	ErrorDescription: tidcommon.I18nMessage{
+		Key:          "error.flowexecservice.max_call_depth_exceeded_description",
+		DefaultValue: "The maximum allowed call depth has been exceeded during flow execution",
+	},
+}

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -565,6 +565,8 @@ var defaultMessages = map[string]string{
 	"error.flowexecservice.invalid_node_response_description": "Error response received from the node",
 	"error.flowexecservice.invalid_request_payload": "Invalid request payload",
 	"error.flowexecservice.invalid_request_payload_description": "Failed to decode request payload",
+	"error.flowexecservice.max_call_depth_exceeded": "Maximum call depth exceeded",
+	"error.flowexecservice.max_call_depth_exceeded_description": "The maximum allowed call depth has been exceeded during flow execution",
 	"error.flowexecservice.recovery_not_allowed": "Recovery not allowed",
 	"error.flowexecservice.recovery_not_allowed_description": "Recovery flow is disabled for the application",
 	"error.flowexecservice.registration_not_allowed": "Registration not allowed",

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonElementPropertyFactory.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonElementPropertyFactory.tsx
@@ -31,6 +31,7 @@ import startCase from 'lodash-es/startCase';
 import {type ComponentType, type ReactElement, useState, useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 import CheckboxPropertyField from './CheckboxPropertyField';
+import RichTextActionFields from './rich-text/RichTextActionFields';
 import RichTextWithTranslation from './rich-text/RichTextWithTranslation';
 import TextPropertyField from './TextPropertyField';
 import FlowBuilderElementConstants from '../../constants/FlowBuilderElementConstants';
@@ -197,11 +198,14 @@ function CommonElementPropertyFactory({
   if (propertyKey === 'label') {
     if (resource.type === ElementTypes.RichText) {
       return (
-        <RichTextWithTranslation
-          onChange={(html: string) => onChange(propertyKey, html, resource, true)}
-          resource={resource}
-          {...rest}
-        />
+        <>
+          <RichTextWithTranslation
+            onChange={(html: string) => onChange(propertyKey, html, resource, true)}
+            resource={resource}
+            {...rest}
+          />
+          <RichTextActionFields resource={resource} onChange={onChange} />
+        </>
       );
     }
   }

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonElementPropertyFactory.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonElementPropertyFactory.test.tsx
@@ -59,6 +59,10 @@ vi.mock('../rich-text/RichTextWithTranslation', () => ({
   ),
 }));
 
+vi.mock('../rich-text/RichTextActionFields', () => ({
+  default: () => <div data-testid="rich-text-action-fields" />,
+}));
+
 vi.mock('../CheckboxPropertyField', () => ({
   default: ({
     resource,

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/RichTextActionFields.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/RichTextActionFields.tsx
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, FormControl, FormControlLabel, FormLabel, Stack, Switch, TextField, Typography} from '@wso2/oxygen-ui';
+import {useEdges, useReactFlow} from '@xyflow/react';
+import {useEffect, useMemo, useState, type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
+import VisualFlowConstants from '../../../constants/VisualFlowConstants';
+import type {Resource} from '../../../models/resources';
+
+/**
+ * Props interface for the RichTextActionFields component.
+ */
+export interface RichTextActionFieldsPropsInterface {
+  resource: Resource;
+  onChange: (propertyKey: string, newValue: unknown, resource: Resource, debounce?: boolean) => void;
+}
+
+/**
+ * RichTextActionInterface defines the shape of the `action` property on a rich-text resource. It is used to
+ * determine whether the rich text should behave as an interactive link and, if so, which step it
+ * should trigger when clicked.
+ */
+export interface RichTextActionInterface {
+  ref?: string;
+}
+
+/**
+ * RichTextActionFields is a React component that renders the action configuration fields for a rich-text resource.
+ *
+ * @param param0 - The props for the component, including the resource and onChange handler.
+ * @returns A React element representing the action configuration fields.
+ */
+function RichTextActionFields({resource, onChange}: RichTextActionFieldsPropsInterface): ReactElement {
+  const {t} = useTranslation();
+  const {getEdges, setEdges} = useReactFlow();
+  const edges = useEdges();
+
+  const action: RichTextActionInterface | undefined = useMemo<RichTextActionInterface | undefined>(() => {
+    const r = resource as Resource & {action?: RichTextActionInterface};
+    return r.action;
+  }, [resource]);
+
+  const handleId = `${resource.id}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`;
+  // Show the connected target reactively — the "Connected step" field mirrors whatever
+  // edge is currently sourced from this rich-text handle. No user typing; edges drive it.
+  const connectedTarget: string = useMemo<string>(
+    () => edges.find((edge) => edge.sourceHandle === handleId)?.target ?? '',
+    [edges, handleId],
+  );
+
+  // ResourceProperties filters `propertyKey === 'action'` from updating the currently
+  // selected resource view, so the parent-driven `action` reference never rebroadcasts
+  // to this component. Track enabled state locally and seed it from the resource on mount.
+  const [isEnabled, setIsEnabled] = useState<boolean>(Boolean(action));
+
+  // Re-seed the local enabled state whenever a different resource is selected. `action`
+  // itself isn't re-broadcast (see comment on isEnabled), so key off resource id.
+  useEffect(() => {
+    setIsEnabled(Boolean(action));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: action is stale for the same resource
+  }, [resource.id]);
+
+  const handleToggle = (enabled: boolean): void => {
+    setIsEnabled(enabled);
+    if (enabled) {
+      // Preserve the widget's predefined ref if there is one (e.g. Self Sign Up Link
+      // ships with `action_signup`). Otherwise seed an empty ref — the connect handler
+      // will fill it in with the target node's id once the author draws an edge.
+      onChange('action', {ref: action?.ref ?? ''}, resource);
+    } else {
+      // Drop any edges the author drew from this rich-text's source handle — the
+      // handle is about to disappear, so orphaned edges would dangle otherwise.
+      setEdges(getEdges().filter((edge) => edge.sourceHandle !== handleId));
+      // Use `null` as an explicit "disabled" sentinel: lodash `set` treats it distinctly
+      // from `undefined` (which some downstream passes may strip), and the adapter reads
+      // it as falsy so the source Handle actually unmounts.
+      onChange('action', null, resource);
+    }
+  };
+
+  return (
+    <Stack gap={2} data-testid="rich-text-action-fields">
+      <Typography variant="body2" color="text.secondary">
+        {t(
+          'flows:core.elements.richText.action.description',
+          'Turn this rich text into an interactive link. When on, the link inside triggers the connected step instead of navigating.',
+        )}
+      </Typography>
+      <Box>
+        <FormControlLabel
+          sx={{ml: 0}}
+          control={
+            <Switch
+              data-testid="rich-text-action-enabled"
+              checked={isEnabled}
+              onChange={(e) => handleToggle(e.target.checked)}
+              sx={{mr: 1}}
+            />
+          }
+          label={t('flows:core.elements.richText.action.enabled.label', 'Use as an interactive link')}
+        />
+      </Box>
+      {isEnabled && (
+        <FormControl fullWidth size="small">
+          <FormLabel htmlFor="rich-text-action-ref">
+            {t('flows:core.elements.richText.action.ref.label', 'Connected step')}
+          </FormLabel>
+          <TextField
+            id="rich-text-action-ref"
+            data-testid="rich-text-action-ref"
+            value={connectedTarget}
+            placeholder={t(
+              'flows:core.elements.richText.action.ref.placeholder',
+              'Draw an edge from the link to a step',
+            )}
+            size="small"
+            fullWidth
+            slotProps={{input: {readOnly: true}}}
+          />
+        </FormControl>
+      )}
+    </Stack>
+  );
+}
+
+export default RichTextActionFields;

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/__tests__/RichTextActionFields.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/__tests__/RichTextActionFields.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint-disable @typescript-eslint/non-nullable-type-assertion-style */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import RichTextActionFields from '../RichTextActionFields';
+import type {Resource} from '@/features/flows/models/resources';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+const mockSetEdges = vi.fn();
+const mockGetEdges = vi.fn(() => []);
+const mockEdges: {sourceHandle?: string; target?: string}[] = [];
+vi.mock('@xyflow/react', () => ({
+  useReactFlow: () => ({
+    getEdges: mockGetEdges,
+    setEdges: mockSetEdges,
+  }),
+  useEdges: () => mockEdges,
+}));
+
+const makeResource = (overrides: Partial<Resource> = {}): Resource =>
+  ({
+    id: 'rt-1',
+    type: 'RICH_TEXT',
+    category: 'DISPLAY',
+    resourceType: 'ELEMENT',
+    ...overrides,
+  }) as Resource;
+
+describe('RichTextActionFields', () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the toggle in the off position when action is undefined', () => {
+    render(<RichTextActionFields resource={makeResource()} onChange={onChange} />);
+    const toggle = screen.getByTestId('rich-text-action-enabled').querySelector('input') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    expect(screen.queryByTestId('rich-text-action-ref')).not.toBeInTheDocument();
+  });
+
+  it('turning the toggle on writes an empty action ref via onChange', () => {
+    render(<RichTextActionFields resource={makeResource()} onChange={onChange} />);
+    const toggle = screen.getByTestId('rich-text-action-enabled').querySelector('input') as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledWith('action', {ref: ''}, expect.anything());
+  });
+
+  it('preserves an existing action ref when the toggle is turned back on', () => {
+    // Widget-supplied refs (e.g. Self Sign Up Link ships `action_signup`) must survive
+    // a disable→enable cycle so the anchor's data-action-ref still matches at runtime.
+    const resource = makeResource({action: {ref: 'action_signup'}} as unknown as Partial<Resource>);
+    render(<RichTextActionFields resource={resource} onChange={onChange} />);
+    const toggle = screen.getByTestId('rich-text-action-enabled').querySelector('input') as HTMLInputElement;
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenLastCalledWith('action', {ref: 'action_signup'}, resource);
+  });
+
+  it('renders the connected step field as read-only when action is enabled', () => {
+    const resource = makeResource({action: {ref: 'action_signup'}} as unknown as Partial<Resource>);
+    render(<RichTextActionFields resource={resource} onChange={onChange} />);
+    const input = screen.getByTestId('rich-text-action-ref').querySelector('input') as HTMLInputElement;
+    expect(input.readOnly).toBe(true);
+  });
+
+  it('turning the toggle off clears the action', () => {
+    const resource = makeResource({action: {ref: 'action_signup'}} as unknown as Partial<Resource>);
+    render(<RichTextActionFields resource={resource} onChange={onChange} />);
+    const toggle = screen.getByTestId('rich-text-action-enabled').querySelector('input') as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledWith('action', null, resource);
+  });
+});

--- a/frontend/apps/console/src/features/flows/components/resources/elements/CommonElementFactory.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/CommonElementFactory.tsx
@@ -134,7 +134,7 @@ function CommonElementFactory({
     return <TypographyAdapter stepId={stepId} resource={resource} />;
   }
   if (resource.type === ElementTypes.RichText) {
-    return <RichTextAdapter resource={resource} />;
+    return <RichTextAdapter resource={resource} elementIndex={elementIndex} />;
   }
   if (resource.type === ElementTypes.Divider) {
     return <DividerAdapter resource={resource} />;

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/RichTextAdapter.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/RichTextAdapter.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,10 +16,13 @@
  * under the License.
  */
 import {useTemplateLiteralResolver} from '@thunderid/hooks';
+import {Position, useNodeId, useUpdateNodeInternals} from '@xyflow/react';
 import DOMPurify from 'dompurify';
 import parse from 'html-react-parser';
-import {useMemo, type ReactElement} from 'react';
+import {useEffect, useMemo, useRef, type ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
+import NodeHandle from './NodeHandle';
+import VisualFlowConstants from '@/features/flows/constants/VisualFlowConstants';
 import type {Element as FlowElement} from '@/features/flows/models/elements';
 import './RichTextAdapter.scss';
 
@@ -42,6 +45,7 @@ import './RichTextAdapter.scss';
  */
 export type RichTextElement = FlowElement & {
   label?: string;
+  action?: {ref?: string; eventType?: string};
 };
 
 /**
@@ -52,33 +56,69 @@ export interface RichTextAdapterPropsInterface {
    * The rich text element properties.
    */
   resource: FlowElement;
+  /**
+   * Index of this element within its parent container, used as a positionKey so React Flow
+   * re-measures the source handle when the rich text is reordered.
+   */
+  elementIndex?: number;
 }
 
 /**
- * Adapter for the Rich Text component.
- *
- * @param props - Props injected to the component.
- * @returns The RichTextAdapter component.
+ * Adapter for the Rich Text component. When the component carries an `action.ref` (i.e.
+ * a sentinel-marked anchor inside the HTML should dispatch a flow action), a source
+ * NodeHandle is rendered so the author can draw an edge from the rich text to a target
+ * step — matching the button-action wiring UX.
  */
-function RichTextAdapter({resource}: RichTextAdapterPropsInterface): ReactElement {
+function RichTextAdapter({resource, elementIndex = undefined}: RichTextAdapterPropsInterface): ReactElement {
   const {t} = useTranslation();
 
   const {resolveAll} = useTemplateLiteralResolver();
 
   const richTextElement = resource as RichTextElement;
   const textContent = richTextElement?.label ?? '';
+  const isActionEnabled = Boolean(richTextElement.action);
+  const parentNodeId = useNodeId();
+  const updateNodeInternals = useUpdateNodeInternals();
+
+  // React Flow does not observe subtree mutations, so it needs to be told to re-measure
+  // when the source Handle is added or removed by the action-enabled toggle. Only fire
+  // when the enabled value actually transitions — measuring on mount (or on any parent
+  // re-render where isActionEnabled is the same) forces React Flow to re-run its initial
+  // fitView, which locks the canvas into a zoomed-in state on flow load.
+  const prevIsActionEnabledRef = useRef<boolean>(isActionEnabled);
+  useEffect(() => {
+    if (prevIsActionEnabledRef.current === isActionEnabled) {
+      return;
+    }
+    prevIsActionEnabledRef.current = isActionEnabled;
+    if (parentNodeId) {
+      updateNodeInternals(parentNodeId);
+    }
+  }, [parentNodeId, updateNodeInternals, isActionEnabled]);
 
   const sanitizedHtml: string = useMemo(
     () =>
       DOMPurify.sanitize(resolveAll(textContent, {t}) ?? textContent, {
-        ADD_ATTR: ['target'],
+        ADD_ATTR: ['target', 'data-action-ref'],
         RETURN_TRUSTED_TYPE: false,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- resolveAll is stable
     [textContent, t],
   );
 
-  return <div className="rich-text-content">{parse(sanitizedHtml)}</div>;
+  return (
+    <div className="rich-text-content rich-text-adapter">
+      {parse(sanitizedHtml)}
+      {isActionEnabled && (
+        <NodeHandle
+          id={`${richTextElement.id}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`}
+          type="source"
+          position={Position.Right}
+          positionKey={elementIndex}
+        />
+      )}
+    </div>
+  );
 }
 
 export default RichTextAdapter;

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/__tests__/RichTextAdapter.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/__tests__/RichTextAdapter.test.tsx
@@ -25,6 +25,22 @@ import type {Element as FlowElement} from '@/features/flows/models/elements';
 // Mock dependencies
 vi.mock('../RichTextAdapter.scss', () => ({}));
 
+const mockUpdateNodeInternals = vi.fn();
+const mockUseNodeId = vi.fn<() => string | null>(() => 'node-1');
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => null,
+  Position: {Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom'},
+  useNodeId: () => mockUseNodeId(),
+  useUpdateNodeInternals: () => mockUpdateNodeInternals,
+}));
+
+vi.mock('../NodeHandle', () => ({
+  default: ({id, type, position}: {id: string; type: string; position: string}) => (
+    <div data-testid="node-handle" data-handle-id={id} data-handle-type={type} data-position={position} />
+  ),
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -45,6 +61,7 @@ describe('RichTextAdapter', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseNodeId.mockReturnValue('node-1');
   });
 
   describe('Rendering', () => {
@@ -119,6 +136,57 @@ describe('RichTextAdapter', () => {
 
       expect(container1.querySelector('.rich-text-content')).toBeInTheDocument();
       expect(container2.querySelector('.rich-text-content')).toBeInTheDocument();
+    });
+  });
+
+  describe('Action-enabled source handle', () => {
+    it('should render a source NodeHandle when the element has an action defined', () => {
+      const resource = createMockElement({action: {ref: 'target-1'}} as Record<string, unknown>);
+
+      const {getByTestId} = render(<RichTextAdapter resource={resource} />);
+
+      const handle = getByTestId('node-handle');
+      expect(handle).toHaveAttribute('data-handle-id', 'richtext-1_NEXT');
+      expect(handle).toHaveAttribute('data-handle-type', 'source');
+      expect(handle).toHaveAttribute('data-position', 'right');
+    });
+
+    it('should not render the source NodeHandle when the element has no action', () => {
+      const resource = createMockElement();
+
+      const {queryByTestId} = render(<RichTextAdapter resource={resource} />);
+
+      expect(queryByTestId('node-handle')).toBeNull();
+    });
+
+    it('should call updateNodeInternals when isActionEnabled transitions from false to true', () => {
+      const {rerender} = render(<RichTextAdapter resource={createMockElement()} />);
+      // Initial render: prev=current, effect runs but returns early
+      expect(mockUpdateNodeInternals).not.toHaveBeenCalled();
+
+      rerender(<RichTextAdapter resource={createMockElement({action: {ref: 'x'}} as Record<string, unknown>)} />);
+
+      expect(mockUpdateNodeInternals).toHaveBeenCalledWith('node-1');
+    });
+
+    it('should call updateNodeInternals when isActionEnabled transitions from true to false', () => {
+      const {rerender} = render(
+        <RichTextAdapter resource={createMockElement({action: {ref: 'x'}} as Record<string, unknown>)} />,
+      );
+      expect(mockUpdateNodeInternals).not.toHaveBeenCalled();
+
+      rerender(<RichTextAdapter resource={createMockElement()} />);
+
+      expect(mockUpdateNodeInternals).toHaveBeenCalledWith('node-1');
+    });
+
+    it('should skip updateNodeInternals when parentNodeId is null even after a transition', () => {
+      mockUseNodeId.mockReturnValue(null);
+      const {rerender} = render(<RichTextAdapter resource={createMockElement()} />);
+
+      rerender(<RichTextAdapter resource={createMockElement({action: {ref: 'x'}} as Record<string, unknown>)} />);
+
+      expect(mockUpdateNodeInternals).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/apps/console/src/features/flows/components/resources/steps/CommonStepFactory.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/CommonStepFactory.tsx
@@ -18,6 +18,7 @@
 
 import type {NodeProps} from '@xyflow/react';
 import type {ReactElement} from 'react';
+import Call from './call/Call';
 import End from './end/End';
 import Execution from './execution/Execution';
 import Rule from './rule/Rule';
@@ -115,6 +116,10 @@ function CommonStepFactory({
 
   if (resources?.[0].type === StepTypes.End) {
     return <End resources={resources} data={data} {...rest} />;
+  }
+
+  if (resources?.[0].type === StepTypes.Call) {
+    return <Call resources={resources} data={data} {...rest} />;
   }
 
   return null;

--- a/frontend/apps/console/src/features/flows/components/resources/steps/__tests__/CommonStepFactory.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/__tests__/CommonStepFactory.test.tsx
@@ -71,6 +71,14 @@ vi.mock('../end/End', () => ({
   ),
 }));
 
+vi.mock('../call/Call', () => ({
+  default: ({resources, data}: {resources: Step[]; data: unknown}) => (
+    <div data-testid="call-step" data-resource-count={resources.length} data-has-data={!!data}>
+      Call Step
+    </div>
+  ),
+}));
+
 describe('CommonStepFactory', () => {
   const createWrapper = () => {
     function Wrapper({children}: {children: ReactNode}) {
@@ -315,6 +323,35 @@ describe('CommonStepFactory', () => {
       );
 
       expect(screen.getByTestId('end-step')).toHaveAttribute('data-has-data', 'true');
+    });
+  });
+
+  describe('Call Step', () => {
+    it('should render Call component for CALL step type', () => {
+      const callStep = createMockStep({type: StepTypes.Call});
+
+      render(<CommonStepFactory {...defaultNodeProps} resourceId="resource-1" resources={[callStep]} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByTestId('call-step')).toBeInTheDocument();
+      expect(screen.getByTestId('call-step')).toHaveAttribute('data-resource-count', '1');
+    });
+
+    it('should pass data to Call component', () => {
+      const callStep = createMockStep({type: StepTypes.Call});
+
+      render(
+        <CommonStepFactory
+          {...defaultNodeProps}
+          resourceId="resource-1"
+          resources={[callStep]}
+          data={{flow: {ref: 'flow-x'}}}
+        />,
+        {wrapper: createWrapper()},
+      );
+
+      expect(screen.getByTestId('call-step')).toHaveAttribute('data-has-data', 'true');
     });
   });
 

--- a/frontend/apps/console/src/features/flows/components/resources/steps/call/Call.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/call/Call.tsx
@@ -1,0 +1,271 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Box,
+  Button,
+  Card,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import {CogIcon, ExternalLink as ExternalLinkIcon, TrashIcon} from '@wso2/oxygen-ui-icons-react';
+import {Handle, Position, useNodeId, useReactFlow} from '@xyflow/react';
+import {memo, useMemo, useState, type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
+import {useNavigate} from 'react-router';
+import ValidationErrorBoundary from '../../../validation-panel/ValidationErrorBoundary';
+import type {CommonStepFactoryPropsInterface} from '../CommonStepFactory';
+import useGetFlows from '@/features/flows/api/useGetFlows';
+import VisualFlowConstants from '@/features/flows/constants/VisualFlowConstants';
+import useInteractionState from '@/features/flows/hooks/useInteractionState';
+import useUIPanelState from '@/features/flows/hooks/useUIPanelState';
+import {FlowType} from '@/features/flows/models/flows';
+import {ResourceTypes} from '@/features/flows/models/resources';
+import type {BasicFlowDefinition} from '@/features/flows/models/responses';
+import {StepCategories, StepTypes, type Step, type StepData} from '@/features/flows/models/steps';
+import '../execution/ExecutionMinimal.scss';
+
+export type CallPropsInterface = CommonStepFactoryPropsInterface;
+
+type CallStepData = StepData & {flow?: {ref?: string}};
+
+const CALL_NODE_WIDTH = 260;
+
+const FLOW_TYPE_TO_ROUTE_SEGMENT: Record<string, string> = {
+  [FlowType.AUTHENTICATION]: 'signin',
+  [FlowType.REGISTRATION]: 'registration',
+  [FlowType.RECOVERY]: 'recovery',
+};
+
+/**
+ * Call Node component for cross-flow invocation. Visually mirrors ExecutionMinimal but
+ * exposes a flow reference instead of an executor and exposes both `onSuccess` (right) and
+ * `onFailure` (bottom) handles. The node card also carries an "open referenced flow"
+ * shortcut that jumps the builder to the callee flow (with an unsaved-changes confirm).
+ */
+function Call({resources, data}: CallPropsInterface): ReactElement {
+  const stepId: string | null = useNodeId();
+  const {t} = useTranslation();
+  const navigate = useNavigate();
+  const {setLastInteractedResource, setLastInteractedStepId} = useInteractionState();
+  const {setIsOpenResourcePropertiesPanel} = useUIPanelState();
+  const {deleteElements} = useReactFlow();
+  const {data: flowsData} = useGetFlows({limit: 100});
+  const [isOpenConfirmDialog, setIsOpenConfirmDialog] = useState<boolean>(false);
+
+  const callData: CallStepData = (data as CallStepData) ?? {};
+  const flowRef: string = callData.flow?.ref ?? '';
+  const paletteEntry: Step | undefined = resources?.[0];
+  const displayLabel: string = paletteEntry?.display?.label ?? t('flows:core.call.unconfiguredLabel', 'Call flow');
+
+  const referencedFlow: BasicFlowDefinition | undefined = useMemo<BasicFlowDefinition | undefined>(
+    () => (flowsData?.flows ?? []).find((f: BasicFlowDefinition) => f.id === flowRef),
+    [flowsData, flowRef],
+  );
+
+  const canOpen = Boolean(referencedFlow && FLOW_TYPE_TO_ROUTE_SEGMENT[referencedFlow.flowType]);
+
+  const resource: Step = {
+    ...(paletteEntry ?? ({} as Step)),
+    id: stepId ?? '',
+    type: StepTypes.Call,
+    category: StepCategories.Workflow,
+    resourceType: ResourceTypes.Step,
+    data: callData,
+    display: {
+      ...(paletteEntry?.display ?? {}),
+      label: displayLabel,
+      showOnResourcePanel: false,
+    },
+  } as Step;
+
+  const handleConfigClick = (): void => {
+    if (stepId !== null) {
+      setLastInteractedStepId(stepId);
+    }
+    setLastInteractedResource(resource);
+    setIsOpenResourcePropertiesPanel(true);
+  };
+
+  const handleCardClick = (): void => {
+    if (stepId !== null) {
+      setLastInteractedStepId(stepId);
+    }
+    setLastInteractedResource(resource);
+  };
+
+  const handleDelete = (): void => {
+    if (stepId) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      deleteElements({nodes: [{id: stepId}]});
+    }
+  };
+
+  const handleOpenReferencedFlow = (event: React.MouseEvent): void => {
+    event.stopPropagation();
+    if (!referencedFlow) {
+      return;
+    }
+    if (!FLOW_TYPE_TO_ROUTE_SEGMENT[referencedFlow.flowType]) {
+      return;
+    }
+    setIsOpenConfirmDialog(true);
+  };
+
+  const handleConfirmOpenReferencedFlow = (): void => {
+    setIsOpenConfirmDialog(false);
+    if (!referencedFlow) {
+      return;
+    }
+    const segment: string | undefined = FLOW_TYPE_TO_ROUTE_SEGMENT[referencedFlow.flowType];
+    if (!segment) {
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    navigate(`/flows/${segment}/${referencedFlow.id}`);
+  };
+
+  const bodyLabel: string = referencedFlow
+    ? referencedFlow.name
+    : t('flows:core.call.selectFlow', 'Select a flow to invoke');
+
+  return (
+    <ValidationErrorBoundary resource={resource}>
+      <Box
+        className="execution-minimal-step has-branching call-step"
+        data-testid="call-node"
+        sx={{width: CALL_NODE_WIDTH}}
+      >
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+          className="execution-minimal-step-action-panel"
+          sx={{backgroundColor: 'secondary.main', height: 44, px: 2, py: 1.25}}
+        >
+          <Typography variant="body2" sx={{color: 'common.white', fontWeight: 500}}>
+            {displayLabel}
+          </Typography>
+          <Box display="flex" alignItems="center" gap={0.5}>
+            <Tooltip title={t('flows:core.call.tooltip.configure', 'Configure')}>
+              <IconButton size="small" onClick={handleConfigClick} sx={{color: 'common.white'}}>
+                <CogIcon size={18} />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title={t('flows:core.call.tooltip.delete', 'Delete')}>
+              <IconButton size="small" onClick={handleDelete} sx={{color: 'common.white'}}>
+                <TrashIcon size={18} />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+        <Handle type="target" position={Position.Left} />
+        <Card
+          className="execution-minimal-step-content"
+          onClick={handleCardClick}
+          sx={{p: 2}}
+          data-testid="call-node-content"
+        >
+          <Box display="flex" alignItems="center" justifyContent="space-between" gap={1}>
+            <Box sx={{minWidth: 0, flex: 1}}>
+              <Typography variant="caption" sx={{display: 'block', opacity: 0.7}}>
+                {t('flows:core.call.referencedFlow', 'Referenced flow')}
+              </Typography>
+              <Typography
+                variant="body2"
+                data-testid="call-node-flow-ref"
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  color: referencedFlow ? 'text.primary' : 'text.secondary',
+                  fontStyle: referencedFlow ? 'normal' : 'italic',
+                }}
+              >
+                {bodyLabel}
+              </Typography>
+            </Box>
+            <Tooltip
+              title={
+                canOpen
+                  ? t('flows:core.call.tooltip.openFlow', 'Open referenced flow')
+                  : t('flows:core.call.tooltip.openFlowDisabled', 'Configure a referenced flow to enable')
+              }
+            >
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={handleOpenReferencedFlow}
+                  disabled={!canOpen}
+                  data-testid="call-open-referenced-flow"
+                >
+                  <ExternalLinkIcon size={16} />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </Box>
+        </Card>
+        <Tooltip title={t('flows:core.call.handles.success', 'On success')} placement="right">
+          <Box className="handle-wrapper success-wrapper">
+            <Handle
+              type="source"
+              position={Position.Right}
+              id={`${stepId ?? ''}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`}
+              className="execution-handle-success"
+            />
+          </Box>
+        </Tooltip>
+        <Tooltip title={t('flows:core.call.handles.failure', 'On failure')} placement="bottom">
+          <Box className="handle-wrapper failure-wrapper">
+            <Handle type="source" position={Position.Bottom} id="failure" className="execution-handle-failure" />
+          </Box>
+        </Tooltip>
+      </Box>
+      <Dialog
+        open={isOpenConfirmDialog}
+        onClose={() => setIsOpenConfirmDialog(false)}
+        maxWidth="sm"
+        fullWidth
+        data-testid="call-open-referenced-flow-dialog"
+      >
+        <DialogTitle>{t('flows:core.call.openFlow.dialog.title', 'Open referenced flow?')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {t('flows:core.call.openFlow.dialog.description', 'Any unsaved changes to the current flow will be lost.')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setIsOpenConfirmDialog(false)}>
+            {t('flows:core.call.openFlow.dialog.cancel', 'Cancel')}
+          </Button>
+          <Button onClick={handleConfirmOpenReferencedFlow} color="primary" variant="contained">
+            {t('flows:core.call.openFlow.dialog.confirm', 'Continue')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </ValidationErrorBoundary>
+  );
+}
+
+export default memo(Call);

--- a/frontend/apps/console/src/features/flows/components/resources/steps/call/__tests__/Call.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/call/__tests__/Call.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import Call from '../Call';
+import type {Step} from '@/features/flows/models/steps';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const mockUseGetFlows = vi.fn<() => unknown>();
+vi.mock('@/features/flows/api/useGetFlows', () => ({
+  default: (): unknown => mockUseGetFlows(),
+}));
+
+const mockDeleteElements = vi.fn();
+const mockUseNodeId = vi.fn<() => string | null>(() => 'call-node-id');
+
+vi.mock('@xyflow/react', () => ({
+  // eslint-disable-next-line react/require-default-props
+  Handle: ({type, position, id}: {type: string; position: string; id?: string}) => (
+    <div data-testid={`handle-${type}-${id ?? position}`} data-position={position} data-handle-id={id} />
+  ),
+  Position: {Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom'},
+  useNodeId: () => mockUseNodeId(),
+  useReactFlow: () => ({deleteElements: mockDeleteElements}),
+}));
+
+const mockSetLastInteractedResource = vi.fn();
+const mockSetLastInteractedStepId = vi.fn();
+vi.mock('@/features/flows/hooks/useInteractionState', () => ({
+  default: () => ({
+    setLastInteractedResource: mockSetLastInteractedResource,
+    setLastInteractedStepId: mockSetLastInteractedStepId,
+  }),
+}));
+
+const mockSetIsOpenResourcePropertiesPanel = vi.fn();
+vi.mock('@/features/flows/hooks/useUIPanelState', () => ({
+  default: () => ({setIsOpenResourcePropertiesPanel: mockSetIsOpenResourcePropertiesPanel}),
+}));
+
+const paletteResource: Step = {
+  id: 'call-palette',
+  type: 'CALL',
+  category: 'WORKFLOW',
+  resourceType: 'STEP',
+  display: {label: 'Call Flow'},
+} as unknown as Step;
+
+const renderCall = (data?: Record<string, unknown>) => {
+  const props = {
+    resources: [paletteResource],
+    data: data as never,
+    resourceId: 'call-palette',
+    id: 'call-node-id',
+    type: 'CALL',
+    position: {x: 0, y: 0},
+    selected: false,
+    isConnectable: true,
+  } as unknown as Parameters<typeof Call>[0];
+  return render(<Call {...props} />);
+};
+
+describe('Call', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseNodeId.mockReturnValue('call-node-id');
+    mockUseGetFlows.mockReturnValue({data: {flows: []}, isLoading: false, error: null});
+  });
+
+  describe('Rendering', () => {
+    it('falls back to the default "Call flow" label when no palette resource is provided', () => {
+      const props = {
+        resources: [],
+        data: {} as never,
+        resourceId: 'call-palette',
+        id: 'call-node-id',
+        type: 'CALL',
+        position: {x: 0, y: 0},
+        selected: false,
+        isConnectable: true,
+      } as unknown as Parameters<typeof Call>[0];
+      render(<Call {...props} />);
+      expect(screen.getAllByText(/call flow/i).length).toBeGreaterThan(0);
+    });
+
+    it('records the last interacted resource when the card body is clicked', () => {
+      renderCall({flow: {ref: 'flow-abc'}});
+      fireEvent.click(screen.getByTestId('call-node-content'));
+      expect(mockSetLastInteractedStepId).toHaveBeenCalledWith('call-node-id');
+      expect(mockSetLastInteractedResource).toHaveBeenCalled();
+      // handleCardClick does not open the properties panel
+      expect(mockSetIsOpenResourcePropertiesPanel).not.toHaveBeenCalled();
+    });
+
+    it('shows the flow name in the body when the referenced flow is resolvable', () => {
+      mockUseGetFlows.mockReturnValue({
+        data: {flows: [{id: 'flow-123', name: 'My Flow', flowType: 'AUTHENTICATION'}]},
+        isLoading: false,
+        error: null,
+      });
+      renderCall({flow: {ref: 'flow-123'}});
+      expect(screen.getByTestId('call-node-flow-ref')).toHaveTextContent('My Flow');
+    });
+
+    it('shows the "Select a flow to invoke" placeholder when no flow ref is set', () => {
+      renderCall({});
+      expect(screen.getByTestId('call-node-flow-ref')).toHaveTextContent(/select a flow/i);
+    });
+
+    it('shows the palette label in the header', () => {
+      renderCall({});
+      expect(screen.getAllByText('Call Flow').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Handles', () => {
+    it('renders the target handle on the left', () => {
+      renderCall({flow: {ref: 'f1'}});
+      const target = screen.getByTestId('handle-target-left');
+      expect(target).toHaveAttribute('data-position', 'left');
+    });
+
+    it('renders a right-positioned success source handle', () => {
+      renderCall({flow: {ref: 'f1'}});
+      const handles = screen.getAllByTestId(/^handle-source-/);
+      const right = handles.find((h) => h.getAttribute('data-position') === 'right');
+      expect(right).toBeTruthy();
+    });
+
+    it('renders the failure source handle on the bottom with id "failure"', () => {
+      renderCall({flow: {ref: 'f1'}});
+      const failure = screen.getByTestId('handle-source-failure');
+      expect(failure).toHaveAttribute('data-position', 'bottom');
+      expect(failure).toHaveAttribute('data-handle-id', 'failure');
+    });
+  });
+
+  describe('Configure button', () => {
+    it('opens the properties panel and sets the interacted resource on click', () => {
+      const {container} = renderCall({flow: {ref: 'flow-abc'}});
+      const configBtn = container.querySelectorAll('button')[0];
+      expect(configBtn).toBeTruthy();
+      fireEvent.click(configBtn);
+      expect(mockSetLastInteractedStepId).toHaveBeenCalledWith('call-node-id');
+      expect(mockSetIsOpenResourcePropertiesPanel).toHaveBeenCalledWith(true);
+      expect(mockSetLastInteractedResource).toHaveBeenCalled();
+    });
+  });
+
+  describe('Delete button', () => {
+    it('calls deleteElements with the node id', () => {
+      const {container} = renderCall({flow: {ref: 'flow-abc'}});
+      const deleteBtn = container.querySelectorAll('button')[1];
+      expect(deleteBtn).toBeTruthy();
+      fireEvent.click(deleteBtn);
+      expect(mockDeleteElements).toHaveBeenCalledWith({nodes: [{id: 'call-node-id'}]});
+    });
+
+    it('does not call deleteElements when nodeId is empty', () => {
+      mockUseNodeId.mockReturnValue('');
+      const {container} = renderCall({});
+      const deleteBtn = container.querySelectorAll('button')[1];
+      fireEvent.click(deleteBtn);
+      expect(mockDeleteElements).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Open referenced flow', () => {
+    it('is disabled when no flow is referenced', () => {
+      renderCall({});
+      expect(screen.getByTestId('call-open-referenced-flow')).toBeDisabled();
+    });
+
+    it('is disabled when the referenced flow id does not resolve to a known flow', () => {
+      mockUseGetFlows.mockReturnValue({data: {flows: []}, isLoading: false, error: null});
+      renderCall({flow: {ref: 'unknown-flow'}});
+      expect(screen.getByTestId('call-open-referenced-flow')).toBeDisabled();
+    });
+
+    it('navigates to the referenced AUTHENTICATION flow after confirmation', () => {
+      mockUseGetFlows.mockReturnValue({
+        data: {flows: [{id: 'flow-a', name: 'Flow A', flowType: 'AUTHENTICATION'}]},
+        isLoading: false,
+        error: null,
+      });
+      renderCall({flow: {ref: 'flow-a'}});
+      fireEvent.click(screen.getByTestId('call-open-referenced-flow'));
+      fireEvent.click(screen.getByRole('button', {name: /continue/i}));
+      expect(mockNavigate).toHaveBeenCalledWith('/flows/signin/flow-a');
+    });
+
+    it('navigates to the referenced REGISTRATION flow after confirmation', () => {
+      mockUseGetFlows.mockReturnValue({
+        data: {flows: [{id: 'flow-r', name: 'Reg', flowType: 'REGISTRATION'}]},
+        isLoading: false,
+        error: null,
+      });
+      renderCall({flow: {ref: 'flow-r'}});
+      fireEvent.click(screen.getByTestId('call-open-referenced-flow'));
+      fireEvent.click(screen.getByRole('button', {name: /continue/i}));
+      expect(mockNavigate).toHaveBeenCalledWith('/flows/registration/flow-r');
+    });
+
+    it('navigates to the referenced RECOVERY flow after confirmation', () => {
+      mockUseGetFlows.mockReturnValue({
+        data: {flows: [{id: 'flow-rec', name: 'Rec', flowType: 'RECOVERY'}]},
+        isLoading: false,
+        error: null,
+      });
+      renderCall({flow: {ref: 'flow-rec'}});
+      fireEvent.click(screen.getByTestId('call-open-referenced-flow'));
+      fireEvent.click(screen.getByRole('button', {name: /continue/i}));
+      expect(mockNavigate).toHaveBeenCalledWith('/flows/recovery/flow-rec');
+    });
+
+    it('does not navigate when the user cancels the confirmation dialog', () => {
+      mockUseGetFlows.mockReturnValue({
+        data: {flows: [{id: 'flow-a', name: 'Flow A', flowType: 'AUTHENTICATION'}]},
+        isLoading: false,
+        error: null,
+      });
+      renderCall({flow: {ref: 'flow-a'}});
+      fireEvent.click(screen.getByTestId('call-open-referenced-flow'));
+      fireEvent.click(screen.getByRole('button', {name: /cancel/i}));
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/apps/console/src/features/flows/constants/VisualFlowConstants.ts
+++ b/frontend/apps/console/src/features/flows/constants/VisualFlowConstants.ts
@@ -58,6 +58,7 @@ class VisualFlowConstants {
     StepTypes.View,
     StepTypes.Rule,
     StepTypes.Execution,
+    StepTypes.Call,
     TemplateTypes.Basic,
     TemplateTypes.BasicFederated,
     TemplateTypes.Blank,
@@ -81,7 +82,10 @@ class VisualFlowConstants {
     WidgetTypes.EUDIWallet,
     WidgetTypes.PasskeyAuthentication,
     WidgetTypes.Provisioning,
+    WidgetTypes.MagicLink,
     WidgetTypes.SelfSignUpLink,
+    WidgetTypes.SignInLink,
+    WidgetTypes.RecoveryLink,
     ElementTypes.Timer,
   ];
 
@@ -112,7 +116,10 @@ class VisualFlowConstants {
     WidgetTypes.GithubFederation,
     WidgetTypes.EUDIWallet,
     WidgetTypes.PasskeyAuthentication,
+    WidgetTypes.MagicLink,
     WidgetTypes.SelfSignUpLink,
+    WidgetTypes.SignInLink,
+    WidgetTypes.RecoveryLink,
     ElementTypes.Timer,
   ];
 

--- a/frontend/apps/console/src/features/flows/data/steps.json
+++ b/frontend/apps/console/src/features/flows/data/steps.json
@@ -265,5 +265,24 @@
       "image": "assets/images/icons/check-mark-inside-a-black-box.svg",
       "showOnResourcePanel": false
     }
+  },
+  {
+    "resourceType": "STEP",
+    "category": "WORKFLOW",
+    "type": "CALL",
+    "version": "0.1.0",
+    "deprecated": false,
+    "deletable": true,
+    "display": {
+      "label": "Call Flow",
+      "image": "assets/images/icons/play.svg",
+      "showOnResourcePanel": true,
+      "description": "Invoke another flow and resume when it completes."
+    },
+    "data": {
+      "flow": {
+        "ref": ""
+      }
+    }
   }
 ]

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
@@ -29,11 +29,13 @@ import useVisualFlowHandlers from '../useVisualFlowHandlers';
 // Mock @xyflow/react
 const mockGetNodes = vi.fn();
 const mockGetEdges = vi.fn();
+const mockUpdateNodeData = vi.fn();
 
 vi.mock('@xyflow/react', () => ({
   useReactFlow: () => ({
     getNodes: mockGetNodes,
     getEdges: mockGetEdges,
+    updateNodeData: mockUpdateNodeData,
   }),
   MarkerType: {
     ArrowClosed: 'arrowclosed',
@@ -214,6 +216,208 @@ describe('useVisualFlowHandlers', () => {
       });
 
       expect(onEdgeResolve).toHaveBeenCalledWith(connection, [{id: 'node-1'}, {id: 'node-2'}]);
+    });
+
+    describe('RichText action ref auto-population', () => {
+      const richTextComponentId = 'rt-1';
+      const nextSuffix = '_NEXT';
+
+      const buildRichTextNode = (actionRef: string | undefined = '') => ({
+        id: 'view-1',
+        data: {
+          components: [
+            {
+              id: richTextComponentId,
+              type: 'RICH_TEXT',
+              action: actionRef === undefined ? undefined : {ref: actionRef},
+            },
+          ],
+        },
+      });
+
+      it('should populate RichText action.ref when edge is drawn from its next handle', () => {
+        mockGetNodes.mockReturnValue([buildRichTextNode(''), {id: 'target-1', data: {}}]);
+
+        const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+          wrapper: createWrapper(),
+        });
+
+        const connection: Connection = {
+          source: 'view-1',
+          target: 'target-1',
+          sourceHandle: `${richTextComponentId}${nextSuffix}`,
+          targetHandle: null,
+        };
+
+        act(() => {
+          result.current.handleConnect(connection);
+        });
+
+        expect(mockUpdateNodeData).toHaveBeenCalledTimes(1);
+        const [nodeId, updater] = mockUpdateNodeData.mock.calls[0];
+        expect(nodeId).toBe('view-1');
+        // Invoke the updater with the current node to inspect the produced data
+        const updated = updater({data: buildRichTextNode('').data});
+        expect(updated.components[0]).toEqual({
+          id: richTextComponentId,
+          type: 'RICH_TEXT',
+          action: {ref: 'target-1'},
+        });
+      });
+
+      it('should update RichText action.ref nested inside a container component', () => {
+        const nested = {
+          id: 'view-1',
+          data: {
+            components: [
+              {
+                id: 'block-1',
+                type: 'BLOCK',
+                components: [
+                  {
+                    id: richTextComponentId,
+                    type: 'RICH_TEXT',
+                    action: {ref: ''},
+                  },
+                ],
+              },
+            ],
+          },
+        };
+        mockGetNodes.mockReturnValue([nested, {id: 'target-2'}]);
+
+        const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+          wrapper: createWrapper(),
+        });
+
+        act(() => {
+          result.current.handleConnect({
+            source: 'view-1',
+            target: 'target-2',
+            sourceHandle: `${richTextComponentId}${nextSuffix}`,
+            targetHandle: null,
+          });
+        });
+
+        expect(mockUpdateNodeData).toHaveBeenCalledTimes(1);
+        const [, updater] = mockUpdateNodeData.mock.calls[0];
+        const updated = updater({data: nested.data});
+        expect(updated.components[0].components[0].action).toEqual({ref: 'target-2'});
+      });
+
+      it('should not call updateNodeData when RichText already has the target ref', () => {
+        mockGetNodes.mockReturnValue([buildRichTextNode('target-1'), {id: 'target-1'}]);
+
+        const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+          wrapper: createWrapper(),
+        });
+
+        act(() => {
+          result.current.handleConnect({
+            source: 'view-1',
+            target: 'target-1',
+            sourceHandle: `${richTextComponentId}${nextSuffix}`,
+            targetHandle: null,
+          });
+        });
+
+        expect(mockUpdateNodeData).not.toHaveBeenCalled();
+      });
+
+      it('should not touch RichText when the component has no action defined', () => {
+        // action === undefined means the rich-text is display-only; the hook should skip it
+        mockGetNodes.mockReturnValue([
+          {
+            id: 'view-1',
+            data: {components: [{id: richTextComponentId, type: 'RICH_TEXT'}]},
+          },
+          {id: 'target-1'},
+        ]);
+
+        const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+          wrapper: createWrapper(),
+        });
+
+        act(() => {
+          result.current.handleConnect({
+            source: 'view-1',
+            target: 'target-1',
+            sourceHandle: `${richTextComponentId}${nextSuffix}`,
+            targetHandle: null,
+          });
+        });
+
+        expect(mockUpdateNodeData).not.toHaveBeenCalled();
+      });
+
+      it('should ignore connections whose sourceHandle does not end with _NEXT', () => {
+        mockGetNodes.mockReturnValue([buildRichTextNode(''), {id: 'target-1'}]);
+
+        const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+          wrapper: createWrapper(),
+        });
+
+        act(() => {
+          result.current.handleConnect({
+            source: 'view-1',
+            target: 'target-1',
+            sourceHandle: `${richTextComponentId}_OTHER`,
+            targetHandle: null,
+          });
+        });
+
+        expect(mockUpdateNodeData).not.toHaveBeenCalled();
+      });
+
+      it('should skip auto-population when source node has no components (non-step data)', () => {
+        mockGetNodes.mockReturnValue([{id: 'view-1', data: {}}, {id: 'target-1'}]);
+
+        const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+          wrapper: createWrapper(),
+        });
+
+        act(() => {
+          result.current.handleConnect({
+            source: 'view-1',
+            target: 'target-1',
+            sourceHandle: `${richTextComponentId}${nextSuffix}`,
+            targetHandle: null,
+          });
+        });
+
+        expect(mockUpdateNodeData).not.toHaveBeenCalled();
+      });
+
+      it('should leave non-matching components untouched when updating', () => {
+        const sourceNode = {
+          id: 'view-1',
+          data: {
+            components: [
+              {id: 'other', type: 'RICH_TEXT', action: {ref: 'existing'}},
+              {id: richTextComponentId, type: 'RICH_TEXT', action: {ref: ''}},
+            ],
+          },
+        };
+        mockGetNodes.mockReturnValue([sourceNode, {id: 'target-1'}]);
+
+        const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+          wrapper: createWrapper(),
+        });
+
+        act(() => {
+          result.current.handleConnect({
+            source: 'view-1',
+            target: 'target-1',
+            sourceHandle: `${richTextComponentId}${nextSuffix}`,
+            targetHandle: null,
+          });
+        });
+
+        const [, updater] = mockUpdateNodeData.mock.calls[0];
+        const updated = updater({data: sourceNode.data});
+        expect(updated.components[0].action).toEqual({ref: 'existing'});
+        expect(updated.components[1].action).toEqual({ref: 'target-1'});
+      });
     });
 
     it('should use current edgeStyle from context', () => {

--- a/frontend/apps/console/src/features/flows/hooks/useVisualFlowHandlers.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useVisualFlowHandlers.ts
@@ -33,6 +33,10 @@ import {
 import {useRef} from 'react';
 import useFlowConfig from './useFlowConfig';
 import useFlowPlugins from './useFlowPlugins';
+import VisualFlowConstants from '../constants/VisualFlowConstants';
+import type {Element} from '../models/elements';
+import {ElementTypes} from '../models/elements';
+import type {StepData} from '../models/steps';
 
 /**
  * Props interface for useVisualFlowHandlers hook
@@ -90,9 +94,66 @@ const useVisualFlowHandlers = (props: UseVisualFlowHandlersProps): UseVisualFlow
     handleConnect: (connection: Connection): void => {
       const {props: currentProps, reactFlowInstance: rf, edgeStyle: currentEdgeStyle} = depsRef.current;
       const {onEdgeResolve, setEdges} = currentProps;
-      const {getNodes} = rf;
+      const {getNodes, updateNodeData} = rf;
 
       const currentNodes = getNodes();
+
+      // If the edge originates from a rich-text action handle, copy the target node's id
+      // into the rich-text component's `action.ref`. Author-facing UX: they draw the edge
+      // and the "Connected step" field auto-populates.
+      const nextSuffix = VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX;
+      if (
+        connection.sourceHandle &&
+        connection.sourceHandle.endsWith(nextSuffix) &&
+        connection.source &&
+        connection.target
+      ) {
+        const componentId = connection.sourceHandle.slice(0, -nextSuffix.length);
+        const sourceNode = currentNodes.find((n) => n.id === connection.source);
+        const components = (sourceNode?.data as StepData | undefined)?.components;
+        if (components) {
+          const targetId: string = connection.target;
+          let changed = false;
+
+          const updateRichTextRef = (elements: Element[]): Element[] => {
+            let localChanged = false;
+            const next = elements.map((el) => {
+              if (el.id === componentId && el.type === ElementTypes.RichText) {
+                const withAction = el as Element & {action?: {ref?: string}};
+                if (withAction.action !== undefined && withAction.action.ref !== targetId) {
+                  localChanged = true;
+                  return {...el, action: {...withAction.action, ref: targetId}} as Element;
+                }
+              }
+
+              if (el.components) {
+                const nestedNext = updateRichTextRef(el.components);
+                if (nestedNext !== el.components) {
+                  localChanged = true;
+                  return {...el, components: nestedNext};
+                }
+              }
+
+              return el;
+            });
+
+            if (localChanged) {
+              changed = true;
+              return next;
+            }
+
+            return elements;
+          };
+
+          const nextComponents = updateRichTextRef(components);
+          if (changed) {
+            updateNodeData(connection.source, (node) => ({
+              ...(node.data as StepData),
+              components: nextComponents,
+            }));
+          }
+        }
+      }
 
       if (onEdgeResolve) {
         const newEdge: Edge = onEdgeResolve(connection, currentNodes);

--- a/frontend/apps/console/src/features/flows/models/__tests__/steps.test.ts
+++ b/frontend/apps/console/src/features/flows/models/__tests__/steps.test.ts
@@ -66,8 +66,12 @@ describe('steps models', () => {
       expect(StepTypes.End).toBe('END');
     });
 
-    it('should have exactly 4 step types', () => {
-      expect(Object.keys(StepTypes)).toHaveLength(4);
+    it('should have Call type', () => {
+      expect(StepTypes.Call).toBe('CALL');
+    });
+
+    it('should have exactly 5 step types', () => {
+      expect(Object.keys(StepTypes)).toHaveLength(5);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/models/flows.ts
+++ b/frontend/apps/console/src/features/flows/models/flows.ts
@@ -102,6 +102,12 @@ export const FlowNodeType = {
    * Terminal node indicating the end of the flow
    */
   END: 'END',
+
+  /**
+   * Cross-flow invocation node that transfers execution to another flow and resumes
+   * at the configured target when the callee completes.
+   */
+  CALL: 'CALL',
 } as const;
 
 /**

--- a/frontend/apps/console/src/features/flows/models/responses.ts
+++ b/frontend/apps/console/src/features/flows/models/responses.ts
@@ -259,6 +259,12 @@ export interface FlowNode {
     value: string;
     onSkip?: string;
   };
+  /**
+   * Cross-flow reference for CALL nodes. Carries the ID of the flow to invoke.
+   */
+  flow?: {
+    ref: string;
+  };
 }
 
 /**

--- a/frontend/apps/console/src/features/flows/models/steps.ts
+++ b/frontend/apps/console/src/features/flows/models/steps.ts
@@ -84,6 +84,7 @@ export const StepTypes = {
   Rule: 'RULE',
   Execution: 'TASK_EXECUTION',
   End: 'END',
+  Call: 'CALL',
 } as const;
 
 export const StaticStepTypes = {

--- a/frontend/apps/console/src/features/flows/models/widget.ts
+++ b/frontend/apps/console/src/features/flows/models/widget.ts
@@ -47,7 +47,10 @@ export const WidgetTypes = {
   EUDIWallet: 'EUDI_WALLET',
   PasskeyAuthentication: 'PASSKEY_AUTHENTICATION',
   Provisioning: 'PROVISIONING',
+  MagicLink: 'MAGIC_LINK',
   SelfSignUpLink: 'SELF_SIGN_UP_LINK',
+  SignInLink: 'SIGN_IN_LINK',
+  RecoveryLink: 'RECOVERY_LINK',
 } as const;
 
 export type WidgetTypes = (typeof WidgetTypes)[keyof typeof WidgetTypes];

--- a/frontend/apps/console/src/features/flows/utils/__tests__/flowToCanvasTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/flowToCanvasTransformer.test.ts
@@ -583,5 +583,101 @@ describe('flowToCanvasTransformer', () => {
         expect(result.nodes[0].deletable).toBe(true);
       });
     });
+
+    describe('CALL node transformation', () => {
+      it('should transform CALL node with flow ref, resourceType and category', () => {
+        const flowData = createBaseFlowData([
+          {
+            id: 'call-1',
+            type: 'CALL',
+            flow: {ref: 'referenced-flow'},
+            onSuccess: 'next-node',
+            onFailure: 'failure-node',
+            layout: {position: {x: 300, y: 400}, size: {width: 260, height: 120}},
+          },
+        ]);
+
+        const result = transformFlowToCanvas(flowData);
+
+        expect(result.nodes).toHaveLength(1);
+        expect(result.nodes[0]).toMatchObject({
+          id: 'call-1',
+          type: StepTypes.Call,
+          resourceType: 'STEP',
+          category: 'WORKFLOW',
+        });
+        expect(result.nodes[0].data).toMatchObject({
+          flow: {ref: 'referenced-flow'},
+          action: {
+            type: 'CALL',
+            flow: {ref: 'referenced-flow'},
+            onSuccess: 'next-node',
+            onFailure: 'failure-node',
+          },
+        });
+      });
+
+      it('should default flow to {ref: ""} when the API node has no flow field', () => {
+        const flowData = createBaseFlowData([
+          {
+            id: 'call-1',
+            type: 'CALL',
+            layout: {position: {x: 0, y: 0}, size: {width: 260, height: 120}},
+          },
+        ]);
+
+        const result = transformFlowToCanvas(flowData);
+
+        expect(result.nodes[0].data).toMatchObject({
+          flow: {ref: ''},
+          action: {type: 'CALL', flow: {ref: ''}},
+        });
+      });
+
+      it('should generate the onSuccess edge from a CALL node using the _NEXT source handle', () => {
+        const flowData = createBaseFlowData([
+          {id: 'call-1', type: 'CALL', flow: {ref: 'ref'}, onSuccess: 'next-1'},
+          {id: 'next-1', type: 'END'},
+        ]);
+
+        const result = transformFlowToCanvas(flowData);
+
+        const successEdge = result.edges.find((e) => e.id === 'call-1-to-next-1');
+        expect(successEdge).toBeDefined();
+        expect(successEdge).toMatchObject({
+          source: 'call-1',
+          target: 'next-1',
+          sourceHandle: `call-1${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`,
+          type: 'smoothstep',
+        });
+      });
+
+      it('should generate the onFailure edge from a CALL node using the "failure" source handle', () => {
+        const flowData = createBaseFlowData([
+          {id: 'call-1', type: 'CALL', flow: {ref: 'ref'}, onFailure: 'fail-1'},
+          {id: 'fail-1', type: 'END'},
+        ]);
+
+        const result = transformFlowToCanvas(flowData);
+
+        const failureEdge = result.edges.find((e) => e.id === 'call-1-failure-to-fail-1');
+        expect(failureEdge).toBeDefined();
+        expect(failureEdge).toMatchObject({
+          source: 'call-1',
+          target: 'fail-1',
+          sourceHandle: 'failure',
+        });
+      });
+
+      it('should not emit edges when CALL onSuccess/onFailure targets are missing from the node list', () => {
+        const flowData = createBaseFlowData([
+          {id: 'call-1', type: 'CALL', flow: {ref: 'ref'}, onSuccess: 'missing-1', onFailure: 'missing-2'},
+        ]);
+
+        const result = transformFlowToCanvas(flowData);
+
+        expect(result.edges).toHaveLength(0);
+      });
+    });
   });
 });

--- a/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
@@ -1824,4 +1824,104 @@ describe('reactFlowTransformer', () => {
       expect(result.nodes[0].prompts?.[0].action?.executor).toEqual({name: 'TestExecutor'});
     });
   });
+
+  describe('CALL node transformation', () => {
+    it('should map CALL step type to CALL flow node type', () => {
+      const canvasData: ReactFlowCanvasData = {
+        nodes: [createNode('call-1', StepTypes.Call, {x: 10, y: 20})],
+        edges: [],
+      };
+
+      const result = transformReactFlow(canvasData);
+
+      expect(result.nodes[0].type).toBe('CALL');
+    });
+
+    it('should read flow.ref from data.flow', () => {
+      const canvasData: ReactFlowCanvasData = {
+        nodes: [
+          createNode('call-1', StepTypes.Call, {x: 0, y: 0}, {
+            flow: {ref: 'referenced-flow-id'},
+          } as unknown as StepData),
+        ],
+        edges: [],
+      };
+
+      const result = transformReactFlow(canvasData);
+
+      expect(result.nodes[0].flow).toEqual({ref: 'referenced-flow-id'});
+    });
+
+    it('should fall back to data.action.flow.ref when data.flow is absent', () => {
+      const canvasData: ReactFlowCanvasData = {
+        nodes: [
+          createNode('call-1', StepTypes.Call, {x: 0, y: 0}, {
+            action: {type: 'CALL', flow: {ref: 'flow-from-action'}},
+          } as unknown as StepData),
+        ],
+        edges: [],
+      };
+
+      const result = transformReactFlow(canvasData);
+
+      expect(result.nodes[0].flow).toEqual({ref: 'flow-from-action'});
+    });
+
+    it('should omit flow when neither data.flow nor data.action.flow provides a ref', () => {
+      const canvasData: ReactFlowCanvasData = {
+        nodes: [createNode('call-1', StepTypes.Call)],
+        edges: [],
+      };
+
+      const result = transformReactFlow(canvasData);
+
+      expect(result.nodes[0].flow).toBeUndefined();
+    });
+
+    it('should derive onSuccess from the next-handle edge', () => {
+      const canvasData: ReactFlowCanvasData = {
+        nodes: [createNode('call-1', StepTypes.Call), createNode('success-1', StepTypes.End)],
+        edges: [createEdge('e-success', 'call-1', 'success-1', 'call-1_NEXT')],
+      };
+
+      const result = transformReactFlow(canvasData);
+
+      const callNode = result.nodes.find((n) => n.id === 'call-1')!;
+      expect(callNode.onSuccess).toBe('success-1');
+      expect(callNode.onFailure).toBeUndefined();
+    });
+
+    it('should derive onFailure from the failure-handle edge', () => {
+      const canvasData: ReactFlowCanvasData = {
+        nodes: [createNode('call-1', StepTypes.Call), createNode('failure-1', StepTypes.End)],
+        edges: [createEdge('e-failure', 'call-1', 'failure-1', 'failure')],
+      };
+
+      const result = transformReactFlow(canvasData);
+
+      const callNode = result.nodes.find((n) => n.id === 'call-1')!;
+      expect(callNode.onFailure).toBe('failure-1');
+    });
+
+    it('should populate both onSuccess and onFailure when both edges exist', () => {
+      const canvasData: ReactFlowCanvasData = {
+        nodes: [
+          createNode('call-1', StepTypes.Call, {x: 0, y: 0}, {flow: {ref: 'ref-1'}} as unknown as StepData),
+          createNode('success-1', StepTypes.End),
+          createNode('failure-1', StepTypes.End),
+        ],
+        edges: [
+          createEdge('e-success', 'call-1', 'success-1', 'call-1_NEXT'),
+          createEdge('e-failure', 'call-1', 'failure-1', 'failure'),
+        ],
+      };
+
+      const result = transformReactFlow(canvasData);
+
+      const callNode = result.nodes.find((n) => n.id === 'call-1')!;
+      expect(callNode.flow).toEqual({ref: 'ref-1'});
+      expect(callNode.onSuccess).toBe('success-1');
+      expect(callNode.onFailure).toBe('failure-1');
+    });
+  });
 });

--- a/frontend/apps/console/src/features/flows/utils/flowToCanvasTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/flowToCanvasTransformer.ts
@@ -69,6 +69,7 @@ const NODE_TO_STEP_TYPE_MAP: Record<string, string> = {
   TASK_EXECUTION: StepTypes.Execution,
   DECISION: StepTypes.Rule,
   END: StepTypes.End,
+  CALL: StepTypes.Call,
   START: StaticStepTypes.Start,
 };
 
@@ -131,6 +132,33 @@ function restoreButtonAction(
   }
 
   return component;
+}
+
+/**
+ * Walks a component tree looking for a RICH_TEXT whose author-defined `action.ref` matches
+ * the given ref. Used at edge-generation time so the resulting edge attaches to the
+ * component-scoped source handle (`${component.id}${NEXT_HANDLE_SUFFIX}`) rather than an
+ * `action.ref`-scoped one that doesn't exist for rich text.
+ */
+function findRichTextComponentByActionRef(components: Element[] | undefined, actionRef: string): Element | undefined {
+  if (!components || components.length === 0) {
+    return undefined;
+  }
+
+  for (const component of components) {
+    const richAction = (component as Element & {action?: {ref?: string}}).action;
+    if (component.type === ElementTypes.RichText && richAction?.ref === actionRef) {
+      return component;
+    }
+    if (component.components) {
+      const found = findRichTextComponentByActionRef(component.components, actionRef);
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 /**
@@ -257,6 +285,21 @@ function transformNodeToCanvas(apiNode: FlowNode): CanvasNode {
     canvasNode.category = 'WORKFLOW';
   }
 
+  // Handle CALL nodes (cross-flow invocation)
+  if (stepType === StepTypes.Call) {
+    canvasNode.data = {
+      flow: apiNode.flow ?? {ref: ''},
+      action: {
+        type: 'CALL',
+        flow: apiNode.flow ?? {ref: ''},
+        onSuccess: apiNode.onSuccess,
+        onFailure: apiNode.onFailure,
+      },
+    };
+    canvasNode.resourceType = 'STEP';
+    canvasNode.category = 'WORKFLOW';
+  }
+
   // Handle END nodes
   if (stepType === StepTypes.End) {
     if (apiNode.meta?.components) {
@@ -318,10 +361,18 @@ function generateEdgesFromNodes(apiNodes: FlowNode[]): Edge[] {
       if (nodeActions) {
         nodeActions.forEach((action) => {
           if (action.nextNode && nodeIds.has(action.nextNode)) {
+            // For RICH_TEXT the source handle is scoped by component.id (matches the
+            // widget-drop convention). For ACTION buttons, action.ref already equals
+            // component.id so the same lookup naturally works.
+            const richTextSource = findRichTextComponentByActionRef(
+              node.meta?.components as Element[] | undefined,
+              action.ref,
+            );
+            const handleBase = richTextSource ? richTextSource.id : action.ref;
             edges.push({
               id: action.ref,
               source: node.id,
-              sourceHandle: `${action.ref}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`,
+              sourceHandle: `${handleBase}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`,
               target: action.nextNode,
               type: 'smoothstep',
               animated: false,
@@ -407,6 +458,37 @@ function generateEdgesFromNodes(apiNodes: FlowNode[]): Edge[] {
       });
 
       // Handle onFailure for decision nodes
+      if (node.onFailure && nodeIds.has(node.onFailure)) {
+        edges.push({
+          id: `${node.id}-failure-to-${node.onFailure}`,
+          source: node.id,
+          sourceHandle: 'failure',
+          target: node.onFailure,
+          type: 'smoothstep',
+          animated: false,
+          markerEnd: {
+            type: MarkerType.Arrow,
+          },
+        });
+      }
+    }
+
+    // Handle CALL node connections
+    if (stepType === StepTypes.Call) {
+      if (node.onSuccess && nodeIds.has(node.onSuccess)) {
+        edges.push({
+          id: `${node.id}-to-${node.onSuccess}`,
+          source: node.id,
+          sourceHandle: `${node.id}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`,
+          target: node.onSuccess,
+          type: 'smoothstep',
+          animated: false,
+          markerEnd: {
+            type: MarkerType.Arrow,
+          },
+        });
+      }
+
       if (node.onFailure && nodeIds.has(node.onFailure)) {
         edges.push({
           id: `${node.id}-failure-to-${node.onFailure}`,

--- a/frontend/apps/console/src/features/flows/utils/generateFlowGraph.ts
+++ b/frontend/apps/console/src/features/flows/utils/generateFlowGraph.ts
@@ -75,14 +75,21 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const metaComponents: any[] = [];
 
-  // Self Sign Up Link component — shared across auth blocks
+  // Self Sign Up Link component — shared across auth blocks. The anchor is sentinel-marked
+  // with `data-action-ref="action_signup"`, and the component carries a matching `action`
+  // wiring so the SDK's RICH_TEXT renderer dispatches the action instead of navigating.
   const selfSignUpLink = {
     category: 'DISPLAY',
     type: 'RICH_TEXT',
     id: 'self_sign_up_link',
+    action: {
+      ref: 'action_signup',
+      eventType: 'SUBMIT',
+    },
     label:
       '<p class="rich-text-paragraph"><span class="rich-text-pre-wrap">Don\'t have an account? </span>' +
-      '<a href="{{meta(application.sign_up_url)}}" target="_blank" rel="noopener noreferrer" class="rich-text-link">' +
+      '<a href="{{meta(application.sign_up_url)}}" data-action-ref="action_signup" target="_blank" ' +
+      'rel="noopener noreferrer" class="rich-text-link">' +
       '<span class="rich-text-pre-wrap">Sign up</span></a></p>',
   };
 

--- a/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
@@ -22,7 +22,7 @@ import VisualFlowConstants from '../constants/VisualFlowConstants';
 import {ActionTypes} from '../models/actions';
 import type {Element} from '../models/elements';
 import {ElementCategories, ElementTypes, ActionEventTypes, ButtonTypes} from '../models/elements';
-import type {StepData} from '../models/steps';
+import type {StepAction, StepData} from '../models/steps';
 import {StepTypes, StaticStepTypes} from '../models/steps';
 
 /**
@@ -73,6 +73,9 @@ interface FlowNode {
   onFailure?: string;
   onIncomplete?: string;
   next?: string;
+  flow?: {
+    ref: string;
+  };
 }
 
 /**
@@ -144,6 +147,7 @@ const STEP_TO_NODE_TYPE_MAP: Record<string, string> = {
   [StepTypes.Execution]: 'TASK_EXECUTION',
   [StepTypes.Rule]: 'DECISION',
   [StepTypes.End]: 'END',
+  [StepTypes.Call]: 'CALL',
   [StaticStepTypes.Start]: 'START',
   [StaticStepTypes.UserOnboard]: 'END',
 };
@@ -203,7 +207,9 @@ function shouldPromoteToSubmit(components: Element[]): boolean {
  */
 function cleanComponents(components: Element[], promoteSubmit = false): Record<string, unknown>[] {
   return components.map((component) => {
-    // Extract and remove internal properties (including action which is defined in node.actions)
+    // Extract and remove internal properties (including action which is defined in node.actions
+    // for ACTION/RESEND components). For RICH_TEXT, `action` is the SDK-facing wiring
+    // (`{ref, eventType}`) and MUST be preserved end-to-end.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- config is excluded from output
     const {variants, display, config, action, ...rest} = component as Element & {
       variants?: unknown;
@@ -216,6 +222,17 @@ function cleanComponents(components: Element[], promoteSubmit = false): Record<s
     const cleanedComponent: Record<string, unknown> = {
       ...rest,
     };
+
+    // Preserve the SDK-facing `action` wiring on RICH_TEXT components so the runtime
+    // renderer can dispatch the anchor click as a flow action. Only `ref` survives —
+    // `onSuccess` is a canvas-only hint used by the widget-drop edge generator, and the
+    // nextNode wiring lives in `prompts.action.nextNode` from `extractActionFromComponent`.
+    if (component.type === ElementTypes.RichText && action !== undefined) {
+      const richTextAction = action as {ref?: string};
+      if (richTextAction.ref !== undefined) {
+        cleanedComponent.action = {ref: richTextAction.ref};
+      }
+    }
 
     // For input field components, ensure ref property is set
     // ref is the attribute selected from the dropdown (e.g., 'username', 'email')
@@ -360,6 +377,27 @@ function extractPrompts(components: Element[], nodeId: string, edges: Edge[]): F
 
       return action.nextNode ? action : undefined;
     }
+
+    // RICH_TEXT components with a wired action expose a source handle on the component
+    // itself (id = `${component.id}${NEXT_HANDLE_SUFFIX}`), matching the button-handle
+    // convention. An edge drawn from that handle to a target step becomes a prompt-action
+    // `{ref: component.action.ref, nextNode: <target>}`. The `ref` value is author-defined
+    // (matches the anchor's `data-action-ref` in the sanitized HTML for SDK-side click
+    // dispatch); the handle id is component-scoped so the widget-drop edge generator can
+    // wire it without knowing the ref.
+    if (component.type === ElementTypes.RichText) {
+      const richTextAction = (component as Element & {action?: {ref?: string}}).action;
+      if (!richTextAction) {
+        return undefined;
+      }
+      const expectedHandle = `${component.id}${NEXT_HANDLE_SUFFIX}`;
+      const connectedEdge = edges.find((edge) => edge.source === nodeId && edge.sourceHandle === expectedHandle);
+      if (!connectedEdge) {
+        return undefined;
+      }
+      return {ref: richTextAction.ref ?? component.id, nextNode: connectedEdge.target};
+    }
+
     return undefined;
   }
 
@@ -556,6 +594,26 @@ function transformNode(canvasNode: Node<StepData>, edges: Edge[]): FlowNode {
     const nextNode = findNextNode(canvasNode, edges);
     if (nextNode) {
       flowNode.onSuccess = nextNode;
+    }
+  }
+
+  // Handle CALL nodes (cross-flow invocation)
+  if (canvasNode.type === StepTypes.Call) {
+    const callData = stepData as (StepData & {flow?: {ref?: string}}) | undefined;
+    const actionFlow = (callData?.action as (StepAction & {flow?: {ref?: string}}) | undefined)?.flow;
+    const flowRef: string | undefined = callData?.flow?.ref ?? actionFlow?.ref;
+    if (flowRef) {
+      flowNode.flow = {ref: flowRef};
+    }
+
+    const successNode = findNextNode(canvasNode, edges);
+    if (successNode) {
+      flowNode.onSuccess = successNode;
+    }
+
+    const failureEdge = edges.find((edge) => edge.source === canvasNode.id && edge.sourceHandle === 'failure');
+    if (failureEdge) {
+      flowNode.onFailure = failureEdge.target;
     }
   }
 

--- a/frontend/apps/console/src/features/flows/validation/validation-rules.ts
+++ b/frontend/apps/console/src/features/flows/validation/validation-rules.ts
@@ -22,7 +22,7 @@ import {ActionEventTypes, BlockTypes, ElementCategories, ElementTypes} from '../
 import type {Element as FlowElement} from '../models/elements';
 import Notification, {NotificationType} from '../models/notification';
 import type {Resource} from '../models/resources';
-import {ExecutionTypes} from '../models/steps';
+import {ExecutionTypes, StepTypes} from '../models/steps';
 import type {StepData} from '../models/steps';
 
 /**
@@ -189,6 +189,17 @@ export const VALIDATION_RULES: ValidationRuleDefinition[] = [
     match: (r) => (r as {data?: StepData}).data?.action?.executor?.name === ExecutionTypes.SMSExecutor,
     fields: [{name: 'data.properties.senderId', errorMessageKey: 'flows:core.validation.fields.input.senderId'}],
     generalMessageKey: 'flows:core.validation.fields.executor.general',
+  },
+
+  // ---------------------------------------------------------------------------
+  // Node Validation Rules
+  // ---------------------------------------------------------------------------
+
+  // CALL: referenced flow must be set
+  {
+    match: (r) => (r as {type?: string}).type === StepTypes.Call,
+    fields: [{name: 'data.flow.ref', errorMessageKey: 'flows:core.validation.fields.call.flowRef'}],
+    generalMessageKey: 'flows:core.validation.fields.call.general',
   },
 
   // ---------------------------------------------------------------------------

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/ResourceProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/ResourceProperties.tsx
@@ -20,6 +20,7 @@ import {FormControl, FormLabel, MenuItem, Select} from '@wso2/oxygen-ui';
 import {memo, useCallback, useMemo, type ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
 import ButtonExtendedProperties from './extended-properties/ButtonExtendedProperties';
+import CallProperties from './extended-properties/CallProperties';
 import ExecutionExtendedProperties from './extended-properties/ExecutionExtendedProperties';
 import FieldExtendedProperties from './extended-properties/FieldExtendedProperties';
 import RulesProperties from './nodes/RulesProperties';
@@ -146,6 +147,14 @@ function ResourceProperties({
 
       return null;
     case StepCategories.Workflow:
+      if (resource.type === StepTypes.Call) {
+        return (
+          <>
+            {renderElementId()}
+            <CallProperties resource={resource} onChange={handleChange} />
+          </>
+        );
+      }
       return (
         <>
           {renderElementId()}

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
@@ -76,6 +76,14 @@ vi.mock('../extended-properties/ButtonExtendedProperties', () => ({
   ),
 }));
 
+vi.mock('../extended-properties/CallProperties', () => ({
+  default: ({resource}: {resource: Resource}) => (
+    <div data-testid="call-properties" data-resource-id={resource.id}>
+      Call Properties
+    </div>
+  ),
+}));
+
 vi.mock('../extended-properties/ExecutionExtendedProperties', () => ({
   default: ({resource}: {resource: Resource}) => (
     <div data-testid="execution-extended-properties" data-resource-id={resource.id}>
@@ -319,6 +327,48 @@ describe('ResourceProperties', () => {
       );
 
       expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('Workflow Category - Call Type', () => {
+    it('should render CallProperties for Call type', () => {
+      const resource = createMockResource({
+        id: 'call-1',
+        category: StepCategories.Workflow,
+        type: StepTypes.Call,
+      } as Partial<Resource>);
+
+      render(
+        <ResourceProperties
+          resource={resource}
+          properties={{}}
+          onChange={mockOnChange}
+          onVariantChange={mockOnVariantChange}
+        />,
+      );
+
+      expect(screen.getByTestId('call-properties')).toBeInTheDocument();
+      expect(screen.getByTestId('call-properties')).toHaveAttribute('data-resource-id', 'call-1');
+      expect(screen.queryByTestId('execution-extended-properties')).not.toBeInTheDocument();
+    });
+
+    it('should render element ID for Call type', () => {
+      const resource = createMockResource({
+        id: 'call-42',
+        category: StepCategories.Workflow,
+        type: StepTypes.Call,
+      } as Partial<Resource>);
+
+      render(
+        <ResourceProperties
+          resource={resource}
+          properties={{}}
+          onChange={mockOnChange}
+          onVariantChange={mockOnVariantChange}
+        />,
+      );
+
+      expect(screen.getByTestId('resource-property-factory-id')).toHaveAttribute('data-property-value', 'call-42');
     });
   });
 

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/CallProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/CallProperties.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {FormControl, FormHelperText, FormLabel, MenuItem, Select, Stack, Typography} from '@wso2/oxygen-ui';
+import {useMemo, type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
+import {useParams} from 'react-router';
+import useGetFlows from '@/features/flows/api/useGetFlows';
+import type {CommonResourcePropertiesPropsInterface} from '@/features/flows/components/resource-property-panel/ResourceProperties';
+import useValidationStatus from '@/features/flows/hooks/useValidationStatus';
+import type {BasicFlowDefinition} from '@/features/flows/models/responses';
+import type {StepData} from '@/features/flows/models/steps';
+
+export type CallPropertiesPropsInterface = CommonResourcePropertiesPropsInterface;
+
+function CallProperties({resource, onChange}: CallPropertiesPropsInterface): ReactElement {
+  const {t} = useTranslation();
+  const {flowId} = useParams<{flowId: string}>();
+  const {data, isLoading, error} = useGetFlows({limit: 100});
+  const {selectedNotification} = useValidationStatus();
+
+  const currentRef = useMemo<string>(() => {
+    const stepData = resource?.data as (StepData & {flow?: {ref?: string}}) | undefined;
+    return stepData?.flow?.ref ?? '';
+  }, [resource]);
+
+  // Widget-seeded UI hint: when a call step is inserted via a composite widget
+  // (e.g. Sign In Link), the widget pins a preferred flow type so the dropdown
+  // only lists flows of that type. Purely presentational — the backend still
+  // accepts any flow ref, so re-dropping the widget or picking again from a
+  // generic Call step lifts the filter.
+  const filterFlowType: string | undefined = useMemo<string | undefined>(() => {
+    const stepData = resource?.data as (StepData & {flow?: {filterFlowType?: string}}) | undefined;
+    return stepData?.flow?.filterFlowType;
+  }, [resource]);
+
+  const flows: BasicFlowDefinition[] = useMemo<BasicFlowDefinition[]>(() => {
+    const list = data?.flows ?? [];
+    return list.filter(
+      (f: BasicFlowDefinition) => f.id !== flowId && (!filterFlowType || f.flowType === filterFlowType),
+    );
+  }, [data, flowId, filterFlowType]);
+
+  const isRefKnown: boolean = useMemo<boolean>(
+    () => Boolean(currentRef) && flows.some((f: BasicFlowDefinition) => f.id === currentRef),
+    [currentRef, flows],
+  );
+
+  const fieldNotificationKey = `${resource?.id}_data.flow.ref`;
+  const validatorMessage: string = selectedNotification?.hasResourceFieldNotification(fieldNotificationKey)
+    ? selectedNotification.getResourceFieldNotification(fieldNotificationKey)
+    : '';
+
+  const staleRefMessage: string =
+    !validatorMessage && currentRef && !isLoading && !isRefKnown
+      ? t('flows:core.call.properties.flow.error.unknown', 'The referenced flow no longer exists. Pick a valid flow.')
+      : '';
+
+  const errorMessage: string = validatorMessage || staleRefMessage;
+
+  const handleChange = (selected: string): void => {
+    onChange('data.flow', filterFlowType ? {ref: selected, filterFlowType} : {ref: selected}, resource);
+  };
+
+  if (error) {
+    return (
+      <Typography variant="body2" color="error" data-testid="call-properties-error">
+        {t('flows:core.call.properties.loadError', 'Failed to load available flows')}
+      </Typography>
+    );
+  }
+
+  return (
+    <Stack gap={2} data-testid="call-properties">
+      <Typography variant="body2" color="text.secondary">
+        {t('flows:core.call.properties.description', 'Pick the flow to invoke when this node executes.')}
+      </Typography>
+      <FormControl fullWidth size="small" error={Boolean(errorMessage)}>
+        <FormLabel htmlFor="call-flow-ref-select">
+          {t('flows:core.call.properties.flow.label', 'Referenced flow')}
+        </FormLabel>
+        <Select
+          id="call-flow-ref-select"
+          data-testid="call-flow-ref-select"
+          value={isRefKnown ? currentRef : ''}
+          disabled={isLoading || flows.length === 0}
+          onChange={(e) => handleChange(String(e.target.value))}
+          displayEmpty
+          fullWidth
+        >
+          <MenuItem value="" disabled>
+            {isLoading
+              ? t('flows:core.call.properties.flow.loading', 'Loading flows…')
+              : t('flows:core.call.properties.flow.placeholder', 'Select a flow')}
+          </MenuItem>
+          {flows.map((f: BasicFlowDefinition) => (
+            <MenuItem key={f.id} value={f.id}>
+              {f.name} ({f.flowType})
+            </MenuItem>
+          ))}
+        </Select>
+        {errorMessage && <FormHelperText data-testid="call-flow-ref-error">{errorMessage}</FormHelperText>}
+      </FormControl>
+    </Stack>
+  );
+}
+
+export default CallProperties;

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/CallProperties.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/CallProperties.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import CallProperties from '../CallProperties';
+import type {Resource} from '@/features/flows/models/resources';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+vi.mock('react-router', () => ({
+  useParams: () => ({flowId: 'current-flow-id'}),
+}));
+
+const mockUseGetFlows = vi.fn<() => unknown>();
+vi.mock('@/features/flows/api/useGetFlows', () => ({
+  default: (): unknown => mockUseGetFlows(),
+}));
+
+vi.mock('@/features/flows/hooks/useValidationStatus', () => ({
+  default: () => ({selectedNotification: null}),
+}));
+
+const makeResource = (overrides: Partial<Resource> = {}): Resource =>
+  ({
+    id: 'call-step-1',
+    type: 'CALL',
+    category: 'WORKFLOW',
+    resourceType: 'STEP',
+    data: {flow: {ref: ''}},
+    ...overrides,
+  }) as Resource;
+
+describe('CallProperties', () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the description and the flow dropdown label', () => {
+    mockUseGetFlows.mockReturnValue({data: {flows: []}, isLoading: false, error: null});
+    render(<CallProperties resource={makeResource()} onChange={onChange} />);
+    expect(screen.getByText('Pick the flow to invoke when this node executes.')).toBeInTheDocument();
+    expect(screen.getByText('Referenced flow')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the flow list fails to load', () => {
+    mockUseGetFlows.mockReturnValue({data: undefined, isLoading: false, error: new Error('boom')});
+    render(<CallProperties resource={makeResource()} onChange={onChange} />);
+    expect(screen.getByTestId('call-properties-error')).toBeInTheDocument();
+  });
+
+  it('disables the dropdown while flows are loading', () => {
+    mockUseGetFlows.mockReturnValue({data: undefined, isLoading: true, error: null});
+    render(<CallProperties resource={makeResource()} onChange={onChange} />);
+    const select = screen.getByTestId('call-flow-ref-select');
+    const combobox = select.querySelector('[role="combobox"]');
+    expect(combobox).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('lists flows from the API and excludes the flow currently being edited', () => {
+    mockUseGetFlows.mockReturnValue({
+      data: {
+        flows: [
+          {id: 'flow-a', name: 'Flow A', flowType: 'AUTHENTICATION'},
+          {id: 'flow-b', name: 'Flow B', flowType: 'REGISTRATION'},
+          {id: 'current-flow-id', name: 'Self', flowType: 'AUTHENTICATION'},
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    render(<CallProperties resource={makeResource()} onChange={onChange} />);
+    fireEvent.mouseDown(screen.getByTestId('call-flow-ref-select').querySelector('[role="combobox"]')!);
+    expect(screen.getByText('Flow A (AUTHENTICATION)')).toBeInTheDocument();
+    expect(screen.getByText('Flow B (REGISTRATION)')).toBeInTheDocument();
+    expect(screen.queryByText('Self (AUTHENTICATION)')).not.toBeInTheDocument();
+  });
+
+  it('writes the chosen flow id back to data.flow', () => {
+    mockUseGetFlows.mockReturnValue({
+      data: {flows: [{id: 'flow-a', name: 'Flow A', flowType: 'AUTHENTICATION'}]},
+      isLoading: false,
+      error: null,
+    });
+    const resource = makeResource();
+    render(<CallProperties resource={resource} onChange={onChange} />);
+    fireEvent.mouseDown(screen.getByTestId('call-flow-ref-select').querySelector('[role="combobox"]')!);
+    fireEvent.click(screen.getByText('Flow A (AUTHENTICATION)'));
+    expect(onChange).toHaveBeenCalledWith('data.flow', {ref: 'flow-a'}, resource);
+  });
+});

--- a/frontend/apps/console/src/features/login-flow/data/widgets.json
+++ b/frontend/apps/console/src/features/login-flow/data/widgets.json
@@ -1079,160 +1079,6 @@
   },
   {
     "resourceType": "WIDGET",
-    "category": "FLOW",
-    "type": "PROVISIONING",
-    "display": {
-      "label": "Provisioning",
-      "description": "Provision a user and prompt for missing schema attributes using dynamic inputs",
-      "image": "assets/images/icons/user.svg",
-      "showOnResourcePanel": true
-    },
-    "config": {
-      "data": {
-        "__generationMeta__": {
-          "defaultPropertySelectorId": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
-          "replacers": [
-            {
-              "key": "PROVISIONING_EXECUTOR_STEP_ID",
-              "type": "ID"
-            },
-            {
-              "key": "PROVISIONING_PROMPT_STEP_ID",
-              "type": "ID"
-            }
-          ]
-        },
-        "steps": [
-          {
-            "id": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
-            "type": "TASK_EXECUTION",
-            "size": {
-              "width": 200,
-              "height": 113
-            },
-            "position": {
-              "x": 760,
-              "y": 360
-            },
-            "data": {
-              "action": {
-                "type": "EXECUTOR",
-                "executor": {
-                  "name": "ProvisioningExecutor"
-                },
-                "onSuccess": "",
-                "onFailure": "",
-                "onIncomplete": "{{PROVISIONING_PROMPT_STEP_ID}}"
-              },
-              "properties": {
-                "allowCrossOUProvisioning": false,
-                "includeOptional": false,
-                "includeOptionalCredentials": false,
-                "maxPerPrompt": 5,
-                "assignGroup": "",
-                "assignRole": ""
-              }
-            }
-          },
-          {
-            "id": "{{PROVISIONING_PROMPT_STEP_ID}}",
-            "type": "VIEW",
-            "size": {
-              "width": 360,
-              "height": 220
-            },
-            "position": {
-              "x": 1120,
-              "y": 260
-            },
-            "data": {
-              "components": [
-                {
-                  "id": "{{ID}}",
-                  "category": "DISPLAY",
-                  "type": "IMAGE",
-                  "src": "{{ meta(application.logoUrl) }}",
-                  "alt": "Application logo",
-                  "height": "60",
-                  "width": ""
-                },
-                {
-                  "id": "{{ID}}",
-                  "category": "DISPLAY",
-                  "type": "TEXT",
-                  "align": "center",
-                  "variant": "HEADING_1",
-                  "label": "Complete your details"
-                },
-                {
-                  "id": "{{ID}}",
-                  "category": "BLOCK",
-                  "type": "BLOCK",
-                  "components": [
-                    {
-                      "id": "{{ID}}",
-                      "category": "DISPLAY",
-                      "type": "DYNAMIC_INPUT_PLACEHOLDER"
-                    },
-                    {
-                      "id": "{{ID}}",
-                      "category": "ACTION",
-                      "type": "ACTION",
-                      "variant": "PRIMARY",
-                      "eventType": "SUBMIT",
-                      "label": "Continue",
-                      "action": {
-                        "type": "NEXT",
-                        "onSuccess": "{{PROVISIONING_EXECUTOR_STEP_ID}}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      }
-    }
-  },
-  {
-    "resourceType": "WIDGET",
-    "category": "COMPOSITE",
-    "type": "SELF_SIGN_UP_LINK",
-    "display": {
-      "label": "Self Sign Up Link",
-      "description": "A rich text link to redirect users to the self-registration page",
-      "image": "UserPlus",
-      "showOnResourcePanel": true
-    },
-    "config": {
-      "data": {
-        "__generationMeta__": {
-          "strategy": "MERGE_WITH_DROP_POINT"
-        },
-        "steps": [
-          {
-            "__generationMeta__": {
-              "strategy": "MERGE_WITH_DROP_POINT"
-            },
-            "type": "VIEW",
-            "data": {
-              "components": [
-                {
-                  "category": "DISPLAY",
-                  "type": "RICH_TEXT",
-                  "id": "{{ID}}",
-                  "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"{{meta(application.sign_up_url)}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>"
-                }
-              ]
-            }
-          }
-        ]
-      }
-    }
-  },
-  {
-    "resourceType": "WIDGET",
     "category": "COMPOSITE",
     "type": "MAGIC_LINK",
     "display": {
@@ -1512,6 +1358,325 @@
                   "name": "AuthAssertExecutor"
                 },
                 "onSuccess": "END",
+                "onFailure": ""
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "resourceType": "WIDGET",
+    "category": "FLOW",
+    "type": "PROVISIONING",
+    "display": {
+      "label": "Provisioning",
+      "description": "Provision a user and prompt for missing schema attributes using dynamic inputs",
+      "image": "assets/images/icons/user.svg",
+      "showOnResourcePanel": true
+    },
+    "config": {
+      "data": {
+        "__generationMeta__": {
+          "defaultPropertySelectorId": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
+          "replacers": [
+            {
+              "key": "PROVISIONING_EXECUTOR_STEP_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PROVISIONING_PROMPT_STEP_ID",
+              "type": "ID"
+            }
+          ]
+        },
+        "steps": [
+          {
+            "id": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 760,
+              "y": 360
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "ProvisioningExecutor"
+                },
+                "onSuccess": "",
+                "onFailure": "",
+                "onIncomplete": "{{PROVISIONING_PROMPT_STEP_ID}}"
+              },
+              "properties": {
+                "allowCrossOUProvisioning": false,
+                "includeOptional": false,
+                "includeOptionalCredentials": false,
+                "maxPerPrompt": 5,
+                "assignGroup": "",
+                "assignRole": ""
+              }
+            }
+          },
+          {
+            "id": "{{PROVISIONING_PROMPT_STEP_ID}}",
+            "type": "VIEW",
+            "size": {
+              "width": 360,
+              "height": 220
+            },
+            "position": {
+              "x": 1120,
+              "y": 260
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "IMAGE",
+                  "src": "{{ meta(application.logoUrl) }}",
+                  "alt": "Application logo",
+                  "height": "60",
+                  "width": ""
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "align": "center",
+                  "variant": "HEADING_1",
+                  "label": "Complete your details"
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "DISPLAY",
+                      "type": "DYNAMIC_INPUT_PLACEHOLDER"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "Continue",
+                      "action": {
+                        "type": "NEXT",
+                        "onSuccess": "{{PROVISIONING_EXECUTOR_STEP_ID}}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "resourceType": "WIDGET",
+    "category": "COMPOSITE",
+    "type": "SELF_SIGN_UP_LINK",
+    "display": {
+      "label": "Self Sign Up Link",
+      "description": "A rich text link plus a Call node that invokes a self-registration flow",
+      "image": "UserPlus",
+      "showOnResourcePanel": true
+    },
+    "config": {
+      "data": {
+        "__generationMeta__": {
+          "strategy": "MERGE_WITH_DROP_POINT",
+          "replacers": [
+            {
+              "key": "SELF_SIGN_UP_CALL_STEP_ID",
+              "type": "ID"
+            }
+          ]
+        },
+        "steps": [
+          {
+            "__generationMeta__": {
+              "strategy": "MERGE_WITH_DROP_POINT"
+            },
+            "type": "VIEW",
+            "data": {
+              "components": [
+                {
+                  "category": "DISPLAY",
+                  "type": "RICH_TEXT",
+                  "id": "{{ID}}",
+                  "action": {
+                    "ref": "action_signup",
+                    "onSuccess": "{{SELF_SIGN_UP_CALL_STEP_ID}}"
+                  },
+                  "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"#\" data-action-ref=\"action_signup\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>"
+                }
+              ]
+            }
+          },
+          {
+            "id": "{{SELF_SIGN_UP_CALL_STEP_ID}}",
+            "type": "CALL",
+            "size": {
+              "width": 260,
+              "height": 130
+            },
+            "position": {
+              "x": 700,
+              "y": 300
+            },
+            "data": {
+              "flow": {"ref": "", "filterFlowType": "REGISTRATION"},
+              "action": {
+                "type": "CALL",
+                "flow": {"ref": ""},
+                "onSuccess": "",
+                "onFailure": ""
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "resourceType": "WIDGET",
+    "category": "COMPOSITE",
+    "type": "SIGN_IN_LINK",
+    "display": {
+      "label": "Sign In Link",
+      "description": "A rich text link plus a Call node that invokes a sign-in flow",
+      "image": "LogIn",
+      "showOnResourcePanel": true
+    },
+    "config": {
+      "data": {
+        "__generationMeta__": {
+          "strategy": "MERGE_WITH_DROP_POINT",
+          "replacers": [
+            {
+              "key": "SIGN_IN_CALL_STEP_ID",
+              "type": "ID"
+            }
+          ]
+        },
+        "steps": [
+          {
+            "__generationMeta__": {
+              "strategy": "MERGE_WITH_DROP_POINT"
+            },
+            "type": "VIEW",
+            "data": {
+              "components": [
+                {
+                  "category": "DISPLAY",
+                  "type": "RICH_TEXT",
+                  "id": "{{ID}}",
+                  "action": {
+                    "ref": "action_signin",
+                    "onSuccess": "{{SIGN_IN_CALL_STEP_ID}}"
+                  },
+                  "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Already have an account? </span><a href=\"#\" data-action-ref=\"action_signin\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign in</span></a></p>"
+                }
+              ]
+            }
+          },
+          {
+            "id": "{{SIGN_IN_CALL_STEP_ID}}",
+            "type": "CALL",
+            "size": {
+              "width": 260,
+              "height": 130
+            },
+            "position": {
+              "x": 700,
+              "y": 300
+            },
+            "data": {
+              "flow": {"ref": "", "filterFlowType": "AUTHENTICATION"},
+              "action": {
+                "type": "CALL",
+                "flow": {"ref": ""},
+                "onSuccess": "",
+                "onFailure": ""
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "resourceType": "WIDGET",
+    "category": "COMPOSITE",
+    "type": "RECOVERY_LINK",
+    "display": {
+      "label": "Recovery Link",
+      "description": "A rich text link plus a Call node that invokes a password recovery flow",
+      "image": "KeyRound",
+      "showOnResourcePanel": true
+    },
+    "config": {
+      "data": {
+        "__generationMeta__": {
+          "strategy": "MERGE_WITH_DROP_POINT",
+          "replacers": [
+            {
+              "key": "RECOVERY_CALL_STEP_ID",
+              "type": "ID"
+            }
+          ]
+        },
+        "steps": [
+          {
+            "__generationMeta__": {
+              "strategy": "MERGE_WITH_DROP_POINT"
+            },
+            "type": "VIEW",
+            "data": {
+              "components": [
+                {
+                  "category": "DISPLAY",
+                  "type": "RICH_TEXT",
+                  "id": "{{ID}}",
+                  "action": {
+                    "ref": "action_recovery",
+                    "onSuccess": "{{RECOVERY_CALL_STEP_ID}}"
+                  },
+                  "label": "<p class=\"rich-text-paragraph\"><a href=\"#\" data-action-ref=\"action_recovery\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Forgot password?</span></a></p>"
+                }
+              ]
+            }
+          },
+          {
+            "id": "{{RECOVERY_CALL_STEP_ID}}",
+            "type": "CALL",
+            "size": {
+              "width": 260,
+              "height": 130
+            },
+            "position": {
+              "x": 700,
+              "y": 300
+            },
+            "data": {
+              "flow": {"ref": "", "filterFlowType": "RECOVERY"},
+              "action": {
+                "type": "CALL",
+                "flow": {"ref": ""},
+                "onSuccess": "",
                 "onFailure": ""
               }
             }

--- a/frontend/packages/design/src/components/flow/FlowComponentRenderer.tsx
+++ b/frontend/packages/design/src/components/flow/FlowComponentRenderer.tsx
@@ -82,6 +82,8 @@ export default function FlowComponentRenderer({
         signUpFallbackUrl={signUpFallbackUrl}
         signInFallbackUrl={signInFallbackUrl}
         forgotPasswordFallbackUrl={forgotPasswordFallbackUrl}
+        values={values}
+        onSubmit={onSubmit}
       />
     );
   }

--- a/frontend/packages/design/src/components/flow/adapters/RichTextAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/RichTextAdapter.tsx
@@ -16,10 +16,11 @@
  * under the License.
  */
 
+import {EmbeddedFlowComponentType, EmbeddedFlowEventType, type EmbeddedFlowComponent} from '@thunderid/react';
 import {cn, containsMetaTemplate, replaceMetaTemplate} from '@thunderid/utils';
 import {Box} from '@wso2/oxygen-ui';
 import DOMPurify from 'dompurify';
-import type {JSX} from 'react';
+import type {JSX, MouseEvent as ReactMouseEvent} from 'react';
 import useDesign from '../../../contexts/Design/useDesign';
 import type {FlowComponent} from '../../../models/flow';
 
@@ -47,6 +48,27 @@ if (typeof window !== 'undefined') {
 }
 const RECOVERY_ENABLED_META_KEY = 'isRecoveryFlowEnabled';
 
+// When a RICH_TEXT component has a wired action, the anchor's href is decorative — the
+// click is intercepted and dispatched as a flow action. Strip navigation attributes so
+// hover, middle-click, and right-click "open in new tab" don't leak the placeholder URL.
+function neutralizeActionAnchors(html: string, actionRef: string): string {
+  const anyHasSentinel = /<a\b[^>]*\sdata-action-ref\s*=/i.test(html);
+  return html.replace(/<a\b([^>]*)>/gi, (match: string, attrs: string) => {
+    if (anyHasSentinel) {
+      const sentinelMatch = /\sdata-action-ref\s*=\s*(?:"([^"]*)"|'([^']*)')/i.exec(attrs);
+      const anchorRef = sentinelMatch ? (sentinelMatch[1] ?? sentinelMatch[2]) : undefined;
+      if (anchorRef !== actionRef) {
+        return match;
+      }
+    }
+    const stripped = attrs
+      .replace(/\shref\s*=\s*(?:"[^"]*"|'[^']*')/gi, '')
+      .replace(/\starget\s*=\s*(?:"[^"]*"|'[^']*')/gi, '')
+      .replace(/\srel\s*=\s*(?:"[^"]*"|'[^']*')/gi, '');
+    return `<a${stripped} href="#">`;
+  });
+}
+
 interface RichTextAdapterProps {
   component: FlowComponent;
   resolve: (template: string | undefined) => string | undefined;
@@ -65,6 +87,18 @@ interface RichTextAdapterProps {
    * `application.forgot_password_url` but recovery is enabled.
    */
   forgotPasswordFallbackUrl?: string;
+  /**
+   * Current form values, passed to `onSubmit` when a wired anchor click
+   * dispatches the component's `action`.
+   */
+  values?: Record<string, string>;
+  /**
+   * Fired when the rich text carries a wired `action` and one of its anchors is
+   * clicked. The adapter synthesizes an ACTION-shaped component whose `id`
+   * matches the action ref so the caller can dispatch `flow/execute` as it would
+   * for a real button.
+   */
+  onSubmit?: (action: EmbeddedFlowComponent, inputs: Record<string, string>) => void;
 }
 
 export default function RichTextAdapter({
@@ -73,9 +107,64 @@ export default function RichTextAdapter({
   signUpFallbackUrl = undefined,
   signInFallbackUrl = undefined,
   forgotPasswordFallbackUrl = undefined,
+  values = undefined,
+  onSubmit = undefined,
 }: RichTextAdapterProps): JSX.Element | null {
   const {isDesignEnabled} = useDesign();
   const rawLabel = typeof component.label === 'string' ? component.label : undefined;
+  const richTextAction = component.action;
+
+  // When the component carries a wired `action`, intercept anchor clicks inside the
+  // sanitized HTML and dispatch as a flow action instead of following the anchor's
+  // native href. This takes precedence over the URL-sniffing branches below, which
+  // are the pre-action-wiring workaround for authoring simple sign-up/recovery
+  // links from a template.
+  if (richTextAction?.ref && rawLabel) {
+    const resolvedLabel = resolve(rawLabel) ?? rawLabel;
+    const actionRef = richTextAction.ref;
+
+    const handleClick = (event: ReactMouseEvent<HTMLDivElement>): void => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      const anchor = target.closest('a');
+      if (!anchor) {
+        return;
+      }
+      const containerHasSentinel = event.currentTarget.querySelector('a[data-action-ref]') !== null;
+      if (containerHasSentinel) {
+        const anchorRef = anchor.getAttribute('data-action-ref');
+        if (!anchorRef || anchorRef !== actionRef) {
+          return;
+        }
+      }
+      event.preventDefault();
+      if (!onSubmit) {
+        return;
+      }
+      const syntheticAction: EmbeddedFlowComponent = {
+        eventType: EmbeddedFlowEventType.Trigger,
+        id: actionRef,
+        ref: actionRef,
+        type: EmbeddedFlowComponentType.Action,
+      };
+      onSubmit(syntheticAction, values ?? {});
+    };
+
+    const sanitized = DOMPurify.sanitize(resolvedLabel, {ADD_ATTR: ['target', 'data-action-ref']});
+    const finalHtml = neutralizeActionAnchors(sanitized, actionRef);
+
+    return (
+      <Box
+        className={cn('Flow--richText')}
+        sx={{mb: 1, textAlign: isDesignEnabled ? 'center' : 'left'}}
+        onClick={handleClick}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{__html: finalHtml}}
+      />
+    );
+  }
 
   // When any component label embeds a sign-up URL meta template we treat the
   // whole element as the "sign up link" block.  Show it only when self

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -2964,6 +2964,10 @@ const translations = {
     // Validation messages - executor
     'core.validation.fields.executor.general': 'The executor <0>{{id}}</0> is not properly configured.',
 
+    // Validation messages - call
+    'core.validation.fields.call.general': 'The Call node <0>{{id}}</0> has no referenced flow.',
+    'core.validation.fields.call.flowRef': 'Referenced flow is required',
+
     // Validation messages - button
     'core.validation.fields.button.general':
       'Required fields are not properly configured for the button with ID <code>{{id}}</code>.',
@@ -3028,6 +3032,31 @@ const translations = {
     'core.elements.richText.linkEditor.apply': 'Apply',
     'core.elements.richText.linkEditor.editLink': 'Edit Link',
     'core.elements.richText.linkEditor.viewLink': 'Link',
+    'core.elements.richText.action.description':
+      'Turn this rich text into an interactive link. When on, the link inside triggers the connected step instead of navigating.',
+    'core.elements.richText.action.enabled.label': 'Use as an interactive link',
+    'core.elements.richText.action.ref.label': 'Connected step',
+
+    // Call step
+    'core.call.unconfiguredLabel': 'Call flow',
+    'core.call.selectFlow': 'Select a flow to invoke',
+    'core.call.referencedFlow': 'Referenced flow',
+    'core.call.tooltip.configure': 'Configure',
+    'core.call.tooltip.delete': 'Delete',
+    'core.call.tooltip.openFlow': 'Open referenced flow',
+    'core.call.tooltip.openFlowDisabled': 'Configure a referenced flow to enable',
+    'core.call.handles.success': 'On success',
+    'core.call.handles.failure': 'On failure',
+    'core.call.openFlow.dialog.title': 'Open referenced flow?',
+    'core.call.openFlow.dialog.description': 'Any unsaved changes to the current flow will be lost.',
+    'core.call.openFlow.dialog.cancel': 'Cancel',
+    'core.call.openFlow.dialog.confirm': 'Continue',
+    'core.call.properties.description': 'Pick the flow to invoke when this node executes.',
+    'core.call.properties.loadError': 'Failed to load available flows',
+    'core.call.properties.flow.label': 'Referenced flow',
+    'core.call.properties.flow.placeholder': 'Select a flow',
+    'core.call.properties.flow.loading': 'Loading flows…',
+    'core.call.properties.flow.error.unknown': 'The referenced flow no longer exists. Pick a valid flow.',
 
     // Elements - text element
     'core.elements.text.align.label': 'Align',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,8 +242,8 @@ catalogs:
       specifier: 14.6.1
       version: 14.6.1
     '@thunderid/react':
-      specifier: 0.3.4
-      version: 0.3.4
+      specifier: 0.3.6
+      version: 0.3.6
     '@thunderid/react-router':
       specifier: 0.2.3
       version: 0.2.3
@@ -633,10 +633,10 @@ importers:
         version: link:../../packages/logger
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/react-router':
         specifier: 'catalog:'
-        version: 0.2.3(@thunderid/react@0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 0.2.3(@thunderid/react@0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -823,10 +823,10 @@ importers:
         version: link:../../packages/logger
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/react-router':
         specifier: 'catalog:'
-        version: 0.2.3(@thunderid/react@0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 0.2.3(@thunderid/react@0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -965,7 +965,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.11.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1062,7 +1062,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.11.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1156,7 +1156,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.11.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1268,7 +1268,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.11.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1380,7 +1380,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.11.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1477,7 +1477,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.11.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1592,7 +1592,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.11.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1820,7 +1820,7 @@ importers:
         version: link:../logger
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../utils
@@ -2072,7 +2072,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       i18next:
         specifier: 'catalog:'
         version: 25.6.0(typescript@5.9.3)
@@ -2396,7 +2396,7 @@ importers:
     dependencies:
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.11.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.11.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -6172,20 +6172,20 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@thunderid/browser@0.3.2':
-    resolution: {integrity: sha512-2FleXbJe8aBbplvzzEBDLQti5CWxgzCYXepuOLKK7c9FDTq2F5+Y1puo2IMZzkRXQt90ReKI1G7/cBq4yA7RrA==}
-
   '@thunderid/browser@0.3.3':
     resolution: {integrity: sha512-HFmwvwsXTM6VzND7M7OTRdtlk4XQSY1PudI/UldYv43TfND+6zg9s6+10A17UlQA7GxSOvMjxLe2Ye4UnbTofg==}
+
+  '@thunderid/browser@0.3.4':
+    resolution: {integrity: sha512-glIyptBNqrrChwjuQQ1rpnHjtAS9utXk/3LhxYnYBRxQgMgn13ZgeTTtXmPU/kXAB9laHK7kQH0A+T8cBu4X5w==}
 
   '@thunderid/javascript@0.0.5':
     resolution: {integrity: sha512-lMjbHCsNgYWclUiPlN3CA6vjKSyjIBIxVGSnuJwiC9eVakVsWmRuxkO8KX6AWlA4SRHgpGLMnD4ZE5lpM+gi9g==}
 
-  '@thunderid/javascript@0.3.7':
-    resolution: {integrity: sha512-/ipYhs46TsNxfVvwPI0x5Ki5aL1GNn5vPhVzL8m9yG+OrFBY05CS33hhGHDj/AvYiqrxE0j9H2NvCCoCOCwinA==}
-
   '@thunderid/javascript@0.3.8':
     resolution: {integrity: sha512-v58Cr/OTQyM/9bRY3OyyMFvUlSXrZ4Dq174+EQiODmpauPIYmQIfBVgX9TyrFReBPlbclDU8wRjqpXsmGpae7Q==}
+
+  '@thunderid/javascript@0.3.9':
+    resolution: {integrity: sha512-mej3MUiJOXWftbhdQxjKlkXdIVTpq11NMYEZcrBjLwt9Qb5iOi5hhanCYuydRsyrDJcQjrl4Kb+eG8jXkOaxFg==}
 
   '@thunderid/react-router@0.2.3':
     resolution: {integrity: sha512-m78BrOtJO15PoBXHBfLOG7bewWuCqenb+iyTR4sbyXIvbjxK5Dyw2pnYt6BKaM0FdCY6VFNldXrqSH2SX1wnXg==}
@@ -6194,15 +6194,15 @@ packages:
       react: '>=16.8.0'
       react-router: '>=6.30.1'
 
-  '@thunderid/react@0.3.4':
-    resolution: {integrity: sha512-lJujwXrx7P+k8gYn9FhXgpqYdVkFubKbA7iASyb/1OCNDwusBu/P2HLvYKg/Mb9paxJjP9t/DutcoIXaQNYhcw==}
+  '@thunderid/react@0.3.5':
+    resolution: {integrity: sha512-aKW7CWl2JBbhlkbrZ+lSdFAQFE9TA4g2G4MAfnnNDoF5gv7fH5NM0rgXD4D7BHLjMhUb4ZWaT3OcrHUBsjok7w==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@thunderid/react@0.3.5':
-    resolution: {integrity: sha512-aKW7CWl2JBbhlkbrZ+lSdFAQFE9TA4g2G4MAfnnNDoF5gv7fH5NM0rgXD4D7BHLjMhUb4ZWaT3OcrHUBsjok7w==}
+  '@thunderid/react@0.3.6':
+    resolution: {integrity: sha512-1ObPm3Em65Pqw/vpsxTT39Ukgwe/1wPPvfKa8g1oyhPD74smwpsNZS1Ub3wYaJhmx3vFSZglSGFHy/M4fgPlqA==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -18075,9 +18075,9 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@thunderid/browser@0.3.2':
+  '@thunderid/browser@0.3.3':
     dependencies:
-      '@thunderid/javascript': 0.3.7
+      '@thunderid/javascript': 0.3.8
       base64url: 3.0.1
       buffer: 6.0.3
       core-js: 3.42.0
@@ -18088,9 +18088,9 @@ snapshots:
       stream-browserify: 3.0.0
       tslib: 2.8.1
 
-  '@thunderid/browser@0.3.3':
+  '@thunderid/browser@0.3.4':
     dependencies:
-      '@thunderid/javascript': 0.3.8
+      '@thunderid/javascript': 0.3.9
       base64url: 3.0.1
       buffer: 6.0.3
       core-js: 3.42.0
@@ -18106,28 +18106,28 @@ snapshots:
       jose: 5.2.0
       tslib: 2.8.1
 
-  '@thunderid/javascript@0.3.7':
-    dependencies:
-      jose: 5.2.0
-      tslib: 2.8.1
-
   '@thunderid/javascript@0.3.8':
     dependencies:
       jose: 5.2.0
       tslib: 2.8.1
 
-  '@thunderid/react-router@0.2.3(@thunderid/react@0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@thunderid/javascript@0.3.9':
     dependencies:
-      '@thunderid/react': 0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      jose: 5.2.0
+      tslib: 2.8.1
+
+  '@thunderid/react-router@0.2.3(@thunderid/react@0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@thunderid/react': 0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-router: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
 
-  '@thunderid/react@0.3.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@thunderid/react@0.3.5(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@thunderid/browser': 0.3.2
+      '@thunderid/browser': 0.3.3
       '@types/react': 19.2.14
       dompurify: 3.4.11
       react: 19.2.3
@@ -18136,11 +18136,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@thunderid/react@0.3.5(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@thunderid/react@0.3.6(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@thunderid/browser': 0.3.3
+      '@thunderid/browser': 0.3.4
       '@types/react': 19.2.14
       dompurify: 3.4.11
       react: 19.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ catalog:
   '@testing-library/jest-dom': 6.9.1
   '@testing-library/react': 16.3.0
   '@testing-library/user-event': 14.6.1
-  '@thunderid/react': 0.3.4
+  '@thunderid/react': 0.3.6
   '@thunderid/react-router': 0.2.3
   '@types/lodash-es': 4.17.12
   '@types/node': 24.7.2
@@ -158,7 +158,7 @@ auditConfig:
 
 minimumReleaseAgeExclude:
   - tmp@0.2.7
-  - '@thunderid/browser@0.3.2'
-  - '@thunderid/javascript@0.3.7'
+  - '@thunderid/browser@0.3.4'
+  - '@thunderid/javascript@0.3.9'
   - '@thunderid/react-router@0.2.3'
-  - '@thunderid/react@0.3.4'
+  - '@thunderid/react@0.3.6'


### PR DESCRIPTION
### Purpose
This pull request adds call node UI implementation to the flow builder UI and bumps `@thunderid/react` version to onboard call node changes to the gate. This involves introducing call node widgets, steps and improvements to the rich text component to define action ref.

Additionally this PR increases the max call depth limit to `10` and modifies call node depth exceeding error to be a client error.

### Approach
### Backend: Flow Execution Limits & Error Handling

**Call depth limit and error reporting:**
- Increased `maxCallDepth` from 5 to 10 to allow deeper flow nesting (`engine.go`).
- Added a new client-facing error (`ErrorMaxCallDepthExceeded`) with internationalized messages and changed the log level from error to debug when the call depth is exceeded (`engine.go`, `error_constants.go`, `defaults.go`) [[1]](diffhunk://#diff-994db006ec85b11148c244ca8b6586775bdf8920db2a42b9e6df0ac82fc8ec9aL825-R827) [[2]](diffhunk://#diff-4d106c38709ce1b4f4ecc8ab2e295d28d9a2a2b96428b6aeac696093ad6c07a7R197-R209) [[3]](diffhunk://#diff-3254c1a5eab4b5b8f23152f5816d78f7544c0d52e7f4af65d9c4bd64a7a13ebdR568-R569).

### Frontend: Rich Text Interactive Linking

**Rich Text action configuration UI:**
- Added the `RichTextActionFields` component, which provides a toggle and read-only field for connecting rich text elements to steps. Includes logic for enabling/disabling actions and handling edge connections (`RichTextActionFields.tsx`).
- Integrated `RichTextActionFields` into the property panel, so it appears when editing a rich text label (`CommonElementPropertyFactory.tsx`) [[1]](diffhunk://#diff-13204ee311a6e2cb387603e00531354d027e9e08ba1d10b935f9d2ca12ab30e7R34) [[2]](diffhunk://#diff-13204ee311a6e2cb387603e00531354d027e9e08ba1d10b935f9d2ca12ab30e7R201-R208).
- Added a comprehensive test suite for the new action fields component (`RichTextActionFields.test.tsx`).

**Rich Text element rendering:**
- Updated `RichTextAdapter` to render a source handle when an action is enabled, allowing authors to visually connect rich text elements to other steps. Ensured re-measurement of node internals when the action state changes and passed `elementIndex` for handle positioning (`RichTextAdapter.tsx`, `CommonElementFactory.tsx`) [[1]](diffhunk://#diff-3ad7adf6936cb6be39accc4be6b9e958e78bcf81e424cd42f7541dc8ab4f2f0bR19-R25) [[2]](diffhunk://#diff-3ad7adf6936cb6be39accc4be6b9e958e78bcf81e424cd42f7541dc8ab4f2f0bR48) [[3]](diffhunk://#diff-3ad7adf6936cb6be39accc4be6b9e958e78bcf81e424cd42f7541dc8ab4f2f0bR59-R121) F33c821aL134R134, [[4]](diffhunk://#diff-af8e5c41c679cb32cdd41d69e8871f82a7f5babe9cbced97ce1a2e8cc06cbc19L137-R137).

### Frontend: Step Factory

**Support for Call steps:**
- Updated the step factory to render the new `Call` step type (`CommonStepFactory.tsx`) [[1]](diffhunk://#diff-93aa55bc43d2fc86e2a86d3b4aeb7aaf3484fe48466c674b81e91459c5bf49a9R21) [[2]](diffhunk://#diff-93aa55bc43d2fc86e2a86d3b4aeb7aaf3484fe48466c674b81e91459c5bf49a9R121-R124).

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2025

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3650
- https://github.com/thunder-id/javascript-sdks/pull/16

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Call** workflow step to invoke another flow, including referenced-flow selection and validation.
  * Introduced **rich-text interactive link** editing and rendering, plus click-to-trigger wired actions and connected-step context.
  * Extended visual-flow support for **CALL** nodes and additional link widget types, with automatic wiring of rich-text “next” references.
* **Bug Fixes**
  * Increased maximum flow call depth and returns a dedicated user-facing error when exceeded.
  * Hardened rich-text sanitization to prevent unsafe link behavior.
* **Tests**
  * Added/expanded unit tests for Call step, Call properties, and rich-text interactive-link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->