### PR TITLE
Cascade deletion support for apps, agents and groups

### DIFF
--- a/api/agent.yaml
+++ b/api/agent.yaml
@@ -1199,7 +1199,9 @@ paths:
       summary: Delete an agent by id
       description: |
         Deletes the agent, its inbound auth profile, and its OAuth client profile. Group
-        memberships and role assignments are automatically removed by cascade.
+        memberships and role assignments are automatically removed by cascade. The delete is
+        fail-closed and retriable: if dependency cleanup fails, the agent is left intact and the
+        operation can be retried.
       parameters:
         - in: path
           name: id

--- a/api/application.yaml
+++ b/api/application.yaml
@@ -657,7 +657,10 @@ paths:
       tags:
         - Applications
       summary: Delete an application
-      description: Delete an application using its ID.
+      description: |
+        Deletes an application using its ID. Its group memberships and role assignments are
+        automatically removed by cascade. The delete is fail-closed and retriable: if dependency
+        cleanup fails, the application is left intact and the operation can be retried.
       parameters:
         - in: path
           name: id

--- a/api/group.yaml
+++ b/api/group.yaml
@@ -385,6 +385,10 @@ paths:
       tags:
         - Groups
       summary: Delete a group by id
+      description: |
+        Deletes a group using its ID. Its role assignments and its memberships in other groups are
+        automatically removed by cascade. The delete is fail-closed and retriable: if dependency
+        cleanup fails, the group is left intact and the operation can be retried.
       parameters:
         - in: path
           name: id

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -409,6 +409,9 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		user:        userService,
 		idp:         idpService,
 		notifSender: notifSenderMgtSvc,
+		application: applicationService,
+		agent:       agentService,
+		group:       groupService,
 	}, applicationService, agentService, flowMgtService, roleAssignmentService, groupService)
 
 	// Initialize design resolve service for theme and layout resolution
@@ -480,6 +483,9 @@ type dependencyConsumers struct {
 	user        user.UserServiceInterface
 	idp         idp.IDPServiceInterface
 	notifSender notification.NotificationSenderMgtSvcInterface
+	application application.ApplicationServiceInterface
+	agent       agent.AgentServiceInterface
+	group       group.GroupServiceInterface
 }
 
 // registerDependencyRegistry builds the dependency registry from the given providers and wires it
@@ -491,6 +497,9 @@ func registerDependencyRegistry(consumers dependencyConsumers, providers ...reso
 	consumers.user.SetDependencyRegistry(registry)
 	consumers.idp.SetDependencyRegistry(registry)
 	consumers.notifSender.SetDependencyRegistry(registry)
+	consumers.application.SetDependencyRegistry(registry)
+	consumers.agent.SetDependencyRegistry(registry)
+	consumers.group.SetDependencyRegistry(registry)
 }
 
 // unregisterServices unregisters all services that require cleanup during shutdown.

--- a/backend/internal/agent/handler_test.go
+++ b/backend/internal/agent/handler_test.go
@@ -115,6 +115,8 @@ func (s *InlineStubAgentService) GetResourceDependencies(
 	return nil, nil
 }
 
