### PR TITLE
Improve revocation convensions

### DIFF
--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -83,11 +83,7 @@ func Initialize(
 	if err != nil {
 		return err
 	}
-	// Wire the revocation feature: registers the RFC 7009 endpoint (write path) and returns the
-	// shared deny-list enforcement service (read path) — a single enforcement instance with a circuit breaker
-	// and fail-closed policy, injected across the hot path: refresh grant, token exchange, and
-	// introspection.
-	_, enforcementService := revocation.Initialize(
+	enforcementService := revocation.Initialize(
 		mux, jwtService, actorProvider, authnProvider, discoveryService, observabilitySvc)
 	grantHandlerProvider := granthandlers.Initialize(
 		jwtService, oauth2AuthzService, tokenBuilder, tokenValidator,

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -254,6 +254,7 @@ const (
 	ClaimCompletedAuthClass string = "completed_auth_class"
 	ClaimDPoPJkt            string = "dpop_jkt"
 	ClaimCIBAAuthReqID      string = "ciba_auth_req_id"
+	ClaimClientID           string = "client_id"
 )
 
 // OIDC subject types.

--- a/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
+++ b/backend/internal/oauth/oauth2/granthandlers/grant_handler.go
@@ -21,12 +21,8 @@ package granthandlers
 
 import (
 	"context"
-	"errors"
 
-	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
-	"github.com/thunder-id/thunderid/internal/oauth/oauth2/revocation"
-	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
@@ -39,32 +35,6 @@ type GrantHandlerInterface interface {
 	) *model.ErrorResponse
 	HandleGrant(ctx context.Context, tokenRequest *model.TokenRequest, oauthApp *providers.OAuthClient) (
 		*model.TokenResponseDTO, *model.ErrorResponse)
-}
-
-// enforceRevocation runs the single-token deny-list check for jti and maps the outcome to an OAuth
-// error response shared by the grant handlers. It returns nil when the token may proceed, revokedErr
-// (the caller's grant-specific error) when the token is on the deny list, and a fail-closed
-// server_error when the deny list cannot be consulted.
-func enforceRevocation(
-	ctx context.Context,
-	enforcementService revocation.EnforcementServiceInterface,
-	jti string,
-	revokedErr *model.ErrorResponse,
-	logger *log.Logger,
-) *model.ErrorResponse {
-	switch err := enforcementService.EnsureNotRevoked(ctx, jti); {
-	case err == nil:
-		return nil
-	case errors.Is(err, revocation.ErrTokenRevoked):
-		return revokedErr
-	default:
-		logger.Error(ctx, "Token revocation status could not be verified; failing closed",
-			log.Error(err))
-		return &model.ErrorResponse{
-			Error:            constants.ErrorServerError,
-			ErrorDescription: "Token revocation status could not be verified",
-		}
-	}
 }
 
 // RefreshTokenGrantHandlerInterface defines the interface for handling refresh token grants.

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -124,13 +124,11 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 
 	// Reject refresh tokens that have been revoked (RFC 7009 deny list). Fail closed when the
 	// operation DB cannot be consulted.
-	revokedErr := &model.ErrorResponse{
-		Error:            constants.ErrorInvalidGrant,
-		ErrorDescription: "Invalid refresh token",
-	}
-	if errResp := enforceRevocation(
-		ctx, h.enforcementService, refreshTokenClaims.JTI, revokedErr, logger,
-	); errResp != nil {
+	if errResp := enforceRevocation(ctx, h.enforcementService, refreshTokenClaims.JTI,
+		&model.ErrorResponse{
+			Error:            constants.ErrorInvalidGrant,
+			ErrorDescription: "Invalid refresh token",
+		}, logger); errResp != nil {
 		return nil, errResp
 	}
 

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -156,13 +156,11 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	}
 
 	// Reject a revoked subject token (RFC 7009 deny list). JTI is set only for self-issued tokens.
-	subjectRevoked := &model.ErrorResponse{
-		Error:            constants.ErrorInvalidRequest,
-		ErrorDescription: "Invalid subject_token",
-	}
-	if errResp := enforceRevocation(
-		ctx, h.enforcementService, subjectClaims.JTI, subjectRevoked, logger,
-	); errResp != nil {
+	if errResp := enforceRevocation(ctx, h.enforcementService, subjectClaims.JTI,
+		&model.ErrorResponse{
+			Error:            constants.ErrorInvalidRequest,
+			ErrorDescription: "Invalid subject_token",
+		}, logger); errResp != nil {
 		return nil, errResp
 	}
 
@@ -177,13 +175,11 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 				ErrorDescription: "Invalid actor_token",
 			}
 		}
-		actorRevoked := &model.ErrorResponse{
-			Error:            constants.ErrorInvalidRequest,
-			ErrorDescription: "Invalid actor_token",
-		}
-		if errResp := enforceRevocation(
-			ctx, h.enforcementService, actorClaims.JTI, actorRevoked, logger,
-		); errResp != nil {
+		if errResp := enforceRevocation(ctx, h.enforcementService, actorClaims.JTI,
+			&model.ErrorResponse{
+				Error:            constants.ErrorInvalidRequest,
+				ErrorDescription: "Invalid actor_token",
+			}, logger); errResp != nil {
 			return nil, errResp
 		}
 	}

--- a/backend/internal/oauth/oauth2/granthandlers/utils.go
+++ b/backend/internal/oauth/oauth2/granthandlers/utils.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package granthandlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/revocation"
+	"github.com/thunder-id/thunderid/internal/system/log"
+)
+
+// enforceRevocation runs the single-token deny-list check for jti and maps the outcome to an OAuth
+// error response shared by the grant handlers. It returns nil when the token may proceed, revokedErr
+// (the caller's grant-specific error) when the token is on the deny list, and a fail-closed
+// server_error when the deny list cannot be consulted.
+func enforceRevocation(
+	ctx context.Context,
+	enforcementService revocation.EnforcementServiceInterface,
+	jti string,
+	revokedErr *model.ErrorResponse,
+	logger *log.Logger,
+) *model.ErrorResponse {
+	switch err := enforcementService.EnsureNotRevoked(ctx, jti); {
+	case err == nil:
+		return nil
+	case errors.Is(err, revocation.ErrTokenRevoked):
+		return revokedErr
+	default:
+		logger.Error(ctx, "Token revocation status could not be verified", log.Error(err))
+		return &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Token revocation status could not be verified",
+		}
+	}
+}

