### PR TITLE
Support trusted token audiences for token exchange

### DIFF
--- a/backend/internal/connection/oidc.go
+++ b/backend/internal/connection/oidc.go
@@ -42,6 +42,7 @@ type oidcConnectionRequest struct {
 	Scopes                []string `json:"scopes,omitempty"`
 	Prompt                string   `json:"prompt,omitempty"`
 	TokenExchangeEnabled  *bool    `json:"tokenExchangeEnabled,omitempty"`
+	TrustedTokenAudience  string   `json:"trustedTokenAudience,omitempty"`
 
 	AttributeConfiguration *providers.AttributeConfiguration `json:"attributeConfiguration,omitempty"`
 }
@@ -64,6 +65,7 @@ type oidcConnectionResponse struct {
 	Scopes                []string `json:"scopes,omitempty"`
 	Prompt                string   `json:"prompt,omitempty"`
 	TokenExchangeEnabled  *bool    `json:"tokenExchangeEnabled,omitempty"`
+	TrustedTokenAudience  string   `json:"trustedTokenAudience,omitempty"`
 
 	AttributeConfiguration *providers.AttributeConfiguration `json:"attributeConfiguration,omitempty"`
 }
@@ -87,6 +89,7 @@ func oidcToIDPDTO(req oidcConnectionRequest) (*providers.IDPDTO, error) {
 		{idp.PropIssuer, req.Issuer, false},
 		{idp.PropScopes, joinScopes(req.Scopes), false},
 		{idp.PropPrompt, req.Prompt, false},
+		{idp.PropTrustedTokenAudience, req.TrustedTokenAudience, false},
 	}
 	if req.TokenExchangeEnabled != nil {
 		fields = append(fields, struct {
@@ -94,6 +97,12 @@ func oidcToIDPDTO(req oidcConnectionRequest) (*providers.IDPDTO, error) {
 			value    string
 			isSecret bool
 		}{idp.PropTokenExchangeEnabled, strconv.FormatBool(*req.TokenExchangeEnabled), false})
+	} else if req.TrustedTokenAudience != "" {
+		fields = append(fields, struct {
+			name     string
+			value    string
+			isSecret bool
+		}{idp.PropTokenExchangeEnabled, "true", false})
 	}
 	for _, field := range fields {
 		if props, err = appendProperty(props, field.name, field.value, field.isSecret); err != nil {
@@ -130,6 +139,7 @@ func oidcFromIDPDTO(dto providers.IDPDTO) (oidcConnectionResponse, error) {
 		Issuer:                values[idp.PropIssuer],
 		Scopes:                splitScopes(values[idp.PropScopes]),
 		Prompt:                values[idp.PropPrompt],
+		TrustedTokenAudience:  values[idp.PropTrustedTokenAudience],
 	}
 	if raw, ok := values[idp.PropTokenExchangeEnabled]; ok {
 		if enabled, parseErr := strconv.ParseBool(raw); parseErr == nil {

--- a/backend/internal/connection/oidc_test.go
+++ b/backend/internal/connection/oidc_test.go
@@ -54,6 +54,7 @@ func (s *OIDCTestSuite) TestToIDPDTOMapsEndpointsAndTokenExchange() {
 		Name: "Okta", ClientID: "c", ClientSecret: "s", RedirectURI: "https://app/cb",
 		AuthorizationEndpoint: "https://okta/auth", TokenEndpoint: "https://okta/token",
 		Issuer: "https://okta", TokenExchangeEnabled: boolPtr(true),
+		TrustedTokenAudience: "okta-client-id",
 	})
 	s.Require().NoError(err)
 	s.Equal(providers.IDPTypeOIDC, dto.Type)
@@ -63,6 +64,21 @@ func (s *OIDCTestSuite) TestToIDPDTOMapsEndpointsAndTokenExchange() {
 	s.Equal("https://okta/auth", values[idp.PropAuthorizationEndpoint])
 	s.Equal("https://okta", values[idp.PropIssuer])
 	s.Equal("true", values[idp.PropTokenExchangeEnabled])
+	s.Equal("okta-client-id", values[idp.PropTrustedTokenAudience])
+}
+
+func (s *OIDCTestSuite) TestToIDPDTOEnablesTokenExchangeWithTrustedAudience() {
+	dto, err := oidcToIDPDTO(oidcConnectionRequest{
+		Name: "Okta", ClientID: "c", ClientSecret: "s", RedirectURI: "https://app/cb",
+		AuthorizationEndpoint: "https://okta/auth", TokenEndpoint: "https://okta/token",
+		Issuer: "https://okta", TrustedTokenAudience: "okta-client-id",
+	})
+	s.Require().NoError(err)
+
+	values, err := propertyValues(dto.Properties)
+	s.Require().NoError(err)
+	s.Equal("true", values[idp.PropTokenExchangeEnabled])
+	s.Equal("okta-client-id", values[idp.PropTrustedTokenAudience])
 }
 
 func (s *OIDCTestSuite) TestAttributeConfigurationRoundTrips() {
@@ -100,6 +116,7 @@ func (s *OIDCTestSuite) TestGetParsesTokenExchangeAndMasks() {
 			Properties: []cmodels.Property{
 				mustProperty(s.T(), idp.PropClientSecret, "s3cret", true),
 				mustProperty(s.T(), idp.PropTokenExchangeEnabled, "true", false),
+				mustProperty(s.T(), idp.PropTrustedTokenAudience, "okta-client-id", false),
 			},
 		}, (*tidcommon.ServiceError)(nil))
 
@@ -114,6 +131,7 @@ func (s *OIDCTestSuite) TestGetParsesTokenExchangeAndMasks() {
 	s.Equal(maskedSecretValue, resp.ClientSecret)
 	s.Require().NotNil(resp.TokenExchangeEnabled)
 	s.True(*resp.TokenExchangeEnabled)
+	s.Equal("okta-client-id", resp.TrustedTokenAudience)
 }
 
 func (s *OIDCTestSuite) TestUpdateAndDelete() {

--- a/backend/internal/idp/constants.go
+++ b/backend/internal/idp/constants.go
@@ -35,6 +35,7 @@ const (
 	PropPrompt                = "prompt"
 	PropIssuer                = "issuer"
 	PropTokenExchangeEnabled  = "token_exchange_enabled"
+	PropTrustedTokenAudience  = "trusted_token_audience"
 )
 
 // Known endpoints for Google OAuth2/OIDC.
@@ -95,6 +96,7 @@ var idpPropertyConfigs = map[providers.IDPType]idpPropertyConfig{
 			PropPrompt,
 			PropIssuer,
 			PropTokenExchangeEnabled,
+			PropTrustedTokenAudience,
 		},
 		Defaults: map[string]string{},
 	},

--- a/backend/internal/idp/utils_test.go
+++ b/backend/internal/idp/utils_test.go
@@ -624,6 +624,21 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_TokenExchangeOnly_OIDC_Suc
 	s.NotNil(result)
 }
 
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_TokenExchangeAudience_OIDC_Succeeds() {
+	propIssuer, _ := cmodels.NewProperty(PropIssuer, "https://accounts.google.com", false)
+	propJWKS, _ := cmodels.NewProperty(PropJwksEndpoint, "https://www.googleapis.com/oauth2/v3/certs", false)
+	propTokenExchange, _ := cmodels.NewProperty(PropTokenExchangeEnabled, "true", false)
+	propAudience, _ := cmodels.NewProperty(
+		PropTrustedTokenAudience, "407408718192.apps.googleusercontent.com", false)
+
+	properties := []cmodels.Property{*propIssuer, *propJWKS, *propTokenExchange, *propAudience}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeOIDC, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+}
+
 func (s *IDPUtilsTestSuite) TestValidateIDPProperties_TokenExchangeEnabled_MissingIssuer_Fails() {
 	// OIDC IDP with token_exchange_enabled=true but missing issuer should fail.
 	prop1, _ := cmodels.NewProperty(PropClientID, "your_client_id", false)

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -247,15 +247,12 @@ func (tv *tokenValidator) ValidateSubjectToken(
 		return nil, fmt.Errorf("invalid subject token signature: %v", svcErr.Error)
 	}
 
-	// Validate that the external token's audience contains this server's issuer.
-	serverIssuer := tv.cfg.JWT.Issuer
 	auds, audErr := extractAudiences(claims)
 	if audErr != nil {
 		return nil, fmt.Errorf("failed to extract audience from external token: %w", audErr)
 	}
-	if !slices.Contains(auds, serverIssuer) {
-		return nil, fmt.Errorf(
-			"external token audience does not contain expected server issuer %q", serverIssuer)
+	if err := tv.validateExternalTokenAudience(auds, issuerInfo); err != nil {
+		return nil, err
 	}
 
 	return tv.extractSubjectTokenClaims(token, iss, claims, oauthApp, issuerInfo.AttributeMappings)
@@ -284,9 +281,10 @@ func (tv *tokenValidator) ValidateToken(ctx context.Context, token string) (map[
 
 // tokenExchangeIssuerInfo holds the resolved properties needed to validate an external token.
 type tokenExchangeIssuerInfo struct {
-	Issuer            string
-	JWKSURL           string
-	AttributeMappings []providers.AttributeMapping
+	Issuer               string
+	JWKSURL              string
+	TrustedTokenAudience string
+	AttributeMappings    []providers.AttributeMapping
 }
 
 // resolveExternalIssuer looks up an external IDP whose issuer property matches the given issuer.
@@ -312,10 +310,29 @@ func (tv *tokenValidator) resolveExternalIssuer(ctx context.Context, issuer stri
 	}
 
 	return &tokenExchangeIssuerInfo{
-		Issuer:            issuer,
-		JWKSURL:           jwksURL,
-		AttributeMappings: idp.GetAttributeMappings(&idpDTO),
+		Issuer:               issuer,
+		JWKSURL:              jwksURL,
+		TrustedTokenAudience: idp.GetPropertyValue(idpDTO.Properties, idp.PropTrustedTokenAudience),
+		AttributeMappings:    idp.GetAttributeMappings(&idpDTO),
 	}, nil
+}
+
+func (tv *tokenValidator) validateExternalTokenAudience(auds []string, issuerInfo *tokenExchangeIssuerInfo) error {
+	serverIssuer := tv.cfg.JWT.Issuer
+	if slices.Contains(auds, serverIssuer) {
+		return nil
+	}
+
+	if issuerInfo.TrustedTokenAudience != "" && slices.Contains(auds, issuerInfo.TrustedTokenAudience) {
+		return nil
+	}
+
+	if issuerInfo.TrustedTokenAudience != "" {
+		return fmt.Errorf("external token audience does not contain expected server issuer %q or configured "+
+			"trusted token audience", serverIssuer)
+	}
+
+	return fmt.Errorf("external token audience does not contain expected server issuer %q", serverIssuer)
 }
 
 // extractSubjectTokenClaims extracts and validates claims from a decoded subject token.

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -2242,8 +2242,9 @@ func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_EmptyClientI
 // ============================================================================
 
 const (
-	testExternalIssuer = "https://external-idp.example.com"
-	testExternalJWKS   = "https://external-idp.example.com/.well-known/jwks.json"
+	testExternalIssuer       = "https://external-idp.example.com"
+	testExternalJWKS         = "https://external-idp.example.com/.well-known/jwks.json"
+	testTrustedTokenAudience = "google-client-id.apps.googleusercontent.com"
 )
 
 type ExternalIDPValidatorTestSuite struct {
@@ -2301,6 +2302,68 @@ func buildExternalIDPDTOs() []providers.IDPDTO {
 	return []providers.IDPDTO{
 		{Properties: []cmodels.Property{*propTokenExchange, *propJWKS, *propIssuer}},
 	}
+}
+
+func buildExternalIDPDTOsWithAudience() []providers.IDPDTO {
+	idpDTOs := buildExternalIDPDTOs()
+	propAudience, _ := cmodels.NewProperty(idp.PropTrustedTokenAudience, testTrustedTokenAudience, false)
+	idpDTOs[0].Properties = append(idpDTOs[0].Properties, *propAudience)
+	return idpDTOs
+}
+
+func (suite *ExternalIDPValidatorTestSuite) validateConfiguredAudienceSubjectToken(
+	aud interface{},
+) *SubjectTokenClaims {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": testExternalIssuer,
+		"aud": aud,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	}
+	token := suite.createExternalJWT(claims)
+	idpDTOs := buildExternalIDPDTOsWithAudience()
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, token, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+	return result
+}
+
+func (suite *ExternalIDPValidatorTestSuite) validateRejectedExternalAudience(
+	aud interface{},
+	idpDTOs []providers.IDPDTO,
+) {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": testExternalIssuer,
+		"aud": aud,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	}
+	token := suite.createExternalJWT(claims)
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, token, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(),
+		"external token audience does not contain expected server issuer")
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
 // createExternalJWT creates a signed-looking JWT for an external IDP test.
@@ -2364,29 +2427,27 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Success_ConfiguredAudience() {
+	result := suite.validateConfiguredAudienceSubjectToken(testTrustedTokenAudience)
+	assert.Equal(suite.T(), "ext-user-123", result.Sub)
+}
+
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Success_ServerIssuerAud() {
+	result := suite.validateConfiguredAudienceSubjectToken("https://example.com")
+	assert.Equal(suite.T(), "ext-user-123", result.Sub)
+}
+
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Success_ConfiguredAudienceList() {
+	result := suite.validateConfiguredAudienceSubjectToken([]interface{}{testTrustedTokenAudience, "other-audience"})
+	assert.Equal(suite.T(), "ext-user-123", result.Sub)
+}
+
 func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Error_AudNotServerIssuer() {
-	now := time.Now().Unix()
-	claims := map[string]interface{}{
-		"sub": "ext-user-123",
-		"iss": testExternalIssuer,
-		"aud": "some-client-id",
-		"exp": float64(now + 3600),
-		"nbf": float64(now - 60),
-	}
-	token := suite.createExternalJWT(claims)
-	idpDTOs := buildExternalIDPDTOs()
+	suite.validateRejectedExternalAudience("some-client-id", buildExternalIDPDTOs())
+}
 
-	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
-		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
-	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, token, testExternalJWKS).Return(nil)
-
-	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
-
-	assert.Error(suite.T(), err)
-	assert.Nil(suite.T(), result)
-	assert.Contains(suite.T(), err.Error(), "external token audience does not contain expected server issuer")
-	suite.mockIDPService.AssertExpectations(suite.T())
-	suite.mockJWTService.AssertExpectations(suite.T())
+func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Error_AudNotConfiguredAudience() {
+	suite.validateRejectedExternalAudience("unexpected-client-id", buildExternalIDPDTOsWithAudience())
 }
 
 func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Error_MissingAudClaim() {

--- a/docs/content/guides/guides/identity-providers/add-oidc-provider.mdx
+++ b/docs/content/guides/guides/identity-providers/add-oidc-provider.mdx
@@ -85,6 +85,7 @@ curl -kL -X POST https://localhost:8090/identity-providers \
 | `logout_endpoint` | The provider's end-session endpoint. |
 | `prompt` | The `prompt` parameter to send in authorization requests (for example, `login`, `consent`). |
 | `token_exchange_enabled` | Set to `true` to enable token exchange with this provider. Requires `issuer` and `jwks_endpoint`. |
+| `trusted_token_audience` | The accepted `aud` claim value for tokens from this provider during token exchange. Use this when the provider issues tokens whose audience is the provider client ID or API audience instead of the <ProductName /> issuer. |
 
 ## Attribute Configuration
 
@@ -151,7 +152,8 @@ curl -kL -X POST https://localhost:8090/identity-providers \
       { "name": "jwks_endpoint", "value": "https://<provider>/oauth2/v1/keys", "isSecret": false },
       { "name": "issuer", "value": "https://<provider>", "isSecret": false },
       { "name": "scopes", "value": "openid email profile", "isSecret": false },
-      { "name": "token_exchange_enabled", "value": "true", "isSecret": false }
+      { "name": "token_exchange_enabled", "value": "true", "isSecret": false },
+      { "name": "trusted_token_audience", "value": "<provider-client-id>", "isSecret": false }
     ]
   }'
 ```

--- a/docs/content/guides/guides/identity-providers/token-exchange-idp.mdx
+++ b/docs/content/guides/guides/identity-providers/token-exchange-idp.mdx
@@ -28,13 +28,14 @@ This is different from the [trusted issuer](../../trusted-issuer) feature. Trust
 
 ## Step 1: Register the External Identity Provider
 
-Register the external IdP in <ProductName /> and enable it for token exchange. Only three properties are required for a token-exchange-only IdP:
+Register the external IdP in <ProductName /> and enable it for token exchange. Three properties are required for a token-exchange-only IdP:
 
 | Property | Required | Description |
 |----------|----------|-------------|
 | `issuer` | Yes | The exact `iss` claim value in tokens from this IdP. <ProductName /> matches incoming tokens against this value to identify which IdP issued them. |
 | `jwks_endpoint` | Yes | The IdP's JWKS URL. <ProductName /> fetches public signing keys from this URL to verify token signatures. |
 | `token_exchange_enabled` | Yes | Set to `"true"` to allow this IdP's tokens to be exchanged. |
+| `trusted_token_audience` | No | An additional accepted `aud` claim value for tokens from this IdP. Use this when the external token audience is the external client ID or API audience instead of the <ProductName /> issuer. |
 
 The redirect-flow OIDC properties (`client_secret`, `redirect_uri`, `authorization_endpoint`, `token_endpoint`) are not required unless the same IdP is also used for redirect-based sign-in.
 
@@ -48,7 +49,8 @@ curl -X POST https://thunder.example.com/identity-providers \
     "properties": [
       {"name": "issuer", "value": "https://api.asgardeo.io/t/myorg/oauth2/token"},
       {"name": "jwks_endpoint", "value": "https://api.asgardeo.io/t/myorg/oauth2/jwks"},
-      {"name": "token_exchange_enabled", "value": "true"}
+      {"name": "token_exchange_enabled", "value": "true"},
+      {"name": "trusted_token_audience", "value": "my-external-client-id"}
     ]
   }'
 ```
@@ -107,7 +109,7 @@ When processing an external token for exchange, <ProductName />:
 
 1. Extracts the `iss` claim and matches it against registered IdPs with `token_exchange_enabled=true`.
 2. Fetches the matching IdP's JWKS and verifies the token signature.
-3. Checks that the token's `aud` claim contains this <ProductName /> instance's own issuer.
+3. Checks the token's `aud` claim. <ProductName /> accepts the token when `aud` contains this <ProductName /> instance's own issuer, or when it contains the IdP's configured `trusted_token_audience`.
 4. Validates `exp` (and `nbf` if present) with the configured clock-skew leeway.
 5. Extracts the `sub` claim and non-standard claims as user attributes.
 

--- a/frontend/apps/console/src/features/connections/components/__tests__/ConnectionForm.test.tsx
+++ b/frontend/apps/console/src/features/connections/components/__tests__/ConnectionForm.test.tsx
@@ -26,6 +26,14 @@ vi.mock('react-i18next', () => ({
 }));
 vi.mock('@thunderid/contexts', () => ({useToast: () => ({showToast: vi.fn()})}));
 
+function getConnectionField(id: string): HTMLElement {
+  const field = document.getElementById(`connection-field-${id}`);
+  if (!field) {
+    throw new Error(`Expected connection field ${id} to exist`);
+  }
+  return field;
+}
+
 describe('ConnectionForm', () => {
   const baseProps = {
     type: 'google' as const,
@@ -51,7 +59,7 @@ describe('ConnectionForm', () => {
     expect(screen.getByText('connections:form.fields.clientSecret.hint')).toBeInTheDocument();
     expect(screen.getByText('connections:form.fields.scopes.hint')).toBeInTheDocument();
 
-    fireEvent.blur(screen.getByPlaceholderText('1234567890-abc.apps.googleusercontent.com'));
+    fireEvent.blur(getConnectionField('clientId'));
 
     expect(screen.getByText('connections:validation.required')).toBeInTheDocument();
     expect(screen.queryByText('connections:form.fields.clientId.hint')).not.toBeInTheDocument();
@@ -61,7 +69,7 @@ describe('ConnectionForm', () => {
     const onFieldChange = vi.fn();
     render(<ConnectionForm {...baseProps} onFieldChange={onFieldChange} />);
 
-    fireEvent.change(screen.getByPlaceholderText('1234567890-abc.apps.googleusercontent.com'), {
+    fireEvent.change(getConnectionField('clientId'), {
       target: {value: 'my-client-id'},
     });
 

--- a/frontend/apps/console/src/features/connections/config/connectionFormFields.ts
+++ b/frontend/apps/console/src/features/connections/config/connectionFormFields.ts
@@ -77,6 +77,15 @@ const oauthFields = (namePlaceholder: string, clientIdPlaceholder: string): Conn
   },
 ];
 
+const TRUSTED_TOKEN_AUDIENCE_FIELD: ConnectionFieldDef = {
+  name: 'trustedTokenAudience',
+  labelKey: 'connections:form.fields.trustedTokenAudience.label',
+  hintKey: 'connections:form.fields.trustedTokenAudience.hint',
+  kind: 'text',
+  optional: true,
+  placeholder: 'my-external-client-id',
+};
+
 /**
  * Ordered field definitions per connection type, driving the shared {@link ConnectionForm}
  * and its dynamically-built validation schema.
@@ -155,5 +164,6 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       kind: 'scopes',
       placeholder: 'openid email profile',
     },
+    TRUSTED_TOKEN_AUDIENCE_FIELD,
   ],
 };

--- a/frontend/apps/console/src/features/connections/models/connection.ts
+++ b/frontend/apps/console/src/features/connections/models/connection.ts
@@ -143,6 +143,7 @@ export interface OIDCConnectionRequest extends OAuthConnectionRequest {
   logoutEndpoint?: string;
   issuer?: string;
   tokenExchangeEnabled?: boolean;
+  trustedTokenAudience?: string;
 }
 
 export type ConnectionRequest = OAuthConnectionRequest | OIDCConnectionRequest;

--- a/frontend/apps/console/src/features/connections/utils/__tests__/connectionFormMapping.test.ts
+++ b/frontend/apps/console/src/features/connections/utils/__tests__/connectionFormMapping.test.ts
@@ -78,6 +78,20 @@ describe('formValuesToRequest', () => {
     expect(payload.scopes).toEqual(['openid', 'email']);
   });
 
+  it('includes trusted token audience when configured', () => {
+    const payload = formValuesToRequest(
+      {
+        ...base,
+        authorizationEndpoint: 'https://i/a',
+        tokenEndpoint: 'https://i/t',
+        trustedTokenAudience: 'my-external-client-id',
+      },
+      OIDC_FIELDS,
+      {mode: 'create'},
+    ) as unknown as Record<string, unknown>;
+    expect(payload.trustedTokenAudience).toBe('my-external-client-id');
+  });
+
   it('omits the secret on edit when not replacing (keep stored value)', () => {
     const payload = formValuesToRequest(base, GOOGLE_FIELDS, {
       mode: 'edit',
@@ -123,6 +137,7 @@ describe('formValuesToRequest', () => {
         userInfoEndpoint: '',
         jwksEndpoint: '',
         scopes: '',
+        trustedTokenAudience: '',
       },
       OIDC_FIELDS,
       {mode: 'create'},

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1602,6 +1602,8 @@ const translations = {
     'form.fields.issuer.label': 'Issuer',
     'form.fields.issuer.hint': 'Issuer identifier expected in tokens from this provider.',
     'form.fields.tokenExchangeEnabled.label': 'Enable token exchange',
+    'form.fields.trustedTokenAudience.label': 'Trusted token audience',
+    'form.fields.trustedTokenAudience.hint': 'Accepted audience value for external tokens during token exchange.',
     'form.optional': 'Optional',
     'form.secret.update': 'Update',
     'form.secret.keepHelp': 'Leave unchanged to keep the stored secret.',

--- a/tests/integration/oauth/token/tokenexchange_test.go
+++ b/tests/integration/oauth/token/tokenexchange_test.go
@@ -30,8 +30,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thunder-id/thunderid/tests/integration/testutils"
 	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
 )
 
 const (
@@ -41,6 +41,7 @@ const (
 	tokenExchangeTestUser     = "te_test_user"
 	tokenExchangeTestPassword = "TePassword123!"
 	tokenExchangeTestEmail    = "te_test@example.com"
+	tokenExchangeMockOIDCPort = 8094
 )
 
 type TokenExchangeTestSuite struct {
@@ -389,6 +390,65 @@ type TokenExchangeResponse struct {
 	ErrorDescription string `json:"error_description,omitempty"`
 }
 
+func (ts *TokenExchangeTestSuite) getMockOIDCIDToken(
+	mockOIDCServer *testutils.MockOIDCServer,
+	clientID, clientSecret, redirectURI string,
+) string {
+	ts.T().Helper()
+
+	authURL, err := url.Parse(mockOIDCServer.GetAuthorizeURL())
+	ts.Require().NoError(err, "Failed to parse mock OIDC authorize URL")
+
+	query := authURL.Query()
+	query.Set("client_id", clientID)
+	query.Set("redirect_uri", redirectURI)
+	query.Set("response_type", "code")
+	query.Set("scope", "openid email profile")
+	query.Set("state", "token-exchange-state")
+	authURL.RawQuery = query.Encode()
+
+	noRedirectClient := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	authResp, err := noRedirectClient.Get(authURL.String())
+	ts.Require().NoError(err, "Failed to call mock OIDC authorize endpoint")
+	defer authResp.Body.Close()
+	ts.Require().Equal(http.StatusFound, authResp.StatusCode, "Mock OIDC authorize should redirect with a code")
+
+	location := authResp.Header.Get("Location")
+	ts.Require().NotEmpty(location, "Mock OIDC authorize response should include Location header")
+
+	redirectedURL, err := url.Parse(location)
+	ts.Require().NoError(err, "Failed to parse mock OIDC redirect URL")
+	code := redirectedURL.Query().Get("code")
+	ts.Require().NotEmpty(code, "Mock OIDC redirect should include authorization code")
+
+	formData := url.Values{}
+	formData.Set("grant_type", "authorization_code")
+	formData.Set("code", code)
+	formData.Set("client_id", clientID)
+	formData.Set("client_secret", clientSecret)
+	formData.Set("redirect_uri", redirectURI)
+
+	tokenResp, err := http.PostForm(mockOIDCServer.GetTokenURL(), formData)
+	ts.Require().NoError(err, "Failed to call mock OIDC token endpoint")
+	defer tokenResp.Body.Close()
+	ts.Require().Equal(http.StatusOK, tokenResp.StatusCode, "Mock OIDC token endpoint should return tokens")
+
+	var tokenData map[string]interface{}
+	err = json.NewDecoder(tokenResp.Body).Decode(&tokenData)
+	ts.Require().NoError(err, "Failed to parse mock OIDC token response")
+
+	idToken, ok := tokenData["id_token"].(string)
+	ts.Require().True(ok, "Mock OIDC token response should contain id_token")
+	ts.Require().NotEmpty(idToken, "Mock OIDC id_token should not be empty")
+
+	return idToken
+}
+
 // TestTokenExchange_BasicSuccess tests basic successful token exchange
 func (ts *TokenExchangeTestSuite) TestTokenExchange_BasicSuccess() {
 	formData := url.Values{}
@@ -410,6 +470,81 @@ func (ts *TokenExchangeTestSuite) TestTokenExchange_BasicSuccess() {
 	claims, err := testutils.DecodeJWT(resp.AccessToken)
 	ts.Require().NoError(err, "Access token should be a valid JWT")
 	ts.Equal(ts.userID, claims.Sub, "Subject should match user ID")
+}
+
+func (ts *TokenExchangeTestSuite) TestTokenExchange_ExternalIDP_WithTrustedTokenAudience() {
+	const (
+		externalClientID     = "external-oidc-client-id"
+		externalClientSecret = "mock-oidc-secret"
+		externalSubject      = "external-oidc-subject"
+		redirectURI          = "https://localhost:3000/callback"
+	)
+
+	mockOIDCServer, err := testutils.NewMockOIDCServer(
+		tokenExchangeMockOIDCPort, externalClientID, externalClientSecret)
+	ts.Require().NoError(err, "Failed to create mock OIDC server")
+
+	mockOIDCServer.AddUser(&testutils.OIDCUserInfo{
+		Sub:           externalSubject,
+		Email:         "external-user@example.com",
+		EmailVerified: true,
+		Name:          "External User",
+	})
+
+	err = mockOIDCServer.Start()
+	ts.Require().NoError(err, "Failed to start mock OIDC server")
+	defer func() {
+		if stopErr := mockOIDCServer.Stop(); stopErr != nil {
+			ts.T().Logf("Failed to stop mock OIDC server: %v", stopErr)
+		}
+	}()
+
+	idpID, err := testutils.CreateIDP(testutils.IDP{
+		Name:        fmt.Sprintf("Token Exchange Trusted Audience IdP %d", time.Now().UnixNano()),
+		Description: "Mock OIDC IdP for trusted token audience token exchange test",
+		Type:        "OIDC",
+		Properties: []testutils.IDPProperty{
+			{Name: "issuer", Value: mockOIDCServer.GetURL(), IsSecret: false},
+			{Name: "jwks_endpoint", Value: mockOIDCServer.GetJWKSURL(), IsSecret: false},
+			{Name: "token_exchange_enabled", Value: "true", IsSecret: false},
+			{Name: "trusted_token_audience", Value: externalClientID, IsSecret: false},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create mock OIDC IdP")
+	defer func() {
+		if deleteErr := testutils.DeleteIDP(idpID); deleteErr != nil {
+			ts.T().Logf("Failed to delete mock OIDC IdP: %v", deleteErr)
+		}
+	}()
+
+	externalIDToken := ts.getMockOIDCIDToken(mockOIDCServer, externalClientID, externalClientSecret, redirectURI)
+	externalClaims, err := testutils.DecodeJWT(externalIDToken)
+	ts.Require().NoError(err, "Mock OIDC id_token should be a valid JWT")
+	ts.Equal(mockOIDCServer.GetURL(), externalClaims.Iss, "External token issuer should match IdP issuer")
+	ts.Equal(externalClientID, externalClaims.Aud, "External token audience should be the external client ID")
+
+	formData := url.Values{}
+	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	formData.Set("subject_token", externalIDToken)
+	formData.Set("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
+
+	authHeader := "Basic " + basicAuth(tokenExchangeClientID, tokenExchangeClientSecret)
+
+	resp, statusCode, err := ts.exchangeToken(formData.Encode(), authHeader)
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusOK, statusCode)
+	ts.NotEmpty(resp.AccessToken, "Access token should be present")
+	ts.Equal("urn:ietf:params:oauth:token-type:access_token", resp.IssuedTokenType)
+
+	claims, err := testutils.DecodeJWT(resp.AccessToken)
+	ts.Require().NoError(err, "Access token should be a valid JWT")
+	ts.Equal(externalSubject, claims.Sub, "Issued token subject should match external token subject")
+	ts.assertAudienceContains(claims, tokenExchangeClientID)
+	ts.Equal(
+		"urn:ietf:params:oauth:grant-type:token-exchange",
+		claims.Additional["grant_type"],
+		"Issued token should record token exchange grant type",
+	)
 }
 
 // TestTokenExchange_WithAudience tests token exchange with audience parameter


### PR DESCRIPTION
### Purpose
This PR adds support for configuring trusted token audiences for external identity provider token exchange.

Previously, external subject tokens had to contain the ThunderID issuer in the `aud` claim. Some providers, such as Google, issue ID tokens with the OAuth client ID as the audience. This caused valid external JWTs to fail token exchange with `Invalid subject_token`.

This change introduces `trusted_token_audiences` so administrators can configure accepted external token audiences per IdP. The Console Connections UI also exposes this setting for Google and OIDC connections.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- Added a new IdP property, `trusted_token_audiences`, for OIDC and Google IdPs.
- Updated token exchange validation to:
  - accept any configured trusted audience when `trusted_token_audiences` is set;
  - preserve the existing fallback behavior of requiring the ThunderID issuer in `aud` when no trusted audience is configured.
- Updated the `/connections` backend API to save and return trusted token audiences.
- Added the **Trusted token audiences** field to the Console Connections UI.
- Updated related identity provider documentation with the new property.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/3869

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **trusted token audience** setting for OIDC connections.
  * During token exchange, external tokens are accepted when their `aud` matches the configured trusted value (including `aud` as an array).
  * Automatically enables token exchange when needed based on the trusted audience configuration.

* **Documentation**
  * Updated OIDC and token-exchange guides with the new `trusted_token_audience` property and example payloads.

* **Tests**
  * Expanded unit, handler, validation, and integration coverage for trusted audience mapping and successful token exchange.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->