### PR TITLE
Harden static file serving against path traversal and sanitize docs data-page attribute

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -341,8 +342,16 @@ func createStaticFileHandler(routePrefix, directory string, logger *log.Logger) 
 			}
 		}
 
-		// Get the file path
+		// Assert the resolved path stays within `directory` before touching the filesystem.
 		filePath := path.Join(directory, r.URL.Path)
+		cleanDir := filepath.Clean(directory)
+		if filePath != cleanDir && !strings.HasPrefix(filePath, cleanDir+string(os.PathSeparator)) {
+			logger.Warn(r.Context(), "Rejected request with out-of-bounds path",
+				log.String("requested_path", r.URL.Path),
+				log.String("route_prefix", routePrefix))
+			http.NotFound(w, r)
+			return
+		}
 
 		// Check if the requested file is index.html
 		isIndexHTML := r.URL.Path == "/index.html" || path.Base(filePath) == "index.html"

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -278,6 +278,19 @@ func TestCreateStaticFileHandler(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.Equal(t, string(indexContent), rr.Body.String())
 	})
+
+	t.Run("rejects path escaping the served directory", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/app/placeholder", nil)
+		// Set an out-of-bounds path directly to exercise the containment check,
+		// bypassing the ServeMux normalization that would run in production.
+		req.URL.Path = "/app/../../../../etc/passwd"
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+		assert.NotContains(t, rr.Body.String(), "root:")
+	})
 }
 
 func TestCreateStaticFileHandler_CacheHeaders(t *testing.T) {

--- a/docs/src/theme/Root.tsx
+++ b/docs/src/theme/Root.tsx
@@ -45,7 +45,12 @@ export default function Root({children = null}: PropsWithChildren<Record<string,
       ? 'home'
       : pathname.replace(/\//g, '-').replace(/^-|-$/g, '') || 'home';
 
-    html.setAttribute('data-page', pagePath);
+    // Allowlist the derived value to safe attribute characters. setAttribute writes an
+    // attribute value (not markup) and does not execute HTML, but this makes the safety
+    // explicit and clears the DOM-XSS finding for this sink.
+    const safePagePath = pagePath.replace(/[^a-z0-9-]/gi, '') || 'home';
+
+    html.setAttribute('data-page', safePagePath);
   }, [location.pathname, baseUrl]);
 
   // Restore persona selection from localStorage before first paint.


### PR DESCRIPTION
### Purpose

Adds explicit input validation in two request-handling paths:

1. The static file handler at `backend/cmd/server/main.go` now verifies that a resolved file path stays within the served directory before touching the filesystem.
2. The docs theme at `docs/src/theme/Root.tsx` now normalizes the derived `data-page` value to a known-safe character set before applying it.

These make existing implicit guarantees explicit and more robust.

### Approach

- Static file handler: after joining the request path onto the served directory, assert containment. If the resolved path is not the served directory itself and does not sit under `directory` + path separator, respond with 404 before any `os.Stat` or `http.ServeFile` call.
- Docs theme: restrict the derived `data-page` value to `[a-z0-9-]` before writing it, falling back to `home` when the result is empty.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security for static file serving by blocking directory traversal attempts.
  - Prevented unauthorized access to files outside the application’s designated content directory.
  - Sanitized page identifiers used in the documentation interface and provided a safe fallback for invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->