### PR TITLE
Route http.Server connection errors through the system logger

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -212,6 +212,7 @@ func createHTTPServer(ctx context.Context, logger *log.Logger, cfg *config.Confi
 		ReadHeaderTimeout: 10 * time.Second, // Mitigate Slowloris attacks
 		WriteTimeout:      10 * time.Second,
 		IdleTimeout:       120 * time.Second,
+		ErrorLog:          log.NewServerErrorLog(logger),
 	}
 
 	return server

--- a/backend/internal/system/log/log.go
+++ b/backend/internal/system/log/log.go
@@ -22,6 +22,7 @@ package log
 import (
 	"context"
 	"errors"
+	stdlog "log"
 	"log/slog"
 	"os"
 	"strings"
@@ -181,6 +182,27 @@ func (l *Logger) Error(ctx context.Context, msg string, fields ...Field) {
 func (l *Logger) Fatal(ctx context.Context, msg string, fields ...Field) {
 	l.internal.ErrorContext(ctx, msg, convertFields(fields)...)
 	os.Exit(1)
+}
+
+// serverErrorWriter adapts the standard library logger output used by
+// http.Server.ErrorLog into the framework logger. Connection-level errors
+// such as TLS handshake failures are emitted at WARN level so they are
+// routed through the structured logger instead of being written raw to stderr.
+type serverErrorWriter struct {
+	logger *Logger
+}
+
+// Write forwards each http.Server error line to the framework logger at WARN level.
+func (w *serverErrorWriter) Write(p []byte) (int, error) {
+	w.logger.Warn(context.Background(), strings.TrimSpace(string(p)))
+	return len(p), nil
+}
+
+// NewServerErrorLog returns a standard library *log.Logger suitable for
+// http.Server.ErrorLog that routes server connection errors (e.g. TLS
+// handshake errors) through the framework logger at WARN level.
+func NewServerErrorLog(logger *Logger) *stdlog.Logger {
+	return stdlog.New(&serverErrorWriter{logger: logger}, "", 0)
 }
 
 // parseLogLevel parses the log level string and returns the corresponding slog.Level.

--- a/backend/internal/system/log/log_test.go
+++ b/backend/internal/system/log/log_test.go
@@ -394,6 +394,54 @@ func (suite *LogTestSuite) TestGetLoggerUsesContextHandler() {
 	assert.True(suite.T(), ok, "GetLogger should wrap the handler with contextHandler")
 }
 
+func (suite *LogTestSuite) TestServerErrorWriterWrite() {
+	var buf bytes.Buffer
+	log := newContextTestLogger(&buf)
+	w := &serverErrorWriter{logger: log}
+
+	input := []byte("http: TLS handshake error from 127.0.0.1:56960: remote error: tls: unknown certificate\n")
+	n, err := w.Write(input)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), len(input), n)
+
+	output := buf.String()
+	assert.Contains(suite.T(), output, "level=WARN")
+	assert.Contains(suite.T(), output, "http: TLS handshake error from 127.0.0.1:56960")
+	// The trailing newline should be trimmed from the logged message.
+	assert.NotContains(suite.T(), output, "certificate\\n")
+}
+
+func (suite *LogTestSuite) TestServerErrorWriterRespectsLevel() {
+	var buf bytes.Buffer
+	log := newContextTestLogger(&buf)
+	log.levelVar = new(slog.LevelVar)
+	log.levelVar.Set(slog.LevelError)
+	log.internal = slog.New(&contextHandler{Handler: slog.NewTextHandler(&buf,
+		&slog.HandlerOptions{Level: log.levelVar})})
+	w := &serverErrorWriter{logger: log}
+
+	_, err := w.Write([]byte("some server error"))
+
+	assert.NoError(suite.T(), err)
+	// WARN is below the ERROR threshold, so nothing should be emitted.
+	assert.Empty(suite.T(), buf.String())
+}
+
+func (suite *LogTestSuite) TestNewServerErrorLog() {
+	var buf bytes.Buffer
+	log := newContextTestLogger(&buf)
+
+	errorLog := NewServerErrorLog(log)
+	assert.NotNil(suite.T(), errorLog)
+
+	errorLog.Print("connection reset by peer")
+
+	output := buf.String()
+	assert.Contains(suite.T(), output, "level=WARN")
+	assert.Contains(suite.T(), output, "connection reset by peer")
+}
+
 func (suite *LogTestSuite) TestConvertFields() {
 	fields := []Field{
 		{Key: "string", Value: "value"},


### PR DESCRIPTION
### Purpose
`http.Server` connection-level errors (for example `http: TLS handshake error from ...: remote error: tls: unknown certificate`) were being written raw to stderr by Go's default standard-library logger, bypassing the structured logging framework entirely. This meant they ignored the configured log level and formatting.

This PR routes those errors through the framework logger so they are emitted as structured log records at a dedicated level.

### Approach
- Added a `serverErrorWriter` (`io.Writer`) and a `NewServerErrorLog(logger)` constructor in `internal/system/log` that wraps a standard library `*log.Logger` and forwards each `http.Server` error line to the framework logger at **WARN** level. TLS handshake failures are client-side certificate rejections, so they are operationally interesting but not server faults — WARN keeps them visible without being treated as errors.
- Set `ErrorLog: log.NewServerErrorLog(logger)` on the `http.Server` in `cmd/server/main.go`.

`context.Background()` is used in the writer because these errors occur below the HTTP handler layer, where no request context (and therefore no trace ID) is available.

### Related Issues
- Fixes thunder-id/thunderid#2124

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server-side connection and startup errors (such as TLS handshake failures) are now logged through the application’s logger, improving consistency with the rest of the system.
  * Server error output is cleaned up and formatted more clearly instead of going to the default server error stream.
* **Tests**
  * Added coverage to verify server error lines are translated into warning logs and that log-level filtering is respected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->