### PR TITLE
Cascade delete role and group assignments on user deletion

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -409,7 +409,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		user:        userService,
 		idp:         idpService,
 		notifSender: notifSenderMgtSvc,
-	}, applicationService, agentService, flowMgtService)
+	}, applicationService, agentService, flowMgtService, roleAssignmentService, groupService)
 
 	// Initialize design resolve service for theme and layout resolution
 	designResolveService := resolve.Initialize(mux, themeMgtService, layoutMgtService, applicationService)

--- a/backend/internal/design/theme/mgt/service_test.go
+++ b/backend/internal/design/theme/mgt/service_test.go
@@ -606,6 +606,10 @@ func (s *stubUsageRegistry) GetDependencies(
 	return s.resp, s.err
 }
 
+func (s *stubUsageRegistry) CascadeDelete(_ context.Context, _, _ string) (int, error) {
+	return 0, nil
+}
+
 // Test GetThemeUsages - Empty ID
 func (suite *ThemeServiceTestSuite) TestGetThemeUsages_EmptyID() {
 	result, err := suite.service.GetThemeUsages(context.Background(), "", 10, 0)

--- a/backend/internal/flow/mgt/service_test.go
+++ b/backend/internal/flow/mgt/service_test.go
@@ -77,6 +77,10 @@ func (r *stubDependencyRegistry) GetDependencies(
 	return r.resp, r.err
 }
 
+func (r *stubDependencyRegistry) CascadeDelete(context.Context, string, string) (int, error) {
+	return 0, nil
+}
+
 func (s *FlowMgtServiceTestSuite) SetupTest() {
 	s.mockStore = newFlowStoreInterfaceMock(s.T())
 	s.mockInference = newFlowInferenceServiceInterfaceMock(s.T())

--- a/backend/internal/group/GroupServiceInterface_mock_test.go
+++ b/backend/internal/group/GroupServiceInterface_mock_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -175,6 +176,78 @@ func (_c *GroupServiceInterfaceMock_AddMembersToGroups_Call) Return(serviceError
 }
 
 func (_c *GroupServiceInterfaceMock_AddMembersToGroups_Call) RunAndReturn(run func(ctx context.Context, members []Member, groupIDs []string) *common.ServiceError) *GroupServiceInterfaceMock_AddMembersToGroups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CascadeDeleteDependencies provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) CascadeDeleteDependencies(ctx context.Context, resourceType string, id string) (int, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CascadeDeleteDependencies")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// GroupServiceInterfaceMock_CascadeDeleteDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CascadeDeleteDependencies'
+type GroupServiceInterfaceMock_CascadeDeleteDependencies_Call struct {
+	*mock.Call
+}
+
+// CascadeDeleteDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *GroupServiceInterfaceMock_Expecter) CascadeDeleteDependencies(ctx interface{}, resourceType interface{}, id interface{}) *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	return &GroupServiceInterfaceMock_CascadeDeleteDependencies_Call{Call: _e.mock.On("CascadeDeleteDependencies", ctx, resourceType, id)}
+}
+
+func (_c *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call) Return(n int, err error) *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) (int, error)) *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -784,6 +857,80 @@ func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) Return(groupListRespon
 }
 
 func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int, includeDisplay bool) (*GroupListResponse, *common.ServiceError)) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceDependencies provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) GetResourceDependencies(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceDependencies")
+	}
+
+	var r0 []resourcedependency.ResourceDependency
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]resourcedependency.ResourceDependency, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []resourcedependency.ResourceDependency); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]resourcedependency.ResourceDependency)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// GroupServiceInterfaceMock_GetResourceDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceDependencies'
+type GroupServiceInterfaceMock_GetResourceDependencies_Call struct {
+	*mock.Call
+}
+
+// GetResourceDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *GroupServiceInterfaceMock_Expecter) GetResourceDependencies(ctx interface{}, resourceType interface{}, id interface{}) *GroupServiceInterfaceMock_GetResourceDependencies_Call {
+	return &GroupServiceInterfaceMock_GetResourceDependencies_Call{Call: _e.mock.On("GetResourceDependencies", ctx, resourceType, id)}
+}
+
+func (_c *GroupServiceInterfaceMock_GetResourceDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *GroupServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetResourceDependencies_Call) Return(resourceDependencys []resourcedependency.ResourceDependency, err error) *GroupServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Return(resourceDependencys, err)
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetResourceDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error)) *GroupServiceInterfaceMock_GetResourceDependencies_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/group/composite_store.go
+++ b/backend/internal/group/composite_store.go
@@ -344,6 +344,12 @@ func (c *compositeGroupStore) RemoveGroupMembers(ctx context.Context, groupID st
 	return c.dbStore.RemoveGroupMembers(ctx, groupID, members)
 }
 
