### PR TITLE
Simplify public URL configuration

### DIFF
--- a/backend/cmd/server/config/default.json
+++ b/backend/cmd/server/config/default.json
@@ -15,9 +15,6 @@
     }
   },
   "gate_client": {
-    "hostname": "localhost",
-    "port": 8090,
-    "scheme": "https",
     "path": "/gate"
   },
   "tls": {

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -22,10 +22,13 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	urlpath "path"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -594,6 +597,43 @@ func LoadConfig(configPath string, defaultPath string, serverHome string) (*Conf
 
 	// Merge user configuration with defaults
 	mergeConfigs(&cfg, &userCfg)
+
+	// Default gate_client to the server's own URL when not explicitly configured, so the gate only
+	// needs configuring when it is hosted separately from the server.
+	if cfg.GateClient.Hostname == "" || cfg.GateClient.Port == 0 || cfg.GateClient.Scheme == "" {
+		serverURL, err := url.Parse(engineconfig.GetServerURL(&cfg.Server))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse server URL for gate_client derivation: %w", err)
+		}
+		if cfg.GateClient.Scheme == "" {
+			cfg.GateClient.Scheme = serverURL.Scheme
+		}
+		if cfg.GateClient.Hostname == "" {
+			cfg.GateClient.Hostname = serverURL.Hostname()
+		}
+		if cfg.GateClient.Port == 0 {
+			if portStr := serverURL.Port(); portStr != "" {
+				if port, perr := strconv.Atoi(portStr); perr == nil {
+					cfg.GateClient.Port = port
+				}
+			} else if serverURL.Scheme == "http" {
+				cfg.GateClient.Port = 80
+			} else {
+				cfg.GateClient.Port = 443
+			}
+		}
+	}
+
+	// The resolved gate client host must be reachable by a browser. A bind-all address
+	// (0.0.0.0 or ::) produces broken login/error redirects. This happens when server.hostname
+	// is a bind address and neither server.public_url nor gate_client.hostname is configured,
+	// so fail fast with actionable guidance.
+	if isBindAllHost(cfg.GateClient.Hostname) {
+		return nil, fmt.Errorf("gate client hostname resolved to an unreachable bind-all address %q; "+
+			"set server.public_url (or gate_client.hostname) to a browser-reachable host",
+			cfg.GateClient.Hostname)
+	}
+
 	// Derive login_path and error_path from path if not explicitly set
 	if cfg.GateClient.Path != "" {
 		if cfg.GateClient.LoginPath == "" {
@@ -729,6 +769,15 @@ func mergeStructs(base, user reflect.Value) {
 			base.Set(user)
 		}
 	}
+}
+
+// isBindAllHost reports whether host is an unspecified/bind-all IP address (0.0.0.0 or ::).
+// Such an address is valid to bind a listener to but can never be reached by a browser, so it
+// is invalid as a redirect target. Empty hosts and hostnames such as "localhost" are not
+// treated as bind-all.
+func isBindAllHost(host string) bool {
+	ip := net.ParseIP(strings.TrimSpace(host))
+	return ip != nil && ip.IsUnspecified()
 }
 
 // isZeroValue checks if a reflect.Value represents the zero value for its type.

--- a/backend/internal/system/config/config_test.go
+++ b/backend/internal/system/config/config_test.go
@@ -180,6 +180,185 @@ notification:
 	assert.Equal(suite.T(), "mysql", config.Database.Config.SQLite.Path)
 }
 
