### PR TITLE
Support configurable default resource server.

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -160,19 +160,6 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// Add to exporters list (must be done after initializing list)
 	exporters = append(exporters, i18nExporter)
 
-	// Initialize the server-wide configuration service with the CORS section handler.
-	serverConfigHandlers := map[serverconfig.ConfigName]serverconfig.ServerConfigHandlerInterface{
-		serverconfig.ConfigNameCORS: cors.OriginHandler{},
-	}
-	serverConfigService, serverConfigExporter, err := serverconfig.Initialize(mux, cacheManager, serverConfigHandlers)
-	if err != nil {
-		logger.Fatal(ctx, "Failed to initialize server config service", log.Error(err))
-	}
-	exporters = append(exporters, serverConfigExporter)
-
-	// CORS origins come from the server-config cors section.
-	cors.InitializeDynamicMatcher(serverConfigService)
-
 	ouAuthzService, err := sysauthz.Initialize()
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize system authorization service", log.Error(err))
@@ -422,6 +409,20 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	// Initialize flow metadata service
 	_ = flowmeta.Initialize(mux, actorProvider, ouService, designResolveService, i18nService)
+
+	// Initialize server-wide configuration after its handler dependencies.
+	serverConfigHandlers := map[serverconfig.ConfigName]serverconfig.ServerConfigHandlerInterface{
+		serverconfig.ConfigNameCORS:                  cors.OriginHandler{},
+		serverconfig.ConfigNameDefaultResourceServer: resource.NewDefaultResourceServerConfigHandler(resourceService),
+	}
+	serverConfigService, serverConfigExporter, err := serverconfig.Initialize(mux, cacheManager, serverConfigHandlers)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to initialize server config service", log.Error(err))
+	}
+	exporters = append(exporters, serverConfigExporter)
+
+	// CORS origins come from the server-config cors section.
+	cors.InitializeDynamicMatcher(serverConfigService)
 
 	// Initialize export service with collected exporters
 	_ = export.Initialize(mux, exporters)

