### PR TITLE
[Doc] Add AuthZEN MCP authorization walkthrough

### DIFF
--- a/api/authzen.yaml
+++ b/api/authzen.yaml
@@ -21,7 +21,7 @@ tags:
     description: AuthZEN policy decision point and access evaluation APIs.
 
 security:
-  - OAuth2: [system]
+  - DirectAuthSecret: []
 
 paths:
   /.well-known/authzen-configuration:
@@ -78,6 +78,8 @@ paths:
                 $ref: "#/components/schemas/AccessEvaluationResponse"
         "400":
           $ref: "#/components/responses/AuthZENClientError"
+        "401":
+          $ref: "#/components/responses/DirectAuthError"
         "500":
           $ref: "#/components/responses/AuthZENServerError"
 
@@ -126,6 +128,8 @@ paths:
                 $ref: "#/components/schemas/AccessEvaluationsResponse"
         "400":
           $ref: "#/components/responses/AuthZENClientError"
+        "401":
+          $ref: "#/components/responses/DirectAuthError"
         "500":
           $ref: "#/components/responses/AuthZENServerError"
 
@@ -160,23 +164,18 @@ paths:
                 $ref: "#/components/schemas/AccessSearchResponse"
         "400":
           $ref: "#/components/responses/AuthZENClientError"
+        "401":
+          $ref: "#/components/responses/DirectAuthError"
         "500":
           $ref: "#/components/responses/AuthZENServerError"
 
 components:
   securitySchemes:
-    OAuth2:
-      type: oauth2
-      flows:
-        authorizationCode:
-          authorizationUrl: https://localhost:8090/oauth2/authorize
-          tokenUrl: https://localhost:8090/oauth2/token
-          scopes:
-            system: Access to system management APIs
-        clientCredentials:
-          tokenUrl: https://localhost:8090/oauth2/token
-          scopes:
-            system: Access to system management APIs
+    DirectAuthSecret:
+      type: apiKey
+      in: header
+      name: Direct-Auth-Secret
+      description: Server-level secret required to call AuthZEN access endpoints.
 
   responses:
     AuthZENClientError:
@@ -202,6 +201,22 @@ components:
             internalServerError:
               value:
                 error: Internal server error
+    DirectAuthError:
+      description: Missing or invalid Direct Auth Secret.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SecurityErrorResponse"
+          examples:
+            unauthorized:
+              value:
+                code: AUTH-4010
+                message:
+                  key: error.auth.unauthorized
+                  defaultValue: Unauthorized
+                description:
+                  key: error.auth.unauthorized_description
+                  defaultValue: Authentication is required to access this resource
 
   schemas:
     AuthZENMetadataResponse:
@@ -374,3 +389,32 @@ components:
             - Invalid action
             - Invalid resource
             - Internal server error
+
+    SecurityErrorResponse:
+      type: object
+      required:
+        - code
+        - message
+        - description
+      properties:
+        code:
+          type: string
+          description: Error code.
+          example: AUTH-4010
+        message:
+          $ref: "#/components/schemas/LocalizedMessage"
+        description:
+          $ref: "#/components/schemas/LocalizedMessage"
+
+    LocalizedMessage:
+      type: object
+      required:
+        - key
+        - defaultValue
+      properties:
+        key:
+          type: string
+          description: Message key.
+        defaultValue:
+          type: string
+          description: Default message.

--- a/docs/content/use-cases/ai-agents/mcp-authorization/configure-it-yourself.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/configure-it-yourself.mdx
@@ -24,15 +24,36 @@ Navigate to **Applications** → **Add Application** and choose **Browser App** 
 | Allowed grants       | `authorization_code`, `refresh_token`                                                                                              |
 | PKCE                 | Required                                                                                                                          |
 | Allowed user types   | `Customer`                                                                                                                        |
