### PR TITLE
Add admin password reset for users

### DIFF
--- a/api/user.yaml
+++ b/api/user.yaml
@@ -514,6 +514,104 @@ paths:
         "500":
           description: Internal server error
 
+  /users/{id}/update-credentials:
+    post:
+      tags:
+        - Users
+      summary: Update user credentials by id
+      description: |
+        Sets new credential values (such as passwords) for a user. Only credential
+        fields defined in the user type schema can be updated. System-managed
+        credentials (e.g. passkeys) are rejected.
+
+        You do not need to provide all credential fields; only the fields present
+        in the request body are updated.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          example: "9a475e1e-b0cb-4b29-8df5-2e5b24fb0ed3"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserCredentialsRequest'
+            example:
+              credentials:
+                password: "n3wP@ssword!"
+      responses:
+        "204":
+          description: Credentials updated
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing-credentials:
+                  summary: Missing credentials
+                  value:
+                    code: "USR-1017"
+                    message:
+                      key: "error.userservice.missing_credentials"
+                      defaultValue: "Missing credentials"
+                    description:
+                      key: "error.userservice.missing_credentials_description"
+                      defaultValue: "At least one credential field must be provided"
+                invalid-credential:
+                  summary: Invalid credential fields
+                  value:
+                    code: "USR-1024"
+                    message:
+                      key: "error.userservice.invalid_credential"
+                      defaultValue: "Invalid request format"
+                    description:
+                      key: "error.userservice.invalid_credential_description"
+                      defaultValue: "Invalid credential fields in request"
+                cannot-modify-declarative-resource:
+                  summary: Cannot modify declarative resource
+                  value:
+                    code: "USR-1025"
+                    message:
+                      key: "error.userservice.cannot_modify_declarative_resource"
+                      defaultValue: "Cannot modify declarative resource"
+                    description:
+                      key: "error.userservice.cannot_modify_declarative_resource_description"
+                      defaultValue: "The user is declarative and cannot be modified or deleted"
+        "404":
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "USR-1003"
+                message:
+                  key: "error.userservice.user_not_found"
+                  defaultValue: "User not found"
+                description:
+                  key: "error.userservice.user_not_found_description"
+                  defaultValue: "The user with the specified id does not exist"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "USR-5000"
+                message:
+                  key: "error.internal_server_error"
+                  defaultValue: "Internal server error"
+                description:
+                  key: "error.internal_server_error_description"
+                  defaultValue: "An unexpected error occurred while processing the request"
+
   /users/{id}/groups:
     get:
       tags:
@@ -2037,6 +2135,16 @@ components:
           type: object
           description: "User attributes"
           additionalProperties: true
+
+    UpdateUserCredentialsRequest:
+      type: object
+      required: [credentials]
+      properties:
+        credentials:
+          type: object
+          description: "Credential key-value pairs to update. Keys must match credential fields defined in the user type schema."
+          additionalProperties:
+            type: string
 
     UserType:
       type: object

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -1044,6 +1044,8 @@ var defaultMessages = map[string]string{
 	"error.userservice.authentication_failed_description": "Invalid credentials provided",
 	"error.userservice.cannot_modify_declarative_resource": "Cannot modify declarative resource",
 	"error.userservice.cannot_modify_declarative_resource_description": "The user is declarative and cannot be modified or deleted",
+	"error.userservice.credential_update_not_allowed": "Credential update not allowed",
+	"error.userservice.credential_update_not_allowed_description": "The credential updates through this endpoint are not allowed",
 	"error.userservice.email_conflict": "Email conflict",
 	"error.userservice.email_conflict_description": "A user with the same email already exists",
 	"error.userservice.handle_path_required": "Handle path required",

--- a/backend/internal/user/error_constants.go
+++ b/backend/internal/user/error_constants.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -325,6 +325,20 @@ var (
 			Key: "error.userservice.user_has_blocking_dependencies_description",
 			DefaultValue: "The user cannot be deleted because other resources depend on it. " +
 				"Remove or reassign them first.",
+		},
+	}
+	// ErrorCredentialUpdateNotAllowed is returned when an attempt is made to update credentials
+	// for a user that does not allow it.
+	ErrorCredentialUpdateNotAllowed = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "USR-1028",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.userservice.credential_update_not_allowed",
+			DefaultValue: "Credential update not allowed",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "error.userservice.credential_update_not_allowed_description",
+			DefaultValue: "The credential updates through this endpoint are not allowed",
 		},
 	}
 )

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -475,6 +475,47 @@ func (uh *userHandler) HandleSelfUserCredentialUpdateRequest(w http.ResponseWrit
 	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
 	logger.Debug(ctx, "Self user credential update response sent",
 		log.MaskedString(log.LoggerKeyUserID, userID))
+}
+
+// HandleUserCredentialUpdateRequest handles credential updates for a user by an admin.
+func (uh *userHandler) HandleUserCredentialUpdateRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
+
+	id := r.PathValue("id")
+	if strings.TrimSpace(id) == "" {
+		handleError(ctx, w, &ErrorMissingUserID)
+		return
+	}
+
+	updateRequest, err := sysutils.DecodeJSONBody[UpdateUserCredentialsRequest](r)
+	if err != nil {
+		var valErr *sysutils.ValidationError
+		if errors.As(err, &valErr) {
+			sysutils.WriteStructuredErrorResponse(w, http.StatusBadRequest, "Validation Failed", valErr.Errors)
+			return
+		}
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
+		return
+	}
+	if updateRequest == nil {
+		handleError(ctx, w, &ErrorInvalidRequestFormat)
+		return
+	}
+	attrStr := strings.TrimSpace(string(updateRequest.Credentials))
+	if len(updateRequest.Credentials) == 0 || attrStr == "{}" {
+		handleError(ctx, w, &ErrorMissingCredentials)
+		return
+	}
+
+	if svcErr := uh.userService.UpdateUserCredentials(ctx, id, updateRequest.Credentials); svcErr != nil {
+		handleError(ctx, w, svcErr)
+		return
+	}
+
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusNoContent, nil)
+	logger.Debug(ctx, "User credential update response sent",
+		log.MaskedString(log.LoggerKeyUserID, id))
 }
 
 // parsePaginationParams parses limit and offset query parameters from the request.