+// DeleteMembershipsByMember deletes memberships for the member from the database store only.
+func (c *compositeGroupStore) DeleteMembershipsByMember(
+	ctx context.Context, memberType, memberID string) (int64, error) {
+	return c.dbStore.DeleteMembershipsByMember(ctx, memberType, memberID)
+}
+
 // GetGroupsByIDs returns groups matching the given IDs, merged from both stores.
 func (c *compositeGroupStore) GetGroupsByIDs(ctx context.Context, groupIDs []string) ([]GroupBasicDAO, error) {
 	dbGroups, err := c.dbStore.GetGroupsByIDs(ctx, groupIDs)

--- a/backend/internal/group/file_based_store.go
+++ b/backend/internal/group/file_based_store.go
@@ -425,6 +425,13 @@ func (f *fileBasedGroupStore) RemoveGroupMembers(ctx context.Context, groupID st
 	return errors.New("RemoveGroupMembers is not supported in file-based store")
 }
 
+// DeleteMembershipsByMember is a no-op for the file-based store: declarative groups hold no mutable
+// runtime memberships to cascade-delete, so there is nothing to remove.
+func (f *fileBasedGroupStore) DeleteMembershipsByMember(
+	_ context.Context, _, _ string) (int64, error) {
+	return 0, nil
+}
+
 // GetGroupsByIDs returns groups matching any of the given IDs.
 func (f *fileBasedGroupStore) GetGroupsByIDs(ctx context.Context, groupIDs []string) ([]GroupBasicDAO, error) {
 	if len(groupIDs) == 0 {

--- a/backend/internal/group/groupStoreInterface_mock_test.go
+++ b/backend/internal/group/groupStoreInterface_mock_test.go
@@ -347,6 +347,78 @@ func (_c *groupStoreInterfaceMock_DeleteGroup_Call) RunAndReturn(run func(ctx co
 	return _c
 }
 
+// DeleteMembershipsByMember provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) DeleteMembershipsByMember(ctx context.Context, memberType string, memberID string) (int64, error) {
+	ret := _mock.Called(ctx, memberType, memberID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteMembershipsByMember")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int64, error)); ok {
+		return returnFunc(ctx, memberType, memberID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int64); ok {
+		r0 = returnFunc(ctx, memberType, memberID)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, memberType, memberID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// groupStoreInterfaceMock_DeleteMembershipsByMember_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteMembershipsByMember'
+type groupStoreInterfaceMock_DeleteMembershipsByMember_Call struct {
+	*mock.Call
+}
+
+// DeleteMembershipsByMember is a helper method to define mock.On call
+//   - ctx context.Context
+//   - memberType string
+//   - memberID string
+func (_e *groupStoreInterfaceMock_Expecter) DeleteMembershipsByMember(ctx interface{}, memberType interface{}, memberID interface{}) *groupStoreInterfaceMock_DeleteMembershipsByMember_Call {
+	return &groupStoreInterfaceMock_DeleteMembershipsByMember_Call{Call: _e.mock.On("DeleteMembershipsByMember", ctx, memberType, memberID)}
+}
+
+func (_c *groupStoreInterfaceMock_DeleteMembershipsByMember_Call) Run(run func(ctx context.Context, memberType string, memberID string)) *groupStoreInterfaceMock_DeleteMembershipsByMember_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_DeleteMembershipsByMember_Call) Return(n int64, err error) *groupStoreInterfaceMock_DeleteMembershipsByMember_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_DeleteMembershipsByMember_Call) RunAndReturn(run func(ctx context.Context, memberType string, memberID string) (int64, error)) *groupStoreInterfaceMock_DeleteMembershipsByMember_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroup provides a mock function for the type groupStoreInterfaceMock
 func (_mock *groupStoreInterfaceMock) GetGroup(ctx context.Context, id string) (GroupDAO, error) {
 	ret := _mock.Called(ctx, id)

--- a/backend/internal/group/service.go
+++ b/backend/internal/group/service.go
@@ -34,6 +34,7 @@ import (
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
@@ -63,6 +64,9 @@ type GroupServiceInterface interface {
 	RemoveGroupMembers(ctx context.Context, groupID string, members []Member) (*Group, *tidcommon.ServiceError)
 	AddMembersToGroups(ctx context.Context, members []Member,
 		groupIDs []string) *tidcommon.ServiceError
+	GetResourceDependencies(
+		ctx context.Context, resourceType, id string) ([]resourcedependency.ResourceDependency, error)
+	CascadeDeleteDependencies(ctx context.Context, resourceType, id string) (int, error)
 }
 
 // groupService is the default implementation of the GroupServiceInterface.
@@ -1336,4 +1340,30 @@ func (gs *groupService) validateAndProcessHandlePath(handlePath string) *tidcomm
 		}
 	}
 	return nil
+}
+
+// GetResourceDependencies implements resourcedependency.Provider. Group memberships are cleaned up
+// via cascade rather than surfaced as blocking usages, so no dependencies are reported here.
+func (gs *groupService) GetResourceDependencies(
+	_ context.Context, _, _ string) ([]resourcedependency.ResourceDependency, error) {
+	return []resourcedependency.ResourceDependency{}, nil
+}
+
+// CascadeDeleteDependencies implements resourcedependency.CascadeDeleter. It removes the group
+// memberships held by the given principal when that principal is deleted. Only user, app and agent
+// principals (stored as entity members) are handled; other resource types have no memberships.
+func (gs *groupService) CascadeDeleteDependencies(
+	ctx context.Context, resourceType, id string) (int, error) {
+	switch resourceType {
+	case resourcedependency.ResourceTypeUser,
+		resourcedependency.ResourceTypeApplication,
+		resourcedependency.ResourceTypeAgent:
+		deleted, err := gs.groupStore.DeleteMembershipsByMember(ctx, string(memberTypeEntity), id)
+		if err != nil {
+			return 0, err
+		}
+		return int(deleted), nil
+	default:
+		return 0, nil
+	}
 }

--- a/backend/internal/group/service_test.go
+++ b/backend/internal/group/service_test.go
@@ -34,6 +34,7 @@ import (
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
@@ -2897,4 +2898,52 @@ func TestCheckGroupAccess_AuthzError(t *testing.T) {
 	err := service.checkGroupAccess(context.Background(), security.ActionReadGroup, testOUID1, "grp-001")
 	require.NotNil(t, err)
 	require.Equal(t, tidcommon.InternalServerError.Code, err.Code)
+}
+
+// --- Cascade / dependency provider ---
+
+func (suite *GroupServiceTestSuite) TestGetResourceDependencies_ReturnsEmpty() {
+	service := &groupService{}
+	result, err := service.GetResourceDependencies(
+		context.Background(), resourcedependency.ResourceTypeUser, "user-1")
+	suite.NoError(err)
+	suite.Empty(result)
+}
+
+func (suite *GroupServiceTestSuite) TestCascadeDeleteDependencies_User_DeletesMemberships() {
+	storeMock := newGroupStoreInterfaceMock(suite.T())
+	storeMock.On("DeleteMembershipsByMember", mock.Anything, string(memberTypeEntity), "user-1").
+		Return(int64(2), nil)
+	service := &groupService{groupStore: storeMock}
+
+	deleted, err := service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeUser, "user-1")
+
+	suite.NoError(err)
+	suite.Equal(2, deleted)
+}
+
+func (suite *GroupServiceTestSuite) TestCascadeDeleteDependencies_UnknownType_NoOp() {
+	storeMock := newGroupStoreInterfaceMock(suite.T())
+	service := &groupService{groupStore: storeMock}
+
+	deleted, err := service.CascadeDeleteDependencies(context.Background(), "theme", "theme-1")
+
+	suite.NoError(err)
+	suite.Equal(0, deleted)
+	storeMock.AssertNotCalled(suite.T(), "DeleteMembershipsByMember",
+		mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (suite *GroupServiceTestSuite) TestCascadeDeleteDependencies_StoreError() {
+	storeMock := newGroupStoreInterfaceMock(suite.T())
+	storeMock.On("DeleteMembershipsByMember", mock.Anything, string(memberTypeEntity), "user-1").
+		Return(int64(0), errors.New("db error"))
+	service := &groupService{groupStore: storeMock}
+
+	deleted, err := service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeUser, "user-1")
+
+	suite.Error(err)
+	suite.Equal(0, deleted)
 }

--- a/backend/internal/group/store.go
+++ b/backend/internal/group/store.go
@@ -53,6 +53,7 @@ type groupStoreInterface interface {
 		ctx context.Context, oUID string, limit, offset int) ([]GroupBasicDAO, error)
 	AddGroupMembers(ctx context.Context, groupID string, members []Member) error
 	RemoveGroupMembers(ctx context.Context, groupID string, members []Member) error
+	DeleteMembershipsByMember(ctx context.Context, memberType, memberID string) (int64, error)
 	GetGroupsByIDs(ctx context.Context, groupIDs []string) ([]GroupBasicDAO, error)
 	IsGroupDeclarative(ctx context.Context, id string) (bool, error)
 	GetTransitiveGroupsForEntity(ctx context.Context, entityID string) ([]providers.EntityGroup, error)
@@ -504,6 +505,23 @@ func (s *groupStore) RemoveGroupMembers(ctx context.Context, groupID string, mem
 	}
 
 	return nil
+}
+
+// DeleteMembershipsByMember deletes all group memberships held by a given member principal across
+// groups, returning the number removed.
+func (s *groupStore) DeleteMembershipsByMember(
+	ctx context.Context, memberType, memberID string) (int64, error) {
+	dbClient, err := s.dbProvider.GetUserDBClient()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	rowsAffected, err := dbClient.ExecuteContext(
+		ctx, QueryDeleteGroupMembershipsByMember, memberType, memberID, s.deploymentID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete memberships for member: %w", err)
+	}
+	return rowsAffected, nil
 }
 
 // GetGroupsByIDs retrieves groups by a list of IDs.

--- a/backend/internal/group/store_constants.go
+++ b/backend/internal/group/store_constants.go
@@ -67,7 +67,7 @@ func buildGetGroupsCountByOUIDsQuery(
 ) (dbmodel.DBQuery, []interface{}) {
 	if len(ouIDs) == 0 {
 		return dbmodel.DBQuery{
-			ID:            "GRQ-GROUP_MGT-03",
+			ID:            "GRQ-GROUP_MGT-22",
 			Query:         "SELECT 0 WHERE 1=0",
 			PostgresQuery: "SELECT 0 WHERE 1=0",
 			SQLiteQuery:   "SELECT 0 WHERE 1=0",
@@ -110,7 +110,7 @@ func buildGetGroupsByOUIDsQuery(
 ) (dbmodel.DBQuery, []interface{}) {
 	if len(ouIDs) == 0 {
 		return dbmodel.DBQuery{
-			ID:            "GRQ-GROUP_MGT-04",
+			ID:            "GRQ-GROUP_MGT-23",
 			Query:         `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE 1=0`,
 			PostgresQuery: `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE 1=0`,
 			SQLiteQuery:   `SELECT ID, OU_ID, NAME, DESCRIPTION FROM "GROUP" WHERE 1=0`,
@@ -195,6 +195,14 @@ var (
 	QueryDeleteGroupMembers = dbmodel.DBQuery{
 		ID:    "GRQ-GROUP_MGT-11",
 		Query: `DELETE FROM "GROUP_MEMBER_REFERENCE" WHERE GROUP_ID = $1 AND DEPLOYMENT_ID = $2`,
+	}
+
+	// QueryDeleteGroupMembershipsByMember deletes all group memberships for a given member across
+	// groups (used to cascade-delete memberships when the member principal is deleted).
+	QueryDeleteGroupMembershipsByMember = dbmodel.DBQuery{
+		ID: "GRQ-GROUP_MGT-21",
+		Query: `DELETE FROM "GROUP_MEMBER_REFERENCE" ` +
+			`WHERE MEMBER_TYPE = $1 AND MEMBER_ID = $2 AND DEPLOYMENT_ID = $3`,
 	}
 
 	// QueryAddMemberToGroup is the query to assign member to a group.

--- a/backend/internal/group/store_test.go
+++ b/backend/internal/group/store_test.go
@@ -1980,3 +1980,35 @@ func (suite *GroupStoreTestSuite) TestGroupStore_GetTransitiveGroupsForEntity() 
 		})
 	}
 }
+
+func (suite *GroupStoreTestSuite) TestDeleteMembershipsByMember() {
+	suite.Run("success returns rows affected", func() {
+		providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
+		dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
+		providerMock.On("GetUserDBClient").Return(dbClientMock, nil).Once()
+		dbClientMock.On("ExecuteContext", mock.Anything, QueryDeleteGroupMembershipsByMember,
+			string(memberTypeEntity), "user-1", testDeploymentID).Return(int64(2), nil).Once()
+
+		store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+		deleted, err := store.DeleteMembershipsByMember(
+			context.Background(), string(memberTypeEntity), "user-1")
+
+		require.NoError(suite.T(), err)
+		require.Equal(suite.T(), int64(2), deleted)
+	})
+
+	suite.Run("db error is propagated", func() {
+		providerMock := providermock.NewDBProviderInterfaceMock(suite.T())
+		dbClientMock := providermock.NewDBClientInterfaceMock(suite.T())
+		providerMock.On("GetUserDBClient").Return(dbClientMock, nil).Once()
+		dbClientMock.On("ExecuteContext", mock.Anything, QueryDeleteGroupMembershipsByMember,
+			string(memberTypeEntity), "user-1", testDeploymentID).Return(int64(0), errors.New("db error")).Once()
+
+		store := &groupStore{dbProvider: providerMock, deploymentID: testDeploymentID}
+		deleted, err := store.DeleteMembershipsByMember(
+			context.Background(), string(memberTypeEntity), "user-1")
+
+		require.Error(suite.T(), err)
+		require.Equal(suite.T(), int64(0), deleted)
+	})
+}

--- a/backend/internal/idp/service_test.go
+++ b/backend/internal/idp/service_test.go
@@ -59,6 +59,10 @@ func (r *stubDependencyRegistry) GetDependencies(
 	return r.resp, r.err
 }
 
+func (r *stubDependencyRegistry) CascadeDelete(context.Context, string, string) (int, error) {
+	return 0, nil
+}
+
 // newNoBlockingDepsRegistry returns a registry reporting confirmed-empty dependencies, so that
 // deletion is permitted by the blocking guard.
 func newNoBlockingDepsRegistry() *stubDependencyRegistry {

--- a/backend/internal/notification/mgt_service_test.go
+++ b/backend/internal/notification/mgt_service_test.go
@@ -51,6 +51,10 @@ func (r *stubDependencyRegistry) GetDependencies(
 	return r.resp, r.err
 }
 
+func (r *stubDependencyRegistry) CascadeDelete(context.Context, string, string) (int, error) {
+	return 0, nil
+}
+
 // newNoBlockingDepsRegistry returns a registry reporting confirmed-empty dependencies, so that
 // deletion is permitted by the blocking guard.
 func newNoBlockingDepsRegistry() *stubDependencyRegistry {

--- a/backend/internal/role/RoleAssignmentServiceInterface_mock_test.go
+++ b/backend/internal/role/RoleAssignmentServiceInterface_mock_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -164,6 +165,152 @@ func (_c *RoleAssignmentServiceInterfaceMock_AddAssignments_Call) Return(service
 }
 
 func (_c *RoleAssignmentServiceInterfaceMock_AddAssignments_Call) RunAndReturn(run func(ctx context.Context, id string, assignments []RoleAssignment) *common.ServiceError) *RoleAssignmentServiceInterfaceMock_AddAssignments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CascadeDeleteDependencies provides a mock function for the type RoleAssignmentServiceInterfaceMock
+func (_mock *RoleAssignmentServiceInterfaceMock) CascadeDeleteDependencies(ctx context.Context, resourceType string, id string) (int, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CascadeDeleteDependencies")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CascadeDeleteDependencies'
+type RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call struct {
+	*mock.Call
+}
+
+// CascadeDeleteDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *RoleAssignmentServiceInterfaceMock_Expecter) CascadeDeleteDependencies(ctx interface{}, resourceType interface{}, id interface{}) *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	return &RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call{Call: _e.mock.On("CascadeDeleteDependencies", ctx, resourceType, id)}
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call) Return(n int, err error) *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) (int, error)) *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceDependencies provides a mock function for the type RoleAssignmentServiceInterfaceMock
+func (_mock *RoleAssignmentServiceInterfaceMock) GetResourceDependencies(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceDependencies")
+	}
+
+	var r0 []resourcedependency.ResourceDependency
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]resourcedependency.ResourceDependency, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []resourcedependency.ResourceDependency); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]resourcedependency.ResourceDependency)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceDependencies'
+type RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call struct {
+	*mock.Call
+}
+
+// GetResourceDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *RoleAssignmentServiceInterfaceMock_Expecter) GetResourceDependencies(ctx interface{}, resourceType interface{}, id interface{}) *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call {
+	return &RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call{Call: _e.mock.On("GetResourceDependencies", ctx, resourceType, id)}
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call) Return(resourceDependencys []resourcedependency.ResourceDependency, err error) *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Return(resourceDependencys, err)
+	return _c
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error)) *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/role/assignment_service.go
+++ b/backend/internal/role/assignment_service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/entitytype"
 	"github.com/thunder-id/thunderid/internal/group"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )
