### PR TITLE
Fix wayfinder declarative resources

### DIFF
--- a/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
@@ -1196,7 +1196,7 @@ nodes:
           components:
             - id: consent_input
               ref: consent_decisions
-              type: CONSENT
+              type: CONSENT_INPUT
               required: true
             - type: ACTION
               id: consent_action_deny
@@ -1212,7 +1212,7 @@ nodes:
       - inputs:
           - ref: consent_input
             identifier: consent_decisions
-            type: CONSENT
+            type: CONSENT_INPUT
             required: true
         action:
           ref: consent_action_allow
@@ -1220,7 +1220,7 @@ nodes:
       - inputs:
           - ref: consent_input
             identifier: consent_decisions
-            type: CONSENT
+            type: CONSENT_INPUT
             required: true
         action:
           ref: consent_action_deny
@@ -1401,7 +1401,7 @@ nodes:
           components:
             - id: consent_input
               ref: consent_decisions
-              type: CONSENT
+              type: CONSENT_INPUT
               required: true
             - type: ACTION
               id: consent_action_deny
@@ -1417,7 +1417,7 @@ nodes:
       - inputs:
           - ref: consent_input
             identifier: consent_decisions
-            type: CONSENT
+            type: CONSENT_INPUT
             required: true
         action:
           ref: consent_action_allow
@@ -1425,7 +1425,7 @@ nodes:
       - inputs:
           - ref: consent_input
             identifier: consent_decisions
-            type: CONSENT
+            type: CONSENT_INPUT
             required: true
         action:
           ref: consent_action_deny
@@ -1847,3 +1847,11 @@ attributes:
   displayName: Alex Carter
 credentials:
   password: "{{.ALEX_CARTER_PASSWORD}}"
+
+---
+# resource_type: server_config
+# Allows the Wayfinder web app's browser origin to call the server
+name: cors
+value:
+  allowedOrigins:
+    - "http://localhost:5173"

--- a/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
@@ -1057,7 +1057,7 @@ nodes:
           components:
             - id: consent_input
               ref: consent_decisions
-              type: CONSENT
+              type: CONSENT_INPUT
               required: true
             - type: ACTION
               id: consent_action_deny
@@ -1073,7 +1073,7 @@ nodes:
       - inputs:
           - ref: consent_input
             identifier: consent_decisions
-            type: CONSENT
+            type: CONSENT_INPUT
             required: true
         action:
           ref: consent_action_allow
@@ -1081,7 +1081,7 @@ nodes:
       - inputs:
           - ref: consent_input
             identifier: consent_decisions
-            type: CONSENT
+            type: CONSENT_INPUT
             required: true
         action:
           ref: consent_action_deny
@@ -1262,7 +1262,7 @@ nodes:
           components:
             - id: consent_input
               ref: consent_decisions
-              type: CONSENT
+              type: CONSENT_INPUT
               required: true
             - type: ACTION
               id: consent_action_deny
@@ -1278,7 +1278,7 @@ nodes:
       - inputs:
           - ref: consent_input
             identifier: consent_decisions
-            type: CONSENT
+            type: CONSENT_INPUT
             required: true
         action:
           ref: consent_action_allow
@@ -1286,7 +1286,7 @@ nodes:
       - inputs:
           - ref: consent_input
             identifier: consent_decisions
-            type: CONSENT
+            type: CONSENT_INPUT
             required: true
         action:
           ref: consent_action_deny
@@ -1813,3 +1813,10 @@ inboundAuthConfig:
       pkceRequired: true
       publicClient: true
 
+---
+# resource_type: server_config
+# Allows the Wayfinder web app's browser origin to call the server
+name: cors
+value:
+  allowedOrigins:
+    - "http://localhost:5173"


### PR DESCRIPTION
### Purpose
This pull request updates the consent input type references and adds CORS configuration to the Wayfinder sample app YAML files fixing the declarative resource import issue.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3733

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the consent prompt in the Wayfinder CIBA email and SMS flows to use the newer consent input experience.
  * Added CORS support for the Wayfinder web app local development origin, improving browser-based connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->