### PR TITLE
Add e2e tests for console b2c try it out

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -488,6 +488,12 @@ jobs:
           name: sample-app-react-sdk
           path: target/dist/sample-app-react-sdk-*.zip
 
+      - name: 📦 Upload Built Wayfinder Sample App
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sample-app-wayfinder
+          path: target/dist/sample-app-wayfinder-*.zip
+
   test-integration:
     name: 🧪 Integration Tests (${{ matrix.database }})
     needs: [build, build_samples, detect-code-changes]
@@ -640,6 +646,12 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: sample-app-react-sdk
+          path: target/dist/
+
+      - name: 📥 Download Built Wayfinder Sample App
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sample-app-wayfinder
           path: target/dist/
 
       - name: 📂 Extract Server to E2E
@@ -939,6 +951,54 @@ jobs:
           
           echo "Sample App started successfully!"
 
+      - name: 🧳 Extract and Start Wayfinder Sample
+        run: |
+          echo "Extracting Wayfinder Sample..."
+          mkdir -p tests/e2e/wayfinder-sample
+
+          WAYFINDER_ZIP=$(find target/dist -name "sample-app-wayfinder-*.zip" | head -n 1)
+
+          if [ -z "$WAYFINDER_ZIP" ]; then
+            echo "⚠️  Warning: Wayfinder sample zip not found in target/dist"
+            ls -la target/dist/
+            exit 1
+          fi
+
+          echo "Found wayfinder sample: $WAYFINDER_ZIP"
+          unzip -q "$WAYFINDER_ZIP" -d tests/e2e/wayfinder-sample
+
+          cd tests/e2e/wayfinder-sample
+          EXTRACTED_DIR=$(find . -maxdepth 1 -type d -name "sample-app-wayfinder-*" | head -n 1)
+          if [ -n "$EXTRACTED_DIR" ]; then
+            mv "$EXTRACTED_DIR"/* .
+            rmdir "$EXTRACTED_DIR"
+          fi
+
+          echo "Installing wayfinder workspace dependencies..."
+          npm install --no-audit --no-fund
+
+          echo "Seeding backend SQLite database..."
+          npm --workspace backend run seed
+
+          echo "Starting Wayfinder Sample (backend + smtp + frontend + lounge)..."
+          npm run dev:b2c > wayfinder.log 2>&1 &
+
+          echo "Waiting for Wayfinder frontend on http://localhost:5173..."
+          for i in {1..60}; do
+            if curl -s http://localhost:5173 > /dev/null 2>&1; then
+              echo "Wayfinder frontend is UP!"
+              break
+            fi
+            echo "Still waiting ($i/60)..."
+            sleep 2
+          done
+
+          if ! curl -s http://localhost:5173 > /dev/null 2>&1; then
+            echo "Wayfinder frontend failed to start within 2 minutes"
+            cat wayfinder.log || true
+            exit 1
+          fi
+
       - name: 📦 Install E2E Dependencies
         run: pnpm install --frozen-lockfile
 
@@ -969,6 +1029,10 @@ jobs:
           MOCK_SMS_SERVER_PORT: ${{ vars.MOCK_SMS_SERVER_PORT || 8098 }}
           SAMPLE_APP_USERNAME: ${{ secrets.SAMPLE_APP_USERNAME || 'e2e-test-user' }}
           SAMPLE_APP_PASSWORD: ${{ secrets.SAMPLE_APP_PASSWORD || 'e2e-test-password' }}
+          # Wayfinder Sample (welcome try-it-out tests)
+          WAYFINDER_APP_URL: 'http://localhost:5173'
+          WAYFINDER_TEST_USERNAME: 'john.doe'
+          WAYFINDER_TEST_PASSWORD: 'john.doe'
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() }}

--- a/tests/e2e/.env.example
+++ b/tests/e2e/.env.example
@@ -11,6 +11,13 @@ SAMPLE_APP_ID=your_sample_app_id_here
 SAMPLE_APP_USERNAME=e2e-test-user
 SAMPLE_APP_PASSWORD=e2e-test-password
 
+# Wayfinder Sample Configuration (for console welcome try-it-out tests)
+# The wayfinder sample must be pre-started at WAYFINDER_APP_URL. When unset,
+# the welcome try-it-out tests are skipped.
+WAYFINDER_APP_URL=http://localhost:5173
+WAYFINDER_TEST_USERNAME=john.doe
+WAYFINDER_TEST_PASSWORD=john.doe
+
 # Test User Credentials
 TEST_USER_USERNAME=your_testuser_username_here
 TEST_USER_PASSWORD=your_testuser_password_here
@@ -18,5 +25,3 @@ TEST_USER_PASSWORD=your_testuser_password_here
 # Mock SMS Server Configuration (for MFA tests)
 # Port for the mock SMS server that captures OTP messages
 MOCK_SMS_SERVER_PORT=8098
-
-

--- a/tests/e2e/configs/routes/console-routes.ts
+++ b/tests/e2e/configs/routes/console-routes.ts
@@ -43,6 +43,12 @@ export const ConsoleRoutes = {
   /** Dashboard page */
   dashboard: "/console/dashboard",
 