@@ -47,6 +48,9 @@ type RoleAssignmentServiceInterface interface {
 	RemoveAssignments(ctx context.Context, id string, assignments []RoleAssignment) *tidcommon.ServiceError
 	AddAssigneesToRoles(ctx context.Context, assignments []RoleAssignment,
 		roleIDs []string) *tidcommon.ServiceError
+	GetResourceDependencies(
+		ctx context.Context, resourceType, id string) ([]resourcedependency.ResourceDependency, error)
+	CascadeDeleteDependencies(ctx context.Context, resourceType, id string) (int, error)
 }
 
 // roleAssignmentService is the default implementation of RoleAssignmentServiceInterface.
@@ -594,4 +598,30 @@ func normalizeAssignments(assignments []RoleAssignment) []RoleAssignment {
 		normalized[i] = RoleAssignment{ID: a.ID, Type: t}
 	}
 	return normalized
+}
+
+// GetResourceDependencies implements resourcedependency.Provider. Role assignments are cleaned up
+// via cascade rather than surfaced as blocking usages, so no dependencies are reported here.
+func (as *roleAssignmentService) GetResourceDependencies(
+	_ context.Context, _, _ string) ([]resourcedependency.ResourceDependency, error) {
+	return []resourcedependency.ResourceDependency{}, nil
+}
+
+// CascadeDeleteDependencies implements resourcedependency.CascadeDeleter. It removes the role
+// assignments held by the given principal when that principal is deleted. Only user, app and agent
+// principals (stored as entity assignees) are handled; other resource types have no assignments.
+func (as *roleAssignmentService) CascadeDeleteDependencies(
+	ctx context.Context, resourceType, id string) (int, error) {
+	switch resourceType {
+	case resourcedependency.ResourceTypeUser,
+		resourcedependency.ResourceTypeApplication,
+		resourcedependency.ResourceTypeAgent:
+		deleted, err := as.roleStore.DeleteAssignmentsByAssignee(ctx, string(assigneeTypeEntity), id)
+		if err != nil {
+			return 0, err
+		}
+		return int(deleted), nil
+	default:
+		return 0, nil
+	}
 }

