### PR TITLE
Add Identity Assertion Authorization Grant (ID-JAG) support

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -1267,6 +1267,37 @@ components:
           description: The validity period of the refresh token in seconds. If not specified, falls back to application-level or deployment default.
           example: 86400
 
+    IDJAGConfig:
+      type: object
+      description: |
+        Identity Assertion Authorization Grant (ID-JAG) configuration for OAuth applications
+        (draft-ietf-oauth-identity-assertion-authz-grant). Governs whether this application may
+        exchange a self-issued ID token for an ID-JAG targeted at an external resource
+        authorization server, via the token endpoint's token-exchange grant with
+        requested_token_type=urn:ietf:params:oauth:token-type:id-jag.
+      properties:
+        enabled:
+          type: boolean
+          description: >-
+            Enable ID-JAG issuance for this application. Requires a confidential client
+            (tokenEndpointAuthMethod other than "none") and at least one entry in
+            allowedAudiences.
+          example: true
+          default: false
+        allowedAudiences:
+          type: array
+          items:
+            type: string
+          description: |
+            Resource authorization server identifiers this application may request ID-JAGs for.
+            The audience parameter on the token-exchange request must exactly match one of
+            these values.
+          example: ["https://api.partner.example.com"]
+        validityPeriod:
+          type: integer
+          description: The validity period of an issued ID-JAG in seconds. Defaults to 300 if not specified.
+          example: 300
+          default: 300
 
     UserInfoConfig:
       type: object
@@ -1373,8 +1404,13 @@ components:
           type: array
           items:
             type: string
-            enum: ["authorization_code", "client_credentials", "refresh_token", "implicit", "password", "urn:ietf:params:oauth:grant-type:token-exchange"]
-          description: A list of grant types supported by the OAuth application. Defaults to ["authorization_code"] if not specified.
+            enum: ["authorization_code", "client_credentials", "refresh_token", "implicit", "password", "urn:ietf:params:oauth:grant-type:token-exchange", "urn:ietf:params:oauth:grant-type:jwt-bearer"]
+          description: >-
+            A list of grant types supported by the OAuth application. Defaults to
+            ["authorization_code"] if not specified. The
+            urn:ietf:params:oauth:grant-type:jwt-bearer grant, used to present an ID-JAG assertion
+            issued by a trusted external IdP (draft-ietf-oauth-identity-assertion-authz-grant),
+            requires a confidential client (tokenEndpointAuthMethod other than "none").
           example: ["authorization_code", "refresh_token"]
         responseTypes:
           type: array
@@ -1430,6 +1466,8 @@ components:
               $ref: '#/components/schemas/IDTokenConfig'
             refreshToken:
               $ref: '#/components/schemas/RefreshTokenConfig'
+            idJag:
+              $ref: '#/components/schemas/IDJAGConfig'
         userInfo:
           $ref: '#/components/schemas/UserInfoConfig'
         scopeClaims:
@@ -1479,8 +1517,13 @@ components:
           type: array
           items:
             type: string
-            enum: ["authorization_code", "client_credentials", "refresh_token", "implicit", "password", "urn:ietf:params:oauth:grant-type:token-exchange"]
-          description: A list of grant types supported by the OAuth application. Defaults to ["authorization_code"] if not specified.
+            enum: ["authorization_code", "client_credentials", "refresh_token", "implicit", "password", "urn:ietf:params:oauth:grant-type:token-exchange", "urn:ietf:params:oauth:grant-type:jwt-bearer"]
+          description: >-
+            A list of grant types supported by the OAuth application. Defaults to
+            ["authorization_code"] if not specified. The
+            urn:ietf:params:oauth:grant-type:jwt-bearer grant, used to present an ID-JAG assertion
+            issued by a trusted external IdP (draft-ietf-oauth-identity-assertion-authz-grant),
+            requires a confidential client (tokenEndpointAuthMethod other than "none").
           example: ["authorization_code", "refresh_token"]
         responseTypes:
           type: array
@@ -1536,6 +1579,8 @@ components:
               $ref: '#/components/schemas/IDTokenConfig'
             refreshToken:
               $ref: '#/components/schemas/RefreshTokenConfig'
+            idJag:
+              $ref: '#/components/schemas/IDJAGConfig'
         userInfo:
           $ref: '#/components/schemas/UserInfoConfig'
         scopeClaims:

--- a/api/connections.yaml
+++ b/api/connections.yaml
@@ -612,6 +612,7 @@ components:
         scopes: { type: array, items: { type: string } }
         prompt: { type: string }
         tokenExchangeEnabled: { type: boolean }
+        idJagEnabled: { type: boolean, description: "Enable ID-JAG issuance for this identity provider (draft-ietf-oauth-identity-assertion-authz-grant), so that self-issued ID tokens naming it as issuer can be trusted for the jwt-bearer grant. Requires issuer and jwksEndpoint to be set." }
         attributeConfiguration: { $ref: '#/components/schemas/AttributeConfiguration' }
     OIDCConnectionCreateRequest:
       allOf:
@@ -637,6 +638,7 @@ components:
         scopes: { type: array, items: { type: string } }
         prompt: { type: string }
         tokenExchangeEnabled: { type: boolean }
+        idJagEnabled: { type: boolean, description: "Enable ID-JAG issuance for this identity provider (draft-ietf-oauth-identity-assertion-authz-grant), so that self-issued ID tokens naming it as issuer can be trusted for the jwt-bearer grant. Requires issuer and jwksEndpoint to be set." }
         attributeConfiguration: { $ref: '#/components/schemas/AttributeConfiguration' }
 
     AttributeConfiguration:

--- a/api/discovery.yaml
+++ b/api/discovery.yaml
@@ -56,6 +56,7 @@ paths:
                   - authorization_code
                   - client_credentials
                   - refresh_token
+                  - urn:ietf:params:oauth:grant-type:jwt-bearer
                 token_endpoint_auth_methods_supported:
                   - client_secret_basic
                   - client_secret_post
@@ -99,6 +100,7 @@ paths:
                   - authorization_code
                   - client_credentials
                   - refresh_token
+                  - urn:ietf:params:oauth:grant-type:jwt-bearer
                 token_endpoint_auth_methods_supported:
                   - client_secret_basic
                   - client_secret_post

--- a/api/oauth2.yaml
+++ b/api/oauth2.yaml
@@ -189,8 +189,26 @@ paths:
       description: |
         Issues access tokens, refresh tokens, and ID tokens. Supports the following grant types:
         `authorization_code`, `client_credentials`, `refresh_token`, `password`,
-        `urn:ietf:params:oauth:grant-type:token-exchange` (RFC 8693).
+        `urn:ietf:params:oauth:grant-type:token-exchange` (RFC 8693), and
+        `urn:ietf:params:oauth:grant-type:jwt-bearer` (draft-ietf-oauth-identity-assertion-authz-grant).
         Requires client authentication via HTTP Basic auth or `client_id`/`client_secret` form parameters.
+
+        Token exchange additionally supports requesting an Identity Assertion Authorization Grant
+        (ID-JAG) by setting `requested_token_type` to
+        `urn:ietf:params:oauth:token-type:id-jag`, with `subject_token_type` set to
+        `urn:ietf:params:oauth:token-type:id_token` and a single required `audience` value matching
+        one of the client's configured `allowedAudiences`. The `resource` parameter is optional and,
+        when present, is embedded in the issued ID-JAG for the resource authorization server to
+        process. Requires the client to be confidential and to have ID-JAG issuance enabled
+        (`token.idJag.enabled`) on its application configuration. The response has
+        `issued_token_type=urn:ietf:params:oauth:token-type:id-jag` and `token_type=N_A`, since the
+        issued value is a JWT authorization grant rather than an access token.
+
+        The `urn:ietf:params:oauth:grant-type:jwt-bearer` grant presents an ID-JAG assertion (obtained
+        from a trusted external IdP) via the required `assertion` parameter, and exchanges it for a
+        ThunderID access token. Optional `scope` and `resource` parameters further narrow the granted
+        scopes and audience; `resource` must be a subset of the assertion's own `resource` claim when
+        the assertion carries one. No refresh token is issued for this grant.
       tags:
         - Token
       requestBody:
@@ -559,6 +577,7 @@ components:
             - refresh_token
             - password
             - urn:ietf:params:oauth:grant-type:token-exchange
+            - urn:ietf:params:oauth:grant-type:jwt-bearer
           description: The OAuth 2.0 grant type.
         client_id:
           type: string
@@ -601,13 +620,29 @@ components:
           description: The type URI of the actor token.
         requested_token_type:
           type: string
-          description: The desired type of the issued token.
+          description: >-
+            The desired type of the issued token (token exchange only). Set to
+            `urn:ietf:params:oauth:token-type:id-jag` to request an Identity Assertion Authorization
+            Grant instead of an access token; this requires `subject_token_type` to be
+            `urn:ietf:params:oauth:token-type:id_token` and exactly one `audience` value.
         audience:
           type: string
-          description: Target audience for the issued token. May be repeated.
+          description: >-
+            Target audience for the issued token. May be repeated for token exchange. Required, and
+            limited to exactly one value, when requesting an ID-JAG
+            (`requested_token_type=urn:ietf:params:oauth:token-type:id-jag`); the value must match one
+            of the client's configured `allowedAudiences`.
         resource:
           type: string
-          description: Resource indicator (RFC 8707). May be repeated.
+          description: >-
+            Resource indicator (RFC 8707). May be repeated. Optional for ID-JAG requests, where it is
+            embedded in the issued ID-JAG's `resource` claim. For the jwt-bearer grant, when present it
+            must be a subset of the assertion's own `resource` claim.
+        assertion:
+          type: string
+          description: >-
+            ID-JAG assertion JWT issued by a trusted external IdP (draft-ietf-oauth-identity-assertion-authz-grant).
+            Required for the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant.
 
     TokenResponse:
       type: object

--- a/backend/internal/connection/oidc.go
+++ b/backend/internal/connection/oidc.go
@@ -43,6 +43,7 @@ type oidcConnectionRequest struct {
 	Prompt                string   `json:"prompt,omitempty"`
 	TokenExchangeEnabled  *bool    `json:"tokenExchangeEnabled,omitempty"`
 	TrustedTokenAudience  string   `json:"trustedTokenAudience,omitempty"`
+	IDJagEnabled          *bool    `json:"idJagEnabled,omitempty"`
 
 	AttributeConfiguration *providers.AttributeConfiguration `json:"attributeConfiguration,omitempty"`
 }
@@ -66,6 +67,7 @@ type oidcConnectionResponse struct {
 	Prompt                string   `json:"prompt,omitempty"`
 	TokenExchangeEnabled  *bool    `json:"tokenExchangeEnabled,omitempty"`
 	TrustedTokenAudience  string   `json:"trustedTokenAudience,omitempty"`
+	IDJagEnabled          *bool    `json:"idJagEnabled,omitempty"`
 
 	AttributeConfiguration *providers.AttributeConfiguration `json:"attributeConfiguration,omitempty"`
 }
@@ -103,6 +105,13 @@ func oidcToIDPDTO(req oidcConnectionRequest) (*providers.IDPDTO, error) {
 			value    string
 			isSecret bool
 		}{idp.PropTokenExchangeEnabled, "true", false})
