### PR TITLE
Block connection deletion when dependencies exist

### DIFF
--- a/api/connections.yaml
+++ b/api/connections.yaml
@@ -126,6 +126,32 @@ paths:
         "401": { $ref: '#/components/responses/Unauthorized' }
         "403": { $ref: '#/components/responses/Forbidden' }
         "500": { $ref: '#/components/responses/InternalServerError' }
+  /connections/google/{id}/usages:
+    parameters:
+      - { $ref: '#/components/parameters/ConnectionID' }
+    get:
+      tags: [Connections]
+      summary: Get Google connection usages
+      description: |
+        Returns the resources that reference this connection, aggregated across all resource
+        types (for example, flows that use it). Informational only — it drives the pre-delete
+        confirmation dialog in the UI and does not gate deletion on the server.
+
+        Each usage entry includes a `behaviorOnDelete` field describing what happens to the
+        referencing resource if the connection is deleted:
+        - `fallback`: the reference is kept as-is.
+        - `cascade`: the resource is permanently deleted along with the connection.
+        - `restrict`: the resource blocks deletion of the connection.
+
+        When usage data is unavailable (e.g. the server has not fully initialised),
+        `totalResults` and `summary` are `null` rather than `0`/empty. Consumers must treat
+        `null` as "unknown" and `0` as "confirmed empty".
+      responses:
+        "200": { $ref: '#/components/responses/ConnectionUsages' }
+        "404": { $ref: '#/components/responses/NotFound' }
+        "401": { $ref: '#/components/responses/Unauthorized' }
+        "403": { $ref: '#/components/responses/Forbidden' }
+        "500": { $ref: '#/components/responses/InternalServerError' }
 
   /connections/github:
     get:
@@ -196,6 +222,32 @@ paths:
       summary: Delete a GitHub connection
       responses:
         "204": { description: Connection deleted }
+        "404": { $ref: '#/components/responses/NotFound' }
+        "401": { $ref: '#/components/responses/Unauthorized' }
+        "403": { $ref: '#/components/responses/Forbidden' }
+        "500": { $ref: '#/components/responses/InternalServerError' }
+  /connections/github/{id}/usages:
+    parameters:
+      - { $ref: '#/components/parameters/ConnectionID' }
+    get:
+      tags: [Connections]
+      summary: Get GitHub connection usages
+      description: |
+        Returns the resources that reference this connection, aggregated across all resource
+        types (for example, flows that use it). Informational only — it drives the pre-delete
+        confirmation dialog in the UI and does not gate deletion on the server.
+
+        Each usage entry includes a `behaviorOnDelete` field describing what happens to the
+        referencing resource if the connection is deleted:
+        - `fallback`: the reference is kept as-is.
+        - `cascade`: the resource is permanently deleted along with the connection.
+        - `restrict`: the resource blocks deletion of the connection.
+
+        When usage data is unavailable (e.g. the server has not fully initialised),
+        `totalResults` and `summary` are `null` rather than `0`/empty. Consumers must treat
+        `null` as "unknown" and `0` as "confirmed empty".
+      responses:
+        "200": { $ref: '#/components/responses/ConnectionUsages' }
         "404": { $ref: '#/components/responses/NotFound' }
         "401": { $ref: '#/components/responses/Unauthorized' }
         "403": { $ref: '#/components/responses/Forbidden' }
@@ -274,6 +326,32 @@ paths:
         "401": { $ref: '#/components/responses/Unauthorized' }
         "403": { $ref: '#/components/responses/Forbidden' }
         "500": { $ref: '#/components/responses/InternalServerError' }
+  /connections/oidc/{id}/usages:
+    parameters:
+      - { $ref: '#/components/parameters/ConnectionID' }
+    get:
+      tags: [Connections]
+      summary: Get OIDC connection usages
+      description: |
+        Returns the resources that reference this connection, aggregated across all resource
+        types (for example, flows that use it). Informational only — it drives the pre-delete
+        confirmation dialog in the UI and does not gate deletion on the server.
+
+        Each usage entry includes a `behaviorOnDelete` field describing what happens to the
+        referencing resource if the connection is deleted:
+        - `fallback`: the reference is kept as-is.
+        - `cascade`: the resource is permanently deleted along with the connection.
+        - `restrict`: the resource blocks deletion of the connection.
+
+        When usage data is unavailable (e.g. the server has not fully initialised),
+        `totalResults` and `summary` are `null` rather than `0`/empty. Consumers must treat
+        `null` as "unknown" and `0` as "confirmed empty".
+      responses:
+        "200": { $ref: '#/components/responses/ConnectionUsages' }
+        "404": { $ref: '#/components/responses/NotFound' }
+        "401": { $ref: '#/components/responses/Unauthorized' }
+        "403": { $ref: '#/components/responses/Forbidden' }
+        "500": { $ref: '#/components/responses/InternalServerError' }
 
 components:
   securitySchemes:
@@ -308,6 +386,21 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/ConnectionInstanceSummary'
+    ConnectionUsages:
+      description: Resources that reference this connection
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ConnectionUsagesResponse' }
+          example:
+            totalResults: 1
+            count: 1
+            summary:
+              flow: 1
+            usages:
+              - resourceType: flow
+                id: "f1b2c3d4-0000-0000-0000-000000000001"
+                displayName: "Login Flow"
+                behaviorOnDelete: restrict
     BadRequest:
       description: Bad request
       content:
