### PR TITLE
Block user deletion when blocking dependencies are present

### DIFF
--- a/backend/internal/agent/service.go
+++ b/backend/internal/agent/service.go
@@ -459,11 +459,12 @@ func (s *agentService) getAgentsByOwner(
 		if owner != ownerID {
 			continue
 		}
+		// An agent cannot exist without its owner, so ownership blocks the owner's deletion.
 		usages = append(usages, resourcedependency.ResourceDependency{
 			ResourceType:     resourcedependency.ResourceTypeAgent,
 			ID:               e.ID,
 			DisplayName:      name,
-			BehaviorOnDelete: resourcedependency.BehaviorFallback,
+			BehaviorOnDelete: resourcedependency.BehaviorRestrict,
 		})
 	}
 	return usages, nil

--- a/backend/internal/agent/service_test.go
+++ b/backend/internal/agent/service_test.go
@@ -2192,7 +2192,7 @@ func (suite *AgentServiceTestSuite) TestGetResourceDependencies_ByOwner_Success(
 	assert.NoError(suite.T(), err)
 	suite.Require().Len(result, 1)
 	assert.Equal(suite.T(), resourcedependency.ResourceTypeAgent, result[0].ResourceType)
-	assert.Equal(suite.T(), resourcedependency.BehaviorFallback, result[0].BehaviorOnDelete)
+	assert.Equal(suite.T(), resourcedependency.BehaviorRestrict, result[0].BehaviorOnDelete)
 	assert.Equal(suite.T(), "agent-1", result[0].ID)
 	assert.Equal(suite.T(), "Agent One", result[0].DisplayName)
 }

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -1069,6 +1069,8 @@ var defaultMessages = map[string]string{
 	"error.userservice.organization_unit_not_found_description": "The specified organization unit does not exist",
 	"error.userservice.schema_validation_failed": "Schema validation failed",
 	"error.userservice.schema_validation_failed_description": "User attributes do not conform to the required schema",
+	"error.userservice.user_has_blocking_dependencies": "User cannot be deleted",
+	"error.userservice.user_has_blocking_dependencies_description": "The user cannot be deleted because other resources depend on it. Remove or reassign them first.",
 	"error.userservice.user_not_found": "User not found",
 	"error.userservice.user_not_found_description": "The user with the specified id does not exist",
 	"error.userservice.user_type_not_found": "User type not found",

--- a/backend/internal/system/resourcedependency/registry.go
+++ b/backend/internal/system/resourcedependency/registry.go
@@ -33,6 +33,30 @@ const loggerComponentName = "DependencyRegistry"
 // resolves it to the system default at read time when the target is deleted.
 const BehaviorFallback = "fallback"
 
+// BehaviorRestrict indicates the referencing resource forbids deletion of the target while the
+// reference exists; the caller must remove or reassign the reference before the target can be deleted.
+const BehaviorRestrict = "restrict"
+
+// isBlocking reports whether a behaviorOnDelete value forbids deletion of the referenced resource.
+func isBlocking(behaviorOnDelete string) bool {
+	return behaviorOnDelete == BehaviorRestrict
+}
+
+// BlockingUsages returns the dependencies in the response whose behaviorOnDelete forbids deletion
+// of the target resource. Returns an empty slice when there are none.
+func BlockingUsages(resp *DependenciesResponse) []ResourceDependency {
+	blocking := make([]ResourceDependency, 0)
+	if resp == nil {
+		return blocking
+	}
+	for _, u := range resp.Usages {
+		if isBlocking(u.BehaviorOnDelete) {
+			blocking = append(blocking, u)
+		}
+	}
+	return blocking
+}
+
 // Resource type identifiers shared across dependency providers and consumers.
 const (
 	ResourceTypeTheme       = "theme"

--- a/backend/internal/user/error_constants.go
+++ b/backend/internal/user/error_constants.go
@@ -312,6 +312,21 @@ var (
 			DefaultValue: "Multiple users match the provided filters",
 		},
 	}
+	// ErrorUserHasBlockingDependencies is returned when a user cannot be deleted because other
+	// resources depend on it in a way that forbids deletion (e.g. agents owned by the user).
+	ErrorUserHasBlockingDependencies = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "USR-1027",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.userservice.user_has_blocking_dependencies",
+			DefaultValue: "User cannot be deleted",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key: "error.userservice.user_has_blocking_dependencies_description",
+			DefaultValue: "The user cannot be deleted because other resources depend on it. " +
+				"Remove or reassign them first.",
+		},
+	}
 )
 
 // Error variables

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -514,7 +514,8 @@ func handleError(ctx context.Context, w http.ResponseWriter, svcErr *tidcommon.S
 			ErrorUserNotFound.Code,
 			ErrorOrganizationUnitNotFound.Code:
 			statusCode = http.StatusNotFound
-		case ErrorAttributeConflict.Code:
+		case ErrorAttributeConflict.Code,
+			ErrorUserHasBlockingDependencies.Code:
 			statusCode = http.StatusConflict
 		case ErrorHandlePathRequired.Code,
 			ErrorInvalidHandlePath.Code,

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
@@ -774,6 +775,11 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *tidcommon
 		return svcErr
 	}
 
