### PR TITLE
Fixed a TOC sidebar bug that makes it clip for longer sidebars

### DIFF
--- a/docs/content/guides/getting-started/connect-your-application/android.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/android.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: Android Quickstart
 sidebar_position: 8.5
 persona: app

--- a/docs/content/guides/getting-started/connect-your-application/browser.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/browser.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: Vanilla JavaScript Quickstart
 sidebar_position: 4
 persona: app

--- a/docs/content/guides/getting-started/connect-your-application/express.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/express.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: Express Quickstart
 sidebar_position: 3
 persona: app

--- a/docs/content/guides/getting-started/connect-your-application/flutter.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/flutter.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: Flutter Quickstart
 sidebar_position: 9
 persona: app

--- a/docs/content/guides/getting-started/connect-your-application/index.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/index.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: Connect Your Application
 sidebar_position: 1
 persona: app

--- a/docs/content/guides/getting-started/connect-your-application/ios.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/ios.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: iOS Quickstart
 sidebar_position: 8
 persona: app

--- a/docs/content/guides/getting-started/connect-your-application/nextjs.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/nextjs.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: Next.js Quickstart
 sidebar_position: 3
 persona: app

--- a/docs/content/guides/getting-started/connect-your-application/node.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/node.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: Node.js Quickstart
 sidebar_position: 5
 persona: app

--- a/docs/content/guides/getting-started/connect-your-application/nuxt.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/nuxt.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: Nuxt Quickstart
 sidebar_position: 3
 persona: app

--- a/docs/content/guides/getting-started/connect-your-application/react.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/react.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: React Quickstart
 sidebar_position: 1
 persona: app

--- a/docs/content/guides/getting-started/connect-your-application/vue.mdx
+++ b/docs/content/guides/getting-started/connect-your-application/vue.mdx
@@ -1,5 +1,5 @@
 ---
-toc_progress: stepper
+toc_progress: quickstart
 title: Vue Quickstart
 sidebar_position: 2
 persona: app

--- a/docs/content/guides/getting-started/get-thunderid.mdx
+++ b/docs/content/guides/getting-started/get-thunderid.mdx
@@ -1,6 +1,5 @@
 ---
 title: Get started
-toc_progress: stepper
 sidebar_position: 2
 description: Download and run using the release artifact, Docker Compose, or Helm
 ---