@@ -367,6 +460,74 @@ components:
         id: { type: string, format: uuid }
         name: { type: string, example: "My Google" }
         description: { type: string }
+
+    ConnectionUsage:
+      type: object
+      description: A single resource that references the connection.
+      required:
+        - resourceType
+        - id
+        - displayName
+        - behaviorOnDelete
+      properties:
+        resourceType:
+          type: string
+          description: Type of the referencing resource.
+          enum: [flow]
+          example: flow
+        id:
+          type: string
+          format: uuid
+          description: Identifier of the referencing resource.
+          example: "f1b2c3d4-0000-0000-0000-000000000001"
+        displayName:
+          type: string
+          description: Human-readable name of the referencing resource.
+          example: "Login Flow"
+        behaviorOnDelete:
+          type: string
+          description: |
+            What happens to this resource when the connection is deleted.
+            - `fallback`: the reference is kept as-is.
+            - `cascade`: the resource is permanently deleted.
+            - `restrict`: the resource blocks deletion of the connection.
+          enum: [fallback, cascade, restrict]
+          example: restrict
+
+    ConnectionUsagesSummary:
+      type: object
+      nullable: true
+      description: |
+        Per-resource-type count of usages, keyed by resource type
+        (e.g. `flow`). Null when the counts could not be determined.
+      additionalProperties:
+        type: integer
+      example:
+        flow: 1
+
+    ConnectionUsagesResponse:
+      type: object
+      description: |
+        Resources that reference a connection, aggregated across all resource types.
+        Drives pre-delete confirmation dialogs; informational only.
+      properties:
+        totalResults:
+          type: integer
+          nullable: true
+          description: |
+            Total number of resources that reference the connection.
+            Null when usage data is unavailable; 0 means confirmed empty.
+          example: 1
+        count:
+          type: integer
+          description: Number of results returned.
+          example: 1
+        summary:
+          $ref: '#/components/schemas/ConnectionUsagesSummary'
+        usages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConnectionUsage'
 
     GoogleConnectionUpdateRequest:
       type: object

--- a/backend/internal/connection/handler.go
+++ b/backend/internal/connection/handler.go
@@ -187,6 +187,25 @@ func (h *handler) deleteInstance(idpType providers.IDPType) http.HandlerFunc {
 	}
 }
 