+func (s *InlineStubAgentService) SetDependencyRegistry(resourcedependency.Registry) {}
+
 func TestHandleAgentPostRequest_Success(t *testing.T) {
 	stubService := &InlineStubAgentService{
 		OnCreateAgent: func(

--- a/backend/internal/agent/service.go
+++ b/backend/internal/agent/service.go
@@ -59,6 +59,7 @@ type AgentServiceInterface interface {
 		clientID, clientSecret string, client inboundmodel.InboundClient, svcErr *tidcommon.ServiceError)
 	GetResourceDependencies(
 		ctx context.Context, resourceType, id string) ([]resourcedependency.ResourceDependency, error)
+	SetDependencyRegistry(r resourcedependency.Registry)
 }
 
 type agentService struct {
@@ -66,6 +67,7 @@ type agentService struct {
 	entityService        entity.EntityServiceInterface
 	inboundClientService inboundclient.InboundClientServiceInterface
 	ouService            oupkg.OrganizationUnitServiceInterface
+	dependencyRegistry   resourcedependency.Registry
 }
 
 func newAgentService(
@@ -350,6 +352,12 @@ func (s *agentService) UpdateAgent(ctx context.Context, agentID string,
 }
 
 // DeleteAgent removes the agent and its associated inbound client.
+// SetDependencyRegistry injects the dependency registry. Called by servicemanager after the
+// provider services are initialized to avoid a cyclic import.
+func (s *agentService) SetDependencyRegistry(r resourcedependency.Registry) {
+	s.dependencyRegistry = r
+}
+
 func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *tidcommon.ServiceError {
 	if agentID == "" {
 		return &ErrorMissingAgentID
@@ -369,6 +377,20 @@ func (s *agentService) DeleteAgent(ctx context.Context, agentID string) *tidcomm
 	}
 	if existing.IsReadOnly {
 		return &ErrorCannotModifyDeclarativeResource
+	}
+
+	// Remove dependents that must be deleted with the agent (e.g. its role assignments and group
+	// memberships). Run before the deletes so a cleanup failure aborts and leaves the agent
+	// retriable. Fails closed when the registry is unavailable.
+	if s.dependencyRegistry == nil {
+		s.logger.Error(ctx, "Dependency registry not set; refusing to delete agent",
+			log.String("agentID", agentID))
+		return &tidcommon.InternalServerError
+	}
+	if _, err := s.dependencyRegistry.CascadeDelete(ctx, resourcedependency.ResourceTypeAgent, agentID); err != nil {
+		s.logger.Error(ctx, "Failed to cascade-delete agent dependencies",
+			log.String("agentID", agentID), log.Error(err))
+		return &tidcommon.InternalServerError
 	}
 
 	if err := s.inboundClientService.DeleteInboundClient(ctx, agentID); err != nil &&

--- a/backend/internal/agent/service_test.go
+++ b/backend/internal/agent/service_test.go
@@ -131,8 +131,23 @@ func (suite *AgentServiceTestSuite) setupService() (
 		entityService:        mockEntity,
 		inboundClientService: mockInbound,
 		ouService:            mockOU,
+		dependencyRegistry:   noopDepRegistry{},
 	}
 	return svc, mockEntity, mockInbound, mockOU
+}
+
+// noopDepRegistry is a no-op resourcedependency.Registry for tests that don't exercise cascade.
+type noopDepRegistry struct{ cascadeErr error }
+
+func (noopDepRegistry) RegisterProvider(resourcedependency.Provider) {}
+
+func (noopDepRegistry) GetDependencies(
+	context.Context, string, string) (*resourcedependency.DependenciesResponse, error) {
+	return &resourcedependency.DependenciesResponse{}, nil
+}
+
+func (r noopDepRegistry) CascadeDelete(context.Context, string, string) (int, error) {
+	return 0, r.cascadeErr
 }
 
 // buildAgentEntityFixture returns an providers.Entity with system attributes for the given fields.
@@ -2534,4 +2549,19 @@ func (suite *AgentServiceTestSuite) TestValidateOUExists_StoreError_NonNotFound(
 	svcErr := svc.validateOUExists(context.Background(), testOUID)
 	suite.Require().NotNil(svcErr)
 	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *AgentServiceTestSuite) TestDeleteAgent_AbortedWhenCascadeFails() {
+	svc, mockEntity, mockInbound, _ := suite.setupService()
+	svc.SetDependencyRegistry(noopDepRegistry{cascadeErr: errors.New("cascade failed")})
+
+	agentEntity := buildAgentEntityFixture(testAgentName, "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	svcErr := svc.DeleteAgent(context.Background(), testAgentID)
+
+	assert.NotNil(suite.T(), svcErr)
+	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, svcErr.Code)
+	mockInbound.AssertNotCalled(suite.T(), "DeleteInboundClient", mock.Anything, mock.Anything)
 }

--- a/backend/internal/application/ApplicationServiceInterface_mock_test.go
+++ b/backend/internal/application/ApplicationServiceInterface_mock_test.go
@@ -448,6 +448,46 @@ func (_c *ApplicationServiceInterfaceMock_GetResourceDependencies_Call) RunAndRe
 	return _c
 }
 
+// SetDependencyRegistry provides a mock function for the type ApplicationServiceInterfaceMock
+func (_mock *ApplicationServiceInterfaceMock) SetDependencyRegistry(r resourcedependency.Registry) {
+	_mock.Called(r)
+	return
+}
+
+// ApplicationServiceInterfaceMock_SetDependencyRegistry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDependencyRegistry'
+type ApplicationServiceInterfaceMock_SetDependencyRegistry_Call struct {
+	*mock.Call
+}
+
+// SetDependencyRegistry is a helper method to define mock.On call
+//   - r resourcedependency.Registry
+func (_e *ApplicationServiceInterfaceMock_Expecter) SetDependencyRegistry(r interface{}) *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call {
+	return &ApplicationServiceInterfaceMock_SetDependencyRegistry_Call{Call: _e.mock.On("SetDependencyRegistry", r)}
+}
+
+func (_c *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call) Run(run func(r resourcedependency.Registry)) *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 resourcedependency.Registry
+		if args[0] != nil {
+			arg0 = args[0].(resourcedependency.Registry)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call) Return() *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run func(r resourcedependency.Registry)) *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Run(run)
+	return _c
+}
+
 // UpdateApplication provides a mock function for the type ApplicationServiceInterfaceMock
 func (_mock *ApplicationServiceInterfaceMock) UpdateApplication(ctx context.Context, appID string, app *model.ApplicationDTO) (*model.ApplicationDTO, *common.ServiceError) {
 	ret := _mock.Called(ctx, appID, app)

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -60,6 +60,7 @@ type ApplicationServiceInterface interface {
 	DeleteApplication(ctx context.Context, appID string) *tidcommon.ServiceError
 	GetResourceDependencies(
 		ctx context.Context, resourceType, id string) ([]resourcedependency.ResourceDependency, error)
+	SetDependencyRegistry(r resourcedependency.Registry)
 }
 
 // ApplicationService is the default implementation of the ApplicationServiceInterface.
@@ -69,6 +70,7 @@ type applicationService struct {
 	entityProvider       entityprovider.EntityProviderInterface
 	ouService            oupkg.OrganizationUnitServiceInterface
 	i18nService          i18nmgt.I18nServiceInterface
+	dependencyRegistry   resourcedependency.Registry
 }
 
 // newApplicationService creates a new instance of ApplicationService.
@@ -565,6 +567,12 @@ func appRequiresClientSecret(cfg *providers.OAuthConfigWithSecret) bool {
 }
 
 // DeleteApplication delete the application for given app id.
+// SetDependencyRegistry injects the dependency registry. Called by servicemanager after the
+// provider services are initialized to avoid a cyclic import.
+func (as *applicationService) SetDependencyRegistry(r resourcedependency.Registry) {
+	as.dependencyRegistry = r
+}
+
 func (as *applicationService) DeleteApplication(ctx context.Context, appID string) *tidcommon.ServiceError {
 	if appID == "" {
 		return &ErrorInvalidApplicationID
@@ -580,11 +588,25 @@ func (as *applicationService) DeleteApplication(ctx context.Context, appID strin
 		return &ErrorApplicationNotFound
 	}
 
-	// Delete config.
-	if appErr := as.inboundClientService.DeleteInboundClient(ctx, appID); appErr != nil {
-		if errors.Is(appErr, inboundclient.ErrInboundClientNotFound) {
-			return nil
-		}
+	// Remove dependents that must be deleted with the application (e.g. its role assignments and
+	// group memberships). Run before the deletes so a cleanup failure aborts and leaves the
+	// application retriable. Fails closed when the registry is unavailable.
+	if as.dependencyRegistry == nil {
+		as.logger.Error(ctx, "Dependency registry not set; refusing to delete application",
+			log.String("appID", appID))
+		return &tidcommon.InternalServerError
+	}
+	if _, err := as.dependencyRegistry.CascadeDelete(
+		ctx, resourcedependency.ResourceTypeApplication, appID); err != nil {
+		as.logger.Error(ctx, "Failed to cascade-delete application dependencies",
+			log.String("appID", appID), log.Error(err))
+		return &tidcommon.InternalServerError
+	}
+
+	// Delete config. A missing inbound client is non-fatal (e.g. on a retry after a partial
+	// delete) so the remaining delete steps still run.
+	if appErr := as.inboundClientService.DeleteInboundClient(ctx, appID); appErr != nil &&
+		!errors.Is(appErr, inboundclient.ErrInboundClientNotFound) {
 		if svcErr := as.translateInboundClientError(ctx, appErr); svcErr != nil {
 			return svcErr
 		}

--- a/backend/internal/application/service_test.go
+++ b/backend/internal/application/service_test.go
@@ -165,8 +165,39 @@ func (suite *ServiceTestSuite) setupTestService() (
 		inboundClientService: mockStore,
 		entityProvider:       mockEntityProvider,
 		ouService:            mockOUService,
+		dependencyRegistry:   noopDepRegistry{},
 	}
 	return service, mockStore
+}
+
+// noopDepRegistry is a no-op resourcedependency.Registry for tests that don't exercise cascade.
+type noopDepRegistry struct{ cascadeErr error }
+
+func (noopDepRegistry) RegisterProvider(resourcedependency.Provider) {}
+
+func (noopDepRegistry) GetDependencies(
+	context.Context, string, string) (*resourcedependency.DependenciesResponse, error) {
+	return &resourcedependency.DependenciesResponse{}, nil
+}
+
+func (r noopDepRegistry) CascadeDelete(context.Context, string, string) (int, error) {
+	return 0, r.cascadeErr
+}
+
+// recordingDepRegistry is a resourcedependency.Registry that records CascadeDelete invocations so
+// tests can assert dependents were removed. cascadeCalls is incremented on each CascadeDelete.
+type recordingDepRegistry struct{ cascadeCalls *int }
+
+func (recordingDepRegistry) RegisterProvider(resourcedependency.Provider) {}
+
+func (recordingDepRegistry) GetDependencies(
+	context.Context, string, string) (*resourcedependency.DependenciesResponse, error) {
+	return &resourcedependency.DependenciesResponse{}, nil
+}
+
+func (r recordingDepRegistry) CascadeDelete(context.Context, string, string) (int, error) {
+	*r.cascadeCalls++
+	return 1, nil
 }
 
 // resetIdentifyEntity removes broad IdentifyEntity expectations from the entity provider mock
@@ -3944,4 +3975,37 @@ func (suite *ServiceTestSuite) TestCleanupStaleI18nKeys_DeleteError() {
 	svcErr := service.cleanupStaleI18nKeys(context.Background(), testServiceAppID, existing, updated)
 
 	assert.Equal(suite.T(), &tidcommon.InternalServerError, svcErr)
+}
+
+func (suite *ServiceTestSuite) TestDeleteApplication_AbortedWhenCascadeFails() {
+	service, mockStore := suite.setupTestService()
+	service.SetDependencyRegistry(noopDepRegistry{cascadeErr: errors.New("cascade failed")})
+
+	svcErr := service.DeleteApplication(context.Background(), testServiceAppID)
+
+	assert.NotNil(suite.T(), svcErr)
+	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, svcErr.Code)
+	mockStore.AssertNotCalled(suite.T(), "DeleteInboundClient", mock.Anything, mock.Anything)
+}
+
+// TestDeleteApplication_EntityDeleteFailsAfterCascade verifies that when dependency cleanup
+// succeeds but the later entity delete fails, the service surfaces an error while the dependents
+// have already been removed (partial-state, retriable).
+func (suite *ServiceTestSuite) TestDeleteApplication_EntityDeleteFailsAfterCascade() {
+	service, mockStore := suite.setupTestService()
+	cascadeCalls := 0
+	service.SetDependencyRegistry(recordingDepRegistry{cascadeCalls: &cascadeCalls})
+
+	mockStore.On("DeleteInboundClient", mock.Anything, testServiceAppID).Return(nil)
+	ep := resetEntityProviderMethod(service, "DeleteEntity")
+	ep.On("DeleteEntity", mock.Anything).Return(
+		entityprovider.NewEntityProviderError(entityprovider.ErrorCodeSystemError, "delete failed", ""))
+
+	svcErr := service.DeleteApplication(context.Background(), testServiceAppID)
+
+	assert.NotNil(suite.T(), svcErr)
+	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, svcErr.Code)
+	// Dependents were removed even though the application delete did not complete.
+	assert.Equal(suite.T(), 1, cascadeCalls)
+	ep.AssertCalled(suite.T(), "DeleteEntity", mock.Anything)
 }

--- a/backend/internal/group/GroupServiceInterface_mock_test.go
+++ b/backend/internal/group/GroupServiceInterface_mock_test.go
@@ -1011,6 +1011,46 @@ func (_c *GroupServiceInterfaceMock_RemoveGroupMembers_Call) RunAndReturn(run fu
 	return _c
 }
 
+// SetDependencyRegistry provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) SetDependencyRegistry(r resourcedependency.Registry) {
+	_mock.Called(r)
+	return
+}
+
+// GroupServiceInterfaceMock_SetDependencyRegistry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDependencyRegistry'
+type GroupServiceInterfaceMock_SetDependencyRegistry_Call struct {
+	*mock.Call
+}
+
+// SetDependencyRegistry is a helper method to define mock.On call
+//   - r resourcedependency.Registry
+func (_e *GroupServiceInterfaceMock_Expecter) SetDependencyRegistry(r interface{}) *GroupServiceInterfaceMock_SetDependencyRegistry_Call {
+	return &GroupServiceInterfaceMock_SetDependencyRegistry_Call{Call: _e.mock.On("SetDependencyRegistry", r)}
+}
+
+func (_c *GroupServiceInterfaceMock_SetDependencyRegistry_Call) Run(run func(r resourcedependency.Registry)) *GroupServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 resourcedependency.Registry
+		if args[0] != nil {
+			arg0 = args[0].(resourcedependency.Registry)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_SetDependencyRegistry_Call) Return() *GroupServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run func(r resourcedependency.Registry)) *GroupServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Run(run)
+	return _c
+}
+
 // UpdateGroup provides a mock function for the type GroupServiceInterfaceMock
 func (_mock *GroupServiceInterfaceMock) UpdateGroup(ctx context.Context, groupID string, request UpdateGroupRequest) (*Group, *common.ServiceError) {
 	ret := _mock.Called(ctx, groupID, request)

--- a/backend/internal/group/service.go
+++ b/backend/internal/group/service.go
@@ -67,16 +67,18 @@ type GroupServiceInterface interface {
 	GetResourceDependencies(
 		ctx context.Context, resourceType, id string) ([]resourcedependency.ResourceDependency, error)
 	CascadeDeleteDependencies(ctx context.Context, resourceType, id string) (int, error)
+	SetDependencyRegistry(r resourcedependency.Registry)
 }
 
 // groupService is the default implementation of the GroupServiceInterface.
 type groupService struct {
-	groupStore        groupStoreInterface
-	ouService         oupkg.OrganizationUnitServiceInterface
-	entityService     entity.EntityServiceInterface
-	entityTypeService entitytype.EntityTypeServiceInterface
-	transactioner     transaction.Transactioner
-	authzService      sysauthz.SystemAuthorizationServiceInterface
+	groupStore         groupStoreInterface
+	ouService          oupkg.OrganizationUnitServiceInterface
+	entityService      entity.EntityServiceInterface
+	entityTypeService  entitytype.EntityTypeServiceInterface
+	transactioner      transaction.Transactioner
+	authzService       sysauthz.SystemAuthorizationServiceInterface
+	dependencyRegistry resourcedependency.Registry
 }
 
 // newGroupServiceWithStore creates a new instance of GroupService with an externally provided store.
@@ -573,6 +575,12 @@ func (gs *groupService) UpdateGroup(
 }
 
 // DeleteGroup delete the specified group by its id.
+// SetDependencyRegistry injects the dependency registry. Called by servicemanager after the
+// provider services are initialized to avoid a cyclic import.
+func (gs *groupService) SetDependencyRegistry(r resourcedependency.Registry) {
+	gs.dependencyRegistry = r
+}
+
 func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *tidcommon.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	logger.Debug(ctx, "Deleting group", log.String("id", groupID))
@@ -590,40 +598,44 @@ func (gs *groupService) DeleteGroup(ctx context.Context, groupID string) *tidcom
 		return &ErrorImmutableGroup
 	}
 
