### PR TITLE
Skip provisioning when a local user is already resolved

### DIFF
--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -101,14 +101,11 @@ func (p *provisioningExecutor) Execute(ctx *providers.NodeContext) (*providers.E
 		AuthUser:       ctx.AuthUser,
 	}
 
-	// If it's an authentication flow, skip execution if the user is not eligible for provisioning
-	if ctx.FlowType == providers.FlowTypeAuthentication {
-		eligible, ok := ctx.RuntimeData[common.RuntimeKeyUserEligibleForProvisioning]
-		if !ok || eligible != dataValueTrue {
-			logger.Debug(ctx.Context, "User is not eligible for provisioning, skipping execution")
-			execResp.Status = providers.ExecComplete
-			return execResp, nil
-		}
+	// In an authentication flow, provisioning is only performed when the user is eligible for it
+	// and no local user has already been resolved.
+	if p.shouldSkipProvisioningInAuthFlow(ctx, logger) {
+		execResp.Status = providers.ExecComplete
+		return execResp, nil
 	}
 
 	if !p.HasRequiredInputs(ctx, execResp) {
@@ -214,6 +211,30 @@ func (p *provisioningExecutor) Execute(ctx *providers.NodeContext) (*providers.E
 	}
 
 	return execResp, nil
+}
+
+// shouldSkipProvisioningInAuthFlow reports whether provisioning must be skipped in an authentication
+// flow. Provisioning is skipped when the user is not eligible for it, or when a local user has already
+// been resolved during federated authentication (for example via account linking on a configured IdP
+// attribute), in which case the flow continues with the resolved user instead of provisioning a new one.
+func (p *provisioningExecutor) shouldSkipProvisioningInAuthFlow(ctx *providers.NodeContext,
+	logger *log.Logger) bool {
+	if ctx.FlowType != providers.FlowTypeAuthentication {
+		return false
+	}
+
+	eligible, ok := ctx.RuntimeData[common.RuntimeKeyUserEligibleForProvisioning]
+	if !ok || eligible != dataValueTrue {
+		logger.Debug(ctx.Context, "User is not eligible for provisioning, skipping execution")
+		return true
+	}
+
+	if ref := ctx.AuthUser.EntityReference(); ref != nil && ref.EntityID != "" {
+		logger.Debug(ctx.Context, "A local user is already resolved, skipping provisioning")
+		return true
+	}
+
+	return false
 }
 
 // authenticateProvisionedUser authenticates the newly provisioned user and updates the executor response.

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -800,6 +800,38 @@ func (suite *ProvisioningExecutorTestSuite) TestExecute_UserEligibleForProvision
 	suite.mockEntityProvider.AssertExpectations(suite.T())
 }
 
+func (suite *ProvisioningExecutorTestSuite) TestExecute_LocalUserAlreadyResolved_SkipsProvisioning() {
+	var authUser providers.AuthUser
+	err := authUser.UnmarshalJSON([]byte(
+		`{"entityReference":{"entityId":"user-linked"},"attributes":{}}`))
+	suite.Require().NoError(err)
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		AuthUser:    authUser,
+		UserInputs: map[string]string{
+			attributeEmail: "resolved@example.com",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyUserEligibleForProvisioning: dataValueTrue,
+			attributeEmail: "resolved@example.com",
+			ouIDKey:        testOUID,
+			userTypeKey:    testUserType,
+		},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	assert.Empty(suite.T(), resp.RuntimeData[common.RuntimeKeyUserAutoProvisioned])
+	// Neither identification nor creation should be attempted once a local user is resolved.
+	suite.mockEntityProvider.AssertNotCalled(suite.T(), "IdentifyEntity", mock.Anything)
+	suite.mockEntityProvider.AssertNotCalled(suite.T(), "CreateEntity", mock.Anything, mock.Anything)
+}
+
 func (suite *ProvisioningExecutorTestSuite) TestExecute_UserAutoProvisionedFlag_SetAfterCreation() {
 	suite.expectSchemaForProvisioning()
 	attrs := map[string]interface{}{"username": "newuser", attributeEmail: "new@example.com"}


### PR DESCRIPTION
### Purpose
When multiple federated IdPs are configured with account linking, authenticating via a newly added IdP could fail provisioning with `FET-1081` (attribute conflict), even though the local user was already resolved by a linked attribute (e.g. email). Provisioning would still run and try to re-create the user.

### Approach
Skip provisioning in an authentication flow when the auth user already has a resolved entity reference, so the flow continues with the linked user instead of attempting to provision a duplicate.

### Related Issues
- Refs #3269

### Related PRs
- Builds on #3676

### Checklist
- [x] Followed the contribution guidelines.
- [x] Tests provided.
    - [x] Unit Tests

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provisioning behavior during authentication flows by skipping provisioning when a local user is already resolved or when the user isn’t eligible.
  * Ensured the flow now exits cleanly without performing extra provisioning steps in these cases.

* **Tests**
  * Added coverage for authentication flows where an existing local user should not trigger provisioning, confirming no entity lookup or creation occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->