### PR TITLE
Fix broken anchor links in documentation

### DIFF
--- a/docs/content/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/flows/advanced-configurations.mdx
@@ -2240,7 +2240,7 @@ GET /oauth2/authorize
   &nonce=xyz789
 ```
 
-ACR filtering only takes effect when the flow contains a [`LOGIN_OPTIONS` PROMPT node](#login-options-variant) with `authMethodMapping` configured. Without it, `acr_values` have no effect on the flow.
+ACR filtering only takes effect when the flow contains a [`LOGIN_OPTIONS` PROMPT node](#prompt-node) with `authMethodMapping` configured. Without it, `acr_values` have no effect on the flow.
 
 **Using `acr_values` with the `LOGIN_OPTIONS` node**
 

--- a/docs/content/guides/identity-providers/add-oidc-provider.mdx
+++ b/docs/content/guides/identity-providers/add-oidc-provider.mdx
@@ -101,7 +101,7 @@ Behavior:
 - The local attribute must be defined in the user type's schema; this is validated when you save the connection.
 - An attribute whose name is mapped is renamed to its local attribute; attributes without a mapping pass through unchanged.
 
-The mapping applies both when a user signs in through this connection in an authentication flow and when a token from this provider is exchanged (see [Trusted Issuer](../../trusted-issuer#attribute-configuration)). The resulting local attributes flow into the issued access and ID tokens, subject to the application's `userAttributes` configuration.
+The mapping applies both when a user signs in through this connection in an authentication flow and when a token from this provider is exchanged (see [Trusted Issuer](../../trusted-issuer)). The resulting local attributes flow into the issued access and ID tokens, subject to the application's `userAttributes` configuration.
 
 ### Account Linking
 


### PR DESCRIPTION
### Purpose

Two documentation pages contain in-page or cross-page links whose anchor fragments do not exist on the target page. Clicking them loads the page but fails to scroll to the intended section.

### Approach

Repointed each link to the anchor of the section that actually holds the referenced content:

1. `guides/flows/advanced-configurations.mdx`: the ACR Values section linked to `#login-options-variant`, but the target is a `<summary>Login Options Variant</summary>` element inside a collapsible block, which never receives an anchor id. Repointed to the closest heading, `### Prompt Node` (`#prompt-node`), which documents the `LOGIN_OPTIONS` variant.

2. `guides/identity-providers/add-oidc-provider.mdx`: the attribute mapping section linked to `../../trusted-issuer#attribute-configuration`, a heading that does not exist on the Trusted Issuer page. Repointed to root doc.

### Related Issues

- N/A

### Related PRs

- N/A

### Checklist

- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks

- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected cross-references for configuring ACR values in flows.
  * Updated Trusted Issuer links for mapped attribute behavior during token exchange.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
