### PR TITLE
Handle OU deletion i18n errors in the Console

### DIFF
--- a/frontend/packages/configure-organization-units/src/api/useDeleteOrganizationUnit.ts
+++ b/frontend/packages/configure-organization-units/src/api/useDeleteOrganizationUnit.ts
@@ -88,8 +88,5 @@ export default function useDeleteOrganizationUnit(): UseMutationResult<void, Err
       });
       showToast(t('delete.success'), 'success');
     },
-    onError: () => {
-      showToast(t('delete.error'), 'error');
-    },
   });
 }

--- a/frontend/packages/configure-organization-units/src/components/OrganizationUnitDeleteDialog.tsx
+++ b/frontend/packages/configure-organization-units/src/components/OrganizationUnitDeleteDialog.tsx
@@ -20,7 +20,7 @@ import {Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Bu
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import useDeleteOrganizationUnit from '../api/useDeleteOrganizationUnit';
-import type {ApiError} from '../models/api-error';
+import type {ApiError, I18nMessage} from '../models/api-error';
 
 export interface OrganizationUnitDeleteDialogProps {
   /**
@@ -46,11 +46,26 @@ export interface OrganizationUnitDeleteDialogProps {
 }
 
 /**
+ * Resolves a backend error field to a display string. The field may be a plain
+ * string or a translatable {@link I18nMessage} object; objects are reduced to
+ * their `defaultValue` so they are never rendered directly as React children.
+ */
+function resolveField(value: I18nMessage | string | undefined): string | null {
+  if (typeof value === 'string') {
+    return value.trim() ? value : null;
+  }
+
+  const defaultValue = value?.defaultValue;
+
+  return defaultValue?.trim() ? defaultValue : null;
+}
+
+/**
  * Extracts a user-friendly error message from the API error response.
  */
 function getErrorMessage(err: Error, fallback: string): string {
   const {response} = err as Error & {response?: {data?: ApiError}};
-  const description = response?.data?.description ?? null;
+  const description = resolveField(response?.data?.description);
   const message = err.message?.trim() ? err.message : null;
 
   return description ?? message ?? fallback;

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitDeleteDialog.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitDeleteDialog.test.tsx
@@ -123,6 +123,62 @@ describe('OrganizationUnitDeleteDialog', () => {
     });
   });
 
+  it('should resolve object-shaped description to its defaultValue', async () => {
+    const onError = vi.fn();
+    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
+      options.onError(
+        Object.assign(new Error('Organization unit has children'), {
+          response: {
+            data: {
+              code: 'OU-1006',
+              message: {
+                key: 'error.ouservice.organization_unit_has_children',
+                defaultValue: 'Organization unit has children',
+              },
+              description: {
+                key: 'error.ouservice.organization_unit_has_children_description',
+                defaultValue: 'Cannot delete organization unit with children or users/groups',
+              },
+            },
+          },
+        }),
+      );
+    });
+
+    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onError={onError} />);
+
+    fireEvent.click(screen.getByText(t('common:actions.delete')));
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith('Cannot delete organization unit with children or users/groups');
+    });
+  });
+
+  it('should fall back to error message when object-shaped description has empty defaultValue', async () => {
+    const onError = vi.fn();
+    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
+      options.onError(
+        Object.assign(new Error('Something went wrong'), {
+          response: {
+            data: {
+              code: 'OU-1006',
+              message: {key: 'k', defaultValue: 'm'},
+              description: {key: 'k', defaultValue: '   '},
+            },
+          },
+        }),
+      );
+    });
+
+    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onError={onError} />);
+
+    fireEvent.click(screen.getByText(t('common:actions.delete')));
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith('Something went wrong');
+    });
+  });
+
   it('should use fallback error message when error has no response data', async () => {
     const onError = vi.fn();
     mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {

--- a/frontend/packages/configure-organization-units/src/models/api-error.ts
+++ b/frontend/packages/configure-organization-units/src/models/api-error.ts
@@ -32,8 +32,8 @@
  * ```typescript
  * const error: ApiError = {
  *   code: 'OU-60001',
- *   message: 'Organization unit not found',
- *   description: 'No organization unit exists with the given ID'
+ *   message: {key: 'error.ouservice.not_found', defaultValue: 'Organization unit not found'},
+ *   description: {key: 'error.ouservice.not_found_description', defaultValue: 'No organization unit exists with the given ID'}
  * };
  * ```
  */
@@ -45,14 +45,39 @@ export interface ApiError {
   code: string;
 
   /**
-   * Short error message
-   * @example 'Organization unit not found'
+   * Short error message. The backend serializes this as a translatable
+   * {@link I18nMessage} object, but plain strings are tolerated for safety.
    */
-  message: string;
+  message: I18nMessage | string;
 
   /**
-   * Detailed error description
-   * @example 'No organization unit exists with the given ID'
+   * Detailed error description. The backend serializes this as a translatable
+   * {@link I18nMessage} object, but plain strings are tolerated for safety.
    */
-  description: string;
+  description: I18nMessage | string;
+}
+
+/**
+ * Translatable message returned by the backend, carrying a translation key
+ * and a human-readable default value.
+ *
+ * @public
+ */
+export interface I18nMessage {
+  /**
+   * Translation key
+   * @example 'error.ouservice.organization_unit_has_children_description'
+   */
+  key: string;
+
+  /**
+   * Human-readable fallback used when no translation is available
+   * @example 'Cannot delete organization unit with children or users/groups'
+   */
+  defaultValue: string;
+
+  /**
+   * Optional parameters substituted into the default value
+   */
+  params?: Record<string, string>;
 }


### PR DESCRIPTION
### Purpose

When deleting an organization unit that has children (or attached users/groups), the backend returns an error such as:

```json
{
  "code": "OU-1006",
  "message": {"key": "error.ouservice.organization_unit_has_children", "defaultValue": "Organization unit has children"},
  "description": {"key": "error.ouservice.organization_unit_has_children_description", "defaultValue": "Cannot delete organization unit with children or users/groups"}
}
```

The Console rendered a **blank page** instead of showing the error, and after that was fixed a **second, duplicate toast** appeared. This PR fixes both.

Fixed
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/23003cc2-9be0-45d1-b425-84d95f02bd0a" />



**Root causes**
1. The backend serializes error `message`/`description` as translatable `I18nMessage` **objects** (`{key, defaultValue, params}`), but the OU package's local `ApiError` type declared them as `string`. `getErrorMessage` returned the raw object, which was then rendered directly as a React child (`<Alert>{message}</Alert>`) — React throws "Objects are not valid as a React child" and blanks the page.
2. The delete hook showed a generic error toast while the dialog/pages also surfaced the specific error via their own snackbar, producing two messages once the crash was fixed.

### Approach

- Corrected the OU package `ApiError` model: `message`/`description` are now typed as `I18nMessage | string` (added the `I18nMessage` interface), tolerating both shapes.
- Added a `resolveField` helper in `OrganizationUnitDeleteDialog` that reduces an `I18nMessage` object to its `defaultValue` (and handles plain strings), so `getErrorMessage` always returns a string. Users now see the specific backend description.
- Removed the redundant generic `onError` toast from `useDeleteOrganizationUnit`, leaving the single specific snackbar. The success toast is retained (it is the edit page's only success confirmation, since that page navigates away).
- Added unit tests covering the object-shaped `description` (the OU-1006 case) and the empty-`defaultValue` fallback.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided.
    - [x] Unit Tests

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization unit deletion error messages to correctly handle API-provided translated message objects.
  * Kept fallback behavior for standard text and whitespace/empty descriptions.
  * Prevented duplicate error notifications during deletion failures.
* **Tests**
  * Added unit tests covering translated error descriptions (including nested `defaultValue`) and fallback to the top-level message when descriptions are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->