+	}
+	if req.IDJagEnabled != nil {
+		fields = append(fields, struct {
+			name     string
+			value    string
+			isSecret bool
+		}{idp.PropIDJagEnabled, strconv.FormatBool(*req.IDJagEnabled), false})
 	}
 	for _, field := range fields {
 		if props, err = appendProperty(props, field.name, field.value, field.isSecret); err != nil {
@@ -144,6 +153,11 @@ func oidcFromIDPDTO(dto providers.IDPDTO) (oidcConnectionResponse, error) {
 	if raw, ok := values[idp.PropTokenExchangeEnabled]; ok {
 		if enabled, parseErr := strconv.ParseBool(raw); parseErr == nil {
 			resp.TokenExchangeEnabled = &enabled
+		}
+	}
+	if raw, ok := values[idp.PropIDJagEnabled]; ok {
+		if enabled, parseErr := strconv.ParseBool(raw); parseErr == nil {
+			resp.IDJagEnabled = &enabled
 		}
 	}
 	resp.AttributeConfiguration = dto.AttributeConfiguration

--- a/backend/internal/connection/oidc_test.go
+++ b/backend/internal/connection/oidc_test.go
@@ -81,6 +81,20 @@ func (s *OIDCTestSuite) TestToIDPDTOEnablesTokenExchangeWithTrustedAudience() {
 	s.Equal("okta-client-id", values[idp.PropTrustedTokenAudience])
 }
 
+func (s *OIDCTestSuite) TestToIDPDTOMapsIDJagEnabled() {
+	dto, err := oidcToIDPDTO(oidcConnectionRequest{
+		Name: "Okta", ClientID: "c", ClientSecret: "s", RedirectURI: "https://app/cb",
+		AuthorizationEndpoint: "https://okta/auth", TokenEndpoint: "https://okta/token",
+		Issuer: "https://okta", JwksEndpoint: "https://okta/keys",
+		IDJagEnabled: boolPtr(true),
+	})
+	s.Require().NoError(err)
+
+	values, err := propertyValues(dto.Properties)
+	s.Require().NoError(err)
+	s.Equal("true", values[idp.PropIDJagEnabled])
+}
+
 func (s *OIDCTestSuite) TestAttributeConfigurationRoundTrips() {
 	attrCfg := &providers.AttributeConfiguration{
 		UserTypeResolution: &providers.UserTypeResolution{Default: "Person"},
@@ -132,6 +146,29 @@ func (s *OIDCTestSuite) TestGetParsesTokenExchangeAndMasks() {
 	s.Require().NotNil(resp.TokenExchangeEnabled)
 	s.True(*resp.TokenExchangeEnabled)
 	s.Equal("okta-client-id", resp.TrustedTokenAudience)
+}
+
+func (s *OIDCTestSuite) TestGetParsesIDJagEnabled() {
+	s.mockIDP.On("GetIdentityProvider", mock.Anything, "o-2").
+		Return(&providers.IDPDTO{
+			ID:   "o-2",
+			Name: "External",
+			Type: providers.IDPTypeOIDC,
+			Properties: []cmodels.Property{
+				mustProperty(s.T(), idp.PropIDJagEnabled, "true", false),
+			},
+		}, (*tidcommon.ServiceError)(nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/connections/oidc/o-2", nil)
+	req.SetPathValue("id", "o-2")
+	rr := httptest.NewRecorder()
+	getHandler(s.handler, providers.IDPTypeOIDC, oidcFromIDPDTO)(rr, req)
+
+	s.Equal(http.StatusOK, rr.Code)
+	var resp oidcConnectionResponse
+	s.Require().NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	s.Require().NotNil(resp.IDJagEnabled)
+	s.True(*resp.IDJagEnabled)
 }
 
 func (s *OIDCTestSuite) TestUpdateAndDelete() {

--- a/backend/internal/idp/constants.go
+++ b/backend/internal/idp/constants.go
@@ -36,6 +36,7 @@ const (
 	PropIssuer                = "issuer"
 	PropTokenExchangeEnabled  = "token_exchange_enabled"
 	PropTrustedTokenAudience  = "trusted_token_audience"
+	PropIDJagEnabled          = "id_jag_enabled"
 )
 
 // Known endpoints for Google OAuth2/OIDC.
@@ -97,6 +98,7 @@ var idpPropertyConfigs = map[providers.IDPType]idpPropertyConfig{
 			PropIssuer,
 			PropTokenExchangeEnabled,
 			PropTrustedTokenAudience,
+			PropIDJagEnabled,
 		},
 		Defaults: map[string]string{},
 	},

--- a/backend/internal/inboundclient/error_constants.go
+++ b/backend/internal/inboundclient/error_constants.go
@@ -104,6 +104,12 @@ var (
 	ErrOAuthNoneAuthCannotHaveCertOrSecret = errors.New("none auth method cannot have certificate or secret")
 	// ErrOAuthClientCredentialsCannotUseNoneAuth is returned when client_credentials uses none auth method.
 	ErrOAuthClientCredentialsCannotUseNoneAuth = errors.New("client_credentials cannot use none auth method")
+	// ErrOAuthClientJWTBearerCannotUseNoneAuth is returned when the jwt-bearer grant uses none auth method.
+	// The jwt-bearer (ID-JAG) grant relies on client_id binding and requires a confidential client.
+	ErrOAuthClientJWTBearerCannotUseNoneAuth = errors.New("jwt-bearer grant cannot use none auth method")
+	// ErrOAuthClientIDJAGCannotUseNoneAuth is returned when an ID-JAG configuration uses none auth method.
+	// Requesting ID-JAGs requires a confidential client.
+	ErrOAuthClientIDJAGCannotUseNoneAuth = errors.New("ID-JAG configuration cannot use none auth method")
 	// ErrOAuthPublicClientMustUseNoneAuth is returned when a public client uses an auth method other than none.
 	ErrOAuthPublicClientMustUseNoneAuth = errors.New("public client must use none auth method")
 	// ErrOAuthPublicClientMustHavePKCE is returned when a public client does not have PKCE required.

--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -933,6 +933,15 @@ func validateTokenEndpointAuthMethod(p *providers.OAuthProfile, hasClientSecret 
 		if slices.Contains(p.GrantTypes, string(providers.GrantTypeClientCredentials)) {
 			return ErrOAuthClientCredentialsCannotUseNoneAuth
 		}
+		// The jwt-bearer (ID-JAG) grant is bound to the client via client_id only, so it requires a
+		// confidential client.
+		if slices.Contains(p.GrantTypes, string(providers.GrantTypeJWTBearer)) {
+			return ErrOAuthClientJWTBearerCannotUseNoneAuth
+		}
+		// Requesting ID-JAGs is likewise restricted to confidential clients.
+		if p.Token != nil && p.Token.IDJAG != nil && p.Token.IDJAG.Enabled {
+			return ErrOAuthClientIDJAGCannotUseNoneAuth
+		}
 	}
 	return nil
 }
@@ -1190,6 +1199,7 @@ func applyInboundDefaults(c *inboundmodel.InboundClient, oauthProfile *providers
 		AccessToken:  accessToken,
 		IDToken:      idToken,
 		RefreshToken: refreshToken,
+		IDJAG:        resolveIDJAG(oauthProfile.Token),
 	}
 	oauthProfile.UserInfo = resolveUserInfo(oauthProfile.UserInfo, idToken)
 	oauthProfile.ScopeClaims = resolveScopeClaims(oauthProfile.ScopeClaims)
@@ -1317,6 +1327,23 @@ func resolveUserAccessTokenSubConfig(
 		}
 	}
 	return userConfig
+}
+
+// resolveIDJAG resolves the ID-JAG config, defaulting the validity period when unset. Returns nil when
+// the application has no ID-JAG block configured, which disables ID-JAG issuance for the application.
+func resolveIDJAG(in *providers.OAuthTokenConfig) *providers.IDJAGConfig {
+	if in == nil || in.IDJAG == nil {
+		return nil
+	}
+	validityPeriod := in.IDJAG.ValidityPeriod
+	if validityPeriod <= 0 {
+		validityPeriod = providers.DefaultIDJAGValidityPeriod
+	}
+	return &providers.IDJAGConfig{
+		Enabled:          in.IDJAG.Enabled,
+		AllowedAudiences: in.IDJAG.AllowedAudiences,
+		ValidityPeriod:   validityPeriod,
+	}
 }
 
 // resolveUserInfo resolves user info config, defaulting user attributes to the ID token config.

--- a/backend/internal/inboundclient/service_test.go
+++ b/backend/internal/inboundclient/service_test.go
@@ -671,6 +671,28 @@ func (suite *InboundClientServiceTestSuite) TestValidateTokenEndpointAuthMethod_
 	assert.ErrorIs(suite.T(), err, ErrOAuthClientCredentialsCannotUseNoneAuth)
 }
 
+func (suite *InboundClientServiceTestSuite) TestValidateTokenEndpointAuthMethod_NoneJWTBearerRejected() {
+	p := &providers.OAuthProfile{
+		TokenEndpointAuthMethod: "none",
+		PublicClient:            true,
+		GrantTypes:              []string{string(providers.GrantTypeJWTBearer)},
+	}
+	err := validateTokenEndpointAuthMethod(p, false)
+	assert.ErrorIs(suite.T(), err, ErrOAuthClientJWTBearerCannotUseNoneAuth)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateTokenEndpointAuthMethod_NoneIDJAGConfigRejected() {
+	p := &providers.OAuthProfile{
+		TokenEndpointAuthMethod: "none",
+		PublicClient:            true,
+		Token: &providers.OAuthTokenConfig{
+			IDJAG: &providers.IDJAGConfig{Enabled: true},
+		},
+	}
+	err := validateTokenEndpointAuthMethod(p, false)
+	assert.ErrorIs(suite.T(), err, ErrOAuthClientIDJAGCannotUseNoneAuth)
+}
+
 // validateUserInfoConfig — happy paths
 
 func (suite *InboundClientServiceTestSuite) TestValidateUserInfoConfig_NilUserInfo() {
@@ -1093,6 +1115,55 @@ func (suite *InboundClientServiceTestSuite) TestResolveAssertion_InputOverridesD
 		&inboundmodel.AssertionConfig{ValidityPeriod: 600},
 	)
 	assert.Equal(suite.T(), int64(1200), out.ValidityPeriod)
+}
+
+// ----- resolveIDJAG -----
+
+func (suite *InboundClientServiceTestSuite) TestResolveIDJAG_NilReturnsNil() {
+	assert.Nil(suite.T(), resolveIDJAG(nil))
+	assert.Nil(suite.T(), resolveIDJAG(&providers.OAuthTokenConfig{}))
+}
+
+func (suite *InboundClientServiceTestSuite) TestResolveIDJAG_NegativeValidityDefaults() {
+	out := resolveIDJAG(&providers.OAuthTokenConfig{
+		IDJAG: &providers.IDJAGConfig{
+			Enabled:          true,
+			AllowedAudiences: []string{"https://rs.example.com"},
+			ValidityPeriod:   -5,
+		},
+	})
+	assert.NotNil(suite.T(), out)
+	assert.True(suite.T(), out.Enabled)
+	assert.Equal(suite.T(), providers.DefaultIDJAGValidityPeriod, out.ValidityPeriod)
+	assert.Equal(suite.T(), []string{"https://rs.example.com"}, out.AllowedAudiences)
+}
+
+func (suite *InboundClientServiceTestSuite) TestResolveIDJAG_ZeroValidityDefaults() {
+	out := resolveIDJAG(&providers.OAuthTokenConfig{
+		IDJAG: &providers.IDJAGConfig{ValidityPeriod: 0},
+	})
+	assert.NotNil(suite.T(), out)
+	assert.Equal(suite.T(), providers.DefaultIDJAGValidityPeriod, out.ValidityPeriod)
+}
+
+func (suite *InboundClientServiceTestSuite) TestResolveIDJAG_PositiveValidityPreserved() {
+	out := resolveIDJAG(&providers.OAuthTokenConfig{
+		IDJAG: &providers.IDJAGConfig{ValidityPeriod: 900},
+	})
+	assert.NotNil(suite.T(), out)
+	assert.Equal(suite.T(), int64(900), out.ValidityPeriod)
+}
+
+func (suite *InboundClientServiceTestSuite) TestResolveIDJAG_PropagatesEnabled() {
+	out := resolveIDJAG(&providers.OAuthTokenConfig{
+		IDJAG: &providers.IDJAGConfig{
+			Enabled:          true,
+			AllowedAudiences: []string{"https://rs.example.com"},
+		},
+	})
+	assert.NotNil(suite.T(), out)
+	assert.True(suite.T(), out.Enabled)
+	assert.Equal(suite.T(), []string{"https://rs.example.com"}, out.AllowedAudiences)
 }
 
 // ----- resolveOAuthTokens -----

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -101,7 +101,7 @@ func (ah *authorizeHandler) HandleAuthCallbackPostRequest(w http.ResponseWriter,
 	switch oAuthMessage.RequestType {
 	case oauth2const.TypeAuthorizationResponseFromEngine:
 		authID := oAuthMessage.AuthID
-		assertion := oAuthMessage.RequestBodyParams[oauth2const.Assertion]
+		assertion := oAuthMessage.RequestBodyParams[oauth2const.RequestParamAssertion]
 
 		redirectURI, authErr := ah.authZService.HandleAuthorizationCallback(ctx, authID, assertion)
 		if authErr != nil {
@@ -200,7 +200,7 @@ func (ah *authorizeHandler) getOAuthMessageForPostRequest(r *http.Request) (*OAu
 
 	// TODO: Require to handle other types such as user consent, etc.
 	bodyParams := map[string]string{
-		oauth2const.Assertion: authZReq.Assertion,
+		oauth2const.RequestParamAssertion: authZReq.Assertion,
 	}
 
 	return &OAuthMessage{

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -56,6 +56,7 @@ const (
 	RequestParamActorTokenType      string = "actor_token_type"
 	RequestParamRequestedTokenType  string = "requested_token_type"
 	RequestParamAudience            string = "audience"
+	RequestParamAssertion           string = "assertion"
 	RequestParamClaims              string = "claims"
 	RequestParamClaimsLocales       string = "claims_locales"
 	RequestParamNonce               string = "nonce"
@@ -103,7 +104,6 @@ const (
 	ShowInsecureWarning   string = "showInsecureWarning"
 	AppID                 string = "applicationId"
 	ExecutionID           string = "executionId"
-	Assertion             string = "assertion"
 )
 
 // Oauth message types.
@@ -132,6 +132,9 @@ const (
 const (
 	TokenTypeBearer = "Bearer"
 	TokenTypeDPoP   = "DPoP"
+	// TokenTypeNA is the token_type returned in an RFC 8693 response whose issued token is not an
+	// access token. It is used for the ID-JAG (Identity Assertion Authorization Grant) response.
+	TokenTypeNA = "N_A"
 )
 
 // TokenTypeIdentifier defines a type for RFC 8693 token type identifiers.
@@ -147,6 +150,10 @@ const (
 	TokenTypeIdentifierIDToken TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:id_token"
 	//nolint:gosec // Token type identifier, not a credential
 	TokenTypeIdentifierJWT TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:jwt"
+	// TokenTypeIdentifierIDJAG is the requested/issued token type for an Identity Assertion
+	// Authorization Grant (draft-ietf-oauth-identity-assertion-authz-grant).
+	//nolint:gosec // Token type identifier, not a credential
+	TokenTypeIdentifierIDJAG TokenTypeIdentifier = "urn:ietf:params:oauth:token-type:id-jag"
 )
 
 // supportedTokenTypeIdentifiers is the single source of truth for all supported token type identifiers.
@@ -155,6 +162,7 @@ var supportedTokenTypeIdentifiers = []TokenTypeIdentifier{
 	TokenTypeIdentifierRefreshToken,
 	TokenTypeIdentifierIDToken,
 	TokenTypeIdentifierJWT,
+	TokenTypeIdentifierIDJAG,
 }
 
 // IsValid checks if the TokenTypeIdentifier is valid.
@@ -256,6 +264,10 @@ const (
 	ClaimAuthorizedPermissions  string = "authorized_permissions"
 	ClaimAuthorizationRequestID string = "authorization_request_id"
 	ClaimClientID               string = "client_id"
+	// ClaimIDP identifies the source identity provider (by issuer) that authenticated the subject of a
+	// jwt-bearer-grant (ID-JAG) access token, so downstream consumers can distinguish a federated
+	// principal from a local one.
+	ClaimIDP string = "idp"
 )
 
 // OIDC subject types.

--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -274,12 +274,13 @@ func TestGetSupportedGrantTypes(t *testing.T) {
 	supported := constants.GetSupportedGrantTypes()
 
 	assert.NotNil(t, supported)
-	assert.Equal(t, 5, len(supported))
+	assert.Equal(t, 6, len(supported))
 	assert.Contains(t, supported, "authorization_code")
 	assert.Contains(t, supported, "client_credentials")
 	assert.Contains(t, supported, "refresh_token")
 	assert.Contains(t, supported, "urn:ietf:params:oauth:grant-type:token-exchange")
 	assert.Contains(t, supported, "urn:openid:params:grant-type:ciba")
+	assert.Contains(t, supported, "urn:ietf:params:oauth:grant-type:jwt-bearer")
 	assert.NotContains(t, supported, "password")
 	assert.NotContains(t, supported, "implicit")
 }

--- a/backend/internal/oauth/oauth2/granthandlers/jwt_bearer.go
+++ b/backend/internal/oauth/oauth2/granthandlers/jwt_bearer.go
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package granthandlers
+
+import (
+	"context"
+	"slices"
+
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/resourceindicators"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
+	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+)
+
+// jwtBearerGrantHandler handles the jwt-bearer grant type used to present an ID-JAG assertion
+// (draft-ietf-oauth-identity-assertion-authz-grant) issued by a trusted external IdP.
+type jwtBearerGrantHandler struct {
+	tokenBuilder    tokenservice.TokenBuilderInterface
+	tokenValidator  tokenservice.TokenValidatorInterface
+	resourceService providers.ResourceServerProvider
+}
+
+// newJWTBearerGrantHandler creates a new instance of jwtBearerGrantHandler.
+func newJWTBearerGrantHandler(
+	tokenBuilder tokenservice.TokenBuilderInterface,
+	tokenValidator tokenservice.TokenValidatorInterface,
+	resourceService providers.ResourceServerProvider,
+) GrantHandlerInterface {
+	return &jwtBearerGrantHandler{
+		tokenBuilder:    tokenBuilder,
+		tokenValidator:  tokenValidator,
+		resourceService: resourceService,
+	}
+}
+
+// ValidateGrant validates the jwt-bearer grant type request.
+func (h *jwtBearerGrantHandler) ValidateGrant(ctx context.Context, tokenRequest *model.TokenRequest,
+	oauthApp *providers.OAuthClient) *model.ErrorResponse {
+	if providers.GrantType(tokenRequest.GrantType) != providers.GrantTypeJWTBearer {
+		return &model.ErrorResponse{
+			Error:            constants.ErrorUnsupportedGrantType,
+			ErrorDescription: "Unsupported grant type",
+		}
+	}
+
+	if tokenRequest.Assertion == "" {
+		return &model.ErrorResponse{
+			Error:            constants.ErrorInvalidRequest,
+			ErrorDescription: "Missing required parameter: assertion",
+		}
+	}
+
+	// An ID-JAG is a bearer assertion whose only anti-theft protection is its client_id binding, which
+	// is worthless for a public client. Restrict the grant to confidential clients.
+	if oauthApp.TokenEndpointAuthMethod == providers.TokenEndpointAuthMethodNone {
+		return &model.ErrorResponse{
+			Error:            constants.ErrorInvalidClient,
+			ErrorDescription: "The jwt-bearer grant requires a confidential client",
+		}
+	}
+
+	return nil
+}
+
+// HandleGrant handles the jwt-bearer grant type. It validates an ID-JAG assertion issued by a trusted
+// external IdP, binds it to the authenticated client, and issues a ThunderID access token whose
+// subject is the assertion's subject. No refresh token is issued. The inbound ID-JAG assertion is not
+// sender-constrained (DPoP binding of the assertion is out of scope), but the issued access token is
+// DPoP-bound when the request carries a DPoP proof, like every other grant.
+func (h *jwtBearerGrantHandler) HandleGrant(ctx context.Context, tokenRequest *model.TokenRequest,
+	oauthApp *providers.OAuthClient) (
+	*model.TokenResponseDTO, *model.ErrorResponse) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTBearerGrantHandler"))
+
+	assertionClaims, err := h.tokenValidator.ValidateIDJAGAssertion(
+		ctx, tokenRequest.Assertion, tokenRequest.ClientID)
+	if err != nil {
+		logger.Debug(ctx, "Failed to validate ID-JAG assertion", log.Error(err))
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorInvalidGrant,
+			ErrorDescription: "Invalid assertion",
+		}
+	}
+
+	// Granted scopes = (assertion scope ∩ the app's registered scopes), further intersected with the
+	// request scope parameter when present.
+	grantedScopes := intersectScopes(assertionClaims.Scopes, oauthApp.Scopes)
+	if tokenRequest.Scope != "" {
+		grantedScopes = intersectScopes(grantedScopes, tokenservice.ParseScopes(tokenRequest.Scope))
+	}
+
+	// When the assertion carries a resource claim (RFC 8707), the resource AS resolves it to registered
+	// Resource Servers, narrows the granted scopes to what those Resource Servers permit, and derives
+	// the token audience from the resolved Resource Servers. A resource parameter on the jwt-bearer
+	// request may further narrow the assertion's resources but must not widen them. When the assertion
+	// carries no resource claim, the audience is composed from the granted scopes as before.
+	var audiences []string
+	var errResp *model.ErrorResponse
+	if len(assertionClaims.Resources) > 0 {
+		resources := assertionClaims.Resources
+		if len(tokenRequest.Resources) > 0 {
+			for _, r := range tokenRequest.Resources {
+				if !slices.Contains(assertionClaims.Resources, r) {
+					return nil, &model.ErrorResponse{
+						Error: constants.ErrorInvalidTarget,
+						ErrorDescription: "The resource parameter must be a subset of the " +
+							"assertion's resource claim",
+					}
+				}
+			}
+			resources = tokenRequest.Resources
+		}
+
+		resolvedRSes, resErr := resourceindicators.ResolveResourceServers(ctx, h.resourceService, resources)
+		if resErr != nil {
+			return nil, resErr
+		}
+		rsValidScopes, rsErr := resourceindicators.ComputeRSValidScopes(
+			ctx, h.resourceService, resolvedRSes, grantedScopes)
+		if rsErr != nil {
+			return nil, rsErr
+		}
+		grantedScopes = resourceindicators.UnionScopes(rsValidScopes)
+
+		audiences, errResp = resourceindicators.ComposeAudiences(
+			ctx, h.resourceService, tokenRequest.ClientID, resolvedRSes, grantedScopes)
+	} else {
+		// Compose the audience following the client_credentials pattern: Resource Server identifiers
+		// discovered from the granted scopes, else the clientID fallback.
+		audiences, errResp = resourceindicators.ComposeAudiences(
+			ctx, h.resourceService, tokenRequest.ClientID, nil, grantedScopes)
+	}
+	if errResp != nil {
+		return nil, errResp
+	}
+
+	// The subject is the external IdP's identifier carried in the assertion; no local user resolution
+	// or attribute mapping is performed in v1. The access token carries the source IdP as the `idp`
+	// claim so that this external `sub` is not mistaken for a local user id by downstream consumers.
+	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, &tokenservice.AccessTokenBuildContext{
+		Subject:           assertionClaims.Sub,
+		Audiences:         audiences,
+		ClientID:          tokenRequest.ClientID,
+		Scopes:            grantedScopes,
+		SubjectAttributes: make(map[string]interface{}),
+		GrantType:         string(providers.GrantTypeJWTBearer),
+		OAuthApp:          oauthApp,
+		SourceIDP:         assertionClaims.Iss,
+		DPoPJkt:           dpop.GetJkt(ctx),
+	})
+	if err != nil {
+		logger.Error(ctx, "Failed to generate token", log.Error(err))
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Failed to generate token",
+		}
+	}
+
+	return &model.TokenResponseDTO{
+		AccessToken: *accessToken,
+	}, nil
+}
+
+// intersectScopes returns the scopes present in both a and b, preserving the order of a.
+func intersectScopes(a, b []string) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return []string{}
+	}
+	set := make(map[string]struct{}, len(b))
+	for _, s := range b {
+		set[s] = struct{}{}
+	}
+	out := make([]string, 0, len(a))
+	for _, s := range a {
+		if _, ok := set[s]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/backend/internal/oauth/oauth2/granthandlers/jwt_bearer_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/jwt_bearer_test.go
@@ -1,0 +1,445 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package granthandlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/tokenservicemock"
+	"github.com/thunder-id/thunderid/tests/mocks/resourcemock"
+)
+
+const testAssertion = "test-id-jag-assertion" //nolint:gosec // Test assertion, not a real credential
+
+type JWTBearerGrantHandlerTestSuite struct {
+	suite.Suite
+	mockTokenBuilder    *tokenservicemock.TokenBuilderInterfaceMock
+	mockTokenValidator  *tokenservicemock.TokenValidatorInterfaceMock
+	mockResourceService *resourcemock.ResourceServiceInterfaceMock
+	handler             *jwtBearerGrantHandler
+	oauthApp            *providers.OAuthClient
+}
+
+func TestJWTBearerGrantHandlerSuite(t *testing.T) {
+	suite.Run(t, new(JWTBearerGrantHandlerTestSuite))
+}
+
+func (suite *JWTBearerGrantHandlerTestSuite) SetupTest() {
+	suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
+	suite.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(suite.T())
+	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	suite.mockResourceService.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+		Return([]providers.ResourceServer{}, nil).Maybe()
+	suite.handler = &jwtBearerGrantHandler{
+		tokenBuilder:    suite.mockTokenBuilder,
+		tokenValidator:  suite.mockTokenValidator,
+		resourceService: suite.mockResourceService,
+	}
+
+	suite.oauthApp = &providers.OAuthClient{
+		ID:         "app123",
+		ClientID:   testClientID,
+		GrantTypes: []providers.GrantType{providers.GrantTypeJWTBearer},
+		Scopes:     []string{"read", "write"},
+		Token: &providers.OAuthTokenConfig{
+			AccessToken: &providers.AccessTokenConfig{
+				UserConfig: &providers.AccessTokenSubConfig{
+					ValidityPeriod: 3600,
+				},
+			},
+		},
+	}
+}
+
+func (suite *JWTBearerGrantHandlerTestSuite) TestNewJWTBearerGrantHandler() {
+	handler := newJWTBearerGrantHandler(suite.mockTokenBuilder, suite.mockTokenValidator,
+		suite.mockResourceService)
+	assert.NotNil(suite.T(), handler)
+	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
+}
+
+func (suite *JWTBearerGrantHandlerTestSuite) TestValidateGrant_Success() {
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+	}
+
+	result := suite.handler.ValidateGrant(context.Background(), tokenRequest, suite.oauthApp)
+	assert.Nil(suite.T(), result)
+}
+
+func (suite *JWTBearerGrantHandlerTestSuite) TestValidateGrant_WrongGrantType() {
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeTokenExchange),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+	}
+
+	result := suite.handler.ValidateGrant(context.Background(), tokenRequest, suite.oauthApp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), constants.ErrorUnsupportedGrantType, result.Error)
+}
+
+func (suite *JWTBearerGrantHandlerTestSuite) TestValidateGrant_MissingAssertion() {
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+	}
+
+	result := suite.handler.ValidateGrant(context.Background(), tokenRequest, suite.oauthApp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, result.Error)
+	assert.Contains(suite.T(), result.ErrorDescription, "Missing required parameter: assertion")
+}
+
+// A public (none-auth) client cannot present an ID-JAG because the grant's only anti-theft protection
+// is the client_id binding, which a public client cannot safeguard.
+func (suite *JWTBearerGrantHandlerTestSuite) TestValidateGrant_PublicClientRejected() {
+	suite.oauthApp.TokenEndpointAuthMethod = providers.TokenEndpointAuthMethodNone
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+	}
+
+	result := suite.handler.ValidateGrant(context.Background(), tokenRequest, suite.oauthApp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), constants.ErrorInvalidClient, result.Error)
+	assert.Contains(suite.T(), result.ErrorDescription, "confidential client")
+}
+
+func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_Success() {
+	now := time.Now().Unix()
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+		Return(&tokenservice.IDJAGAssertionClaims{
+			Sub:    testUserID,
+			Iss:    testCustomIssuer,
+			Scopes: []string{"read", "write"},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID &&
+				ctx.ClientID == testClientID &&
+				ctx.GrantType == string(providers.GrantTypeJWTBearer) &&
+				ctx.SourceIDP == testCustomIssuer &&
+				len(ctx.Audiences) == 1 && ctx.Audiences[0] == testClientID &&
+				tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite &&
+				ctx.DPoPJkt == ""
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 3600,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+		Subject:   testUserID,
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), testTokenExchangeJWT, result.AccessToken.Token)
+	assert.Equal(suite.T(), testUserID, result.AccessToken.Subject)
+	assert.Empty(suite.T(), result.RefreshToken.Token)
+}
+
+// The issued access token is DPoP-bound when the request carries a DPoP proof, like every other grant;
+// only the inbound ID-JAG assertion itself is exempt from sender-constraining.
+func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_DPoPProof_PropagatesJktToBuilder() {
+	now := time.Now().Unix()
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+		Return(&tokenservice.IDJAGAssertionClaims{
+			Sub:    testUserID,
+			Iss:    testCustomIssuer,
+			Scopes: []string{"read", "write"},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.DPoPJkt == "thumbprint-jb"
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeDPoP,
+		IssuedAt:  now,
+		ExpiresIn: 3600,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+		Subject:   testUserID,
+	}, nil)
+
+	ctx := dpop.WithJkt(context.Background(), "thumbprint-jb")
+	result, errResp := suite.handler.HandleGrant(ctx, tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), constants.TokenTypeDPoP, result.AccessToken.TokenType)
+}
+
+func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_InvalidAssertion() {
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+		Return(nil, errors.New("assertion audience does not match server issuer"))
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidGrant, errResp.Error)
+	assert.Equal(suite.T(), "Invalid assertion", errResp.ErrorDescription)
+}
+
+// Granted scopes are the intersection of the assertion scopes, the app's registered scopes, and the
+// request scope parameter.
+func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_ScopeIntersection() {
+	now := time.Now().Unix()
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+		Scope:     "read admin",
+	}
+
+	// Assertion carries [read write], app registers [read write], request narrows to [read admin].
+	// Only "read" survives all three; "write" not requested, "admin" not registered/asserted.
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+		Return(&tokenservice.IDJAGAssertionClaims{
+			Sub:    testUserID,
+			Iss:    testCustomIssuer,
+			Scopes: []string{"read", "write"},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 3600,
+		Scopes:    []string{"read"},
+		ClientID:  testClientID,
+		Subject:   testUserID,
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"read"}, result.AccessToken.Scopes)
+}
+
+// RFC 8707: when the assertion carries a resource claim, the resource AS resolves it to registered
+// Resource Servers and uses their identifiers as the access token audience instead of the clientID
+// fallback.
+func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_AssertionResource_AudienceFromResolvedRS() {
+	now := time.Now().Unix()
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+		Return(&tokenservice.IDJAGAssertionClaims{
+			Sub:       testUserID,
+			Iss:       testCustomIssuer,
+			Scopes:    []string{"read", "write"},
+			Resources: []string{testRS01URI},
+		}, nil)
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, testRS01URI).
+		Return(&providers.ResourceServer{ID: testRS01URI, Identifier: testRS01URI}, nil)
+	// RS defines only "read"; "write" is dropped by scope narrowing.
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything, testRS01URI, []string{"read", "write"}).
+		Return([]string{"write"}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI &&
+				tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 3600,
+		Scopes:    []string{"read"},
+		ClientID:  testClientID,
+		Subject:   testUserID,
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"read"}, result.AccessToken.Scopes)
+}
+
+// RFC 8707: when the assertion carries no resource claim, behavior is unchanged — audience composed
+// from the granted scopes via the client_credentials pattern.
+func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_AssertionNoResource_CurrentBehaviorUnchanged() {
+	now := time.Now().Unix()
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+		Return(&tokenservice.IDJAGAssertionClaims{
+			Sub:    testUserID,
+			Iss:    testCustomIssuer,
+			Scopes: []string{"read", "write"},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testClientID &&
+				tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 3600,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+		Subject:   testUserID,
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"read", "write"}, result.AccessToken.Scopes)
+}
+
+// RFC 8707: a request resource parameter that is a subset of the assertion's resources narrows the
+// audience to the requested resource server only.
+func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_RequestResourceNarrowsAssertionResource_Accepted() {
+	now := time.Now().Unix()
+	const testRS02URI = "https://rs02.example.com"
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+		Resources: []string{testRS01URI},
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+		Return(&tokenservice.IDJAGAssertionClaims{
+			Sub:       testUserID,
+			Iss:       testCustomIssuer,
+			Scopes:    []string{"read", "write"},
+			Resources: []string{testRS01URI, testRS02URI},
+		}, nil)
+	suite.mockResourceService.On("GetResourceServerByIdentifier", mock.Anything, testRS01URI).
+		Return(&providers.ResourceServer{ID: testRS01URI, Identifier: testRS01URI}, nil)
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything, testRS01URI, []string{"read", "write"}).
+		Return([]string{}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 3600,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+		Subject:   testUserID,
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+// RFC 8707: a request resource parameter not present in the assertion's resources is rejected as
+// invalid_target — the request can narrow the assertion's resources but not widen them.
+func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_RequestResourceNotInAssertionResource_InvalidTarget() {
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+		Resources: []string{"https://not-granted.example.com"},
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+		Return(&tokenservice.IDJAGAssertionClaims{
+			Sub:       testUserID,
+			Iss:       testCustomIssuer,
+			Scopes:    []string{"read", "write"},
+			Resources: []string{testRS01URI},
+		}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
+}
+
+func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_TokenBuildError() {
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+		Return(&tokenservice.IDJAGAssertionClaims{
+			Sub:    testUserID,
+			Iss:    testCustomIssuer,
+			Scopes: []string{"read"},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).
+		Return(nil, errors.New("token generation failed"))
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorServerError, errResp.Error)
+}

--- a/backend/internal/oauth/oauth2/granthandlers/provider.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider.go
@@ -41,6 +41,7 @@ type GrantHandlerProvider struct {
 	refreshTokenGrantHandler      GrantHandlerInterface
 	tokenExchangeGrantHandler     GrantHandlerInterface
 	cibaGrantHandler              GrantHandlerInterface
+	jwtBearerGrantHandler         GrantHandlerInterface
 }
 
 // newGrantHandlerProvider creates a new instance of GrantHandlerProvider.
@@ -67,6 +68,8 @@ func newGrantHandlerProvider(
 		tokenExchangeGrantHandler: newTokenExchangeGrantHandler(
 			tokenBuilder, tokenValidator, resourceService),
 		cibaGrantHandler: newCIBAGrantHandler(cibaService, tokenBuilder, attrCacheService),
+		jwtBearerGrantHandler: newJWTBearerGrantHandler(
+			tokenBuilder, tokenValidator, resourceService),
 	}
 }
 
@@ -83,6 +86,8 @@ func (p *GrantHandlerProvider) GetGrantHandler(grantType providers.GrantType) (G
 		return p.tokenExchangeGrantHandler, nil
 	case providers.GrantTypeCIBA:
 		return p.cibaGrantHandler, nil
+	case providers.GrantTypeJWTBearer:
+		return p.jwtBearerGrantHandler, nil
 	default:
 		return nil, constants.UnSupportedGrantTypeError
 	}

--- a/backend/internal/oauth/oauth2/granthandlers/provider_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider_test.go
@@ -134,6 +134,14 @@ func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_CIBA() {
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
 }
 
+func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_JWTBearer() {
+	handler, err := suite.provider.GetGrantHandler(providers.GrantTypeJWTBearer)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), handler)
+	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
+}
+
 func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_UnsupportedGrantType() {
 	unsupportedGrantTypes := []struct {
 		name      string
@@ -160,6 +168,7 @@ func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_AllSupportedType
 		providers.GrantTypeAuthorizationCode,
 		providers.GrantTypeRefreshToken,
 		providers.GrantTypeCIBA,
+		providers.GrantTypeJWTBearer,
 	}
 
 	for _, grantType := range supportedTypes {

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -21,6 +21,7 @@ package granthandlers
 import (
 	"context"
 	"errors"
+	"slices"
 
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
@@ -120,10 +121,22 @@ func (h *tokenExchangeGrantHandler) ValidateGrant(ctx context.Context, tokenRequ
 		}
 		// TODO: Add support for other token types if needed
 		if requestedType != constants.TokenTypeIdentifierAccessToken &&
-			requestedType != constants.TokenTypeIdentifierJWT {
+			requestedType != constants.TokenTypeIdentifierJWT &&
+			requestedType != constants.TokenTypeIdentifierIDJAG {
 			return &model.ErrorResponse{
-				Error:            constants.ErrorInvalidRequest,
-				ErrorDescription: "Unsupported requested_token_type. Only access tokens and JWT tokens are supported",
+				Error: constants.ErrorInvalidRequest,
+				ErrorDescription: "Unsupported requested_token_type. Only access tokens, JWT tokens, " +
+					"and ID-JAGs are supported",
+			}
+		}
+
+		// The draft restricts the subject token to an identity assertion; we support only ID tokens in v1.
+		if requestedType == constants.TokenTypeIdentifierIDJAG &&
+			tokenRequest.SubjectTokenType != string(constants.TokenTypeIdentifierIDToken) {
+			return &model.ErrorResponse{
+				Error: constants.ErrorInvalidRequest,
+				ErrorDescription: "ID-JAG requests require subject_token_type " +
+					"urn:ietf:params:oauth:token-type:id_token",
 			}
 		}
 	}
@@ -136,6 +149,13 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	oauthApp *providers.OAuthClient) (
 	*model.TokenResponseDTO, *model.ErrorResponse) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TokenExchangeGrantHandler"))
+
+	// An ID-JAG request (draft-ietf-oauth-identity-assertion-authz-grant) follows a distinct path:
+	// it exchanges a self-issued ID token for a JWT authorization grant targeted at an external
+	// resource authorization server, rather than issuing an access token.
+	if constants.TokenTypeIdentifier(tokenRequest.RequestedTokenType) == constants.TokenTypeIdentifierIDJAG {
+		return h.handleIDJAGGrant(ctx, tokenRequest, oauthApp)
+	}
 
 	// Validate and extract subject token claims. ValidateSubjectToken enforces the RFC 7009 deny list
 	// for self-issued tokens; a revoked token is rejected as invalid_request like any other invalid
@@ -234,6 +254,109 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 
 	return &model.TokenResponseDTO{
 		AccessToken: *accessToken,
+	}, nil
+}
+
+// handleIDJAGGrant issues an ID-JAG (Identity Assertion Authorization Grant) in response to a
+// token-exchange request with requested_token_type=urn:ietf:params:oauth:token-type:id-jag. The
+// subject_token must be a self-issued token, and the audience parameter must match one of the
+// application's configured allowed audiences. DPoP binding is out of scope for ID-JAGs.
+func (h *tokenExchangeGrantHandler) handleIDJAGGrant(ctx context.Context, tokenRequest *model.TokenRequest,
+	oauthApp *providers.OAuthClient) (*model.TokenResponseDTO, *model.ErrorResponse) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TokenExchangeGrantHandler"))
+
+	// The resource parameter (RFC 8707) is optional for ID-JAG requests; when present it is validated
+	// up front and later embedded in the ID-JAG's `resource` claim for the resource AS to process.
+	if errResp := resourceindicators.ValidateResourceURIs(tokenRequest.Resources); errResp != nil {
+		return nil, errResp
+	}
+
+	// The application must have ID-JAG enabled and configured with at least one allowed audience.
+	if oauthApp == nil || oauthApp.Token == nil || oauthApp.Token.IDJAG == nil ||
+		!oauthApp.Token.IDJAG.Enabled || len(oauthApp.Token.IDJAG.AllowedAudiences) == 0 {
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorInvalidTarget,
+			ErrorDescription: "The client is not permitted to request ID-JAGs",
+		}
+	}
+
+	// Only confidential clients may request ID-JAGs; a public client cannot safely hold the grant.
+	if oauthApp.TokenEndpointAuthMethod == providers.TokenEndpointAuthMethodNone {
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorInvalidClient,
+			ErrorDescription: "ID-JAG requests require a confidential client",
+		}
+	}
+
+	// The audience parameter is required and must exactly match a configured allowed audience. Exactly
+	// one audience is permitted so the issued ID-JAG is unambiguously targeted at a single RS.
+	if len(tokenRequest.Audiences) == 0 {
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorInvalidTarget,
+			ErrorDescription: "The audience parameter is required for ID-JAG requests",
+		}
+	}
+	if len(tokenRequest.Audiences) > 1 {
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorInvalidTarget,
+			ErrorDescription: "Exactly one audience is required for ID-JAG requests",
+		}
+	}
+	audience := tokenRequest.Audiences[0]
+	if !slices.Contains(oauthApp.Token.IDJAG.AllowedAudiences, audience) {
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorInvalidTarget,
+			ErrorDescription: "The requested audience is not permitted for this client",
+		}
+	}
+
+	// The subject token must be a genuine self-issued ID token. ValidateIDJAGSubjectToken rejects
+	// access tokens (typ at+jwt), refresh tokens (access_token_sub claim), and external-issuer subject
+	// tokens, so a re-audienced token-exchange access token cannot be laundered into an ID-JAG.
+	subjectClaims, err := h.tokenValidator.ValidateIDJAGSubjectToken(ctx, tokenRequest.SubjectToken, oauthApp)
+	if err != nil {
+		logger.Debug(ctx, "Failed to validate subject token for ID-JAG request", log.Error(err))
+		if errors.Is(err, revocation.ErrEnforcementUnavailable) {
+			return nil, &model.ErrorResponse{
+				Error:            constants.ErrorServerError,
+				ErrorDescription: "Token revocation status could not be verified",
+			}
+		}
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorInvalidRequest,
+			ErrorDescription: "subject_token must be an ID token issued to this client",
+		}
+	}
+
+	// Bind the subject token to the authenticated client: the draft requires the assertion's audience
+	// to match the client_id of the client authentication.
+	if len(subjectClaims.Aud) == 0 || !slices.Contains(subjectClaims.Aud, tokenRequest.ClientID) {
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorInvalidRequest,
+			ErrorDescription: "subject_token audience does not match the authenticated client",
+		}
+	}
+
+	grantedScopes := tokenservice.ParseScopes(tokenRequest.Scope)
+
+	idjag, err := h.tokenBuilder.BuildIDJAG(ctx, &tokenservice.IDJAGBuildContext{
+		Subject:   subjectClaims.Sub,
+		Audience:  audience,
+		ClientID:  tokenRequest.ClientID,
+		Scopes:    grantedScopes,
+		Resources: tokenRequest.Resources,
+		OAuthApp:  oauthApp,
+	})
+	if err != nil {
+		logger.Error(ctx, "Failed to generate ID-JAG", log.Error(err))
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Failed to generate token",
+		}
+	}
+
+	return &model.TokenResponseDTO{
+		AccessToken: *idjag,
 	}, nil
 }
 

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -1235,7 +1235,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_UnsupportedID
 	assert.NotNil(suite.T(), errResp)
 	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
 	assert.Contains(suite.T(), errResp.ErrorDescription, "Unsupported requested_token_type")