+	// Refuse deletion while other resources block it (e.g. agents owned by the user).
+	if svcErr := us.ensureNoBlockingDependencies(ctx, userID, logger); svcErr != nil {
+		return svcErr
+	}
+
 	err = us.entityService.DeleteEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
@@ -786,6 +792,64 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *tidcommon
 
 	logger.Debug(ctx, "Successfully deleted user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return nil
+}
+
+// ensureNoBlockingDependencies refuses deletion when other resources depend on the user in a way
+// that forbids it (behaviorOnDelete == restrict), such as agents that list the user as their owner.
+// Because deletion is destructive, it fails closed: if dependency data cannot be determined, the
+// deletion is refused rather than allowed.
+func (us *userService) ensureNoBlockingDependencies(
+	ctx context.Context, userID string, logger *log.Logger) *tidcommon.ServiceError {
+	if us.dependencyRegistry == nil {
+		logger.Error(ctx, "Dependency registry not set; refusing to delete user",
+			log.MaskedString(log.LoggerKeyUserID, userID))
+		return &tidcommon.InternalServerError
+	}
+
+	deps, err := us.dependencyRegistry.GetDependencies(ctx, resourcedependency.ResourceTypeUser, userID)
+	if err != nil {
+		return logErrorAndReturnServerError(ctx, logger, "Failed to evaluate user dependencies", err,
+			log.MaskedString(log.LoggerKeyUserID, userID))
+	}
+	// Fail closed: nil TotalResults means a provider failed to report, so usage is unknown.
+	if deps == nil || deps.TotalResults == nil {
+		logger.Error(ctx, "User dependency data unavailable; refusing to delete user",
+			log.MaskedString(log.LoggerKeyUserID, userID))
+		return &tidcommon.InternalServerError
+	}
+
+	blocking := resourcedependency.BlockingUsages(deps)
+	if len(blocking) == 0 {
+		return nil
+	}
+
+	logger.Debug(ctx, "User has blocking dependencies; deletion refused",
+		log.MaskedString(log.LoggerKeyUserID, userID), log.Int("blockingCount", len(blocking)))
+	return tidcommon.CustomServiceError(ErrorUserHasBlockingDependencies, tidcommon.I18nMessage{
+		Key: "error.userservice.user_has_blocking_dependencies_description",
+		DefaultValue: fmt.Sprintf(
+			"The user cannot be deleted because %s depend on it. Remove or reassign them first.",
+			summarizeBlockingUsages(blocking)),
+	})
+}
+
+// summarizeBlockingUsages renders a deterministic, human-readable summary of blocking dependencies
+// grouped by resource type, e.g. "2 agent(s)".
+func summarizeBlockingUsages(usages []resourcedependency.ResourceDependency) string {
+	counts := make(map[string]int)
+	for _, u := range usages {
+		counts[u.ResourceType]++
+	}
+	types := make([]string, 0, len(counts))
+	for rt := range counts {
+		types = append(types, rt)
+	}
+	sort.Strings(types)
+	parts := make([]string, 0, len(types))
+	for _, rt := range types {
+		parts = append(parts, fmt.Sprintf("%d %s(s)", counts[rt], rt))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // SetDependencyRegistry injects the dependency registry. Called by servicemanager after the

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -888,8 +888,9 @@ func TestUserService_DeleteUser(t *testing.T) {
 	storeMock.On("DeleteEntity", mock.Anything, userID).Return(nil).Once()
 
 	service := &userService{
-		entityService: storeMock,
-		authzService:  newAllowAllAuthz(t),
+		entityService:      storeMock,
+		authzService:       newAllowAllAuthz(t),
+		dependencyRegistry: newNoBlockingDepsRegistry(),
 	}
 
 	err := service.DeleteUser(context.Background(), userID)
@@ -1791,10 +1792,11 @@ func TestUserService_MoreErrorCases(t *testing.T) {
 	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 	authzMock := newAllowAllAuthz(t)
 	service := &userService{
-		entityService:     storeMock,
-		ouService:         ouServiceMock,
-		entityTypeService: entityTypeMock,
-		authzService:      authzMock,
+		entityService:      storeMock,
+		ouService:          ouServiceMock,
+		entityTypeService:  entityTypeMock,
+		authzService:       authzMock,
+		dependencyRegistry: newNoBlockingDepsRegistry(),
 	}
 	ctx := context.Background()
 
@@ -2793,6 +2795,101 @@ func TestUserService_DeleteUser_PreFetchAndAuthzChecks(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// DeleteUser – blocking dependency guard
+// ---------------------------------------------------------------------------
+
+// newDeletableUserStore builds an entity mock for a user that passes the pre-delete checks.
+func newDeletableUserStore(t *testing.T) *entitymock.EntityServiceInterfaceMock {
+	t.Helper()
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).
+		Return(&providers.Entity{
+			Category: providers.EntityCategoryUser, ID: svcTestUserID1, OUID: testOrgID,
+		}, nil).Once()
+	return storeMock
+}
+
+func TestUserService_DeleteUser_BlockedByOwnedAgent(t *testing.T) {
+	userID := svcTestUserID1
+	storeMock := newDeletableUserStore(t)
+
+	service := &userService{
+		entityService:      storeMock,
+		authzService:       newAllowAllAuthz(t),
+		dependencyRegistry: newBlockingDepsRegistry(),
+	}
+
+	err := service.DeleteUser(context.Background(), userID)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorUserHasBlockingDependencies.Code, err.Code)
+	storeMock.AssertNotCalled(t, "DeleteEntity", mock.Anything, mock.Anything)
+}
+
+func TestUserService_DeleteUser_AllowedWhenOnlyNonBlockingDependencies(t *testing.T) {
+	userID := svcTestUserID1
+	storeMock := newDeletableUserStore(t)
+	storeMock.On("DeleteEntity", mock.Anything, userID).Return(nil).Once()
+
+	total := 1
+	registry := &stubUsageRegistry{resp: &resourcedependency.DependenciesResponse{
+		TotalResults: &total,
+		Count:        1,
+		Usages: []resourcedependency.ResourceDependency{
+			{ResourceType: resourcedependency.ResourceTypeApplication, ID: "app-1",
+				DisplayName: "Portal", BehaviorOnDelete: resourcedependency.BehaviorFallback},
+		},
+	}}
+
+	service := &userService{
+		entityService:      storeMock,
+		authzService:       newAllowAllAuthz(t),
+		dependencyRegistry: registry,
+	}
+
+	err := service.DeleteUser(context.Background(), userID)
+	require.Nil(t, err)
+	storeMock.AssertNumberOfCalls(t, "DeleteEntity", 1)
+}
+
+func TestUserService_DeleteUser_RefusedWhenDependenciesUnknown(t *testing.T) {
+	userID := svcTestUserID1
+	storeMock := newDeletableUserStore(t)
+
+	// TotalResults nil signals a provider failed to report; deletion must fail closed.
+	registry := &stubUsageRegistry{resp: &resourcedependency.DependenciesResponse{
+		TotalResults: nil,
+		Usages:       []resourcedependency.ResourceDependency{},
+	}}
+
+	service := &userService{
+		entityService:      storeMock,
+		authzService:       newAllowAllAuthz(t),
+		dependencyRegistry: registry,
+	}
+
+	err := service.DeleteUser(context.Background(), userID)
+	require.NotNil(t, err)
+	require.Equal(t, tidcommon.InternalServerError.Code, err.Code)
+	storeMock.AssertNotCalled(t, "DeleteEntity", mock.Anything, mock.Anything)
+}
+
+func TestUserService_DeleteUser_RefusedWhenRegistryUnset(t *testing.T) {
+	userID := svcTestUserID1
+	storeMock := newDeletableUserStore(t)
+
+	service := &userService{
+		entityService: storeMock,
+		authzService:  newAllowAllAuthz(t),
+	}
+
+	err := service.DeleteUser(context.Background(), userID)
+	require.NotNil(t, err)
+	require.Equal(t, tidcommon.InternalServerError.Code, err.Code)
+	storeMock.AssertNotCalled(t, "DeleteEntity", mock.Anything, mock.Anything)
+}
+
 // TestUpdateUser_DeclarativeResource tests that UpdateUser returns ErrorCannotModifyDeclarativeResource
 // when the user is declarative.
 func TestUpdateUser_DeclarativeResource(t *testing.T) {
@@ -3371,8 +3468,9 @@ func TestUserService_DeleteUser_NotFoundOnDelete(t *testing.T) {
 	storeMock.On("DeleteEntity", mock.Anything, userID).Return(entitypkg.ErrEntityNotFound).Once()
 
 	service := &userService{
-		entityService: storeMock,
-		authzService:  newAllowAllAuthz(t),
+		entityService:      storeMock,
+		authzService:       newAllowAllAuthz(t),
+		dependencyRegistry: newNoBlockingDepsRegistry(),
 	}
 
 	err := service.DeleteUser(context.Background(), userID)
@@ -3496,6 +3594,30 @@ func (s *stubUsageRegistry) GetDependencies(
 
 func newUserForUsages(id string) *providers.Entity {
 	return &providers.Entity{ID: id, Category: providers.EntityCategoryUser, Type: "Person"}
+}
+
+// newNoBlockingDepsRegistry returns a registry reporting confirmed-empty dependencies, so that
+// deletion is permitted by the blocking guard.
+func newNoBlockingDepsRegistry() *stubUsageRegistry {
+	total := 0
+	return &stubUsageRegistry{resp: &resourcedependency.DependenciesResponse{
+		TotalResults: &total,
+		Usages:       []resourcedependency.ResourceDependency{},
+	}}
+}
+
+// newBlockingDepsRegistry returns a registry reporting a single blocking (restrict) dependency.
+func newBlockingDepsRegistry() *stubUsageRegistry {
+	total := 1
+	return &stubUsageRegistry{resp: &resourcedependency.DependenciesResponse{
+		TotalResults: &total,
+		Count:        1,
+		Summary:      map[string]int{resourcedependency.ResourceTypeAgent: 1},
+		Usages: []resourcedependency.ResourceDependency{
+			{ResourceType: resourcedependency.ResourceTypeAgent, ID: "agent-1",
+				DisplayName: "Support Agent", BehaviorOnDelete: resourcedependency.BehaviorRestrict},
+		},
+	}}
 }
 
 func TestUserService_GetUserUsages_MissingID(t *testing.T) {

--- a/frontend/packages/configure-users/src/components/UserDeleteDialog.tsx
+++ b/frontend/packages/configure-users/src/components/UserDeleteDialog.tsx
@@ -60,8 +60,10 @@ export default function UserDeleteDialog({
   const {data: usagesData, isLoading: isLoadingUsages} = useGetUserUsages(userId, open);
 
   const usagesKnown = usagesData !== undefined && usagesData.totalResults !== null;
-  const visibleUsages = usagesData?.usages.slice(0, MAX_VISIBLE_USAGES) ?? [];
-  const hiddenCount = (usagesData?.totalResults ?? 0) - visibleUsages.length;
+  const blockingUsages = usagesData?.usages.filter((usage) => usage.behaviorOnDelete === 'restrict') ?? [];
+  const hasBlockingUsages = usagesKnown && blockingUsages.length > 0;
+  const visibleBlocking = blockingUsages.slice(0, MAX_VISIBLE_USAGES);
+  const hiddenBlockingCount = blockingUsages.length - visibleBlocking.length;
 
   const handleCancel = (): void => {
     if (deleteUser.isPending) return;
@@ -101,23 +103,26 @@ export default function UserDeleteDialog({
           <Alert severity="warning" sx={{mb: 2}}>
             {t('users:delete.disclaimer', 'All associated data will be permanently removed.')}
           </Alert>
-        ) : (usagesData?.totalResults ?? 0) > 0 ? (
-          <Alert severity="warning" sx={{mb: 2}}>
+        ) : hasBlockingUsages ? (
+          <Alert severity="error" sx={{mb: 2}}>
             <Typography variant="body2" sx={{mb: 1}}>
-              {t('users:delete.usages.title', 'The following agents list this user as their owner:')}
+              {t(
+                'users:delete.blocking.title',
+                'This user cannot be deleted until the following agents are reassigned or removed:',
+              )}
             </Typography>
             <List dense disablePadding>
-              {visibleUsages.map((usage) => (
+              {visibleBlocking.map((usage) => (
                 <ListItem key={usage.id} disableGutters sx={{py: 0}}>
                   <ListItemText primary={<Typography variant="body2">{usage.displayName}</Typography>} />
                 </ListItem>
               ))}
-              {hiddenCount > 0 && (
+              {hiddenBlockingCount > 0 && (
                 <ListItem disableGutters sx={{py: 0}}>
                   <ListItemText
                     primary={
                       <Typography variant="body2" color="text.secondary">
-                        {t('users:delete.usages.more', {count: hiddenCount, defaultValue: '+{{count}} more'})}
+                        {t('users:delete.usages.more', {count: hiddenBlockingCount, defaultValue: '+{{count}} more'})}
                       </Typography>
                     }
                   />
@@ -145,7 +150,7 @@ export default function UserDeleteDialog({
           onClick={handleConfirm}
           color="error"
           variant="contained"
-          disabled={deleteUser.isPending || !userId || isLoadingUsages}
+          disabled={deleteUser.isPending || !userId || isLoadingUsages || hasBlockingUsages}
         >
           {deleteUser.isPending ? t('common:status.deleting', 'Deleting...') : t('common:actions.delete', 'Delete')}
         </Button>

--- a/frontend/packages/configure-users/src/components/__tests__/UserDeleteDialog.test.tsx
+++ b/frontend/packages/configure-users/src/components/__tests__/UserDeleteDialog.test.tsx
@@ -114,26 +114,29 @@ describe('UserDeleteDialog', () => {
       expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
     });
 
-    it('should list the agents that own the user', () => {
+    it('should list blocking agents and disable delete when the user owns agents', () => {
       const usages: UserUsagesResponse = {
         totalResults: 2,
         count: 2,
         summary: {agent: 2},
         usages: [
-          {resourceType: 'agent', id: 'agent-1', displayName: 'Support Agent', behaviorOnDelete: 'fallback'},
-          {resourceType: 'agent', id: 'agent-2', displayName: 'Billing Agent', behaviorOnDelete: 'fallback'},
+          {resourceType: 'agent', id: 'agent-1', displayName: 'Support Agent', behaviorOnDelete: 'restrict'},
+          {resourceType: 'agent', id: 'agent-2', displayName: 'Billing Agent', behaviorOnDelete: 'restrict'},
         ],
       };
       getUsagesMock.mockReturnValue({data: usages, isLoading: false});
 
       render(<UserDeleteDialog open userId="user-123" onClose={mockOnClose} />);
 
-      expect(screen.getByText('The following agents list this user as their owner:')).toBeInTheDocument();
+      expect(
+        screen.getByText('This user cannot be deleted until the following agents are reassigned or removed:'),
+      ).toBeInTheDocument();
       expect(screen.getByText('Support Agent')).toBeInTheDocument();
       expect(screen.getByText('Billing Agent')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
     });
 
-    it('should show a "+N more" row when usages exceed the visible limit', () => {
+    it('should show a "+N more" row when blocking usages exceed the visible limit', () => {
       const usages: UserUsagesResponse = {
         totalResults: 7,
         count: 7,
@@ -142,7 +145,7 @@ describe('UserDeleteDialog', () => {
           resourceType: 'agent',
           id: `agent-${i}`,
           displayName: `Agent ${i}`,
-          behaviorOnDelete: 'fallback' as const,
+          behaviorOnDelete: 'restrict' as const,
         })),
       };
       getUsagesMock.mockReturnValue({data: usages, isLoading: false});

--- a/frontend/packages/configure-users/src/models/users.ts
+++ b/frontend/packages/configure-users/src/models/users.ts
@@ -209,7 +209,7 @@ export interface UserUsage {
   resourceType: string;
   id: string;
   displayName: string;
-  behaviorOnDelete: 'fallback' | 'cascade';
+  behaviorOnDelete: 'fallback' | 'cascade' | 'restrict';
 }
 
 /**

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -740,6 +740,7 @@ const translations = {
     'delete.usages.none': 'No agents currently list this user as their owner.',
     'delete.usages.title': 'The following agents list this user as their owner:',
     'delete.usages.more': '+{{count}} more',
+    'delete.blocking.title': 'This user cannot be deleted until the following agents are reassigned or removed:',
   },
 
   // ============================================================================


### PR DESCRIPTION
### Purpose
Prevent deleting a user while other resources depend on that user in a way that forbids deletion (e.g. agents that list the user as their owner). Previously such deletions succeeded, orphaning the dependent resources.

### Approach
- Added a `restrict` `behaviorOnDelete` semantic to the resource-dependency registry (`IsBlocking`, `BlockingUsages` helpers) to represent dependencies that forbid deletion of the target.
- Marked agent-ownership dependencies as `restrict` instead of `fallback`, since an agent cannot exist without its owner.
- Enforced the check in `userService.DeleteUser` via `ensureNoBlockingDependencies`, which fails closed: if the dependency registry is unset or dependency data cannot be determined, deletion is refused with an internal error.
- Added the `ErrorUserHasBlockingDependencies` (`USR-1027`) client error, mapped to `409 Conflict` in the handler, with a human-readable summary of the blocking resources.
- Updated the Console `UserDeleteDialog` to distinguish blocking from non-blocking usages, show an error alert listing blocking agents, and disable the delete action until they are reassigned or removed.

### Related Issues
- Fixes thunder-id/thunderid#3739

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User deletion now blocks when dependent resources still exist, and the dialog shows which items must be removed or reassigned first.
  * Added clearer messages for deletion-blocked cases.
* **Bug Fixes**
  * Deleting a user now returns a conflict instead of proceeding when blocking dependencies are present.
  * The delete dialog now disables confirmation in blocking scenarios and lists the affected items.
* **Tests**
  * Added and updated coverage for blocked, allowed, and unavailable dependency-check cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->