-| Authentication flow  | `wayfinder-agent-auth-flow` (the same flow the Wayfinder Concierge uses, so the consent screen surfaces each `wayfinder:booking:*` permission as a toggle)        |
+| Authentication flow  | `wayfinder-agent-auth-flow` (the same flow the Wayfinder Concierge uses, so the consent screen surfaces each `booking:*` permission as a toggle)        |
 
 See [Manage Applications](../../../../guides/guides/applications/manage-applications).
 
-The walkthrough relies on the consent screen at sign-in to narrow what the external client gets. `john.doe` keeps his existing `Booking User` role unchanged, and picks which `wayfinder:booking:*` permissions to release the first time he signs in through Inspector.
+The walkthrough relies on the consent screen at sign-in to narrow what the external client gets. `john.doe` keeps his existing `Booking User` role unchanged, and picks which `booking:*` permissions to release the first time he signs in through Inspector.
 
 :::info[Alternative: Dynamic Client Registration]
 If you don't want to register every MCP client up-front, <ProductName /> also supports [Dynamic Client Registration](../../../../guides/guides/protocols/oauth-oidc/dynamic-client-registration). An MCP client that supports DCR can discover <ProductName /> through the MCP server's protected-resource metadata and register itself, after which it uses its issued credentials for the same authorization-code flow. The tryout uses static registration for predictability. DCR is the right choice when you can't enumerate every client in advance.
 :::
+
+## Configure the Direct Auth Secret
+
+If you want the Wayfinder MCP server to call the <ProductName /> AuthZEN PDP instead of checking token scopes locally, configure the server-level Direct Auth Secret for the PDP call.
+
+Open the <ProductName /> deployment configuration and set:
+
+```yaml
+server:
+  security:
+    direct_auth_secret: "wayfinder-direct-auth-secret"
+```
+
+Restart <ProductName /> after updating the deployment configuration. Then set the same value in `samples/apps/wayfinder-sample/backend/.env`:
+
+```env
+AUTHORIZATION_MODE=authzen
+THUNDERID_DIRECT_AUTH_SECRET=wayfinder-direct-auth-secret
+```
+
+The Direct Auth Secret authenticates the Wayfinder Server when it calls the protected AuthZEN API. The secret does not grant booking permissions and does not replace the user or agent. The Wayfinder MCP server still uses the incoming MCP token to choose the AuthZEN evaluation subject.
 
 ## Start the Sample
 

--- a/docs/content/use-cases/ai-agents/mcp-authorization/identity-concepts.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/identity-concepts.mdx
@@ -18,34 +18,51 @@ The application registers redirect URIs for MCP Inspector:
 - `http://localhost:6274/oauth/callback/debug`: MCP Inspector's debug callback.
 - `http://localhost:6274/oauth/callback`: MCP Inspector's standard callback.
 
-`EXTERNAL-MCP-CLIENT` is wired to the same authentication flow as the Wayfinder Concierge, so the OAuth consent screen surfaces each requested `wayfinder:booking:*` permission as an individual toggle at sign-in time.
+`EXTERNAL-MCP-CLIENT` is wired to the same authentication flow as the Wayfinder Concierge, so the OAuth consent screen surfaces each requested `booking:*` permission as an individual toggle at sign-in time.
 
 See [Manage Applications](../../../../guides/guides/applications/manage-applications).
 
 ## Consent at Sign-In
 
-`john.doe` already holds the `Booking User` role: read, create, and cancel. The tryout doesn't add a narrower role; instead, the narrowing happens at the **consent screen** the first time `john.doe` signs in through Inspector. He picks which `wayfinder:booking:*` permissions to release to the external client.
+`john.doe` already holds the `Booking User` role with read, create, and cancel permissions. The tryout doesn't add a narrower role; instead, the narrowing happens at the **consent screen** the first time `john.doe` signs in through Inspector. He picks which `booking:*` permissions to release to the external client.
 
