### PR TITLE
Omit query parameters from access logs

### DIFF
--- a/backend/internal/system/log/accesslog.go
+++ b/backend/internal/system/log/accesslog.go
@@ -55,7 +55,7 @@ func AccessLogHandler(logger *Logger, next http.Handler) http.Handler {
 			host,
 			start.Format("02/Jan/2006:15:04:05 -0700"),
 			r.Method,
-			r.RequestURI,
+			r.URL.Path,
 			r.Proto,
 			lrw.statusCode,
 			lrw.size,

--- a/backend/internal/system/log/accesslog_test.go
+++ b/backend/internal/system/log/accesslog_test.go
@@ -62,7 +62,7 @@ func (suite *AccessLogTestSuite) TestAccessLogHandler() {
 
 	handler := AccessLogHandler(log, testHandler)
 
-	req := httptest.NewRequest("GET", "/test", nil)
+	req := httptest.NewRequest("GET", "/test?include=display&token=secret", nil)
 	req.RemoteAddr = "192.168.1.1:12345"
 
 	rr := httptest.NewRecorder()
@@ -78,6 +78,9 @@ func (suite *AccessLogTestSuite) TestAccessLogHandler() {
 	assert.Contains(suite.T(), output, "192.168.1.1")
 	assert.Contains(suite.T(), output, "GET /test")
 	assert.Contains(suite.T(), output, "200")
+	// Verify that query parameters are not written to the access log
+	assert.NotContains(suite.T(), output, "include=display")
+	assert.NotContains(suite.T(), output, "token=secret")
 	// Verify that escape characters are not present in the log output
 	assert.NotContains(suite.T(), output, `\"`)
 }


### PR DESCRIPTION
### Purpose
The access log handler logged the full request URI including query parameters via `r.RequestURI`, so query strings were written to access logs. Query strings can carry sensitive or PII data (filters, identifiers, tokens passed as query params) and should not be persisted in access logs.

```
time=2026-07-10T10:34:33.200+05:30 level=INFO msg="127.0.0.1 - - [10/Jul/2026:10:34:33 +0530] GET /users?include=display&access_token=TOKEN HTTP/1.1 401 223 0 c6c90255-653f-483e-a365-eb990ce0796e" trace_id=c6c90255-653f-483e-a365-eb990ce0796e
```

```
time=2026-07-10T10:36:02.722+05:30 level=INFO msg="127.0.0.1 - - [10/Jul/2026:10:36:02 +0530] GET /users HTTP/1.1 401 223 0 9fecf032-1819-4f08-93f6-1b71499e38e3" trace_id=9fecf032-1819-4f08-93f6-1b71499e38e3
```

### Approach
Log `r.URL.Path` instead of `r.RequestURI` in `AccessLogHandler` so only the request path is recorded and the query string is dropped. 
This also aligns the handler with the rest of the backend, which consistently uses `r.URL.Path` for request-path logging and routing. 
The existing unit test now issues a request with query parameters (`?include=display&token=secret`) and asserts they do not appear in the log output.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/3788

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access log privacy by recording only the request path, excluding query parameters that may contain sensitive information.
  * Preserved existing logging details, including response status, size, timing, protocol, host, and correlation ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->