-	assert.Contains(suite.T(), errResp.ErrorDescription, "Only access tokens and JWT tokens are supported")
+	assert.Contains(suite.T(), errResp.ErrorDescription, "Only access tokens, JWT tokens, and ID-JAGs are supported")
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_UnsupportedRefreshTokenType() {
@@ -1252,7 +1252,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_UnsupportedRe
 	assert.NotNil(suite.T(), errResp)
 	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
 	assert.Contains(suite.T(), errResp.ErrorDescription, "Unsupported requested_token_type")
-	assert.Contains(suite.T(), errResp.ErrorDescription, "Only access tokens and JWT tokens are supported")
+	assert.Contains(suite.T(), errResp.ErrorDescription, "Only access tokens, JWT tokens, and ID-JAGs are supported")
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_CompleteTokenExchangeFlow() {
@@ -2568,4 +2568,650 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_Multipl
 	assert.Nil(suite.T(), errResp)
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), []string{"read", "write"}, result.AccessToken.Scopes)
+}
+
+// ============================================================================
+// ID-JAG Issuance Tests (draft-ietf-oauth-identity-assertion-authz-grant)
+// The server issuer configured in SetupTest is testIDJAGServerIssuer.
+// ============================================================================
+
+const testIDJAGServerIssuer = "https://auth.example.com"
+const testIDJAGAudience = "https://rs.example.com"
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_IDJAGRequestedTokenType() {
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierIDToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+	}
+
+	result := suite.handler.ValidateGrant(context.Background(), tokenRequest, suite.oauthApp)
+	assert.Nil(suite.T(), result)
+}
+
+// An ID-JAG request must present an ID token as the subject_token; any other subject_token_type is
+// rejected as invalid_request per the draft's restriction to identity assertions.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_IDJAGWrongSubjectTokenType() {
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+	}
+
+	result := suite.handler.ValidateGrant(context.Background(), tokenRequest, suite.oauthApp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, result.Error)
+	assert.Contains(suite.T(), result.ErrorDescription,
+		"ID-JAG requests require subject_token_type urn:ietf:params:oauth:token-type:id_token")
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_Success() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testIDJAGServerIssuer,
+		"aud": testClientID,
+		"exp": float64(now + 3600),
+	})
+
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   string(constants.TokenTypeIdentifierIDToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+		Scope:              testScopeRead,
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID,
+			Iss: testIDJAGServerIssuer,
+			Aud: []string{testClientID},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildIDJAG", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.IDJAGBuildContext) bool {
+			return ctx.Subject == testUserID &&
+				ctx.Audience == testIDJAGAudience &&
+				ctx.ClientID == testClientID &&
+				tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
+		})).Return(&model.TokenDTO{
+		Token:     "test-id-jag",
+		TokenType: constants.TokenTypeNA,
+		IssuedAt:  now,
+		ExpiresIn: 300,
+		Scopes:    []string{testScopeRead},
+		ClientID:  testClientID,
+		Subject:   testUserID,
+		Audiences: []string{testIDJAGAudience},
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), "test-id-jag", result.AccessToken.Token)
+	assert.Equal(suite.T(), constants.TokenTypeNA, result.AccessToken.TokenType)
+	assert.Equal(suite.T(), testClientID, result.AccessToken.ClientID)
+	assert.Equal(suite.T(), testUserID, result.AccessToken.Subject)
+	assert.Equal(suite.T(), []string{testIDJAGAudience}, result.AccessToken.Audiences)
+	assert.Equal(suite.T(), []string{testScopeRead}, result.AccessToken.Scopes)
+	// No refresh token is issued for ID-JAGs.
+	assert.Empty(suite.T(), result.RefreshToken.Token)
+}
+
+// RFC 8707: a resource parameter present on an ID-JAG request is embedded in the issued ID-JAG's
+// resource claim, threaded through IDJAGBuildContext.Resources.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_ResourcePresent_ThreadedToBuildContext() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testIDJAGServerIssuer,
+		"aud": testClientID,
+		"exp": float64(now + 3600),
+	})
+
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   string(constants.TokenTypeIdentifierIDToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+		Resources:          []string{testRS01URI},
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID,
+			Iss: testIDJAGServerIssuer,
+			Aud: []string{testClientID},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildIDJAG", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.IDJAGBuildContext) bool {
+			return len(ctx.Resources) == 1 && ctx.Resources[0] == testRS01URI
+		})).Return(&model.TokenDTO{
+		Token:     "test-id-jag",
+		TokenType: constants.TokenTypeNA,
+		IssuedAt:  now,
+		ExpiresIn: 300,
+		ClientID:  testClientID,
+		Subject:   testUserID,
+		Audiences: []string{testIDJAGAudience},
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+// RFC 8707: when no resource parameter is present, the ID-JAG is still valid and no Resources are
+// threaded to the build context.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_ResourceAbsent_BuildContextEmpty() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testIDJAGServerIssuer,
+		"aud": testClientID,
+		"exp": float64(now + 3600),
+	})
+
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   string(constants.TokenTypeIdentifierIDToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID,
+			Iss: testIDJAGServerIssuer,
+			Aud: []string{testClientID},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildIDJAG", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.IDJAGBuildContext) bool {
+			return len(ctx.Resources) == 0
+		})).Return(&model.TokenDTO{
+		Token:     "test-id-jag",
+		TokenType: constants.TokenTypeNA,
+		IssuedAt:  now,
+		ExpiresIn: 300,
+		ClientID:  testClientID,
+		Subject:   testUserID,
+		Audiences: []string{testIDJAGAudience},
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+// RFC 8707 §2: an invalid resource URI (not an absolute URI) is rejected as invalid_target before any
+// subject token validation occurs.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_InvalidResourceURIRejected() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierIDToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+		Resources:          []string{"not-a-valid-uri"},
+	}
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
+	suite.mockTokenValidator.AssertNotCalled(suite.T(), "ValidateIDJAGSubjectToken",
+		mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_AudienceNotAllowed() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{"https://evil.example.com"},
+	}
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_MissingAudience() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+	}
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription, "audience parameter is required")
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_SubjectTokenValidationFailedRejected() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testCustomIssuer,
+		"exp": float64(now + 3600),
+	})
+
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+	}
+
+	// ValidateIDJAGSubjectToken rejects external-issuer (and other invalid) subject tokens itself; the
+	// handler maps any validation failure to a single invalid_request response.
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(nil, fmt.Errorf("subject_token must be issued by this server, got issuer %q", testCustomIssuer))
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription, "subject_token must be an ID token issued to this client")
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_NoIDJAGConfigRejected() {
+	// suite.oauthApp has no IDJAG config configured in SetupTest.
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+	}
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription, "not permitted to request ID-JAGs")
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_DisabledRejected() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          false,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+	}
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription, "not permitted to request ID-JAGs")
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_InvalidSubjectToken() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, "subject-token", suite.oauthApp).
+		Return(nil, errors.New("invalid signature"))
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription,
+		"subject_token must be an ID token issued to this client")
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_SubjectTokenEnforcementUnavailable() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, "subject-token", suite.oauthApp).
+		Return(nil, revocation.ErrEnforcementUnavailable)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorServerError, errResp.Error)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_BuildError() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testIDJAGServerIssuer,
+		"aud": testClientID,
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   string(constants.TokenTypeIdentifierIDToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID,
+			Iss: testIDJAGServerIssuer,
+			Aud: []string{testClientID},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildIDJAG", mock.Anything, mock.Anything).
+		Return(nil, errors.New("signing failed"))
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorServerError, errResp.Error)
+}
+
+// A public (none-auth) client cannot request ID-JAGs; the grant requires a confidential client.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_PublicClientRejected() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	suite.oauthApp.TokenEndpointAuthMethod = providers.TokenEndpointAuthMethodNone
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+	}
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidClient, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription, "confidential client")
+}
+
+// An ID-JAG must target a single RS; supplying more than one audience is rejected as invalid_target.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_MultipleAudiencesRejected() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       "subject-token",
+		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience, "https://rs2.example.com"},
+	}
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription, "Exactly one audience")
+}
+
+// The subject token must be bound to the authenticated client: its aud must contain the client_id.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_SubjectTokenAudMismatchRejected() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testIDJAGServerIssuer,
+		"aud": "another-client",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   string(constants.TokenTypeIdentifierIDToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID,
+			Iss: testIDJAGServerIssuer,
+			Aud: []string{"another-client"},
+		}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription,
+		"subject_token audience does not match the authenticated client")
+}
+
+// An empty subject-token audience does not satisfy the client binding and is rejected.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_SubjectTokenEmptyAudRejected() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testIDJAGServerIssuer,
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   string(constants.TokenTypeIdentifierIDToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID,
+			Iss: testIDJAGServerIssuer,
+		}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription,
+		"subject_token audience does not match the authenticated client")
+}
+
+// A subject token whose multi-valued aud includes the authenticated client satisfies the binding.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_SubjectTokenMultiAudContainingClientAccepted() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testIDJAGServerIssuer,
+		"aud": []string{"another-client", testClientID},
+		"exp": float64(now + 3600),
+	})
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   string(constants.TokenTypeIdentifierIDToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+		Scope:              testScopeRead,
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID,
+			Iss: testIDJAGServerIssuer,
+			Aud: []string{"another-client", testClientID},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildIDJAG", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.IDJAGBuildContext) bool {
+			return ctx.Subject == testUserID && ctx.Audience == testIDJAGAudience
+		})).Return(&model.TokenDTO{
+		Token:     "test-id-jag",
+		TokenType: constants.TokenTypeNA,
+		IssuedAt:  now,
+		ExpiresIn: 300,
+		Scopes:    []string{testScopeRead},
+		ClientID:  testClientID,
+		Subject:   testUserID,
+		Audiences: []string{testIDJAGAudience},
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), "test-id-jag", result.AccessToken.Token)
+}
+
+// All requested scopes are granted as-is; ID-JAG no longer applies a per-application scope allowlist.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_ScopesPassthrough() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		Enabled:          true,
+		AllowedAudiences: []string{testIDJAGAudience},
+	}
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testIDJAGServerIssuer,
+		"aud": testClientID,
+		"exp": float64(now + 3600),
+	})
+	tokenRequest := &model.TokenRequest{
+		GrantType:          string(providers.GrantTypeTokenExchange),
+		ClientID:           testClientID,
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   string(constants.TokenTypeIdentifierIDToken),
+		RequestedTokenType: string(constants.TokenTypeIdentifierIDJAG),
+		Audiences:          []string{testIDJAGAudience},
+		Scope:              "read delete",
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID,
+			Iss: testIDJAGServerIssuer,
+			Aud: []string{testClientID},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildIDJAG", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.IDJAGBuildContext) bool {
+			return tokenservice.JoinScopes(ctx.Scopes) == "read delete"
+		})).Return(&model.TokenDTO{
+		Token:     "test-id-jag",
+		TokenType: constants.TokenTypeNA,
+		IssuedAt:  now,
+		ExpiresIn: 300,
+		Scopes:    []string{"read", "delete"},
+		ClientID:  testClientID,
+		Subject:   testUserID,
+		Audiences: []string{testIDJAGAudience},
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"read", "delete"}, result.AccessToken.Scopes)
 }