--- a/docs/content/use-cases/ai-agents/mcp-authorization/try-it-out.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/try-it-out.mdx
@@ -39,7 +39,7 @@ The Wayfinder Server validates the issued access token on every MCP call and enf
 
 Complete the [AI Agents Set Up Your Environment](../../try-it-out#set-up-your-environment) first. The same bundle also seeds the `EXTERNAL-MCP-CLIENT` application used here.
 
-<Stepper stepNode="h3" as="h4">
+<Stepper stepNode="h3" as="h3">
 
 ### Verify the New Application
 

--- a/docs/content/use-cases/b2c/try-it-out/setup.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/setup.mdx
@@ -15,7 +15,7 @@ Skip the bundle import and follow [Configure It Yourself](../configure-it-yourse
 
 ## Set Up Your Environment
 
-<Stepper stepNode="h3" as="h4">
+<Stepper stepNode="h3" as="h3">
 
 ### Run <ProductName />
 

--- a/docs/content/use-cases/vc/try-it-out/setup.mdx
+++ b/docs/content/use-cases/vc/try-it-out/setup.mdx
@@ -15,7 +15,7 @@ Skip the bundle import and follow [Configure It Yourself](../configure-it-yourse
 
 ## Set Up Your Environment
 
-<Stepper stepNode="h3" as="h4">
+<Stepper stepNode="h3" as="h3">
 
 ### Get <ProductName />
 

--- a/docs/src/theme/TOC/index.tsx
+++ b/docs/src/theme/TOC/index.tsx
@@ -33,7 +33,7 @@ class DocContextGuard extends Component<{children: React.ReactNode}, {failed: bo
 
 function StepperPageDetector({onDetect}: {onDetect: (v: boolean) => void}) {
   const doc = useDoc();
-  const isStepper = (doc?.frontMatter as Record<string, unknown>)?.toc_progress === 'stepper';
+  const isStepper = (doc?.frontMatter as Record<string, unknown>)?.toc_progress === 'quickstart';
   useEffect(() => { onDetect(isStepper); }, [isStepper, onDetect]);
   return null;
 }
@@ -191,10 +191,33 @@ export default function TOC(props: OriginalTOCProps): React.ReactElement {
       const ai = links.findIndex(l => l.classList.contains('table-of-contents__link--active'));
       if (ai === -1) {
         // Check if a *hidden* link (e.g. inactive tab heading) has the active class.
-        // If so, hold the current fill — we're in a hidden section, not at the top.
         const hiddenActive = toc.querySelector('a.table-of-contents__link--active');
         if (hiddenActive) return;
-        // Nothing active anywhere — debounce reset so we clear on genuine top-of-page scroll
+
+        // Fallback for headings Docusaurus doesn't track (e.g. H4 from Stepper).
+        // Compute active index from scroll position using the heading elements directly.
+        const anchors = links
+          .map(link => {
+            const id = link.getAttribute('href')?.slice(1);
+            return id ? document.getElementById(id) : null;
+          })
+          .filter((el): el is HTMLElement => el !== null);
+        if (anchors.length) {
+          let activeI = 0;
+          for (let i = 0; i < anchors.length; i++) {
+            if (anchors[i].getBoundingClientRect().top - 100 <= 0) activeI = i;
+          }
+          if (anchors[activeI].getBoundingClientRect().top - 100 <= 0) {
+            if (resetTimerRef.current !== null) {
+              clearTimeout(resetTimerRef.current);
+              resetTimerRef.current = null;
+            }
+            setFillPct((activeI + 0.5) / links.length);
+            return;
+          }
+        }
+
+        // Genuinely at top — debounce reset
         resetTimerRef.current ??= setTimeout(() => {
           setFillPct(0);
           resetTimerRef.current = null;
@@ -215,10 +238,16 @@ export default function TOC(props: OriginalTOCProps): React.ReactElement {
       const allLinks = getVisibleLinks();
       if (!allLinks.length) return;
 
-      const items: LinkItem[] = allLinks.map(link => ({
-        y: link.getBoundingClientRect().top + link.getBoundingClientRect().height / 2 - tocRect.top,
-        isNested: link.closest('ul') !== ul,
-      }));
+      // Use content-relative y (add scrollTop) so the SVG covers the full
+      // scrollable height, not just the visible viewport slice.
+      const tocScrollTop = toc.scrollTop;
+      const items: LinkItem[] = allLinks.map(link => {
+        const r = link.getBoundingClientRect();
+        return {
+          y: r.top + r.height / 2 - tocRect.top + tocScrollTop,
+          isNested: link.closest('ul') !== ul,
+        };
+      });
 
       setLinkCount(items.length);
       // Stepper headings have MuiTypography-root; plain markdown headings don't
@@ -229,8 +258,9 @@ export default function TOC(props: OriginalTOCProps): React.ReactElement {
       }));
       const minOffset = parseFloat(window.getComputedStyle(ul).paddingTop) || 0;
       const svgT = Math.max(minOffset, items[0].y);
-      const lastBottom = allLinks[allLinks.length - 1].getBoundingClientRect().bottom - tocRect.top;
-      const svgB = Math.min(Math.max(items[items.length - 1].y, lastBottom), tocRect.height);
+      // No height cap — SVG covers the full scrollable content so it isn't clipped
+      const lastBottom = allLinks[allLinks.length - 1].getBoundingClientRect().bottom - tocRect.top + tocScrollTop;
+      const svgB = Math.max(items[items.length - 1].y, lastBottom);
 
       setSvgTop(svgT);
       setSvgHeight(Math.max(0, svgB - svgT));
@@ -285,7 +315,7 @@ export default function TOC(props: OriginalTOCProps): React.ReactElement {
   );
 
   const primary = 'var(--ifm-color-primary)';
-  const muted   = 'var(--ifm-color-emphasis-300)';
+  const muted   = 'var(--oxygen-palette-divider)';
 
   // Clip stops at: top of active circle (circles light up via per-element transition),
   // or at the dot center (dot lights up via per-element transition-delay after line arrives).
@@ -337,7 +367,7 @@ export default function TOC(props: OriginalTOCProps): React.ReactElement {
           <svg
             aria-hidden="true"
             style={{
-              height: svgHeight, left: '16px', overflow: 'visible',
+              height: svgHeight, left: '24px', overflow: 'visible',
               pointerEvents: 'none', position: 'absolute', top: svgTop,
               width: `${X_INNER + 2}px`,
             }}
@@ -353,8 +383,8 @@ export default function TOC(props: OriginalTOCProps): React.ReactElement {
                 />
               </clipPath>
             </defs>
-            <path d={pathD} fill="none" stroke={muted} strokeLinecap="round" strokeWidth="2" />
-            <path d={pathD} fill="none" stroke={primary} strokeLinecap="round" strokeWidth="3"
+            <path d={pathD} fill="none" stroke={muted} strokeLinecap="round" strokeWidth="1.5" />
+            <path d={pathD} fill="none" stroke={primary} strokeLinecap="round" strokeWidth="2"
               clipPath="url(#toc-fill-clip)" />
           </svg>
         ),


### PR DESCRIPTION
### Purpose
$subject

Also improved the styling for the sidebar.

<img width="329" height="504" alt="image" src="https://github.com/user-attachments/assets/545962f1-2cd8-4dc4-9566-96be4ac92713" />


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table-of-contents progress tracking with a more reliable active-section fallback when no TOC link is marked active.
  * Refined TOC overlay geometry/positioning for more consistent visual alignment during scrolling.

* **Documentation**
  * Updated multiple walkthrough pages’ progress configuration (`toc_progress`) from `stepper` to `quickstart`.
  * Adjusted step heading rendering to a more consistent heading level across several “try it out” and quickstart sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->