-	var capturedSvcErr *tidcommon.ServiceError
-
-	err := gs.transactioner.Transact(ctx, func(txCtx context.Context) error {
-		existingGroupDAO, err := gs.groupStore.GetGroup(txCtx, groupID)
-		if err != nil {
-			if errors.Is(err, ErrGroupNotFound) {
-				logger.Debug(ctx, "Group not found", log.String("id", groupID))
-				capturedSvcErr = &ErrorGroupNotFound
-				return errors.New("rollback for group not found")
-			}
-			return err
-		}
-
-		if err := gs.checkGroupAccess(
-			txCtx,
-			security.ActionDeleteGroup,
-			existingGroupDAO.OUID,
-			groupID,
-		); err != nil {
-			capturedSvcErr = err
-			return errors.New("rollback for unauthorized access")
-		}
-
-		if err := gs.groupStore.DeleteGroup(txCtx, groupID); err != nil {
-			return err
-		}
-		return nil
-	})
-
-	if capturedSvcErr != nil {
-		return capturedSvcErr
+	if gs.dependencyRegistry == nil {
+		logger.Error(ctx, "Dependency registry not set; refusing to delete group", log.String("id", groupID))
+		return &tidcommon.InternalServerError
 	}
 
+	existingGroupDAO, err := gs.groupStore.GetGroup(ctx, groupID)
 	if err != nil {
+		if errors.Is(err, ErrGroupNotFound) {
+			logger.Debug(ctx, "Group not found", log.String("id", groupID))
+			return &ErrorGroupNotFound
+		}
+		logger.Error(ctx, "Failed to delete group", log.Error(err), log.String("groupID", groupID))
+		return &tidcommon.InternalServerError
+	}
+
+	if svcErr := gs.checkGroupAccess(
+		ctx,
+		security.ActionDeleteGroup,
+		existingGroupDAO.OUID,
+		groupID,
+	); svcErr != nil {
+		return svcErr
+	}
+
+	// Remove dependents that must be deleted with the group (its role assignments and its
+	// memberships in other groups). This spans other databases, so run it before (and outside) the
+	// group-delete transaction: a failure aborts and leaves the group retriable, and the
+	// cross-store cleanup does not hold the group transaction open.
+	if _, cascadeErr := gs.dependencyRegistry.CascadeDelete(
+		ctx, resourcedependency.ResourceTypeGroup, groupID); cascadeErr != nil {
+		logger.Error(ctx, "Failed to cascade-delete group dependencies",
+			log.String("id", groupID), log.Error(cascadeErr))
+		return &tidcommon.InternalServerError
+	}
+
+	if err := gs.transactioner.Transact(ctx, func(txCtx context.Context) error {
+		return gs.groupStore.DeleteGroup(txCtx, groupID)
+	}); err != nil {
 		logger.Error(ctx, "Failed to delete group", log.Error(err), log.String("groupID", groupID))
 		return &tidcommon.InternalServerError
 	}
@@ -1354,16 +1366,21 @@ func (gs *groupService) GetResourceDependencies(
 // principals (stored as entity members) are handled; other resource types have no memberships.
 func (gs *groupService) CascadeDeleteDependencies(
 	ctx context.Context, resourceType, id string) (int, error) {
+	var memberType MemberType
 	switch resourceType {
 	case resourcedependency.ResourceTypeUser,
 		resourcedependency.ResourceTypeApplication,
 		resourcedependency.ResourceTypeAgent:
-		deleted, err := gs.groupStore.DeleteMembershipsByMember(ctx, string(memberTypeEntity), id)
-		if err != nil {
-			return 0, err
-		}
-		return int(deleted), nil
+		memberType = memberTypeEntity
+	case resourcedependency.ResourceTypeGroup:
+		memberType = MemberTypeGroup
 	default:
 		return 0, nil
 	}
+
+	deleted, err := gs.groupStore.DeleteMembershipsByMember(ctx, string(memberType), id)
+	if err != nil {
+		return 0, err
+	}
+	return int(deleted), nil
 }

--- a/backend/internal/group/service_test.go
+++ b/backend/internal/group/service_test.go
@@ -1498,9 +1498,10 @@ func (suite *GroupServiceTestSuite) TestGroupService_DeleteGroup() {
 				authzSvc = newAllowAllAuthz(suite.T())
 			}
 			service := &groupService{
-				authzService:  authzSvc,
-				groupStore:    storeMock,
-				transactioner: &stubTransactioner{},
+				authzService:       authzSvc,
+				groupStore:         storeMock,
+				transactioner:      &stubTransactioner{},
+				dependencyRegistry: noopDepRegistry{},
 			}
 
 			err := service.DeleteGroup(context.Background(), tc.id)
@@ -2946,4 +2947,49 @@ func (suite *GroupServiceTestSuite) TestCascadeDeleteDependencies_StoreError() {
 
 	suite.Error(err)
 	suite.Equal(0, deleted)
+}
+
+// noopDepRegistry is a no-op resourcedependency.Registry for tests that don't exercise cascade.
+type noopDepRegistry struct{ cascadeErr error }
+
+func (noopDepRegistry) RegisterProvider(resourcedependency.Provider) {}
+
+func (noopDepRegistry) GetDependencies(
+	context.Context, string, string) (*resourcedependency.DependenciesResponse, error) {
+	return &resourcedependency.DependenciesResponse{}, nil
+}
+
+func (r noopDepRegistry) CascadeDelete(context.Context, string, string) (int, error) {
+	return 0, r.cascadeErr
+}
+
+func (suite *GroupServiceTestSuite) TestCascadeDeleteDependencies_Group_DeletesMemberships() {
+	storeMock := newGroupStoreInterfaceMock(suite.T())
+	storeMock.On("DeleteMembershipsByMember", mock.Anything, string(MemberTypeGroup), "group-1").
+		Return(int64(1), nil)
+	service := &groupService{groupStore: storeMock}
+
+	deleted, err := service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeGroup, "group-1")
+
+	suite.NoError(err)
+	suite.Equal(1, deleted)
+}
+
+func (suite *GroupServiceTestSuite) TestDeleteGroup_AbortedWhenCascadeFails() {
+	storeMock := newGroupStoreInterfaceMock(suite.T())
+	storeMock.On("IsGroupDeclarative", mock.Anything, "grp-001").Return(false, nil).Once()
+	storeMock.On("GetGroup", mock.Anything, "grp-001").
+		Return(GroupDAO{ID: "grp-001", OUID: testOUID1}, nil).Once()
+	service := &groupService{
+		authzService:       newAllowAllAuthz(suite.T()),
+		groupStore:         storeMock,
+		transactioner:      &stubTransactioner{},
+		dependencyRegistry: noopDepRegistry{cascadeErr: errors.New("cascade failed")},
+	}
+
+	err := service.DeleteGroup(context.Background(), "grp-001")
+
+	suite.Require().NotNil(err)
+	storeMock.AssertNotCalled(suite.T(), "DeleteGroup", mock.Anything, mock.Anything)
 }

--- a/backend/internal/role/assignment_service.go
+++ b/backend/internal/role/assignment_service.go
@@ -612,16 +612,21 @@ func (as *roleAssignmentService) GetResourceDependencies(
 // principals (stored as entity assignees) are handled; other resource types have no assignments.
 func (as *roleAssignmentService) CascadeDeleteDependencies(
 	ctx context.Context, resourceType, id string) (int, error) {
+	var assigneeType AssigneeType
 	switch resourceType {
 	case resourcedependency.ResourceTypeUser,
 		resourcedependency.ResourceTypeApplication,
 		resourcedependency.ResourceTypeAgent:
-		deleted, err := as.roleStore.DeleteAssignmentsByAssignee(ctx, string(assigneeTypeEntity), id)
-		if err != nil {
-			return 0, err
-		}
-		return int(deleted), nil
+		assigneeType = assigneeTypeEntity
+	case resourcedependency.ResourceTypeGroup:
+		assigneeType = AssigneeTypeGroup
 	default:
 		return 0, nil
 	}
+
+	deleted, err := as.roleStore.DeleteAssignmentsByAssignee(ctx, string(assigneeType), id)
+	if err != nil {
+		return 0, err
+	}
+	return int(deleted), nil
 }

--- a/backend/internal/role/assignment_service_test.go
+++ b/backend/internal/role/assignment_service_test.go
@@ -780,3 +780,14 @@ func (suite *RoleAssignmentServiceTestSuite) TestCascadeDeleteDependencies_Store
 	suite.Error(err)
 	suite.Equal(0, deleted)
 }
+
+func (suite *RoleAssignmentServiceTestSuite) TestCascadeDeleteDependencies_Group_DeletesAssignments() {
+	suite.mockStore.On("DeleteAssignmentsByAssignee", mock.Anything, string(AssigneeTypeGroup), "group-1").
+		Return(int64(1), nil)
+
+	deleted, err := suite.service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeGroup, "group-1")
+
+	suite.NoError(err)
+	suite.Equal(1, deleted)
+}