+func (suite *ConfigTestSuite) TestLoadConfigGateClientDefaultsToServer() {
+	tempDir := suite.T().TempDir()
+
+	// gate_client omitted entirely: hostname/port/scheme derive from the server config.
+	userContent := `
+server:
+  hostname: "user-host"
+  port: 8095
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
+`
+	userFile := suite.createTempFile(tempDir, "user*.yaml", userContent)
+
+	config, err := LoadConfig(userFile, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+
+	assert.Equal(suite.T(), "user-host", config.GateClient.Hostname)
+	assert.Equal(suite.T(), 8095, config.GateClient.Port)
+	assert.Equal(suite.T(), "https", config.GateClient.Scheme)
+}
+
+func (suite *ConfigTestSuite) TestLoadConfigGateClientDefaultsToServerPublicURL() {
+	tempDir := suite.T().TempDir()
+
+	// gate_client omitted and server exposes a public_url: gate_client derives from the public_url.
+	userContent := `
+server:
+  hostname: "0.0.0.0"
+  port: 8090
+  public_url: "https://thunderid.local:9443"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
+`
+	userFile := suite.createTempFile(tempDir, "user*.yaml", userContent)
+
+	config, err := LoadConfig(userFile, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+
+	assert.Equal(suite.T(), "thunderid.local", config.GateClient.Hostname)
+	assert.Equal(suite.T(), 9443, config.GateClient.Port)
+	assert.Equal(suite.T(), "https", config.GateClient.Scheme)
+}
+
+func (suite *ConfigTestSuite) TestLoadConfigGateClientDefaultsToServerPublicURLWithoutPort() {
+	tempDir := suite.T().TempDir()
+
+	// public_url without an explicit port: gate_client falls back to the scheme's default port.
+	userContent := `
+server:
+  hostname: "0.0.0.0"
+  port: 8090
+  public_url: "https://thunderid.local"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
+`
+	userFile := suite.createTempFile(tempDir, "user*.yaml", userContent)
+
+	config, err := LoadConfig(userFile, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+
+	assert.Equal(suite.T(), "thunderid.local", config.GateClient.Hostname)
+	assert.Equal(suite.T(), 443, config.GateClient.Port)
+	assert.Equal(suite.T(), "https", config.GateClient.Scheme)
+}
+
+func (suite *ConfigTestSuite) TestLoadConfigGateClientPartialOverride() {
+	tempDir := suite.T().TempDir()
+
+	// Only gate_client.path is set: host/port/scheme still inherit from the server config.
+	userContent := `
+server:
+  hostname: "user-host"
+  port: 8095
+  http_only: true
+gate_client:
+  path: "/login"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
+`
+	userFile := suite.createTempFile(tempDir, "user*.yaml", userContent)
+
+	config, err := LoadConfig(userFile, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+
+	assert.Equal(suite.T(), "user-host", config.GateClient.Hostname)
+	assert.Equal(suite.T(), 8095, config.GateClient.Port)
+	assert.Equal(suite.T(), "http", config.GateClient.Scheme)
+	assert.Equal(suite.T(), "/login", config.GateClient.Path)
+}
+
+func (suite *ConfigTestSuite) TestLoadConfigGateClientDefaultsToServerHTTPPublicURLWithoutPort() {
+	tempDir := suite.T().TempDir()
+
+	// http public_url without an explicit port: gate_client falls back to port 80.
+	userContent := `
+server:
+  hostname: "0.0.0.0"
+  port: 8090
+  public_url: "http://thunderid.local"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
+`
+	userFile := suite.createTempFile(tempDir, "user*.yaml", userContent)
+
+	config, err := LoadConfig(userFile, "", tempDir)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), config)
+
+	assert.Equal(suite.T(), "thunderid.local", config.GateClient.Hostname)
+	assert.Equal(suite.T(), 80, config.GateClient.Port)
+	assert.Equal(suite.T(), "http", config.GateClient.Scheme)
+}
+
+func (suite *ConfigTestSuite) TestLoadConfigGateClientUnspecifiedHostFails() {
+	tempDir := suite.T().TempDir()
+
+	// server binds to 0.0.0.0 with no public_url and no explicit gate_client host: the gate
+	// client would resolve to the unreachable bind address, so loading must fail.
+	userContent := `
+server:
+  hostname: "0.0.0.0"
+  port: 8090
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
+`
+	userFile := suite.createTempFile(tempDir, "user*.yaml", userContent)
+
+	config, err := LoadConfig(userFile, "", tempDir)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), config)
+	assert.Contains(suite.T(), err.Error(), "unreachable")
+}
+
+func (suite *ConfigTestSuite) TestLoadConfigGateClientMalformedPublicURLFails() {
+	tempDir := suite.T().TempDir()
+
+	// gate_client derives from a malformed public_url (non-numeric port): parsing must fail loudly
+	// rather than silently leaving gate_client empty.
+	userContent := `
+server:
+  hostname: "0.0.0.0"
+  port: 8090
+  public_url: "https://thunderid.local:notaport"
+notification:
+  otp:
+    length: 6
+    use_numeric_only: true
+    validity_period_seconds: 120
+`
+	userFile := suite.createTempFile(tempDir, "user*.yaml", userContent)
+
+	config, err := LoadConfig(userFile, "", tempDir)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), config)
+	assert.Contains(suite.T(), err.Error(), "failed to parse server URL")
+}
+
 func (suite *ConfigTestSuite) TestLoadConfigLogLevel() {
 	tempDir := suite.T().TempDir()
 

--- a/build.ps1
+++ b/build.ps1
@@ -1739,7 +1739,9 @@ function Run-Frontend {
         & pnpm build:frontend
         
         Write-Host "Starting frontend applications in the background..."
-        # Start frontend processes in background
+        # In dev the apps are served on their own origins, so point them at the backend via
+        # THUNDERID_DEV_SERVER_URL (injected into __DEV_SERVER_URL__; applied only in dev builds).
+        $env:THUNDERID_DEV_SERVER_URL = $PUBLIC_URL
         $frontendProcess = Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "pnpm", "-r", "--parallel", "--filter", "@thunderid/console", "--filter", "@thunderid/gate", "dev" -PassThru -NoNewWindow
         $script:FRONTEND_PID = $frontendProcess.Id
     }

--- a/build.sh
+++ b/build.sh
@@ -1172,8 +1172,10 @@ function run_frontend() {
     pnpm build:frontend
     
     echo "Starting frontend applications in the background..."
-    # Start frontend processes in background
-    pnpm -r --parallel --filter "@thunderid/console" --filter "@thunderid/gate" dev &
+    # In dev the apps are served on their own origins, so point them at the backend via
+    # THUNDERID_DEV_SERVER_URL (injected into __DEV_SERVER_URL__; applied only in dev builds).
+    THUNDERID_DEV_SERVER_URL="$PUBLIC_URL" \
+        pnpm -r --parallel --filter "@thunderid/console" --filter "@thunderid/gate" dev &
     FRONTEND_PID=$!
     
     # Return to script directory

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -31,17 +31,20 @@ Controls the <ProductName /> server's network settings and identity.
 | `server.hostname` | `localhost` | The hostname or IP address the server binds to |
 | `server.port` | `8090` | Port the server listens on |
 | `server.http_only` | `false` | If `true`, disables HTTPS and uses HTTP only (not recommended for production) |
+| `server.public_url` | _(derived from server hostname, port and protocol)_ | The public URL clients use to reach the server, if it differs from the bind address. Derived when unset. |
 | `server.identifier` | `default-deployment` | Unique identifier for this deployment instance |
+
+When `server.public_url` is set, the `gate_client` settings below default to the corresponding hostname, port, and protocol from that URL. Most deployments only need to configure the server section.
 
 ## Gate Client Configuration
 
-Configures the connection to <ProductName /> Gate (the login UI).
+Configures the connection to <ProductName /> Gate (the login UI). Every setting is optional. By default, the `gate_client` settings are derived from `server.public_url`, so you only need to configure this section when Gate is hosted separately from the server.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `gate_client.hostname` | `localhost` | The hostname where <ProductName /> Gate is hosted |
-| `gate_client.port` | `8090` | Port where <ProductName /> Gate is accessible |
-| `gate_client.scheme` | `https` | Protocol scheme (`http` or `https`) |
+| `gate_client.hostname` | _(server's hostname)_ | The hostname where <ProductName /> Gate is hosted |
+| `gate_client.port` | _(server's port)_ | Port where <ProductName /> Gate is accessible |
+| `gate_client.scheme` | _(server's scheme)_ | Protocol scheme (`http` or `https`) |
 | `gate_client.path` | `/gate` | Base path for <ProductName /> Gate |
 
 ## TLS Configuration

--- a/frontend/apps/console/public/config.js
+++ b/frontend/apps/console/public/config.js
@@ -43,9 +43,6 @@ window.__THUNDERID_RUNTIME_CONFIG__ = {
       'system:usertype:view',
     ],
   },
-  server: {
-    hostname: 'localhost',
-    port: 8090,
-    http_only: false,
-  },
+  // Defaults to the origin this app is served from. Add a `server` block with `public_url`
+  // (or `hostname`, `port`, `http_only`) to target a different backend.
 };

--- a/frontend/apps/console/src/main.tsx
+++ b/frontend/apps/console/src/main.tsx
@@ -32,6 +32,14 @@ if (typeof window !== 'undefined') {
   setCnPrefix(window.__THUNDERID_RUNTIME_CONFIG__?.brand?.product_name ?? '');
 }
 
+// Seed the runtime config with the dev backend URL when unset (dev only).
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  const runtimeConfig = window.__THUNDERID_RUNTIME_CONFIG__;
+  if (runtimeConfig && !runtimeConfig.server) {
+    runtimeConfig.server = {public_url: __DEV_SERVER_URL__};
+  }
+}
+
 const queryClient: QueryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/frontend/apps/console/vite.config.ts
+++ b/frontend/apps/console/vite.config.ts
@@ -49,8 +49,12 @@ const VERSION = readFileSync(publicVersionFile, 'utf-8').trim();
 const ANALYZER_ENABLED = process.env.ANALYZE === 'true';
 const BUNDLE_ANALYSIS_ENABLED = process.env.CODECOV_BUNDLE_UPLOAD === 'true';
 
+// Dev backend URL, from THUNDERID_DEV_SERVER_URL (default https://localhost:8090). Injected into
+// __DEV_SERVER_URL__ only for the dev server; production builds receive an empty string.
+const DEV_SERVER_URL = process.env.THUNDERID_DEV_SERVER_URL?.trim();
+
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({command}) => ({
   base: BASE_URL,
   build: {
     rollupOptions: {
@@ -85,6 +89,13 @@ export default defineConfig({
   define: {
     VERSION: JSON.stringify(VERSION),
     ANALYZER_ENABLED: JSON.stringify(ANALYZER_ENABLED),
+    __DEV_SERVER_URL__: JSON.stringify(
+      command === 'serve'
+        ? DEV_SERVER_URL && DEV_SERVER_URL.length > 0
+          ? DEV_SERVER_URL
+          : 'https://localhost:8090'
+        : '',
+    ),
   },
   plugins: [
     prismjsInjectCore(),
@@ -192,4 +203,4 @@ export default defineConfig({
       ],
     },
   },
-});
+}));

--- a/frontend/apps/gate/public/config.js
+++ b/frontend/apps/gate/public/config.js
@@ -27,9 +27,6 @@ window.__THUNDERID_RUNTIME_CONFIG__ = {
   client: {
     base: '/gate',
   },
-  server: {
-    hostname: 'localhost',
-    port: 8090,
-    http_only: false,
-  },
+  // Defaults to the origin this app is served from. Add a `server` block with `public_url`
+  // (or `hostname`, `port`, `http_only`) to target a different backend.
 };

--- a/frontend/apps/gate/src/main.tsx
+++ b/frontend/apps/gate/src/main.tsx
@@ -31,6 +31,14 @@ if (typeof window !== 'undefined') {
   setCnPrefix(window.__THUNDERID_RUNTIME_CONFIG__?.brand?.product_name ?? '');
 }
 
+// Seed the runtime config with the dev backend URL when unset (dev only).
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  const runtimeConfig = window.__THUNDERID_RUNTIME_CONFIG__;
+  if (runtimeConfig && !runtimeConfig.server) {
+    runtimeConfig.server = {public_url: __DEV_SERVER_URL__};
+  }
+}
+
 const queryClient: QueryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/frontend/apps/gate/src/vite-env.d.ts
+++ b/frontend/apps/gate/src/vite-env.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,10 +17,8 @@
  */
 
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-svgr/client" />
 
 declare global {
-  const VERSION: string;
   const __DEV_SERVER_URL__: string;
 }
 

--- a/frontend/apps/gate/vite.config.ts
+++ b/frontend/apps/gate/vite.config.ts
@@ -34,9 +34,22 @@ const BASE_URL = process.env.BASE_URL ?? '/gate';
 const ANALYZER_ENABLED = process.env.ANALYZE === 'true';
 const BUNDLE_ANALYSIS_ENABLED = process.env.CODECOV_BUNDLE_UPLOAD === 'true';
 
+// Dev backend URL, from THUNDERID_DEV_SERVER_URL (default https://localhost:8090). Injected into
+// __DEV_SERVER_URL__ only for the dev server; production builds receive an empty string.
+const DEV_SERVER_URL = process.env.THUNDERID_DEV_SERVER_URL?.trim();
+
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({command}) => ({
   base: BASE_URL,
+  define: {
+    __DEV_SERVER_URL__: JSON.stringify(
+      command === 'serve'
+        ? DEV_SERVER_URL && DEV_SERVER_URL.length > 0
+          ? DEV_SERVER_URL
+          : 'https://localhost:8090'
+        : '',
+    ),
+  },
   build: {
     rollupOptions: {
       output: {
@@ -155,4 +168,4 @@ export default defineConfig({
       ],
     },
   },
-});
+}));

--- a/frontend/packages/contexts/src/Config/ConfigContext.tsx
+++ b/frontend/packages/contexts/src/Config/ConfigContext.tsx
@@ -40,21 +40,21 @@ export interface ConfigContextType {
 
   /**
    * Gets the server hostname from the configuration
-   * @returns The server hostname (e.g., "localhost")
+   * @returns The server hostname (e.g., "localhost"), or undefined when not configured
    */
-  getServerHostname: () => string;
+  getServerHostname: () => string | undefined;
 
   /**
    * Gets the server port from the configuration
-   * @returns The server port number (e.g., 8090)
+   * @returns The server port number (e.g., 8090), or undefined when not configured
    */
-  getServerPort: () => number;
+  getServerPort: () => number | undefined;
 
   /**
    * Checks if HTTP-only mode is enabled in the configuration
-   * @returns True if HTTP-only mode is enabled, false if HTTPS is used
+   * @returns True if HTTP-only mode is enabled, false if HTTPS is used, or undefined when not configured
    */
-  isHttpOnly: () => boolean;
+  isHttpOnly: () => boolean | undefined;
 
   /**
    * Gets the client ID from the configuration

--- a/frontend/packages/contexts/src/Config/ConfigProvider.tsx
+++ b/frontend/packages/contexts/src/Config/ConfigProvider.tsx
@@ -86,17 +86,21 @@ export default function ConfigProvider({children}: ConfigProviderProps) {
       config,
       getServerUrl: () => {
         // If public_url is provided, use it directly
-        if (config.server.public_url) {
+        if (config.server?.public_url) {
           return config.server.public_url;
         }
-        // Otherwise, construct from hostname, port, and http_only
-        const {hostname, port, http_only: httpOnly} = config.server;
-        const protocol: string = httpOnly ? 'http' : 'https';
-        return `${protocol}://${hostname}:${port}`;
+        // Otherwise, construct from hostname, port, and http_only when configured
+        const {hostname, port, http_only: httpOnly} = config.server ?? {};
+        if (hostname && port !== undefined) {
+          const protocol: string = httpOnly ? 'http' : 'https';
+          return `${protocol}://${hostname}:${port}`;
+        }
+        // Fall back to the URL the app is served from
+        return typeof window !== 'undefined' ? window.location.origin : '';
       },
-      getServerHostname: () => config.server.hostname,
-      getServerPort: () => config.server.port,
-      isHttpOnly: () => config.server.http_only,
+      getServerHostname: () => config.server?.hostname,
+      getServerPort: () => config.server?.port,
+      isHttpOnly: () => config.server?.http_only,
       getClientId: () => config.client.client_id,
       getScopes: () => config.client.scopes ?? [],
       getClientUrl: () => {
@@ -140,12 +144,16 @@ export default function ConfigProvider({children}: ConfigProviderProps) {
           return `${protocol}://${hostname}:${port}`;
         }
         // Fall back to resource server URL
-        if (config.server.public_url) {
+        if (config.server?.public_url) {
           return config.server.public_url;
         }
-        const {hostname, port, http_only: httpOnly} = config.server;
-        const protocol: string = httpOnly ? 'http' : 'https';
-        return `${protocol}://${hostname}:${port}`;
+        const {hostname, port, http_only: httpOnly} = config.server ?? {};
+        if (hostname && port !== undefined) {
+          const protocol: string = httpOnly ? 'http' : 'https';
+          return `${protocol}://${hostname}:${port}`;
+        }
+        // Fall back to the URL the app is served from
+        return typeof window !== 'undefined' ? window.location.origin : '';
       },
       getTrustedIssuerClientId: () => {
         if (config.trusted_issuer?.client_id) {

--- a/frontend/packages/contexts/src/Config/__tests__/ConfigProvider.test.tsx
+++ b/frontend/packages/contexts/src/Config/__tests__/ConfigProvider.test.tsx
@@ -121,6 +121,16 @@ describe('ConfigProvider', () => {
     expect(getTestId('server-url')).toBe('https://example.com');
   });
 
+  it('falls back to the served origin when no server block is configured', () => {
+    renderWithConfig(buildConfig({server: undefined}), ConfigConsumer);
+    expect(getTestId('server-url')).toBe(window.location.origin);
+  });
+
+  it('falls back to the served origin when hostname and port are not configured', () => {
+    renderWithConfig(buildConfig({server: {http_only: false}}), ConfigConsumer);
+    expect(getTestId('server-url')).toBe(window.location.origin);
+  });
+
   // --- getTrustedIssuerUrl ---
 
   describe('getTrustedIssuerUrl', () => {
@@ -168,6 +178,11 @@ describe('ConfigProvider', () => {
         ConfigConsumer,
       );
       expect(getTestId('trusted-issuer-url')).toBe('https://api.example.com');
+    });
+
+    it('falls back to the served origin when neither trusted_issuer nor server host is configured', () => {
+      renderWithConfig(buildConfig({server: undefined}), ConfigConsumer);
+      expect(getTestId('trusted-issuer-url')).toBe(window.location.origin);
     });
   });
 

--- a/frontend/packages/contexts/src/Config/types.ts
+++ b/frontend/packages/contexts/src/Config/types.ts
@@ -26,26 +26,28 @@ import {OxygenThemeType} from '@wso2/oxygen-ui/styles/index';
  */
 export interface ServerConfig {
   /**
-   * Server hostname or IP address
+   * Server hostname or IP address. Optional — when omitted (along with public_url),
+   * the server URL is derived from the URL the app is served from (window.location.origin).
    * @example "localhost", "api.example.com", "192.168.1.100"
    */
-  hostname: string;
+  hostname?: string;
 
   /**
-   * Server port number
+   * Server port number. Optional — see hostname.
    * @example 8090, 3000, 8080
    */
-  port: number;
+  port?: number;
 
   /**
    * Whether to use HTTP only (no HTTPS). When true, connections will use HTTP protocol.
    * When false, HTTPS will be used for secure connections.
    */
-  http_only: boolean;
+  http_only?: boolean;
 
   /**
    * Optional public URL for the server. If provided, this will be used instead of
-   * constructing the URL from hostname, port, and http_only.
+   * constructing the URL from hostname, port, and http_only, or falling back to the
+   * served origin. Set this only when the external URL differs from the accessed URL.
    * @example "https://example.com", "https://api.local:8080"
    */
   public_url?: string;
@@ -243,8 +245,11 @@ export interface ProductConfig {
   /** Client-specific configuration including authentication settings */
   client: ClientConfig;
 
-  /** Server connection configuration for API resource calls */
-  server: ServerConfig;
+  /**
+   * Server connection configuration for API resource calls. Optional — when omitted,
+   * the server URL defaults to the URL the app is served from (window.location.origin).
+   */
+  server?: ServerConfig;
 
   /** Optional trusted issuer configuration for external token validation */
   trusted_issuer?: TrustedIssuerConfig;

--- a/install/helm/conf/apps/console/config.js
+++ b/install/helm/conf/apps/console/config.js
@@ -31,15 +31,13 @@ window.__THUNDERID_RUNTIME_CONFIG__ = {
     client_id: {{ .Values.configuration.consoleClient.clientId | quote }},
     scopes: {{ .Values.configuration.consoleClient.scopes }},
   },
+  {{- if .Values.configuration.server.publicUrl }}
+  // Defaults to the origin this app is served from. Required only when the server's
+  // external URL differs.
   server: {
-    // Not used when public_url is set
-    hostname: "0.0.0.0",
-    port: {{ .Values.configuration.server.port }},
-    http_only: {{ .Values.configuration.server.httpOnly }},
-    {{- if .Values.configuration.server.publicUrl }}
     public_url: {{ .Values.configuration.server.publicUrl | quote }},
-    {{- end }}
   },
+  {{- end }}
   {{- if .Values.configuration.consoleClient.trustedIssuer }}
   trusted_issuer: {
     hostname: {{ .Values.configuration.consoleClient.trustedIssuer.hostname | quote }},

--- a/install/helm/conf/apps/gate/config.js
+++ b/install/helm/conf/apps/gate/config.js
@@ -29,13 +29,11 @@ window.__THUNDERID_RUNTIME_CONFIG__ = {
   client: {
     base: {{ .Values.configuration.gateClient.path | quote }},
   },
+  {{- if .Values.configuration.server.publicUrl }}
+  // Defaults to the origin this app is served from. Required only when the server's
+  // external URL differs.
   server: {
-    // Not used when public_url is set
-    hostname: "0.0.0.0",
-    port: {{ .Values.configuration.server.port }},
-    http_only: {{ .Values.configuration.server.httpOnly }},
-    {{- if .Values.configuration.server.publicUrl }}
     public_url: {{ .Values.configuration.server.publicUrl | quote }},
-    {{- end }}
   },
+  {{- end }}
 };

--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -40,11 +40,25 @@ server:
   {{- end }}
 
 gate_client:
+  # hostname/port/scheme default to the server's public URL. Required only when Gate is hosted separately.
+  {{- if .Values.configuration.gateClient.hostname }}
   hostname: {{ .Values.configuration.gateClient.hostname | quote }}
+  {{- end }}
+  {{- if .Values.configuration.gateClient.port }}
   port: {{ .Values.configuration.gateClient.port }}
+  {{- end }}
+  {{- if .Values.configuration.gateClient.scheme }}
   scheme: {{ .Values.configuration.gateClient.scheme | quote }}
+  {{- end }}
+  {{- if .Values.configuration.gateClient.path }}
+  path: {{ .Values.configuration.gateClient.path | quote }}
+  {{- end }}
+  {{- if .Values.configuration.gateClient.loginPath }}
   login_path: {{ .Values.configuration.gateClient.loginPath | quote }}
+  {{- end }}
+  {{- if .Values.configuration.gateClient.errorPath }}
   error_path: {{ .Values.configuration.gateClient.errorPath | quote }}
+  {{- end }}
 
 tls:
   min_version: {{ .Values.configuration.tls.minVersion | quote }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -150,6 +150,8 @@ configuration:
   server:
     port: 8090
     httpOnly: false
+    # The URL where users reach ThunderID in their browser.
+    # ThunderID uses it to build the login and error redirect links.
     publicUrl: "https://thunderid.local"
     # Security configuration.
     # jwksCacheTtl controls how long fetched JWKS responses are cached in-process for
@@ -170,12 +172,13 @@ configuration:
     #       - claim: "ouId"
     #         value: "<tenant-ou-id>"
 
-  # Gate client configuration
+  # Gate client configuration.
+  # hostname/port/scheme default to server.publicUrl. Required only when Gate is hosted separately.
   gateClient:
-    hostname: "thunderid.local"
-    port: 443
-    scheme: "https"
     path: "/gate"
+    # hostname: "thunderid.local"
+    # port: 443
+    # scheme: "https"
 
   # Branding configuration for the Console and Gate frontends.
   # productName: Display name shown in the browser tab and UI.

--- a/install/quick-start/README.md
+++ b/install/quick-start/README.md
@@ -93,11 +93,8 @@ server:
   port: <your-port>                              # e.g. 8090
   public_url: "https://<your-host>:<your-port>" # e.g. https://thunderid.local:8090
 
-gate_client:
-  hostname: "<your-host>"
-  port: <your-port>
-  scheme: "https"
-  path: "/gate"
+# gate_client is optional and defaults to server.public_url.
+# Required only when Gate is hosted separately from the server.
 
 passkey:
   allowed_origins:


### PR DESCRIPTION
### Purpose
Changing ThunderID's public URL (hostname, port, or protocol) previously required editing the same information in many places: the backend server config, the gate_client block, both frontend config.js files, and the Helm deployment. There was no single source of truth, so the host/port/scheme was duplicated everywhere and easy to get partially wrong, leading to redirect and login failures.

This PR makes the served/accessed URL the effective source of truth for the common case:

The frontend apps (Console and Gate) derive the backend API URL from the origin they are served from when nothing is configured, so the server block in config.js becomes optional.
The backend gate_client settings default to the server's own public URL when unset, so gate_client only needs configuring when Gate is hosted separately from the server.
The result: for the common deployment, changing the hostname requires no edits to the default configuration. public_url remains the explicit override for cases where the externally reachable URL differs from what the browser accesses.

Excludes the CORS and passkey allowed-origin auto-include work discussed in the issue. 


### Approach

  Frontend (runtime derivation from the served URL):
- Made the `server` block and its `hostname`, `port`, and `http_only` fields optional in the config types.
- `getServerUrl()` and the trusted-issuer fallback that depends on it now return `window.location.origin` when no `public_url` or `hostname`/`port` is configured, matching the pattern `getClientUrl()` already used.
- Removed the hardcoded `server` blocks from the Console and Gate `config.js` files, replacing them with guidance comments. The default configs now ship with no hardcoded host, so the apps use whatever URL they are served from.
- Added unit tests for the served-origin fallback in `getServerUrl()` and `getTrustedIssuerUrl()`.

Backend (`gate_client` defaults to the server's URL):

- `LoadConfig` now derives `gate_client.hostname`, `port`, and `scheme` from the server's public URL (via `GetServerURL`) when they are not explicitly set, falling back to the scheme's default port (80 for http, 443 for https) when the URL carries no explicit port. Removed the hardcoded `gate_client` defaults from `default.json`.
- Added a startup guard: if the resolved `gate_client` hostname is a bind-all address (`0.0.0.0` or `::`), config loading fails with an actionable message telling the operator to set `server.public_url` (or `gate_client.hostname`) to a browser-reachable host. This prevents a silent misconfiguration that would otherwise produce broken login and error redirects.
- Added unit tests covering derivation from `hostname`/`port`, derivation from `public_url` (with and without an explicit port, over http and https), partial overrides, and the bind-all failure case.

Local development:

- The dev apps are served on their own Vite origin rather than by the backend, so each app's `vite.config` injects a build-time constant `__DEV_SERVER_URL__` (from `THUNDERID_DEV_SERVER_URL`, defaulting to `https://localhost:8090`) for the dev server only. Production builds receive an empty string.
- `main.tsx` seeds the runtime config with this value only under an `import.meta.env.DEV` guard, so the block is removed from production bundles by dead-code elimination and never affects a real deployment. The `build.sh` and `build.ps1` scripts pass the backend's public URL through this variable.

Documentation:

- Updated the configuration guide, quick-start README, and Helm `values.yaml` to document the new optional defaults for `gate_client` and the frontend `server` block, and to describe `public_url` as the single override point.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/3406

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now derives backend connection defaults from the server’s public-facing URL when separate Gate client settings aren’t provided.
  * Dev mode automatically wires the frontend to the current backend origin via the dev server URL.

* **Bug Fixes**
  * Added stricter validation to fail fast when backend hostname is unreachable (e.g., bind-all addresses without a browser-reachable public URL).
  * Improved client-side URL fallback behavior when server configuration is missing or partial.

* **Documentation**
  * Updated configuration guidance to describe `server.public_url` and the new defaulting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->