### PR TITLE
Fix wayfinder sample provisioning in try-consumer CLI flow

### DIFF
--- a/tools/cli/internal/commands/sample/sample.go
+++ b/tools/cli/internal/commands/sample/sample.go
@@ -283,6 +283,17 @@ func runWithResult(
 		}
 	}
 
+	// Free ports held by a previous run's sample services before restarting. A
+	// stale frontend still bound to 5173, for example, would otherwise push the
+	// new dev server to another port while the browser keeps hitting the old one.
+	ports := sampleServicePorts(aiEnabled)
+	for _, p := range ports {
+		setup.KillPort(p)
+	}
+	for _, p := range ports {
+		setup.WaitForPortFree(p, 10*time.Second)
+	}
+
 	// Start sample services.
 	progress("Starting " + sampleName + " services...")
 	if err := startSampleServices(sampleDir, aiEnabled); err != nil {
@@ -292,8 +303,16 @@ func runWithResult(
 	return proc, meta.sampleURL, serverURL, nil
 }
 
+// defaultAuthMode is the sample auth mode the CLI provisions. The wayfinder
+// config is organized by auth mode (e.g. "redirect", "app-native"); the
+// redirect flow is the default consumer experience.
+const defaultAuthMode = "redirect"
+
 // findSampleConfig locates the config YAML and env file within dir.
 // The ZIP may extract to a nested subdirectory, so we search one level deep.
+// The config may live under an auth-mode subdirectory such as
+// <slug>-config/redirect (current layout) or directly under <slug>-config
+// (legacy layout); both are checked, in that order.
 func findSampleConfig(dir string) (configYAML, configEnv, sampleDir string, err error) {
 	candidates := []string{dir}
 	entries, _ := os.ReadDir(dir)
@@ -302,15 +321,19 @@ func findSampleConfig(dir string) (configYAML, configEnv, sampleDir string, err 
 			candidates = append(candidates, filepath.Join(dir, e.Name()))
 		}
 	}
+	configDir := product.Slug + "-config"
+	configSubDirs := []string{filepath.Join(configDir, defaultAuthMode), configDir}
 	for _, base := range candidates {
-		configDir := product.Slug + "-config"
-		yaml := filepath.Join(base, configDir, configDir+".yaml")
-		env := filepath.Join(base, configDir, product.Slug+".env")
-		if _, err := os.Stat(yaml); err == nil {
-			return yaml, env, base, nil
+		for _, sub := range configSubDirs {
+			yaml := filepath.Join(base, sub, configDir+".yaml")
+			env := filepath.Join(base, sub, product.Slug+".env")
+			if _, err := os.Stat(yaml); err == nil {
+				return yaml, env, base, nil
+			}
 		}
 	}
-	return "", "", "", fmt.Errorf("%s-config/%s-config.yaml not found in %s", product.Slug, product.Slug, dir)
+	return "", "", "", fmt.Errorf("%s/%s.yaml not found in %s",
+		filepath.Join(configDir, defaultAuthMode), configDir, dir)
 }
 
 // parseEnvFile reads KEY=VALUE lines into a map.
@@ -361,7 +384,8 @@ func ReadServiceEnv(sampleDir, envTarget string) map[string]string {
 }
 
 // writeResources splits the multi-document YAML, substitutes template variables,
-// and writes each document to thunderRoot/repository/resources/<type>/<id>.yaml.
+// and writes each document to thunderRoot/config/resources/<type>/<id>.yaml,
+// the directory the server loads declarative resources from at startup.
 func writeResources(yamlPath string, vars map[string]string, thunderRoot string) error {
 	raw, err := os.ReadFile(yamlPath)
 	if err != nil {
@@ -398,7 +422,7 @@ func writeResources(yamlPath string, vars map[string]string, thunderRoot string)
 			filename = fmt.Sprintf("%s_%04d.yaml", resourceType, i)
 		}
 
-		target := filepath.Join(thunderRoot, "repository", "resources", dir)
+		target := filepath.Join(thunderRoot, "config", "resources", dir)
 		if err := os.MkdirAll(target, 0o755); err != nil {
 			return err
 		}
@@ -482,6 +506,23 @@ func writeServiceEnv(sampleDir, thunderURL string, vars map[string]string, opts 
 		b.WriteString(k + "=" + v + "\n")
 	}
 	return os.WriteFile(filepath.Join(sampleDir, opts.EnvTarget, ".env"), []byte(b.String()), 0o644)
+}
+
+// sampleServicePorts returns the localhost ports the sample's dev services bind,
+// so a previous run's orphaned processes can be freed before restarting. The
+// ai-agent (8790) only runs in AI mode.
+func sampleServicePorts(aiEnabled bool) []int {
+	ports := []int{
+		5173, // frontend (Vite)
+		8787, // backend API
+		8788, // SMTP inbox UI
+		2525, // SMTP server
+		8795, // lounge kiosk
+	}
+	if aiEnabled {
+		ports = append(ports, 8790) // ai-agent
+	}
+	return ports
 }
 
 // startSampleServices launches the sample services in the background via npm.

--- a/tools/cli/internal/commands/sample/sample_test.go
+++ b/tools/cli/internal/commands/sample/sample_test.go
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package sample
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/thunder-id/thunderid/tools/cli/internal/product"
+)
+
+// writeConfig creates <dir>/<rel>/<slug>-config.yaml and its env file.
+func writeConfig(t *testing.T, dir, rel string) (yamlPath, envPath string) {
+	t.Helper()
+	configDir := product.Slug + "-config"
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(full, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	yamlPath = filepath.Join(full, configDir+".yaml")
+	envPath = filepath.Join(full, product.Slug+".env")
+	if err := os.WriteFile(yamlPath, []byte("resources: []\n"), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	if err := os.WriteFile(envPath, []byte("KEY=value\n"), 0o644); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+	return yamlPath, envPath
+}
+
+func TestFindSampleConfig(t *testing.T) {
+	configDir := product.Slug + "-config"
+
+	t.Run("auth-mode subdirectory layout", func(t *testing.T) {
+		dir := t.TempDir()
+		wantYAML, wantEnv := writeConfig(t, dir, filepath.Join(configDir, defaultAuthMode))
+
+		gotYAML, gotEnv, sampleDir, err := findSampleConfig(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotYAML != wantYAML {
+			t.Errorf("yaml: got %q, want %q", gotYAML, wantYAML)
+		}
+		if gotEnv != wantEnv {
+			t.Errorf("env: got %q, want %q", gotEnv, wantEnv)
+		}
+		if sampleDir != dir {
+			t.Errorf("sampleDir: got %q, want %q", sampleDir, dir)
+		}
+	})
+
+	t.Run("legacy flat layout", func(t *testing.T) {
+		dir := t.TempDir()
+		wantYAML, wantEnv := writeConfig(t, dir, configDir)
+
+		gotYAML, gotEnv, _, err := findSampleConfig(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotYAML != wantYAML {
+			t.Errorf("yaml: got %q, want %q", gotYAML, wantYAML)
+		}
+		if gotEnv != wantEnv {
+			t.Errorf("env: got %q, want %q", gotEnv, wantEnv)
+		}
+	})
+
+	t.Run("nested extraction subdirectory", func(t *testing.T) {
+		dir := t.TempDir()
+		nested := filepath.Join("wayfinder-v1", configDir, defaultAuthMode)
+		wantYAML, _ := writeConfig(t, dir, nested)
+
+		gotYAML, _, sampleDir, err := findSampleConfig(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotYAML != wantYAML {
+			t.Errorf("yaml: got %q, want %q", gotYAML, wantYAML)
+		}
+		if wantBase := filepath.Join(dir, "wayfinder-v1"); sampleDir != wantBase {
+			t.Errorf("sampleDir: got %q, want %q", sampleDir, wantBase)
+		}
+	})
+
+	t.Run("auth-mode preferred over flat", func(t *testing.T) {
+		dir := t.TempDir()
+		writeConfig(t, dir, configDir)
+		wantYAML, _ := writeConfig(t, dir, filepath.Join(configDir, defaultAuthMode))
+
+		gotYAML, _, _, err := findSampleConfig(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotYAML != wantYAML {
+			t.Errorf("yaml: got %q, want %q (auth-mode should win)", gotYAML, wantYAML)
+		}
+	})
+
+	t.Run("missing config", func(t *testing.T) {
+		if _, _, _, err := findSampleConfig(t.TempDir()); err == nil {
+			t.Fatal("expected error for missing config, got nil")
+		}
+	})
+}
+
+func TestSampleServicePorts(t *testing.T) {
+	b2c := sampleServicePorts(false)
+	if got := len(b2c); got != 5 {
+		t.Fatalf("b2c ports: got %d, want 5 (%v)", got, b2c)
+	}
+	for _, p := range []int{5173, 8787, 8788, 2525, 8795} {
+		if !slices.Contains(b2c, p) {
+			t.Errorf("b2c ports missing %d: %v", p, b2c)
+		}
+	}
+	if slices.Contains(b2c, 8790) {
+		t.Errorf("b2c ports must not include the ai-agent port 8790: %v", b2c)
+	}
+
+	if ai := sampleServicePorts(true); !slices.Contains(ai, 8790) {
+		t.Errorf("ai ports must include the ai-agent port 8790: %v", ai)
+	}
+}
+
+func TestWriteResources(t *testing.T) {
+	thunderRoot := t.TempDir()
+	yamlPath := filepath.Join(t.TempDir(), "resources.yaml")
+	content := "" +
+		"# resource_type: application\n" +
+		"id: wayfinder-app\n" +
+		"clientId: \"{{.WAYFINDER_CLIENT_ID}}\"\n" +
+		"---\n" +
+		"# resource_type: user_type\n" +
+		"id: wayfinder-customer-type\n" +
+		"name: Customer\n"
+	if err := os.WriteFile(yamlPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	vars := map[string]string{"WAYFINDER_CLIENT_ID": "WAYFINDER"}
+	if err := writeResources(yamlPath, vars, thunderRoot); err != nil {
+		t.Fatalf("writeResources: %v", err)
+	}
+
+	// Resources must land under config/resources/<dir>, the directory the server
+	// loads declarative resources from at startup.
+	appFile := filepath.Join(thunderRoot, "config", "resources", "applications", "wayfinder-app.yaml")
+	got, err := os.ReadFile(appFile)
+	if err != nil {
+		t.Fatalf("expected application at %s: %v", appFile, err)
+	}
+	if !strings.Contains(string(got), "clientId: \"WAYFINDER\"") {
+		t.Errorf("template var not substituted; got:\n%s", got)
+	}
+
+	// user_type has no entry in typeToDir and must fall back to "<type>s".
+	utFile := filepath.Join(thunderRoot, "config", "resources", "user_types", "wayfinder-customer-type.yaml")
+	if _, err := os.Stat(utFile); err != nil {
+		t.Errorf("expected user_type at %s: %v", utFile, err)
+	}
+
+	// The legacy repository/resources path must no longer be used.
+	if _, err := os.Stat(filepath.Join(thunderRoot, "repository")); !os.IsNotExist(err) {
+		t.Errorf("resources written to legacy repository/ path")
+	}
+}


### PR DESCRIPTION
### Purpose

Fixes the CLI `/try-consumer` flow, which failed to provision the Wayfinder sample end to end. Three related defects blocked a working setup:

1. **Config not found.** After PR #3319 reorganized the sample config into auth-mode subdirectories (`thunderid-config/redirect/`, `thunderid-config/app-native/`), `findSampleConfig` still looked only for the flat `thunderid-config/thunderid-config.yaml` and aborted with `thunderid-config/thunderid-config.yaml not found`.
2. **Resources imported but never loaded.** `writeResources` wrote the declarative resources to `repository/resources/<type>/`, but the server loads them from `config/resources/<type>/` at startup. Nothing read `repository/resources`, so the WAYFINDER application was never created, resources were absent from the console, and sign-in failed with `invalid_request / Invalid client_id`.
3. **Stale dev servers on repeated runs.** The flow freed the product ports (8090, 9090) but not the sample service ports. A previous run's frontend left bound to 5173 pushed the new Vite server onto another port, so the browser kept hitting a stale build that showed the "Add `VITE_THUNDER_CLIENT_ID` and `VITE_THUNDER_BASE_URL`" banner with sign-in disabled.

### Approach

1. `findSampleConfig` now checks the auth-mode subdirectory first (`<slug>-config/redirect`, the default consumer flow, matching the console default), falling back to the legacy flat layout for older bundles. Extracted the config-dir naming to a `defaultAuthMode` constant and updated the not-found error to point at the current path.
2. `writeResources` now writes to `config/resources/<type>/`, the directory the server loads declarative resources from on startup. The per-type subdirectory names produced by the existing type map plus the `<type>+"s"` fallback were verified against every registered loader `DirectoryName` (applications, agents, flows, roles, resource_servers, user_types, server_configs, credential_configurations, presentation_definitions).
3. Before restarting sample services, the flow now frees the ports those services bind (5173 frontend, 8787 backend, 8788/2525 SMTP, 8795 lounge, and 8790 ai-agent in AI mode), mirroring the existing `KillPort` and `WaitForPortFree` handling for the product ports.

### Related Issues
- Fixes #3816

### Related PRs
- Regression introduced by #3319

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sample startup reliability by clearing occupied local ports before relaunching dev services.
  * Updated sample config detection to find files in both the newer auth-mode layout and the legacy layout, with clearer errors when files are missing.
  * Adjusted where declarative resources are written so they land in the expected config resources location.
* **Tests**
  * Added coverage for config discovery, port selection, and resource output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->