### PR TITLE
Filter OIDC scopes by application scopes

### DIFF
--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -256,6 +256,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 	}
 
 	oidcScopes, nonOidcScopes := oauth2utils.SeparateOIDCAndNonOIDCScopes(scope, app.ScopeClaims)
+	oidcScopes = oauth2utils.FilterOIDCScopesByAllowedScopes(oidcScopes, app.Scopes)
 
 	// Resolve resource identifiers to Resource Servers and downscope non-OIDC scopes against
 	// the union of permissions defined on those Resource Servers. Unknown identifiers cause

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -165,6 +165,7 @@ func (suite *AuthorizeServiceTestSuite) testApp() *providers.OAuthClient {
 		RedirectURIs: []string{"https://client.example.com/callback"},
 		GrantTypes:   []providers.GrantType{providers.GrantTypeAuthorizationCode},
 		PKCERequired: false,
+		Scopes:       []string{"openid", "profile", "email"},
 	}
 }
 
@@ -335,6 +336,39 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Su
 	assert.Equal(suite.T(), testAuthID, result.QueryParams[oauth2const.AuthID])
 	assert.Equal(suite.T(), "test-app-id", result.QueryParams[oauth2const.AppID])
 	assert.Equal(suite.T(), "test-flow-id", result.QueryParams[oauth2const.ExecutionID])
+}
+
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_FiltersOIDCScopesByAppScopes() {
+	app := suite.testApp()
+	app.Scopes = []string{"profile"}
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, mock.Anything, app).
+		Return(false, "", "")
+	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything, mock.Anything).Return("test-flow-id", nil)
+
+	var captured authRequestContext
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, value authRequestContext) {
+			captured = value
+		}).Return(testAuthID, nil)
+
+	msg := &OAuthMessage{
+		RequestType: oauth2const.TypeInitialAuthorizationRequest,
+		RequestQueryParams: map[string]string{
+			"client_id":     "test-client-id",
+			"redirect_uri":  "https://client.example.com/callback",
+			"response_type": "code",
+			"scope":         "openid email profile",
+			"state":         "test-state",
+		},
+	}
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"profile"}, captured.OAuthParameters.StandardScopes)
 }
 
 func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_InsecureRedirectURI() {

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -109,6 +109,7 @@ func (s *parService) HandlePushedAuthorizationRequest(
 
 	scope := params[oauth2const.RequestParamScope]
 	oidcScopes, nonOidcScopes := oauth2utils.SeparateOIDCAndNonOIDCScopes(scope, oauthApp.ScopeClaims)
+	oidcScopes = oauth2utils.FilterOIDCScopesByAllowedScopes(oidcScopes, oauthApp.Scopes)
 
 	// Resolve resource identifiers to Resource Servers and downscope non-OIDC scopes against
 	// the union of permissions defined on those Resource Servers. Unknown identifiers cause

--- a/backend/internal/oauth/oauth2/par/service_test.go
+++ b/backend/internal/oauth/oauth2/par/service_test.go
@@ -81,6 +81,7 @@ func (s *ServiceTestSuite) newTestApp() *providers.OAuthClient {
 		GrantTypes:              []providers.GrantType{providers.GrantTypeAuthorizationCode},
 		ResponseTypes:           []providers.ResponseType{providers.ResponseTypeCode},
 		TokenEndpointAuthMethod: providers.TokenEndpointAuthMethodClientSecretBasic,
+		Scopes:                  []string{"openid", "profile", "email"},
 	}
 }
 
@@ -365,6 +366,27 @@ func (s *ServiceTestSuite) TestHandlePAR_ScopesDownscopedAgainstResourceServers(
 	assert.Empty(s.T(), errCode)
 	assert.NotNil(s.T(), resp)
 	assert.Equal(s.T(), []string{"read"}, captured.OAuthParameters.PermissionScopes)
+}
+
+func (s *ServiceTestSuite) TestHandlePAR_FiltersOIDCScopesByAppScopes() {
+	store := newParStoreInterfaceMock(s.T())
+	var captured pushedAuthorizationRequest
+	store.EXPECT().Store(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, req pushedAuthorizationRequest, _ int64) {
+			captured = req
+		}).Return("test-uri", nil)
+
+	svc := newPARService(store, s.newPermissiveResourceMock(), s.testCfg)
+	app := s.newTestApp()
+	app.Scopes = []string{"profile"}
+	params := s.newValidParams()
+	params[oauth2const.RequestParamScope] = "openid email profile"
+
+	resp, errCode, _ := svc.HandlePushedAuthorizationRequest(s.ctx, params, nil, app, "")
+
+	assert.Empty(s.T(), errCode)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(), []string{"profile"}, captured.OAuthParameters.StandardScopes)
 }
 
 func (s *ServiceTestSuite) TestHandlePAR_AcrValuesPropagated() {

--- a/backend/internal/oauth/oauth2/utils/oauthutils.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils.go
@@ -152,6 +152,26 @@ func SeparateOIDCAndNonOIDCScopes(scopes string, scopeClaimsMapping map[string][
 	return oidcScopes, nonOidcScopes
 }
 
+// FilterOIDCScopesByAllowedScopes filters requested OIDC scopes against the application's active scopes.
+func FilterOIDCScopesByAllowedScopes(oidcScopes []string, allowedScopes []string) []string {
+	if allowedScopes == nil {
+		return oidcScopes
+	}
+
+	allowedScopeSet := make(map[string]struct{}, len(allowedScopes))
+	for _, scope := range allowedScopes {
+		allowedScopeSet[scope] = struct{}{}
+	}
+
+	filteredScopes := make([]string, 0, len(oidcScopes))
+	for _, scope := range oidcScopes {
+		if _, ok := allowedScopeSet[scope]; ok {
+			filteredScopes = append(filteredScopes, scope)
+		}
+	}
+	return filteredScopes
+}
+
 // ParseClaimsRequest parses the claims parameter JSON string into a ClaimsRequest struct.
 // Returns nil if the input is empty.
 // Returns an error if the JSON is malformed or violates OIDC spec constraints.

--- a/backend/internal/oauth/oauth2/utils/oauthutils_test.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils_test.go
@@ -787,6 +787,33 @@ func (suite *OAuth2UtilsTestSuite) TestSeparateOIDCAndNonOIDCScopes_WithCustomSc
 	}
 }
 