--- a/backend/internal/user/handler_test.go
+++ b/backend/internal/user/handler_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -294,6 +294,154 @@ func TestHandleSelfUserCredentialUpdateRequest_MultipleCredentialTypes(t *testin
 	require.Equal(t, http.StatusNoContent, rr.Code)
 	require.Equal(t, 0, rr.Body.Len())
 	// Verify that UpdateUserCredentials was called exactly once with all credentials
+	mockSvc.AssertNumberOfCalls(t, "UpdateUserCredentials", 1)
+}
+
+func TestHandleUserCredentialUpdateRequest_Success(t *testing.T) {
+	userID := testUserID789
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	credentialsJSON := json.RawMessage(`{"password":"new-password"}`)
+	mockSvc.On("UpdateUserCredentials", mock.Anything, userID, credentialsJSON).Return(nil)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/users/"+userID+"/update-credentials",
+		bytes.NewBufferString(`{"credentials":{"password":"new-password"}}`))
+	req.SetPathValue("id", userID)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserCredentialUpdateRequest(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+	require.Equal(t, 0, rr.Body.Len())
+}
+
+func TestHandleUserCredentialUpdateRequest_MissingUserID(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+
+	req := httptest.NewRequest(http.MethodPost, "/users/update-credentials",
+		bytes.NewBufferString(`{"credentials":{"password":"new-password"}}`))
+	req.SetPathValue("id", "")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserCredentialUpdateRequest(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorMissingUserID.Code, errResp.Code)
+}
+
+func TestHandleUserCredentialUpdateRequest_MissingCredentials(t *testing.T) {
+	userID := testUserID789
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+
+	req := httptest.NewRequest(http.MethodPost, "/users/"+userID+"/update-credentials",
+		bytes.NewBufferString(`{"credentials":{}}`))
+	req.SetPathValue("id", userID)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserCredentialUpdateRequest(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorMissingCredentials.Code, errResp.Code)
+}
+
+func TestHandleUserCredentialUpdateRequest_InvalidBody(t *testing.T) {
+	userID := testUserID789
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+
+	req := httptest.NewRequest(http.MethodPost, "/users/"+userID+"/update-credentials",
+		bytes.NewBufferString(`{"credentials":`))
+	req.SetPathValue("id", userID)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserCredentialUpdateRequest(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var errResp apierror.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, ErrorInvalidRequestFormat.Code, errResp.Code)
+}
+
+func TestHandleUserCredentialUpdateRequest_ErrorCases(t *testing.T) {
+	userID := testUserID789
+
+	testCases := []struct {
+		name             string
+		requestBody      string
+		mockJSON         json.RawMessage
+		mockError        *tidcommon.ServiceError
+		expectedHTTPCode int
+		expectedErrCode  string
+	}{
+		{
+			name:             "User not found",
+			requestBody:      `{"credentials":{"password":"test_password"}}`,
+			mockJSON:         json.RawMessage(`{"password":"test_password"}`),
+			mockError:        &ErrorUserNotFound,
+			expectedHTTPCode: http.StatusNotFound,
+			expectedErrCode:  ErrorUserNotFound.Code,
+		},
+		{
+			name:             "Invalid credential type",
+			requestBody:      `{"credentials":{"unsupported_type":"some_value"}}`,
+			mockJSON:         json.RawMessage(`{"unsupported_type":"some_value"}`),
+			mockError:        &ErrorInvalidCredential,
+			expectedHTTPCode: http.StatusBadRequest,
+			expectedErrCode:  ErrorInvalidCredential.Code,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockSvc := NewUserServiceInterfaceMock(t)
+			mockSvc.On("UpdateUserCredentials", mock.Anything, userID, tc.mockJSON).Return(tc.mockError)
+
+			handler := newUserHandler(mockSvc)
+			req := httptest.NewRequest(http.MethodPost, "/users/"+userID+"/update-credentials",
+				bytes.NewBufferString(tc.requestBody))
+			req.SetPathValue("id", userID)
+			rr := httptest.NewRecorder()
+
+			handler.HandleUserCredentialUpdateRequest(rr, req)
+
+			require.Equal(t, tc.expectedHTTPCode, rr.Code)
+
+			var errResp apierror.ErrorResponse
+			require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+			require.Equal(t, tc.expectedErrCode, errResp.Code)
+		})
+	}
+}
+
+func TestHandleUserCredentialUpdateRequest_MultipleCredentialTypes(t *testing.T) {
+	userID := testUserID789
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	credentialsJSON := json.RawMessage(`{"password":"new-password","pin":"1234"}`)
+	mockSvc.On("UpdateUserCredentials", mock.Anything, userID, credentialsJSON).Return(nil)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodPost, "/users/"+userID+"/update-credentials",
+		bytes.NewBufferString(`{"credentials":{"password":"new-password","pin":"1234"}}`))
+	req.SetPathValue("id", userID)
+	rr := httptest.NewRecorder()
+
+	handler.HandleUserCredentialUpdateRequest(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+	require.Equal(t, 0, rr.Body.Len())
 	mockSvc.AssertNumberOfCalls(t, "UpdateUserCredentials", 1)
 }
 