--- a/backend/internal/resource/default_resource_server_config.go
+++ b/backend/internal/resource/default_resource_server_config.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package resource
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// DefaultResourceServerConfig contains the default resource server configuration.
+type DefaultResourceServerConfig struct {
+	ResourceServerID string `json:"resourceServerId" yaml:"resourceServerId"`
+}
+
+// DefaultResourceServerConfigHandler handles default resource server configuration.
+type DefaultResourceServerConfigHandler struct {
+	resourceService ResourceServiceInterface
+}
+
+// NewDefaultResourceServerConfigHandler creates a default resource server configuration handler.
+func NewDefaultResourceServerConfigHandler(
+	resourceService ResourceServiceInterface,
+) *DefaultResourceServerConfigHandler {
+	if resourceService == nil {
+		panic("default resource server config handler requires a non-nil resource service")
+	}
+	return &DefaultResourceServerConfigHandler{resourceService: resourceService}
+}
+
+// Decode parses a default resource server configuration.
+func (*DefaultResourceServerConfigHandler) Decode(raw json.RawMessage) (any, error) {
+	if len(raw) == 0 {
+		return DefaultResourceServerConfig{}, nil
+	}
+	var cfg DefaultResourceServerConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// Validate validates a default resource server configuration.
+func (h *DefaultResourceServerConfigHandler) Validate(incoming, readOnly, _ any) error {
+	cfg, _ := incoming.(DefaultResourceServerConfig)
+	if ro, ok := readOnly.(DefaultResourceServerConfig); ok && ro.ResourceServerID != "" {
+		return errDeclarativeDefaultLocked
+	}
+	if cfg.ResourceServerID == "" {
+		return nil
+	}
+	if _, svcErr := h.resourceService.GetResourceServer(context.Background(), cfg.ResourceServerID); svcErr != nil {
+		if svcErr.Code == ErrorResourceServerNotFound.Code {
+			return errUnknownDefaultResourceServer
+		}
+		return errDefaultResourceServerLookupFailed
+	}
+	return nil
+}
+
+// Merge combines read-only and writable default resource server configurations.
+func (*DefaultResourceServerConfigHandler) Merge(readOnly, writable any) any {
+	if ro, ok := readOnly.(DefaultResourceServerConfig); ok && ro.ResourceServerID != "" {
+		return ro
+	}
+	if w, ok := writable.(DefaultResourceServerConfig); ok {
+		return w
+	}
+	return DefaultResourceServerConfig{}
+}

--- a/backend/internal/resource/default_resource_server_config_test.go
+++ b/backend/internal/resource/default_resource_server_config_test.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package resource
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+)
+
+type DefaultResourceServerConfigHandlerTestSuite struct {
+	suite.Suite
+}
+
+func TestDefaultResourceServerConfigHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(DefaultResourceServerConfigHandlerTestSuite))
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) marshal(v any) string {
+	out, err := json.Marshal(v)
+	suite.Require().NoError(err)
+	return string(out)
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) handler() *DefaultResourceServerConfigHandler {
+	return NewDefaultResourceServerConfigHandler(NewResourceServiceInterfaceMock(suite.T()))
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestDecodeEmptyYieldsEmptyConfig() {
+	decoded, err := suite.handler().Decode(json.RawMessage(nil))
+	suite.Require().NoError(err)
+	assert.JSONEq(suite.T(), `{"resourceServerId":""}`, suite.marshal(decoded))
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestDecodeValidObject() {
+	decoded, err := suite.handler().Decode(json.RawMessage(`{"resourceServerId":"abc"}`))
+	suite.Require().NoError(err)
+	assert.Equal(suite.T(), DefaultResourceServerConfig{ResourceServerID: "abc"}, decoded)
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestDecodeMalformedJSON() {
+	_, err := suite.handler().Decode(json.RawMessage(`{not json`))
+	assert.Error(suite.T(), err)
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestValidateUnsetAccepted() {
+	h := NewDefaultResourceServerConfigHandler(NewResourceServiceInterfaceMock(suite.T()))
+	assert.NoError(suite.T(), h.Validate(DefaultResourceServerConfig{}, nil, nil))
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestValidateKnownIDAccepted() {
+	mockSvc := NewResourceServiceInterfaceMock(suite.T())
+	mockSvc.EXPECT().GetResourceServer(mock.Anything, "rs-1").Return(&providers.ResourceServer{ID: "rs-1"}, nil)
+	h := NewDefaultResourceServerConfigHandler(mockSvc)
+	assert.NoError(suite.T(), h.Validate(DefaultResourceServerConfig{ResourceServerID: "rs-1"}, nil, nil))
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestValidateUnknownIDRejected() {
+	mockSvc := NewResourceServiceInterfaceMock(suite.T())
+	mockSvc.EXPECT().GetResourceServer(mock.Anything, "missing").Return(nil, &ErrorResourceServerNotFound)
+	h := NewDefaultResourceServerConfigHandler(mockSvc)
+	assert.Error(suite.T(), h.Validate(DefaultResourceServerConfig{ResourceServerID: "missing"}, nil, nil))
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestValidateInternalErrorRejected() {
+	mockSvc := NewResourceServiceInterfaceMock(suite.T())
+	mockSvc.EXPECT().GetResourceServer(mock.Anything, "rs-1").Return(nil, &tidcommon.InternalServerError)
+	h := NewDefaultResourceServerConfigHandler(mockSvc)
+	err := h.Validate(DefaultResourceServerConfig{ResourceServerID: "rs-1"}, nil, nil)
+	assert.ErrorIs(suite.T(), err, errDefaultResourceServerLookupFailed)
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestValidateRejectsWriteWhenDeclarativeSet() {
+	h := NewDefaultResourceServerConfigHandler(NewResourceServiceInterfaceMock(suite.T()))
+	err := h.Validate(
+		DefaultResourceServerConfig{ResourceServerID: "rs-2"},
+		DefaultResourceServerConfig{ResourceServerID: "rs-1"},
+		DefaultResourceServerConfig{},
+	)
+	assert.Error(suite.T(), err)
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestValidateRejectsClearWhenDeclarativeSet() {
+	h := NewDefaultResourceServerConfigHandler(NewResourceServiceInterfaceMock(suite.T()))
+	err := h.Validate(
+		DefaultResourceServerConfig{},
+		DefaultResourceServerConfig{ResourceServerID: "rs-1"},
+		DefaultResourceServerConfig{},
+	)
+	assert.Error(suite.T(), err)
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestMergeReadOnlyWins() {
+	merged := suite.handler().
+		Merge(DefaultResourceServerConfig{ResourceServerID: "ro"}, DefaultResourceServerConfig{ResourceServerID: "w"})
+	assert.Equal(suite.T(), DefaultResourceServerConfig{ResourceServerID: "ro"}, merged)
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestMergeFallsBackToWritable() {
+	merged := suite.handler().
+		Merge(DefaultResourceServerConfig{}, DefaultResourceServerConfig{ResourceServerID: "w"})
+	assert.Equal(suite.T(), DefaultResourceServerConfig{ResourceServerID: "w"}, merged)
+}
+
+func (suite *DefaultResourceServerConfigHandlerTestSuite) TestMergeBothEmpty() {
+	merged := suite.handler().
+		Merge(DefaultResourceServerConfig{}, DefaultResourceServerConfig{})
+	assert.Equal(suite.T(), DefaultResourceServerConfig{}, merged)
+}

--- a/backend/internal/resource/error_constants.go
+++ b/backend/internal/resource/error_constants.go
@@ -369,6 +369,17 @@ var (
 
 	// errResultLimitExceededInCompositeMode is the internal sentinel error for composite mode limit exceeded.
 	errResultLimitExceededInCompositeMode = errors.New("result limit exceeded in composite mode")
+
+	// errUnknownDefaultResourceServer is returned when the configured resource server does not exist.
+	errUnknownDefaultResourceServer = errors.New(
+		"default resource server does not resolve to an existing resource server")
+
+	// errDeclarativeDefaultLocked is returned when attempting to override a declarative default.
+	errDeclarativeDefaultLocked = errors.New(
+		"default resource server is set declaratively and cannot be overridden")
+
+	// errDefaultResourceServerLookupFailed is returned when resource server lookup fails.
+	errDefaultResourceServerLookupFailed = errors.New("failed to resolve default resource server")
 )
 
 // consentSyncError wraps an underlying ServiceError from the consent service, allowing callers

--- a/backend/internal/serverconfig/constants.go
+++ b/backend/internal/serverconfig/constants.go
@@ -25,11 +25,14 @@ type ConfigName string
 const (
 	// ConfigNameCORS is the configuration key for runtime-mutable CORS allowed origins.
 	ConfigNameCORS ConfigName = "cors"
+	// ConfigNameDefaultResourceServer is the configuration key for the default resource server.
+	ConfigNameDefaultResourceServer ConfigName = "defaultResourceServer"
 )
 
 // supportedConfigNames lists all the supported server configuration names.
 var supportedConfigNames = []ConfigName{
 	ConfigNameCORS,
+	ConfigNameDefaultResourceServer,
 }
 
 // IsValid reports whether the config name is one of the supported values.

--- a/backend/internal/serverconfig/constants_test.go
+++ b/backend/internal/serverconfig/constants_test.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package serverconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultResourceServerConfigNameSupported(t *testing.T) {
+	assert.Equal(t, ConfigName("defaultResourceServer"), ConfigNameDefaultResourceServer)
+	assert.True(t, ConfigNameDefaultResourceServer.IsValid())
+	assert.Contains(t, supportedConfigNames, ConfigNameDefaultResourceServer)
+}

--- a/tests/integration/importexport/import_export_fresh_pack_test.go
+++ b/tests/integration/importexport/import_export_fresh_pack_test.go
@@ -28,8 +28,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thunder-id/thunderid/tests/integration/testutils"
 	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
 )
 
 type exportRequest struct {
@@ -176,6 +176,67 @@ func (suite *ImportExportFreshPackSuite) putServerConfigCORS(allowedOrigins stri
 
 func (suite *ImportExportFreshPackSuite) getServerConfigCORS() string {
 	req, err := http.NewRequest(http.MethodGet, testutils.TestServerURL+"/server-config/cors", nil)
+	suite.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+	return string(body)
+}
+
+func (suite *ImportExportFreshPackSuite) TestDefaultResourceServerExportImportRoundTrip() {
+	const resourceServerID = "01900000-0000-7000-8000-000000000020"
+
+	suite.putServerConfigDefaultResourceServer(resourceServerID)
+
+	exported, err := suite.exportResources(exportRequest{ServerConfigs: []string{"defaultResourceServer"}})
+	suite.Require().NoError(err)
+	suite.Require().Contains(exported, resourceServerID)
+
+	suite.putServerConfigDefaultResourceServer("")
+	suite.Require().NotContains(suite.getServerConfigDefaultResourceServer(), resourceServerID)
+
+	importResp, err := suite.importResources(importRequest{
+		Content: exported,
+		Options: importOptions{Upsert: true, ContinueOnError: true, Target: "runtime"},
+	})
+	suite.Require().NoError(err)
+
+	var serverConfigResult *importItem
+	for i := range importResp.Results {
+		if importResp.Results[i].ResourceType == "server_config" {
+			serverConfigResult = &importResp.Results[i]
+			break
+		}
+	}
+	suite.Require().NotNil(serverConfigResult, "import results should include a server_config item")
+	suite.Equal("success", serverConfigResult.Status)
+
+	suite.Require().Contains(suite.getServerConfigDefaultResourceServer(), resourceServerID)
+
+	suite.putServerConfigDefaultResourceServer("")
+}
+
+func (suite *ImportExportFreshPackSuite) putServerConfigDefaultResourceServer(resourceServerID string) {
+	body := `{"resourceServerId":"` + resourceServerID + `"}`
+	req, err := http.NewRequest(http.MethodPut,
+		testutils.TestServerURL+"/server-config/defaultResourceServer", bytes.NewReader([]byte(body)))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+}
+
+func (suite *ImportExportFreshPackSuite) getServerConfigDefaultResourceServer() string {
+	req, err := http.NewRequest(http.MethodGet,
+		testutils.TestServerURL+"/server-config/defaultResourceServer", nil)
 	suite.Require().NoError(err)
 
 	resp, err := testutils.GetHTTPClient().Do(req)

--- a/tests/integration/serverconfig/default_resource_server_api_test.go
+++ b/tests/integration/serverconfig/default_resource_server_api_test.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package serverconfig
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+type DefaultResourceServerAPITestSuite struct {
+	suite.Suite
+	adminClient *http.Client
+}
+
+func TestDefaultResourceServerAPITestSuite(t *testing.T) {
+	suite.Run(t, new(DefaultResourceServerAPITestSuite))
+}
+
+func (suite *DefaultResourceServerAPITestSuite) SetupSuite() {
+	suite.adminClient = testutils.GetHTTPClient()
+}
+
+func (suite *DefaultResourceServerAPITestSuite) SetupTest()     { suite.clear() }
+func (suite *DefaultResourceServerAPITestSuite) TearDownSuite() { suite.clear() }
+
+func (suite *DefaultResourceServerAPITestSuite) TestListIncludesSection() {
+	status, body := suite.get(serverConfigURL)
+	suite.Require().Equal(http.StatusOK, status)
+
+	var names []string
+	suite.Require().NoError(json.Unmarshal(body, &names))
+	suite.Contains(names, "defaultResourceServer")
+}
+
+func (suite *DefaultResourceServerAPITestSuite) TestPutExistingIDPersistsAndReads() {
+	status, _ := suite.put(`{"resourceServerId":"` + systemResourceServerID + `"}`)
+	suite.Require().Equal(http.StatusOK, status)
+
+	layers := suite.getLayers()
+	suite.Equal(systemResourceServerID, layers.Writable.ResourceServerID)
+	suite.Equal(systemResourceServerID, layers.Merged.ResourceServerID)
+}
+
+func (suite *DefaultResourceServerAPITestSuite) TestPutUnknownIDReturns400AndDoesNotPersist() {
+	status, body := suite.put(`{"resourceServerId":"00000000-0000-0000-0000-000000000000"}`)
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("SCF-1003", suite.errorCode(body))
+
+	suite.Empty(suite.getLayers().Writable.ResourceServerID)
+}
+
+func (suite *DefaultResourceServerAPITestSuite) TestClearIsAccepted() {
+	suite.Require().Equal(http.StatusOK, suite.mustPut(`{"resourceServerId":"`+systemResourceServerID+`"}`))
+
+	status, _ := suite.put(`{"resourceServerId":""}`)
+	suite.Require().Equal(http.StatusOK, status)
+	suite.Empty(suite.getLayers().Writable.ResourceServerID)
+}
+
+func (suite *DefaultResourceServerAPITestSuite) clear() {
+	suite.Require().Equal(http.StatusOK, suite.mustPut(`{"resourceServerId":""}`))
+}
+
+func (suite *DefaultResourceServerAPITestSuite) mustPut(body string) int {
+	status, _ := suite.put(body)
+	return status
+}
+
+func (suite *DefaultResourceServerAPITestSuite) put(body string) (int, []byte) {
+	req, err := http.NewRequest(http.MethodPut, defaultResourceServerConfigURL, strings.NewReader(body))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.adminClient.Do(req)
+	suite.Require().NoError(err)
+	defer closeBodyQuietly(suite.T(), resp.Body)
+
+	respBody, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	return resp.StatusCode, respBody
+}
+
+func (suite *DefaultResourceServerAPITestSuite) get(url string) (int, []byte) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	suite.Require().NoError(err)
+
+	resp, err := suite.adminClient.Do(req)
+	suite.Require().NoError(err)
+	defer closeBodyQuietly(suite.T(), resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	return resp.StatusCode, body
+}
+
+func (suite *DefaultResourceServerAPITestSuite) getLayers() defaultResourceServerLayers {
+	status, body := suite.get(defaultResourceServerConfigURL)
+	suite.Require().Equal(http.StatusOK, status)
+	var layers defaultResourceServerLayers
+	suite.Require().NoError(json.Unmarshal(body, &layers))
+	return layers
+}
+
+func (suite *DefaultResourceServerAPITestSuite) errorCode(body []byte) string {
+	var errResp apiErrorResponse
+	suite.Require().NoError(json.Unmarshal(body, &errResp))
+	return errResp.Code
+}

--- a/tests/integration/serverconfig/model.go
+++ b/tests/integration/serverconfig/model.go
@@ -29,6 +29,10 @@ const (
 	serverConfigURL = testServerURL + "/server-config"
 	corsConfigURL   = serverConfigURL + "/cors"
 
+	defaultResourceServerConfigURL = serverConfigURL + "/defaultResourceServer"
+
+	systemResourceServerID = "01900000-0000-7000-8000-000000000020"
+
 	// sampleOrigin / otherOrigin are valid origins used to exercise the writable layer's read/write and
 	// replace round-trips. The only registered config consumer is CORS, so stored values must be valid
 	// CORS origins.
@@ -65,4 +69,14 @@ type serverConfigLayers struct {
 	ReadOnly corsSectionValue `json:"readOnly"`
 	Writable corsSectionValue `json:"writable"`
 	Merged   corsSectionValue `json:"merged"`
+}
+
+type defaultResourceServerValue struct {
+	ResourceServerID string `json:"resourceServerId"`
+}
+
+type defaultResourceServerLayers struct {
+	ReadOnly defaultResourceServerValue `json:"readOnly"`
+	Writable defaultResourceServerValue `json:"writable"`
+	Merged   defaultResourceServerValue `json:"merged"`
 }


### PR DESCRIPTION
### Purpose

  Adds a server-level `defaultResourceServer` configuration as requested in #3854.

  The configuration stores a resource server ID and validates that the referenced resource server exists. It ships unset and is not yet used during OAuth token
  issuance; that integration will be handled separately.

  ### Approach

  - Added `defaultResourceServer` as a supported server configuration.
  - Added a resource-domain configuration handler for decoding, validation, and layered merging.
  - Treats declarative configuration as authoritative and prevents runtime overrides.
  - Validates configured IDs through the resource service.
  - Initializes server configuration after the resource service so validation is available during declarative loading.
  - Uses the generic server-config import/export mechanism.
  - Added unit and integration coverage for API operations, validation, and import/export round trips.

  ### Related Issues

  - Resolves #3854
  - Related to #3852

  ### Related PRs

  - N/A

  ### Checklist

  - [x] Followed the contribution guidelines.
  - [x] Manual test round performed and verified.
  - [x] Documentation provided. (N/A — no documentation changes required)
      - [x] Ran Vale and fixed all errors and warnings. (N/A — no documentation changes)
  - [x] Tests provided.
      - [x] Unit Tests
      - [x] Integration Tests
  - [ ] Breaking changes. (N/A — this change is backward compatible)
      - [ ] Breaking changes section filled. (N/A)
      - [ ] `breaking change` label added. (N/A)

  ### Security checks

  - [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-
  guidelines/secure-coding-guidlines/introduction/).
  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a `defaultResourceServer` setting in server configuration.
  * Exposed the setting via the REST API and included it in import/export round-trips.
* **Bug Fixes**
  * Improved validation to allow only known resource server IDs.
  * Enforced “locked” behavior when a declarative default is set, preventing overrides.
* **Tests**
  * Added unit tests for decoding/validation/merge behavior.
  * Added integration tests covering listing, GET/PUT, clearing, error handling, and export/import restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->