+  /** Welcome landing page (shown on first login) */
+  welcome: "/console/welcome",
+
+  /** Welcome try-out: Secured Web Application flow */
+  welcomeTryoutApp: "/console/welcome/tryout/securing-application",
+
   /** Applications list page */
   applications: "/console/applications",
 

--- a/tests/e2e/fixtures/console/console-pom.fixture.ts
+++ b/tests/e2e/fixtures/console/console-pom.fixture.ts
@@ -30,6 +30,7 @@ import { ConsoleSigninPage } from "../../pages/authentication";
 import { UsersPage } from "../../pages/user-management";
 import { ApplicationsPage } from "../../pages/applications";
 import { SettingsPage } from "../../pages/settings";
+import { WelcomePage } from "../../pages/welcome";
 
 const baseUrl = process.env.BASE_URL || "";
 
@@ -38,6 +39,7 @@ type POMFixtures = {
   usersPage: UsersPage;
   applicationsPage: ApplicationsPage;
   settingsPage: SettingsPage;
+  welcomePage: WelcomePage;
 };
 
 export const test = base.extend<POMFixtures>({
@@ -60,6 +62,11 @@ export const test = base.extend<POMFixtures>({
   settingsPage: async ({ authenticatedPage }, use) => {
     await use(new SettingsPage(authenticatedPage, baseUrl));
   },
+
+  // Welcome page requires auth, uses authenticatedPage fixture
+  welcomePage: async ({ authenticatedPage }, use) => {
+    await use(new WelcomePage(authenticatedPage, baseUrl));
+  },
 });
 
 export { expect } from "@playwright/test";
@@ -67,3 +74,4 @@ export { ConsoleSigninPage } from "../../pages/authentication";
 export { UsersPage, type UserFormData } from "../../pages/user-management";
 export { ApplicationsPage, type ApplicationFormData } from "../../pages/applications";
 export { SettingsPage } from "../../pages/settings";
+export { WelcomePage } from "../../pages/welcome";

--- a/tests/e2e/fixtures/console/index.ts
+++ b/tests/e2e/fixtures/console/index.ts
@@ -42,3 +42,4 @@ export { ConsoleSigninPage } from "../../pages/authentication";
 export { UsersPage, type UserFormData } from "../../pages/user-management";
 export { ApplicationsPage, type ApplicationFormData } from "../../pages/applications";
 export { SettingsPage } from "../../pages/settings";
+export { WelcomePage } from "../../pages/welcome";

--- a/tests/e2e/pages/welcome/index.ts
+++ b/tests/e2e/pages/welcome/index.ts
@@ -16,8 +16,4 @@
  * under the License.
  */
 
-export { ConsoleSigninPage } from "./authentication";
-export { UsersPage, type UserFormData } from "./user-management";
-export { ApplicationsPage, type ApplicationFormData } from "./applications";
-export { SettingsPage } from "./settings";
-export { WelcomePage } from "./welcome";
+export { WelcomePage } from "./welcome.page";

--- a/tests/e2e/pages/welcome/welcome.page.ts
+++ b/tests/e2e/pages/welcome/welcome.page.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Page, Locator, expect, Download } from "@playwright/test";
+import { ConsoleRoutes } from "../../configs/routes/console-routes";
+import { BasePage } from "../base.page";
+import { Timeouts } from "../../constants/timeouts";
+
+const WAYFINDER_ASSET_PATTERN = /^sample-app-wayfinder-[0-9A-Za-z.+-]+\.zip$/i;
+
+export class WelcomePage extends BasePage {
+  readonly baseUrl: string;
+
+  // Welcome landing
+  readonly securedWebAppTile: Locator;
+
+  // Tryout page - sample setup
+  readonly sampleSetupHeader: Locator;
+  readonly downloadLink: Locator;
+  readonly importConfigButton: Locator;
+  readonly importSuccessMessage: Locator;
+  readonly importAlreadyDoneMessage: Locator;
+
+  // Tryout page - scenario tabs
+  readonly signInTab: Locator;
+  readonly signUpTab: Locator;
+
+  constructor(page: Page, baseUrl: string) {
+    super(page);
+    this.baseUrl = baseUrl;
+
+    this.securedWebAppTile = page.getByRole("button", { name: /Secured Web Application/i });
+
+    this.sampleSetupHeader = page.getByRole("button", { name: /Setup Wayfinder Sample/i });
+    this.downloadLink = page.getByRole("link", { name: /^Download$/ });
+    this.importConfigButton = page.getByRole("button", { name: /^Configure in\s+\S+/i });
+    this.importSuccessMessage = page.getByText(/Wayfinder sample configured in .* successfully/i);
+    this.importAlreadyDoneMessage = page.getByText(/Wayfinder sample already configured/i);
+
+    this.signInTab = page.getByRole("tab", { name: /^Sign-In$/i });
+    this.signUpTab = page.getByRole("tab", { name: /^Self Sign-Up$/i });
+  }
+
+  /**
+   * Navigate directly to the welcome landing page.
+   * Clears the dismissed-welcome flag so the page renders even after prior visits.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(`${this.baseUrl}${ConsoleRoutes.home}`, {
+      waitUntil: "domcontentloaded",
+      timeout: Timeouts.PAGE_LOAD,
+    });
+    await this.page.evaluate(() => {
+      const keys: string[] = [];
+      for (let i = 0; i < sessionStorage.length; i++) {
+        const k = sessionStorage.key(i);
+        if (
+          k &&
+          (k.endsWith(":welcome:dismissed") ||
+            k.endsWith(":wayfinder-config-imported") ||
+            k.endsWith(":wayfinder-setup-expanded"))
+        ) {
+          keys.push(k);
+        }
+      }
+      keys.forEach(k => sessionStorage.removeItem(k));
+    });
+    await this.page.goto(`${this.baseUrl}${ConsoleRoutes.welcome}`, {
+      waitUntil: "networkidle",
+      timeout: Timeouts.PAGE_LOAD,
+    });
+  }
+
+  async verifyWelcomeLoaded(): Promise<void> {
+    expect(this.page.url()).toContain(ConsoleRoutes.welcome);
+    await this.securedWebAppTile.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+  }
+
+  async clickSecuredWebAppTile(): Promise<void> {
+    await this.securedWebAppTile.first().click();
+    await this.page.waitForURL(new RegExp(`${ConsoleRoutes.welcomeTryoutApp}$`), { timeout: Timeouts.PAGE_LOAD });
+  }
+
+  async verifyTryoutPageLoaded(): Promise<void> {
+    expect(this.page.url()).toContain(ConsoleRoutes.welcomeTryoutApp);
+    await this.sampleSetupHeader.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+  }
+
+  /**
+   * Click the wayfinder sample download button and assert a download starts.
+   * Returns the suggested filename so the caller can verify it matches the expected pattern.
+   */
+  async triggerDownload(): Promise<Download> {
+    await this.downloadLink.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await expect(this.downloadLink.first()).toHaveAttribute("href", /sample-app-wayfinder-.+\.zip/i);
+
+    // The download button is an anchor with target="_blank". Playwright fires the
+    // download event on the browser context regardless of the target tab.
+    const [download] = await Promise.all([
+      this.page.context().waitForEvent("download", { timeout: 30000 }),
+      this.downloadLink.first().click(),
+    ]);
+    expect(download.suggestedFilename()).toMatch(WAYFINDER_ASSET_PATTERN);
+    return download;
+  }
+
+  /**
+   * Trigger the Configure/Import action for the wayfinder bundle and wait for success.
+   * Accepts either the "success" or "alreadyDone" terminal state.
+   */
+  async importWayfinderBundle(): Promise<void> {
+    // If a previous run left the bundle configured, the button is replaced with the alreadyDone state.
+    if (
+      await this.importAlreadyDoneMessage
+        .first()
+        .isVisible()
+        .catch(() => false)
+    ) {
+      return;
+    }
+    await this.importConfigButton.first().waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
+    await expect(this.importConfigButton.first()).toBeEnabled({ timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.importConfigButton.first().click();
+    await expect(this.importSuccessMessage.first().or(this.importAlreadyDoneMessage.first())).toBeVisible({
+      timeout: 30000,
+    });
+  }
+
+  async selectSignInTab(): Promise<void> {
+    await this.signInTab.first().click();
+  }
+
+  async selectSignUpTab(): Promise<void> {
+    await this.signUpTab.first().click();
+  }
+}

--- a/tests/e2e/tests/welcome/welcome-tryout.spec.ts
+++ b/tests/e2e/tests/welcome/welcome-tryout.spec.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Welcome Try-It-Out E2E Tests
+ *
+ * Exercises the console welcome guide for the "Secured Web Application" journey:
+ *   1. Welcome landing → Secured Web Application tile
+ *   2. Sample setup section → Download button triggers a real download
+ *   3. Configure/Import bundle into ThunderID
+ *   4. Try-out use cases: Sign-In and Self Sign-Up against a preconfigured wayfinder sample
+ *
+ * The wayfinder sample is expected to be pre-started. Tests are skipped if WAYFINDER_APP_URL is not provided.
+ *
+ * Required environment variables:
+ * - BASE_URL: Console base URL
+ * - WAYFINDER_APP_URL: Pre-started wayfinder sample URL (e.g. http://localhost:5173)
+ * - WAYFINDER_TEST_USERNAME: Seed user shipped with the wayfinder bundle (default: john.doe)
+ * - WAYFINDER_TEST_PASSWORD: Seed user password (default: john.doe)
+ * - SERVER_URL: ThunderID server URL for post-test user cleanup (default: https://localhost:8090)
+ * - ADMIN_USERNAME / ADMIN_PASSWORD: Admin creds used for cleanup
+ */
+
+import { test, expect } from "../../fixtures/console";
+import { SampleAppLoginPage } from "../../pages/sample-app";
+import { getAdminToken } from "../../utils/authentication";
+
+const wayfinderUrl = process.env.WAYFINDER_APP_URL || "http://localhost:5173";
+const seedUsername = process.env.WAYFINDER_TEST_USERNAME || "john.doe";
+const seedPassword = process.env.WAYFINDER_TEST_PASSWORD || "john.doe";
+const serverUrl = process.env.SERVER_URL || "https://localhost:8090";
+
+test.describe("Console Welcome — Try It Out (Secured Web Application)", () => {
+  const createdSignupUsernames: string[] = [];
+
+  test.afterAll(async ({ request }) => {
+    if (createdSignupUsernames.length === 0) return;
+    try {
+      const token = await getAdminToken(request);
+      for (const username of createdSignupUsernames) {
+        try {
+          const res = await request.get(`${serverUrl}/users?filter=username eq "${username}"`, {
+            headers: { Authorization: `Bearer ${token}` },
+            ignoreHTTPSErrors: true,
+          });
+          if (!res.ok()) continue;
+          const data = await res.json();
+          const userId = data?.users?.[0]?.id;
+          if (!userId) continue;
+          await request.delete(`${serverUrl}/users/${userId}`, {
+            headers: { Authorization: `Bearer ${token}` },
+            ignoreHTTPSErrors: true,
+          });
+          console.log(`Cleaned up signup test user: ${username} (${userId})`);
+        } catch (e) {
+          console.warn(`Failed to clean up ${username}:`, e);
+        }
+      }
+    } catch (e) {
+      console.warn("User cleanup skipped (admin token acquisition failed):", e);
+    }
+  });
+
+  /** TC001: Welcome → Try-out sample setup → Download works → Import succeeds → Sign-In tab renders */
+  test("TC001: Welcome guide loads and drives user through sample setup and sign-in tryout", async ({
+    welcomePage,
+    page,
+  }) => {
+    await test.step("Open welcome landing", async () => {
+      await welcomePage.goto();
+      await welcomePage.verifyWelcomeLoaded();
+      await welcomePage.screenshot("welcome-tc001-landing");
+    });
+
+    await test.step("Open Secured Web Application try-out", async () => {
+      await welcomePage.clickSecuredWebAppTile();
+      await welcomePage.verifyTryoutPageLoaded();
+      await welcomePage.screenshot("welcome-tc001-tryout-open");
+    });
+
+    await test.step("Download button triggers a wayfinder sample download", async () => {
+      const download = await welcomePage.triggerDownload();
+      console.log("Download suggested filename:", download.suggestedFilename());
+      // Cancel so we don't persist the multi-MB zip.
+      await download.cancel().catch(() => {});
+    });
+
+    await test.step("Configure wayfinder bundle in ThunderID", async () => {
+      await welcomePage.importWayfinderBundle();
+      await welcomePage.screenshot("welcome-tc001-imported");
+    });
+
+    await test.step("Sign-In tryout — perform login against preconfigured wayfinder sample", async () => {
+      await welcomePage.selectSignInTab();
+      const sampleAppLoginPage = new SampleAppLoginPage(page);
+      await sampleAppLoginPage.goto(wayfinderUrl);
+      await sampleAppLoginPage.verifyHomePageLoaded();
+      await sampleAppLoginPage.clickSignInButton();
+      await sampleAppLoginPage.verifyLoginPageLoaded();
+      await sampleAppLoginPage.login(seedUsername, seedPassword);
+      await sampleAppLoginPage.verifyLoggedIn();
+    });
+  });
+
+  /** TC002: Self Sign-Up tryout — register a new user via the wayfinder sample gate */
+  test("TC002: Self Sign-Up tryout — register new user via the wayfinder sample", async ({ welcomePage, page }) => {
+    const timestamp = Date.now();
+    const signupUsername = `welcome-signup-${timestamp}`;
+    const signupPassword = "SignupTest@123";
+    const signupEmail = `${signupUsername}@example.com`;
+
+    await test.step("Ensure wayfinder bundle is configured", async () => {
+      await welcomePage.goto();
+      await welcomePage.clickSecuredWebAppTile();
+      await welcomePage.verifyTryoutPageLoaded();
+      await welcomePage.importWayfinderBundle();
+    });
+
+    await test.step("Open Self Sign-Up tryout tab", async () => {
+      await welcomePage.selectSignUpTab();
+      await welcomePage.screenshot("welcome-tc002-signup-tab");
+    });
+
+    await test.step("Register new user through wayfinder sample gate", async () => {
+      const sampleAppLoginPage = new SampleAppLoginPage(page);
+      await sampleAppLoginPage.goto(wayfinderUrl);
+      await sampleAppLoginPage.verifyHomePageLoaded();
+      await sampleAppLoginPage.clickSignInButton();
+      await sampleAppLoginPage.verifyLoginPageLoaded();
+
+      const signUpLink = page
+        .locator('a:has-text("Sign Up"), a:has-text("sign up"), button:has-text("Sign Up"), button:has-text("Sign up")')
+        .first();
+      await expect(signUpLink).toBeVisible({ timeout: 10000 });
+      await signUpLink.click();
+
+      await page.locator('input[name="username"]').first().fill(signupUsername);
+      await page.locator('input[name="password"]').first().fill(signupPassword);
+
+      const continueButton = page
+        .locator('button[type="submit"]:has-text("Continue"), button:has-text("Continue")')
+        .first();
+      await continueButton.click();
+
+      await expect(page.locator('input[name="email"]').first()).toBeVisible({ timeout: 10000 });
+      await page.locator('input[name="email"]').first().fill(signupEmail);
+      await page.locator('input[name="given_name"]').first().fill("Welcome");
+      await page.locator('input[name="family_name"]').first().fill("Signup");
+
+      const submitButton = page
+        .locator(
+          'button[type="submit"]:has-text("Sign Up"), button[type="submit"]:has-text("Sign up"), button[type="submit"]:has-text("Submit")'
+        )
+        .first();
+      await submitButton.click();
+
+      // Successful signup should land the user in the authenticated wayfinder shell.
+      const avatarOrLogout = page.locator('button[aria-haspopup="true"], button:has(div[class*="MuiAvatar"])').first();
+      await avatarOrLogout.waitFor({ state: "visible", timeout: 30000 });
+
+      createdSignupUsernames.push(signupUsername);
+      await new SampleAppLoginPage(page).screenshot("welcome-tc002-signed-up");
+    });
+  });
+});


### PR DESCRIPTION
### Purpose
This pull request adds end-to-end (E2E) test coverage for the Console Welcome "Try It Out" experience, specifically for the "Secured Web Application" journey and its integration with the Wayfinder sample application. The changes include new page objects, test specs, and supporting configuration and routing updates to enable automated testing of the welcome flow, sample download, bundle import, and try-out scenarios (sign-in and self sign-up).

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for the Console Welcome “Try It Out” flow, including downloading a sample bundle, importing/configuring it, and continuing into secured sign-in and self sign-up experiences.
  * Extended the E2E environment sample with Wayfinder app URL and test credentials for welcome try-it-out testing.

* **Tests**
  * Introduced a Playwright E2E suite for the secured web application welcome journey, with automatic cleanup of accounts created during self sign-up.

* **Chores**
  * Updated the E2E pipeline to package, run, and start the Wayfinder sample app as part of the Playwright run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->