--- a/backend/internal/oauth/oauth2/model/token.go
+++ b/backend/internal/oauth/oauth2/model/token.go
@@ -39,6 +39,7 @@ type TokenRequest struct {
 	RequestedTokenType string   `json:"requested_token_type,omitempty"`
 	Audiences          []string `json:"audiences,omitempty"`
 	AuthReqID          string   `json:"auth_req_id,omitempty"`
+	Assertion          string   `json:"assertion,omitempty"`
 }
 
 // TokenResponse represents the OAuth2 token response.

--- a/backend/internal/oauth/oauth2/token/handler.go
+++ b/backend/internal/oauth/oauth2/token/handler.go
@@ -113,6 +113,7 @@ func (th *tokenHandler) HandleTokenRequest(w http.ResponseWriter, r *http.Reques
 		RequestedTokenType: r.FormValue(constants.RequestParamRequestedTokenType),
 		Audiences:          r.Form[constants.RequestParamAudience],
 		AuthReqID:          r.FormValue(constants.RequestParamAuthReqID),
+		Assertion:          r.FormValue(constants.RequestParamAssertion),
 	}
 
 	// Delegate all business logic to the token service.

--- a/backend/internal/oauth/oauth2/token/service.go
+++ b/backend/internal/oauth/oauth2/token/service.go
@@ -256,9 +256,12 @@ func (ts *tokenService) ProcessTokenRequest(
 	// For token exchange, determine the issued_token_type from the request.
 	if grantType == providers.GrantTypeTokenExchange {
 		requestedTokenType := tokenRequest.RequestedTokenType
-		if requestedTokenType == "" || requestedTokenType == string(constants.TokenTypeIdentifierAccessToken) {
+		switch {
+		case requestedTokenType == string(constants.TokenTypeIdentifierIDJAG):
+			tokenResponse.IssuedTokenType = string(constants.TokenTypeIdentifierIDJAG)
+		case requestedTokenType == "" || requestedTokenType == string(constants.TokenTypeIdentifierAccessToken):
 			tokenResponse.IssuedTokenType = string(constants.TokenTypeIdentifierAccessToken)
-		} else {
+		default:
 			tokenResponse.IssuedTokenType = string(constants.TokenTypeIdentifierJWT)
 		}
 	}

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -38,6 +38,7 @@ type TokenBuilderInterface interface {
 	BuildAccessToken(ctx context.Context, tokenCtx *AccessTokenBuildContext) (*oauth2model.TokenDTO, error)
 	BuildRefreshToken(ctx context.Context, tokenCtx *RefreshTokenBuildContext) (*oauth2model.TokenDTO, error)
 	BuildIDToken(ctx context.Context, tokenCtx *IDTokenBuildContext) (*oauth2model.TokenDTO, error)
+	BuildIDJAG(ctx context.Context, tokenCtx *IDJAGBuildContext) (*oauth2model.TokenDTO, error)
 }
 
 // TokenBuilder implements TokenBuilderInterface.
@@ -117,6 +118,63 @@ func (tb *tokenBuilder) BuildAccessToken(
 	return tokenDTO, nil
 }
 
+// BuildIDJAG builds an Identity Assertion Authorization Grant (ID-JAG) JWT targeted at an external
+// resource authorization server (draft-ietf-oauth-identity-assertion-authz-grant). The token carries
+// typ=oauth-id-jag+jwt and is signed with the server's own key. token_type is "N_A" because the
+// issued token is not an access token.
+func (tb *tokenBuilder) BuildIDJAG(
+	ctx context.Context,
+	tokenCtx *IDJAGBuildContext,
+) (*oauth2model.TokenDTO, error) {
+	if tokenCtx == nil {
+		return nil, fmt.Errorf("build context cannot be nil")
+	}
+
+	validityPeriod := providers.DefaultIDJAGValidityPeriod
+	if tokenCtx.OAuthApp != nil && tokenCtx.OAuthApp.Token != nil && tokenCtx.OAuthApp.Token.IDJAG != nil &&
+		tokenCtx.OAuthApp.Token.IDJAG.ValidityPeriod > 0 {
+		validityPeriod = tokenCtx.OAuthApp.Token.IDJAG.ValidityPeriod
+	}
+
+	claims := map[string]interface{}{
+		"aud":       tokenCtx.Audience,
+		"client_id": tokenCtx.ClientID,
+	}
+	if len(tokenCtx.Scopes) > 0 {
+		claims["scope"] = JoinScopes(tokenCtx.Scopes)
+	}
+	// RFC 8707: a single resource is embedded as a string, multiple resources as an array.
+	if len(tokenCtx.Resources) == 1 {
+		claims["resource"] = tokenCtx.Resources[0]
+	} else if len(tokenCtx.Resources) > 1 {
+		claims["resource"] = tokenCtx.Resources
+	}
+
+	token, iat, err := tb.jwtService.GenerateJWT(
+		ctx,
+		tokenCtx.Subject,
+		tb.cfg.JWT.Issuer,
+		validityPeriod,
+		claims,
+		jwt.TokenTypeIDJAG,
+		"",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ID-JAG: %v", err.Error)
+	}
+
+	return &oauth2model.TokenDTO{
+		Token:     token,
+		TokenType: constants.TokenTypeNA,
+		IssuedAt:  iat,
+		ExpiresIn: validityPeriod,
+		Scopes:    tokenCtx.Scopes,
+		ClientID:  tokenCtx.ClientID,
+		Subject:   tokenCtx.Subject,
+		Audiences: []string{tokenCtx.Audience},
+	}, nil
+}
+
 // buildAccessTokenClaims builds the claims map for an access token.
 func (tb *tokenBuilder) buildAccessTokenClaims(
 	ctx *AccessTokenBuildContext,
@@ -143,6 +201,13 @@ func (tb *tokenBuilder) buildAccessTokenClaims(
 	// Set after merging subject attributes to prevent them from overwriting this system claim.
 	if ctx.AttributeCacheID != "" {
 		claims["aci"] = ctx.AttributeCacheID
+	}
+
+	// Set after merging user attributes so a federated principal's attributes cannot spoof the source
+	// IdP. For a jwt-bearer-grant (ID-JAG) token the `sub` is an external IdP identifier and MUST be
+	// interpreted together with this claim.
+	if ctx.SourceIDP != "" {
+		claims[constants.ClaimIDP] = ctx.SourceIDP
 	}
 
 	if ctx.ActorClaims != nil {

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/jwksresolver"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
+	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/tests/mocks/httpmock"
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwemock"
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
@@ -60,6 +61,7 @@ const (
 	testUserName     = "John Doe"
 	testAppID        = "app123"
 	testCacheID      = "test-cache-id"
+	testIDJAGAud     = "https://rs.example.com"
 )
 
 type TokenBuilderTestSuite struct {
@@ -195,6 +197,40 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_ClientAttributes_Merges
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
+// A jwt-bearer-grant (ID-JAG) access token carries the source IdP issuer as the `idp` claim so
+// downstream consumers can distinguish a federated principal from a local one.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithSourceIDP() {
+	ctx := &AccessTokenBuildContext{
+		Subject:           "ext-user-123",
+		Audiences:         []string{"app123"},
+		ClientID:          "test-client",
+		Scopes:            []string{"read"},
+		SubjectAttributes: map[string]interface{}{},
+		GrantType:         string(providers.GrantTypeJWTBearer),
+		OAuthApp:          suite.oauthApp,
+		SourceIDP:         "https://idp.example.com",
+	}
+
+	expectedToken := testAccessToken
+	expectedIat := time.Now().Unix()
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
+		"ext-user-123",
+		"https://example.com",
+		int64(3600),
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			return claims[constants.ClaimIDP] == "https://idp.example.com"
+		}), mock.Anything, mock.Anything,
+	).Return(expectedToken, expectedIat, nil)
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
 func (suite *TokenBuilderTestSuite) TestBuildAccessToken_UserAttributes_EmbedsComputedOUClaims() {
 	oauthApp := &providers.OAuthClient{
 		ClientID: "test-client",
@@ -221,6 +257,39 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_UserAttributes_EmbedsCo
 			return claims["email"] == "a@b.com" && claims["ouId"] == "ou-789"
 		}), mock.Anything, mock.Anything,
 	).Return(testAccessToken, time.Now().Unix(), nil)
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// The `idp` claim is only emitted when SourceIDP is set, so ordinary grants do not carry it.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_NoSourceIDPOmitsClaim() {
+	ctx := &AccessTokenBuildContext{
+		Subject:           "user123",
+		Audiences:         []string{"app123"},
+		ClientID:          "test-client",
+		Scopes:            []string{"read"},
+		SubjectAttributes: map[string]interface{}{},
+		GrantType:         string(providers.GrantTypeAuthorizationCode),
+		OAuthApp:          suite.oauthApp,
+	}
+
+	expectedToken := testAccessToken
+	expectedIat := time.Now().Unix()
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
+		"user123",
+		"https://example.com",
+		int64(3600),
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			_, hasIDP := claims[constants.ClaimIDP]
+			return !hasIDP
+		}), mock.Anything, mock.Anything,
+	).Return(expectedToken, expectedIat, nil)
 
 	result, err := suite.builder.BuildAccessToken(context.Background(), ctx)
 
