### PR TITLE
Fix insufficient permissions error during user creation

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.yaml
+++ b/backend/cmd/server/bootstrap/01-default-resources.yaml
@@ -943,7 +943,7 @@ nodes:
   type: TASK_EXECUTION
   properties:
     requiredScopes:
-    - system
+    - system:user
   executor:
     name: PermissionValidator
   onSuccess: user_type_resolver

--- a/backend/internal/flow/executor/permission_validator.go
+++ b/backend/internal/flow/executor/permission_validator.go
@@ -82,9 +82,10 @@ func (e *permissionValidator) Execute(ctx *providers.NodeContext) (*providers.Ex
 		log.Int("permissionCount", len(userPermissions)),
 		log.String("permissions", strings.Join(userPermissions, ", ")))
 
-	// Check if any of the required permissions are present
+	// Check if any of the required permissions are satisfied, using hierarchical
+	// scope matching (e.g. a "system" permission satisfies a "system:user" requirement).
 	if !slices.ContainsFunc(requiredScopes, func(reqScope string) bool {
-		return slices.Contains(userPermissions, reqScope)
+		return security.HasSufficientPermission(userPermissions, reqScope)
 	}) {
 		logger.Debug(ctx.Context, "Request lacks required scope",
 			log.Any("requiredScopes", requiredScopes))

--- a/backend/internal/flow/executor/permission_validator_test.go
+++ b/backend/internal/flow/executor/permission_validator_test.go
@@ -223,6 +223,78 @@ func (suite *PermissionValidatorTestSuite) TestExecute_AuthorizedPermissionsChec
 	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
 }
 
+func (suite *PermissionValidatorTestSuite) TestExecute_HierarchicalScopeCheck_Success() {
+	type testCase struct {
+		name           string
+		requiredScopes []interface{}
+		contextScopes  []string
+	}
+
+	testCases := []testCase{
+		{
+			name:           "Root scope satisfies a narrower required scope",
+			requiredScopes: []interface{}{"system:user"},
+			contextScopes:  []string{"system"},
+		},
+		{
+			name:           "Exact scoped permission still satisfies its own requirement",
+			requiredScopes: []interface{}{"system:user"},
+			contextScopes:  []string{"system:user"},
+		},
+		{
+			name:           "Parent scope satisfies a deeply nested required scope",
+			requiredScopes: []interface{}{"system:user:view"},
+			contextScopes:  []string{"system"},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.name, func(t *testing.T) {
+			httpCtx := context.Background()
+			authCtx := security.NewSecurityContextForTest(
+				"user1", "ou1", "token",
+				tc.contextScopes, nil,
+			)
+			httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
+
+			ctx := &providers.NodeContext{
+				ExecutionID: "test-flow",
+				Context:     httpCtx,
+				NodeProperties: map[string]interface{}{
+					propertyKeyRequiredScopes: tc.requiredScopes,
+				},
+			}
+
+			resp, err := suite.executor.Execute(ctx)
+
+			assert.NoError(t, err)
+			assert.Equal(t, providers.ExecComplete, resp.Status)
+		})
+	}
+}
+
+func (suite *PermissionValidatorTestSuite) TestExecute_HierarchicalScopeCheck_Failure() {
+	httpCtx := context.Background()
+	authCtx := security.NewSecurityContextForTest(
+		"user1", "ou1", "token",
+		[]string{"system:user"}, nil,
+	)
+	httpCtx = security.WithSecurityContextTest(httpCtx, authCtx)
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "test-flow",
+		Context:     httpCtx,
+		NodeProperties: map[string]interface{}{
+			propertyKeyRequiredScopes: []interface{}{"system"},
+		},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
+}
+
 func (suite *PermissionValidatorTestSuite) TestExecute_NoHTTPContext() {
 	ctx := &providers.NodeContext{
 		ExecutionID: "test-flow",


### PR DESCRIPTION
### Purpose
Resolves an issue where attempting to create a new user from the Console resulted in an "insufficient permissions" error when the logged-in admin only had the `system:user` scope.

### Approach
Updated the `01-default-resources.yaml` bootstrap file. The `permission_validator` task in the user onboarding flow was incorrectly requiring the full `system` scope. Changed `requiredScopes` to `system:user` since this is the intended granular permission needed for user creation. 

### Related Issues
- Fixes #3769 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the user onboarding flow permission validation to require the more specific `system:user` scope instead of the broader `system` scope.
  * Improved permission checking to support hierarchical scope matching, so broader permissions can satisfy narrower requirements when applicable.
* **Tests**
  * Added coverage for hierarchical scope permission validation, including both success and insufficient-permission failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->