+// usagesInstance returns a handler that lists the resources referencing an instance of a
+// connection type. Drives the pre-delete confirmation dialog.
+func (h *handler) usagesInstance(idpType providers.IDPType) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		id := r.PathValue("id")
+		if strings.TrimSpace(id) == "" {
+			writeServiceError(ctx, w, &idp.ErrorInvalidIDPID)
+			return
+		}
+		usages, svcErr := h.svc.usagesByType(ctx, idpType, id)
+		if svcErr != nil {
+			writeServiceError(ctx, w, svcErr)
+			return
+		}
+		sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, usages)
+	}
+}
+
 // handleListConnections handles GET /connections, returning the available connection types
 // with their configured status and instance count.
 func (h *handler) handleListConnections(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/connection/handler_test.go
+++ b/backend/internal/connection/handler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/idp"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/idp/idpmock"
@@ -160,4 +161,52 @@ func (s *HandlerTestSuite) TestDeleteEmptyID() {
 	rr := httptest.NewRecorder()
 	s.handler.deleteInstance(providers.IDPTypeGoogle)(rr, req)
 	s.Equal(http.StatusBadRequest, rr.Code)
+}
+
+func (s *HandlerTestSuite) TestUsagesEmptyID() {
+	req := httptest.NewRequest(http.MethodGet, "/connections/google//usages", nil)
+	rr := httptest.NewRecorder()
+	s.handler.usagesInstance(providers.IDPTypeGoogle)(rr, req)
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.mockIDP.AssertNotCalled(s.T(), "GetIDPUsages", mock.Anything, mock.Anything)
+}
+
+func (s *HandlerTestSuite) TestUsagesServiceError() {
+	s.mockIDP.On("GetIdentityProvider", mock.Anything, "missing").
+		Return((*providers.IDPDTO)(nil), &idp.ErrorIDPNotFound)
+
+	req := httptest.NewRequest(http.MethodGet, "/connections/google/missing/usages", nil)
+	req.SetPathValue("id", "missing")
+	rr := httptest.NewRecorder()
+	s.handler.usagesInstance(providers.IDPTypeGoogle)(rr, req)
+	s.Equal(http.StatusNotFound, rr.Code)
+}
+
+func (s *HandlerTestSuite) TestUsagesSuccess() {
+	total := 1
+	usages := &resourcedependency.DependenciesResponse{
+		TotalResults: &total,
+		Count:        1,
+		Summary:      map[string]int{"flow": 1},
+		Usages: []resourcedependency.ResourceDependency{
+			{ResourceType: "flow", ID: "flow-1", DisplayName: "Login Flow", BehaviorOnDelete: "restrict"},
+		},
+	}
+	s.mockIDP.On("GetIdentityProvider", mock.Anything, "g-1").
+		Return(&providers.IDPDTO{ID: "g-1", Type: providers.IDPTypeGoogle}, (*tidcommon.ServiceError)(nil))
+	s.mockIDP.On("GetIDPUsages", mock.Anything, "g-1").Return(usages, (*tidcommon.ServiceError)(nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/connections/google/g-1/usages", nil)
+	req.SetPathValue("id", "g-1")
+	rr := httptest.NewRecorder()
+	s.handler.usagesInstance(providers.IDPTypeGoogle)(rr, req)
+
+	s.Equal(http.StatusOK, rr.Code)
+	var resp resourcedependency.DependenciesResponse
+	s.Require().NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	s.Require().NotNil(resp.TotalResults)
+	s.Equal(1, *resp.TotalResults)
+	s.Require().Len(resp.Usages, 1)
+	s.Equal("flow-1", resp.Usages[0].ID)
+	s.Equal("restrict", resp.Usages[0].BehaviorOnDelete)
 }

--- a/backend/internal/connection/init.go
+++ b/backend/internal/connection/init.go
@@ -93,4 +93,13 @@ func registerVendorRoutes(mux *http.ServeMux, h *handler, base string, idpType p
 	mux.HandleFunc(middleware.WithCORS("PUT "+base+"/{id}", update, itemOpts))
 	mux.HandleFunc(middleware.WithCORS("DELETE "+base+"/{id}", h.deleteInstance(idpType), itemOpts))
 	mux.HandleFunc(middleware.WithCORS("OPTIONS "+base+"/{id}", noContent, itemOpts))
+
+	usagesOpts := middleware.CORSOptions{
+		AllowedMethods:   []string{"GET"},
+		AllowedHeaders:   middleware.DefaultAllowedHeaders,
+		AllowCredentials: true,
+		MaxAge:           600,
+	}
+	mux.HandleFunc(middleware.WithCORS("GET "+base+"/{id}/usages", h.usagesInstance(idpType), usagesOpts))
+	mux.HandleFunc(middleware.WithCORS("OPTIONS "+base+"/{id}/usages", noContent, usagesOpts))
 }

--- a/backend/internal/connection/service.go
+++ b/backend/internal/connection/service.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	"github.com/thunder-id/thunderid/internal/idp"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -104,4 +105,14 @@ func (s *service) deleteByType(ctx context.Context, idpType providers.IDPType, i
 		return svcErr
 	}
 	return s.idpService.DeleteIdentityProvider(ctx, id)
+}
+
+// usagesByType verifies the instance is of the expected type, then returns the resources that
+// reference it. Drives the pre-delete confirmation dialog.
+func (s *service) usagesByType(ctx context.Context, idpType providers.IDPType, id string) (
+	*resourcedependency.DependenciesResponse, *tidcommon.ServiceError) {
+	if _, svcErr := s.getByType(ctx, idpType, id); svcErr != nil {
+		return nil, svcErr
+	}
+	return s.idpService.GetIDPUsages(ctx, id)
 }

--- a/backend/internal/connection/service_test.go
+++ b/backend/internal/connection/service_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/idp"
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
 	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/idp/idpmock"
@@ -173,4 +174,33 @@ func (s *ServiceTestSuite) TestDeleteByTypeGetFails() {
 	svcErr := s.svc.deleteByType(context.Background(), providers.IDPTypeGoogle, "missing")
 	s.Require().NotNil(svcErr)
 	s.mockIDP.AssertNotCalled(s.T(), "DeleteIdentityProvider", mock.Anything, mock.Anything)
+}
+
+func (s *ServiceTestSuite) TestUsagesByTypeDelegates() {
+	total := 1
+	usages := &resourcedependency.DependenciesResponse{
+		TotalResults: &total,
+		Count:        1,
+		Summary:      map[string]int{"flow": 1},
+		Usages: []resourcedependency.ResourceDependency{
+			{ResourceType: "flow", ID: "flow-1", DisplayName: "Login Flow", BehaviorOnDelete: "restrict"},
+		},
+	}
+	s.mockIDP.On("GetIdentityProvider", mock.Anything, "g-1").
+		Return(&providers.IDPDTO{ID: "g-1", Type: providers.IDPTypeGoogle}, (*tidcommon.ServiceError)(nil))
+	s.mockIDP.On("GetIDPUsages", mock.Anything, "g-1").Return(usages, (*tidcommon.ServiceError)(nil))
+
+	result, svcErr := s.svc.usagesByType(context.Background(), providers.IDPTypeGoogle, "g-1")
+	s.Nil(svcErr)
+	s.Equal(usages, result)
+}
+
+func (s *ServiceTestSuite) TestUsagesByTypeGetFails() {
+	s.mockIDP.On("GetIdentityProvider", mock.Anything, "missing").
+		Return((*providers.IDPDTO)(nil), &idp.ErrorIDPNotFound)
+
+	result, svcErr := s.svc.usagesByType(context.Background(), providers.IDPTypeGoogle, "missing")
+	s.Require().NotNil(svcErr)
+	s.Nil(result)
+	s.mockIDP.AssertNotCalled(s.T(), "GetIDPUsages", mock.Anything, mock.Anything)
 }

--- a/backend/internal/idp/IDPServiceInterface_mock_test.go
+++ b/backend/internal/idp/IDPServiceInterface_mock_test.go
@@ -169,6 +169,76 @@ func (_c *IDPServiceInterfaceMock_DeleteIdentityProvider_Call) RunAndReturn(run 
 	return _c
 }
 
+// GetIDPUsages provides a mock function for the type IDPServiceInterfaceMock
+func (_mock *IDPServiceInterfaceMock) GetIDPUsages(ctx context.Context, idpID string) (*resourcedependency.DependenciesResponse, *common.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIDPUsages")
+	}
+
+	var r0 *resourcedependency.DependenciesResponse
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*resourcedependency.DependenciesResponse, *common.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *resourcedependency.DependenciesResponse); ok {
+		r0 = returnFunc(ctx, idpID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcedependency.DependenciesResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// IDPServiceInterfaceMock_GetIDPUsages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIDPUsages'
+type IDPServiceInterfaceMock_GetIDPUsages_Call struct {
+	*mock.Call
+}
+
+// GetIDPUsages is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+func (_e *IDPServiceInterfaceMock_Expecter) GetIDPUsages(ctx interface{}, idpID interface{}) *IDPServiceInterfaceMock_GetIDPUsages_Call {
+	return &IDPServiceInterfaceMock_GetIDPUsages_Call{Call: _e.mock.On("GetIDPUsages", ctx, idpID)}
+}
+
+func (_c *IDPServiceInterfaceMock_GetIDPUsages_Call) Run(run func(ctx context.Context, idpID string)) *IDPServiceInterfaceMock_GetIDPUsages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIDPUsages_Call) Return(dependenciesResponse *resourcedependency.DependenciesResponse, serviceError *common.ServiceError) *IDPServiceInterfaceMock_GetIDPUsages_Call {
+	_c.Call.Return(dependenciesResponse, serviceError)
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIDPUsages_Call) RunAndReturn(run func(ctx context.Context, idpID string) (*resourcedependency.DependenciesResponse, *common.ServiceError)) *IDPServiceInterfaceMock_GetIDPUsages_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIdentityProvider provides a mock function for the type IDPServiceInterfaceMock
 func (_mock *IDPServiceInterfaceMock) GetIdentityProvider(ctx context.Context, idpID string) (*providers.IDPDTO, *common.ServiceError) {
 	ret := _mock.Called(ctx, idpID)

--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -50,6 +50,7 @@ type IDPServiceInterface interface {
 		idp *providers.IDPDTO,
 	) (*providers.IDPDTO, *tidcommon.ServiceError)
 	DeleteIdentityProvider(ctx context.Context, idpID string) *tidcommon.ServiceError
+	GetIDPUsages(ctx context.Context, idpID string) (*resourcedependency.DependenciesResponse, *tidcommon.ServiceError)
 	SetDependencyRegistry(r resourcedependency.Registry)
 }
 
@@ -342,6 +343,44 @@ func (is *idpService) DeleteIdentityProvider(ctx context.Context, idpID string) 
 // provider services are initialized to avoid a cyclic import.
 func (is *idpService) SetDependencyRegistry(r resourcedependency.Registry) {
 	is.dependencyRegistry = r
+}
+
+// GetIDPUsages returns the resources that reference this identity provider, such as flows that use
+// it. It is informational — it drives the pre-delete confirmation dialog and does not gate deletion
+// on the server (deletion is gated separately by ensureNoBlockingDependencies).
+func (is *idpService) GetIDPUsages(
+	ctx context.Context, idpID string,
+) (*resourcedependency.DependenciesResponse, *tidcommon.ServiceError) {
+	if strings.TrimSpace(idpID) == "" {
+		return nil, &ErrorInvalidIDPID
+	}
+
+	if _, err := is.idpStore.GetIdentityProvider(ctx, idpID); err != nil {
+		if errors.Is(err, ErrIDPNotFound) {
+			return nil, &ErrorIDPNotFound
+		}
+		is.logger.Error(ctx, "Failed to retrieve identity provider", log.Error(err), log.String("idpID", idpID))
+		return nil, &tidcommon.InternalServerError
+	}
+
+	if is.dependencyRegistry == nil {
+		is.logger.Warn(ctx, "Dependency registry not set; returning unknown dependencies",
+			log.String("idpID", idpID))
+		return &resourcedependency.DependenciesResponse{
+			TotalResults: nil,
+			Count:        0,
+			Summary:      nil,
+			Usages:       []resourcedependency.ResourceDependency{},
+		}, nil
+	}
+
+	result, err := is.dependencyRegistry.GetDependencies(ctx, resourcedependency.ResourceTypeIDP, idpID)
+	if err != nil {
+		is.logger.Error(ctx, "Failed to get identity provider usages", log.Error(err), log.String("idpID", idpID))
+		return nil, &tidcommon.InternalServerError
+	}
+
+	return result, nil
 }
 
 // ensureNoBlockingDependencies refuses deletion when other resources depend on the identity provider

--- a/backend/internal/idp/service_test.go
+++ b/backend/internal/idp/service_test.go
@@ -731,6 +731,80 @@ func (s *IDPServiceTestSuite) TestDeleteIdentityProvider_Success() {
 	s.mockStore.AssertExpectations(s.T())
 }
 
+// TestGetIDPUsages_ReturnsDependencies verifies usages are returned for an existing IDP.
+func (s *IDPServiceTestSuite) TestGetIDPUsages_ReturnsDependencies() {
+	total := 1
+	usages := &resourcedependency.DependenciesResponse{
+		TotalResults: &total,
+		Count:        1,
+		Usages: []resourcedependency.ResourceDependency{
+			{ResourceType: resourcedependency.ResourceTypeFlow, ID: "flow-1",
+				DisplayName: "Google Login", BehaviorOnDelete: resourcedependency.BehaviorRestrict},
+		},
+	}
+	s.idpService.dependencyRegistry = &stubDependencyRegistry{resp: usages}
+	s.mockStore.On("GetIdentityProvider", mock.Anything, "idp-123").
+		Return(&providers.IDPDTO{ID: "idp-123"}, nil)
+
+	result, err := s.idpService.GetIDPUsages(context.Background(), "idp-123")
+
+	s.Nil(err)
+	s.Equal(usages, result)
+	s.mockStore.AssertExpectations(s.T())
+}
+
+// TestGetIDPUsages_EmptyID validates the empty-ID guard.
+func (s *IDPServiceTestSuite) TestGetIDPUsages_EmptyID() {
+	result, err := s.idpService.GetIDPUsages(context.Background(), "")
+
+	s.Nil(result)
+	s.NotNil(err)
+	s.Equal(ErrorInvalidIDPID.Code, err.Code)
+}
+
+// TestGetIDPUsages_NotFound verifies a not-found error when the IDP does not exist.
+func (s *IDPServiceTestSuite) TestGetIDPUsages_NotFound() {
+	s.mockStore.On("GetIdentityProvider", mock.Anything, "missing").
+		Return((*providers.IDPDTO)(nil), ErrIDPNotFound)
+
+	result, err := s.idpService.GetIDPUsages(context.Background(), "missing")
+
+	s.Nil(result)
+	s.NotNil(err)
+	s.Equal(ErrorIDPNotFound.Code, err.Code)
+	s.mockStore.AssertExpectations(s.T())
+}
+
+// TestGetIDPUsages_GetStoreError verifies a store error while retrieving the IDP maps to an
+// internal server error.
+func (s *IDPServiceTestSuite) TestGetIDPUsages_GetStoreError() {
+	s.mockStore.On("GetIdentityProvider", mock.Anything, "idp-123").
+		Return((*providers.IDPDTO)(nil), errors.New("database error"))
+
+	result, err := s.idpService.GetIDPUsages(context.Background(), "idp-123")
+
+	s.Nil(result)
+	s.NotNil(err)
+	s.Equal(tidcommon.InternalServerError.Code, err.Code)
+	s.mockStore.AssertExpectations(s.T())
+}
+
+// TestGetIDPUsages_RegistryUnset returns unknown dependencies rather than failing when the
+// registry was never wired in (informational endpoint, unlike deletion which fails closed).
+func (s *IDPServiceTestSuite) TestGetIDPUsages_RegistryUnset() {
+	s.idpService.dependencyRegistry = nil
+	s.mockStore.On("GetIdentityProvider", mock.Anything, "idp-123").
+		Return(&providers.IDPDTO{ID: "idp-123"}, nil)
+
+	result, err := s.idpService.GetIDPUsages(context.Background(), "idp-123")
+
+	s.Nil(err)
+	s.Require().NotNil(result)
+	s.Nil(result.TotalResults)
+	s.Empty(result.Usages)
+	s.mockStore.AssertExpectations(s.T())
+}
+
 // TestDeleteIdentityProvider_EmptyID tests empty ID validation
 func (s *IDPServiceTestSuite) TestDeleteIdentityProvider_EmptyID() {
 	err := s.idpService.DeleteIdentityProvider(context.Background(), "")

--- a/backend/tests/mocks/idp/idpmock/IDPServiceInterface_mock.go
+++ b/backend/tests/mocks/idp/idpmock/IDPServiceInterface_mock.go
@@ -170,6 +170,76 @@ func (_c *IDPServiceInterfaceMock_DeleteIdentityProvider_Call) RunAndReturn(run 
 	return _c
 }
 
+// GetIDPUsages provides a mock function for the type IDPServiceInterfaceMock
+func (_mock *IDPServiceInterfaceMock) GetIDPUsages(ctx context.Context, idpID string) (*resourcedependency.DependenciesResponse, *common.ServiceError) {
+	ret := _mock.Called(ctx, idpID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIDPUsages")
+	}
+
+	var r0 *resourcedependency.DependenciesResponse
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*resourcedependency.DependenciesResponse, *common.ServiceError)); ok {
+		return returnFunc(ctx, idpID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *resourcedependency.DependenciesResponse); ok {
+		r0 = returnFunc(ctx, idpID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resourcedependency.DependenciesResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// IDPServiceInterfaceMock_GetIDPUsages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIDPUsages'
+type IDPServiceInterfaceMock_GetIDPUsages_Call struct {
+	*mock.Call
+}
+
+// GetIDPUsages is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idpID string
+func (_e *IDPServiceInterfaceMock_Expecter) GetIDPUsages(ctx interface{}, idpID interface{}) *IDPServiceInterfaceMock_GetIDPUsages_Call {
+	return &IDPServiceInterfaceMock_GetIDPUsages_Call{Call: _e.mock.On("GetIDPUsages", ctx, idpID)}
+}
+
+func (_c *IDPServiceInterfaceMock_GetIDPUsages_Call) Run(run func(ctx context.Context, idpID string)) *IDPServiceInterfaceMock_GetIDPUsages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIDPUsages_Call) Return(dependenciesResponse *resourcedependency.DependenciesResponse, serviceError *common.ServiceError) *IDPServiceInterfaceMock_GetIDPUsages_Call {
+	_c.Call.Return(dependenciesResponse, serviceError)
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_GetIDPUsages_Call) RunAndReturn(run func(ctx context.Context, idpID string) (*resourcedependency.DependenciesResponse, *common.ServiceError)) *IDPServiceInterfaceMock_GetIDPUsages_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIdentityProvider provides a mock function for the type IDPServiceInterfaceMock
 func (_mock *IDPServiceInterfaceMock) GetIdentityProvider(ctx context.Context, idpID string) (*providers.IDPDTO, *common.ServiceError) {
 	ret := _mock.Called(ctx, idpID)

--- a/frontend/apps/console/src/features/connections/api/useGetConnectionUsages.ts
+++ b/frontend/apps/console/src/features/connections/api/useGetConnectionUsages.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import {useConfig} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import ConnectionQueryKeys from '../constants/query-keys';
+import type {ConnectionType, ConnectionUsagesResponse} from '../models/connection';
+
+/**
+ * Fetch the resources that reference a connection instance, such as flows that use it
+ * (GET /connections/{type}/{id}/usages). Used to populate the pre-delete confirmation dialog.
+ *
+ * @param type - The connection type
+ * @param id - The connection instance identifier
+ * @param enabled - Whether the query should run (default true)
+ */
+export default function useGetConnectionUsages(
+  type: ConnectionType,
+  id: string | undefined,
+  enabled = true,
+): UseQueryResult<ConnectionUsagesResponse> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+
+  return useQuery<ConnectionUsagesResponse>({
+    queryKey: [ConnectionQueryKeys.CONNECTION_USAGES, type, id],
+    enabled: Boolean(id) && enabled,
+    queryFn: async (): Promise<ConnectionUsagesResponse> => {
+      const serverUrl: string = getServerUrl();
+      const response: {
+        data: ConnectionUsagesResponse;
+      } = await http.request({
+        url: `${serverUrl}/connections/${type}/${id}/usages`,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      return response.data;
+    },
+  });
+}

--- a/frontend/apps/console/src/features/connections/components/ConnectionDeleteDialog.tsx
+++ b/frontend/apps/console/src/features/connections/components/ConnectionDeleteDialog.tsx
@@ -16,12 +16,31 @@
  * under the License.
  */
 
-import {Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle} from '@wso2/oxygen-ui';
+import {
+  Alert,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
+import useGetConnectionUsages from '../api/useGetConnectionUsages';
+import type {ConnectionType} from '../models/connection';
+
+const MAX_VISIBLE_USAGES = 5;
 
 interface ConnectionDeleteDialogProps {
   open: boolean;
+  connectionType: ConnectionType;
+  connectionId: string;
   connectionName: string;
   isPending: boolean;
   onConfirm: () => void;
@@ -30,6 +49,8 @@ interface ConnectionDeleteDialogProps {
 
 export default function ConnectionDeleteDialog({
   open,
+  connectionType,
+  connectionId,
   connectionName,
   isPending,
   onConfirm,
@@ -37,11 +58,53 @@ export default function ConnectionDeleteDialog({
 }: ConnectionDeleteDialogProps): JSX.Element {
   const {t} = useTranslation('connections');
 
+  const {data: usagesData, isLoading: isLoadingUsages} = useGetConnectionUsages(
+    connectionType,
+    connectionId || undefined,
+    open,
+  );
+
+  const usagesKnown = usagesData !== undefined && usagesData.totalResults !== null;
+  const blockingUsages = usagesData?.usages.filter((usage) => usage.behaviorOnDelete === 'restrict') ?? [];
+  const hasBlockingUsages = usagesKnown && blockingUsages.length > 0;
+  const visibleBlocking = blockingUsages.slice(0, MAX_VISIBLE_USAGES);
+  const hiddenBlockingCount = blockingUsages.length - visibleBlocking.length;
+
   return (
     <Dialog open={open} onClose={isPending ? undefined : onClose} maxWidth="sm" fullWidth>
       <DialogTitle>{t('delete.title')}</DialogTitle>
       <DialogContent>
-        <DialogContentText>{t('delete.message', {name: connectionName})}</DialogContentText>
+        <DialogContentText sx={{mb: 2}}>{t('delete.message', {name: connectionName})}</DialogContentText>
+
+        {isLoadingUsages ? (
+          <Alert severity="info" icon={<CircularProgress size={16} />}>
+            {t('delete.usages.loading')}
+          </Alert>
+        ) : hasBlockingUsages ? (
+          <Alert severity="error">
+            <Typography variant="body2" sx={{mb: 1}}>
+              {t('delete.blocking.title')}
+            </Typography>
+            <List dense disablePadding>
+              {visibleBlocking.map((usage) => (
+                <ListItem key={usage.id} disableGutters sx={{py: 0}}>
+                  <ListItemText primary={<Typography variant="body2">{usage.displayName}</Typography>} />
+                </ListItem>
+              ))}
+              {hiddenBlockingCount > 0 && (
+                <ListItem disableGutters sx={{py: 0}}>
+                  <ListItemText
+                    primary={
+                      <Typography variant="body2" color="text.secondary">
+                        {t('delete.usages.more', {count: hiddenBlockingCount})}
+                      </Typography>
+                    }
+                  />
+                </ListItem>
+              )}
+            </List>
+          </Alert>
+        ) : null}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={isPending}>
@@ -51,7 +114,7 @@ export default function ConnectionDeleteDialog({
           onClick={onConfirm}
           color="error"
           variant="contained"
-          disabled={isPending}
+          disabled={isPending || isLoadingUsages || hasBlockingUsages}
           data-testid="connection-delete-confirm"
         >
           {t('common:actions.delete')}

--- a/frontend/apps/console/src/features/connections/components/__tests__/ConnectionDeleteDialog.test.tsx
+++ b/frontend/apps/console/src/features/connections/components/__tests__/ConnectionDeleteDialog.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import type {ConnectionUsagesResponse} from '../../models/connection';
+import ConnectionDeleteDialog from '../ConnectionDeleteDialog';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, arg?: unknown): string => {
+      const translations: Record<string, string> = {
+        'delete.title': 'Delete connection',
+        'delete.usages.loading': 'Checking affected resources…',
+        'delete.blocking.title':
+          'This connection cannot be deleted until the following resources are updated or removed:',
+        'common:actions.cancel': 'Cancel',
+        'common:actions.delete': 'Delete',
+      };
+      if (translations[key]) return translations[key];
+      if (arg && typeof arg === 'object') {
+        const obj = arg as {name?: string; count?: number};
+        if (key === 'delete.message') return `Are you sure you want to delete “${obj.name}”?`;
+        if (key === 'delete.usages.more') return `+${obj.count} more`;
+      }
+      return key;
+    },
+  }),
+}));
+
+const {getUsagesMock} = vi.hoisted(() => ({
+  getUsagesMock: vi.fn<() => {data: ConnectionUsagesResponse | undefined; isLoading: boolean}>(),
+}));
+vi.mock('../../api/useGetConnectionUsages', () => ({
+  default: () => getUsagesMock(),
+}));
+
+describe('ConnectionDeleteDialog', () => {
+  const onConfirm = vi.fn();
+  const onClose = vi.fn();
+
+  const renderDialog = (): void => {
+    render(
+      <ConnectionDeleteDialog
+        open
+        connectionType="google"
+        connectionId="g1"
+        connectionName="My Google"
+        isPending={false}
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />,
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUsagesMock.mockReturnValue({data: {totalResults: 0, count: 0, summary: {}, usages: []}, isLoading: false});
+  });
+
+  it('confirms deletion when there are no blocking usages', () => {
+    renderDialog();
+
+    const confirm = screen.getByTestId('connection-delete-confirm');
+    expect(confirm).not.toBeDisabled();
+    fireEvent.click(confirm);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables delete and shows a loading alert while usages are fetched', () => {
+    getUsagesMock.mockReturnValue({data: undefined, isLoading: true});
+    renderDialog();
+
+    expect(screen.getByText('Checking affected resources…')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-delete-confirm')).toBeDisabled();
+  });
+
+  it('lists blocking resources and disables delete', () => {
+    const usages: ConnectionUsagesResponse = {
+      totalResults: 2,
+      count: 2,
+      summary: {flow: 2},
+      usages: [
+        {resourceType: 'flow', id: 'flow-1', displayName: 'Login Flow', behaviorOnDelete: 'restrict'},
+        {resourceType: 'flow', id: 'flow-2', displayName: 'Signup Flow', behaviorOnDelete: 'restrict'},
+      ],
+    };
+    getUsagesMock.mockReturnValue({data: usages, isLoading: false});
+    renderDialog();
+
+    expect(
+      screen.getByText('This connection cannot be deleted until the following resources are updated or removed:'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Login Flow')).toBeInTheDocument();
+    expect(screen.getByText('Signup Flow')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-delete-confirm')).toBeDisabled();
+  });
+
+  it('shows a "+N more" row when blocking usages exceed the visible limit', () => {
+    const usages: ConnectionUsagesResponse = {
+      totalResults: 7,
+      count: 7,
+      summary: {flow: 7},
+      usages: Array.from({length: 7}, (_, i) => ({
+        resourceType: 'flow',
+        id: `flow-${i}`,
+        displayName: `Flow ${i}`,
+        behaviorOnDelete: 'restrict' as const,
+      })),
+    };
+    getUsagesMock.mockReturnValue({data: usages, isLoading: false});
+    renderDialog();
+
+    expect(screen.getByText('+2 more')).toBeInTheDocument();
+  });
+
+  it('does not block deletion when usage data is unknown', () => {
+    getUsagesMock.mockReturnValue({data: {totalResults: null, count: 0, summary: null, usages: []}, isLoading: false});
+    renderDialog();
+
+    expect(screen.getByTestId('connection-delete-confirm')).not.toBeDisabled();
+  });
+});

--- a/frontend/apps/console/src/features/connections/constants/query-keys.ts
+++ b/frontend/apps/console/src/features/connections/constants/query-keys.ts
@@ -44,6 +44,11 @@ const ConnectionQueryKeys = {
    * Key for a single connection instance (GET /connections/{type}/{id})
    */
   CONNECTION: 'connection',
+
+  /**
+   * Key for the resources referencing a connection instance (GET /connections/{type}/{id}/usages)
+   */
+  CONNECTION_USAGES: 'connection-usages',
 } as const;
 
 export default ConnectionQueryKeys;

--- a/frontend/apps/console/src/features/connections/models/connection.ts
+++ b/frontend/apps/console/src/features/connections/models/connection.ts
@@ -55,6 +55,27 @@ export interface ConnectionListResponse {
 }
 
 /**
+ * A single resource that references a connection (e.g. a flow that uses it).
+ */
+export interface ConnectionUsage {
+  resourceType: string;
+  id: string;
+  displayName: string;
+  behaviorOnDelete: 'fallback' | 'cascade' | 'restrict';
+}
+
+/**
+ * Response for the connection usages endpoint (GET /connections/{type}/{id}/usages).
+ * totalResults is null when usage data is unavailable; 0 means confirmed empty.
+ */
+export interface ConnectionUsagesResponse {
+  totalResults: number | null;
+  count: number;
+  summary: Record<string, number> | null;
+  usages: ConnectionUsage[];
+}
+
+/**
  * Lightweight configured instance (GET /connections/{type}).
  */
 export interface ConnectionInstanceSummary {

--- a/frontend/apps/console/src/features/connections/pages/ConnectionDetailPage.tsx
+++ b/frontend/apps/console/src/features/connections/pages/ConnectionDetailPage.tsx
@@ -288,6 +288,8 @@ export default function ConnectionDetailPage(): JSX.Element | null {
 
           <ConnectionDeleteDialog
             open={deleteOpen}
+            connectionType={connectionType}
+            connectionId={resolvedId ?? ''}
             connectionName={data?.name ?? ''}
             isPending={deleteMutation.isPending}
             onConfirm={handleDelete}

--- a/frontend/apps/console/src/features/connections/pages/__tests__/ConnectionDetailPage.test.tsx
+++ b/frontend/apps/console/src/features/connections/pages/__tests__/ConnectionDetailPage.test.tsx
@@ -67,6 +67,9 @@ vi.mock('../../api/useConnection', () => ({
 vi.mock('../../api/useConnectionInstances', () => ({default: () => ({data: [], isLoading: false})}));
 vi.mock('../../api/useUpdateConnection', () => ({default: () => ({mutateAsync: updateMock, isPending: false})}));
 vi.mock('../../api/useDeleteConnection', () => ({default: () => ({mutate: deleteMock, isPending: false})}));
+vi.mock('../../api/useGetConnectionUsages', () => ({
+  default: () => ({data: {totalResults: 0, count: 0, summary: {}, usages: []}, isLoading: false}),
+}));
 
 vi.mock('../../components/ConnectionForm', () => ({
   default: function StubConnectionForm({onFieldChange}: {onFieldChange: (name: string, value: string) => void}) {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1628,6 +1628,9 @@ const translations = {
     // Delete dialog
     'delete.title': 'Delete connection',
     'delete.message': 'Are you sure you want to delete “{{name}}”? This action cannot be undone.',
+    'delete.usages.loading': 'Checking affected resources…',
+    'delete.usages.more': '+{{count}} more',
+    'delete.blocking.title': 'This connection cannot be deleted until the following resources are updated or removed:',
 
     // Toasts
     'create.success': 'Connection created successfully.',


### PR DESCRIPTION
### Purpose

Extend the "block deletion when dependencies exist" experience — already implemented for users — to connections. The backend already refuses to delete a connection that has blocking dependencies (e.g. flows that reference it), but the console surfaced no advance warning: the delete action just failed. This PR adds a connection usages endpoint and updates the connection delete dialog to check for, list, and block on dependent resources before deletion.

### Approach

**Backend — connection usages endpoint**
- Added `GetIDPUsages` to the identity-provider service (mirrors `GetUserUsages`): validates the ID, confirms the IDP exists, and returns dependency data from the resource-dependency registry. Being informational, it returns "unknown" when the registry is unset rather than failing closed (deletion remains gated separately by `ensureNoBlockingDependencies`).
- Added `usagesByType` to the connection service (verifies the instance is the expected vendor type, then delegates) and exposed `GET /connections/{type}/{id}/usages`.

**Frontend — connection delete dialog**
- New `useGetConnectionUsages` hook + `ConnectionUsage`/`ConnectionUsagesResponse` models and query key.
- `ConnectionDeleteDialog` now fetches usages when open, shows a loading alert while checking, lists resources with `behaviorOnDelete: restrict` in an error alert (capped at 5 with a "+N more" row), and disables the Delete button while loading or when blocked. `ConnectionDetailPage` passes the connection type and id through.
- Added the `connections` i18n strings (`delete.usages.loading`, `delete.usages.more`, `delete.blocking.title`).

This mirrors the existing user delete dialog for consistency.

### Related Issues
- Fixes #3792

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connection “usages” retrieval and pre-delete checks that identify resources referencing a connection.
  * Updated the delete dialog to display related usages, block deletion when required, and show a “+N more” indicator for additional items.
* **Bug Fixes**
  * Improved delete flow behavior for empty/unavailable usage data and during loading (delete confirmation is disabled until usages finish loading).
* **Documentation**
  * Added new user-facing messages for delete loading status and blocking warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->