### PR TITLE
Fix Configure Guide Inconsistency on gate client configurations.

### DIFF
--- a/docs/content/community/contributing/contributing-code/configure-and-run.mdx
+++ b/docs/content/community/contributing/contributing-code/configure-and-run.mdx
@@ -17,9 +17,9 @@ hide_table_of_contents: false
 To allow additional origins, add them to `backend/cmd/server/config/resources/server_configs/cors.yaml` or set them at runtime with `PUT /server-config/cors`.
 :::
 
-Open `backend/cmd/server/deployment.yaml` and make the following change:
-
 **Configure the Gate client:**
+
+Open `backend/cmd/server/deployment.yaml` and make the following change:
 
 ```yaml
 gate_client:


### PR DESCRIPTION
### Purpose

In the Configure and Run contributor guide, the instruction "Open backend/cmd/server/deployment.yaml and make the following change:" was placed above the Configure the Gate client: heading — right after the CORS allowed origins: section, which requires no deployment.yaml edit.

This misled readers into opening deployment.yaml while still in the CORS section. The deployment.yaml edit only applies to the Gate client (gate_client.port).

This PR moves that instruction below the Configure the Gate client: heading, so it directly precedes the gate_client YAML snippet it refers to.

### Approach

Documentation-only reorder in docs/content/community/contributing/contributing-code/configure-and-run.mdx — swapped two lines so the "Open deployment.yaml…" instruction sits under the correct heading. No content added or removed.

### Related Issues

- Fixes thunder-id/thunderid#3782

### Related PRs

- N/A

### Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. <!-- verified rendered ordering in the guide -->
- [x] Documentation provided. (Add links if there are any)
  - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
  - [ ] Unit Tests
  - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
  - [ ] Breaking changes section filled.
  - [ ] breaking change label added.

### Security checks

- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.