### PR TITLE
Fix user credentials handling in UpdateUser method and update tests

### DIFF
--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -557,7 +557,7 @@ func (us *userService) UpdateUser(
 	// hashing, merging with existing credentials, and entity update.
 	e := userToEntity(user)
 	e.SystemAttributes = existingEntity.SystemAttributes
-	_, err = us.entityService.UpdateEntity(ctx, userID, e)
+	updated, err := us.entityService.UpdateEntity(ctx, userID, e)
 	if err != nil {
 		if svcErr := mapEntityError(err); svcErr != nil {
 			return nil, svcErr
@@ -566,6 +566,8 @@ func (us *userService) UpdateUser(
 			log.MaskedString(log.LoggerKeyUserID, userID))
 	}
 
+	// Sync cleaned attributes back — entity service removed credential fields from Attributes.
+	user.Attributes = updated.Attributes
 	logger.Debug(ctx, "Successfully updated user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return user, nil
 }

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -915,7 +915,10 @@ func TestUserService_UpdateUser(t *testing.T) {
 	// Mock UpdateEntity call
 	storeMock.On("UpdateEntity", mock.Anything, userID, mock.MatchedBy(func(e *providers.Entity) bool {
 		return e.ID == userID
-	})).Return((*providers.Entity)(nil), nil).Once()
+	})).Return(&providers.Entity{
+		ID:         userID,
+		Attributes: updatedUser.Attributes,
+	}, nil).Once()
 
 	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
@@ -940,6 +943,8 @@ func TestUserService_UpdateUser(t *testing.T) {
 	storeMock.AssertNumberOfCalls(t, "UpdateEntity", 1)
 }
 
+// TestUserService_UpdateUser_WithCredentials tests that UpdateUser passes credentials in
+// attributes through to the entity service without leaking them.
 func TestUserService_UpdateUser_WithCredentials(t *testing.T) {
 	userID := svcTestUserID1
 
@@ -971,7 +976,10 @@ func TestUserService_UpdateUser_WithCredentials(t *testing.T) {
 	// Mock UpdateEntity - entity service handles credential extraction internally
 	storeMock.On("UpdateEntity", mock.Anything, userID, mock.MatchedBy(func(e *providers.Entity) bool {
 		return e.ID == userID
-	})).Return((*providers.Entity)(nil), nil).Once()
+	})).Return(&providers.Entity{
+		ID:         userID,
+		Attributes: json.RawMessage(`{"email":"test@example.com"}`), // password is removed
+	}, nil).Once()
 
 	service := &userService{
 		entityService:     storeMock,
@@ -986,6 +994,8 @@ func TestUserService_UpdateUser_WithCredentials(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, userID, resp.ID)
+	require.JSONEq(t, `{"email":"test@example.com"}`, string(resp.Attributes))
+	require.NotContains(t, string(resp.Attributes), "password")
 
 	// Verify all expected calls were made
 	storeMock.AssertExpectations(t)
@@ -1078,7 +1088,10 @@ func TestUserService_UpdateUser_ErrorPaths(t *testing.T) {
 						Type:     testUserType,
 					}, nil).Once()
 				storeMock.On("UpdateEntity", mock.Anything, userID, mock.Anything).
-					Return((*providers.Entity)(nil), nil).Once()
+					Return(&providers.Entity{
+						ID:         userID,
+						Attributes: json.RawMessage(`{"email":"updated@example.com"}`),
+					}, nil).Once()
 			},
 			expectedError: nil,
 		},
@@ -1348,7 +1361,10 @@ func TestUserService_UpdateUser_AuthzBranches(t *testing.T) {
 					Return(&entitytype.EntityType{OUID: existingOU},
 						(*tidcommon.ServiceError)(nil)).Maybe()
 				storeMock.On("UpdateEntity", mock.Anything, userID, mock.Anything).
-					Return((*providers.Entity)(nil), nil).Maybe()
+					Return(&providers.Entity{
+						ID:         userID,
+						Attributes: json.RawMessage(`{"email":"test@example.com"}`),
+					}, nil).Maybe()
 			}
 
 			if tt.setupExtraMocks != nil {
@@ -1386,6 +1402,8 @@ func TestUserService_UpdateUser_AuthzBranches(t *testing.T) {
 	}
 }
 
+// TestUserService_UpdateUser_PreservesMultipleCredentials verifies that UpdateUser correctly
+// processes multiple credentials while preserving existing attributes and not leaking passwords.
 func TestUserService_UpdateUser_PreservesMultipleCredentials(t *testing.T) {
 	ctx := context.Background()
 	userID := svcTestUserID123
@@ -1433,7 +1451,15 @@ func TestUserService_UpdateUser_PreservesMultipleCredentials(t *testing.T) {
 	// Mock UpdateEntity — entity service handles credential extraction, hashing, and merging internally
 	storeMock.On("UpdateEntity", mock.Anything, userID, mock.MatchedBy(func(e *providers.Entity) bool {
 		return e.ID == userID
-	})).Return((*providers.Entity)(nil), nil).Once()
+	})).Return(&providers.Entity{
+		ID: userID,
+		Attributes: json.RawMessage(`{
+			"username": "john.doe",
+			"email": "john.updated@example.com",
+			"given_name": "John",
+			"family_name": "Doe"
+		}`), // password is removed
+	}, nil).Once()
 
 	// Create service
 	service := &userService{
@@ -1450,6 +1476,13 @@ func TestUserService_UpdateUser_PreservesMultipleCredentials(t *testing.T) {
 	require.Nil(t, svcErr)
 	require.NotNil(t, result)
 	require.Equal(t, userID, result.ID)
+	require.JSONEq(t, `{
+		"username": "john.doe",
+		"email": "john.updated@example.com",
+		"given_name": "John",
+		"family_name": "Doe"
+	}`, string(result.Attributes))
+	require.NotContains(t, string(result.Attributes), "password")
 
 	// Verify all mocks were called
 	storeMock.AssertExpectations(t)


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

The native REST API PUT method for users/<id> exposes credentials in the response if it was provided in the request. This PR fixes removes these fields from the response data.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

No

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

The Entity service, which is used internally to update the user, strips credentials by default. But the response is using the userData from the request rather than the output from the Entity service. This changes the response data to use the output from the Entity Service, which has credential fields stripped.

### Related Issues
- Fixes #3806 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated user profiles now return cleaned attributes after a successful update.
  * Credential fields (such as passwords) are no longer included in returned user attributes.
  * Improved consistency when updating users with multiple credentials, ensuring returned attributes match the expected merged/cleaned state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->