--- a/backend/internal/user/init.go
+++ b/backend/internal/user/init.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -100,7 +100,7 @@ func registerRoutes(mux *http.ServeMux, userHandler *userHandler) {
 	}, opts1))
 
 	opts2 := middleware.CORSOptions{
-		AllowedMethods:   []string{"GET", "PUT", "DELETE"},
+		AllowedMethods:   []string{"GET", "PUT", "DELETE", "POST"},
 		AllowedHeaders:   middleware.DefaultAllowedHeaders,
 		AllowCredentials: true,
 		MaxAge:           600,
@@ -132,6 +132,17 @@ func registerRoutes(mux *http.ServeMux, userHandler *userHandler) {
 			path := strings.TrimPrefix(r.URL.Path, "/users/")
 			r.SetPathValue("id", strings.Split(path, "/")[0])
 			userHandler.HandleUserDeleteRequest(w, r)
+		}, opts2))
+	mux.HandleFunc(middleware.WithCORS("POST /users/",
+		func(w http.ResponseWriter, r *http.Request) {
+			path := strings.TrimPrefix(r.URL.Path, "/users/")
+			segments := strings.Split(path, "/")
+			if len(segments) == 2 && segments[1] == "update-credentials" {
+				r.SetPathValue("id", segments[0])
+				userHandler.HandleUserCredentialUpdateRequest(w, r)
+			} else {
+				http.NotFound(w, r)
+			}
 		}, opts2))
 	mux.HandleFunc(middleware.WithCORS("OPTIONS /users/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/backend/internal/user/model.go
+++ b/backend/internal/user/model.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -94,6 +94,11 @@ type UpdateUserRequest struct {
 // UpdateSelfUserRequest represents the request body for updating the authenticated user.
 type UpdateSelfUserRequest struct {
 	Attributes json.RawMessage `json:"attributes,omitempty"`
+}
+
+// UpdateUserCredentialsRequest represents the request body for updating user credentials by an admin.
+type UpdateUserCredentialsRequest struct {
+	Credentials json.RawMessage `json:"credentials,omitempty"`
 }
 
 // CreateUserByPathRequest represents the request body for creating a user under a handle path.

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -553,8 +553,32 @@ func (us *userService) UpdateUser(
 		return nil, svcErr
 	}
 
-	// Entity service handles schema validation, credential extraction from attributes,
-	// hashing, merging with existing credentials, and entity update.
+	// Reject credential fields: this endpoint is for attribute and user metadata updates only.
+	// Credentials must go through the dedicated update-credentials endpoint.
+	if len(user.Attributes) > 0 {
+		schemaCredentialInfos, svcErr := us.entityTypeService.GetAttributes(ctx,
+			entitytype.TypeCategoryUser, user.Type, true, false, false)
+		if svcErr != nil {
+			if svcErr.Code == entitytype.ErrorEntityTypeNotFound.Code {
+				return nil, &ErrorEntityTypeNotFound
+			}
+			return nil, logErrorAndReturnServerError(ctx, logger, "Failed to get credential attributes from schema",
+				fmt.Errorf("schema service error: %s", svcErr.ErrorDescription.DefaultValue),
+				log.MaskedString(log.LoggerKeyUserID, userID))
+		}
+		if len(schemaCredentialInfos) > 0 {
+			var attrs map[string]any
+			if err := json.Unmarshal(user.Attributes, &attrs); err != nil {
+				return nil, &ErrorInvalidRequestFormat
+			}
+			for _, credInfo := range schemaCredentialInfos {
+				if _, ok := attrs[credInfo.Attribute]; ok {
+					return nil, &ErrorCredentialUpdateNotAllowed
+				}
+			}
+		}
+	}
+
 	e := userToEntity(user)
 	e.SystemAttributes = existingEntity.SystemAttributes
 	updated, err := us.entityService.UpdateEntity(ctx, userID, e)
@@ -681,6 +705,14 @@ func (us *userService) UpdateUserCredentials(
 
 	if len(credentialsMap) == 0 {
 		return &ErrorMissingCredentials
+	}
+
+	// Reject system-managed credential types (e.g., passkey). Only schema-defined
+	// credentials may be updated through this endpoint.
+	for credTypeStr := range credentialsMap {
+		if CredentialType(credTypeStr).IsSystemManaged() {
+			return &ErrorInvalidCredential
+		}
 	}
 
 	// Fetch user outside the transaction to resolve the OU ID for the authorization check.

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -636,13 +636,11 @@ func TestUserService_UpdateUserCredentials_Rejections(t *testing.T) {
 		wantErrCode   string
 	}{
 		{
-			// Passkeys are not schema credentials and must be rejected via the user
-			// credentials API. They are managed via the dedicated passkey registration flows.
-			// Entity service surfaces ErrInvalidCredential via the allowlist.
-			name:          "RejectsPasskeys",
-			payload:       `{"passkey":"passkey-credential-1"}`,
-			mockEntityErr: entitypkg.ErrInvalidCredential,
-			wantErrCode:   ErrorInvalidCredential.Code,
+			// Passkeys are system-managed credentials and must be rejected explicitly
+			// at the user service level before reaching the entity service.
+			name:        "RejectsPasskeys",
+			payload:     `{"passkey":"passkey-credential-1"}`,
+			wantErrCode: ErrorInvalidCredential.Code,
 		},
 		{
 			// Schema credentials must be plain strings; arrays/objects fail JSON unmarshal
@@ -661,13 +659,7 @@ func TestUserService_UpdateUserCredentials_Rejections(t *testing.T) {
 				Return(&providers.Entity{
 					Category: providers.EntityCategoryUser, ID: svcTestUserID1, Type: "Person",
 				}, nil).
-				Once()
-			if tc.mockEntityErr != nil {
-				userStoreMock.
-					On("UpdateCredentials", mock.Anything, svcTestUserID1, mock.Anything).
-					Return(tc.mockEntityErr).
-					Once()
-			}
+				Maybe()
 
 			service := &userService{
 				entityService: userStoreMock,
@@ -929,6 +921,8 @@ func TestUserService_UpdateUser(t *testing.T) {
 	entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
 		Return(&entitytype.EntityType{OUID: testOrgID}, (*tidcommon.ServiceError)(nil)).
 		Once()
+	entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+		Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Once()
 
 	service := &userService{
 		entityService:     storeMock,
@@ -943,12 +937,9 @@ func TestUserService_UpdateUser(t *testing.T) {
 	storeMock.AssertNumberOfCalls(t, "UpdateEntity", 1)
 }
 
-// TestUserService_UpdateUser_WithCredentials tests that UpdateUser passes credentials in
-// attributes through to the entity service without leaking them.
-func TestUserService_UpdateUser_WithCredentials(t *testing.T) {
+func TestUserService_UpdateUser_RejectsCredentialAttributes(t *testing.T) {
 	userID := svcTestUserID1
 
-	// Test that UpdateUser passes credentials in attributes through to entity service
 	updatedUser := User{
 		ID:         userID,
 		OUID:       testOrgID,
@@ -961,25 +952,17 @@ func TestUserService_UpdateUser_WithCredentials(t *testing.T) {
 	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	// Mock GetUser pre-fetch for authz check
 	storeMock.On("GetEntity", mock.Anything, userID).
 		Return(&providers.Entity{
 			Category: providers.EntityCategoryUser, ID: userID, OUID: testOrgID, Type: testUserType,
 		}, nil).Once()
 
-	// Mock validation calls
 	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
 		Return(true, (*tidcommon.ServiceError)(nil)).Once()
 	entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
 		Return(&entitytype.EntityType{OUID: testOrgID}, (*tidcommon.ServiceError)(nil)).Once()
-
-	// Mock UpdateEntity - entity service handles credential extraction internally
-	storeMock.On("UpdateEntity", mock.Anything, userID, mock.MatchedBy(func(e *providers.Entity) bool {
-		return e.ID == userID
-	})).Return(&providers.Entity{
-		ID:         userID,
-		Attributes: json.RawMessage(`{"email":"test@example.com"}`), // password is removed
-	}, nil).Once()
+	entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+		Return([]entitytype.AttributeInfo{{Attribute: "password"}}, (*tidcommon.ServiceError)(nil)).Once()
 
 	service := &userService{
 		entityService:     storeMock,
@@ -990,17 +973,9 @@ func TestUserService_UpdateUser_WithCredentials(t *testing.T) {
 
 	resp, err := service.UpdateUser(context.Background(), userID, &updatedUser)
 
-	// Assertions
-	require.Nil(t, err)
-	require.NotNil(t, resp)
-	require.Equal(t, userID, resp.ID)
-	require.JSONEq(t, `{"email":"test@example.com"}`, string(resp.Attributes))
-	require.NotContains(t, string(resp.Attributes), "password")
-
-	// Verify all expected calls were made
-	storeMock.AssertExpectations(t)
-	ouServiceMock.AssertExpectations(t)
-	entityTypeMock.AssertExpectations(t)
+	require.Nil(t, resp)
+	require.NotNil(t, err)
+	require.Equal(t, ErrorCredentialUpdateNotAllowed.Code, err.Code)
 }
 
 func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
@@ -1019,7 +994,7 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 	}{
 		{
 			name:       "UpdateEntity_EntityNotFound",
-			attributes: `{"email":"test@example.com","password":"newPassword"}`,
+			attributes: `{"email":"test@example.com"}`,
 			setupMocks: func(
 				storeMock *entitymock.EntityServiceInterfaceMock,
 				ouServiceMock *oumock.OrganizationUnitServiceInterfaceMock,
@@ -1030,6 +1005,8 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 				entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
 					Return(&entitytype.EntityType{OUID: testOrgID},
 						(*tidcommon.ServiceError)(nil)).Maybe()
+				entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+					Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Maybe()
 				storeMock.On("GetEntity", mock.Anything, userID).
 					Return(&providers.Entity{
 						Category: providers.EntityCategoryUser,
@@ -1044,7 +1021,7 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 		},
 		{
 			name:       "UpdateEntity_StoreError",
-			attributes: `{"email":"test@example.com","password":"newPass"}`,
+			attributes: `{"email":"test@example.com"}`,
 			setupMocks: func(
 				storeMock *entitymock.EntityServiceInterfaceMock,
 				ouServiceMock *oumock.OrganizationUnitServiceInterfaceMock,
@@ -1055,6 +1032,8 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 				entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
 					Return(&entitytype.EntityType{OUID: testOrgID},
 						(*tidcommon.ServiceError)(nil)).Maybe()
+				entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+					Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Maybe()
 				storeMock.On("GetEntity", mock.Anything, userID).
 					Return(&providers.Entity{
 						Category: providers.EntityCategoryUser,
@@ -1079,6 +1058,121 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 					Return(true, (*tidcommon.ServiceError)(nil)).Once()
 				entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
 					Return(&entitytype.EntityType{OUID: testOrgID},
+						(*tidcommon.ServiceError)(nil)).Once()
+				entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+					Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Once()
+				storeMock.On("GetEntity", mock.Anything, userID).
+					Return(&providers.Entity{
+						Category: providers.EntityCategoryUser,
+						ID:       userID,
+						OUID:     testOrgID,
+						Type:     testUserType,
+					}, nil).Once()
+				storeMock.On("UpdateEntity", mock.Anything, userID, mock.Anything).
+					Return(&providers.Entity{
+						Category:   providers.EntityCategoryUser,
+						ID:         userID,
+						OUID:       testOrgID,
+						Type:       testUserType,
+						Attributes: json.RawMessage(`{"email":"updated@example.com"}`),
+					}, nil).Once()
+			},
+			expectedError: nil,
+		},
+		{
+			name:       "GetAttributes_EntityTypeNotFound",
+			attributes: `{"email":"test@example.com"}`,
+			setupMocks: func(
+				storeMock *entitymock.EntityServiceInterfaceMock,
+				ouServiceMock *oumock.OrganizationUnitServiceInterfaceMock,
+				entityTypeMock *entitytypemock.EntityTypeServiceInterfaceMock,
+			) {
+				storeMock.On("GetEntity", mock.Anything, userID).
+					Return(&providers.Entity{
+						Category: providers.EntityCategoryUser,
+						ID:       userID,
+						OUID:     testOrgID,
+						Type:     testUserType,
+					}, nil).Once()
+				ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
+					Return(true, (*tidcommon.ServiceError)(nil)).Once()
+				entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+					Return(&entitytype.EntityType{OUID: testOrgID},
+						(*tidcommon.ServiceError)(nil)).Once()
+				entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+					Return(nil, &entitytype.ErrorEntityTypeNotFound).Once()
+			},
+			expectedError: &ErrorEntityTypeNotFound,
+		},
+		{
+			name:       "GetAttributes_GenericError",
+			attributes: `{"email":"test@example.com"}`,
+			setupMocks: func(
+				storeMock *entitymock.EntityServiceInterfaceMock,
+				ouServiceMock *oumock.OrganizationUnitServiceInterfaceMock,
+				entityTypeMock *entitytypemock.EntityTypeServiceInterfaceMock,
+			) {
+				storeMock.On("GetEntity", mock.Anything, userID).
+					Return(&providers.Entity{
+						Category: providers.EntityCategoryUser,
+						ID:       userID,
+						OUID:     testOrgID,
+						Type:     testUserType,
+					}, nil).Once()
+				ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
+					Return(true, (*tidcommon.ServiceError)(nil)).Once()
+				entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+					Return(&entitytype.EntityType{OUID: testOrgID},
+						(*tidcommon.ServiceError)(nil)).Once()
+				entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+					Return(nil, &tidcommon.ServiceError{
+						Code:             "USRS-9999",
+						ErrorDescription: tidcommon.I18nMessage{DefaultValue: "unexpected schema error"},
+					}).Once()
+			},
+			expectedError: &tidcommon.InternalServerError,
+		},
+		{
+			name:       "CredentialCheck_InvalidJSON",
+			attributes: `{not valid json`,
+			setupMocks: func(
+				storeMock *entitymock.EntityServiceInterfaceMock,
+				ouServiceMock *oumock.OrganizationUnitServiceInterfaceMock,
+				entityTypeMock *entitytypemock.EntityTypeServiceInterfaceMock,
+			) {
+				storeMock.On("GetEntity", mock.Anything, userID).
+					Return(&providers.Entity{
+						Category: providers.EntityCategoryUser,
+						ID:       userID,
+						OUID:     testOrgID,
+						Type:     testUserType,
+					}, nil).Once()
+				ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
+					Return(true, (*tidcommon.ServiceError)(nil)).Once()
+				entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+					Return(&entitytype.EntityType{OUID: testOrgID},
+						(*tidcommon.ServiceError)(nil)).Once()
+				entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+					Return([]entitytype.AttributeInfo{{Attribute: "password"}},
+						(*tidcommon.ServiceError)(nil)).Once()
+			},
+			expectedError: &ErrorInvalidRequestFormat,
+		},
+		{
+			name:       "CredentialCheck_NoMatchingCredentialFields",
+			attributes: `{"email":"test@example.com","username":"john"}`,
+			setupMocks: func(
+				storeMock *entitymock.EntityServiceInterfaceMock,
+				ouServiceMock *oumock.OrganizationUnitServiceInterfaceMock,
+				entityTypeMock *entitytypemock.EntityTypeServiceInterfaceMock,
+			) {
+				ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
+					Return(true, (*tidcommon.ServiceError)(nil)).Once()
+				entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+					Return(&entitytype.EntityType{OUID: testOrgID},
+						(*tidcommon.ServiceError)(nil)).Once()
+				entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+					Return([]entitytype.AttributeInfo{{Attribute: "password"}},
 						(*tidcommon.ServiceError)(nil)).Once()
 				storeMock.On("GetEntity", mock.Anything, userID).
 					Return(&providers.Entity{
@@ -1360,6 +1454,8 @@ func TestUserService_UpdateUser_AuthzBranches(t *testing.T) {
 				entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
 					Return(&entitytype.EntityType{OUID: existingOU},
 						(*tidcommon.ServiceError)(nil)).Maybe()
+				entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+					Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Maybe()
 				storeMock.On("UpdateEntity", mock.Anything, userID, mock.Anything).
 					Return(&providers.Entity{
 						ID:         userID,
@@ -1402,14 +1498,11 @@ func TestUserService_UpdateUser_AuthzBranches(t *testing.T) {
 	}
 }
 
-// TestUserService_UpdateUser_PreservesMultipleCredentials verifies that UpdateUser correctly
-// processes multiple credentials while preserving existing attributes and not leaking passwords.
-func TestUserService_UpdateUser_PreservesMultipleCredentials(t *testing.T) {
+func TestUserService_UpdateUser_RejectsCredentialInMixedAttributes(t *testing.T) {
 	ctx := context.Background()
 	userID := svcTestUserID123
 	testOU := testOrgID
 
-	// User update with password in attributes — entity service handles credential extraction internally
 	updatedUser := User{
 		ID:   userID,
 		Type: testUserType,
@@ -1417,49 +1510,29 @@ func TestUserService_UpdateUser_PreservesMultipleCredentials(t *testing.T) {
 		Attributes: json.RawMessage(`{
 			"username": "john.doe",
 			"email": "john.updated@example.com",
-			"given_name": "John",
-			"family_name": "Doe",
 			"password": "NewPassword456!"
 		}`),
 	}
 
-	// Setup mocks
 	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
 	storeMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	// Mock GetUser pre-fetch for authz check
 	storeMock.On("GetEntity", mock.Anything, userID).
 		Return(&providers.Entity{
 			Category: providers.EntityCategoryUser, ID: userID, OUID: testOU, Type: testUserType,
 		}, nil).Once()
 
-	// Mock OU validation
 	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOU).
 		Return(true, (*tidcommon.ServiceError)(nil)).Once()
-	ouServiceMock.On("IsParent", mock.Anything, testOU).
-		Return(true, (*tidcommon.ServiceError)(nil)).Maybe()
-
-	// Mock schema validation
 	entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
 		Return(&entitytype.EntityType{
 			Name: testUserType,
 			OUID: testOU,
 		}, (*tidcommon.ServiceError)(nil)).Once()
-
-	// Mock UpdateEntity — entity service handles credential extraction, hashing, and merging internally
-	storeMock.On("UpdateEntity", mock.Anything, userID, mock.MatchedBy(func(e *providers.Entity) bool {
-		return e.ID == userID
-	})).Return(&providers.Entity{
-		ID: userID,
-		Attributes: json.RawMessage(`{
-			"username": "john.doe",
-			"email": "john.updated@example.com",
-			"given_name": "John",
-			"family_name": "Doe"
-		}`), // password is removed
-	}, nil).Once()
+	entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType, true, false, false).
+		Return([]entitytype.AttributeInfo{{Attribute: "password"}}, (*tidcommon.ServiceError)(nil)).Once()
 
 	// Create service
 	service := &userService{
@@ -1469,25 +1542,11 @@ func TestUserService_UpdateUser_PreservesMultipleCredentials(t *testing.T) {
 		authzService:      newAllowAllAuthz(t),
 	}
 
-	// Execute UpdateUser
 	result, svcErr := service.UpdateUser(ctx, userID, &updatedUser)
 
-	// Assertions
-	require.Nil(t, svcErr)
-	require.NotNil(t, result)
-	require.Equal(t, userID, result.ID)
-	require.JSONEq(t, `{
-		"username": "john.doe",
-		"email": "john.updated@example.com",
-		"given_name": "John",
-		"family_name": "Doe"
-	}`, string(result.Attributes))
-	require.NotContains(t, string(result.Attributes), "password")
-
-	// Verify all mocks were called
-	storeMock.AssertExpectations(t)
-	ouServiceMock.AssertExpectations(t)
-	entityTypeMock.AssertExpectations(t)
+	require.Nil(t, result)
+	require.NotNil(t, svcErr)
+	require.Equal(t, ErrorCredentialUpdateNotAllowed.Code, svcErr.Code)
 }
 
 func TestUserService_GetUserList(t *testing.T) {
@@ -2002,6 +2061,8 @@ func TestUserService_UpdateUser_SchemaNotFound(t *testing.T) {
 	resp, svcErr := service.UpdateUser(context.Background(), svcTestUserID1, user)
 	require.Nil(t, resp)
 	require.NotNil(t, svcErr)
+	// The error can come from either validateOrganizationUnitForUserType or the credential check.
+	// Both map entitytype.ErrorEntityTypeNotFound to ErrorEntityTypeNotFound.
 	require.Equal(t, ErrorEntityTypeNotFound, *svcErr)
 }
 

--- a/docs/content/guides/guides/users/manage-users.mdx
+++ b/docs/content/guides/guides/users/manage-users.mdx
@@ -57,6 +57,15 @@ The attributes available during onboarding depend on the selected user type. See
 3. To update group membership, add or remove groups on the **Groups** tab.
 4. Click **Save**.
 
+### Update User Credentials
+
+Credential fields (such as passwords) are write-only and cannot be viewed. To set new credential values for a user:
+
+1. Open the user from the **Users** list.
+2. In the **Credentials** section, click **Update Credentials**.
+3. Fill in the credential fields you want to update. You do not need to update all credentials; empty fields are skipped.
+4. Click **Save**.
+
 ## Delete a User
 
 1. Open the user from the **Users** list.

--- a/frontend/packages/configure-users/src/api/useUpdateUserCredentials.ts
+++ b/frontend/packages/configure-users/src/api/useUpdateUserCredentials.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useMutation, type UseMutationResult} from '@tanstack/react-query';
+import {useConfig, useToast} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import {useTranslation} from 'react-i18next';
+
+export interface UpdateUserCredentialsVariables {
+  userId: string;
+  data: {
+    credentials: Record<string, string>;
+  };
+}
+
+export default function useUpdateUserCredentials(): UseMutationResult<void, Error, UpdateUserCredentialsVariables> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+  const {t} = useTranslation('users');
+  const {showToast} = useToast();
+
+  return useMutation<void, Error, UpdateUserCredentialsVariables>({
+    mutationFn: async ({userId, data}: UpdateUserCredentialsVariables): Promise<void> => {
+      const serverUrl: string = getServerUrl();
+
+      await http.request({
+        url: `${serverUrl}/users/${userId}/update-credentials`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: data,
+      } as unknown as Parameters<typeof http.request>[0]);
+    },
+    onSuccess: () => {
+      showToast(t('updateCredentials.success'), 'success');
+    },
+    onError: () => {
+      showToast(t('updateCredentials.error'), 'error');
+    },
+  });
+}

--- a/frontend/packages/configure-users/src/components/CredentialFieldInput.tsx
+++ b/frontend/packages/configure-users/src/components/CredentialFieldInput.tsx
@@ -29,7 +29,7 @@ interface CredentialFieldInputProps {
   helperText?: string;
   color: 'error' | 'primary';
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onBlur: () => void;
+  onBlur?: () => void;
   inputRef: React.Ref<HTMLInputElement>;
   name: string;
   ariaLabel?: string;
@@ -44,7 +44,7 @@ function CredentialFieldInput({
   helperText = undefined,
   color,
   onChange,
-  onBlur,
+  onBlur = undefined,
   inputRef,
   name,
   ariaLabel = undefined,

--- a/frontend/packages/configure-users/src/components/edit-user/CredentialResetDialog.tsx
+++ b/frontend/packages/configure-users/src/components/edit-user/CredentialResetDialog.tsx
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  FormControl,
+  FormLabel,
+  Stack,
+} from '@wso2/oxygen-ui';
+import {useState, type JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import type {CredentialFieldInfo} from './CredentialsTabPanel';
+import useUpdateUserCredentials from '../../api/useUpdateUserCredentials';
+import CredentialFieldInput from '../CredentialFieldInput';
+
+interface CredentialValues {
+  newValue: string;
+  confirmValue: string;
+}
+
+interface CredentialResetDialogProps {
+  open: boolean;
+  field: CredentialFieldInfo | null;
+  userId: string;
+  onClose: () => void;
+}
+
+export default function CredentialResetDialog({open, field, userId, onClose}: CredentialResetDialogProps): JSX.Element {
+  const {t} = useTranslation();
+  const updateCredentialsMutation = useUpdateUserCredentials();
+
+  const [formValues, setFormValues] = useState<CredentialValues>({newValue: '', confirmValue: ''});
+  const [mismatchError, setMismatchError] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleClose = () => {
+    setFormValues({newValue: '', confirmValue: ''});
+    setMismatchError(false);
+    updateCredentialsMutation.reset();
+    onClose();
+  };
+
+  const handleSave = () => {
+    if (!field || formValues.newValue.trim() === '') return;
+
+    if (formValues.newValue !== formValues.confirmValue) {
+      setMismatchError(true);
+      return;
+    }
+
+    setIsSubmitting(true);
+    updateCredentialsMutation.mutate(
+      {userId, data: {credentials: {[field.fieldName]: formValues.newValue}}},
+      {
+        onSuccess: () => {
+          setIsSubmitting(false);
+          handleClose();
+        },
+        onError: () => {
+          setIsSubmitting(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      {field && (
+        <>
+          <DialogTitle>
+            {t('users:manageUser.sections.credentials.resetTitle', 'Reset {{label}}?', {label: field.label})}
+          </DialogTitle>
+          <DialogContent>
+            <DialogContentText sx={{mb: 2}}>
+              {t(
+                'users:manageUser.sections.credentials.resetDialogMessage',
+                'A new {{label}} will be set for this user. The current {{label}} will be invalidated immediately.',
+                {label: field.label.toLowerCase()},
+              )}
+            </DialogContentText>
+            <Alert severity="warning" sx={{mb: 2}}>
+              {t(
+                'users:manageUser.sections.credentials.resetDialogDisclaimer',
+                'This action cannot be undone. The current {{label}} will stop working as soon as you confirm.',
+                {label: field.label.toLowerCase()},
+              )}
+            </Alert>
+            <Stack spacing={2}>
+              <FormControl fullWidth>
+                <FormLabel sx={{mb: 0.5}}>
+                  {t('users:manageUser.sections.credentials.newValue', 'New {{label}}', {label: field.label})}
+                </FormLabel>
+                <CredentialFieldInput
+                  id={`credential-new-${field.fieldName}`}
+                  name={`new-${field.fieldName}`}
+                  value={formValues.newValue}
+                  placeholder={t('users:manageUser.sections.credentials.newValuePlaceholder', 'Enter new {{label}}', {
+                    label: field.label.toLowerCase(),
+                  })}
+                  required
+                  error={false}
+                  color="primary"
+                  onChange={(e) => {
+                    setFormValues((prev) => ({...prev, newValue: e.target.value}));
+                    setMismatchError(false);
+                  }}
+                  inputRef={null}
+                />
+              </FormControl>
+              <FormControl fullWidth>
+                <FormLabel sx={{mb: 0.5}}>
+                  {t('users:manageUser.sections.credentials.confirmValue', 'Confirm {{label}}', {
+                    label: field.label,
+                  })}
+                </FormLabel>
+                <CredentialFieldInput
+                  id={`credential-confirm-${field.fieldName}`}
+                  name={`confirm-${field.fieldName}`}
+                  value={formValues.confirmValue}
+                  placeholder={t(
+                    'users:manageUser.sections.credentials.confirmValuePlaceholder',
+                    'Confirm new {{label}}',
+                    {
+                      label: field.label.toLowerCase(),
+                    },
+                  )}
+                  required
+                  error={mismatchError}
+                  helperText={
+                    mismatchError
+                      ? t('users:manageUser.sections.credentials.mismatch', 'Values do not match.')
+                      : undefined
+                  }
+                  color={mismatchError ? 'error' : 'primary'}
+                  onChange={(e) => {
+                    setFormValues((prev) => ({...prev, confirmValue: e.target.value}));
+                    setMismatchError(false);
+                  }}
+                  inputRef={null}
+                />
+              </FormControl>
+            </Stack>
+            {updateCredentialsMutation.error && (
+              <Alert severity="error" sx={{mt: 2}}>
+                {updateCredentialsMutation.error.message}
+              </Alert>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleClose} disabled={isSubmitting}>
+              {t('common:actions.cancel', 'Cancel')}
+            </Button>
+            <Button
+              variant="contained"
+              color="error"
+              onClick={handleSave}
+              disabled={isSubmitting || formValues.newValue.trim() === ''}
+            >
+              {isSubmitting
+                ? t('users:manageUser.sections.credentials.resetting', 'Resetting…')
+                : t('users:manageUser.sections.credentials.resetButton', 'Reset {{label}}', {
+                    label: field.label,
+                  })}
+            </Button>
+          </DialogActions>
+        </>
+      )}
+    </Dialog>
+  );
+}

--- a/frontend/packages/configure-users/src/components/edit-user/CredentialsTabPanel.tsx
+++ b/frontend/packages/configure-users/src/components/edit-user/CredentialsTabPanel.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {SettingsCard} from '@thunderid/components';
+import {Box, Button, Stack, Typography} from '@wso2/oxygen-ui';
+import {useState, type JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import CredentialResetDialog from './CredentialResetDialog';
+
+export interface CredentialFieldInfo {
+  fieldName: string;
+  label: string;
+}
+
+interface CredentialsTabPanelProps {
+  userId: string;
+  credentialFields: CredentialFieldInfo[];
+}
+
+export default function CredentialsTabPanel({userId, credentialFields}: CredentialsTabPanelProps): JSX.Element {
+  const {t} = useTranslation();
+
+  const [activeField, setActiveField] = useState<CredentialFieldInfo | null>(null);
+
+  return (
+    <>
+      <SettingsCard
+        title={t('users:manageUser.sections.credentials.resetCredentialsTitle', 'Reset Credentials')}
+        description={t(
+          'users:manageUser.sections.credentials.resetCredentialsDescription',
+          'Reset user credentials. These actions are irreversible.',
+        )}
+      >
+        <Stack spacing={3}>
+          {credentialFields.map((field, index) => (
+            <Box key={field.fieldName} sx={{mt: index > 0 ? 5 : 0}}>
+              <Typography variant="subtitle2" sx={{mb: 0.5}}>
+                {field.label}
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{mb: 1.5}}>
+                {t(
+                  'users:manageUser.sections.credentials.resetHint',
+                  'Resetting will immediately invalidate the current {{label}}.',
+                  {
+                    label: field.label.toLowerCase(),
+                  },
+                )}
+              </Typography>
+              <Button variant="outlined" color="error" onClick={() => setActiveField(field)}>
+                {t('users:manageUser.sections.credentials.resetButton', 'Reset {{label}}', {label: field.label})}
+              </Button>
+            </Box>
+          ))}
+        </Stack>
+      </SettingsCard>
+
+      <CredentialResetDialog
+        open={activeField !== null}
+        field={activeField}
+        userId={userId}
+        onClose={() => setActiveField(null)}
+      />
+    </>
+  );
+}

--- a/frontend/packages/configure-users/src/components/edit-user/__tests__/CredentialResetDialog.test.tsx
+++ b/frontend/packages/configure-users/src/components/edit-user/__tests__/CredentialResetDialog.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent, waitFor} from '@thunderid/test-utils';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import type {UpdateUserCredentialsVariables} from '../../../api/useUpdateUserCredentials';
+import CredentialResetDialog from '../CredentialResetDialog';
+
+// Mock react-i18next. Returns the inline default string.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValueOrOptions?: unknown, options?: unknown): string => {
+      // t(key, defaultString, { label }) — e.g. t('...', 'Reset {{label}}?', { label: 'Password' })
+      if (typeof defaultValueOrOptions === 'string') {
+        const vars = (options ?? {}) as Record<string, string>;
+        return defaultValueOrOptions.replace(/\{\{(\w+)\}\}/g, (_, k: string) => vars[k] ?? '');
+      }
+      // t(key, { defaultValue, ...vars })
+      if (defaultValueOrOptions && typeof defaultValueOrOptions === 'object') {
+        const obj = defaultValueOrOptions as Record<string, string>;
+        if (obj['defaultValue']) {
+          return obj['defaultValue'].replace(/\{\{(\w+)\}\}/g, (_, k: string) => obj[k] ?? '');
+        }
+      }
+      return typeof defaultValueOrOptions === 'string' ? defaultValueOrOptions : _key;
+    },
+  }),
+}));
+
+// Mock useUpdateUserCredentials hook.
+const mockMutate = vi.fn();
+const mockReset = vi.fn();
+const mockUpdateCredentials: {
+  mutate: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  error: Error | null;
+} = {
+  mutate: mockMutate,
+  reset: mockReset,
+  error: null,
+};
+vi.mock('../../../api/useUpdateUserCredentials', () => ({
+  default: () => mockUpdateCredentials,
+}));
+
+const passwordField = {fieldName: 'password', label: 'Password'};
+
+describe('CredentialResetDialog', () => {
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateCredentials.error = null;
+  });
+
+  it('should render dialog when open is true with a field', () => {
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Reset Password?')).toBeInTheDocument();
+  });
+
+  it('should not render dialog content when open is false', () => {
+    render(<CredentialResetDialog open={false} field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should display warning alert and description', () => {
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    expect(
+      screen.getByText(
+        'A new password will be set for this user. The current password will be invalidated immediately.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('This action cannot be undone. The current password will stop working as soon as you confirm.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should disable the reset button when new value is empty', () => {
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    expect(screen.getByRole('button', {name: 'Reset Password'})).toBeDisabled();
+  });
+
+  it('should call onClose when cancel button is clicked', () => {
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reset mutation state when cancel is clicked', () => {
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show mismatch error when values do not match', () => {
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    const newInput = screen.getByPlaceholderText('Enter new password');
+    const confirmInput = screen.getByPlaceholderText('Confirm new password');
+
+    fireEvent.change(newInput, {target: {value: 'newpass123'}});
+    fireEvent.change(confirmInput, {target: {value: 'differentpass'}});
+
+    fireEvent.click(screen.getByRole('button', {name: 'Reset Password'}));
+
+    expect(screen.getByText('Values do not match.')).toBeInTheDocument();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('should clear mismatch error when new value input changes', () => {
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    const newInput = screen.getByPlaceholderText('Enter new password');
+    const confirmInput = screen.getByPlaceholderText('Confirm new password');
+
+    fireEvent.change(newInput, {target: {value: 'newpass123'}});
+    fireEvent.change(confirmInput, {target: {value: 'differentpass'}});
+    fireEvent.click(screen.getByRole('button', {name: 'Reset Password'}));
+
+    expect(screen.getByText('Values do not match.')).toBeInTheDocument();
+
+    // Changing the new value input should clear the error
+    fireEvent.change(newInput, {target: {value: 'newpass456'}});
+
+    expect(screen.queryByText('Values do not match.')).not.toBeInTheDocument();
+  });
+
+  it('should clear mismatch error when confirm value input changes', () => {
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    const newInput = screen.getByPlaceholderText('Enter new password');
+    const confirmInput = screen.getByPlaceholderText('Confirm new password');
+
+    fireEvent.change(newInput, {target: {value: 'newpass123'}});
+    fireEvent.change(confirmInput, {target: {value: 'differentpass'}});
+    fireEvent.click(screen.getByRole('button', {name: 'Reset Password'}));
+
+    expect(screen.getByText('Values do not match.')).toBeInTheDocument();
+
+    fireEvent.change(confirmInput, {target: {value: 'newpass123'}});
+
+    expect(screen.queryByText('Values do not match.')).not.toBeInTheDocument();
+  });
+
+  it('should call mutate with correct data when values match', () => {
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    const newInput = screen.getByPlaceholderText('Enter new password');
+    const confirmInput = screen.getByPlaceholderText('Confirm new password');
+
+    fireEvent.change(newInput, {target: {value: 'newpass123'}});
+    fireEvent.change(confirmInput, {target: {value: 'newpass123'}});
+
+    fireEvent.click(screen.getByRole('button', {name: 'Reset Password'}));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {userId: 'user-123', data: {credentials: {password: 'newpass123'}}},
+      expect.any(Object),
+    );
+  });
+
+  it('should call onClose on successful mutation', async () => {
+    mockMutate.mockImplementation((_vars: UpdateUserCredentialsVariables, options: {onSuccess: () => void}) => {
+      options.onSuccess();
+    });
+
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    const newInput = screen.getByPlaceholderText('Enter new password');
+    const confirmInput = screen.getByPlaceholderText('Confirm new password');
+
+    fireEvent.change(newInput, {target: {value: 'newpass123'}});
+    fireEvent.change(confirmInput, {target: {value: 'newpass123'}});
+
+    fireEvent.click(screen.getByRole('button', {name: 'Reset Password'}));
+
+    await waitFor(() => {
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  it('should display an error alert on mutation failure', () => {
+    mockUpdateCredentials.error = new Error('Network error');
+
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+  });
+
+  it('should not call mutate when new value is only whitespace', () => {
+    render(<CredentialResetDialog open field={passwordField} userId="user-123" onClose={mockOnClose} />);
+
+    const newInput = screen.getByPlaceholderText('Enter new password');
+    const confirmInput = screen.getByPlaceholderText('Confirm new password');
+
+    fireEvent.change(newInput, {target: {value: '   '}});
+    fireEvent.change(confirmInput, {target: {value: '   '}});
+
+    fireEvent.click(screen.getByRole('button', {name: 'Reset Password'}));
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('should use the correct field name for different credential types', () => {
+    const pinField = {fieldName: 'pin', label: 'PIN'};
+
+    render(<CredentialResetDialog open field={pinField} userId="user-123" onClose={mockOnClose} />);
+
+    expect(screen.getByText('Reset PIN?')).toBeInTheDocument();
+
+    const newInput = screen.getByPlaceholderText('Enter new pin');
+    const confirmInput = screen.getByPlaceholderText('Confirm new pin');
+
+    fireEvent.change(newInput, {target: {value: '1234'}});
+    fireEvent.change(confirmInput, {target: {value: '1234'}});
+
+    fireEvent.click(screen.getByRole('button', {name: 'Reset PIN'}));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {userId: 'user-123', data: {credentials: {pin: '1234'}}},
+      expect.any(Object),
+    );
+  });
+});

--- a/frontend/packages/configure-users/src/pages/UserEditPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserEditPage.tsx
@@ -46,6 +46,7 @@ import useGetUser from '../api/useGetUser';
 import useGetUserType from '../api/useGetUserType';
 import useGetUserTypes from '../api/useGetUserTypes';
 import useUpdateUser from '../api/useUpdateUser';
+import CredentialsTabPanel, {type CredentialFieldInfo} from '../components/edit-user/CredentialsTabPanel';
 import QuickCopySection from '../components/edit-user/QuickCopySection';
 import UserDeleteDialog from '../components/UserDeleteDialog';
 import renderSchemaField from '../utils/renderSchemaField';
@@ -113,6 +114,20 @@ export default function UserEditPage() {
       ([, fieldDef]) => !((fieldDef.type === 'string' || fieldDef.type === 'number') && fieldDef.credential),
     );
   }, [userTypeDetails]);
+
+  const credentialFields: CredentialFieldInfo[] = useMemo(() => {
+    if (!userTypeDetails?.schema) return [];
+    return Object.entries(userTypeDetails.schema)
+      .filter(([, fieldDef]) => (fieldDef.type === 'string' || fieldDef.type === 'number') && fieldDef.credential)
+      .map(([fieldName, fieldDef]) => {
+        let label = fieldName;
+        if (fieldDef.displayName) {
+          const resolved = resolveDisplayName(fieldDef.displayName);
+          if (resolved) label = resolved;
+        }
+        return {fieldName, label};
+      });
+  }, [userTypeDetails, resolveDisplayName]);
 
   const displayName = user?.display ?? user?.id ?? '';
 
@@ -282,6 +297,14 @@ export default function UserEditPage() {
           aria-controls="user-tabpanel-0"
           sx={{textTransform: 'none'}}
         />
+        {!user.isReadOnly && credentialFields.length > 0 && (
+          <Tab
+            label={t('users:manageUser.tabs.credentials', 'Credentials')}
+            id="user-tab-1"
+            aria-controls="user-tabpanel-1"
+            sx={{textTransform: 'none'}}
+          />
+        )}
       </Tabs>
 
       {/* Tab Panels */}
@@ -523,6 +546,13 @@ export default function UserEditPage() {
             )}
           </Stack>
         </TabPanel>
+
+        {/* Credentials Tab */}
+        {!user.isReadOnly && credentialFields.length > 0 && (
+          <TabPanel value={activeTab} index={1}>
+            <CredentialsTabPanel userId={userId!} credentialFields={credentialFields} />
+          </TabPanel>
+        )}
       </>
 
       {/* Delete Dialog */}

--- a/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
@@ -431,7 +431,7 @@ describe('UserEditPage', () => {
     it('renders Edit and Delete buttons in view mode', () => {
       render(<UserEditPage />);
 
-      expect(screen.getByRole('button', {name: /edit/i})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /^edit$/i})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: /delete/i})).toBeInTheDocument();
     });
 
@@ -470,7 +470,7 @@ describe('UserEditPage', () => {
       const user = userEvent.setup();
       render(<UserEditPage />);
 
-      const editButton = screen.getByRole('button', {name: /edit/i});
+      const editButton = screen.getByRole('button', {name: /^edit$/i});
       await user.click(editButton);
 
       await waitFor(() => {
@@ -494,7 +494,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
       await user.click(screen.getByRole('button', {name: /^save$/i}));
 
       // Should not call mutateAsync when ouId or type is empty
@@ -521,7 +521,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
       await user.click(screen.getByRole('button', {name: /^save$/i}));
 
       await waitFor(() => {
@@ -539,7 +539,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
       await user.click(screen.getByRole('button', {name: /^save$/i}));
 
       await waitFor(() => {
@@ -551,7 +551,7 @@ describe('UserEditPage', () => {
       const user = userEvent.setup();
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText(/Enter username/i)).toBeInTheDocument();
@@ -591,7 +591,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText(/Enter username/i)).toBeInTheDocument();
@@ -635,7 +635,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText(/Enter username/i)).toBeInTheDocument();
@@ -671,7 +671,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
 
       await waitFor(() => {
         // A field named "password" without credential: true should still appear
@@ -705,7 +705,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      expect(screen.queryByRole('button', {name: /edit/i})).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: /^edit$/i})).not.toBeInTheDocument();
     });
 
     it('shows edit button when schema has at least one non-credential field', () => {
@@ -733,14 +733,14 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      expect(screen.getByRole('button', {name: /edit/i})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /^edit$/i})).toBeInTheDocument();
     });
 
     it('populates form fields with current user data', async () => {
       const user = userEvent.setup();
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText(/Enter username/i)).toHaveValue('john_doe');
@@ -754,7 +754,7 @@ describe('UserEditPage', () => {
       const user = userEvent.setup();
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
 
       const emailInput = await screen.findByPlaceholderText(/Enter email/i);
       await user.clear(emailInput);
@@ -773,7 +773,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
 
       const emailInput = await screen.findByPlaceholderText(/Enter email/i);
       await user.clear(emailInput);
@@ -817,7 +817,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
       await user.click(screen.getByRole('button', {name: /^save$/i}));
 
       await waitFor(() => {
@@ -840,7 +840,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
       await user.click(screen.getByRole('button', {name: /^save$/i}));
 
       await waitFor(() => {
@@ -856,11 +856,11 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
       await user.click(screen.getByRole('button', {name: /^save$/i}));
 
       await waitFor(() => {
-        expect(screen.getByRole('button', {name: /edit/i})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: /^edit$/i})).toBeInTheDocument();
         expect(screen.queryByRole('button', {name: /^save$/i})).not.toBeInTheDocument();
       });
     });
@@ -877,7 +877,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
       await user.click(screen.getByRole('button', {name: /^save$/i}));
 
       await waitFor(() => {
@@ -889,7 +889,7 @@ describe('UserEditPage', () => {
       const user = userEvent.setup();
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
 
       const emailInput = await screen.findByPlaceholderText(/Enter email/i);
       await user.clear(emailInput);
@@ -899,7 +899,7 @@ describe('UserEditPage', () => {
       await user.click(cancelButton);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', {name: /edit/i})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: /^edit$/i})).toBeInTheDocument();
         expect(mockResetUpdateError).toHaveBeenCalled();
       });
     });
@@ -914,7 +914,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
 
       const saveButton = screen.getByRole('button', {name: /^save$/i});
       await user.click(saveButton);
@@ -937,7 +937,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      await user.click(screen.getByRole('button', {name: /edit/i}));
+      await user.click(screen.getByRole('button', {name: /^edit$/i}));
       await user.click(screen.getByRole('button', {name: /^save$/i}));
 
       await waitFor(() => {
@@ -1241,7 +1241,7 @@ describe('UserEditPage', () => {
 
       render(<UserEditPage />);
 
-      expect(screen.queryByRole('button', {name: /edit/i})).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: /^edit$/i})).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -741,6 +741,18 @@ const translations = {
     'delete.usages.title': 'The following agents list this user as their owner:',
     'delete.usages.more': '+{{count}} more',
     'delete.blocking.title': 'This user cannot be deleted until the following agents are reassigned or removed:',
+
+    // Credentials section on edit page
+    'manageUser.sections.credentials.title': 'Credentials',
+    'manageUser.sections.credentials.description': 'Update credential values such as passwords for this user.',
+    'manageUser.sections.credentials.info':
+      'Credential values are write-only and cannot be viewed. You can set new values below.',
+
+    // Update credentials
+    'updateCredentials.button': 'Update Credentials',
+    'updateCredentials.hint': 'Fill in only the credentials you want to update. Empty fields will be skipped.',
+    'updateCredentials.success': 'Credentials updated successfully.',
+    'updateCredentials.error': 'Failed to update credentials. Please try again.',
   },
 
   // ============================================================================

--- a/tests/integration/user/user_indexed_attributes_test.go
+++ b/tests/integration/user/user_indexed_attributes_test.go
@@ -359,7 +359,6 @@ func (suite *IndexedAttributesTestSuite) TestUpdateUserAddIndexedAttribute() {
 		"username":    "update_user1",
 		"email":       "alice@example.com",
 		"displayName": "Alice Updated",
-		"password":    "Pass123!",
 	}
 
 	updatedAttrsJSON, err := json.Marshal(updatedAttributes)
@@ -416,7 +415,6 @@ func (suite *IndexedAttributesTestSuite) TestUpdateUserModifyIndexedAttributeVal
 	updatedAttributes := map[string]interface{}{
 		"username": "update_user2",
 		"email":    "bob@new.com",
-		"password": "Pass123!",
 	}
 
 	updatedAttrsJSON, err := json.Marshal(updatedAttributes)
@@ -475,7 +473,6 @@ func (suite *IndexedAttributesTestSuite) TestUpdateUserRemoveIndexedAttribute() 
 		"username": "update_user3",
 		"email":    "charlie@example.com",
 		"sub":      "sub-charlie",
-		"password": "Pass123!",
 	}
 
 	updatedAttrsJSON, err := json.Marshal(updatedAttributes)

--- a/tests/integration/user/userapi_test.go
+++ b/tests/integration/user/userapi_test.go
@@ -98,10 +98,14 @@ var (
 )
 
 var (
-	createdUserID  string
-	testOUID       string
-	createdGroupID string
-	entityTypeID   string
+	createdUserID            string
+	testOUID                 string
+	createdGroupID           string
+	entityTypeID             string
+	credentialEntityTypeID   string
+	credentialUserID         string
+	credentialUsername        string
+	credentialPassword       string
 )
 
 type UserAPITestSuite struct {
@@ -140,6 +144,44 @@ func (ts *UserAPITestSuite) SetupSuite() {
 	}
 	createdUserID = userID
 
+	// Create user type with credential fields for credential update tests.
+	credentialUsername = "admin.cred.user"
+	credentialPassword = "InitialP@ssw0rd!"
+
+	credentialType := testutils.UserType{
+		Name: "admin-cred-update-type",
+		OUID: testOUID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string", "required": true, "unique": true},
+			"email":    map[string]interface{}{"type": "string", "required": true, "unique": true},
+			"password": map[string]interface{}{"type": "string", "credential": true},
+		},
+	}
+	credTypeID, err := testutils.CreateUserType(credentialType)
+	if err != nil {
+		ts.T().Fatalf("Failed to create credential user type during setup: %v", err)
+	}
+	credentialEntityTypeID = credTypeID
+
+	credAttrs, err := json.Marshal(map[string]interface{}{
+		"username": credentialUsername,
+		"email":    "admin.cred.user@example.com",
+		"password": credentialPassword,
+	})
+	if err != nil {
+		ts.T().Fatalf("Failed to marshal credential user attributes: %v", err)
+	}
+
+	credUserID, err := testutils.CreateUser(testutils.User{
+		OUID:       testOUID,
+		Type:       "admin-cred-update-type",
+		Attributes: credAttrs,
+	})
+	if err != nil {
+		ts.T().Fatalf("Failed to create credential user during setup: %v", err)
+	}
+	credentialUserID = credUserID
+
 	// Create a group and add the created user as a member
 	groupToCreate := testGroup
 	groupToCreate.OUID = testOUID
@@ -164,6 +206,18 @@ func (ts *UserAPITestSuite) TearDownSuite() {
 		err := deleteGroup(createdGroupID)
 		if err != nil {
 			ts.T().Logf("Failed to delete group during teardown: %v", err)
+		}
+	}
+
+	// Delete the credential test user and type
+	if credentialUserID != "" {
+		if err := deleteUser(credentialUserID); err != nil {
+			ts.T().Logf("Failed to delete credential user during teardown: %v", err)
+		}
+	}
+	if credentialEntityTypeID != "" {
+		if err := testutils.DeleteUserType(credentialEntityTypeID); err != nil {
+			ts.T().Logf("Failed to delete credential user type during teardown: %v", err)
 		}
 	}
 
@@ -496,6 +550,149 @@ func (ts *UserAPITestSuite) TestUserGroupsListingNonExistingUser() {
 	if errorResp.Code != "USR-1003" {
 		ts.T().Fatalf("Expected error code USR-1003, got %s", errorResp.Code)
 	}
+}
+
+func (ts *UserAPITestSuite) TestCredentialUpdateByAdmin() {
+	newPassword := credentialPassword + "Updated!"
+
+	payload, err := json.Marshal(map[string]interface{}{
+		"credentials": map[string]interface{}{
+			"password": newPassword,
+		},
+	})
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/users/%s/update-credentials", testServerURL, credentialUserID),
+		bytes.NewReader(payload))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusNoContent, resp.StatusCode)
+
+	// Verify the new password works by authenticating.
+	authenticated, err := testutils.AuthenticateWithCredential(
+		"username", credentialUsername, "password", newPassword)
+	ts.Require().NoError(err)
+	ts.True(authenticated)
+
+	// Verify the old password no longer works.
+	authenticated, err = testutils.AuthenticateWithCredential(
+		"username", credentialUsername, "password", credentialPassword)
+	ts.Require().NoError(err)
+	ts.False(authenticated)
+
+	credentialPassword = newPassword
+}
+
+func (ts *UserAPITestSuite) TestCredentialUpdateByAdmin_EmptyCredentials() {
+	payload, err := json.Marshal(map[string]interface{}{
+		"credentials": map[string]interface{}{},
+	})
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/users/%s/update-credentials", testServerURL, credentialUserID),
+		bytes.NewReader(payload))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (ts *UserAPITestSuite) TestCredentialUpdateByAdmin_MissingCredentialsField() {
+	payload, err := json.Marshal(map[string]interface{}{})
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/users/%s/update-credentials", testServerURL, credentialUserID),
+		bytes.NewReader(payload))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (ts *UserAPITestSuite) TestCredentialUpdateByAdmin_NonExistentUser() {
+	payload, err := json.Marshal(map[string]interface{}{
+		"credentials": map[string]interface{}{
+			"password": "newpassword",
+		},
+	})
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/users/%s/update-credentials", testServerURL, "non-existent-user-id"),
+		bytes.NewReader(payload))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusNotFound, resp.StatusCode)
+}
+
+func (ts *UserAPITestSuite) TestCredentialUpdateByAdmin_SystemManagedCredential() {
+	payload, err := json.Marshal(map[string]interface{}{
+		"credentials": map[string]interface{}{
+			"passkey": "some-passkey-value",
+		},
+	})
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/users/%s/update-credentials", testServerURL, credentialUserID),
+		bytes.NewReader(payload))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (ts *UserAPITestSuite) TestCredentialUpdateByAdmin_PutUserRejectsCredentials() {
+	attrs, err := json.Marshal(map[string]interface{}{
+		"username": credentialUsername,
+		"email":    "admin.cred.user@example.com",
+		"password": "ShouldBeRejected!",
+	})
+	ts.Require().NoError(err)
+
+	payload, err := json.Marshal(map[string]interface{}{
+		"ouId":       testOUID,
+		"type":       "admin-cred-update-type",
+		"attributes": json.RawMessage(attrs),
+	})
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPut,
+		fmt.Sprintf("%s/users/%s", testServerURL, credentialUserID),
+		bytes.NewReader(payload))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusBadRequest, resp.StatusCode)
 }
 
 func retrieveAndValidateUserDetails(ts *UserAPITestSuite, expectedUser testutils.User) {


### PR DESCRIPTION
### Purpose
Add the ability for admins to reset user credentials (such as passwords) through a new dedicated API endpoint and Console UI.

This introduces a `POST /users/{id}/update-credentials` endpoint that accepts credential key-value pairs and updates only the provided fields. The existing `PUT /users/{id}` endpoint now rejects credential fields to enforce separation between attribute updates and credential updates. System-managed credentials (e.g., passkeys) are also rejected from the new endpoint.

On the frontend, the user edit page gains a **Credentials** section with an "Update Credentials" button that reveals credential input fields derived from the user type schema.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
The `PUT /users/{id}` endpoint no longer accepts credential fields (e.g., `password`) in the request body. Credential updates must now go through the new `POST /users/{id}/update-credentials` endpoint.

#### 💥 Impact
Any API client that currently sets or updates user credentials via `PUT /users/{id}` by including credential fields in the `attributes` object will receive a `400` error with code `USR-1028` ("Credential update not allowed"). This affects all direct API consumers and any custom integrations that rely on the existing update user endpoint for password resets or credential changes.

#### 🔄 Migration Guide
**Before:**
```http
PUT /users/{id}
Content-Type: application/json

{
  "attributes": {
    "email": "user@example.com",
    "password": "n3wP@ssword!"
  }
}
```
**After:**
```http
PUT /users/{id}
Content-Type: application/json

{
  "attributes": {
    "email": "user@example.com"
  }
}
```

```http
POST /users/{id}/update-credentials
Content-Type: application/json

{
  "credentials": {
    "password": "n3wP@ssword!"
  }
}

```

---

### Approach
- **New API endpoint**: `POST /users/{id}/update-credentials` accepts a `credentials` object with key-value pairs matching the user type schema. Returns `204` on success. Validates that credentials are non-empty, belong to the schema, and are not system-managed.
- **Existing endpoint hardened**: The `PUT /users/{id}` endpoint now checks incoming attributes against schema credential fields and returns `USR-1028` if any credential field is present, directing callers to use the dedicated endpoint instead.
- **Frontend**: A new `useUpdateUserCredentials` hook calls the endpoint. The `UserEditPage` renders a collapsible credentials form (hidden for read-only/declarative users) with password-style inputs for each credential field defined in the user type schema. Empty fields are skipped on submit.




https://github.com/user-attachments/assets/072209ad-0b3a-40fb-894f-2ef1805e0c5a



- **Tests**: Added handler tests for the new endpoint (valid request, missing body, empty credentials, missing ID) and integration tests covering end-to-end credential update scenarios. Updated existing service tests to reflect the new credential rejection logic on the update user endpoint.
- **Docs**: Added an "Update User Credentials" section to the manage-users guide.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3827

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an admin “Update Credentials” workflow on the user edit page with per-field editing and confirmation.
  * Introduced `POST /users/{id}/update-credentials` to update credential fields (write-only) with support for multiple fields in one request.
* **Bug Fixes**
  * Prevented credential-like fields from being updated via general user updates.
  * Blocked system-managed credential updates (e.g., passkeys).
  * Improved validation and error handling for missing/empty/invalid credential payloads.
* **Documentation**
  * Updated the user management guide with credential update steps.
* **Tests**
  * Added unit and integration coverage for the new endpoint, UI behavior, and rejection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->