### PR TITLE
Bind authentication assertion to auth request ID

### DIFF
--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -191,14 +191,13 @@ const (
 	RuntimeKeyAllowedLoginOptions = "allowed_login_options"
 	// RuntimeKeyAllowRegistrationWithExistingUser indicates whether registration is allowed with an existing user
 	RuntimeKeyAllowRegistrationWithExistingUser = "allowRegistrationWithExistingUser"
-	// RuntimeKeyAuthReqID holds the auth request ID bound to the current flow execution, if applicable.
-	RuntimeKeyAuthReqID = "authReqId"
 	// RuntimeKeyBindingMessage holds the human-readable binding message displayed to the user
 	// on both the consumption device and the authentication device to correlate the CIBA request.
 	RuntimeKeyBindingMessage = "bindingMessage"
 	// RuntimeKeyEntityState holds the entity existence state set by the IdentifyingExecutor in check_state mode.
 	RuntimeKeyEntityState = "entityState"
-	// RuntimeKeyAuthorizationRequestID holds the identifier of the authorization request.
+	// RuntimeKeyAuthorizationRequestID holds the auth request identifier bound to the current flow
+	// execution (the OAuth authorize authId or the CIBA auth_req_id), if applicable.
 	RuntimeKeyAuthorizationRequestID = "authorizationRequestId"
 )
 

--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -171,10 +171,10 @@ func (a *authAssertExecutor) generateAuthAssertion(
 		jwtClaims[oauth2const.ClaimCompletedAuthClass] = completedACR
 	}
 
