### PR TITLE
Document the OAuth 2.0 token revocation endpoint in the API spec

### DIFF
--- a/api/oauth2.yaml
+++ b/api/oauth2.yaml
@@ -23,6 +23,8 @@ tags:
     description: OAuth 2.0 token endpoint for issuing access tokens, refresh tokens, and ID tokens.
   - name: Introspection
     description: Token introspection per RFC 7662.
+  - name: Revocation
+    description: Token revocation per RFC 7009.
   - name: PAR
     description: Pushed Authorization Requests per RFC 9126.
   - name: JWKS
@@ -323,6 +325,51 @@ paths:
                 $ref: '#/components/schemas/OAuthError'
         "401":
           description: Unauthorized — client authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthError'
+
+  /oauth2/revoke:
+    post:
+      summary: Token revocation endpoint
+      description: |
+        Revokes a previously issued access or refresh token. On success the server responds with
+        HTTP 200 and an empty body. A token that cannot be validated — bad signature, malformed, or
+        unknown — is treated as a successful no-op per RFC 7009. Expired tokens with a valid
+        signature remain revocable. Requires client authentication; a client may only revoke tokens
+        issued to it. Implements RFC 7009.
+      tags:
+        - Revocation
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RevokeRequest'
+            example:
+              token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+      responses:
+        "200":
+          description: Token revoked, or a no-op success for a token that cannot be validated. Empty body.
+        "400":
+          description: >-
+            Bad Request — the token parameter is missing (`invalid_request`), or the token was
+            issued to a different client (`invalid_grant`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthError'
+        "401":
+          description: Unauthorized — client authentication failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthError'
+        "500":
+          description: >-
+            Internal server error — the revocation could not be recorded, for example when the
+            operation database is unavailable.
           content:
             application/json:
               schema:
@@ -656,6 +703,21 @@ components:
         token_type_hint:
           type: string
           description: Hint about the type of the submitted token.
+
+    RevokeRequest:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          description: The access or refresh token to revoke.
+        token_type_hint:
+          type: string
+          description: >-
+            Hint about the type of the submitted token (`access_token` or `refresh_token`). Accepted
+            per RFC 7009 §2.1 but optional; ThunderID tokens are self-describing, so the hint does not
+            affect processing.
 
     IntrospectResponse:
       type: object


### PR DESCRIPTION
### Purpose
The RFC 7009 token revocation endpoint (`POST /oauth2/revoke`) shipped in #3727 but was never documented in the OpenAPI spec (`api/oauth2.yaml`), which only described `/oauth2/introspect`. This adds the missing endpoint definition so the spec matches the implementation.

### Approach
Mirrored the existing conventions in `api/oauth2.yaml` (modeled on `/oauth2/introspect`):
- Added a `Revocation` tag (`Token revocation per RFC 7009`).
- Added the `POST /oauth2/revoke` path with responses that match the handler exactly:
  - `200` (empty body) — success, or a no-op success for a token that cannot be validated (bad signature / malformed / unknown). Expired-but-validly-signed tokens are genuinely revocable, per the signature-only verification in the service.
  - `400` — missing `token` (`invalid_request`) or token issued to a different client (`invalid_grant`).
  - `401` — client authentication failed (`invalid_client`).
  - `500` — revocation could not be recorded (e.g. operation DB unavailable).
- Added a `RevokeRequest` schema documenting `token` and `token_type_hint` (accepted per RFC 7009 §2.1 but not acted on, since ThunderID tokens are self-describing).

No behavior change — documentation only.

### Related Issues
- N/A

### Related PRs
- #3727 (introduced the revocation endpoint)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. (YAML validated; responses cross-checked against the handler.)
- [x] Documentation provided. (This PR is the API spec documentation.)
- [ ] Tests provided. (N/A — OpenAPI spec change only.)
- [ ] Breaking changes. (None.)

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for token revocation in the OAuth2 API.
  * Introduced a new revocation endpoint for access and refresh tokens.
  * Added request fields for the token and an optional token type hint.

* **Bug Fixes**
  * Invalid or unverifiable tokens are now handled as successful no-ops, matching expected OAuth2 behavior.
  * Documented clear response codes for missing, invalid, unauthorized, and server error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->