### PR TITLE
Add SAN extension to RSA certificate generation

### DIFF
--- a/.github/actions/generate-certificates/action.yml
+++ b/.github/actions/generate-certificates/action.yml
@@ -27,7 +27,8 @@ runs:
         openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
           -keyout target/out/.cert/server.key \
           -out target/out/.cert/server.cert \
-          -subj "/O=WSO2/OU=${{ inputs.product-name }}/CN=localhost"
+          -subj "/O=WSO2/OU=${{ inputs.product-name }}/CN=localhost" \
+          -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
 
         echo "✅ Shared certificates generated:"
         ls -la target/out/.cert/

--- a/.github/workflows/windows-powershell-validation.yml
+++ b/.github/workflows/windows-powershell-validation.yml
@@ -49,7 +49,8 @@ jobs:
           openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
             -keyout target/out/.cert/server.key \
             -out target/out/.cert/server.cert \
-            -subj "/O=WSO2/OU=${PRODUCT_NAME}/CN=localhost"
+            -subj "/O=WSO2/OU=${PRODUCT_NAME}/CN=localhost" \
+            -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
 
           echo "✅ Shared certificates generated:"
           ls -la target/out/.cert/

--- a/build.ps1
+++ b/build.ps1
@@ -1327,7 +1327,8 @@ function Ensure-Certificates {
                     & openssl req -x509 -nodes -days 365 -newkey rsa:2048 `
                         -keyout $local_key_file `
                         -out $local_cert_file `
-                        -subj "/O=WSO2/OU=$PRODUCT_NAME/CN=localhost" 2>$null
+                        -subj "/O=WSO2/OU=$PRODUCT_NAME/CN=localhost" `
+                        -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" 2>$null
                 }
                 if ($LASTEXITCODE -ne 0) {
                     throw "Error generating certificates: OpenSSL failed with exit code $LASTEXITCODE"

--- a/build.sh
+++ b/build.sh
@@ -944,6 +944,7 @@ function ensure_certificates() {
                     -keyout "$local_key_file" \
                     -out "$local_cert_file" \
                     -subj "/O=WSO2/OU=${PRODUCT_NAME}/CN=localhost" \
+                    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
                     2>&1 >/dev/null
             )
         fi


### PR DESCRIPTION
## Purpose

Adds the `subjectAltName` (SAN) extension to all RSA certificate generation commands, matching the ECDSA path which already includes it.

Fixes #3847

## Approach

Added `-addext "subjectAltName=DNS:localhost,IP:127.0.0.1"` to the RSA `openssl req` commands in:

- `build.sh` — dev server cert generation
- `build.ps1` — PowerShell openssl path (the .NET fallback already has SAN)
- `.github/actions/generate-certificates/action.yml` — CI cert generation
- `.github/workflows/windows-powershell-validation.yml` — Windows CI cert generation

## Testing

Generated a cert with the updated command and verified SAN is present:

```
$ openssl x509 -in server.cert -noout -ext subjectAltName
X509v3 Subject Alternative Name:
    DNS:localhost, IP Address:127.0.0.1
```

## Migration note

Existing developers with cached certs in `target/out/.cert/` or `backend/cmd/server/config/certs/` need to delete them to pick up the fix:

```bash
rm -rf target/out/.cert/
rm -f backend/cmd/server/config/certs/{server,signing,ecdsa-signing}.{cert,key}
make run
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local certificate generation so certificates now include `localhost` and `127.0.0.1` in the trusted names.
  * Updated both Windows and shell-based build flows to generate certificates more reliably during validation and setup.
  * Kept the existing certificate identity details unchanged while making the generated certificates better suited for local development and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->