--- a/backend/internal/oauth/oauth2/introspect/service.go
+++ b/backend/internal/oauth/oauth2/introspect/service.go
@@ -86,8 +86,7 @@ func (s *tokenIntrospectionService) IntrospectToken(
 				Active: false,
 			}, nil
 		}
-		logger.Error(ctx, "Token revocation status could not be verified; failing closed",
-			log.Error(revErr))
+		logger.Error(ctx, "Token revocation status could not be verified", log.Error(revErr))
 		return nil, revErr
 	}
 

--- a/backend/internal/oauth/oauth2/revocation/enforcement_service.go
+++ b/backend/internal/oauth/oauth2/revocation/enforcement_service.go
@@ -20,20 +20,12 @@ package revocation
 
 import (
 	"context"
-	"errors"
 
 	syscontext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/observability/event"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
-
-// ErrTokenRevoked indicates the presented token's JTI is on the deny list.
-var ErrTokenRevoked = errors.New("token has been revoked")
-
-// ErrEnforcementUnavailable indicates the deny list could not be consulted (operation DB
-// unavailable or the circuit is open). Under the fail-closed policy callers MUST reject the token.
-var ErrEnforcementUnavailable = errors.New("token revocation enforcement is unavailable")
 
 // EnforcementServiceInterface enforces the single-token deny list on the AS hot path (introspection, refresh
 // grant, token exchange) under a fail-closed policy: when the deny list cannot be consulted, tokens
@@ -108,7 +100,7 @@ func (c *enforcementService) publishOperationDBUnavailableEvent(ctx context.Cont
 		event.ComponentAuthHandler,
 	).
 		WithStatus(providers.StatusFailure).
-		WithData("error", cause.Error())
+		WithData(event.DataKey.Error, cause.Error())
 
 	c.observabilitySvc.PublishEvent(ctx, evt)
 }