+func (suite *OAuth2UtilsTestSuite) TestFilterOIDCScopesByAllowedScopes() {
+	result := FilterOIDCScopesByAllowedScopes(
+		[]string{"openid", "email", "profile"},
+		[]string{"profile"},
+	)
+
+	assert.Equal(suite.T(), []string{"profile"}, result)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestFilterOIDCScopesByAllowedScopes_NilAllowedScopes() {
+	result := FilterOIDCScopesByAllowedScopes(
+		[]string{"openid", "email", "profile"},
+		nil,
+	)
+
+	assert.Equal(suite.T(), []string{"openid", "email", "profile"}, result)
+}
+
+func (suite *OAuth2UtilsTestSuite) TestFilterOIDCScopesByAllowedScopes_EmptyAllowedScopes() {
+	result := FilterOIDCScopesByAllowedScopes(
+		[]string{"openid", "email", "profile"},
+		[]string{},
+	)
+
+	assert.Empty(suite.T(), result)
+}
+
 // Claims parameter parsing tests
 
 func (suite *OAuth2UtilsTestSuite) TestParseClaimsRequest_ValidJSON() {

--- a/docs/content/guides/guides/protocols/oauth-oidc/claims-and-scopes.mdx
+++ b/docs/content/guides/guides/protocols/oauth-oidc/claims-and-scopes.mdx
@@ -76,8 +76,8 @@ How the request-time scope list becomes the issued-token scope list:
 
 | Scope category | Filtered by resource indicators? | Notes |
 |---|---|---|
-| `openid`, `profile`, `email`, `phone`, `address` | ❌ Always kept | OIDC standard scopes are reserved and pass through unchanged |
-| Custom scopes covered by `scopeClaims` | ❌ Always kept | The application owns these |
+| `openid`, `profile`, `email`, `phone`, `address` | ❌ Not by resource indicators | OpenID Connect standard scopes are reserved. When the application has a scopes allowlist, <ProductName /> only keeps requested scopes that the application allows. |
+| Custom scopes covered by `scopeClaims` | ❌ Not by resource indicators | The application owns these scopes. When the application has a scopes allowlist, <ProductName /> only keeps requested scopes that the application allows. |
 | Permissions owned by a targeted resource server (see [Resource Indicators](../resource-indicators)) | ✅ Kept | RS-defined |
 | Permissions owned by a different resource server | ❌ Dropped silently | RS-defined |
 | Permissions not allowed on the application | ❌ Rejected | Request fails with `invalid_scope` |

--- a/docs/content/guides/key-concepts/authorization.mdx
+++ b/docs/content/guides/key-concepts/authorization.mdx
@@ -26,4 +26,4 @@ See [Resource Indicators](/docs/next/guides/guides/resource-indicators) for usag
 
 ## Scope Filtering
 
-<ProductName /> validates requested scopes against the targeted resource server's permission set. Scopes not defined on the resource server are silently removed from the issued token. OpenID Connect standard scopes (`openid`, `profile`, `email`, `address`, `phone`) and any custom scopes defined in the application's `scope_claims` mapping are not subject to resource server filtering and pass through unchanged.
+<ProductName /> validates requested scopes against the targeted resource server's permission set. Scopes not defined on the resource server are silently removed from the issued token. OpenID Connect standard scopes (`openid`, `profile`, `email`, `address`, `phone`) and any custom scopes defined in the application's `scope_claims` mapping are not subject to resource server filtering. When an application has a scopes allowlist, <ProductName /> still removes any requested OpenID Connect or custom scope-to-claim scope that the application does not allow.

--- a/tests/integration/oauth/authz/authz_scope_test.go
+++ b/tests/integration/oauth/authz/authz_scope_test.go
@@ -21,12 +21,13 @@ package authz
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/thunder-id/thunderid/tests/integration/testutils"
 	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
 )
 
 const (
@@ -399,6 +400,116 @@ func (ts *OAuthAuthzScopeTestSuite) TestOAuthAuthzFlow_WithNoAuthorizedScopes() 
 			scope == "address" || scope == "phone" || scope == "offline_access"
 		ts.Require().True(isOIDCScope, "Scope '%s' should be an OIDC scope", scope)
 	}
+}
+
+// TestOAuthAuthzFlow_FiltersOIDCScopesByApplicationScopes verifies that requested OIDC scopes are
+// filtered by the application's active scopes before token issuance.
+func (ts *OAuthAuthzScopeTestSuite) TestOAuthAuthzFlow_FiltersOIDCScopesByApplicationScopes() {
+	const (
+		clientID     = "oidc_scope_filter_test_client"
+		clientSecret = "oidc_scope_filter_test_secret"
+	)
+
+	appConfig := map[string]interface{}{
+		"name":                      "OIDCScopeFilterTestApp",
+		"description":               "OAuth application for OIDC scope filtering integration test",
+		"ouId":                      scopeTestOUID,
+		"authFlowId":                ts.flowID,
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{"authz-test-person"},
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                clientID,
+					"clientSecret":            clientSecret,
+					"redirectUris":            []string{scopeTestRedirectURI},
+					"grantTypes":              []string{"authorization_code", "refresh_token"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_post",
+					"scopes":                  []string{"profile"},
+				},
+			},
+		},
+	}
+
+	appID, err := ts.createApplicationRaw(appConfig)
+	ts.Require().NoError(err, "Failed to create OAuth application")
+	defer func() {
+		_ = testutils.DeleteApplication(appID)
+	}()
+
+	persistedScopes, err := ts.getApplicationOAuthScopes(appID)
+	ts.Require().NoError(err, "Failed to get persisted OAuth application scopes")
+	ts.Require().ElementsMatch([]string{"profile"}, persistedScopes,
+		"Application should persist only the active OIDC scope used by this test")
+
+	tokenResp, err := testutils.ObtainAccessTokenWithPassword(
+		clientID,
+		scopeTestRedirectURI,
+		"openid email profile",
+		"oauth_authorized_user",
+		"SecurePass123!",
+		false,
+		clientSecret,
+	)
+	ts.Require().NoError(err, "Failed to obtain access token")
+	ts.Require().NotNil(tokenResp, "Token response should not be nil")
+	ts.Require().NotEmpty(tokenResp.AccessToken, "Access token should not be empty")
+
+	tokenResponseScopes := strings.Fields(tokenResp.Scope)
+	ts.Require().ElementsMatch([]string{"profile"}, tokenResponseScopes,
+		"Token response scope should only include active requested OIDC scopes")
+
+	claims, err := testutils.DecodeJWT(tokenResp.AccessToken)
+	ts.Require().NoError(err, "Failed to decode access token")
+
+	scopeRaw, ok := claims.Additional["scope"]
+	ts.Require().True(ok, "scope claim should be present in access token")
+
+	scopeStr, ok := scopeRaw.(string)
+	ts.Require().True(ok, "scope claim should be a string")
+
+	accessTokenScopes := strings.Fields(scopeStr)
+	ts.Require().ElementsMatch([]string{"profile"}, accessTokenScopes,
+		"Access token scope should only include active requested OIDC scopes")
+	ts.Require().Empty(tokenResp.IDToken, "ID token should not be issued when openid is not active")
+}
+
+func (ts *OAuthAuthzScopeTestSuite) getApplicationOAuthScopes(appID string) ([]string, error) {
+	req, err := http.NewRequest(http.MethodGet, testutils.TestServerURL+"/applications/"+appID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get application, status: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var app struct {
+		InboundAuthConfig []struct {
+			OAuthConfig struct {
+				Scopes []string `json:"scopes"`
+			} `json:"config"`
+		} `json:"inboundAuthConfig"`
+	}
+	if err := json.Unmarshal(body, &app); err != nil {
+		return nil, err
+	}
+	if len(app.InboundAuthConfig) == 0 {
+		return nil, fmt.Errorf("application has no inbound auth config")
+	}
+	return app.InboundAuthConfig[0].OAuthConfig.Scopes, nil
 }
 
 // createOAuthApplication creates an OAuth application using the low-level API


### PR DESCRIPTION
### Purpose
OpenID standard scopes requested through the authorization code flow were being carried into issued tokens even when those scopes were not enabled in the application’s active scopes. This caused removed scopes such as `openid` and `email` to appear in the access token, and `id_token` to be generated when `openid` was requested but not allowed by the application.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

The authorize flow already separates requested scopes into OIDC scopes and non-OIDC/resource scopes using `SeparateOIDCAndNonOIDCScopes`. The issue was that only non-OIDC scopes were downscoped later, while OIDC scopes were stored as authorized scopes without checking the application’s configured active scopes.

This PR adds a shared helper, `FilterOIDCScopesByAllowedScopes`, which filters requested OIDC scopes against `OAuthClient.Scopes`.

The filtering is applied immediately after OIDC scope separation in both authorization request entry points:

- `/oauth2/authorize` in `authz/service.go`
- pushed authorization requests in `par/service.go`

So the stored authorization request now contains only OIDC scopes that are both requested by the client and enabled in the application:

`final OIDC scopes = requested OIDC scopes ∩ application active scopes
`
### Related Issues
- https://github.com/thunder-id/thunderid/issues/3361

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC standard scopes are now restricted to the scopes explicitly allowed by the client app during authorization and pushed authorization flows.
  * Prevents disallowed OIDC scopes from being persisted and reflected in issued tokens.

* **Tests**
  * Added unit and integration coverage to validate OIDC scope allowlist filtering for both standard flows and PAR.
  * Added utility tests for the new OIDC filtering behavior and expanded test app scope setup.

* **Documentation**
  * Updated guidance to clarify scope filtering rules, including how the app allowlist constrains both standard OIDC and custom scope/claim mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->