### PR TITLE
Update Identity Provider documentation

### DIFF
--- a/api/connections.yaml
+++ b/api/connections.yaml
@@ -123,6 +123,7 @@ paths:
       responses:
         "204": { description: Connection deleted }
         "404": { $ref: '#/components/responses/NotFound' }
+        "409": { $ref: '#/components/responses/Conflict' }
         "401": { $ref: '#/components/responses/Unauthorized' }
         "403": { $ref: '#/components/responses/Forbidden' }
         "500": { $ref: '#/components/responses/InternalServerError' }
@@ -223,6 +224,7 @@ paths:
       responses:
         "204": { description: Connection deleted }
         "404": { $ref: '#/components/responses/NotFound' }
+        "409": { $ref: '#/components/responses/Conflict' }
         "401": { $ref: '#/components/responses/Unauthorized' }
         "403": { $ref: '#/components/responses/Forbidden' }
         "500": { $ref: '#/components/responses/InternalServerError' }
@@ -323,6 +325,7 @@ paths:
       responses:
         "204": { description: Connection deleted }
         "404": { $ref: '#/components/responses/NotFound' }
+        "409": { $ref: '#/components/responses/Conflict' }
         "401": { $ref: '#/components/responses/Unauthorized' }
         "403": { $ref: '#/components/responses/Forbidden' }
         "500": { $ref: '#/components/responses/InternalServerError' }

--- a/api/idp.yaml
+++ b/api/idp.yaml
@@ -448,6 +448,20 @@ paths:
                     description:
                       key: "error.idpservice.idp_declarative_read_only_description"
                       defaultValue: "The requested identity provider is declarative and cannot be modified or deleted"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "IDP-1013"
+                message:
+                  key: "error.idpservice.idp_has_blocking_dependencies"
+                  defaultValue: "Identity provider cannot be deleted"
+                description:
+                  key: "error.idpservice.idp_has_blocking_dependencies_description"
+                  defaultValue: "The identity provider cannot be deleted because other resources depend on it. Remove or reassign them first."
         "500":
           description: Internal server error
 

--- a/docs/content/guides/guides/identity-providers/manage-identity-providers.mdx
+++ b/docs/content/guides/guides/identity-providers/manage-identity-providers.mdx
@@ -130,7 +130,7 @@ curl -kL -X DELETE https://localhost:8090/identity-providers/<idp-id> \
 A successful delete returns `204 No Content`.
 
 :::warning
-Deleting an identity provider removes it permanently. Any authentication flow that references this IdP will fail at the social login step. Update or remove the flow node before deleting the IdP.
+Deleting an identity provider is permanent. If an authentication flow (or another resource) still references this identity provider, the delete request is rejected with `409 Conflict`. Remove or update the referencing resources — for example, the flow node that uses this IdP — before deleting it.
 :::
 
 :::note


### PR DESCRIPTION
### Purpose
PR #3793 ("Block used connection deletion") changed identity provider / connection deletion to fail closed: deleting a resource that is still referenced (e.g. a flow node using the IdP) is now rejected with `409 Conflict` (error `IDP-1013`, `idp_has_blocking_dependencies`) instead of silently succeeding.

This PR updates the documentation and OpenAPI specs to reflect that behavior, which was previously left stale:

- **`docs/.../manage-identity-providers.mdx`** — the delete warning now states that a referenced IdP is rejected with `409 Conflict` and that referencing resources must be removed/updated first, rather than describing the old "flow will fail at the social login step" behavior.
- **`api/idp.yaml`** — added the `409 Conflict` response (with an `IDP-1013` example) to `DELETE /identity-providers/{id}`.
- **`api/connections.yaml`** — added `409 Conflict` to the Google, GitHub, and OIDC connection `DELETE` operations, reusing the existing `Conflict` response component (matching the POST/PUT operations in the same file).

### Approach
Documentation and spec-only change. The `409` responses were added to the `DELETE` operations to match the status code the backend already returns via `getClientErrorStatusCode` for `ErrorIDPHasBlockingDependencies`.

### Related Issues
- N/A

### Related PRs
- #3793

### Checklist
- [x] Followed the contribution guidelines.
- [x] Documentation provided.
- [ ] Tests provided. (Docs/spec-only change)

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer `409 Conflict` responses for deleting Google, GitHub, OIDC, and identity provider connections.
  * Improved deletion feedback when an identity provider is still in use, so users are told why the action is blocked.
* **Documentation**
  * Updated the identity provider deletion guidance to explain that deletion is permanent and may be prevented if related resources still reference it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->