--- a/backend/internal/oauth/oauth2/revocation/error_constants.go
+++ b/backend/internal/oauth/oauth2/revocation/error_constants.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package revocation
+
+import "errors"
+
+// ErrTokenRevoked indicates the presented token's JTI is on the deny list.
+var ErrTokenRevoked = errors.New("token has been revoked")
+
+// ErrEnforcementUnavailable indicates the deny list could not be consulted (operation DB
+// unavailable or the circuit is open). Under the fail-closed policy callers MUST reject the token.
+var ErrEnforcementUnavailable = errors.New("token revocation enforcement is unavailable")

--- a/backend/internal/oauth/oauth2/revocation/init.go
+++ b/backend/internal/oauth/oauth2/revocation/init.go
@@ -34,8 +34,8 @@ import (
 )
 
 // Initialize wires the revocation feature: it constructs the shared enforcement service (read path)
-// and registers the RFC 7009 revocation endpoint (write path), returning both so the enforcement service can be
-// injected into the hot paths (refresh grant, token exchange, introspection).
+// and registers the RFC 7009 revocation endpoint (write path), returning the enforcement service so
+// it can be injected into the hot paths (refresh grant, token exchange, introspection).
 func Initialize(
 	mux *http.ServeMux,
 	jwtService jwt.JWTServiceInterface,
@@ -43,12 +43,12 @@ func Initialize(
 	authnProvider providers.AuthnProviderManager,
 	discoveryService discovery.DiscoveryServiceInterface,
 	observabilitySvc providers.ObservabilityProvider,
-) (RevocationServiceInterface, EnforcementServiceInterface) {
+) EnforcementServiceInterface {
 	enforcementService := newEnforcementService(observabilitySvc)
 	revocationService := newRevocationService(jwtService, newRevokedTokenStore(), observabilitySvc)
 	revocationHandler := newRevocationHandler(revocationService)
 	registerRoutes(mux, revocationHandler, actorProvider, authnProvider, jwtService, discoveryService)
-	return revocationService, enforcementService
+	return enforcementService
 }
 
 // registerRoutes registers the routes for the token revocation endpoint.

--- a/backend/internal/oauth/oauth2/revocation/init_test.go
+++ b/backend/internal/oauth/oauth2/revocation/init_test.go
@@ -69,10 +69,8 @@ func (suite *InitTestSuite) TearDownTest() {
 func (suite *InitTestSuite) TestInitialize() {
 	mux := http.NewServeMux()
 
-	service, enforcementService := Initialize(mux, suite.mockJWTService, nil, nil, suite.mockDiscoveryService, nil)
+	enforcementService := Initialize(mux, suite.mockJWTService, nil, nil, suite.mockDiscoveryService, nil)
 
-	assert.NotNil(suite.T(), service)
-	assert.Implements(suite.T(), (*RevocationServiceInterface)(nil), service)
 	assert.NotNil(suite.T(), enforcementService)
 	assert.Implements(suite.T(), (*EnforcementServiceInterface)(nil), enforcementService)
 }

--- a/backend/internal/oauth/oauth2/revocation/model.go
+++ b/backend/internal/oauth/oauth2/revocation/model.go
@@ -20,6 +20,17 @@ package revocation
 
 import "time"
 
+// RevokeOutcome is the protocol-level result of a revocation request, mapped to HTTP by the handler.
+type RevokeOutcome int
+
+const (
+	// RevokeOutcomeRevoked indicates success — the token was revoked, or it was invalid/expired/unknown
+	// and treated as a no-op success per RFC 7009 §2.2. Maps to HTTP 200.
+	RevokeOutcomeRevoked RevokeOutcome = iota
+	// RevokeOutcomeNotOwned indicates the token was issued to a different client. Maps to 400 invalid_grant.
+	RevokeOutcomeNotOwned
+)
+
 // RevocationReason enumerates why a single token was revoked.
 type RevocationReason string
 

--- a/backend/internal/oauth/oauth2/revocation/service.go
+++ b/backend/internal/oauth/oauth2/revocation/service.go
@@ -31,17 +31,6 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
-// RevokeOutcome is the protocol-level result of a revocation request, mapped to HTTP by the handler.
-type RevokeOutcome int
-
-const (
-	// RevokeOutcomeRevoked indicates success — the token was revoked, or it was invalid/expired/unknown
-	// and treated as a no-op success per RFC 7009 §2.2. Maps to HTTP 200.
-	RevokeOutcomeRevoked RevokeOutcome = iota
-	// RevokeOutcomeNotOwned indicates the token was issued to a different client. Maps to 400 invalid_grant.
-	RevokeOutcomeNotOwned
-)
-
 // RevocationServiceInterface defines the OAuth2 token revocation service (RFC 7009).
 type RevocationServiceInterface interface {
 	// RevokeToken revokes the presented token on behalf of the authenticated client.
@@ -61,6 +50,7 @@ type revocationService struct {
 	jwtService       jwt.JWTServiceInterface
 	store            RevokedTokenStoreInterface
 	observabilitySvc providers.ObservabilityProvider
+	logger           *log.Logger
 }
 
 // newRevocationService creates a new revocationService (internal use).
@@ -73,6 +63,7 @@ func newRevocationService(
 		jwtService:       jwtService,
 		store:            store,
 		observabilitySvc: observabilitySvc,
+		logger:           log.GetLogger().With(log.String(log.LoggerKeyComponentName, "RevocationService")),
 	}
 }
 
@@ -85,34 +76,32 @@ func newRevocationService(
 func (s *revocationService) RevokeToken(
 	ctx context.Context, token, _, authenticatedClientID string,
 ) (RevokeOutcome, error) {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "RevocationService"))
-
 	// Signature-only verification: a token we did not issue (or a tampered one) must not pollute the
 	// deny list. Expiry is deliberately ignored so expired tokens remain revocable.
 	if err := s.jwtService.VerifyJWTSignature(ctx, token); err != nil {
-		logger.Debug(ctx, "Revocation request for a token that failed signature verification; "+
+		s.logger.Debug(ctx, "Revocation request for a token that failed signature verification; "+
 			"treating as a no-op success per RFC 7009")
 		return RevokeOutcomeRevoked, nil
 	}
 
 	_, payload, decodeErr := jwt.DecodeJWT(token)
 	if decodeErr != nil {
-		logger.Debug(ctx, "Revocation request for an undecodable token; treating as a no-op success")
+		s.logger.Debug(ctx, "Revocation request for an undecodable token; treating as a no-op success")
 		return RevokeOutcomeRevoked, nil
 	}
 
 	jti, _ := payload[constants.ClaimJTI].(string)
 	if jti == "" {
-		logger.Debug(ctx, "Revocation request for a token without a jti claim; nothing to revoke")
+		s.logger.Debug(ctx, "Revocation request for a token without a jti claim; nothing to revoke")
 		return RevokeOutcomeRevoked, nil
 	}
 
 	// Ownership enforcement: a client may only revoke tokens issued to it. ThunderID tokens carry the
 	// owning client in the client_id claim (no azp), so ownership is checked against client_id; a
 	// mismatch is rejected with invalid_grant per RFC 7009 §2.1.
-	tokenClientID, _ := payload["client_id"].(string)
+	tokenClientID, _ := payload[constants.ClaimClientID].(string)
 	if tokenClientID != "" && authenticatedClientID != "" && tokenClientID != authenticatedClientID {
-		logger.Debug(ctx, "Revocation request for a token belonging to a different client")
+		s.logger.Debug(ctx, "Revocation request for a token belonging to a different client")
 		return RevokeOutcomeNotOwned, nil
 	}
 
@@ -133,7 +122,7 @@ func (s *revocationService) RevokeToken(
 // extractExpiryTime returns the token's exp claim as a time, falling back to now when absent
 // (an absent/expired exp simply makes the deny-list row immediately cleanup-eligible).
 func extractExpiryTime(payload map[string]interface{}) time.Time {
-	if exp, ok := payload["exp"].(float64); ok {
+	if exp, ok := payload[constants.ClaimExp].(float64); ok {
 		return time.Unix(int64(exp), 0).UTC()
 	}
 	return time.Now().UTC()
@@ -153,7 +142,7 @@ func (s *revocationService) publishTokenRevokedEvent(ctx context.Context, client
 		WithStatus(providers.StatusSuccess).
 		WithData(event.DataKey.ClientID, clientID).
 		WithData(event.DataKey.JTI, jti).
-		WithData("revocation_reason", string(RevocationReasonExplicit))
+		WithData(event.DataKey.RevocationReason, string(RevocationReasonExplicit))
 
 	s.observabilitySvc.PublishEvent(ctx, evt)
 }

--- a/backend/internal/system/observability/event/datakeys.go
+++ b/backend/internal/system/observability/event/datakeys.go
@@ -47,9 +47,10 @@ var DataKey = struct {
 	FailedStep    string
 
 	// OAuth/Token Keys
-	Scope     string
-	GrantType string
-	JTI       string
+	Scope            string
+	GrantType        string
+	JTI              string
+	RevocationReason string
 
 	// Event Metadata Keys
 	Message     string
@@ -83,9 +84,10 @@ var DataKey = struct {
 	FailedStep:    "failed_step",
 
 	// OAuth/Token Keys
-	Scope:     "scope",
-	GrantType: "grant_type",
-	JTI:       "jti",
+	Scope:            "scope",
+	GrantType:        "grant_type",
+	JTI:              "jti",
+	RevocationReason: "revocation_reason",
 
 	// Event Metadata Keys
 	Message:     "message",


### PR DESCRIPTION
### Purpose
Follow-up to the merged RFC 7009 token revocation PR (#3727), applying the convention improvements. No behavior change — internal cleanup only.

### Approach
- **Reuse claim constants instead of magic strings** — `client_id` and `exp` now use `constants.ClaimClientID` (added) and `constants.ClaimExp`; `jti` already used its constant.
- **Logger as a struct field** — `revocationService` builds its logger once in the constructor and reuses it, instead of re-initializing it inside `RevokeToken`.
- **File layout** — moved the `RevokeOutcome` type to `model.go`, the enforcement sentinel errors to a new `error_constants.go`, and the shared `enforceRevocation` helper out of `grant_handler.go` into a new `utils.go`.
- **Minimize exported surface** — `revocation.Initialize` no longer returns the revocation service (only the enforcement service is consumed by callers); removed the now-redundant wiring comment at the call site.
- **Minor** — inlined the grant-specific error responses into the `enforceRevocation` calls (per review), and trimmed the `"failing closed"` suffix from the revocation-check error log in both the grant path and introspection.

Deferred to a separate PR: unexporting `RevokedTokenStoreInterface` / `RevocationServiceInterface` / `RevokeOutcome` / `RevocationReason`, since those flow through mocked signatures and require a `make mockery` regeneration pass.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3804

### Related PRs
- #3727 (introduced token revocation; source of these review comments)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. (`make lint_backend` -> 0 issues; `go test` for revocation/granthandlers/introspect all pass; full `go build ./...` OK.)
- [ ] Documentation provided. (N/A — internal refactor.)
- [x] Tests provided. (Existing package tests updated and passing; no new behavior.)
- [ ] Breaking changes. (None.)

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer, more consistent token revocation outcomes across refresh, token exchange, and introspection flows.

* **Bug Fixes**
  * Improved fail-closed behavior when revocation status can’t be verified.
  * Enhanced revocation checks to recognize client IDs in token claims.
  * Standardized revoked-token error responses and made related revocation logging more consistent.

* **Chores**
  * Updated revocation observability event payloads to include the revocation reason consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->