--- a/backend/internal/system/resourcedependency/registry.go
+++ b/backend/internal/system/resourcedependency/registry.go
@@ -67,6 +67,7 @@ const (
 	ResourceTypeUser               = "user"
 	ResourceTypeApplication        = "application"
 	ResourceTypeAgent              = "agent"
+	ResourceTypeGroup              = "group"
 	ResourceTypeIDP                = "idp"
 	ResourceTypeNotificationSender = "notificationSender"
 )

--- a/backend/tests/mocks/agentmock/AgentServiceInterface_mock.go
+++ b/backend/tests/mocks/agentmock/AgentServiceInterface_mock.go
@@ -490,6 +490,46 @@ func (_c *AgentServiceInterfaceMock_GetResourceDependencies_Call) RunAndReturn(r
 	return _c
 }
 
+// SetDependencyRegistry provides a mock function for the type AgentServiceInterfaceMock
+func (_mock *AgentServiceInterfaceMock) SetDependencyRegistry(r resourcedependency.Registry) {
+	_mock.Called(r)
+	return
+}
+
+// AgentServiceInterfaceMock_SetDependencyRegistry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDependencyRegistry'
+type AgentServiceInterfaceMock_SetDependencyRegistry_Call struct {
+	*mock.Call
+}
+
+// SetDependencyRegistry is a helper method to define mock.On call
+//   - r resourcedependency.Registry
+func (_e *AgentServiceInterfaceMock_Expecter) SetDependencyRegistry(r interface{}) *AgentServiceInterfaceMock_SetDependencyRegistry_Call {
+	return &AgentServiceInterfaceMock_SetDependencyRegistry_Call{Call: _e.mock.On("SetDependencyRegistry", r)}
+}
+
+func (_c *AgentServiceInterfaceMock_SetDependencyRegistry_Call) Run(run func(r resourcedependency.Registry)) *AgentServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 resourcedependency.Registry
+		if args[0] != nil {
+			arg0 = args[0].(resourcedependency.Registry)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *AgentServiceInterfaceMock_SetDependencyRegistry_Call) Return() *AgentServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *AgentServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run func(r resourcedependency.Registry)) *AgentServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Run(run)
+	return _c
+}
+
 // UpdateAgent provides a mock function for the type AgentServiceInterfaceMock
 func (_mock *AgentServiceInterfaceMock) UpdateAgent(ctx context.Context, agentID string, req *model.UpdateAgentRequest) (*model.AgentCompleteResponse, *common.ServiceError) {
 	ret := _mock.Called(ctx, agentID, req)

--- a/backend/tests/mocks/applicationmock/ApplicationServiceInterface_mock.go
+++ b/backend/tests/mocks/applicationmock/ApplicationServiceInterface_mock.go
@@ -448,6 +448,46 @@ func (_c *ApplicationServiceInterfaceMock_GetResourceDependencies_Call) RunAndRe
 	return _c
 }
 
