### PR TITLE
Flag based instantiation of refresh token handler and token revokation

### DIFF
--- a/backend/cmd/server/config/default.json
+++ b/backend/cmd/server/config/default.json
@@ -112,6 +112,7 @@
   },
   "oauth": {
     "refresh_token": {
+      "enabled" : true,
       "renew_on_grant": false,
       "revoke_previous_on_renew": true,
       "validity_period": 86400
@@ -133,7 +134,10 @@
       "allowed_algs": ["ES256", "PS256", "ES384", "ES512", "EdDSA", "RS256"],
       "max_jti_length": 256
     },
-    "allow_wildcard_redirect_uri": false
+    "allow_wildcard_redirect_uri": false,
+    "token_revocation" : {
+      "enabled" : true
+    }
   },
   "flow": {
     "default_auth_flow_handle": "default-flow",

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -76,17 +76,26 @@ func Initialize(
 	resolver := jwksresolver.Initialize(httpClient)
 	scopeValidator := scope.Initialize()
 	discoveryService := discovery.Initialize(mux, runtimeCrypto, cfg)
-	// The enforcement service (revocation read path) is built before the token service so it can be
-	// injected into the validator, which enforces the deny list as the final step of every validation.
-	enforcementService, refreshTokenRevoker := revocation.Initialize(
-		mux, jwtService, actorProvider, authnProvider, discoveryService, observabilitySvc)
+
+	var enforcementService revocation.EnforcementServiceInterface
+	var refreshTokenRevoker revocation.RefreshTokenRevokerInterface
+	if cfg.OAuth.TokenRevocation.Enabled {
+		// The enforcement service (revocation read path) is built before the token service so it can be
+		// injected into the validator, which enforces the deny list as the final step of every validation.
+		enforcementService, refreshTokenRevoker = revocation.Initialize(
+			mux, jwtService, actorProvider, authnProvider, discoveryService, observabilitySvc)
+	}
+
 	tokenBuilder, tokenValidator := tokenservice.Initialize(
 		cfg, jwtService, jweService, resolver, idpService, enforcementService)
 	parService := par.Initialize(mux, actorProvider, authnProvider, jwtService, discoveryService,
 		resourceService, dpopVerifier, cfg, storeProvider)
 
-	cibaService := ciba.Initialize(mux, jwtService, actorProvider, authnProvider, flowExecService,
-		discoveryService, resourceService, cfg)
+	var cibaService ciba.CIBAServiceInterface
+	if cfg.OAuth.CIBA.Enabled {
+		cibaService = ciba.Initialize(mux, jwtService, actorProvider, authnProvider, flowExecService,
+			discoveryService, resourceService, cfg)
+	}
 
 	oauth2AuthzService, err := oauth2authz.Initialize(mux, actorProvider, resourceService,
 		jwtService, flowExecService, parService, cfg, storeProvider, transactioner)

--- a/backend/internal/oauth/oauth2/callback/callback.go
+++ b/backend/internal/oauth/oauth2/callback/callback.go
@@ -123,6 +123,12 @@ func (d *callbackDispatcher) handleFlowCallback(w http.ResponseWriter, r *http.R
 		utils.WriteSuccessResponse(ctx, w, http.StatusOK, oauth2authz.AuthZPostResponse{RedirectURI: redirectURI})
 
 	case string(providers.GrantTypeCIBA):
+		if !d.cfg.OAuth.CIBA.Enabled {
+			utils.WriteJSONError(ctx, w, oauth2const.ErrorInvalidRequest,
+				"Unsupported callback type", http.StatusBadRequest, nil)
+			return
+		}
+
 		cibaErr := d.cibaService.HandleCallback(ctx, req.AuthID, req.Assertion)
 		if cibaErr != nil {
 			statusCode := http.StatusBadRequest

--- a/backend/internal/oauth/oauth2/callback/callback_test.go
+++ b/backend/internal/oauth/oauth2/callback/callback_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	oauth2authz "github.com/thunder-id/thunderid/internal/oauth/oauth2/authz"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/ciba"
 	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
@@ -51,10 +52,17 @@ func TestCallbackDispatcherSuite(t *testing.T) {
 	suite.Run(t, new(CallbackDispatcherTestSuite))
 }
 
+// cibaEnabledOAuthConfig returns a config with the CIBA callback type enabled.
+func cibaEnabledOAuthConfig() oauthconfig.Config {
+	cfg := testhelpers.OAuthConfig()
+	cfg.OAuth.CIBA.Enabled = true
+	return cfg
+}
+
 func (suite *CallbackDispatcherTestSuite) SetupTest() {
 	suite.mockAuthZ = authzmock.NewAuthorizeServiceInterfaceMock(suite.T())
 	suite.mockCIBA = cibamock.NewCIBAServiceInterfaceMock(suite.T())
-	suite.dispatcher = newCallbackDispatcher(testhelpers.OAuthConfig(), suite.mockAuthZ, suite.mockCIBA)
+	suite.dispatcher = newCallbackDispatcher(cibaEnabledOAuthConfig(), suite.mockAuthZ, suite.mockCIBA)
 
 	_ = config.InitializeServerRuntime("test", &config.Config{
 		JWT: engineconfig.JWTConfig{
@@ -251,6 +259,22 @@ func (suite *CallbackDispatcherTestSuite) TestHandleFlowCallback_CIBA_Error() {
 	var body map[string]string
 	suite.NoError(json.NewDecoder(w.Body).Decode(&body))
 	suite.Equal(oauth2const.ErrorAccessDenied, body["error"])
+}
+
+func (suite *CallbackDispatcherTestSuite) TestHandleFlowCallback_CIBA_Disabled_ReturnsBadRequest() {
+	dispatcher := newCallbackDispatcher(testhelpers.OAuthConfig(), suite.mockAuthZ, suite.mockCIBA)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/auth/callback", strings.NewReader(
+		`{"authId":"auth-req-1","assertion":"ciba-assertion","type":"urn:openid:params:grant-type:ciba"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	dispatcher.handleFlowCallback(w, req)
+
+	suite.Equal(http.StatusBadRequest, w.Code)
+	var body map[string]string
+	suite.NoError(json.NewDecoder(w.Body).Decode(&body))
+	suite.Equal(oauth2const.ErrorInvalidRequest, body["error"])
+	suite.Contains(body["error_description"], "Unsupported callback type")
 }
 
 // --- handleFlowCallback: unsupported type ---

--- a/backend/internal/oauth/oauth2/granthandlers/provider.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider.go
@@ -59,17 +59,27 @@ func newGrantHandlerProvider(
 	refreshTokenRevoker revocation.RefreshTokenRevokerInterface,
 	cfg oauthconfig.Config,
 ) GrantHandlerProviderInterface {
+	var refreshTokenGrantHandler GrantHandlerInterface
+	if cfg.OAuth.RefreshToken.Enabled {
+		refreshTokenGrantHandler = newRefreshTokenGrantHandler(
+			jwtService, tokenBuilder, tokenValidator, attrCacheService, resourceService,
+			refreshTokenRevoker, cfg)
+	}
+
+	var cibaGrantHandler GrantHandlerInterface
+	if cfg.OAuth.CIBA.Enabled {
+		cibaGrantHandler = newCIBAGrantHandler(cibaService, tokenBuilder, attrCacheService)
+	}
+
 	return &GrantHandlerProvider{
 		clientCredentialsGrantHandler: newClientCredentialsGrantHandler(
 			tokenBuilder, ouService, rbacAuthzService, actorProvider, resourceService),
 		authorizationCodeGrantHandler: newAuthorizationCodeGrantHandler(
 			authzService, tokenBuilder, attrCacheService, resourceService),
-		refreshTokenGrantHandler: newRefreshTokenGrantHandler(
-			jwtService, tokenBuilder, tokenValidator, attrCacheService, resourceService,
-			refreshTokenRevoker, cfg),
+		refreshTokenGrantHandler: refreshTokenGrantHandler,
 		tokenExchangeGrantHandler: newTokenExchangeGrantHandler(
 			tokenBuilder, tokenValidator, resourceService),
-		cibaGrantHandler: newCIBAGrantHandler(cibaService, tokenBuilder, attrCacheService),
+		cibaGrantHandler: cibaGrantHandler,
 	}
 }
 
@@ -81,11 +91,17 @@ func (p *GrantHandlerProvider) GetGrantHandler(grantType providers.GrantType) (G
 	case providers.GrantTypeAuthorizationCode:
 		return p.authorizationCodeGrantHandler, nil
 	case providers.GrantTypeRefreshToken:
-		return p.refreshTokenGrantHandler, nil
+		if p.refreshTokenGrantHandler != nil {
+			return p.refreshTokenGrantHandler, nil
+		}
+		return nil, constants.UnSupportedGrantTypeError
 	case providers.GrantTypeTokenExchange:
 		return p.tokenExchangeGrantHandler, nil
 	case providers.GrantTypeCIBA:
-		return p.cibaGrantHandler, nil
+		if p.cibaGrantHandler != nil {
+			return p.cibaGrantHandler, nil
+		}
+		return nil, constants.UnSupportedGrantTypeError
 	default:
 		return nil, constants.UnSupportedGrantTypeError
 	}

--- a/backend/internal/oauth/oauth2/granthandlers/provider_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/actorprovidermock"
@@ -58,6 +59,14 @@ func TestGrantHandlerProviderSuite(t *testing.T) {
 	suite.Run(t, new(GrantHandlerProviderTestSuite))
 }
 
+// enabledOAuthConfig returns a config with the refresh token and CIBA grant handlers enabled.
+func enabledOAuthConfig() oauthconfig.Config {
+	cfg := testhelpers.OAuthConfig()
+	cfg.OAuth.RefreshToken.Enabled = true
+	cfg.OAuth.CIBA.Enabled = true
+	return cfg
+}
+
 func (suite *GrantHandlerProviderTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.authzService = authzmock.NewAuthorizeServiceInterfaceMock(suite.T())
@@ -81,7 +90,7 @@ func (suite *GrantHandlerProviderTestSuite) SetupTest() {
 		suite.mockResourceService,
 		suite.mockCIBAService,
 		revocationmock.NewRefreshTokenRevokerInterfaceMock(suite.T()),
-		testhelpers.OAuthConfig(),
+		enabledOAuthConfig(),
 	)
 }
 
@@ -98,7 +107,7 @@ func (suite *GrantHandlerProviderTestSuite) TestNewGrantHandlerProvider() {
 		suite.mockResourceService,
 		suite.mockCIBAService,
 		revocationmock.NewRefreshTokenRevokerInterfaceMock(suite.T()),
-		testhelpers.OAuthConfig(),
+		enabledOAuthConfig(),
 	)
 	assert.NotNil(suite.T(), provider)
 	assert.Implements(suite.T(), (*GrantHandlerProviderInterface)(nil), provider)
@@ -129,12 +138,64 @@ func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_RefreshToken() {
 	assert.Implements(suite.T(), (*RefreshTokenGrantHandlerInterface)(nil), handler)
 }
 
+func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_TokenExchange() {
+	handler, err := suite.provider.GetGrantHandler(providers.GrantTypeTokenExchange)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), handler)
+	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
+}
+
 func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_CIBA() {
 	handler, err := suite.provider.GetGrantHandler(providers.GrantTypeCIBA)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
+}
+
+func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_RefreshTokenDisabled() {
+	provider := newGrantHandlerProvider(
+		suite.mockJWTService,
+		suite.authzService,
+		suite.mockTokenBuilder,
+		suite.mockTokenValidator,
+		suite.mockAttrCacheService,
+		suite.mockOUService,
+		suite.mockRBACAuthzService,
+		suite.mockEntityProvider,
+		suite.mockResourceService,
+		suite.mockCIBAService,
+		revocationmock.NewRefreshTokenRevokerInterfaceMock(suite.T()),
+		testhelpers.OAuthConfig(),
+	)
+
+	handler, err := provider.GetGrantHandler(providers.GrantTypeRefreshToken)
+
+	assert.Nil(suite.T(), handler)
+	assert.Equal(suite.T(), constants.UnSupportedGrantTypeError, err)
+}
+
+func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_CIBADisabled() {
+	provider := newGrantHandlerProvider(
+		suite.mockJWTService,
+		suite.authzService,
+		suite.mockTokenBuilder,
+		suite.mockTokenValidator,
+		suite.mockAttrCacheService,
+		suite.mockOUService,
+		suite.mockRBACAuthzService,
+		suite.mockEntityProvider,
+		suite.mockResourceService,
+		suite.mockCIBAService,
+		revocationmock.NewRefreshTokenRevokerInterfaceMock(suite.T()),
+		testhelpers.OAuthConfig(),
+	)
+
+	handler, err := provider.GetGrantHandler(providers.GrantTypeCIBA)
+
+	assert.Nil(suite.T(), handler)
+	assert.Equal(suite.T(), constants.UnSupportedGrantTypeError, err)
 }
 
 func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_UnsupportedGrantType() {
@@ -162,6 +223,7 @@ func (suite *GrantHandlerProviderTestSuite) TestGetGrantHandler_AllSupportedType
 		providers.GrantTypeClientCredentials,
 		providers.GrantTypeAuthorizationCode,
 		providers.GrantTypeRefreshToken,
+		providers.GrantTypeTokenExchange,
 		providers.GrantTypeCIBA,
 	}
 

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -120,7 +120,7 @@ func (tv *tokenValidator) ValidateAccessToken(ctx context.Context, token string)
 	scopes := extractScopesFromClaims(claims, false)
 
 	jti, _ := extractStringClaim(claims, constants.ClaimJTI)
-	if err := tv.enforcementService.EnsureNotRevoked(ctx, jti); err != nil {
+	if err := tv.ensureNotRevoked(ctx, jti); err != nil {
 		return nil, err
 	}
 
@@ -186,7 +186,7 @@ func (tv *tokenValidator) ValidateRefreshToken(
 		dpopJkt = s
 	}
 
-	if err := tv.enforcementService.EnsureNotRevoked(ctx, jti); err != nil {
+	if err := tv.ensureNotRevoked(ctx, jti); err != nil {
 		return nil, err
 	}
 
@@ -232,7 +232,7 @@ func (tv *tokenValidator) ValidateSubjectToken(
 		if err != nil {
 			return nil, err
 		}
-		if err := tv.enforcementService.EnsureNotRevoked(ctx, selfClaims.JTI); err != nil {
+		if err := tv.ensureNotRevoked(ctx, selfClaims.JTI); err != nil {
 			return nil, err
 		}
 		return selfClaims, nil
@@ -274,7 +274,7 @@ func (tv *tokenValidator) ValidateToken(ctx context.Context, token string) (map[
 	}
 
 	jti, _ := extractStringClaim(claims, constants.ClaimJTI)
-	if err := tv.enforcementService.EnsureNotRevoked(ctx, jti); err != nil {
+	if err := tv.ensureNotRevoked(ctx, jti); err != nil {
 		return nil, err
 	}
 
@@ -502,4 +502,11 @@ func (tv *tokenValidator) isAuthAssertion(
 	}
 
 	return false
+}
+
+func (tv *tokenValidator) ensureNotRevoked(ctx context.Context, jti string) error {
+	if tv.enforcementService != nil {
+		return tv.enforcementService.EnsureNotRevoked(ctx, jti)
+	}
+	return nil
 }

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -2062,6 +2062,88 @@ func (suite *TokenValidatorTestSuite) TestValidateToken_RevocationEnforced() {
 	}
 }
 
+// When no enforcement service is configured (nil), ensureNotRevoked treats every token as
+// not revoked instead of panicking, so validation proceeds normally for all four call sites
+// that consult the deny list.
+func (suite *TokenValidatorTestSuite) TestEnsureNotRevoked_NilEnforcementService_SkipsCheck() {
+	validator := &tokenValidator{cfg: suite.validator.cfg, jwtService: suite.mockJWTService}
+
+	suite.T().Run("ValidateAccessToken", func(t *testing.T) {
+		claims := map[string]interface{}{
+			"sub":       "user123",
+			"iss":       "https://example.com",
+			"aud":       "test-app",
+			"client_id": "test-client",
+			"jti":       "at-jti-noenforcement",
+		}
+		token := suite.createTestAccessToken(claims)
+		suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "https://example.com").Return(nil).Once()
+
+		result, err := validator.ValidateAccessToken(context.Background(), token)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+	})
+
+	suite.T().Run("ValidateRefreshToken", func(t *testing.T) {
+		now := time.Now().Unix()
+		claims := map[string]interface{}{
+			"sub":              "test-client",
+			"iss":              "https://example.com",
+			"aud":              "test-client",
+			"exp":              float64(now + 3600),
+			"iat":              float64(now),
+			"access_token_sub": "user123",
+			"access_token_aud": testAppID,
+			"grant_type":       "authorization_code",
+			"jti":              "rt-jti-noenforcement",
+		}
+		token := suite.createTestJWT(claims)
+		suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil).Once()
+
+		result, err := validator.ValidateRefreshToken(context.Background(), token, "test-client")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+	})
+
+	suite.T().Run("ValidateSubjectToken", func(t *testing.T) {
+		defaultAudience := suite.getDefaultAudience()
+		now := time.Now().Unix()
+		claims := map[string]interface{}{
+			"sub":   "user123",
+			"iss":   "https://example.com",
+			"aud":   defaultAudience,
+			"exp":   float64(now + 3600),
+			"nbf":   float64(now - 60),
+			"scope": "read write",
+			"jti":   "st-jti-noenforcement",
+		}
+		token := suite.createTestJWT(claims)
+		suite.mockJWTService.On("VerifyJWTSignature", mock.Anything, token).Return(nil).Once()
+
+		result, err := validator.ValidateSubjectToken(context.Background(), token, suite.oauthApp)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+	})
+
+	suite.T().Run("ValidateToken", func(t *testing.T) {
+		claims := map[string]interface{}{
+			"sub": "user123",
+			"iss": "https://example.com",
+			"jti": "vt-jti-noenforcement",
+		}
+		token := suite.createTestJWT(claims)
+		suite.mockJWTService.On("VerifyJWT", mock.Anything, token, "", "").Return(nil).Once()
+
+		result, err := validator.ValidateToken(context.Background(), token)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+	})
+}
+
 func (suite *TokenValidatorTestSuite) TestValidateAccessToken_Error_VerifyFails() {
 	token := "invalid.token.signature"
 

--- a/backend/pkg/thunderidengine/config/config.go
+++ b/backend/pkg/thunderidengine/config/config.go
@@ -166,6 +166,7 @@ type AuthClassConfig struct {
 
 // RefreshTokenConfig holds the refresh token configuration details.
 type RefreshTokenConfig struct {
+	Enabled               bool  `yaml:"enabled"           json:"enabled"`
 	RenewOnGrant          bool  `yaml:"renew_on_grant"           json:"renew_on_grant"`
 	RevokePreviousOnRenew bool  `yaml:"revoke_previous_on_renew" json:"revoke_previous_on_renew"`
 	ValidityPeriod        int64 `yaml:"validity_period"          json:"validity_period"`

--- a/backend/pkg/thunderidengine/engine.go
+++ b/backend/pkg/thunderidengine/engine.go
@@ -36,6 +36,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/flow/interceptor"
 	"github.com/thunder-id/thunderid/internal/oauth"
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/runtimestore"
 	"github.com/thunder-id/thunderid/internal/system/cache"
 	"github.com/thunder-id/thunderid/internal/system/jose"
@@ -45,6 +46,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/transaction"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -89,13 +91,13 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 		logger.Fatal(ctx, "Failed to initialize JOSE services", log.Error(err))
 	}
 
-	runtimeStoreProvider, transactioner, err := runtimestore.Initialize(engineCtx.runtimeDBType,
+	engineCtx.runtimeStoreProvider, engineCtx.transactioner, err = runtimestore.Initialize(engineCtx.runtimeDBType,
 		engineCtx.serverConfig.Identifier)
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize runtime store", log.Error(err))
 	}
 
-	attributeCacheService := attributecache.Initialize(runtimeStoreProvider)
+	engineCtx.attributeCacheService = attributecache.Initialize(engineCtx.runtimeStoreProvider)
 	engineCtx.authAssertGen = assert.Initialize()
 
 	// Initialize flow metadata service
@@ -110,7 +112,7 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 	engineCtx.flowFactory = flowFactory
 	execDeps := executor.ExecutorDependencies{
 		FlowFactory:       engineCtx.flowFactory,
-		AttributeCacheSvc: attributeCacheService,
+		AttributeCacheSvc: engineCtx.attributeCacheService,
 		AuthZService:      engineCtx.authzProvider,
 		ConsentEnforcer:   engineCtx.consentProvider,
 		AuthnProvider:     engineCtx.authnProvider,
@@ -138,14 +140,15 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 	engineCtx.graphBuilder = graphbuilder.Initialize(engineCtx.flowFactory, engineCtx.execRegistry,
 		engineCtx.interceptorRegistry, graphCache)
 
-	flowExecService, err := flowexec.Initialize(mux, engineCtx.flowProvider, engineCtx.actorProvider,
+	engineCtx.flowExecService, err = flowexec.Initialize(mux, engineCtx.flowProvider, engineCtx.actorProvider,
 		engineCtx.execRegistry, engineCtx.interceptorRegistry, engineCtx.observabilitySvc,
-		engineCtx.runtimeCryptoSvc, engineCtx.graphBuilder, runtimeStoreProvider, transactioner, flowConfig)
+		engineCtx.runtimeCryptoSvc, engineCtx.graphBuilder, engineCtx.runtimeStoreProvider,
+		engineCtx.transactioner, flowConfig)
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize flow execution service", log.Error(err))
 	}
 
-	oauthConfig := oauthconfig.Config{
+	oauthCfg := oauthconfig.Config{
 		DeploymentID:  engineCtx.serverConfig.Identifier,
 		RuntimeDBType: engineCtx.runtimeDBType,
 		BaseURL:       config.GetServerURL(&engineCtx.serverConfig),
@@ -153,10 +156,12 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 		OAuth:         engineCtx.oauthConfig,
 		GateClient:    engineCtx.gateClientConfig,
 	}
+	// Initialize OAuth services.
 	err = oauth.Initialize(mux, engineCtx.actorProvider, engineCtx.authnProvider, engineCtx.jwtService,
-		engineCtx.jweService, flowExecService, engineCtx.observabilitySvc, engineCtx.runtimeCryptoSvc,
-		engineCtx.ouProvider, attributeCacheService, engineCtx.authzProvider, engineCtx.resourceProvider,
-		engineCtx.i18nProvider, engineCtx.idpProvider, nil, oauthConfig, runtimeStoreProvider, transactioner)
+		engineCtx.jweService, engineCtx.flowExecService, engineCtx.observabilitySvc, engineCtx.runtimeCryptoSvc,
+		engineCtx.ouProvider, engineCtx.attributeCacheService, engineCtx.authzProvider,
+		engineCtx.resourceProvider, engineCtx.i18nProvider, engineCtx.idpProvider, engineCtx.dpopVerifier,
+		oauthCfg, engineCtx.runtimeStoreProvider, engineCtx.transactioner)
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize OAuth services", log.Error(err))
 	}
@@ -179,6 +184,33 @@ func validateEngineContext(ctx *engineContext) error {
 	}
 	if ctx.authzProvider == nil {
 		return errors.New("thunderidengine: authorization provider is not set")
+	}
+	if ctx.actorProvider == nil {
+		return errors.New("thunderidengine: actor provider is not set")
+	}
+	if ctx.authnProvider == nil {
+		return errors.New("thunderidengine: authn provider is not set")
+	}
+	if ctx.resourceProvider == nil {
+		return errors.New("thunderidengine: resource server provider is not set")
+	}
+	if ctx.ouProvider == nil {
+		return errors.New("thunderidengine: organization unit provider is not set")
+	}
+	if ctx.designResolveProvider == nil {
+		return errors.New("thunderidengine: design provider is not set")
+	}
+	if ctx.flowProvider == nil {
+		return errors.New("thunderidengine: flow provider is not set")
+	}
+	if ctx.i18nProvider == nil {
+		return errors.New("thunderidengine: i18n provider is not set")
+	}
+	if ctx.idpProvider == nil {
+		return errors.New("thunderidengine: idp provider is not set")
+	}
+	if ctx.consentProvider == nil {
+		return errors.New("thunderidengine: consent provider is not set")
 	}
 	return nil
 }
@@ -211,15 +243,19 @@ func (e *engineContext) applyCustomExecutors() error {
 }
 
 type engineContext struct {
-	cacheManager        cache.CacheManagerInterface
-	jwtService          jwt.JWTServiceInterface
-	jweService          jwe.JWEServiceInterface
-	runtimeCryptoSvc    kmprovider.RuntimeCryptoProvider
-	flowFactory         core.FlowFactoryInterface
-	execRegistry        executor.ExecutorRegistryInterface
-	interceptorRegistry interceptor.InterceptorRegistryInterface
-	graphBuilder        graphbuilder.GraphBuilderInterface
-	authAssertGen       assert.AuthAssertGeneratorInterface
+	cacheManager          cache.CacheManagerInterface
+	jwtService            jwt.JWTServiceInterface
+	jweService            jwe.JWEServiceInterface
+	runtimeCryptoSvc      kmprovider.RuntimeCryptoProvider
+	flowFactory           core.FlowFactoryInterface
+	execRegistry          executor.ExecutorRegistryInterface
+	interceptorRegistry   interceptor.InterceptorRegistryInterface
+	graphBuilder          graphbuilder.GraphBuilderInterface
+	authAssertGen         assert.AuthAssertGeneratorInterface
+	dpopVerifier          dpop.VerifierInterface
+	transactioner         transaction.Transactioner
+	flowExecService       flowexec.FlowExecServiceInterface
+	attributeCacheService attributecache.AttributeCacheServiceInterface
 
 	serverHome          string
 	runtimeDBType       string
@@ -243,6 +279,8 @@ type engineContext struct {
 	customExecutors       map[string]providers.Executor
 	observabilitySvc      providers.ObservabilityProvider
 	authzProvider         providers.AuthorizationProvider
+
+	runtimeStoreProvider providers.RuntimeStoreProvider
 }
 
 // Option configures engine initialization.

--- a/backend/pkg/thunderidengine/engine_test.go
+++ b/backend/pkg/thunderidengine/engine_test.go
@@ -29,11 +29,28 @@ import (
 	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+	"github.com/thunder-id/thunderid/tests/mocks/actorprovidermock"
+	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
 	"github.com/thunder-id/thunderid/tests/mocks/authzmock"
+	"github.com/thunder-id/thunderid/tests/mocks/consentprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/executormock"
+	"github.com/thunder-id/thunderid/tests/mocks/flow/flowexecmock"
 	"github.com/thunder-id/thunderid/tests/mocks/observabilityprovidermock"
 )
+
+// fakeResourceProvider, fakeOUProvider, fakeDesignProvider, fakeI18nProvider, and fakeIDPProvider
+// satisfy their respective provider interfaces via embedding, purely to serve as non-nil values in
+// validateEngineContext tests where no method calls are exercised.
+type fakeResourceProvider struct {
+	providers.ResourceServerProvider
+}
+type fakeOUProvider struct {
+	providers.OrganizationUnitProvider
+}
+type fakeDesignProvider struct{ providers.DesignProvider }
+type fakeI18nProvider struct{ providers.I18nProvider }
+type fakeIDPProvider struct{ providers.IDPProvider }
 
 type EngineTestSuite struct {
 	suite.Suite
@@ -62,10 +79,19 @@ func newTestExecutor(t *testing.T, name string) providers.Executor {
 
 func validEngineContext(t *testing.T) *engineContext {
 	return &engineContext{
-		serverHome:       "/tmp/server",
-		serverConfig:     engineconfig.ServerConfig{Identifier: "test-server"},
-		observabilitySvc: newTestObservabilityProvider(t),
-		authzProvider:    newTestAuthzProvider(t),
+		serverHome:            "/tmp/server",
+		serverConfig:          engineconfig.ServerConfig{Identifier: "test-server"},
+		observabilitySvc:      newTestObservabilityProvider(t),
+		authzProvider:         newTestAuthzProvider(t),
+		actorProvider:         actorprovidermock.NewActorProviderMock(t),
+		authnProvider:         managermock.NewAuthnProviderManagerMock(t),
+		resourceProvider:      fakeResourceProvider{},
+		ouProvider:            fakeOUProvider{},
+		designResolveProvider: fakeDesignProvider{},
+		flowProvider:          flowexecmock.NewFlowProviderMock(t),
+		i18nProvider:          fakeI18nProvider{},
+		idpProvider:           fakeIDPProvider{},
+		consentProvider:       consentprovidermock.NewConsentProviderMock(t),
 	}
 }
 
@@ -96,6 +122,60 @@ func (suite *EngineTestSuite) TestValidateEngineContext() {
 		ctx := validEngineContext(t)
 		ctx.authzProvider = nil
 		assert.ErrorContains(t, validateEngineContext(ctx), "authorization provider")
+	})
+
+	suite.T().Run("missing actor provider", func(t *testing.T) {
+		ctx := validEngineContext(t)
+		ctx.actorProvider = nil
+		assert.ErrorContains(t, validateEngineContext(ctx), "actor provider")
+	})
+
+	suite.T().Run("missing authn provider", func(t *testing.T) {
+		ctx := validEngineContext(t)
+		ctx.authnProvider = nil
+		assert.ErrorContains(t, validateEngineContext(ctx), "authn provider")
+	})
+
+	suite.T().Run("missing resource provider", func(t *testing.T) {
+		ctx := validEngineContext(t)
+		ctx.resourceProvider = nil
+		assert.ErrorContains(t, validateEngineContext(ctx), "resource server provider")
+	})
+
+	suite.T().Run("missing ou provider", func(t *testing.T) {
+		ctx := validEngineContext(t)
+		ctx.ouProvider = nil
+		assert.ErrorContains(t, validateEngineContext(ctx), "organization unit provider")
+	})
+
+	suite.T().Run("missing design provider", func(t *testing.T) {
+		ctx := validEngineContext(t)
+		ctx.designResolveProvider = nil
+		assert.ErrorContains(t, validateEngineContext(ctx), "design provider")
+	})
+
+	suite.T().Run("missing flow provider", func(t *testing.T) {
+		ctx := validEngineContext(t)
+		ctx.flowProvider = nil
+		assert.ErrorContains(t, validateEngineContext(ctx), "flow provider")
+	})
+
+	suite.T().Run("missing i18n provider", func(t *testing.T) {
+		ctx := validEngineContext(t)
+		ctx.i18nProvider = nil
+		assert.ErrorContains(t, validateEngineContext(ctx), "i18n provider")
+	})
+
+	suite.T().Run("missing idp provider", func(t *testing.T) {
+		ctx := validEngineContext(t)
+		ctx.idpProvider = nil
+		assert.ErrorContains(t, validateEngineContext(ctx), "idp provider")
+	})
+
+	suite.T().Run("missing consent provider", func(t *testing.T) {
+		ctx := validEngineContext(t)
+		ctx.consentProvider = nil
+		assert.ErrorContains(t, validateEngineContext(ctx), "consent provider")
 	})
 }
 


### PR DESCRIPTION
### Purpose

Added missing coverage
Updated engine.go with latest changes
token revocation is based on the flag, but default revocation flag is enabled
CIBA instantiation is also flag driven, by default flag is enabled
Refresh token grant is also flag driven, by default flag is enabled 

---

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- #3037 

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