-The token Inspector receives carries only the permissions he ticked. The MCP server enforces those per-tool, so the walkthrough can demonstrate scope enforcement by leaving `wayfinder:booking:cancel` unchecked the first time and including it on a later retry, without touching the user's roles.
+The token Inspector receives carries only the permissions he ticked. The MCP server enforces those per-tool, so the walkthrough can demonstrate scope enforcement by leaving `booking:cancel` unchecked the first time and including it on a later retry without touching the user's roles.
 
 See [Authorization](../../../../guides/key-concepts/authorization).
 
 ## Resource Server
 
-This tryout reuses the `wayfinder` resource server defined under [Resources and Permissions](../../identity-concepts#resources-and-permissions). The same `wayfinder:booking:*` permissions protect both `/api/*` (REST) and `/mcp` (MCP tools). The Wayfinder Server enforces them per-route on the REST side and per-tool on the MCP side, against the same service layer.
+This tryout reuses the Wayfinder resource server defined under [Resources and Permissions](../../identity-concepts#resources-and-permissions). The same `booking:*` permissions protect both `/api/*` (REST) and `/mcp` (MCP tools). The Wayfinder Server enforces them per-route on the REST side and per-tool on the MCP side, against the same service layer.
 
 Each MCP tool checks for the same scope its REST counterpart checks for:
 
 | MCP tool | REST endpoint | Required scope |
 | --- | --- | --- |
-| `search_flights` | `GET /api/flights` | None *(token only)* |
-| `recommend_bookings` | `GET /api/bookings/recommended` | `wayfinder:booking:recommend` |
-| `get_flight_bookings` | `GET /api/bookings/flights` | `wayfinder:booking:read` |
-| `create_booking` | `POST /api/bookings` | `wayfinder:booking:create` |
-| `delete_all_bookings` | `DELETE /api/bookings/flights` | `wayfinder:booking:cancel` |
+| `search_flights` | `GET /api/flights` | *(token only)* |
+| `recommend_bookings` | `GET /api/bookings/recommended` | `booking:recommend` |
+| `get_flight_bookings` | `GET /api/bookings/flights` | `booking:read` |
+| `create_booking` | `POST /api/bookings` | `booking:create` |
+| `delete_all_bookings` | `DELETE /api/bookings/flights` | `booking:cancel` |
 
 See [Resource Servers](../../../../guides/guides/resource-servers).
 
+## AuthZEN Authorization Mode
+
+The Wayfinder MCP server supports two authorization modes for protected MCP tools:
+
+- `scope` mode, the default, checks whether the incoming MCP access token carries the required permission.
+- `authzen` mode sends an AuthZEN access evaluation request to the <ProductName /> PDP and uses the returned allow or deny decision.
+
+In `authzen` mode, the Wayfinder Server still validates the incoming MCP token. The token identifies the subject, such as `john.doe` or the Wayfinder Concierge agent. The server then sends an AuthZEN request with:
+
+- `subject.id` from the incoming MCP token.
+- `resource.type` set to the resource server identifier, `http://localhost:8787/mcp`.
+- `action.name` set to the permission string, such as `booking:recommend`.
+
+The server-level Direct Auth Secret authenticates the Wayfinder Server when it calls the protected AuthZEN API. This secret only authorizes the PDP API call. The PDP still evaluates the user or agent from the incoming MCP token.
+
+See [AuthZEN](../../../../guides/guides/protocols/authzen/) and [Policy Decision Point](../../../../guides/guides/protocols/authzen/pdp).
+
 ## Discovery Endpoint
 
-The Wayfinder MCP server publishes a protected-resource metadata document at `GET /.well-known/oauth-protected-resource`. It points at <ProductName /> as the authorization server and lists the supported scopes. MCP Inspector, and any compatible MCP client, reads this document to start the OAuth flow without manual configuration.
+The Wayfinder MCP server publishes a protected-resource metadata document at `GET /.well-known/oauth-protected-resource`. It points at <ProductName /> as the authorization server and lists the supported scopes. MCP Inspector and any compatible MCP client read this document to start the OAuth flow without manual configuration.

--- a/docs/content/use-cases/ai-agents/mcp-authorization/try-it-out.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/try-it-out.mdx
@@ -5,15 +5,17 @@ description: Run the MCP Authorization use case against the Wayfinder sample. Co
 sidebar_position: 2
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import Stepper from '../../../../src/components/Stepper';
 import {NextSteps, NextStepsCard} from '../../../../src/components/NextSteps';
 import { WayfinderMcpOrganization, WayfinderMcpArchitecture } from '../../../../src/components/WayfinderDiagrams';
 
 # Try It Out
 
-Each walkthrough below runs the [Securing MCP](../overview) pattern against the Wayfinder sample. The Wayfinder Server hosts an MCP server on `/mcp` alongside its REST API; an external MCP client signs in through <ProductName /> and calls Wayfinder's tools. The server enforces the scopes in the access token before invoking protected tool handlers.
+Each walkthrough below runs the [Securing MCP](../overview) pattern against the Wayfinder sample. The Wayfinder Server hosts an MCP server on `/mcp` alongside its REST API; an external MCP client signs in through <ProductName /> and calls Wayfinder's tools.
+
+The sample supports two MCP tool authorization modes:
+
+- **Scope-based MCP authorization** checks the permissions already present in the incoming access token.
+- **AuthZEN-based MCP authorization** validates the incoming token, then asks the <ProductName /> policy decision point (PDP) for a runtime allow or deny decision before invoking protected tool handlers.
 
 ## Meet Wayfinder
 
@@ -23,8 +25,8 @@ Wayfinder is the same travel-booking application from the [Securing AI Agents tr
 
 ### Meet the Cast
 
-- **John Doe** signs in to the external MCP client and picks which `wayfinder:booking:*` permissions to grant at consent. He carries the `Booking User` role with read, create, and cancel permissions.
-- **MCP Inspector** is the [reference debug UI](https://github.com/modelcontextprotocol/inspector) for MCP servers: browser-based, speaks the protocol, supports OAuth-protected servers out of the box.
+- **John Doe** signs in to the external MCP client and picks which `booking:*` permissions to grant at consent. He carries the `Booking User` role with read, create, and cancel permissions.
+- **MCP Inspector** is the [reference debug UI](https://github.com/modelcontextprotocol/inspector) for MCP servers. It runs in the browser, speaks the protocol, and supports OAuth-protected servers out of the box.
 
 ## Sample Architecture
 
@@ -39,8 +41,6 @@ The Wayfinder Server validates the issued access token on every MCP call. The se
 ## Set Up Your Environment
 
 Complete the [AI Agents Set Up Your Environment](../../try-it-out/setup) first. The same bundle also seeds the `EXTERNAL-MCP-CLIENT` application used here.
-
-<Stepper stepNode="h3" as="h3">
 
 ### Verify the New Application
 
@@ -66,17 +66,20 @@ value:
     - "http://localhost:6274"
 ```
 
-</Stepper>
-
 ## Walkthroughs
 
 Pick a walkthrough to begin. Each one starts from the setup above.
 
 <NextSteps>
   <NextStepsCard
-    title="MCP Authorization"
-    description="Authorize an external MCP client, list Wayfinder's tools, call a few, and watch scope enforcement deny delete_all_bookings."
+    title="Scope-Based MCP Authorization"
+    description="Authorize an external MCP client, list Wayfinder's tools, call a few, and watch scope enforcement deny the booking deletion tool."
     href="./connect-via-inspector"
+  />
+  <NextStepsCard
+    title="AuthZEN-Based MCP Authorization"
+    description="Enable AuthZEN mode and watch the Wayfinder MCP server ask the PDP for runtime tool decisions."
+    href="./authzen-authorization"
   />
 </NextSteps>
 

--- a/docs/content/use-cases/ai-agents/mcp-authorization/try-it-out/authzen-authorization.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/try-it-out/authzen-authorization.mdx
@@ -1,0 +1,92 @@
+---
+title: AuthZEN-Based MCP Authorization
+docType: use-case
+description: Enable AuthZEN mode for the Wayfinder MCP server and request runtime authorization decisions from {{ProductName}}.
+sidebar_position: 2
+---
+
+# AuthZEN-Based MCP Authorization
+
+In this walkthrough, `john.doe` signs in to MCP Inspector through <ProductName /> and calls a protected Wayfinder MCP tool. Instead of trusting only the scopes in the access token, the Wayfinder MCP server asks the <ProductName /> PDP for a runtime AuthZEN decision before it invokes the tool handler.
+
+:::note Prerequisites
+Complete [Set Up Your Environment](../../../try-it-out/setup) before starting this walkthrough.
+:::
+
+## Walk Through the Use Case
+
+### 1. Verify the Direct Auth Secret
+
+Confirm that `server.security.direct_auth_secret` is set in the <ProductName /> deployment configuration. The local sample uses `wayfinder-direct-auth-secret`.
+
+This secret authenticates the Wayfinder Server when it calls the protected AuthZEN API. It does not replace the signed-in user. The user or agent from the incoming MCP token remains the evaluation subject.
+
+### 2. Enable AuthZEN Mode
+
+Update `samples/apps/wayfinder-sample/backend/.env`:
+
+```env
+AUTHORIZATION_MODE=authzen
+THUNDERID_DIRECT_AUTH_SECRET=wayfinder-direct-auth-secret
+```
+
+Restart the Wayfinder Server after changing the mode.
+
+### 3. Launch MCP Inspector
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Inspector opens in your browser at `http://localhost:6274`.
+
+### 4. Connect to the Wayfinder MCP Server
+
+In the Inspector UI:
+
+- **Transport type:** Streamable HTTP
+- **URL:** `http://localhost:8787/mcp`
+- **OAuth:** enabled
+
+Open Inspector's **Auth** panel and enter the pre-registered client:
+
+- **Client ID:** `EXTERNAL-MCP-CLIENT`
+- Leave the client secret empty.
+
+Click **Connect**. Inspector discovers <ProductName /> through the Wayfinder MCP server's protected-resource metadata and starts the authorization-code + PKCE flow.
+
+### 5. Sign In as John Doe
+
+Sign in as `john.doe` / `john.doe`.
+
+Approve the consent screen. The OAuth flow and consent screen are the same as the scope-based walkthrough.
+
+### 6. Call a Tool John Is Not Allowed to Use
+
+In Inspector's **Tools** tab, call `recommend_bookings`.
+
+`john.doe` has the `Booking User` role, but not the `Recommender` role. The Wayfinder MCP server validates John's token, builds an AuthZEN request, and asks the PDP whether John can perform `booking:recommend` on the Wayfinder MCP resource server.
+
+The PDP denies the request, and the tool does not run.
+
+The Wayfinder Server logs the decision:
+
+```text
+[authzen] DENY subject=wayfinder-john-doe resource=http://localhost:8787/mcp action=booking:recommend
+```
+
+## Try a Variant
+
+- **Grant the Recommender role to John.** Assign the `Recommender` role to `john.doe`, reconnect Inspector, and call `recommend_bookings` again. The PDP now allows the same action for the same user.
+- **Revoke the Recommender role from John.** Remove the `Recommender` role from `john.doe` and call `recommend_bookings` again. The MCP server asks the PDP for a new decision on each protected tool call, so the PDP denies the action after the role change. In scope-based mode, an already-issued token can continue to carry the old permission until the token expires or the user reconnects.
+- **Use the Wayfinder Concierge agent.** Ask the in-product Concierge for recommendations. The Concierge agent has the `Recommender` role, so the backend logs an allow decision for the agent subject:
+
+  ```text
+  [authzen] ALLOW subject=wayfinder-concierge resource=http://localhost:8787/mcp action=booking:recommend
+  ```
+
+## Going Deeper
+
+- Want the default token-scope walkthrough? See [Scope-Based MCP Authorization](../connect-via-inspector).
+- Curious how the AuthZEN PDP call maps to <ProductName /> concepts? See [Identity Concepts](../../identity-concepts#authzen-authorization-mode).
+- Prefer to configure AuthZEN mode manually? See [Configure It Yourself](../../configure-it-yourself#configure-the-direct-auth-secret).

--- a/docs/content/use-cases/ai-agents/mcp-authorization/try-it-out/connect-via-inspector.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/try-it-out/connect-via-inspector.mdx
@@ -1,13 +1,13 @@
 ---
-title: MCP Authorization
 docType: use-case
+title: Scope-Based MCP Authorization
 description: Connect an external MCP client to the Wayfinder MCP server through {{ProductName}}, then watch scope enforcement deny a privileged tool until the user grants the missing permission at consent.
 sidebar_position: 1
 ---
 
-# MCP Authorization
+# Scope-Based MCP Authorization
 
-In this walkthrough, `john.doe` signs in to MCP Inspector through <ProductName />, picks which `wayfinder:booking:*` permissions to grant, and calls a few MCP tools. Calling a tool he didn't grant a permission for hits a `403`. He reconnects, grants the missing permission, and the same call succeeds.
+In this walkthrough, `john.doe` signs in to MCP Inspector through <ProductName />, picks which `booking:*` permissions to grant, and calls a few MCP tools. Calling a tool he didn't grant a permission for hits a `403`. He reconnects, grants the missing permission, and the same call succeeds.
 
 :::note Prerequisites
 Complete [Set Up Your Environment](../../../try-it-out/setup) before starting this walkthrough.
@@ -44,7 +44,7 @@ Click **Connect**. Inspector reads the MCP server's protected-resource metadata,
 
 A browser tab opens with <ProductName />'s sign-in page for the `EXTERNAL-MCP-CLIENT` application. Sign in as `john.doe` / `john.doe`.
 
-The consent screen surfaces each requested `wayfinder:booking:*` permission as an individual toggle. **Tick `wayfinder:booking:read` and `wayfinder:booking:create`. Leave `wayfinder:booking:cancel` unchecked.** Approve.
+The consent screen surfaces each requested `booking:*` permission as an individual toggle. **Tick `booking:read` and `booking:create`. Leave `booking:cancel` unchecked.** Approve.
 
 Inspector receives the authorization code on its loopback callback, exchanges it for an access token at <ProductName />'s `/oauth2/token`, and connects to the MCP server with that token in the `Authorization: Bearer …` header.
 
@@ -54,9 +54,9 @@ In the **Tools** tab, Inspector calls `tools/list` and shows the Wayfinder tool 
 
 ### 5. Call a Tool the User Has Scope For
 
-Pick `search_flights`. Set `from=Colombo`, `to=Singapore`, click **Run Tool**. The result is a JSON list of flights, exactly what `GET /api/flights` returns to the Wayfinder web UI, served from the same service module.
+Pick `search_flights`. Set `from=Colombo`, `to=Singapore`, click **Run Tool**. The result is a JSON list of flights that matches what `GET /api/flights` returns to the Wayfinder web UI, served from the same service module.
 
-Pick `create_booking`. Set `type=flight`, `itemId=flight-cmb-sin-01`, `travelers=1`. The booking succeeds. The token carries `wayfinder:booking:create`, so the MCP server's per-tool scope check passes.
+Pick `create_booking`. Set `type=flight`, `itemId=flight-cmb-sin-01`, `travelers=1`. The booking succeeds. The token carries `booking:create`, so the MCP server's per-tool scope check passes.
 
 ### 6. Call a Tool the User Did Not Grant
 
@@ -65,21 +65,21 @@ Pick `delete_all_bookings`. Click **Run Tool**.
 You see an MCP error:
 
 ```text
-Insufficient scope for tool delete_all_bookings. Required: wayfinder:booking:cancel
+Insufficient scope for tool delete_all_bookings. Required: booking:cancel
 ```
 
-`john.doe` did not tick `wayfinder:booking:cancel` at consent, so the issued token doesn't carry it. The MCP server enforces the per-tool scope before invoking the handler, and the destructive tool stays inaccessible.
+`john.doe` did not tick `booking:cancel` at consent, so the issued token doesn't carry it. The MCP server enforces the per-tool scope before invoking the handler, and the destructive tool stays inaccessible.
 
 ### 7. Grant the Missing Permission and Retry
 
-In Inspector, click **Disconnect** and reconnect. The sign-in flow runs again. This time, tick `wayfinder:booking:cancel` at the consent screen along with the other two.
+In Inspector, click **Disconnect** and reconnect. The sign-in flow runs again. This time, tick `booking:cancel` at the consent screen along with the other two.
 
-A new token is issued, this one carrying `wayfinder:booking:cancel`. Call `delete_all_bookings` again. It succeeds.
+A new token is issued, this one carrying `booking:cancel`. Call `delete_all_bookings` again. It succeeds.
 
 ## Try a Variant
 
-- **Show the JWT.** In Inspector's Auth panel, view the access token's claims. The `aud` is `http://localhost:8787/mcp`, the Wayfinder MCP server's resource indicator, derived from the granted `wayfinder:booking:*` scopes, and `scope` matches exactly what `john.doe` ticked at consent.
-- **Use a different user.** Create a fresh `Customer` user with no roles. Sign in via Inspector. Tools that need a `wayfinder:booking:*` scope fail; browsing tools (`search_flights`, `search_hotels`) still work.
+- **Show the JWT.** In Inspector's Auth panel, view the access token's claims. The `aud` is `http://localhost:8787/mcp`, the Wayfinder MCP server's resource indicator, and `scope` matches exactly what `john.doe` ticked at consent.
+- **Use a different user.** Create a fresh `Customer` user with no roles. Sign in via Inspector. Tools that need a `booking:*` scope fail; browsing tools (`search_flights`, `search_hotels`) still work.
 
 ## Going Deeper
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -312,9 +312,23 @@ const sidebars: SidebarsConfig = {
                       key: 'mcp-authorization-walkthroughs',
                       items: [
                         {
-                          type: 'doc',
-                          id: 'use-cases/ai-agents/mcp-authorization/try-it-out/connect-via-inspector',
+                          type: 'category',
                           label: 'MCP Authorization',
+                          collapsible: true,
+                          collapsed: true,
+                          key: 'mcp-authorization-walkthroughs-mcp-authorization',
+                          items: [
+                            {
+                              type: 'doc',
+                              id: 'use-cases/ai-agents/mcp-authorization/try-it-out/connect-via-inspector',
+                              label: 'Scope-Based',
+                            },
+                            {
+                              type: 'doc',
+                              id: 'use-cases/ai-agents/mcp-authorization/try-it-out/authzen-authorization',
+                              label: 'AuthZEN-Based',
+                            },
+                          ],
                         },
                       ],
                     },


### PR DESCRIPTION
### Purpose
Adds a separate AuthZEN-based MCP authorization walkthrough for the Wayfinder sample, while renaming the existing Inspector walkthrough as scope-based MCP authorization.

This makes the two authorization modes easier to understand:

- Scope-Based MCP Authorization: MCP tools are authorized using permissions already present in the access token.
- AuthZEN-Based MCP Authorization: MCP tools are authorized by asking the ThunderID PDP for a runtime allow/deny decision.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3742

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3775

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized MCP authorization guidance to use `booking:*` permission naming across consent and tool scopes.
  * Added/expanded AuthZEN-based MCP walkthroughs, including runtime allow/deny behavior for protected tool calls.
  * Documented how to configure the server-level Direct Auth Secret and matching environment variable for AuthZEN connectivity.
  * Refreshed “Try It Out” navigation to clearly separate Scope-Based vs AuthZEN paths.
* **API / OpenAPI**
  * Updated the AuthZEN OpenAPI spec to authenticate with `Direct-Auth-Secret` and documented additional `401` error responses (including new error schemas).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->