@@ -1800,6 +1869,235 @@ func (suite *TokenBuilderTestSuite) TestBuildIDToken_Error_UnsupportedCertType()
 	assert.Nil(suite.T(), result)
 	assert.Contains(suite.T(), err.Error(), "failed to resolve ID token encryption key")
 	mockJWE.AssertNotCalled(suite.T(), "Encrypt")
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// ============================================================================
+// BuildIDJAG Tests (draft-ietf-oauth-identity-assertion-authz-grant)
+// ============================================================================
+
+func (suite *TokenBuilderTestSuite) TestBuildIDJAG_Success() {
+	scopeStr := JoinScopes([]string{"read", "write"})
+	ctx := &IDJAGBuildContext{
+		Subject:  "user123",
+		Audience: testIDJAGAud,
+		ClientID: suite.oauthApp.ClientID,
+		Scopes:   []string{"read", "write"},
+		OAuthApp: suite.oauthApp,
+	}
+
+	expectedToken := "test-id-jag"
+	expectedIat := time.Now().Unix()
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
+		"user123",
+		"https://example.com",
+		providers.DefaultIDJAGValidityPeriod,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			return claims["aud"] == testIDJAGAud &&
+				claims["client_id"] == suite.oauthApp.ClientID &&
+				claims["scope"] == scopeStr
+		}),
+		jwt.TokenTypeIDJAG,
+		mock.Anything,
+	).Return(expectedToken, expectedIat, nil)
+
+	result, err := suite.builder.BuildIDJAG(context.Background(), ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), expectedToken, result.Token)
+	assert.Equal(suite.T(), constants.TokenTypeNA, result.TokenType)
+	assert.Equal(suite.T(), expectedIat, result.IssuedAt)
+	assert.Equal(suite.T(), providers.DefaultIDJAGValidityPeriod, result.ExpiresIn)
+	assert.Equal(suite.T(), []string{"read", "write"}, result.Scopes)
+	assert.Equal(suite.T(), suite.oauthApp.ClientID, result.ClientID)
+	assert.Equal(suite.T(), "user123", result.Subject)
+	assert.Equal(suite.T(), []string{testIDJAGAud}, result.Audiences)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *TokenBuilderTestSuite) TestBuildIDJAG_CustomValidityPeriod() {
+	suite.oauthApp.Token.IDJAG = &providers.IDJAGConfig{
+		AllowedAudiences: []string{testIDJAGAud},
+		ValidityPeriod:   600,
+	}
+	ctx := &IDJAGBuildContext{
+		Subject:  "user123",
+		Audience: testIDJAGAud,
+		ClientID: suite.oauthApp.ClientID,
+		OAuthApp: suite.oauthApp,
+	}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
+		"user123",
+		"https://example.com",
+		int64(600),
+		mock.Anything,
+		jwt.TokenTypeIDJAG,
+		mock.Anything,
+	).Return("test-id-jag", time.Now().Unix(), nil)
+
+	result, err := suite.builder.BuildIDJAG(context.Background(), ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), int64(600), result.ExpiresIn)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *TokenBuilderTestSuite) TestBuildIDJAG_EmptyScope_OmitsScopeClaim() {
+	ctx := &IDJAGBuildContext{
+		Subject:  "user123",
+		Audience: testIDJAGAud,
+		ClientID: suite.oauthApp.ClientID,
+		OAuthApp: suite.oauthApp,
+	}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
+		"user123",
+		"https://example.com",
+		providers.DefaultIDJAGValidityPeriod,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			_, hasScope := claims["scope"]
+			return !hasScope && claims["aud"] == testIDJAGAud
+		}),
+		jwt.TokenTypeIDJAG,
+		mock.Anything,
+	).Return("test-id-jag", time.Now().Unix(), nil)
+
+	result, err := suite.builder.BuildIDJAG(context.Background(), ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Empty(suite.T(), result.Scopes)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *TokenBuilderTestSuite) TestBuildIDJAG_SingleResource_ClaimIsString() {
+	ctx := &IDJAGBuildContext{
+		Subject:   "user123",
+		Audience:  testIDJAGAud,
+		ClientID:  suite.oauthApp.ClientID,
+		Resources: []string{"https://rs01.example.com"},
+		OAuthApp:  suite.oauthApp,
+	}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
+		"user123",
+		"https://example.com",
+		providers.DefaultIDJAGValidityPeriod,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			resource, ok := claims["resource"].(string)
+			return ok && resource == "https://rs01.example.com"
+		}),
+		jwt.TokenTypeIDJAG,
+		mock.Anything,
+	).Return("test-id-jag", time.Now().Unix(), nil)
+
+	result, err := suite.builder.BuildIDJAG(context.Background(), ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *TokenBuilderTestSuite) TestBuildIDJAG_MultipleResources_ClaimIsArray() {
+	resources := []string{"https://rs01.example.com", "https://rs02.example.com"}
+	ctx := &IDJAGBuildContext{
+		Subject:   "user123",
+		Audience:  testIDJAGAud,
+		ClientID:  suite.oauthApp.ClientID,
+		Resources: resources,
+		OAuthApp:  suite.oauthApp,
+	}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
+		"user123",
+		"https://example.com",
+		providers.DefaultIDJAGValidityPeriod,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			resourceClaim, ok := claims["resource"].([]string)
+			return ok && assert.ObjectsAreEqual(resources, resourceClaim)
+		}),
+		jwt.TokenTypeIDJAG,
+		mock.Anything,
+	).Return("test-id-jag", time.Now().Unix(), nil)
+
+	result, err := suite.builder.BuildIDJAG(context.Background(), ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *TokenBuilderTestSuite) TestBuildIDJAG_NoResources_OmitsResourceClaim() {
+	ctx := &IDJAGBuildContext{
+		Subject:  "user123",
+		Audience: testIDJAGAud,
+		ClientID: suite.oauthApp.ClientID,
+		OAuthApp: suite.oauthApp,
+	}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything,
+		"user123",
+		"https://example.com",
+		providers.DefaultIDJAGValidityPeriod,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			_, hasResource := claims["resource"]
+			return !hasResource
+		}),
+		jwt.TokenTypeIDJAG,
+		mock.Anything,
+	).Return("test-id-jag", time.Now().Unix(), nil)
+
+	result, err := suite.builder.BuildIDJAG(context.Background(), ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *TokenBuilderTestSuite) TestBuildIDJAG_Error_NilContext() {
+	result, err := suite.builder.BuildIDJAG(context.Background(), nil)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "build context cannot be nil")
+}
+
+func (suite *TokenBuilderTestSuite) TestBuildIDJAG_Error_JWTGenerationFailed() {
+	ctx := &IDJAGBuildContext{
+		Subject:  "user123",
+		Audience: testIDJAGAud,
+		ClientID: suite.oauthApp.ClientID,
+		OAuthApp: suite.oauthApp,
+	}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return("", int64(0), &tidcommon.ServiceError{
+		Type: tidcommon.ServerErrorType,
+		Code: "JWT_GENERATION_FAILED",
+		Error: tidcommon.I18nMessage{
+			Key: "error.test.jwt_generation_failed", DefaultValue: "JWT generation failed",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key: "error.test.failed_to_generate_jwt_token", DefaultValue: "Failed to generate JWT token",
+		},
+	})
+
+	result, err := suite.builder.BuildIDJAG(context.Background(), ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to generate ID-JAG")
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -67,6 +67,10 @@ type AccessTokenBuildContext struct {
 	// DPoPJkt, when set, sender-constrains the access token to the supplied JWK thumbprint.
 	// The token receives a `cnf.jkt` claim and is issued with `token_type=DPoP`.
 	DPoPJkt string
+	// SourceIDP, when set, records the issuer of the external identity provider that authenticated the
+	// subject (used by the jwt-bearer/ID-JAG grant). It is emitted as the `idp` claim so downstream
+	// consumers can distinguish a federated principal from a local one.
+	SourceIDP string
 }
 
 // RefreshTokenBuildContext contains all the information needed to build a refresh token.
@@ -82,6 +86,19 @@ type RefreshTokenBuildContext struct {
 	ClaimsLocales        string
 	DPoPJkt              string
 	ActorSub             string
+}
+
+// IDJAGBuildContext contains all the information needed to build an ID-JAG (Identity Assertion
+// Authorization Grant, draft-ietf-oauth-identity-assertion-authz-grant).
+type IDJAGBuildContext struct {
+	Subject  string
+	Audience string
+	ClientID string
+	Scopes   []string
+	// Resources holds the RFC 8707 resource parameter values, when present on the request. Embedded
+	// in the ID-JAG's `resource` claim so the resource AS can process them on the jwt-bearer leg.
+	Resources []string
+	OAuthApp  *providers.OAuthClient
 }
 
 // IDTokenBuildContext contains all the information needed to build an ID token (OIDC).
@@ -126,6 +143,20 @@ type SubjectTokenClaims struct {
 	CnfJkt string
 	// JTI is the subject token's unique identifier, populated only for self-issued tokens and used
 	// for deny-list (revocation) enforcement. Empty for externally-issued subject tokens.
+	JTI string
+}
+
+// IDJAGAssertionClaims represents the validated claims from an ID-JAG assertion presented on the
+// jwt-bearer grant (draft-ietf-oauth-identity-assertion-authz-grant).
+type IDJAGAssertionClaims struct {
+	Sub    string
+	Iss    string
+	Scopes []string
+	// Resources holds the RFC 8707 `resource` claim values carried by the assertion, when present.
+	// Empty when the assertion carries no resource claim.
+	Resources []string
+	// JTI is the assertion's unique identifier. It is required by the draft and validated for presence;
+	// one-time-use (replay) caching keyed on it is deferred to a future version.
 	JTI string
 }
 

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -44,9 +44,20 @@ type TokenValidatorInterface interface {
 	ValidateRefreshToken(ctx context.Context, token string, clientID string) (*RefreshTokenClaims, error)
 	ValidateSubjectToken(ctx context.Context, token string, oauthApp *providers.OAuthClient) (
 		*SubjectTokenClaims, error)
+	// ValidateIDJAGSubjectToken validates a subject token for the ID-JAG issuance leg of token
+	// exchange (draft-ietf-oauth-identity-assertion-authz-grant). It performs the same validation as
+	// ValidateSubjectToken and additionally requires the token to be a genuine ID token: its typ
+	// header must be "JWT" (rejecting at+jwt access tokens) and it must not carry an access_token_sub
+	// claim (rejecting refresh tokens). This blocks laundering a re-audienced access token or a
+	// refresh token into an ID-JAG.
+	ValidateIDJAGSubjectToken(ctx context.Context, token string, oauthApp *providers.OAuthClient) (
+		*SubjectTokenClaims, error)
 	// ValidateToken verifies a self-issued token's signature and enforces revocation without pinning
 	// its type, returning the raw claims. Used by token introspection, which is token-type agnostic.
 	ValidateToken(ctx context.Context, token string) (map[string]interface{}, error)
+	// ValidateIDJAGAssertion validates an ID-JAG assertion presented on the jwt-bearer grant,
+	// binding it to the authenticated client via its client_id claim.
+	ValidateIDJAGAssertion(ctx context.Context, assertion, clientID string) (*IDJAGAssertionClaims, error)
 }
 
 // TokenValidator implements TokenValidatorInterface.
@@ -211,6 +222,16 @@ func (tv *tokenValidator) ValidateSubjectToken(
 	token string,
 	oauthApp *providers.OAuthClient,
 ) (*SubjectTokenClaims, error) {
+	// An ID-JAG is an authorization grant, not a subject token, and must never be redeemable on token
+	// exchange. Reject it up front based on its typ header before any other processing.
+	header, err := jwt.DecodeJWTHeader(token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode token header: %w", err)
+	}
+	if typ, _ := header["typ"].(string); typ == jwt.TokenTypeIDJAG {
+		return nil, fmt.Errorf("an ID-JAG cannot be presented as a subject_token")
+	}
+
 	claims, err := jwt.DecodeJWTPayload(token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode token: %w", err)
@@ -258,6 +279,48 @@ func (tv *tokenValidator) ValidateSubjectToken(
 	return tv.extractSubjectTokenClaims(token, iss, claims, oauthApp, issuerInfo.AttributeMappings)
 }
 
+// ValidateIDJAGSubjectToken validates a subject token for the ID-JAG issuance leg of token exchange
+// (draft-ietf-oauth-identity-assertion-authz-grant). Beyond the standard subject-token validation
+// performed by ValidateSubjectToken (signature, revocation deny list, time claims, and claim
+// extraction), it enforces that the token is a genuine ID token. The typ header must be "JWT", which
+// rejects access tokens (typ "at+jwt") and blocks laundering a re-audienced token-exchange access
+// token into an ID-JAG. A top-level access_token_sub claim marks a refresh token (which shares
+// typ "JWT" with ID tokens) and is likewise rejected. It also requires the token's issuer to be this
+// server's own configured issuer, since ID-JAGs may only be issued for self-issued subject tokens.
+// The generic ValidateSubjectToken path used by RFC 8693 token exchange and actor-token validation is
+// intentionally left unchanged.
+func (tv *tokenValidator) ValidateIDJAGSubjectToken(
+	ctx context.Context,
+	token string,
+	oauthApp *providers.OAuthClient,
+) (*SubjectTokenClaims, error) {
+	header, err := jwt.DecodeJWTHeader(token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode subject token header: %w", err)
+	}
+	if typ, _ := header["typ"].(string); typ != jwt.TokenTypeJWT {
+		return nil, fmt.Errorf("subject_token must be an ID token, but has typ %q", typ)
+	}
+
+	claims, err := jwt.DecodeJWTPayload(token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode subject token payload: %w", err)
+	}
+	if _, isRefreshToken := claims["access_token_sub"]; isRefreshToken {
+		return nil, fmt.Errorf("subject_token must be an ID token, not a refresh token")
+	}
+
+	subjectClaims, err := tv.ValidateSubjectToken(ctx, token, oauthApp)
+	if err != nil {
+		return nil, err
+	}
+	if subjectClaims.Iss != tv.cfg.JWT.Issuer {
+		return nil, fmt.Errorf("subject_token must be issued by this server, got issuer %q", subjectClaims.Iss)
+	}
+
+	return subjectClaims, nil
+}
+
 // ValidateToken verifies a self-issued token's signature (type-agnostic) and enforces the revocation
 // deny list, returning the raw claims. Token introspection uses this because it accepts both access
 // and refresh tokens and must not pin a token type.
@@ -277,6 +340,124 @@ func (tv *tokenValidator) ValidateToken(ctx context.Context, token string) (map[
 	}
 
 	return claims, nil
+}
+
+// ValidateIDJAGAssertion validates an ID-JAG assertion presented on the jwt-bearer grant
+// (draft-ietf-oauth-identity-assertion-authz-grant). It requires the oauth-id-jag+jwt typ header,
+// resolves the assertion's issuer to a trusted external IdP with ID-JAG enabled, verifies the
+// signature against that IdP's JWKS, validates the time claims, requires the audience to equal this
+// server's issuer, and binds the assertion to the authenticated client via the client_id claim.
+func (tv *tokenValidator) ValidateIDJAGAssertion(
+	ctx context.Context,
+	assertion string,
+	clientID string,
+) (*IDJAGAssertionClaims, error) {
+	header, err := jwt.DecodeJWTHeader(assertion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode assertion header: %w", err)
+	}
+	if typ, _ := header["typ"].(string); typ != jwt.TokenTypeIDJAG {
+		return nil, fmt.Errorf("unsupported assertion type: expected %q", jwt.TokenTypeIDJAG)
+	}
+
+	claims, err := jwt.DecodeJWTPayload(assertion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode assertion payload: %w", err)
+	}
+
+	iss, err := extractStringClaim(claims, "iss")
+	if err != nil {
+		return nil, fmt.Errorf("assertion is missing 'iss' claim: %w", err)
+	}
+
+	issuerInfo, resolveErr := tv.resolveIDJAGIssuer(ctx, iss)
+	if resolveErr != nil {
+		return nil, fmt.Errorf("untrusted assertion issuer %q: %w", iss, resolveErr)
+	}
+
+	if svcErr := tv.jwtService.VerifyJWTSignatureWithJWKS(ctx, assertion, issuerInfo.JWKSURL); svcErr != nil {
+		return nil, fmt.Errorf("invalid assertion signature: %v", svcErr.Error)
+	}
+
+	if err := tv.validateTimeClaims(claims); err != nil {
+		return nil, err
+	}
+
+	// The draft lists jti, iat, and exp as REQUIRED; exp is enforced by validateTimeClaims above.
+	// Require a non-empty jti and an iat here. One-time-use (replay) caching keyed on jti is
+	// intentionally deferred to a future version, so this remains a presence check for forward
+	// compatibility.
+	if _, iatErr := extractInt64Claim(claims, "iat"); iatErr != nil {
+		return nil, fmt.Errorf("assertion is missing 'iat' claim: %w", iatErr)
+	}
+	jti, jtiErr := extractStringClaim(claims, "jti")
+	if jtiErr != nil {
+		return nil, fmt.Errorf("assertion is missing 'jti' claim: %w", jtiErr)
+	}
+
+	serverIssuer := tv.cfg.JWT.Issuer
+	auds, audErr := extractAudiences(claims)
+	if audErr != nil {
+		return nil, fmt.Errorf("assertion is missing 'aud' claim: %w", audErr)
+	}
+	// The draft permits aud to be a string or an array, but an array MUST contain exactly one element.
+	if len(auds) != 1 {
+		return nil, fmt.Errorf("assertion must have exactly one audience")
+	}
+	if auds[0] != serverIssuer {
+		return nil, fmt.Errorf("assertion audience does not match server issuer %q", serverIssuer)
+	}
+
+	assertionClientID, err := extractStringClaim(claims, "client_id")
+	if err != nil {
+		return nil, fmt.Errorf("assertion is missing 'client_id' claim: %w", err)
+	}
+	if assertionClientID != clientID {
+		return nil, fmt.Errorf("assertion 'client_id' does not match the authenticated client")
+	}
+
+	sub, err := extractStringClaim(claims, "sub")
+	if err != nil {
+		return nil, fmt.Errorf("assertion is missing 'sub' claim: %w", err)
+	}
+
+	return &IDJAGAssertionClaims{
+		Sub:       sub,
+		Iss:       iss,
+		Scopes:    extractScopesFromClaims(claims, false),
+		Resources: extractStringSliceClaim(claims, "resource"),
+		JTI:       jti,
+	}, nil
+}
+
+// resolveIDJAGIssuer looks up an external IDP whose issuer property matches the given issuer and
+// requires ID-JAG to be enabled. It mirrors resolveExternalIssuer but is a separate path so token
+// exchange trust resolution is unaffected.
+func (tv *tokenValidator) resolveIDJAGIssuer(ctx context.Context, issuer string) (
+	*tokenExchangeIssuerInfo, error) {
+	if tv.idpService == nil {
+		return nil, fmt.Errorf("no external issuers configured")
+	}
+
+	idpDTOs, svcErr := tv.idpService.GetIdentityProvidersByProperty(ctx, idp.PropIssuer, issuer)
+	if svcErr != nil || len(idpDTOs) == 0 {
+		return nil, fmt.Errorf("no trusted issuer configured for '%s'", issuer)
+	}
+
+	idpDTO := idpDTOs[0]
+	if idp.GetPropertyValue(idpDTO.Properties, idp.PropIDJagEnabled) != "true" {
+		return nil, fmt.Errorf("ID-JAG not enabled for issuer '%s'", issuer)
+	}
+
+	jwksURL := idp.GetPropertyValue(idpDTO.Properties, idp.PropJwksEndpoint)
+	if jwksURL == "" {
+		return nil, fmt.Errorf("no JWKS endpoint configured for issuer '%s'", issuer)
+	}
+
+	return &tokenExchangeIssuerInfo{
+		Issuer:  issuer,
+		JWKSURL: jwksURL,
+	}, nil
 }
 
 // tokenExchangeIssuerInfo holds the resolved properties needed to validate an external token.

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/revocation"
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
 	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/tests/mocks/idp/idpmock"
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
 	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/revocationmock"
@@ -294,6 +295,28 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_MalformedJW
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
 	assert.Contains(suite.T(), err.Error(), "failed to decode token")
+}
+
+// An ID-JAG is an authorization grant, not a subject token; ValidateSubjectToken must reject any token
+// whose typ header marks it as an ID-JAG before any signature or claim processing (typ confusion).
+func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_IDJAGTypRejected() {
+	header := map[string]interface{}{"alg": "RS256", "typ": jwt.TokenTypeIDJAG}
+	claims := map[string]interface{}{
+		"iss": suite.validator.cfg.JWT.Issuer,
+		"sub": "user123",
+		"exp": float64(time.Now().Unix() + 3600),
+	}
+	headerJSON, _ := json.Marshal(header)
+	claimsJSON, _ := json.Marshal(claims)
+	token := fmt.Sprintf("%s.%s.signature",
+		base64.RawURLEncoding.EncodeToString(headerJSON),
+		base64.RawURLEncoding.EncodeToString(claimsJSON))
+
+	result, err := suite.validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "ID-JAG cannot be presented as a subject_token")
 }
 
 // ============================================================================
@@ -737,6 +760,99 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_NonAssertion_Tole
 	assert.NotNil(suite.T(), result)
 	assert.Empty(suite.T(), result.Aud)
 	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// ============================================================================
+// ValidateIDJAGSubjectToken Tests (draft-ietf-oauth-identity-assertion-authz-grant)
+// The ID-JAG issuance leg requires a genuine self-issued ID token as the subject_token.
+// ============================================================================
+
+// A genuine self-issued ID token (typ=JWT, no access_token_sub, sub set, aud contains the client)
+// is accepted and its claims are returned.
+func (suite *TokenValidatorTestSuite) TestValidateIDJAGSubjectToken_Success() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "user123",
+		"iss": "https://example.com",
+		"aud": testClientID,
+		"exp": float64(now + 3600),
+	}
+	token := suite.createTestJWT(claims)
+
+	suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil)
+
+	result, err := suite.validator.ValidateIDJAGSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), "user123", result.Sub)
+	assert.Equal(suite.T(), "https://example.com", result.Iss)
+	assert.Equal(suite.T(), []string{testClientID}, result.Aud)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// Core token-laundering regression: an access token (typ=at+jwt) whose sub and aud=[client_id]
+// would satisfy the ID-JAG client binding under the old aud-only logic is rejected on its typ
+// header, before any signature verification, because it is not a genuine ID token. This is the
+// re-audiencing hop the RFC 8693 token-exchange path could otherwise produce.
+func (suite *TokenValidatorTestSuite) TestValidateIDJAGSubjectToken_RejectsAccessTokenTyp() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "user123",
+		"iss": "https://example.com",
+		"aud": testClientID,
+		"exp": float64(now + 3600),
+	}
+	token := suite.createTestAccessToken(claims)
+
+	result, err := suite.validator.ValidateIDJAGSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "must be an ID token")
+}
+
+// A refresh token carries typ=JWT (shared with ID tokens) but a top-level access_token_sub claim;
+// it is rejected so a refresh token cannot be laundered into an ID-JAG.
+func (suite *TokenValidatorTestSuite) TestValidateIDJAGSubjectToken_RejectsRefreshTokenShape() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub":              testClientID,
+		"iss":              "https://example.com",
+		"aud":              testClientID,
+		"access_token_sub": "user123",
+		"exp":              float64(now + 3600),
+	}
+	token := suite.createTestJWT(claims)
+
+	result, err := suite.validator.ValidateIDJAGSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "refresh token")
+}
+
+// A token whose typ header marks it as an ID-JAG (oauth-id-jag+jwt) is rejected; only typ=JWT is
+// accepted on the ID-JAG subject-token path.
+func (suite *TokenValidatorTestSuite) TestValidateIDJAGSubjectToken_RejectsIDJAGTyp() {
+	header := map[string]interface{}{"alg": "RS256", "typ": jwt.TokenTypeIDJAG}
+	claims := map[string]interface{}{
+		"sub": "user123",
+		"iss": "https://example.com",
+		"aud": testClientID,
+		"exp": float64(time.Now().Unix() + 3600),
+	}
+	headerJSON, _ := json.Marshal(header)
+	claimsJSON, _ := json.Marshal(claims)
+	token := fmt.Sprintf("%s.%s.signature",
+		base64.RawURLEncoding.EncodeToString(headerJSON),
+		base64.RawURLEncoding.EncodeToString(claimsJSON))
+
+	result, err := suite.validator.ValidateIDJAGSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "must be an ID token")
 }
 
 func (suite *TokenValidatorTestSuite) TestValidateRefreshToken_Success_Basic() {
@@ -2427,6 +2543,34 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
+// ID-JAGs may only be issued for self-issued subject tokens. A token that passes the generic
+// ValidateSubjectToken checks (valid external-issuer signature and audience) is still rejected by
+// ValidateIDJAGSubjectToken because its issuer is not this server's own configured issuer.
+func (suite *ExternalIDPValidatorTestSuite) TestValidateIDJAGSubjectToken_ExternalIDP_Error_NotSelfIssuer() {
+	now := time.Now().Unix()
+	claims := map[string]interface{}{
+		"sub": "ext-user-123",
+		"iss": testExternalIssuer,
+		"aud": "https://example.com",
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	}
+	token := suite.createExternalJWT(claims)
+	idpDTOs := buildExternalIDPDTOs()
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, token, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateIDJAGSubjectToken(context.Background(), token, suite.oauthApp)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "subject_token must be issued by this server")
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
 func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP_Success_ConfiguredAudience() {
 	result := suite.validateConfiguredAudienceSubjectToken(testTrustedTokenAudience)
 	assert.Equal(suite.T(), "ext-user-123", result.Sub)
@@ -2718,4 +2862,305 @@ func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_MalformedCnf_Erro
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
+}
+
+// ============================================================================
+// ID-JAG Assertion Validation Tests (draft-ietf-oauth-identity-assertion-authz-grant)
+// The server issuer configured for these tests is "https://example.com".
+// ============================================================================
+
+type IDJAGValidatorTestSuite struct {
+	suite.Suite
+	mockJWTService         *jwtmock.JWTServiceInterfaceMock
+	mockIDPService         *idpmock.IDPServiceInterfaceMock
+	mockEnforcementService *revocationmock.EnforcementServiceInterfaceMock
+	validator              *tokenValidator
+}
+
+func TestIDJAGValidatorTestSuite(t *testing.T) {
+	suite.Run(t, new(IDJAGValidatorTestSuite))
+}
+
+func (suite *IDJAGValidatorTestSuite) SetupTest() {
+	config.ResetServerRuntime()
+	testConfig := &config.Config{
+		JWT: engineconfig.JWTConfig{
+			Issuer:         "https://example.com",
+			ValidityPeriod: 3600,
+			Audience:       "application",
+			Leeway:         30,
+		},
+	}
+	_ = config.InitializeServerRuntime("test", testConfig)
+
+	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
+	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
+	suite.mockEnforcementService = revocationmock.NewEnforcementServiceInterfaceMock(suite.T())
+	suite.mockEnforcementService.On("EnsureNotRevoked", mock.Anything, mock.Anything).Return(nil).Maybe()
+	suite.validator = &tokenValidator{
+		cfg: oauthconfig.Config{
+			JWT: engineconfig.JWTConfig{
+				Issuer:         "https://example.com",
+				ValidityPeriod: 3600,
+				Audience:       "application",
+				Leeway:         30,
+			},
+		},
+		jwtService:         suite.mockJWTService,
+		idpService:         suite.mockIDPService,
+		enforcementService: suite.mockEnforcementService,
+	}
+}
+
+// buildIDJAGIDPDTOs builds a []providers.IDPDTO for a trusted external IdP with ID-JAG enabled.
+func buildIDJAGIDPDTOs() []providers.IDPDTO {
+	propIDJag, _ := cmodels.NewProperty(idp.PropIDJagEnabled, "true", false)
+	propJWKS, _ := cmodels.NewProperty(idp.PropJwksEndpoint, testExternalJWKS, false)
+	propIssuer, _ := cmodels.NewProperty(idp.PropIssuer, testExternalIssuer, false)
+	return []providers.IDPDTO{
+		{Properties: []cmodels.Property{*propIDJag, *propJWKS, *propIssuer}},
+	}
+}
+
+// createAssertion builds a JWT with the given typ header and claims for ID-JAG assertion tests.
+func (suite *IDJAGValidatorTestSuite) createAssertion(typ string, claims map[string]interface{}) string {
+	header := map[string]interface{}{"alg": "RS256", "typ": typ}
+	headerJSON, _ := json.Marshal(header)
+	claimsJSON, _ := json.Marshal(claims)
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	claimsB64 := base64.RawURLEncoding.EncodeToString(claimsJSON)
+	return fmt.Sprintf("%s.%s.signature", headerB64, claimsB64)
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_Success() {
+	claims := suite.idjagClaims()
+	claims["scope"] = JoinScopes([]string{"read", "write"})
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, claims)
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), "ext-user-123", result.Sub)
+	assert.Equal(suite.T(), testExternalIssuer, result.Iss)
+	assert.Equal(suite.T(), []string{"read", "write"}, result.Scopes)
+	assert.Equal(suite.T(), testIDJAGAssertionJTI, result.JTI)
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_SingleResourceClaim() {
+	claims := suite.idjagClaims()
+	claims["resource"] = "https://rs01.example.com"
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, claims)
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"https://rs01.example.com"}, result.Resources)
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_MultipleResourcesClaim() {
+	claims := suite.idjagClaims()
+	claims["resource"] = []string{"https://rs01.example.com", "https://rs02.example.com"}
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, claims)
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"https://rs01.example.com", "https://rs02.example.com"}, result.Resources)
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_NoResourceClaim() {
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, suite.idjagClaims())
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Empty(suite.T(), result.Resources)
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_WrongTyp() {
+	assertion := suite.createAssertion(jwt.TokenTypeJWT, suite.idjagClaims())
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "unsupported assertion type")
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_UntrustedIssuer() {
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, suite.idjagClaims())
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return([]providers.IDPDTO{}, nil)
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "untrusted assertion issuer")
+	suite.mockIDPService.AssertExpectations(suite.T())
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_IDJagNotEnabled() {
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, suite.idjagClaims())
+
+	// IdP has token exchange enabled but NOT ID-JAG.
+	propTokenExchange, _ := cmodels.NewProperty(idp.PropTokenExchangeEnabled, "true", false)
+	propJWKS, _ := cmodels.NewProperty(idp.PropJwksEndpoint, testExternalJWKS, false)
+	propIssuer, _ := cmodels.NewProperty(idp.PropIssuer, testExternalIssuer, false)
+	idpDTOs := []providers.IDPDTO{
+		{Properties: []cmodels.Property{*propTokenExchange, *propJWKS, *propIssuer}},
+	}
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "ID-JAG not enabled")
+	suite.mockIDPService.AssertExpectations(suite.T())
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_InvalidSignature() {
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, suite.idjagClaims())
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).
+		Return(&tidcommon.ServiceError{
+			Type:  tidcommon.ServerErrorType,
+			Code:  "SIGNATURE_VERIFICATION_FAILED",
+			Error: tidcommon.I18nMessage{Key: "error.test.sig_failed", DefaultValue: "Signature verification failed"},
+			ErrorDescription: tidcommon.I18nMessage{
+				Key: "error.test.sig_failed_desc", DefaultValue: "JWT signature verification failed",
+			},
+		})
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "invalid assertion signature")
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// assertRejectsSignedAssertion configures a trusted, ID-JAG-enabled issuer whose signature verifies,
+// then asserts that ValidateIDJAGAssertion rejects the given claims with an error containing errSub.
+// It covers the post-signature validation checks (time, audience, client binding).
+func (suite *IDJAGValidatorTestSuite) assertRejectsSignedAssertion(
+	claims map[string]interface{}, errSub string) {
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, claims)
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), errSub)
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *IDJAGValidatorTestSuite) idjagClaims() map[string]interface{} {
+	now := time.Now().Unix()
+	return map[string]interface{}{
+		"sub":       "ext-user-123",
+		"iss":       testExternalIssuer,
+		"aud":       "https://example.com",
+		"client_id": testClientID,
+		"jti":       testIDJAGAssertionJTI,
+		"iat":       float64(now),
+		"exp":       float64(now + 300),
+	}
+}
+
+const testIDJAGAssertionJTI = "assertion-jti-1" //nolint:gosec // Test identifier, not a credential
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_MissingJTI() {
+	claims := suite.idjagClaims()
+	delete(claims, "jti")
+	suite.assertRejectsSignedAssertion(claims, "missing 'jti' claim")
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_MissingIAT() {
+	claims := suite.idjagClaims()
+	delete(claims, "iat")
+	suite.assertRejectsSignedAssertion(claims, "missing 'iat' claim")
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_Expired() {
+	claims := suite.idjagClaims()
+	claims["exp"] = float64(time.Now().Unix() - 3600)
+	suite.assertRejectsSignedAssertion(claims, "token has expired")
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_AudMismatch() {
+	claims := suite.idjagClaims()
+	claims["aud"] = "https://not-this-server.example.com"
+	suite.assertRejectsSignedAssertion(claims, "assertion audience does not match server issuer")
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_ClientIDMismatch() {
+	claims := suite.idjagClaims()
+	claims["client_id"] = "a-different-client"
+	suite.assertRejectsSignedAssertion(claims, "does not match the authenticated client")
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_MissingClientIDClaim() {
+	claims := suite.idjagClaims()
+	delete(claims, "client_id")
+	suite.assertRejectsSignedAssertion(claims, "missing 'client_id' claim")
+}
+
+// The draft allows aud to be an array only if it contains exactly one element; a two-element aud is
+// rejected even when one element matches the server issuer.
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_MultiValuedAudRejected() {
+	claims := suite.idjagClaims()
+	claims["aud"] = []string{"https://example.com", "https://other.example.com"}
+	suite.assertRejectsSignedAssertion(claims, "assertion must have exactly one audience")
+}
+
+// A single-element aud array is equivalent to a string audience and is accepted.
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_SingleElementAudArrayAccepted() {
+	claims := suite.idjagClaims()
+	claims["aud"] = []string{"https://example.com"}
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, claims)
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), "ext-user-123", result.Sub)
+	suite.mockIDPService.AssertExpectations(suite.T())
+	suite.mockJWTService.AssertExpectations(suite.T())
 }

--- a/backend/internal/system/jose/jwt/constants.go
+++ b/backend/internal/system/jose/jwt/constants.go
@@ -24,4 +24,8 @@ const (
 
 	// TokenTypeAccessToken is the JWT type header value for access tokens as defined in RFC 9068.
 	TokenTypeAccessToken = "at+jwt"
+
+	// TokenTypeIDJAG is the JWT type header value for an Identity Assertion Authorization Grant
+	// (draft-ietf-oauth-identity-assertion-authz-grant).
+	TokenTypeIDJAG = "oauth-id-jag+jwt" //nolint:gosec // JWT typ header value, not a credential
 )

--- a/backend/pkg/thunderidengine/providers/constants.go
+++ b/backend/pkg/thunderidengine/providers/constants.go
@@ -135,7 +135,14 @@ const (
 	GrantTypeTokenExchange GrantType = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec
 	// GrantTypeCIBA represents the OpenID Connect CIBA (Client-Initiated Backchannel Authentication) grant type.
 	GrantTypeCIBA GrantType = "urn:openid:params:grant-type:ciba"
+	// GrantTypeJWTBearer represents the JWT bearer grant type used to present an ID-JAG assertion
+	// (draft-ietf-oauth-identity-assertion-authz-grant) issued by a trusted external IdP.
+	GrantTypeJWTBearer GrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer" //nolint:gosec
 )
+
+// DefaultIDJAGValidityPeriod is the default validity period, in seconds, of an issued ID-JAG when the
+// application does not configure one.
+const DefaultIDJAGValidityPeriod int64 = 300
 
 // ResponseType defines a type for OAuth2 response types.
 type ResponseType string
@@ -169,6 +176,7 @@ var SupportedGrantTypes = []GrantType{
 	GrantTypeRefreshToken,
 	GrantTypeTokenExchange,
 	GrantTypeCIBA,
+	GrantTypeJWTBearer,
 }
 
 // IsValid checks if the GrantType is valid.

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -580,6 +580,16 @@ type OAuthTokenConfig struct {
 	AccessToken  *AccessTokenConfig  `json:"accessToken,omitempty"  yaml:"accessToken,omitempty"  jsonschema:"Access token configuration."`
 	IDToken      *IDTokenConfig      `json:"idToken,omitempty"      yaml:"idToken,omitempty"      jsonschema:"ID token configuration."`
 	RefreshToken *RefreshTokenConfig `json:"refreshToken,omitempty" yaml:"refreshToken,omitempty" jsonschema:"Refresh token configuration."`
+	IDJAG        *IDJAGConfig        `json:"idJag,omitempty"        yaml:"idJag,omitempty"        jsonschema:"Identity Assertion Authorization Grant (ID-JAG) configuration."`
+}
+
+// IDJAGConfig is the Identity Assertion Authorization Grant (ID-JAG) configuration. Enabled must be
+// true and AllowedAudiences must be non-empty for the application to request ID-JAGs via token
+// exchange.
+type IDJAGConfig struct {
+	Enabled          bool     `json:"enabled"                    yaml:"enabled"                    jsonschema:"Enable ID-JAG issuance for this application."`
+	AllowedAudiences []string `json:"allowedAudiences,omitempty" yaml:"allowedAudiences,omitempty" jsonschema:"Resource authorization server identifiers for which this application may request ID-JAGs."`
+	ValidityPeriod   int64    `json:"validityPeriod,omitempty"   yaml:"validityPeriod,omitempty"   jsonschema:"Validity period of an issued ID-JAG in seconds. Defaults to 300 when unset."`
 }
 
 // AccessTokenConfig is the access token configuration, split by token subject: an end user

--- a/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenBuilderInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenBuilderInterface_mock.go
@@ -107,6 +107,74 @@ func (_c *TokenBuilderInterfaceMock_BuildAccessToken_Call) RunAndReturn(run func
 	return _c
 }
 
+// BuildIDJAG provides a mock function for the type TokenBuilderInterfaceMock
+func (_mock *TokenBuilderInterfaceMock) BuildIDJAG(ctx context.Context, tokenCtx *tokenservice.IDJAGBuildContext) (*model.TokenDTO, error) {
+	ret := _mock.Called(ctx, tokenCtx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BuildIDJAG")
+	}
+
+	var r0 *model.TokenDTO
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *tokenservice.IDJAGBuildContext) (*model.TokenDTO, error)); ok {
+		return returnFunc(ctx, tokenCtx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *tokenservice.IDJAGBuildContext) *model.TokenDTO); ok {
+		r0 = returnFunc(ctx, tokenCtx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.TokenDTO)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *tokenservice.IDJAGBuildContext) error); ok {
+		r1 = returnFunc(ctx, tokenCtx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// TokenBuilderInterfaceMock_BuildIDJAG_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildIDJAG'
+type TokenBuilderInterfaceMock_BuildIDJAG_Call struct {
+	*mock.Call
+}
+
+// BuildIDJAG is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tokenCtx *tokenservice.IDJAGBuildContext
+func (_e *TokenBuilderInterfaceMock_Expecter) BuildIDJAG(ctx interface{}, tokenCtx interface{}) *TokenBuilderInterfaceMock_BuildIDJAG_Call {
+	return &TokenBuilderInterfaceMock_BuildIDJAG_Call{Call: _e.mock.On("BuildIDJAG", ctx, tokenCtx)}
+}
+
+func (_c *TokenBuilderInterfaceMock_BuildIDJAG_Call) Run(run func(ctx context.Context, tokenCtx *tokenservice.IDJAGBuildContext)) *TokenBuilderInterfaceMock_BuildIDJAG_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *tokenservice.IDJAGBuildContext
+		if args[1] != nil {
+			arg1 = args[1].(*tokenservice.IDJAGBuildContext)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *TokenBuilderInterfaceMock_BuildIDJAG_Call) Return(tokenDTO *model.TokenDTO, err error) *TokenBuilderInterfaceMock_BuildIDJAG_Call {
+	_c.Call.Return(tokenDTO, err)
+	return _c
+}
+
+func (_c *TokenBuilderInterfaceMock_BuildIDJAG_Call) RunAndReturn(run func(ctx context.Context, tokenCtx *tokenservice.IDJAGBuildContext) (*model.TokenDTO, error)) *TokenBuilderInterfaceMock_BuildIDJAG_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // BuildIDToken provides a mock function for the type TokenBuilderInterfaceMock
 func (_mock *TokenBuilderInterfaceMock) BuildIDToken(ctx context.Context, tokenCtx *tokenservice.IDTokenBuildContext) (*model.TokenDTO, error) {
 	ret := _mock.Called(ctx, tokenCtx)

--- a/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenValidatorInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenValidatorInterface_mock.go
@@ -107,6 +107,154 @@ func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) RunAndReturn(run
 	return _c
 }
 
+// ValidateIDJAGAssertion provides a mock function for the type TokenValidatorInterfaceMock
+func (_mock *TokenValidatorInterfaceMock) ValidateIDJAGAssertion(ctx context.Context, assertion string, clientID string) (*tokenservice.IDJAGAssertionClaims, error) {
+	ret := _mock.Called(ctx, assertion, clientID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateIDJAGAssertion")
+	}
+
+	var r0 *tokenservice.IDJAGAssertionClaims
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*tokenservice.IDJAGAssertionClaims, error)); ok {
+		return returnFunc(ctx, assertion, clientID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *tokenservice.IDJAGAssertionClaims); ok {
+		r0 = returnFunc(ctx, assertion, clientID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*tokenservice.IDJAGAssertionClaims)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, assertion, clientID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateIDJAGAssertion'
+type TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call struct {
+	*mock.Call
+}
+
+// ValidateIDJAGAssertion is a helper method to define mock.On call
+//   - ctx context.Context
+//   - assertion string
+//   - clientID string
+func (_e *TokenValidatorInterfaceMock_Expecter) ValidateIDJAGAssertion(ctx interface{}, assertion interface{}, clientID interface{}) *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call {
+	return &TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call{Call: _e.mock.On("ValidateIDJAGAssertion", ctx, assertion, clientID)}
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call) Run(run func(ctx context.Context, assertion string, clientID string)) *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call) Return(iDJAGAssertionClaims *tokenservice.IDJAGAssertionClaims, err error) *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call {
+	_c.Call.Return(iDJAGAssertionClaims, err)
+	return _c
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call) RunAndReturn(run func(ctx context.Context, assertion string, clientID string) (*tokenservice.IDJAGAssertionClaims, error)) *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ValidateIDJAGSubjectToken provides a mock function for the type TokenValidatorInterfaceMock
+func (_mock *TokenValidatorInterfaceMock) ValidateIDJAGSubjectToken(ctx context.Context, token string, oauthApp *providers.OAuthClient) (*tokenservice.SubjectTokenClaims, error) {
+	ret := _mock.Called(ctx, token, oauthApp)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateIDJAGSubjectToken")
+	}
+
+	var r0 *tokenservice.SubjectTokenClaims
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *providers.OAuthClient) (*tokenservice.SubjectTokenClaims, error)); ok {
+		return returnFunc(ctx, token, oauthApp)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *providers.OAuthClient) *tokenservice.SubjectTokenClaims); ok {
+		r0 = returnFunc(ctx, token, oauthApp)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*tokenservice.SubjectTokenClaims)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *providers.OAuthClient) error); ok {
+		r1 = returnFunc(ctx, token, oauthApp)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// TokenValidatorInterfaceMock_ValidateIDJAGSubjectToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateIDJAGSubjectToken'
+type TokenValidatorInterfaceMock_ValidateIDJAGSubjectToken_Call struct {
+	*mock.Call
+}
+
+// ValidateIDJAGSubjectToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - token string
+//   - oauthApp *providers.OAuthClient
+func (_e *TokenValidatorInterfaceMock_Expecter) ValidateIDJAGSubjectToken(ctx interface{}, token interface{}, oauthApp interface{}) *TokenValidatorInterfaceMock_ValidateIDJAGSubjectToken_Call {
+	return &TokenValidatorInterfaceMock_ValidateIDJAGSubjectToken_Call{Call: _e.mock.On("ValidateIDJAGSubjectToken", ctx, token, oauthApp)}
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateIDJAGSubjectToken_Call) Run(run func(ctx context.Context, token string, oauthApp *providers.OAuthClient)) *TokenValidatorInterfaceMock_ValidateIDJAGSubjectToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 *providers.OAuthClient
+		if args[2] != nil {
+			arg2 = args[2].(*providers.OAuthClient)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateIDJAGSubjectToken_Call) Return(subjectTokenClaims *tokenservice.SubjectTokenClaims, err error) *TokenValidatorInterfaceMock_ValidateIDJAGSubjectToken_Call {
+	_c.Call.Return(subjectTokenClaims, err)
+	return _c
+}
+
+func (_c *TokenValidatorInterfaceMock_ValidateIDJAGSubjectToken_Call) RunAndReturn(run func(ctx context.Context, token string, oauthApp *providers.OAuthClient) (*tokenservice.SubjectTokenClaims, error)) *TokenValidatorInterfaceMock_ValidateIDJAGSubjectToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ValidateRefreshToken provides a mock function for the type TokenValidatorInterfaceMock
 func (_mock *TokenValidatorInterfaceMock) ValidateRefreshToken(ctx context.Context, token string, clientID string) (*tokenservice.RefreshTokenClaims, error) {
 	ret := _mock.Called(ctx, token, clientID)


### PR DESCRIPTION

### Purpose
Implement both legs of draft-ietf-oauth-identity-assertion-authz-grant-04 at the /oauth2/token endpoint.

Leg 1 (issuance): extend the RFC 8693 token-exchange handler so a confidential client can exchange a self-issued ID token for an ID-JAG (requested_token_type=urn:ietf:params:oauth:token-type:id-jag). The issued JWT uses typ=oauth-id-jag+jwt with iss/sub/aud/client_id/jti/ iat/exp/scope, and the response carries issued_token_type=id-jag, token_type=N_A, and no refresh token. Issuance is gated per app by a new token.idJag config (allowedAudiences exact-match, validityPeriod).

Leg 2 (consumption): add the urn:ietf:params:oauth:grant-type:jwt-bearer grant, which validates an ID-JAG issued by a trusted external IdP (new id_jag_enabled IdP property) — enforcing the typ header, JWKS signature, exp/iat/nbf/jti, aud bound to this server's issuer, and the client_id claim bound to the authenticated client — then issues an access token whose subject is the federated principal, tagged with an idp provenance claim.

Both grants are restricted to confidential clients at request and create time. jti/iat presence is required; jti replay caching and DPoP binding are deferred.



### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2440


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **jwt-bearer** grant support and **ID-JAG** issuance via **token exchange**, including token type handling.
  * Introduced **ID-JAG app configuration** (enabled, allowed audiences, validity with defaulting).
  * Extended **OIDC connection** requests/responses with an optional **idJagEnabled** flag.
  * Updated OAuth/OpenAPI docs and discovery examples to advertise **jwt-bearer** support.

* **Bug Fixes**
  * Strengthened validation to reject the **`none`** token endpoint auth method when confidentiality is required.
  * Improved ID-JAG configuration handling and defaulting.

* **Tests**
  * Expanded test coverage for jwt-bearer and ID-JAG grant flows, token building, and validation/defaulting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->