### PR TITLE
Improvements to display MagicLink Authenticator in Assurance list

### DIFF
--- a/backend/internal/flow/executor/utils.go
+++ b/backend/internal/flow/executor/utils.go
@@ -40,6 +40,7 @@ func getAuthnServiceName(executorName string) string {
 		ExecutorNameOIDCAuth:        authncm.AuthenticatorOIDC,
 		ExecutorNameGitHubAuth:      authncm.AuthenticatorGithub,
 		ExecutorNameGoogleAuth:      authncm.AuthenticatorGoogle,
+		ExecutorNameMagicLink:       authncm.AuthenticatorMagicLink,
 	}
 	return executorToAuthnServiceMap[executorName]
 }

--- a/backend/internal/flow/executor/utils_test.go
+++ b/backend/internal/flow/executor/utils_test.go
@@ -51,6 +51,7 @@ func (s *UtilsTestSuite) TestGetAuthnServiceName() {
 		{"OIDC Auth executor", ExecutorNameOIDCAuth, authncm.AuthenticatorOIDC},
 		{"GitHub Auth executor", ExecutorNameGitHubAuth, authncm.AuthenticatorGithub},
 		{"Google Auth executor", ExecutorNameGoogleAuth, authncm.AuthenticatorGoogle},
+		{"MagicLink executor", ExecutorNameMagicLink, authncm.AuthenticatorMagicLink},
 		{"Unknown executor returns empty string", "UnknownExecutor", ""},
 		{"Provisioning executor returns empty string", ExecutorNameProvisioning, ""},
 		{"AuthAssert executor returns empty string", ExecutorNameAuthAssert, ""},


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
fixes https://github.com/thunder-id/thunderid/issues/3013
Magiclink authenticator wasn't getting added to the list of authenticators.
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->
Added a missing conversion line in a utility function.
### Related Issues
- https://github.com/thunder-id/thunderid/issues/3013

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling for magic link flows by correctly routing executor requests to the matching authenticator service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->