+// SetDependencyRegistry provides a mock function for the type ApplicationServiceInterfaceMock
+func (_mock *ApplicationServiceInterfaceMock) SetDependencyRegistry(r resourcedependency.Registry) {
+	_mock.Called(r)
+	return
+}
+
+// ApplicationServiceInterfaceMock_SetDependencyRegistry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDependencyRegistry'
+type ApplicationServiceInterfaceMock_SetDependencyRegistry_Call struct {
+	*mock.Call
+}
+
+// SetDependencyRegistry is a helper method to define mock.On call
+//   - r resourcedependency.Registry
+func (_e *ApplicationServiceInterfaceMock_Expecter) SetDependencyRegistry(r interface{}) *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call {
+	return &ApplicationServiceInterfaceMock_SetDependencyRegistry_Call{Call: _e.mock.On("SetDependencyRegistry", r)}
+}
+
+func (_c *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call) Run(run func(r resourcedependency.Registry)) *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 resourcedependency.Registry
+		if args[0] != nil {
+			arg0 = args[0].(resourcedependency.Registry)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call) Return() *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run func(r resourcedependency.Registry)) *ApplicationServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Run(run)
+	return _c
+}
+
 // UpdateApplication provides a mock function for the type ApplicationServiceInterfaceMock
 func (_mock *ApplicationServiceInterfaceMock) UpdateApplication(ctx context.Context, appID string, app *model.ApplicationDTO) (*model.ApplicationDTO, *common.ServiceError) {
 	ret := _mock.Called(ctx, appID, app)

--- a/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
+++ b/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
@@ -1012,6 +1012,46 @@ func (_c *GroupServiceInterfaceMock_RemoveGroupMembers_Call) RunAndReturn(run fu
 	return _c
 }
 
+// SetDependencyRegistry provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) SetDependencyRegistry(r resourcedependency.Registry) {
+	_mock.Called(r)
+	return
+}
+
+// GroupServiceInterfaceMock_SetDependencyRegistry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDependencyRegistry'
+type GroupServiceInterfaceMock_SetDependencyRegistry_Call struct {
+	*mock.Call
+}
+
+// SetDependencyRegistry is a helper method to define mock.On call
+//   - r resourcedependency.Registry
+func (_e *GroupServiceInterfaceMock_Expecter) SetDependencyRegistry(r interface{}) *GroupServiceInterfaceMock_SetDependencyRegistry_Call {
+	return &GroupServiceInterfaceMock_SetDependencyRegistry_Call{Call: _e.mock.On("SetDependencyRegistry", r)}
+}
+
+func (_c *GroupServiceInterfaceMock_SetDependencyRegistry_Call) Run(run func(r resourcedependency.Registry)) *GroupServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 resourcedependency.Registry
+		if args[0] != nil {
+			arg0 = args[0].(resourcedependency.Registry)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_SetDependencyRegistry_Call) Return() *GroupServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_SetDependencyRegistry_Call) RunAndReturn(run func(r resourcedependency.Registry)) *GroupServiceInterfaceMock_SetDependencyRegistry_Call {
+	_c.Run(run)
+	return _c
+}
+
 // UpdateGroup provides a mock function for the type GroupServiceInterfaceMock
 func (_mock *GroupServiceInterfaceMock) UpdateGroup(ctx context.Context, groupID string, request group.UpdateGroupRequest) (*group.Group, *common.ServiceError) {
 	ret := _mock.Called(ctx, groupID, request)


### PR DESCRIPTION
### Purpose

Extend cascade deletion cleanup to applications, agents, and groups. Deleting one of these resources now removes its dependent role assignments and group memberships before the resource itself is deleted, preventing orphaned authorization and membership state.

This builds on the user-deletion cascade support added in #3802.

### Approach

- Added `ResourceTypeGroup` to the `resourcedependency` registry.
- Introduced `SetDependencyRegistry` on the application, agent, and group services. The registry is injected by `servicemanager` after provider services are initialized to avoid a cyclic import.
- In each `Delete*` path, the service invokes `dependencyRegistry.CascadeDelete(...)` before deleting the resource. The cleanup runs first so a failure aborts the delete and leaves the resource retriable. Deletion fails closed (`InternalServerError`) when the registry is unavailable.
- For groups, the cascade runs ahead of the group store delete; since it spans other databases it is intentionally not part of the group delete transaction.
- Extended `CascadeDeleteDependencies` in the role-assignment and group services to handle the `group` resource type (group assignments and group-in-group memberships).

### Related Issues
- Fixes #3825

### Related PRs
- Builds on #3802

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group resources are now supported in dependency cleanup and deletion flows.
* **Bug Fixes**
  * Deleting applications, agents, or groups now removes related dependent records first via cascade cleanup.
  * Deletions now fail closed (and are retriable) if dependency cleanup fails, preventing partial removals.
  * Group role assignments and memberships are now handled correctly during cascade delete operations.
* **Documentation**
  * Updated DELETE endpoint descriptions for agents, applications, and groups to clarify fail-closed/retriable delete semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->