-	// Bind the assertion to the originating CIBA request when present, so the CIBA callback can
-	// verify that this assertion authorizes the specific auth_req_id it accompanies.
-	if cibaAuthReqID, exists := ctx.RuntimeData[common.RuntimeKeyAuthReqID]; exists && cibaAuthReqID != "" {
-		jwtClaims[oauth2const.ClaimCIBAAuthReqID] = cibaAuthReqID
+	// Bind the assertion to the originating auth request so the corresponding callback can verify this assertion
+	// authorizes the specific request it accompanies.
+	if authReqID, exists := ctx.RuntimeData[common.RuntimeKeyAuthorizationRequestID]; exists && authReqID != "" {
+		jwtClaims[oauth2const.ClaimAuthorizationRequestID] = authReqID
 	}
 
 	requiredAttributes := a.getRequiredUserAttributes(ctx)

--- a/backend/internal/flow/executor/invite_executor.go
+++ b/backend/internal/flow/executor/invite_executor.go
@@ -181,7 +181,7 @@ func (e *inviteExecutor) generateInviteLink(ctx *providers.NodeContext, inviteTo
 	if ctx.EntityID != "" {
 		queryParams.Set(oauth2const.AppID, ctx.EntityID)
 	}
-	if authReqID, ok := ctx.RuntimeData[common.RuntimeKeyAuthReqID]; ok && authReqID != "" {
+	if authReqID, ok := ctx.RuntimeData[common.RuntimeKeyAuthorizationRequestID]; ok && authReqID != "" {
 		queryParams.Set(oauth2const.RequestParamAuthReqID, authReqID)
 	}
 

--- a/backend/internal/flow/executor/invite_executor_test.go
+++ b/backend/internal/flow/executor/invite_executor_test.go
@@ -325,7 +325,7 @@ func (suite *InviteExecutorTestSuite) TestExecute_GenerateMode_IncludesAuthReqID
 		ExecutorMode: ExecutorModeGenerate,
 		UserInputs:   make(map[string]string),
 		RuntimeData: map[string]string{
-			common.RuntimeKeyAuthReqID: "ciba-req-123",
+			common.RuntimeKeyAuthorizationRequestID: "ciba-req-123",
 		},
 	}
 

--- a/backend/internal/oauth/oauth2/authz/error_constants.go
+++ b/backend/internal/oauth/oauth2/authz/error_constants.go
@@ -29,3 +29,7 @@ var errAuthorizationCodeAlreadyConsumed = errors.New("authorization code already
 
 // errAuthRequestNotFound is returned when an authorization request context is not found in the store.
 var errAuthRequestNotFound = errors.New("authorization request context not found")
+
+// errAssertionClaimInvalid is returned when a claim in the flow assertion has an unexpected shape
+// (e.g. wrong JSON type). It distinguishes client-facing input errors from genuine internal decode failures.
+var errAssertionClaimInvalid = errors.New("assertion claim is invalid")

--- a/backend/internal/oauth/oauth2/authz/model.go
+++ b/backend/internal/oauth/oauth2/authz/model.go
@@ -83,8 +83,9 @@ type AuthorizationError struct {
 
 // assertionClaims represents the claims extracted from the flow assertion JWT.
 type assertionClaims struct {
-	userID                string
-	authorizedPermissions string
-	attributeCacheID      string
-	completedACR          string
+	userID                 string
+	authorizedPermissions  string
+	attributeCacheID       string
+	completedACR           string
+	authorizationRequestID string
 }

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -449,6 +449,17 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 		// Decode user attributes from the assertion.
 		claims, authTime, err := decodeAttributesFromAssertion(assertion)
 		if err != nil {
+			if errors.Is(err, errAssertionClaimInvalid) {
+				as.logger.Debug(ctx, "Assertion contains a malformed claim", log.Error(err))
+				authErr = &AuthorizationError{
+					Code:              oauth2const.ErrorInvalidRequest,
+					Message:           "Assertion contains a malformed claim",
+					SendErrorToClient: true,
+					ClientRedirectURI: authRequestCtx.OAuthParameters.RedirectURI,
+					State:             authRequestCtx.OAuthParameters.State,
+				}
+				return err
+			}
 			authErr = &AuthorizationError{
 				Code:              oauth2const.ErrorServerError,
 				Message:           "Failed to process authorization request",
@@ -457,6 +468,19 @@ func (as *authorizeService) HandleAuthorizationCallback(ctx context.Context, aut
 				State:             authRequestCtx.OAuthParameters.State,
 			}
 			return err
+		}
+
+		// Bind the assertion to the specific authorization request
+		if claims.authorizationRequestID == "" || claims.authorizationRequestID != authID {
+			as.logger.Debug(ctx, "Assertion is not bound to the authorization request")
+			authErr = &AuthorizationError{
+				Code:              oauth2const.ErrorAccessDenied,
+				Message:           "Assertion does not match the authorization request",
+				SendErrorToClient: true,
+				ClientRedirectURI: authRequestCtx.OAuthParameters.RedirectURI,
+				State:             authRequestCtx.OAuthParameters.State,
+			}
+			return errors.New("assertion not bound to authorization request")
 		}
 
 		if claims.userID == "" {
@@ -607,8 +631,17 @@ func decodeAttributesFromAssertion(assertion string) (assertionClaims, time.Time
 		completedACR:     base.CompletedACR,
 	}
 
-	if v, ok := payload["authorized_permissions"].(string); ok {
+	if v, ok := payload[oauth2const.ClaimAuthorizedPermissions].(string); ok {
 		claims.authorizedPermissions = v
+	}
+
+	if v, ok := payload[oauth2const.ClaimAuthorizationRequestID]; ok {
+		strValue, ok := v.(string)
+		if !ok {
+			return assertionClaims{}, time.Time{}, fmt.Errorf(
+				"%w: 'authorization_request_id' claim is not a string", errAssertionClaimInvalid)
+		}
+		claims.authorizationRequestID = strValue
 	}
 
 	return claims, base.AuthTime, nil

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -69,12 +69,28 @@ func (s *stubTransactioner) Transact(ctx context.Context, txFunc func(context.Co
 	return txFunc(ctx)
 }
 
-// JWT constants used in service tests.
+// JWT constants used in service tests. All happy-path assertions are bound to testAuthID via
+// the authorization_request_id claim so they pass the assertion<->authorization request binding check.
 const (
-	// Header: {"alg":"none","typ":"JWT"}   Payload: {"sub":"test-user","iat":1701421200}
-	svcJWTWithIat = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJpYXQiOjE3MDE0MjEyMDB9."
-	// Header: {"alg":"none","typ":"JWT"}   Payload: {"sub":"test-user"}
-	svcJWTMinimal = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ0ZXN0LXVzZXIifQ."
+	// Header: {"alg":"none","typ":"JWT"}
+	// Payload: {"sub":"test-user","iat":1701421200,"authorization_request_id":"test-auth-id"}
+	svcJWTWithIat = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." +
+		"eyJzdWIiOiJ0ZXN0LXVzZXIiLCJpYXQiOjE3MDE0MjEyMDAsImF1dGhvcml6YXRpb25fcmVxdWVzdF9pZCI6InRlc3QtYXV0aC1pZCJ9."
+	// Header: {"alg":"none","typ":"JWT"}
+	// Payload: {"sub":"test-user","authorization_request_id":"test-auth-id"}
+	svcJWTMinimal = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." +
+		"eyJzdWIiOiJ0ZXN0LXVzZXIiLCJhdXRob3JpemF0aW9uX3JlcXVlc3RfaWQiOiJ0ZXN0LWF1dGgtaWQifQ."
+	// Header: {"alg":"none","typ":"JWT"}
+	// Payload: {"sub":"test-user","iat":1701421200} — no authorization_request_id claim (unbound).
+	svcJWTUnbound = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJpYXQiOjE3MDE0MjEyMDB9."
+	// Header: {"alg":"none","typ":"JWT"}
+	// Payload: {"sub":"test-user","iat":1701421200,"authorization_request_id":"other-auth-id"}
+	svcJWTMismatched = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." +
+		"eyJzdWIiOiJ0ZXN0LXVzZXIiLCJpYXQiOjE3MDE0MjEyMDAsImF1dGhvcml6YXRpb25fcmVxdWVzdF9pZCI6Im90aGVyLWF1dGgtaWQifQ."
+	// Header: {"alg":"none","typ":"JWT"}
+	// Payload: {"sub":"test-user","iat":1701421200,"authorization_request_id":42}
+	svcJWTNonStringAuthReqID = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0." +
+		"eyJzdWIiOiJ0ZXN0LXVzZXIiLCJpYXQiOjE3MDE0MjEyMDAsImF1dGhvcml6YXRpb25fcmVxdWVzdF9pZCI6NDJ9."
 )
 
 type AuthorizeServiceTestSuite struct {
@@ -544,6 +560,78 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_FailedTo
 	assert.Equal(suite.T(), "https://client.example.com/callback", authErr.ClientRedirectURI)
 }
 
+func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_UnboundAssertion() {
+	// Assertion has no auth_req_id claim → binding check must reject it.
+	authCtx := authRequestContext{
+		OAuthParameters: oauth2model.OAuthParameters{
+			ClientID:    "test-client",
+			RedirectURI: "https://client.example.com/callback",
+			State:       "test-state",
+		},
+	}
+	suite.mockAuthReqStore.EXPECT().GetRequest(mock.Anything, testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(mock.Anything, testAuthID).Return(nil)
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, svcJWTUnbound, "", "").Return(nil)
+
+	svc := suite.newService()
+	redirectURI, authErr := svc.HandleAuthorizationCallback(context.Background(), testAuthID, svcJWTUnbound)
+
+	assert.Empty(suite.T(), redirectURI)
+	assert.NotNil(suite.T(), authErr)
+	assert.Equal(suite.T(), oauth2const.ErrorAccessDenied, authErr.Code)
+	assert.Equal(suite.T(), "Assertion does not match the authorization request", authErr.Message)
+	assert.Equal(suite.T(), "test-state", authErr.State)
+	assert.True(suite.T(), authErr.SendErrorToClient)
+	assert.Equal(suite.T(), "https://client.example.com/callback", authErr.ClientRedirectURI)
+}
+
+func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_MismatchedAssertion() {
+	// Assertion's auth_req_id claim identifies a different authorization request → must reject.
+	authCtx := authRequestContext{
+		OAuthParameters: oauth2model.OAuthParameters{
+			ClientID:    "test-client",
+			RedirectURI: "https://client.example.com/callback",
+			State:       "test-state",
+		},
+	}
+	suite.mockAuthReqStore.EXPECT().GetRequest(mock.Anything, testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(mock.Anything, testAuthID).Return(nil)
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, svcJWTMismatched, "", "").Return(nil)
+
+	svc := suite.newService()
+	redirectURI, authErr := svc.HandleAuthorizationCallback(context.Background(), testAuthID, svcJWTMismatched)
+
+	assert.Empty(suite.T(), redirectURI)
+	assert.NotNil(suite.T(), authErr)
+	assert.Equal(suite.T(), oauth2const.ErrorAccessDenied, authErr.Code)
+	assert.Equal(suite.T(), "Assertion does not match the authorization request", authErr.Message)
+}
+
+func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_NonStringAuthReqID() {
+	// Assertion's authorization_request_id claim is not a string → malformed client input,
+	// mapped to invalid_request rather than server_error.
+	authCtx := authRequestContext{
+		OAuthParameters: oauth2model.OAuthParameters{
+			ClientID:    "test-client",
+			RedirectURI: "https://client.example.com/callback",
+			State:       "test-state",
+		},
+	}
+	suite.mockAuthReqStore.EXPECT().GetRequest(mock.Anything, testAuthID).Return(true, authCtx, nil)
+	suite.mockAuthReqStore.EXPECT().ClearRequest(mock.Anything, testAuthID).Return(nil)
+	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, svcJWTNonStringAuthReqID, "", "").Return(nil)
+
+	svc := suite.newService()
+	redirectURI, authErr := svc.HandleAuthorizationCallback(context.Background(), testAuthID, svcJWTNonStringAuthReqID)
+
+	assert.Empty(suite.T(), redirectURI)
+	assert.NotNil(suite.T(), authErr)
+	assert.Equal(suite.T(), oauth2const.ErrorInvalidRequest, authErr.Code)
+	assert.True(suite.T(), authErr.SendErrorToClient)
+	assert.Equal(suite.T(), "https://client.example.com/callback", authErr.ClientRedirectURI)
+	assert.Equal(suite.T(), "test-state", authErr.State)
+}
+
 func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_PersistAuthCodeError() {
 	authCtx := authRequestContext{
 		OAuthParameters: oauth2model.OAuthParameters{
@@ -615,7 +703,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_WithStat
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleAuthorizationCallback_EmptyAuthorizedPermissions() {
-	// svcJWTWithIat has only "sub" and "iat" — no authorized_permissions.
+	// svcJWTWithIat has no authorized_permissions claim.
 	// Permission scopes in the auth context should be cleared.
 	authCtx := authRequestContext{
 		OAuthParameters: oauth2model.OAuthParameters{

--- a/backend/internal/oauth/oauth2/ciba/assertion_test.go
+++ b/backend/internal/oauth/oauth2/ciba/assertion_test.go
@@ -44,26 +44,26 @@ func buildCIBAAssertion(payload map[string]interface{}) string {
 
 func (suite *AssertionTestSuite) TestDecodeAttributesFromAssertion_CIBAAuthReqIDWrongType_ReturnsError() {
 	assertion := buildCIBAAssertion(map[string]interface{}{
-		"sub":              "user-1",
-		"ciba_auth_req_id": 42,
+		"sub":                      "user-1",
+		"authorization_request_id": 42,
 	})
 
 	_, _, err := decodeAttributesFromAssertion(assertion)
 	suite.Error(err)
-	suite.Contains(err.Error(), "ciba_auth_req_id")
+	suite.Contains(err.Error(), "authorization_request_id")
 }
 
 func (suite *AssertionTestSuite) TestDecodeAttributesFromAssertion_MissingAuthorizedPermissions_NoError() {
 	// authorized_permissions is optional — absence should not cause an error and the
 	// field should default to the empty string.
 	assertion := buildCIBAAssertion(map[string]interface{}{
-		"sub":              "user-1",
-		"ciba_auth_req_id": "auth-req-123",
+		"sub":                      "user-1",
+		"authorization_request_id": "auth-req-123",
 	})
 
 	claims, _, err := decodeAttributesFromAssertion(assertion)
 	suite.NoError(err)
 	suite.Equal("user-1", claims.userID)
-	suite.Equal("auth-req-123", claims.cibaAuthReqID)
+	suite.Equal("auth-req-123", claims.authReqID)
 	suite.Empty(claims.authorizedPermissions)
 }

--- a/backend/internal/oauth/oauth2/ciba/model.go
+++ b/backend/internal/oauth/oauth2/ciba/model.go
@@ -82,6 +82,6 @@ type assertionClaims struct {
 	userID                string
 	attributeCacheID      string
 	completedACR          string
-	cibaAuthReqID         string
+	authReqID             string
 	authorizedPermissions string
 }

--- a/backend/internal/oauth/oauth2/ciba/service.go
+++ b/backend/internal/oauth/oauth2/ciba/service.go
@@ -136,7 +136,7 @@ func (s *cibaService) InitiateBackchannelAuth(
 	cacheTTL := strconv.FormatInt(s.resolveUserAttributesCacheTTL(oauthApp), 10)
 
 	// authReqID is injected into runtime data for two reasons:
-	//   a) auth_assert_executor binds it as the ciba_auth_req_id claim in the assertion JWT,
+	//   a) auth_assert_executor binds it as the authorization_request_id claim in the assertion JWT,
 	//      enabling the callback to verify this assertion authorizes this specific request.
 	//   b) invite_executor includes it in the notification link URL so Gate UI can pass it
 	//      back in the CIBA callback call on flow completion.
@@ -146,7 +146,7 @@ func (s *cibaService) InitiateBackchannelAuth(
 	}
 
 	runtimeData := map[string]string{
-		flowcm.RuntimeKeyAuthReqID:                   authReqID,
+		flowcm.RuntimeKeyAuthorizationRequestID:      authReqID,
 		flowcm.RuntimeKeyClientID:                    oauthApp.ClientID,
 		flowcm.RuntimeKeyRequestedPermissions:        utils.StringifyStringArray(permissionScopes, " "),
 		flowcm.RuntimeKeyRequiredEssentialAttributes: "",
@@ -274,10 +274,10 @@ func (s *cibaService) HandleCallback(ctx context.Context, authReqID, assertion s
 	}
 
 	// Bind the assertion to this specific CIBA request. The auth_req_id is threaded through the
-	// flow runtime data into the assertion as the ciba_auth_req_id claim; requiring it to match the
-	// record prevents an assertion minted for one CIBA request from authorizing another (e.g. a
-	// narrow-scope authentication being replayed against a broader-scope request for the same user).
-	if claims.cibaAuthReqID == "" || claims.cibaAuthReqID != record.AuthReqID {
+	// flow runtime data into the assertion as the authorization_request_id claim; requiring it to
+	// match the record prevents an assertion minted for one CIBA request from authorizing another
+	// (e.g. a narrow-scope authentication being replayed against a broader-scope request for the same user).
+	if claims.authReqID == "" || claims.authReqID != record.AuthReqID {
 		s.logger.Debug(ctx, "Assertion is not bound to the backchannel authentication request",
 			log.MaskedString("auth_req_id", authReqID))
 		return &CIBAError{
@@ -325,7 +325,7 @@ func (s *cibaService) HandleCallback(ctx context.Context, authReqID, assertion s
 
 // resolveExpectedAudience resolves the app entity ID for the given client ID, which the flow uses
 // as the assertion `aud`. It returns an empty string (skipping the audience check) on lookup
-// failure; the ciba_auth_req_id binding remains the primary protection in that case.
+// failure; the authorization_request_id binding remains the primary protection in that case.
 func (s *cibaService) resolveExpectedAudience(ctx context.Context, clientID string) string {
 	app, svcErr := s.inboundClient.GetOAuthClientByClientID(ctx, clientID)
 	if svcErr != nil {
@@ -536,12 +536,12 @@ func decodeAttributesFromAssertion(assertion string) (assertionClaims, time.Time
 		completedACR:     base.CompletedACR,
 	}
 
-	if cibaValue, ok := payload[oauth2const.ClaimCIBAAuthReqID]; ok {
-		strValue, ok := cibaValue.(string)
+	if v, ok := payload[oauth2const.ClaimAuthorizationRequestID]; ok {
+		strValue, ok := v.(string)
 		if !ok {
-			return assertionClaims{}, time.Time{}, errors.New("JWT 'ciba_auth_req_id' claim is not a string")
+			return assertionClaims{}, time.Time{}, errors.New("JWT 'authorization_request_id' claim is not a string")
 		}
-		claims.cibaAuthReqID = strValue
+		claims.authReqID = strValue
 	}
 
 	if v, ok := payload["authorized_permissions"].(string); ok {

--- a/backend/internal/oauth/oauth2/ciba/service_test.go
+++ b/backend/internal/oauth/oauth2/ciba/service_test.go
@@ -169,7 +169,7 @@ func (suite *CIBAServiceTestSuite) TestInitiate_AuthReqIDInjectedIntoRuntimeData
 	var capturedAuthReqID string
 	suite.mockFlowExec.EXPECT().InitiateAndExecute(mock.Anything, mock.MatchedBy(
 		func(initCtx *flowexec.FlowInitContext) bool {
-			capturedAuthReqID = initCtx.RuntimeData[flowcm.RuntimeKeyAuthReqID]
+			capturedAuthReqID = initCtx.RuntimeData[flowcm.RuntimeKeyAuthorizationRequestID]
 			return capturedAuthReqID != ""
 		})).Return(&flowexec.FlowStep{ExecutionID: "exec-1", Status: providers.FlowStatusIncomplete}, nil)
 	suite.mockStore.EXPECT().Add(mock.Anything, mock.MatchedBy(func(r *CIBAAuthRequest) bool {
@@ -523,9 +523,9 @@ func (suite *CIBAServiceTestSuite) TestResolveExpectedAudience_NilApp() {
 		Return(nil, nil)
 
 	assertion := buildTestAssertion(map[string]interface{}{
-		"sub":              testUserID,
-		"ciba_auth_req_id": "auth-req-1",
-		"iat":              float64(time.Now().Unix()),
+		"sub":                      testUserID,
+		"authorization_request_id": "auth-req-1",
+		"iat":                      float64(time.Now().Unix()),
 	})
 	suite.mockStore.EXPECT().GetByID(mock.Anything, "auth-req-1").Return(suite.pendingRecord(), nil)
 	suite.mockJWTService.EXPECT().VerifyJWT(mock.Anything, assertion, "", "").Return(nil)
@@ -614,11 +614,11 @@ func (suite *CIBAServiceTestSuite) pendingRecord() *CIBAAuthRequest {
 func (suite *CIBAServiceTestSuite) TestCallback_Success() {
 	iat := time.Now().Unix()
 	assertion := buildTestAssertion(map[string]interface{}{
-		"sub":                  testUserID,
-		"aci":                  "cache-1",
-		"completed_auth_class": "urn:acr:pwd",
-		"ciba_auth_req_id":     "auth-req-1",
-		"iat":                  float64(iat),
+		"sub":                      testUserID,
+		"aci":                      "cache-1",
+		"completed_auth_class":     "urn:acr:pwd",
+		"authorization_request_id": "auth-req-1",
+		"iat":                      float64(iat),
 	})
 	suite.mockStore.EXPECT().GetByID(mock.Anything, "auth-req-1").Return(suite.pendingRecord(), nil)
 	suite.expectAudienceResolution()
@@ -634,9 +634,9 @@ func (suite *CIBAServiceTestSuite) TestCallback_Success() {
 
 func (suite *CIBAServiceTestSuite) TestCallback_SubMissing() {
 	assertion := buildTestAssertion(map[string]interface{}{
-		"aci":              "cache-1",
-		"ciba_auth_req_id": "auth-req-1",
-		"iat":              float64(time.Now().Unix()),
+		"aci":                      "cache-1",
+		"authorization_request_id": "auth-req-1",
+		"iat":                      float64(time.Now().Unix()),
 	})
 	suite.mockStore.EXPECT().GetByID(mock.Anything, "auth-req-1").Return(suite.pendingRecord(), nil)
 	suite.expectAudienceResolution()
@@ -649,10 +649,10 @@ func (suite *CIBAServiceTestSuite) TestCallback_SubMissing() {
 
 func (suite *CIBAServiceTestSuite) TestCallback_BindingMismatch() {
 	assertion := buildTestAssertion(map[string]interface{}{
-		"sub":              testUserID,
-		"aci":              "cache-1",
-		"ciba_auth_req_id": "other-req",
-		"iat":              float64(time.Now().Unix()),
+		"sub":                      testUserID,
+		"aci":                      "cache-1",
+		"authorization_request_id": "other-req",
+		"iat":                      float64(time.Now().Unix()),
 	})
 	suite.mockStore.EXPECT().GetByID(mock.Anything, "auth-req-1").Return(suite.pendingRecord(), nil)
 	suite.expectAudienceResolution()
@@ -681,10 +681,10 @@ func (suite *CIBAServiceTestSuite) TestCallback_BindingClaimMissing() {
 func (suite *CIBAServiceTestSuite) TestCallback_AudienceResolutionFailureStillBinds() {
 	iat := time.Now().Unix()
 	assertion := buildTestAssertion(map[string]interface{}{
-		"sub":              testUserID,
-		"aci":              "cache-1",
-		"ciba_auth_req_id": "auth-req-1",
-		"iat":              float64(iat),
+		"sub":                      testUserID,
+		"aci":                      "cache-1",
+		"authorization_request_id": "auth-req-1",
+		"iat":                      float64(iat),
 	})
 	suite.mockStore.EXPECT().GetByID(mock.Anything, "auth-req-1").Return(suite.pendingRecord(), nil)
 	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "client-1").
@@ -777,10 +777,10 @@ func (suite *CIBAServiceTestSuite) TestCallback_StoreLookupError() {
 
 func (suite *CIBAServiceTestSuite) TestCallback_MarkAuthenticatedError() {
 	assertion := buildTestAssertion(map[string]interface{}{
-		"sub":              testUserID,
-		"aci":              "cache-1",
-		"ciba_auth_req_id": "auth-req-1",
-		"iat":              float64(time.Now().Unix()),
+		"sub":                      testUserID,
+		"aci":                      "cache-1",
+		"authorization_request_id": "auth-req-1",
+		"iat":                      float64(time.Now().Unix()),
 	})
 	suite.mockStore.EXPECT().GetByID(mock.Anything, "auth-req-1").Return(suite.pendingRecord(), nil)
 	suite.expectAudienceResolution()

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -245,16 +245,17 @@ const (
 
 // Custom JWT claim names.
 const (
-	ClaimUserType           string = "userType"
-	ClaimOUID               string = "ouId"
-	ClaimOUName             string = "ouName"
-	ClaimOUHandle           string = "ouHandle"
-	ClaimClaimsRequest      string = "claims_req"
-	ClaimClaimsLocales      string = "claims_locales"
-	ClaimCompletedAuthClass string = "completed_auth_class"
-	ClaimDPoPJkt            string = "dpop_jkt"
-	ClaimCIBAAuthReqID      string = "ciba_auth_req_id"
-	ClaimClientID           string = "client_id"
+	ClaimUserType               string = "userType"
+	ClaimOUID                   string = "ouId"
+	ClaimOUName                 string = "ouName"
+	ClaimOUHandle               string = "ouHandle"
+	ClaimClaimsRequest          string = "claims_req"
+	ClaimClaimsLocales          string = "claims_locales"
+	ClaimCompletedAuthClass     string = "completed_auth_class"
+	ClaimDPoPJkt                string = "dpop_jkt"
+	ClaimAuthorizedPermissions  string = "authorized_permissions"
+	ClaimAuthorizationRequestID string = "authorization_request_id"
+	ClaimClientID               string = "client_id"
 )
 
 // OIDC subject types.

--- a/backend/internal/oauth/oauth2/utils/assertion.go
+++ b/backend/internal/oauth/oauth2/utils/assertion.go
@@ -41,7 +41,7 @@ type FlowAssertionClaims struct {
 // DecodeFlowAssertionClaims decodes the common flow assertion claims from a JWT string.
 // It extracts sub (user ID), aci (attribute cache ID), completed_auth_class (completed ACR),
 // and iat (authentication time). The raw JWT payload is also returned so callers can extract
-// grant-type-specific claims (e.g. ciba_auth_req_id for CIBA, authorized_permissions for auth code).
+// grant-type-specific claims (e.g. auth_req_id for CIBA, authorized_permissions for auth code).
 func DecodeFlowAssertionClaims(assertion string) (FlowAssertionClaims, map[string]interface{}, error) {
 	claims := FlowAssertionClaims{}
 

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -32,8 +32,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/thunder-id/thunderid/tests/integration/testutils"
 	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
 )
 
 const (
@@ -58,7 +58,7 @@ type TestCase struct {
 }
 
 var (
-	testOUID       string
+	testOUID     string
 	testUserType = testutils.UserType{
 		Name: "authz-test-person",
 		Schema: map[string]interface{}{
@@ -1535,4 +1535,81 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeFlow_IDToken_JWE() {
 	// A JWE compact serialisation has exactly 5 dot-separated parts.
 	parts := strings.Split(idToken, ".")
 	ts.Len(parts, 5, "Encrypted ID token must be a JWE compact serialisation (5 parts)")
+}
+
+// TestAssertionBoundToAuthorizationRequest exercises the assertion<->authorization request binding
+// enforced by the OAuth authorize callback. An assertion minted for one authorization request must
+// not be usable to complete a different authorization request, even if the caller supplies a valid
+// authId for the second request.
+func (ts *AuthzTestSuite) TestAssertionBoundToAuthorizationRequest() {
+	username := "assertion_binding_user"
+	password := "testpass123"
+
+	user := testutils.User{
+		OUID: testOUID,
+		Type: "authz-test-person",
+		Attributes: json.RawMessage(`{
+			"username": "assertion_binding_user",
+			"password": "testpass123",
+			"email": "assertion_binding_user@example.com",
+			"given_name": "Assertion",
+			"family_name": "Binding"
+		}`),
+	}
+	userID, err := testutils.CreateUser(user)
+	ts.Require().NoError(err, "Failed to create test user")
+	defer func() {
+		if err := testutils.DeleteUser(userID); err != nil {
+			ts.T().Logf("Warning: Failed to delete test user: %v", err)
+		}
+	}()
+
+	// Run two independent authorization flows to end up with two (authId, assertion) pairs.
+	authIDA, _ := ts.runFlowToAssertion(username, password, "binding_state_a")
+	authIDB, assertionB := ts.runFlowToAssertion(username, password, "binding_state_b")
+
+	// Cross the streams: submit flow A's authId with flow B's assertion. The binding claim in
+	// assertionB names authIDB, not authIDA, so the callback must reject with access_denied.
+	authzResponse, err := testutils.CompleteAuthorization(authIDA, assertionB)
+	ts.Require().NoError(err, "Callback should return a redirect (200), not an HTTP error")
+
+	parsed, err := url.Parse(authzResponse.RedirectURI)
+	ts.Require().NoError(err, "Failed to parse client redirect URI")
+	ts.Equal("access_denied", parsed.Query().Get("error"),
+		"Mismatched assertion must be rejected with access_denied")
+	ts.Empty(parsed.Query().Get("code"),
+		"No authorization code should be issued for a mismatched assertion")
+
+	// Positive control: submitting flow B's authId with its own assertion should still succeed
+	// (proves the binding check does not spuriously reject legitimate assertions).
+	successResp, err := testutils.CompleteAuthorization(authIDB, assertionB)
+	ts.Require().NoError(err, "Legitimate callback should succeed")
+	code, err := testutils.ExtractAuthorizationCode(successResp.RedirectURI)
+	ts.Require().NoError(err, "Legitimate callback should issue an authorization code")
+	ts.NotEmpty(code, "Authorization code must be issued for the matching authId/assertion pair")
+}
+
+// runFlowToAssertion initiates an OAuth2 authorize flow, drives the authentication flow to
+// completion, and returns the authId issued at initiation along with the resulting assertion.
+func (ts *AuthzTestSuite) runFlowToAssertion(username, password, state string) (string, string) {
+	resp, err := testutils.InitiateAuthorizationFlow(clientID, redirectURI, "code", "openid", state)
+	ts.Require().NoError(err, "Failed to initiate authorization flow")
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusFound, resp.StatusCode, "Expected redirect status")
+
+	authID, executionID, err := testutils.ExtractAuthData(resp.Header.Get("Location"))
+	ts.Require().NoError(err, "Failed to extract auth data from redirect")
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": username,
+		"password": password,
+	}, "action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to execute authentication flow")
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Flow should complete successfully")
+
+	return authID, flowStep.Assertion
 }


### PR DESCRIPTION
### Purpose
This pull request enhances flow security by enforcing assertions (JWTs) are explicitly bound to their originating authorization requests, and adds comprehensive test coverage for these changes. Additionally this standardizes the way authorization request IDs are handled in both OAuth authorization and CIBA (Client-Initiated Backchannel Authentication) flows. It replaces the previous use of `ciba_auth_req_id` and `authReqId` with a unified `authorization_request_id` claim and key throughout the codebase.

### Approach

**Security Improvements:**

* Enforced that assertions (JWTs) must include an `authorization_request_id` claim matching the current authorization request, rejecting assertions that are missing, mismatched, or have a non-string value for this claim.

**Unification and Standardization of Authorization Request ID Handling:**

* Replaced all uses of `ciba_auth_req_id` and `authReqId` with `authorization_request_id` in JWT claims, runtime data keys, and related logic, ensuring a single, consistent identifier is used for both OAuth and CIBA flows.

**Test Enhancements:**

* Added and updated unit and integration tests to verify correct behavior when assertions are unbound, mismatched, or have malformed `authorization_request_id` claims, as well as to ensure the new claim is present in all happy-path cases.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/3218

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization and CIBA flows now consistently bind requests using the `authorization_request_id` claim.

* **Bug Fixes**
  * Improved authorization callback validation: missing, mismatched, or malformed `authorization_request_id` assertions are rejected with the appropriate error and redirected state.
  * Invite links now include the correct request ID query parameter when available.
  * Assertions issued for one flow can’t be reused for another.

* **Tests**
  * Added/updated unit and integration tests for unbound, mismatched, and non-string request ID scenarios, plus corrected JWT fixture coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->