--- a/backend/internal/role/assignment_service_test.go
+++ b/backend/internal/role/assignment_service_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/group"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/tests/mocks/entitymock"
 	"github.com/thunder-id/thunderid/tests/mocks/entitytypemock"
 	"github.com/thunder-id/thunderid/tests/mocks/groupmock"
@@ -738,4 +739,44 @@ func (suite *RoleAssignmentServiceTestSuite) TestAddAssigneesToRoles_MultipleRol
 		context.Background(), assignments, []string{"role1", "role2"})
 
 	suite.Nil(err)
+}
+
+// --- Cascade / dependency provider ---
+
+func (suite *RoleAssignmentServiceTestSuite) TestGetResourceDependencies_ReturnsEmpty() {
+	result, err := suite.service.GetResourceDependencies(
+		context.Background(), resourcedependency.ResourceTypeUser, "user-1")
+	suite.NoError(err)
+	suite.Empty(result)
+}
+
+func (suite *RoleAssignmentServiceTestSuite) TestCascadeDeleteDependencies_User_DeletesAssignments() {
+	suite.mockStore.On("DeleteAssignmentsByAssignee", mock.Anything, string(assigneeTypeEntity), "user-1").
+		Return(int64(3), nil)
+
+	deleted, err := suite.service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeUser, "user-1")
+
+	suite.NoError(err)
+	suite.Equal(3, deleted)
+}
+
+func (suite *RoleAssignmentServiceTestSuite) TestCascadeDeleteDependencies_UnknownType_NoOp() {
+	deleted, err := suite.service.CascadeDeleteDependencies(context.Background(), "theme", "theme-1")
+
+	suite.NoError(err)
+	suite.Equal(0, deleted)
+	suite.mockStore.AssertNotCalled(suite.T(), "DeleteAssignmentsByAssignee",
+		mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (suite *RoleAssignmentServiceTestSuite) TestCascadeDeleteDependencies_StoreError() {
+	suite.mockStore.On("DeleteAssignmentsByAssignee", mock.Anything, string(assigneeTypeEntity), "user-1").
+		Return(int64(0), errors.New("db error"))
+
+	deleted, err := suite.service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeUser, "user-1")
+
+	suite.Error(err)
+	suite.Equal(0, deleted)
 }

--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -367,6 +367,12 @@ func (c *compositeRoleStore) DeleteAssignmentsByRoleID(ctx context.Context, id s
 	return c.dbStore.DeleteAssignmentsByRoleID(ctx, id)
 }
 
+// DeleteAssignmentsByAssignee deletes assignments for the assignee from the database store only.
+func (c *compositeRoleStore) DeleteAssignmentsByAssignee(
+	ctx context.Context, assigneeType, assigneeID string) (int64, error) {
+	return c.dbStore.DeleteAssignmentsByAssignee(ctx, assigneeType, assigneeID)
+}
+
 // AddAssignments adds assignments to a role in the database store only.
 func (c *compositeRoleStore) AddAssignments(ctx context.Context, id string, assignments []RoleAssignment) error {
 	return c.dbStore.AddAssignments(ctx, id, assignments)

--- a/backend/internal/role/file_based_store.go
+++ b/backend/internal/role/file_based_store.go
@@ -324,6 +324,13 @@ func (f *fileBasedStore) DeleteAssignmentsByRoleID(ctx context.Context, id strin
 	return errors.New("DeleteAssignmentsByRoleID is not supported in file-based store")
 }
 
+// DeleteAssignmentsByAssignee is a no-op for the file-based store: declarative roles hold no
+// mutable runtime assignments to cascade-delete, so there is nothing to remove.
+func (f *fileBasedStore) DeleteAssignmentsByAssignee(
+	_ context.Context, _, _ string) (int64, error) {
+	return 0, nil
+}
+
 // AddAssignments is not supported in file-based store.
 func (f *fileBasedStore) AddAssignments(ctx context.Context, id string, assignments []RoleAssignment) error {
 	return errors.New("AddAssignments is not supported in file-based store")

--- a/backend/internal/role/roleStoreInterface_mock_test.go
+++ b/backend/internal/role/roleStoreInterface_mock_test.go
@@ -313,6 +313,78 @@ func (_c *roleStoreInterfaceMock_CreateRole_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// DeleteAssignmentsByAssignee provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) DeleteAssignmentsByAssignee(ctx context.Context, assigneeType string, assigneeID string) (int64, error) {
+	ret := _mock.Called(ctx, assigneeType, assigneeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAssignmentsByAssignee")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int64, error)); ok {
+		return returnFunc(ctx, assigneeType, assigneeID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int64); ok {
+		r0 = returnFunc(ctx, assigneeType, assigneeID)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, assigneeType, assigneeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAssignmentsByAssignee'
+type roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call struct {
+	*mock.Call
+}
+
+// DeleteAssignmentsByAssignee is a helper method to define mock.On call
+//   - ctx context.Context
+//   - assigneeType string
+//   - assigneeID string
+func (_e *roleStoreInterfaceMock_Expecter) DeleteAssignmentsByAssignee(ctx interface{}, assigneeType interface{}, assigneeID interface{}) *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call {
+	return &roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call{Call: _e.mock.On("DeleteAssignmentsByAssignee", ctx, assigneeType, assigneeID)}
+}
+
+func (_c *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call) Run(run func(ctx context.Context, assigneeType string, assigneeID string)) *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call) Return(n int64, err error) *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call) RunAndReturn(run func(ctx context.Context, assigneeType string, assigneeID string) (int64, error)) *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteAssignmentsByRoleID provides a mock function for the type roleStoreInterfaceMock
 func (_mock *roleStoreInterfaceMock) DeleteAssignmentsByRoleID(ctx context.Context, id string) error {
 	ret := _mock.Called(ctx, id)

--- a/backend/internal/role/store.go
+++ b/backend/internal/role/store.go
@@ -50,6 +50,7 @@ type roleStoreInterface interface {
 	UpdateRole(ctx context.Context, id string, role RoleUpdateDetail) error
 	DeleteRole(ctx context.Context, id string) error
 	DeleteAssignmentsByRoleID(ctx context.Context, id string) error
+	DeleteAssignmentsByAssignee(ctx context.Context, assigneeType, assigneeID string) (int64, error)
 	AddAssignments(ctx context.Context, id string, assignments []RoleAssignment) error
 	RemoveAssignments(ctx context.Context, id string, assignments []RoleAssignment) error
 	CheckRoleNameExists(ctx context.Context, ouID, name string) (bool, error)
@@ -400,6 +401,23 @@ func (s *roleStore) DeleteAssignmentsByRoleID(ctx context.Context, id string) er
 		return fmt.Errorf("failed to delete assignments for role: %w", err)
 	}
 	return nil
+}
+
+// DeleteAssignmentsByAssignee deletes all role assignments for a given assignee principal across
+// roles, returning the number removed.
+func (s *roleStore) DeleteAssignmentsByAssignee(
+	ctx context.Context, assigneeType, assigneeID string) (int64, error) {
+	dbClient, err := s.getConfigDBClient()
+	if err != nil {
+		return 0, err
+	}
+
+	rowsAffected, err := dbClient.ExecuteContext(
+		ctx, queryDeleteRoleAssignmentsByAssignee, assigneeType, assigneeID, s.deploymentID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete assignments for assignee: %w", err)
+	}
+	return rowsAffected, nil
 }
 
 // AddAssignments adds assignments to a role.

--- a/backend/internal/role/store_constants.go
+++ b/backend/internal/role/store_constants.go
@@ -116,6 +116,14 @@ var (
 		Query: `DELETE FROM "ROLE_ASSIGNMENT" WHERE ROLE_ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
 
+	// queryDeleteRoleAssignmentsByAssignee deletes all assignments for a given assignee across roles
+	// (used to cascade-delete assignments when the assignee principal is deleted).
+	queryDeleteRoleAssignmentsByAssignee = dbmodel.DBQuery{
+		ID: "RLQ-ROLE_MGT-25",
+		Query: `DELETE FROM "ROLE_ASSIGNMENT" ` +
+			`WHERE ASSIGNEE_TYPE = $1 AND ASSIGNEE_ID = $2 AND DEPLOYMENT_ID = $3`,
+	}
+
 	// queryCheckRoleNameExists checks if a role name already exists for a given organization unit.
 	queryCheckRoleNameExists = dbmodel.DBQuery{
 		ID:    "RLQ-ROLE_MGT-14",

--- a/backend/internal/role/store_test.go
+++ b/backend/internal/role/store_test.go
@@ -2084,3 +2084,29 @@ func (suite *RoleStoreTestSuite) TestGetEntityRoleIDs_IgnoresMalformedRows() {
 	suite.NoError(err)
 	suite.Equal([]string{"role-a", "role-c"}, roleIDs)
 }
+
+func (suite *RoleStoreTestSuite) TestDeleteAssignmentsByAssignee() {
+	suite.Run("success returns rows affected", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil).Once()
+		suite.mockDBClient.On("ExecuteContext", mock.Anything, queryDeleteRoleAssignmentsByAssignee,
+			string(assigneeTypeEntity), "user-1", testDeploymentID).Return(int64(2), nil).Once()
+
+		deleted, err := suite.store.DeleteAssignmentsByAssignee(
+			context.Background(), string(assigneeTypeEntity), "user-1")
+
+		suite.NoError(err)
+		suite.Equal(int64(2), deleted)
+	})
+
+	suite.Run("db error is propagated", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil).Once()
+		suite.mockDBClient.On("ExecuteContext", mock.Anything, queryDeleteRoleAssignmentsByAssignee,
+			string(assigneeTypeEntity), "user-1", testDeploymentID).Return(int64(0), errors.New("db error")).Once()
+
+		deleted, err := suite.store.DeleteAssignmentsByAssignee(
+			context.Background(), string(assigneeTypeEntity), "user-1")
+
+		suite.Error(err)
+		suite.Equal(int64(0), deleted)
+	})
+}

--- a/backend/internal/system/resourcedependency/registry.go
+++ b/backend/internal/system/resourcedependency/registry.go
@@ -116,10 +116,18 @@ type Provider interface {
 	GetResourceDependencies(ctx context.Context, resourceType, id string) ([]ResourceDependency, error)
 }
 
+// CascadeDeleter is an optional interface a Provider may implement to delete its cascade-behavior
+// dependents of a target resource when the target is deleted. Implementations must be idempotent
+// and return the number of dependents removed.
+type CascadeDeleter interface {
+	CascadeDeleteDependencies(ctx context.Context, resourceType, id string) (int, error)
+}
+
 // Registry fans out dependency lookups to all registered providers.
 type Registry interface {
 	RegisterProvider(p Provider)
 	GetDependencies(ctx context.Context, resourceType, id string) (*DependenciesResponse, error)
+	CascadeDelete(ctx context.Context, resourceType, id string) (int, error)
 }
 
 // registry is the default implementation of Registry.
@@ -189,4 +197,25 @@ func (r *registry) GetDependencies(
 		Summary:      summary,
 		Usages:       usages,
 	}, nil
+}
+
+// CascadeDelete asks every provider that implements CascadeDeleter to remove its cascade-behavior
+// dependents of (resourceType, id), returning the total number removed. It stops and returns the
+// error on the first provider failure, so the caller can abort the target deletion.
+func (r *registry) CascadeDelete(ctx context.Context, resourceType, id string) (int, error) {
+	total := 0
+	for _, p := range r.providers {
+		cascader, ok := p.(CascadeDeleter)
+		if !ok {
+			continue
+		}
+		deleted, err := cascader.CascadeDeleteDependencies(ctx, resourceType, id)
+		if err != nil {
+			r.logger.Error(ctx, "Failed to cascade-delete dependencies from provider",
+				log.String("resourceType", resourceType), log.String("id", id), log.Error(err))
+			return total, err
+		}
+		total += deleted
+	}
+	return total, nil
 }

--- a/backend/internal/system/resourcedependency/registry_test.go
+++ b/backend/internal/system/resourcedependency/registry_test.go
@@ -98,3 +98,53 @@ func TestGetDependenciesNoProvidersReturnsEmpty(t *testing.T) {
 	assert.Empty(t, resp.Usages)
 	assert.Empty(t, resp.Summary)
 }
+
+// cascadeStubProvider is a provider that also implements CascadeDeleter.
+type cascadeStubProvider struct {
+	usages  []ResourceDependency
+	deleted int
+	err     error
+}
+
+func (s *cascadeStubProvider) GetResourceDependencies(
+	_ context.Context, _, _ string) ([]ResourceDependency, error) {
+	return s.usages, nil
+}
+
+func (s *cascadeStubProvider) CascadeDeleteDependencies(_ context.Context, _, _ string) (int, error) {
+	return s.deleted, s.err
+}
+
+func TestCascadeDeleteSumsAcrossProvidersAndSkipsNonCascaders(t *testing.T) {
+	reg := newRegistry()
+	// A plain provider (no CascadeDeleter) must be skipped, not fail.
+	reg.RegisterProvider(&stubProvider{usages: []ResourceDependency{}})
+	reg.RegisterProvider(&cascadeStubProvider{deleted: 2})
+	reg.RegisterProvider(&cascadeStubProvider{deleted: 3})
+
+	deleted, err := reg.CascadeDelete(context.Background(), "user", "u1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 5, deleted)
+}
+
+func TestCascadeDeleteStopsOnProviderError(t *testing.T) {
+	reg := newRegistry()
+	reg.RegisterProvider(&cascadeStubProvider{deleted: 1})
+	reg.RegisterProvider(&cascadeStubProvider{err: errors.New("delete failed")})
+
+	deleted, err := reg.CascadeDelete(context.Background(), "user", "u1")
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, deleted)
+}
+
+func TestCascadeDeleteNoProvidersReturnsZero(t *testing.T) {
+	reg := newRegistry()
+	reg.RegisterProvider(&stubProvider{usages: []ResourceDependency{}})
+
+	deleted, err := reg.CascadeDelete(context.Background(), "user", "u1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+}

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -780,6 +780,14 @@ func (us *userService) DeleteUser(ctx context.Context, userID string) *tidcommon
 		return svcErr
 	}
 
+	// Remove dependents that must be deleted with the user (e.g. role assignments). Run before the
+	// entity delete so a cleanup failure aborts the operation and leaves the user retriable. The
+	// registry is guaranteed non-nil here because ensureNoBlockingDependencies fails closed otherwise.
+	if _, err = us.dependencyRegistry.CascadeDelete(ctx, resourcedependency.ResourceTypeUser, userID); err != nil {
+		return logErrorAndReturnServerError(ctx, logger, "Failed to cascade-delete user dependencies", err,
+			log.MaskedString(log.LoggerKeyUserID, userID))
+	}
+
 	err = us.entityService.DeleteEntity(ctx, userID)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -2890,6 +2890,30 @@ func TestUserService_DeleteUser_RefusedWhenRegistryUnset(t *testing.T) {
 	storeMock.AssertNotCalled(t, "DeleteEntity", mock.Anything, mock.Anything)
 }
 
+func TestUserService_DeleteUser_AbortedWhenCascadeFails(t *testing.T) {
+	userID := svcTestUserID1
+	storeMock := newDeletableUserStore(t)
+
+	total := 0
+	registry := &stubUsageRegistry{
+		resp: &resourcedependency.DependenciesResponse{
+			TotalResults: &total, Usages: []resourcedependency.ResourceDependency{},
+		},
+		cascadeErr: errors.New("cascade delete failed"),
+	}
+
+	service := &userService{
+		entityService:      storeMock,
+		authzService:       newAllowAllAuthz(t),
+		dependencyRegistry: registry,
+	}
+
+	err := service.DeleteUser(context.Background(), userID)
+	require.NotNil(t, err)
+	require.Equal(t, tidcommon.InternalServerError.Code, err.Code)
+	storeMock.AssertNotCalled(t, "DeleteEntity", mock.Anything, mock.Anything)
+}
+
 // TestUpdateUser_DeclarativeResource tests that UpdateUser returns ErrorCannotModifyDeclarativeResource
 // when the user is declarative.
 func TestUpdateUser_DeclarativeResource(t *testing.T) {
@@ -3581,8 +3605,9 @@ func TestUserDeclarativeYAML_OUHandleParsed(t *testing.T) {
 
 // stubUsageRegistry is a minimal resourcedependency.Registry for tests.
 type stubUsageRegistry struct {
-	resp *resourcedependency.DependenciesResponse
-	err  error
+	resp       *resourcedependency.DependenciesResponse
+	err        error
+	cascadeErr error
 }
 
 func (s *stubUsageRegistry) RegisterProvider(resourcedependency.Provider) {}
@@ -3590,6 +3615,10 @@ func (s *stubUsageRegistry) RegisterProvider(resourcedependency.Provider) {}
 func (s *stubUsageRegistry) GetDependencies(
 	_ context.Context, _, _ string) (*resourcedependency.DependenciesResponse, error) {
 	return s.resp, s.err
+}
+
+func (s *stubUsageRegistry) CascadeDelete(_ context.Context, _, _ string) (int, error) {
+	return 0, s.cascadeErr
 }
 
 func newUserForUsages(id string) *providers.Entity {

--- a/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
+++ b/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
@@ -9,6 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/group"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -176,6 +177,78 @@ func (_c *GroupServiceInterfaceMock_AddMembersToGroups_Call) Return(serviceError
 }
 
 func (_c *GroupServiceInterfaceMock_AddMembersToGroups_Call) RunAndReturn(run func(ctx context.Context, members []group.Member, groupIDs []string) *common.ServiceError) *GroupServiceInterfaceMock_AddMembersToGroups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CascadeDeleteDependencies provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) CascadeDeleteDependencies(ctx context.Context, resourceType string, id string) (int, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CascadeDeleteDependencies")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// GroupServiceInterfaceMock_CascadeDeleteDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CascadeDeleteDependencies'
+type GroupServiceInterfaceMock_CascadeDeleteDependencies_Call struct {
+	*mock.Call
+}
+
+// CascadeDeleteDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *GroupServiceInterfaceMock_Expecter) CascadeDeleteDependencies(ctx interface{}, resourceType interface{}, id interface{}) *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	return &GroupServiceInterfaceMock_CascadeDeleteDependencies_Call{Call: _e.mock.On("CascadeDeleteDependencies", ctx, resourceType, id)}
+}
+
+func (_c *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call) Return(n int, err error) *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) (int, error)) *GroupServiceInterfaceMock_CascadeDeleteDependencies_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -785,6 +858,80 @@ func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) Return(groupListRespon
 }
 
 func (_c *GroupServiceInterfaceMock_GetGroupsByPath_Call) RunAndReturn(run func(ctx context.Context, handlePath string, limit int, offset int, includeDisplay bool) (*group.GroupListResponse, *common.ServiceError)) *GroupServiceInterfaceMock_GetGroupsByPath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceDependencies provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) GetResourceDependencies(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceDependencies")
+	}
+
+	var r0 []resourcedependency.ResourceDependency
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]resourcedependency.ResourceDependency, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []resourcedependency.ResourceDependency); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]resourcedependency.ResourceDependency)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// GroupServiceInterfaceMock_GetResourceDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceDependencies'
+type GroupServiceInterfaceMock_GetResourceDependencies_Call struct {
+	*mock.Call
+}
+
+// GetResourceDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *GroupServiceInterfaceMock_Expecter) GetResourceDependencies(ctx interface{}, resourceType interface{}, id interface{}) *GroupServiceInterfaceMock_GetResourceDependencies_Call {
+	return &GroupServiceInterfaceMock_GetResourceDependencies_Call{Call: _e.mock.On("GetResourceDependencies", ctx, resourceType, id)}
+}
+
+func (_c *GroupServiceInterfaceMock_GetResourceDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *GroupServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetResourceDependencies_Call) Return(resourceDependencys []resourcedependency.ResourceDependency, err error) *GroupServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Return(resourceDependencys, err)
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetResourceDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error)) *GroupServiceInterfaceMock_GetResourceDependencies_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
+++ b/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
@@ -348,6 +348,78 @@ func (_c *groupStoreInterfaceMock_DeleteGroup_Call) RunAndReturn(run func(ctx co
 	return _c
 }
 
+// DeleteMembershipsByMember provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) DeleteMembershipsByMember(ctx context.Context, memberType string, memberID string) (int64, error) {
+	ret := _mock.Called(ctx, memberType, memberID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteMembershipsByMember")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int64, error)); ok {
+		return returnFunc(ctx, memberType, memberID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int64); ok {
+		r0 = returnFunc(ctx, memberType, memberID)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, memberType, memberID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// groupStoreInterfaceMock_DeleteMembershipsByMember_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteMembershipsByMember'
+type groupStoreInterfaceMock_DeleteMembershipsByMember_Call struct {
+	*mock.Call
+}
+
+// DeleteMembershipsByMember is a helper method to define mock.On call
+//   - ctx context.Context
+//   - memberType string
+//   - memberID string
+func (_e *groupStoreInterfaceMock_Expecter) DeleteMembershipsByMember(ctx interface{}, memberType interface{}, memberID interface{}) *groupStoreInterfaceMock_DeleteMembershipsByMember_Call {
+	return &groupStoreInterfaceMock_DeleteMembershipsByMember_Call{Call: _e.mock.On("DeleteMembershipsByMember", ctx, memberType, memberID)}
+}
+
+func (_c *groupStoreInterfaceMock_DeleteMembershipsByMember_Call) Run(run func(ctx context.Context, memberType string, memberID string)) *groupStoreInterfaceMock_DeleteMembershipsByMember_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_DeleteMembershipsByMember_Call) Return(n int64, err error) *groupStoreInterfaceMock_DeleteMembershipsByMember_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_DeleteMembershipsByMember_Call) RunAndReturn(run func(ctx context.Context, memberType string, memberID string) (int64, error)) *groupStoreInterfaceMock_DeleteMembershipsByMember_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroup provides a mock function for the type groupStoreInterfaceMock
 func (_mock *groupStoreInterfaceMock) GetGroup(ctx context.Context, id string) (group.GroupDAO, error) {
 	ret := _mock.Called(ctx, id)

--- a/backend/tests/mocks/rolemock/RoleAssignmentServiceInterface_mock.go
+++ b/backend/tests/mocks/rolemock/RoleAssignmentServiceInterface_mock.go
@@ -9,6 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/role"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -165,6 +166,152 @@ func (_c *RoleAssignmentServiceInterfaceMock_AddAssignments_Call) Return(service
 }
 
 func (_c *RoleAssignmentServiceInterfaceMock_AddAssignments_Call) RunAndReturn(run func(ctx context.Context, id string, assignments []role.RoleAssignment) *common.ServiceError) *RoleAssignmentServiceInterfaceMock_AddAssignments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CascadeDeleteDependencies provides a mock function for the type RoleAssignmentServiceInterfaceMock
+func (_mock *RoleAssignmentServiceInterfaceMock) CascadeDeleteDependencies(ctx context.Context, resourceType string, id string) (int, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CascadeDeleteDependencies")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CascadeDeleteDependencies'
+type RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call struct {
+	*mock.Call
+}
+
+// CascadeDeleteDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *RoleAssignmentServiceInterfaceMock_Expecter) CascadeDeleteDependencies(ctx interface{}, resourceType interface{}, id interface{}) *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	return &RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call{Call: _e.mock.On("CascadeDeleteDependencies", ctx, resourceType, id)}
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call) Return(n int, err error) *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) (int, error)) *RoleAssignmentServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceDependencies provides a mock function for the type RoleAssignmentServiceInterfaceMock
+func (_mock *RoleAssignmentServiceInterfaceMock) GetResourceDependencies(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceDependencies")
+	}
+
+	var r0 []resourcedependency.ResourceDependency
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]resourcedependency.ResourceDependency, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []resourcedependency.ResourceDependency); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]resourcedependency.ResourceDependency)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceDependencies'
+type RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call struct {
+	*mock.Call
+}
+
+// GetResourceDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *RoleAssignmentServiceInterfaceMock_Expecter) GetResourceDependencies(ctx interface{}, resourceType interface{}, id interface{}) *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call {
+	return &RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call{Call: _e.mock.On("GetResourceDependencies", ctx, resourceType, id)}
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call) Return(resourceDependencys []resourcedependency.ResourceDependency, err error) *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Return(resourceDependencys, err)
+	return _c
+}
+
+func (_c *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error)) *RoleAssignmentServiceInterfaceMock_GetResourceDependencies_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/rolemock/roleStoreInterface_mock.go
+++ b/backend/tests/mocks/rolemock/roleStoreInterface_mock.go
@@ -314,6 +314,78 @@ func (_c *roleStoreInterfaceMock_CreateRole_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// DeleteAssignmentsByAssignee provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) DeleteAssignmentsByAssignee(ctx context.Context, assigneeType string, assigneeID string) (int64, error) {
+	ret := _mock.Called(ctx, assigneeType, assigneeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAssignmentsByAssignee")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int64, error)); ok {
+		return returnFunc(ctx, assigneeType, assigneeID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int64); ok {
+		r0 = returnFunc(ctx, assigneeType, assigneeID)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, assigneeType, assigneeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAssignmentsByAssignee'
+type roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call struct {
+	*mock.Call
+}
+
+// DeleteAssignmentsByAssignee is a helper method to define mock.On call
+//   - ctx context.Context
+//   - assigneeType string
+//   - assigneeID string
+func (_e *roleStoreInterfaceMock_Expecter) DeleteAssignmentsByAssignee(ctx interface{}, assigneeType interface{}, assigneeID interface{}) *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call {
+	return &roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call{Call: _e.mock.On("DeleteAssignmentsByAssignee", ctx, assigneeType, assigneeID)}
+}
+
+func (_c *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call) Run(run func(ctx context.Context, assigneeType string, assigneeID string)) *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call) Return(n int64, err error) *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call) RunAndReturn(run func(ctx context.Context, assigneeType string, assigneeID string) (int64, error)) *roleStoreInterfaceMock_DeleteAssignmentsByAssignee_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteAssignmentsByRoleID provides a mock function for the type roleStoreInterfaceMock
 func (_mock *roleStoreInterfaceMock) DeleteAssignmentsByRoleID(ctx context.Context, id string) error {
 	ret := _mock.Called(ctx, id)


### PR DESCRIPTION
### Purpose

When a user is deleted, remove the resources that reference the user as a principal, which would otherwise be left dangling:

- the user's **role assignments** (`ROLE_ASSIGNMENT`), and
- the user's **group memberships** (`GROUP_MEMBER_REFERENCE`).

This builds on the existing dependency registry (the same mechanism behind the usages endpoint and the delete-blocking guard) — no parallel machinery. Delete-blocking (e.g. owned agents → `409`) is already merged and is not part of this PR.

### Approach

- **Cascade behavior:** added `BehaviorCascade` and an optional `CascadeDeleter` provider interface, plus a `Registry.CascadeDelete` fan-out that invokes every provider implementing it and stops on the first error.
- **Providers declare, target enforces.** The role-assignment and group services implement `CascadeDeleter` to remove a principal's assignments/memberships (`DeleteAssignmentsByAssignee` / `DeleteMembershipsByMember`, added across the db/composite/file stores; users/apps/agents are stored as `entity` assignees/members).
- **`DeleteUser` sequence:** existing checks → blocking guard → **cascade cleanup** → entity delete. Cascade runs before the entity delete so a cleanup failure aborts the operation and leaves the user retriable.
- **Cross-DB note:** role assignments and group memberships live in different databases from the user entity with polymorphic references (no FK), so `ON DELETE CASCADE` is not possible — cleanup is application-level, idempotent, and fail-closed. The immutable (declarative) dependent case is a documented follow-up.
- Also fixes pre-existing duplicate `DBQuery` IDs in the group store (`GRQ-GROUP_MGT-03`/`-04` were reused across a query builder's branches → `-22`/`-23`).

### Related Issues

- Fixes #3801

### Related PRs

- Builds on the dependency-registry and delete-blocking work (#3362, #3712, #3793).

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User deletion now triggers automatic cascade cleanup for related group memberships and role assignments for supported principal types.
  * Resource-dependency handling now includes cascade-deletion behavior to remove dependent data when appropriate.
* **Bug Fixes**
  * Deletion now aborts when cascade cleanup fails, preventing partial removals.
* **Tests**
  * Expanded unit test coverage and updated test doubles to support cascade-deletion, membership deletion, and role-assignment removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->