### PR TITLE
Fix missing product name template in docs

### DIFF
--- a/docs/content/guides/deployment-patterns/observability.mdx
+++ b/docs/content/guides/deployment-patterns/observability.mdx
@@ -303,4 +303,4 @@ If no spans appear, check the following:
 ## Next Steps
 
 - See [Observability Configuration](../../getting-started/configuration#observability-configuration) for the full list of settings for each output backend.
-- See the [Observability Contributing Guide](../../../community/contributing/contributing-code/backend-development/observability) to learn how to add instrumentation to new ThunderID components.
+- See the [Observability Contributing Guide](../../../community/contributing/contributing-code/backend-development/observability) to learn how to add instrumentation to new <ProductName /> components.

--- a/docs/content/guides/getting-started/connect-your-application/android.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/android.mdx
@@ -18,7 +18,7 @@ import {
 
 # Android Quickstart
 
-Use this guide to add <ProductName /> authentication to an Android application using the ThunderID Android SDK for Jetpack Compose.
+Use this guide to add <ProductName /> authentication to an Android application using the <ProductName /> Android SDK for Jetpack Compose.
 
 <TutorialHero>
 
@@ -45,7 +45,7 @@ Check out the complete <RepoLink path="/tree/main/sdks/android/samples/quickstar
 
 ## Run <ProductName />
 
-Start a local ThunderID instance. Pick the method that works best for you:
+Start a local <ProductName /> instance. Pick the method that works best for you:
 
 <RunThunderID />
 
@@ -75,7 +75,7 @@ In Android Studio, create a new project using the **Empty Activity** template wi
 If you already have an existing Android project, skip this step.
 :::
 
-## Install the ThunderID Compose SDK
+## Install the <ProductName /> Compose SDK
 
 Add the <ProductName /> Maven repository to your `settings.gradle.kts`:
 

--- a/docs/content/guides/getting-started/connect-your-application/browser.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/browser.mdx
@@ -43,7 +43,7 @@ Use this guide to add <ProductName /> authentication to a browser-based applicat
 
 ## Run <ProductName />
 
-Start a local ThunderID instance. Pick the method that works best for you:
+Start a local <ProductName /> instance. Pick the method that works best for you:
 
 <RunThunderID />
 

--- a/docs/content/guides/getting-started/connect-your-application/express.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/express.mdx
@@ -43,7 +43,7 @@ Use this guide to add <ProductName /> authentication to an Express app with sign
 
 ## Run <ProductName />
 
-Start a local ThunderID instance. Pick the method that works best for you:
+Start a local <ProductName /> instance. Pick the method that works best for you:
 
 <RunThunderID />
 
@@ -113,7 +113,7 @@ Install the <ProductName /> Express SDK:
 
 ## Add Authentication Middleware and Routes
 
-Create an `index.js` file with ThunderID middleware and auth routes:
+Create an `index.js` file with <ProductName /> middleware and auth routes:
 
 ```js title="index.js" showLineNumbers
 const express = require('express');

--- a/docs/content/guides/getting-started/connect-your-application/flutter.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/flutter.mdx
@@ -46,7 +46,7 @@ Check out the complete <RepoLink path="/tree/main/sdks/flutter/samples/quickstar
 
 ## Run <ProductName />
 
-Start a local ThunderID instance. Pick the method that works best for you:
+Start a local <ProductName /> instance. Pick the method that works best for you:
 
 <RunThunderID />
 

--- a/docs/content/guides/getting-started/connect-your-application/index.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/index.mdx
@@ -7,7 +7,7 @@ description: Choose a framework and connect your application with {{ProductName}
 ---
 # Connect Your Application
 
-Choose a package to integrate sign-in with ThunderID.
+Choose a package to integrate sign-in with <ProductName />.
 
 { /* TODO: Replace this with a React component from OxygenUI. Also the navigation flashes. */ }
 <div className="connect-grid">

--- a/docs/content/guides/getting-started/connect-your-application/ios.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/ios.mdx
@@ -19,7 +19,7 @@ import {
 
 # iOS Quickstart
 
-Use this guide to add <ProductName /> authentication to an iOS application using the ThunderID iOS SDK for SwiftUI.
+Use this guide to add <ProductName /> authentication to an iOS application using the <ProductName /> iOS SDK for SwiftUI.
 
 <TutorialHero>
 
@@ -46,7 +46,7 @@ Check out the complete <RepoLink path="/tree/main/sdks/ios/Samples/Quickstart">i
 
 ## Run <ProductName />
 
-Start a local ThunderID instance. Pick the method that works best for you:
+Start a local <ProductName /> instance. Pick the method that works best for you:
 
 <RunThunderID />
 

--- a/docs/content/guides/getting-started/connect-your-application/node.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/node.mdx
@@ -43,7 +43,7 @@ Use this guide to add <ProductName /> authentication to a vanilla Node.js applic
 
 ## Run <ProductName />
 
-Start a local ThunderID instance. Pick the method that works best for you:
+Start a local <ProductName /> instance. Pick the method that works best for you:
 
 <RunThunderID />
 

--- a/docs/content/guides/getting-started/connect-your-application/react.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/react.mdx
@@ -27,7 +27,7 @@ Use this guide to add <ProductName /> authentication to a React application usin
 
 <TutorialHeroItem icon={<Boxes />}>Create a new React app using Vite</TutorialHeroItem>
 <TutorialHeroItem icon={<Package />}>Install the <code>@thunderid/react</code> package</TutorialHeroItem>
-<TutorialHeroItem icon={<LogIn />}>Build with ThunderID prebuilt components</TutorialHeroItem>
+<TutorialHeroItem icon={<LogIn />}>Build with <ProductName /> prebuilt components</TutorialHeroItem>
 
 ## Prerequisites
 
@@ -42,7 +42,7 @@ Use this guide to add <ProductName /> authentication to a React application usin
 
 ## Run <ProductName />
 
-Start a local ThunderID instance. Pick the method that works best for you:
+Start a local <ProductName /> instance. Pick the method that works best for you:
 
 <RunThunderID />
 
@@ -151,7 +151,7 @@ createRoot(document.getElementById('root')).render(
 | `clientId` | The Client ID from your <ProductName /> application |
 | `baseUrl` | Your <ProductName /> instance URL (e.g., `https://localhost:8090`) |
 
-## Build with ThunderID Components
+## Build with <ProductName /> Components
 
 You can control which content signed-in and signed-out users can see with the prebuilt control components. Replace the content of `App.jsx` with the following, which uses these components:
 

--- a/docs/content/guides/getting-started/connect-your-application/vue.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/vue.mdx
@@ -131,9 +131,9 @@ app.use(ThunderIDPlugin)
 app.mount('#app')
 ```
 
-## Build with ThunderID Components
+## Build with <ProductName /> Components
 
-Update `src/App.vue` with ThunderID authentication components:
+Update `src/App.vue` with <ProductName /> authentication components:
 
 :::warning Configuration
 Replace `<your-client-id>` with the Client ID you obtained when creating the application in <ProductName />.

--- a/docs/content/guides/getting-started/register-an-application.mdx
+++ b/docs/content/guides/getting-started/register-an-application.mdx
@@ -12,20 +12,20 @@ import {NextSteps, NextStepsCard} from '../../../src/components/NextSteps';
 # Register an Application
 
 By the end of this guide you will have:
-- A registered application in ThunderID with a **Client ID**
+- A registered application in <ProductName /> with a **Client ID**
 - A test user you can sign in with
 - Everything ready to [build your sign-in flow](../build-a-flow) and [connect your app](../connect-your-application)
 
 ## Prerequisites
 
-- ThunderID is running. If not, [get ThunderID](../get-thunderid) first.
-- You can reach the ThunderID Console at [https://localhost:8090/console](https://localhost:8090/console).
+- <ProductName /> is running. If not, [get <ProductName />](../get-thunderid) first.
+- You can reach the <ProductName /> Console at [https://localhost:8090/console](https://localhost:8090/console).
 
 <Stepper>
 
 ## Create an application
 
-An application in ThunderID represents your product. When you register an OAuth 2.0 application, you get a **Client ID**, which links your frontend or backend to ThunderID's authentication layer.
+An application in <ProductName /> represents your product. When you register an OAuth 2.0 application, you get a **Client ID**, which links your frontend or backend to <ProductName />'s authentication layer.
 
 1. Sign in to the Console at [https://localhost:8090/console](https://localhost:8090/console) using the default admin credentials (`admin` / `admin`).
 2. Go to **Applications** and click **Add Application**.
@@ -45,7 +45,7 @@ An application in ThunderID represents your product. When you register an OAuth 
 6. On the **Design** screen, optionally choose an application logo and color theme, then click **Continue**.
 7. Under **Sign In Options**, toggle the authentication methods you want to enable (for example, **Username & Password**) and click **Continue**.
 8. Under **Sign-In Experience**:
-   - Set **Sign-In Approach** to **Redirect to ThunderID sign-in/sign-up handling pages**, the recommended approach. Users are sent to ThunderID-hosted pages you control with the Flow Designer.
+   - Set **Sign-In Approach** to **Redirect to <ProductName /> sign-in/sign-up handling pages**, the recommended approach. Users are sent to <ProductName />-hosted pages you control with the Flow Designer.
    - Under **User Access**, select **Customer** (for self-service end users) or **Person** (for admin-managed accounts).
 
    Click **Continue**.

--- a/docs/content/guides/guides/trusted-issuer.mdx
+++ b/docs/content/guides/guides/trusted-issuer.mdx
@@ -2,7 +2,7 @@
 title: Secure ThunderID Using a Third-Party Identity Provider
 ---
 
-# Secure ThunderID Using a Third-Party Identity Provider
+# Secure <ProductName /> Using a Third-Party Identity Provider
 
 By default, <ProductName /> only accepts tokens it issued itself. Your users might authenticate against an external authorization server — another <ProductName /> instance, an enterprise identity provider, or any standard OIDC provider. In that case, those users cannot call <ProductName />'s own APIs or sign in to the <ProductName /> Console unless <ProductName /> can validate their tokens.
 

--- a/docs/content/guides/working-with-ai/skills.mdx
+++ b/docs/content/guides/working-with-ai/skills.mdx
@@ -147,7 +147,7 @@ Run the following command in your terminal, then restart Codex:
 codex plugin marketplace add thunder-id/skills
 ```
 
-After restarting, open **`/plugins`**, select **ThunderID Skills**, install and enable `thunder-id-skills`, then start a new thread.
+After restarting, open **`/plugins`**, select **<ProductName /> Skills**, install and enable `thunder-id-skills`, then start a new thread.
 
 {/* Screenshot placeholder: Codex /plugins panel showing ThunderID Skills installed and enabled */}
 
@@ -169,7 +169,7 @@ After restarting, open **`/plugins`**, select **ThunderID Skills**, install and 
 
 ## Integration Skills
 
-Choose the skill that matches your framework. Each skill registers an application in the ThunderID Console, installs the correct SDK, and wires up authentication in your project.
+Choose the skill that matches your framework. Each skill registers an application in the <ProductName /> Console, installs the correct SDK, and wires up authentication in your project.
 
 ### Frontend
 
@@ -290,23 +290,23 @@ Type a plain-language request in your AI assistant's chat. The assistant detects
 
 | You Say | Skill |
 |---|---|
-| "Set up ThunderID on my machine" | `/setup-thunderid` |
-| "Add ThunderID to my Next.js app" | `/integrate-nextjs` |
-| "Add ThunderID to my Nuxt app" | `/integrate-nuxt` |
-| "Integrate ThunderID into my React app" | `/integrate-react` |
-| "Add ThunderID to my React Router app" | `/integrate-react-router` |
-| "Add ThunderID to my TanStack Router app" | `/integrate-tanstack-router` |
-| "Add ThunderID to my Vue app" | `/integrate-vue` |
+| "Set up <ProductName /> on my machine" | `/setup-thunderid` |
+| "Add <ProductName /> to my Next.js app" | `/integrate-nextjs` |
+| "Add <ProductName /> to my Nuxt app" | `/integrate-nuxt` |
+| "Integrate <ProductName /> into my React app" | `/integrate-react` |
+| "Add <ProductName /> to my React Router app" | `/integrate-react-router` |
+| "Add <ProductName /> to my TanStack Router app" | `/integrate-tanstack-router` |
+| "Add <ProductName /> to my Vue app" | `/integrate-vue` |
 | "Protect routes in my Express app" | `/integrate-express` |
-| "Add ThunderID to my Fastify / Hono app" | `/integrate-node` |
-| "Add ThunderID to my vanilla JS app" | `/integrate-browser` |
-| "Integrate ThunderID without a framework" | `/integrate-javascript` |
-| "Add ThunderID to my Angular / SvelteKit / Python / Go app" | `/integrate-oidc` |
+| "Add <ProductName /> to my Fastify / Hono app" | `/integrate-node` |
+| "Add <ProductName /> to my vanilla JS app" | `/integrate-browser` |
+| "Integrate <ProductName /> without a framework" | `/integrate-javascript` |
+| "Add <ProductName /> to my Angular / SvelteKit / Python / Go app" | `/integrate-oidc` |
 
 You can also invoke skills directly by name. In Claude Code, type `/integrate-nextjs`. In Codex, type `/integrate-nextjs` in a thread. Both assistants run the skill immediately without further prompting.
 
 {/* Screenshot placeholder: Split view showing the same "Add ThunderID to my Next.js app" prompt in Claude Code (left) and Codex (right), each running the integrate-nextjs skill */}
 
 :::tip Run Setup First
-If ThunderID is not running yet, ask your assistant to "set up ThunderID" before running an integration skill. The setup skill outputs the Sample App **Client ID** that the integration skills need to configure your application.
+If <ProductName /> is not running yet, ask your assistant to "set up <ProductName />" before running an integration skill. The setup skill outputs the Sample App **Client ID** that the integration skills need to configure your application.
 :::

--- a/docs/content/sdks/nuxt/apis/components/thunderid-root.mdx
+++ b/docs/content/sdks/nuxt/apis/components/thunderid-root.mdx
@@ -5,7 +5,7 @@ description: Root provider that mounts all authentication context providers
 
 # `<ThunderIDRoot />`
 
-The `ThunderIDRoot` component is the root provider for the ThunderID Nuxt SDK. It mounts the full provider tree — i18n, branding, theme, flow, user, and organization — and must wrap all content that uses ThunderID composables or components.
+The `ThunderIDRoot` component is the root provider for the <ProductName /> Nuxt SDK. It mounts the full provider tree — i18n, branding, theme, flow, user, and organization — and must wrap all content that uses <ProductName /> composables or components.
 
 ## Usage
 
@@ -55,5 +55,5 @@ On mount, `ThunderIDRoot`:
 ## Notes
 
 - `ThunderIDRoot` is auto-registered by the module and does not need to be explicitly imported.
-- It must be an ancestor of any component that uses a ThunderID composable or component.
+- It must be an ancestor of any component that uses a <ProductName /> composable or component.
 - When using Nuxt layouts, wrapping the `<slot />` in the default layout is sufficient.

--- a/docs/content/sdks/nuxt/apis/composables/use-thunderid.mdx
+++ b/docs/content/sdks/nuxt/apis/composables/use-thunderid.mdx
@@ -5,7 +5,7 @@ description: Access authentication state and trigger auth flows
 
 # `useThunderID()`
 
-The `useThunderID` composable provides access to the ThunderID authentication context in Nuxt applications. It exposes reactive auth state and SSR-safe methods for signing in, signing out, and signing up.
+The `useThunderID` composable provides access to the <ProductName /> authentication context in Nuxt applications. It exposes reactive auth state and SSR-safe methods for signing in, signing out, and signing up.
 
 This composable is auto-imported and available in every component, page, and composable without an explicit import.
 

--- a/docs/content/sdks/nuxt/apis/errors/thunderid-error.mdx
+++ b/docs/content/sdks/nuxt/apis/errors/thunderid-error.mdx
@@ -5,7 +5,7 @@ description: Structured error class thrown by the SDK
 
 # `ThunderIDError`
 
-`ThunderIDError` is the structured error class thrown by the ThunderID Nuxt SDK. It extends `Error` and carries a typed `ErrorCode`, an optional HTTP status code, an optional cause, and optional context metadata.
+`ThunderIDError` is the structured error class thrown by the <ProductName /> Nuxt SDK. It extends `Error` and carries a typed `ErrorCode`, an optional HTTP status code, an optional cause, and optional context metadata.
 
 ## Import
 

--- a/docs/content/sdks/nuxt/apis/server/get-thunderid-context.mdx
+++ b/docs/content/sdks/nuxt/apis/server/get-thunderid-context.mdx
@@ -5,7 +5,7 @@ description: Read the typed ThunderID context attached to an H3 event
 
 # `getThunderIDContext()`
 
-`getThunderIDContext` returns the ThunderID context object that the SDK's server plugin attaches to each H3 event during SSR. This gives synchronous access to the session and pre-fetched SSR data without an additional async call.
+`getThunderIDContext` returns the <ProductName /> context object that the SDK's server plugin attaches to each H3 event during SSR. This gives synchronous access to the session and pre-fetched SSR data without an additional async call.
 
 ## Signature
 

--- a/docs/content/sdks/nuxt/apis/server/require-server-session.mdx
+++ b/docs/content/sdks/nuxt/apis/server/require-server-session.mdx
@@ -5,7 +5,7 @@ description: Read the session or throw a 401 error
 
 # `requireServerSession()`
 
-`requireServerSession` reads the ThunderID session from the current H3 event and returns the decoded `ThunderIDSessionPayload`. If no valid session exists, it throws an H3 error with status code `401`.
+`requireServerSession` reads the <ProductName /> session from the current H3 event and returns the decoded `ThunderIDSessionPayload`. If no valid session exists, it throws an H3 error with status code `401`.
 
 ## Signature
 

--- a/docs/content/sdks/nuxt/apis/server/use-server-session.mdx
+++ b/docs/content/sdks/nuxt/apis/server/use-server-session.mdx
@@ -5,7 +5,7 @@ description: Read the session payload from the current request
 
 # `useServerSession()`
 
-`useServerSession` reads the ThunderID session from the current H3 event and returns the decoded `ThunderIDSessionPayload`, or `null` if no valid session exists.
+`useServerSession` reads the <ProductName /> session from the current H3 event and returns the decoded `ThunderIDSessionPayload`, or `null` if no valid session exists.
 
 ## Signature
 

--- a/docs/content/sdks/nuxt/overview.mdx
+++ b/docs/content/sdks/nuxt/overview.mdx
@@ -107,7 +107,7 @@ Server-only utilities imported from `@thunderid/nuxt/server` for use in API rout
 - **[`useServerSession()`](/docs/next/sdks/nuxt/apis/server/use-server-session)** — Read the session payload from the current request, or `null`
 - **[`requireServerSession()`](/docs/next/sdks/nuxt/apis/server/require-server-session)** — Read the session or throw a `401` error
 - **[`getValidAccessToken()`](/docs/next/sdks/nuxt/apis/server/get-valid-access-token)** — Get a valid access token, refreshing it automatically if expired
-- **[`getThunderIDContext()`](/docs/next/sdks/nuxt/apis/server/get-thunderid-context)** — Read the typed ThunderID context attached to an H3 event
+- **[`getThunderIDContext()`](/docs/next/sdks/nuxt/apis/server/get-thunderid-context)** — Read the typed <ProductName /> context attached to an H3 event
 
 ### Utilities
 

--- a/docs/content/sdks/react/apis/components/signed-in.mdx
+++ b/docs/content/sdks/react/apis/components/signed-in.mdx
@@ -5,7 +5,7 @@ description: Conditionally render content for authenticated users
 
 # `<SignedIn />`
 
-The `SignedIn` component conditionally renders its children only when the user is authenticated with ThunderID.
+The `SignedIn` component conditionally renders its children only when the user is authenticated with <ProductName />.
 It checks the current authentication state and displays protected UI content for signed-in users, while rendering optional `fallback` content (or nothing by default) when the user is not authenticated.
 This makes it ideal for guarding routes or UI sections that require authentication.
 

--- a/docs/content/sdks/react/apis/components/signed-out.mdx
+++ b/docs/content/sdks/react/apis/components/signed-out.mdx
@@ -5,7 +5,7 @@ description: Conditionally render content for unauthenticated users
 
 # `<SignedOut />`
 
-The `SignedOut` component conditionally renders its children only when the user is not authenticated with ThunderID.
+The `SignedOut` component conditionally renders its children only when the user is not authenticated with <ProductName />.
 It checks the current authentication state and displays content for unauthenticated users, while rendering optional `fallback` content (or nothing by default) when the user is authenticated.
 This makes it ideal for showing sign-in prompts, public landing pages, or content that should only be visible to guests.
 

--- a/docs/content/sdks/react/apis/components/user.mdx
+++ b/docs/content/sdks/react/apis/components/user.mdx
@@ -5,7 +5,7 @@ description: Display user information
 
 # `<User />`
 
-The `User` component is a declarative way to access the authenticated user object from the ThunderID authentication context. It uses render props to expose the user data, making it easy to display user information or conditionally render UI based on authentication state.
+The `User` component is a declarative way to access the authenticated user object from the <ProductName /> authentication context. It uses render props to expose the user data, making it easy to display user information or conditionally render UI based on authentication state.
 
 ## Usage
 

--- a/docs/content/sdks/react/apis/contexts/thunderid-provider.mdx
+++ b/docs/content/sdks/react/apis/contexts/thunderid-provider.mdx
@@ -9,7 +9,7 @@ The `ThunderIDProvider` is the root context provider component that configures `
 
 ## Overview
 
-The `ThunderIDProvider` initializes the ThunderID authentication client, manages authentication state, and provides context to child components through React Context. It handles token management, user sessions, organization switching, and branding preferences automatically.
+The `ThunderIDProvider` initializes the <ProductName /> authentication client, manages authentication state, and provides context to child components through React Context. It handles token management, user sessions, organization switching, and branding preferences automatically.
 
 ## Usage
 

--- a/docs/content/sdks/react/apis/hooks/use-thunderid.mdx
+++ b/docs/content/sdks/react/apis/hooks/use-thunderid.mdx
@@ -5,7 +5,7 @@ description: Access the authentication context
 
 # `useThunderID()`
 
-The `useThunderID` hook provides access to the ThunderID authentication context in React applications. It allows you to retrieve authentication state, user information, and other context values managed by the `ThunderIDProvider`.
+The `useThunderID` hook provides access to the <ProductName /> authentication context in React applications. It allows you to retrieve authentication state, user information, and other context values managed by the `ThunderIDProvider`.
 
 ## Usage
 

--- a/docs/content/sdks/vue/apis/composables/use-thunderid.mdx
+++ b/docs/content/sdks/vue/apis/composables/use-thunderid.mdx
@@ -41,7 +41,7 @@ This composable must be used inside a component rendered within `<ThunderIDProvi
 
 ## Return Values
 
-The composable returns the full ThunderID context:
+The composable returns the full <ProductName /> context:
 
 | Property | Type | Description |
 | :--- | :--- | :--- |

--- a/docs/content/sdks/vue/apis/providers/thunderid-provider.mdx
+++ b/docs/content/sdks/vue/apis/providers/thunderid-provider.mdx
@@ -9,7 +9,7 @@ The `ThunderIDProvider` is the root provider component that configures `@thunder
 
 ## Overview
 
-The `ThunderIDProvider` initializes the ThunderID authentication client, manages authentication state, and provides context to descendant components through Vue's `provide`/`inject` API. It handles token management, user sessions, organization switching, and branding preferences automatically.
+The `ThunderIDProvider` initializes the <ProductName /> authentication client, manages authentication state, and provides context to descendant components through Vue's `provide`/`inject` API. It handles token management, user sessions, organization switching, and branding preferences automatically.
 
 ## Usage
 

--- a/docs/content/use-cases/ai-agents/overview.mdx
+++ b/docs/content/use-cases/ai-agents/overview.mdx
@@ -28,7 +28,7 @@ In this model:
 
 - Each agent is a first-class identity with its own credentials and assigned permissions.
 - Callers authenticate before invoking protected agent capabilities.
-- ThunderID issues tokens that represent the agent, the user, or both depending on the flow.
+- <ProductName /> issues tokens that represent the agent, the user, or both depending on the flow.
 - Services validate tokens, check scopes, and enforce audience restrictions.
 - Delegated and multi-agent flows preserve actor context so downstream services can audit who initiated each action.
 

--- a/docs/content/use-cases/ai-agents/solution-patterns.mdx
+++ b/docs/content/use-cases/ai-agents/solution-patterns.mdx
@@ -73,7 +73,7 @@ A resource server in <ProductName /> groups related capabilities into a protecte
 
 Audience locking is the primary defense against token replay. When the parent agent in a chain exchanges its token, it specifies a target resource indicator, and <ProductName /> binds the new token to that target. If the child agent tries to use the token against a different service, the service rejects it.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Lets you group related capabilities into resource servers.
 - Lets each resource server define scopes for individual capabilities or capability groups.
@@ -86,7 +86,7 @@ Scopes describe what the bearer of the token may do. The right granularity depen
 
 For agents, scope granularity also shapes downscoping during multi-agent delegation. A parent that holds a coarse `analytics:*` scope can downscope to `analytics:read` for a child; a parent that only holds `analytics:read` cannot widen to `analytics:write` no matter what it does.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports fine-grained scopes when you need per-endpoint control.
 - Supports capability-level scopes for a simpler and more readable permission model.
@@ -97,7 +97,7 @@ For agents, scope granularity also shapes downscoping during multi-agent delegat
 
 When multiple agents participate in a single request, every hop should be visible to the final service. The token carries the original user as subject, and each agent in the chain as a successive actor. The final service can inspect this chain to attribute the action and enforce policies based on how the request arrived — for example, "only allow this if a human user initiated the chain."
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Issues tokens with a subject claim for the originating user when user context exists.
 - Preserves the actor chain across agent-to-agent delegation.
@@ -108,7 +108,7 @@ When multiple agents participate in a single request, every hop should be visibl
 
 Each agent has its own Client ID and Client Secret. These credentials need a lifecycle: issuance at registration, rotation on a schedule, and revocation when the agent is decommissioned or compromised. Because each agent is a distinct identity, revoking one agent's credentials does not affect any other agent's operation.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Generates agent credentials during registration.
 - Supports credential rotation on a schedule or on demand.

--- a/docs/content/use-cases/b2b/multi-tenant-saas.mdx
+++ b/docs/content/use-cases/b2b/multi-tenant-saas.mdx
@@ -28,7 +28,7 @@ Build B2B SaaS identity where each customer gets its own secure workspace, polic
 
 ## B2B SaaS Identity Journey
 
-From a B2B application owner perspective, you need to solve the full customer lifecycle, from sign-up to secure sign-in, security, governance, and growth reporting. ThunderID provides capabilities for each stage.
+From a B2B application owner perspective, you need to solve the full customer lifecycle, from sign-up to secure sign-in, security, governance, and growth reporting. <ProductName /> provides capabilities for each stage.
 
 <B2BSaaSIdentityJourneyRoadmap />
 
@@ -40,7 +40,7 @@ Beyond creating accounts, you often need to integrate sign-up with business oper
 
 For example, a user signs up with Google or GitHub on behalf of a company and provides an organization workspace name. During sign-up, you collect payment details for a free trial so you can charge usage when the trial ends. Billing credential validation happens before completion. After successful sign-up, you publish a sign-up event to Salesforce and Pardot to synchronize customer data for growth tracking and marketing.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports multiple sign-up options:
   - Email and password
@@ -57,7 +57,7 @@ As the next step, you want each customer organization to collaborate safely insi
 
 For example, an admin invites a teammate by email, the teammate accepts the invitation, completes user registration, and joins the correct workspace.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports organization-scoped member invitations by email.
 - Manages invitation lifecycle operations such as resend and expiry.
@@ -70,7 +70,7 @@ As customer organizations grow, you need identity operations that evolve from ba
 
 For example, a customer starts with direct user onboarding and later enables Microsoft Entra ID federation with just-in-time (JIT) provisioning or account linking.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports direct organization user onboarding.
 - Supports bring-your-own-identity-provider (BYOIdP) integration through OIDC.
@@ -86,9 +86,9 @@ When users lose access, you need a recovery journey that restores access quickly
 
 For example, a user who cannot remember credentials completes account recovery by using email OTP.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
-ThunderID supports multiple recovery options:
+<ProductName /> supports multiple recovery options:
 
 - Email magic links
 - Email OTP
@@ -102,7 +102,7 @@ As your business introduces paid plans, you need authorization and entitlement c
 
 For example, when a workspace upgrades from a free plan to a premium plan, users gain access to additional features and administrative capabilities.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports grouping APIs and granting API access to organization workspaces with policy-based controls.
 - Supports role-based access control (RBAC) for workspace users.
@@ -116,7 +116,7 @@ As your customer base scales, you want organizations to manage day-to-day admini
 
 For example, a customer assigns a workspace admin to manage user access while platform-level controls remain with your central team.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports fine-grained delegated administration with organization-scoped roles and permission controls.
 - Lets organization admins assign administrative roles and manage routine identity operations within workspace boundaries.
@@ -128,7 +128,7 @@ As a B2B product owner, you want identity journeys to match both your platform b
 
 For example, one customer sets a custom logo and color theme for workspace sign-in screens.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports branding customization for registration, sign-in, and recovery pages at workspace scope.
 - Supports configurable elements such as logos, colors, and themes while preserving global experience standards.
@@ -140,7 +140,7 @@ As your customer portfolio diversifies, you need flexibility for both global sig
 
 For example, one organization allows only enterprise single sign-on (SSO), while another allows email and social sign-in.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports global sign-in flows.
 - Supports organization-aware sign-in controls.
@@ -152,7 +152,7 @@ Before sign-in, you need reliable organization discovery so users land in the co
 
 For example, a user enters a work email address and your platform routes the user to the correct organization workspace.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports discovery by organization identifier.
 - Supports discovery by email domain mapping.
@@ -165,7 +165,7 @@ As a B2B application owner, you need identity journeys that align with privacy r
 
 For example, a customer requires explicit user consent before optional profile data processing.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports privacy and consent capabilities for regulation-aware identity flows in multi-tenant environments.
 - Lets you design consent steps that align with policy expectations and keep enforcement consistent across workspaces.
@@ -178,9 +178,9 @@ To operate a B2B SaaS platform, you need continuous visibility into usage, risk,
 
 For example, platform admins review failed sign-in trends and deactivate a workspace after repeated suspicious activity.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
-ThunderID supports monitoring dashboards with key indicators such as:
+<ProductName /> supports monitoring dashboards with key indicators such as:
 
 - Monthly active users
 - Inactive users
@@ -191,7 +191,7 @@ ThunderID supports monitoring dashboards with key indicators such as:
 
 These insights support operational planning, risk detection, and growth analysis.
 
-ThunderID also supports governance workflows such as viewing workspace metadata, monitoring workspace activity indicators, and deactivating workspaces when intervention is required. Service provider organizations can view workspace-level breakdowns, and workspace admins can view insights for their own organization workspace.
+<ProductName /> also supports governance workflows such as viewing workspace metadata, monitoring workspace activity indicators, and deactivating workspaces when intervention is required. Service provider organizations can view workspace-level breakdowns, and workspace admins can view insights for their own organization workspace.
 
 ### Troubleshooting
 
@@ -199,7 +199,7 @@ When a customer reports an access issue, you need fast diagnostics at workspace 
 
 For example, support engineers inspect workspace logs to diagnose repeated sign-in failures after an identity provider change.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
 - Supports organization-level logging and diagnostics for authentication and access investigation.
 - Helps teams confirm misconfigurations, identify failure points, and validate corrective actions.
@@ -210,6 +210,6 @@ This support reduces mean time to resolution and improves customer outcomes.
 
 As AI adoption grows, you may want to improve customer experience with AI agents in B2B SaaS use cases. Managing AI agent identity and lifecycle securely becomes an important requirement.
 
-#### How ThunderID Helps
+#### How <ProductName /> Helps
 
-ThunderID will soon support capabilities to help you secure B2B AI agents.
+<ProductName /> will soon support capabilities to help you secure B2B AI agents.

--- a/docs/content/use-cases/b2c/architecture-decisions.mdx
+++ b/docs/content/use-cases/b2c/architecture-decisions.mdx
@@ -11,11 +11,11 @@ Building a B2C application requires identity architecture that supports the comp
 
 Four decisions shape the architecture:
 
-- **Integration pattern:** where identity screens live and how your application and ThunderID divide responsibility.
+- **Integration pattern:** where identity screens live and how your application and <ProductName /> divide responsibility.
 - **Identity sources:** where customer identities come from and which system owns the canonical record.
 - **Tokens and APIs:** how sessions, tokens, permissions, and API validation work after sign-in.
 - **Run and observe:** how your team deploys, monitors, audits, and connects the identity system.
 
-Start with the integration pattern because it defines the boundary between your application and ThunderID. Review the supporting decisions as your application needs more control over identity data, API protection, deployment, or operations.
+Start with the integration pattern because it defines the boundary between your application and <ProductName />. Review the supporting decisions as your application needs more control over identity data, API protection, deployment, or operations.
 
 <B2CArchitectureDecisions prioritizeIntegration />

--- a/docs/content/use-cases/b2c/index.mdx
+++ b/docs/content/use-cases/b2c/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 # B2C Identity Overview
 
-ThunderID provides the identity layer for customer-facing applications, so your product can focus on the customer experience while ThunderID handles sign-up, sign-in, recovery, profile management, and consent.
+<ProductName /> provides the identity layer for customer-facing applications, so your product can focus on the customer experience while <ProductName /> handles sign-up, sign-in, recovery, profile management, and consent.
 
 If you want the supporting design choices first, start with [Architecture Decisions](./architecture-decisions).
 
@@ -31,11 +31,11 @@ This pattern is a good fit when you need to:
 
 ## How the Model Works
 
-In this pattern, ThunderID acts as the identity provider for your customer-facing application.
+In this pattern, <ProductName /> acts as the identity provider for your customer-facing application.
 
 - **End users** own their accounts, sign themselves up, sign in, recover access, and manage their own profile.
 - **Your application** is the web or mobile product the consumer signs into.
-- **ThunderID** runs sign-in, sign-up, recovery, consent, and profile journeys, then issues tokens to the application.
+- **<ProductName />** runs sign-in, sign-up, recovery, consent, and profile journeys, then issues tokens to the application.
 - **External identity providers** such as Google, GitHub, or enterprise identity providers can be added as sign-in options.
 - **Internal teams** such as support agents and administrators are onboarded separately by invitation or direct account creation.
 
@@ -51,8 +51,8 @@ Once you know which B2C identity building blocks apply, review the architecture 
 
 In this step, you can decide:
 
-- Whether to use ThunderID-hosted screens with a redirect-based flow.
-- Whether to render app-native screens while ThunderID controls the identity journey.
+- Whether to use <ProductName />-hosted screens with a redirect-based flow.
+- Whether to render app-native screens while <ProductName /> controls the identity journey.
 - Whether to call direct APIs for a more custom implementation.
 - Which systems own customer identities.
 - How your APIs validate tokens and enforce access.

--- a/docs/content/use-cases/b2c/integration-patterns.mdx
+++ b/docs/content/use-cases/b2c/integration-patterns.mdx
@@ -18,32 +18,32 @@ You can choose the best fit for your application by answering these questions:
 
 ### Redirect-Based
 
-When a user wants to sign in, the app sends them to ThunderID. ThunderID shows the sign-in, sign-up, and recovery screens, then sends the user back signed in. Because the app never sees the user's password, this is the simplest security posture and the quickest path to a working sign-in.
+When a user wants to sign in, the app sends them to <ProductName />. <ProductName /> shows the sign-in, sign-up, and recovery screens, then sends the user back signed in. Because the app never sees the user's password, this is the simplest security posture and the quickest path to a working sign-in.
 
 The pattern covers sign-in, sign-up, recovery, additional-permission requests with consent screens, hosted-page branding, and signing the user out. It fits web apps, single-page apps, and mobile apps. The main trade-off is that the user has to leave the app for a hosted page. This can feel disruptive inside a native mobile app or a heavily branded web experience, and UI customization is limited to what the hosted pages expose.
 
-This pattern is typically built with a standard sign-in library or an SDK provided by ThunderID. The underlying handshake is well-specified and not worth hand-rolling.
+This pattern is typically built with a standard sign-in library or an SDK provided by <ProductName />. The underlying handshake is well-specified and not worth hand-rolling.
 
 ### App-Native
 
-The app renders every screen itself, but the journey lives on ThunderID. This gives the app full control over what the user sees while keeping step ordering, branching, and policy on the server. The pattern is the best fit for native mobile and any all-in-the-app experience.
+The app renders every screen itself, but the journey lives on <ProductName />. This gives the app full control over what the user sees while keeping step ordering, branching, and policy on the server. The pattern is the best fit for native mobile and any all-in-the-app experience.
 
 The full set of journeys is covered with custom UI: sign-in, sign-up, recovery, profile changes that need re-verification, and invitation acceptance. The pattern handles multi-step prompts, multi-factor authentication, and steps that change based on the user or context. Branding is handled entirely in the app.
 
 App-native has two flavors that trade UI granularity for app-side code:
 
-- **Step-by-step (verbose flow):** the app sees every step the journey defines. After each step, it calls ThunderID for the next step's details, renders the screen the server describes, captures the user's input, and posts it back.
-- **Managed (non-verbose flow):** ThunderID orchestrates the journey internally and only exposes outcomes to the app. The app says "the user wants to sign in" and reacts to whatever the product hands back. The app still decides how to render each screen and capture input.
+- **Step-by-step (verbose flow):** the app sees every step the journey defines. After each step, it calls <ProductName /> for the next step's details, renders the screen the server describes, captures the user's input, and posts it back.
+- **Managed (non-verbose flow):** <ProductName /> orchestrates the journey internally and only exposes outcomes to the app. The app says "the user wants to sign in" and reacts to whatever the product hands back. The app still decides how to render each screen and capture input.
 
-This pattern is typically built using a ThunderID SDK. The SDK handles the per-step (step-by-step) or per-outcome (managed) calls and state so the app can focus on UI.
+This pattern is typically built using a <ProductName /> SDK. The SDK handles the per-step (step-by-step) or per-outcome (managed) calls and state so the app can focus on UI.
 
 ### Direct API
 
 Small, single-purpose API calls — for example, authenticate with username and password, or send an OTP and verify it. The app strings these together itself, with no journey between the app and the primitive.
 
-This pattern fits two situations well. First, applications that want the simplest possible sign-in with no application or flow configuration on the ThunderID side. Second, headless or scripted scenarios where a guided journey is not useful, such as server-to-server authentication, internal tools, and automation.
+This pattern fits two situations well. First, applications that want the simplest possible sign-in with no application or flow configuration on the <ProductName /> side. Second, headless or scripted scenarios where a guided journey is not useful, such as server-to-server authentication, internal tools, and automation.
 
-Coverage is typically limited to the primitives ThunderID exposes, often authentication only. Because there is no journey, journey-level policies such as multi-factor and conditional steps are not applied; the app is fully responsible for getting the identity logic right.
+Coverage is typically limited to the primitives <ProductName /> exposes, often authentication only. Because there is no journey, journey-level policies such as multi-factor and conditional steps are not applied; the app is fully responsible for getting the identity logic right.
 
 This pattern is built by calling the APIs directly; an SDK adds little here.
 

--- a/docs/content/use-cases/b2c/overview.mdx
+++ b/docs/content/use-cases/b2c/overview.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 # B2C Identity Overview
 
-ThunderID provides the identity layer for customer-facing applications, so your product can focus on the customer experience while ThunderID handles sign-up, sign-in, recovery, profile management, and consent.
+<ProductName /> provides the identity layer for customer-facing applications, so your product can focus on the customer experience while <ProductName /> handles sign-up, sign-in, recovery, profile management, and consent.
 
 ## When to Choose This Pattern
 
@@ -29,11 +29,11 @@ This pattern is a good fit when you need to:
 
 ## How the Model Works
 
-In this pattern, ThunderID acts as the identity provider for your customer-facing application.
+In this pattern, <ProductName /> acts as the identity provider for your customer-facing application.
 
 - **End users** own their accounts, sign themselves up, sign in, recover access, and manage their own profile.
 - **Your application** is the web or mobile product the consumer signs into.
-- **ThunderID** runs sign-in, sign-up, recovery, consent, and profile journeys, then issues tokens to the application.
+- **<ProductName />** runs sign-in, sign-up, recovery, consent, and profile journeys, then issues tokens to the application.
 - **External identity providers** such as Google, GitHub, or enterprise identity providers can be added as sign-in options.
 - **Internal teams** such as support agents and administrators are onboarded separately by invitation or direct account creation.
 
@@ -49,8 +49,8 @@ Once you know which B2C identity building blocks apply, the next step is to choo
 
 In this step, you can decide:
 
-- Whether to use ThunderID-hosted screens with a redirect-based flow.
-- Whether to render app-native screens while ThunderID controls the identity journey.
+- Whether to use <ProductName />-hosted screens with a redirect-based flow.
+- Whether to render app-native screens while <ProductName /> controls the identity journey.
 - Whether to call direct APIs for a more custom implementation.
 - Which supporting patterns you need for federation, user stores, API protection, and downstream system integration.
 

--- a/docs/content/use-cases/b2c/tokens-and-apis.mdx
+++ b/docs/content/use-cases/b2c/tokens-and-apis.mdx
@@ -16,7 +16,7 @@ Once a user signs in, the application holds a token or session that represents t
 Three patterns cover most consumer scenarios:
 
 - **Stateless tokens:** short-lived access tokens backed by longer refresh tokens, with no server-side session record. Scales easily because no lookup is needed to validate a token. Revocation is best-effort and waits for the token to expire.
-- **Server-backed sessions:** every refresh and session is backed by a server-side record ThunderID can revoke instantly, which gives you true sign-out-everywhere.
+- **Server-backed sessions:** every refresh and session is backed by a server-side record <ProductName /> can revoke instantly, which gives you true sign-out-everywhere.
 - **Sliding-expiry sessions:** sessions extend on each use, so returning users rarely have to sign in again, in return for longer-lived credentials.
 
 Many consumer apps combine the second and third into a long, sliding, revocable session.
@@ -35,9 +35,9 @@ The choice shapes other concerns. A revocable session is needed for sign-out-eve
 
 ## Protect APIs the App Calls
 
-Sign-in is one half of identity; the other is protecting the APIs your app calls after sign-in. ThunderID issues tokens during sign-in, and the same tokens carry the user's permissions to your APIs. The API does not have to know who the user is; it only needs to validate the token and check the permissions inside.
+Sign-in is one half of identity; the other is protecting the APIs your app calls after sign-in. <ProductName /> issues tokens during sign-in, and the same tokens carry the user's permissions to your APIs. The API does not have to know who the user is; it only needs to validate the token and check the permissions inside.
 
-Validation typically happens at the API edge, in a gateway or middleware that verifies JWT signatures or calls ThunderID's introspection endpoint. Permissions are expressed as scopes (what the app may do) and audiences (which API the token is valid for). Grouping related APIs into a resource server lets multiple endpoints share one set of permission rules instead of each endpoint enforcing them ad-hoc.
+Validation typically happens at the API edge, in a gateway or middleware that verifies JWT signatures or calls <ProductName />'s introspection endpoint. Permissions are expressed as scopes (what the app may do) and audiences (which API the token is valid for). Grouping related APIs into a resource server lets multiple endpoints share one set of permission rules instead of each endpoint enforcing them ad-hoc.
 
 **Capabilities:**
 

--- a/docs/content/use-cases/b2c/try-it-out/index.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/index.mdx
@@ -17,7 +17,7 @@ These sample users appear throughout the walkthroughs, each mapped to a specific
 
 ## Architecture
 
-The Wayfinder sample application has three main parts: a consumer web app, a booking API, and ThunderID as the identity provider.
+The Wayfinder sample application has three main parts: a consumer web app, a booking API, and <ProductName /> as the identity provider.
 The following diagram shows how these pieces connect and where the identity flows run in the system.
 
 <WayfinderArchitecture />


### PR DESCRIPTION
### Purpose
Fix missing product name template in docs

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product terminology across guides and use-case docs to consistently use `<ProductName />` instead of the previous name.
  * Clarified quickstart and integration instructions for web, mobile, and framework-specific setup flows.
  * Refreshed AI, B2C, and B2B documentation wording to match current branding and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->